### PR TITLE
BREAKING: update tokens controller allTokens state structure to make network/chainID parent of account

### DIFF
--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -523,7 +523,8 @@ export class TokensController extends BaseController<
    * Takes a new tokens array for the current network/account combination
    * and returns new allTokens state to update to.
    *
-   * @param newTokens - array of token type
+   * @param newTokens - The tokens to set for the current network and selected account.
+   * @returns The updated `allTokens` state.
    */
   _getNewAllTokensState(newTokens: Token[]) {
     const { allTokens } = this.state;


### PR DESCRIPTION
Reconfigures TokensController allTokens state from 
  `{ [accountAddress]: { [chainId] : [] }` to 
  `{ [chainId]: { [accountAddress] : [] }`
  
- BREAKING:
  - A migration will be required in metamask-mobile to reconfigure users' TokenController `allTokens` state to conform to the new state structure.

- CHANGED:

  - Reconfigures TokensController allTokens state from 
  `{ [accountAddress]: { [chainId] : [] }` to 
  `{ [chainId]: { [accountAddress] : [] }` 

**Checklist**

- [X] Tests are included if applicable
- [X] Any added code is fully documented

