### PR TITLE
Update CollectibleContract data when it changes

### DIFF
--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -343,6 +343,62 @@ describe('CollectiblesController', () => {
       ).toHaveLength(1);
     });
 
+    it('should update collectible contract data if it changes', async () => {
+      const { selectedAddress, chainId } = collectiblesController.config;
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+        favorite: false,
+      });
+
+      nock(OPEN_SEA_HOST)
+        .get(`${OPEN_SEA_PATH}/asset_contract/0x01`)
+        .reply(200, {
+          description: 'New Description',
+          symbol: 'FOO',
+          total_supply: 0,
+          collection: {
+            name: 'Name',
+            image_url: 'url',
+          },
+        });
+        expect(
+          collectiblesController.state.allCollectibleContracts[selectedAddress][
+            chainId
+          ][0],
+        ).toStrictEqual({
+          address: '0x01',
+          description: 'Description',
+          logo: 'url',
+          name: 'Name',
+          symbol: 'FOO',
+          totalSupply: 0,
+        });
+
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+        favorite: false,
+      });
+
+      expect(
+        collectiblesController.state.allCollectibleContracts[selectedAddress][
+          chainId
+        ][0],
+      ).toStrictEqual({
+        address: '0x01',
+        description: 'New Description',
+        logo: 'url',
+        name: 'Name',
+        symbol: 'FOO',
+        totalSupply: 0,
+      });
+    });
+
     it('should add collectible and get information from OpenSea', async () => {
       const { selectedAddress, chainId } = collectiblesController.config;
       await collectiblesController.addCollectible('0x01', '1');

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -364,18 +364,19 @@ describe('CollectiblesController', () => {
             image_url: 'url',
           },
         });
-        expect(
-          collectiblesController.state.allCollectibleContracts[selectedAddress][
-            chainId
-          ][0],
-        ).toStrictEqual({
-          address: '0x01',
-          description: 'Description',
-          logo: 'url',
-          name: 'Name',
-          symbol: 'FOO',
-          totalSupply: 0,
-        });
+
+      expect(
+        collectiblesController.state.allCollectibleContracts[selectedAddress][
+          chainId
+        ][0],
+      ).toStrictEqual({
+        address: '0x01',
+        description: 'Description',
+        logo: 'url',
+        name: 'Name',
+        symbol: 'FOO',
+        totalSupply: 0,
+      });
 
       await collectiblesController.addCollectible('0x01', '1', {
         name: 'name',

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -26,7 +26,10 @@ import type {
   ApiCollectibleLastSale,
 } from './CollectibleDetectionController';
 import type { AssetsContractController } from './AssetsContractController';
-import { compareCollectiblesMetadata } from './assetsUtil';
+import {
+  compareCollectiblesMetadata,
+  compareCollectibleContract,
+} from './assetsUtil';
 
 /**
  * @type Collectible
@@ -629,13 +632,6 @@ export class CollectiblesController extends BaseController<
       const collectibleContracts =
         allCollectibleContracts[selectedAddress]?.[chainId] || [];
 
-      const existingEntry = collectibleContracts.find(
-        (collectibleContract) =>
-          collectibleContract.address.toLowerCase() === address.toLowerCase(),
-      );
-      if (existingEntry) {
-        return collectibleContracts;
-      }
       const contractInformation = await this.getCollectibleContractInformation(
         address,
       );
@@ -674,6 +670,26 @@ export class CollectiblesController extends BaseController<
         schema_name && { schemaName: schema_name },
         external_link && { externalLink: external_link },
       );
+
+      const existingEntry = collectibleContracts.find(
+        (collectibleContract) =>
+          collectibleContract.address.toLowerCase() === address.toLowerCase(),
+      );
+
+      if (existingEntry) {
+        if (compareCollectibleContract(newEntry, existingEntry)) {
+          const indexToRemove = collectibleContracts.findIndex(
+            (collectibleContract) =>
+              collectibleContract.address.toLowerCase() ===
+              address.toLowerCase(),
+          );
+          if (indexToRemove !== -1) {
+            collectibleContracts.splice(indexToRemove, 1);
+          }
+        } else {
+          return collectibleContracts;
+        }
+      }
 
       const newCollectibleContracts = [...collectibleContracts, newEntry];
       this.updateNestedCollectibleState(

--- a/src/assets/assetsUtil.test.ts
+++ b/src/assets/assetsUtil.test.ts
@@ -1,5 +1,9 @@
 import * as assetsUtil from './assetsUtil';
-import { Collectible, CollectibleMetadata, CollectibleContract } from './CollectiblesController';
+import {
+  Collectible,
+  CollectibleMetadata,
+  CollectibleContract,
+} from './CollectiblesController';
 
 describe('assetsUtil', () => {
   describe('isCollectibleMetadataEqual', () => {

--- a/src/assets/assetsUtil.test.ts
+++ b/src/assets/assetsUtil.test.ts
@@ -43,7 +43,7 @@ describe('assetsUtil', () => {
       expect(equal).toStrictEqual(false);
     });
 
-    it('should return true if all keys present in metadata match those the Collectible', () => {
+    it('should return false if all keys present in new metadata match those of the collectible metadata in state, but some fields are missing', () => {
       const collectibleMetadata: CollectibleMetadata = {
         name: 'name',
         image: 'image',
@@ -65,10 +65,10 @@ describe('assetsUtil', () => {
         collectibleMetadata,
         collectible,
       );
-      expect(equal).toStrictEqual(true);
+      expect(equal).toStrictEqual(false);
     });
 
-    it('should return true if no key is different', () => {
+    it('should return true if all fields of the metadata in state are present in the new metadata and no values are different', () => {
       const collectibleMetadata: CollectibleMetadata = {
         name: 'name',
         image: 'image',
@@ -140,7 +140,7 @@ describe('assetsUtil', () => {
       expect(equal).toStrictEqual(false);
     });
 
-    it('should return true if all keys present in old contract match those the new contract', () => {
+    it('should return false if all keys present in new contract data match those of the contract data in state, but some fields are missing', () => {
       const oldContract: CollectibleContract = {
         name: 'name',
         logo: 'logo',
@@ -168,10 +168,10 @@ describe('assetsUtil', () => {
         newContract,
         oldContract,
       );
-      expect(equal).toStrictEqual(true);
+      expect(equal).toStrictEqual(false);
     });
 
-    it('should return true if no key is different', () => {
+    it('should return true if no values are different', () => {
       const oldContract: CollectibleContract = {
         name: 'name',
         logo: 'logo',

--- a/src/assets/assetsUtil.test.ts
+++ b/src/assets/assetsUtil.test.ts
@@ -1,9 +1,9 @@
 import * as assetsUtil from './assetsUtil';
-import { Collectible, CollectibleMetadata } from './CollectiblesController';
+import { Collectible, CollectibleMetadata, CollectibleContract } from './CollectiblesController';
 
 describe('assetsUtil', () => {
-  describe('compareCollectiblesMetadata', () => {
-    it('should resolve true if any key is different', () => {
+  describe('isCollectibleMetadataEqual', () => {
+    it('should return false if any key is different', () => {
       const collectibleMetadata: CollectibleMetadata = {
         name: 'name',
         image: 'image',
@@ -32,14 +32,14 @@ describe('assetsUtil', () => {
         animationOriginal: 'animationOriginal',
         externalLink: 'externalLink',
       };
-      const different = assetsUtil.compareCollectiblesMetadata(
+      const equal = assetsUtil.isCollectibleMetadataEqual(
         collectibleMetadata,
         collectible,
       );
-      expect(different).toStrictEqual(true);
+      expect(equal).toStrictEqual(false);
     });
 
-    it('should resolve true if any key is different as always as metadata is not undefined', () => {
+    it('should return true if all keys present in metadata match those the Collectible', () => {
       const collectibleMetadata: CollectibleMetadata = {
         name: 'name',
         image: 'image',
@@ -57,14 +57,14 @@ describe('assetsUtil', () => {
         backgroundColor: 'backgroundColor',
         externalLink: 'externalLink',
       };
-      const different = assetsUtil.compareCollectiblesMetadata(
+      const equal = assetsUtil.isCollectibleMetadataEqual(
         collectibleMetadata,
         collectible,
       );
-      expect(different).toStrictEqual(false);
+      expect(equal).toStrictEqual(true);
     });
 
-    it('should resolve false if no key is different', () => {
+    it('should return true if no key is different', () => {
       const collectibleMetadata: CollectibleMetadata = {
         name: 'name',
         image: 'image',
@@ -93,11 +93,112 @@ describe('assetsUtil', () => {
         animationOriginal: 'animationOriginal',
         externalLink: 'externalLink',
       };
-      const different = assetsUtil.compareCollectiblesMetadata(
+      const equal = assetsUtil.isCollectibleMetadataEqual(
         collectibleMetadata,
         collectible,
       );
-      expect(different).toStrictEqual(false);
+      expect(equal).toStrictEqual(true);
+    });
+  });
+
+  describe('isCollectibleContractEqual', () => {
+    it('should return false if any key is different', () => {
+      const oldContract: CollectibleContract = {
+        name: 'name',
+        logo: 'logo',
+        address: 'address',
+        symbol: 'symbol',
+        description: 'description',
+        totalSupply: 'totalSupply',
+        assetContractType: 'assetContractType',
+        createdDate: 'createdDate',
+        schemaName: 'schemaName',
+        externalLink: 'externalLink',
+      };
+
+      const newContract: CollectibleContract = {
+        name: '[new]name',
+        logo: 'logo',
+        address: 'address',
+        symbol: 'symbol',
+        description: 'description',
+        totalSupply: 'totalSupply',
+        assetContractType: 'assetContractType',
+        createdDate: 'createdDate',
+        schemaName: 'schemaName',
+        externalLink: 'externalLink',
+      };
+
+      const equal = assetsUtil.isCollectibleContractEqual(
+        newContract,
+        oldContract,
+      );
+      expect(equal).toStrictEqual(false);
+    });
+
+    it('should return true if all keys present in old contract match those the new contract', () => {
+      const oldContract: CollectibleContract = {
+        name: 'name',
+        logo: 'logo',
+        address: 'address',
+        symbol: 'symbol',
+        description: 'description',
+        totalSupply: 'totalSupply',
+        assetContractType: 'assetContractType',
+        createdDate: 'createdDate',
+        schemaName: 'schemaName',
+        externalLink: 'externalLink',
+      };
+
+      const newContract: CollectibleContract = {
+        name: 'name',
+        logo: 'logo',
+        address: 'address',
+        symbol: 'symbol',
+        description: 'description',
+        totalSupply: 'totalSupply',
+        assetContractType: 'assetContractType',
+      };
+
+      const equal = assetsUtil.isCollectibleContractEqual(
+        newContract,
+        oldContract,
+      );
+      expect(equal).toStrictEqual(true);
+    });
+
+    it('should return true if no key is different', () => {
+      const oldContract: CollectibleContract = {
+        name: 'name',
+        logo: 'logo',
+        address: 'address',
+        symbol: 'symbol',
+        description: 'description',
+        totalSupply: 'totalSupply',
+        assetContractType: 'assetContractType',
+        createdDate: 'createdDate',
+        schemaName: 'schemaName',
+        externalLink: 'externalLink',
+      };
+
+      const newContract: CollectibleContract = {
+        name: 'name',
+        logo: 'logo',
+        address: 'address',
+        symbol: 'symbol',
+        description: 'description',
+        totalSupply: 'totalSupply',
+        assetContractType: 'assetContractType',
+        createdDate: 'createdDate',
+        schemaName: 'schemaName',
+        externalLink: 'externalLink',
+      };
+
+      const equal = assetsUtil.isCollectibleContractEqual(
+        oldContract,
+        newContract,
+      );
+      expect(equal).toStrictEqual(true);
     });
   });
 });

--- a/src/assets/assetsUtil.ts
+++ b/src/assets/assetsUtil.ts
@@ -1,4 +1,8 @@
-import { Collectible, CollectibleMetadata } from './CollectiblesController';
+import {
+  Collectible,
+  CollectibleMetadata,
+  CollectibleContract,
+} from './CollectiblesController';
 
 /**
  * Compares collectible metadata entries to any collectible entry.
@@ -33,4 +37,35 @@ export function compareCollectiblesMetadata(
     return value;
   }, 0);
   return differentValues > 0;
+}
+
+/**
+ * Compares CollectibleContract entries to any CollectibleContract entry.
+ * We need this method when comparing a new fetched CollectibleContract, in case a entry changed to a defined value,
+ * there's a need to update the CollectibleContract object in state.
+ *
+ * @param newCollectibleContract - CollectibleContract data object.
+ * @param oldCollectibleContract - CollectibleContract object to compare with.
+ * @returns Whether there are differences.
+ */
+export function compareCollectibleContract(
+  newCollectibleContract: CollectibleContract,
+  oldCollectibleContract: CollectibleContract,
+) {
+  const keys: (keyof CollectibleContract)[] = [
+    'address',
+    'assetContractType',
+    'createdDate',
+    'description',
+    'externalLink',
+    'logo',
+    'name',
+    'schemaName',
+    'symbol',
+    'totalSupply',
+  ];
+
+  return keys.some(
+    (key) => newCollectibleContract[key] !== oldCollectibleContract[key],
+  );
 }

--- a/src/assets/assetsUtil.ts
+++ b/src/assets/assetsUtil.ts
@@ -4,6 +4,30 @@ import {
   CollectibleContract,
 } from './CollectiblesController';
 
+const COLLECTIBLE_CONTRACT_KEYS: (keyof CollectibleContract)[] = [
+  'address',
+  'assetContractType',
+  'createdDate',
+  'description',
+  'externalLink',
+  'logo',
+  'name',
+  'schemaName',
+  'symbol',
+  'totalSupply',
+];
+
+const COLLECTIBLE_METADATA_KEYS: (keyof CollectibleMetadata)[] = [
+  'image',
+  'backgroundColor',
+  'imagePreview',
+  'imageThumbnail',
+  'imageOriginal',
+  'animation',
+  'animationOriginal',
+  'externalLink',
+];
+
 /**
  * Compares collectible metadata entries to any collectible entry.
  * We need this method when comparing a new fetched collectible metadata, in case a entry changed to a defined value,
@@ -13,34 +37,19 @@ import {
  * @param collectible - Collectible object to compare with.
  * @returns Whether there are differences.
  */
-export function compareCollectiblesMetadata(
+export function isCollectibleMetadataEqual(
   newCollectibleMetadata: CollectibleMetadata,
   collectible: Collectible,
 ) {
-  const keys: (keyof CollectibleMetadata)[] = [
-    'image',
-    'backgroundColor',
-    'imagePreview',
-    'imageThumbnail',
-    'imageOriginal',
-    'animation',
-    'animationOriginal',
-    'externalLink',
-  ];
-  const differentValues = keys.reduce((value, key) => {
-    if (
+  return !COLLECTIBLE_METADATA_KEYS.some(
+    (key) =>
       newCollectibleMetadata[key] &&
-      newCollectibleMetadata[key] !== collectible[key]
-    ) {
-      return value + 1;
-    }
-    return value;
-  }, 0);
-  return differentValues > 0;
+      newCollectibleMetadata[key] !== collectible[key],
+  );
 }
 
 /**
- * Compares CollectibleContract entries to any CollectibleContract entry.
+ * Compares one CollectibleContract object to another CollectibleContract object.
  * We need this method when comparing a new fetched CollectibleContract, in case a entry changed to a defined value,
  * there's a need to update the CollectibleContract object in state.
  *
@@ -48,24 +57,13 @@ export function compareCollectiblesMetadata(
  * @param oldCollectibleContract - CollectibleContract object to compare with.
  * @returns Whether there are differences.
  */
-export function compareCollectibleContract(
+export function isCollectibleContractEqual(
   newCollectibleContract: CollectibleContract,
   oldCollectibleContract: CollectibleContract,
 ) {
-  const keys: (keyof CollectibleContract)[] = [
-    'address',
-    'assetContractType',
-    'createdDate',
-    'description',
-    'externalLink',
-    'logo',
-    'name',
-    'schemaName',
-    'symbol',
-    'totalSupply',
-  ];
-
-  return keys.some(
-    (key) => newCollectibleContract[key] !== oldCollectibleContract[key],
+  return !COLLECTIBLE_CONTRACT_KEYS.some(
+    (key) =>
+      newCollectibleContract[key] &&
+      newCollectibleContract[key] !== oldCollectibleContract[key],
   );
 }

--- a/src/assets/assetsUtil.ts
+++ b/src/assets/assetsUtil.ts
@@ -30,7 +30,7 @@ const COLLECTIBLE_METADATA_KEYS: (keyof CollectibleMetadata)[] = [
 
 /**
  * Compares collectible metadata entries to any collectible entry.
- * We need this method when comparing a new fetched collectible metadata, in case a entry changed to a defined value,
+ * We need this method when comparing a new fetched collectible metadata, in case an entry changed to a defined value,
  * there's a need to update the collectible in state.
  *
  * @param newCollectibleMetadata - Collectible metadata object.
@@ -41,16 +41,16 @@ export function isCollectibleMetadataEqual(
   newCollectibleMetadata: CollectibleMetadata,
   collectible: Collectible,
 ) {
-  return !COLLECTIBLE_METADATA_KEYS.some(
+  return COLLECTIBLE_METADATA_KEYS.every(
     (key) =>
       newCollectibleMetadata[key] &&
-      newCollectibleMetadata[key] !== collectible[key],
+      newCollectibleMetadata[key] === collectible[key],
   );
 }
 
 /**
  * Compares one CollectibleContract object to another CollectibleContract object.
- * We need this method when comparing a new fetched CollectibleContract, in case a entry changed to a defined value,
+ * We need this method when comparing a new fetched CollectibleContract, in case an entry changed to a defined value,
  * there's a need to update the CollectibleContract object in state.
  *
  * @param newCollectibleContract - CollectibleContract data object.
@@ -61,9 +61,9 @@ export function isCollectibleContractEqual(
   newCollectibleContract: CollectibleContract,
   oldCollectibleContract: CollectibleContract,
 ) {
-  return !COLLECTIBLE_CONTRACT_KEYS.some(
+  return COLLECTIBLE_CONTRACT_KEYS.every(
     (key) =>
       newCollectibleContract[key] &&
-      newCollectibleContract[key] !== oldCollectibleContract[key],
+      newCollectibleContract[key] === oldCollectibleContract[key],
   );
 }


### PR DESCRIPTION
- CHANGED:

  - Modifies the `addCollectibleContract` on the `CollectiblesController` to update `CollectibleContract` data if there is a previous entry in state that matches the address of the contract currently being processed but other fields that don't match.


