### PR TITLE
timeout the fetch of tokenMetadata from token-api.metaswap.codefi.network faster, because it stalls for unknown tokens

### DIFF
--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -143,6 +143,7 @@ export class TokensController extends BaseController<
         this.config.chainId,
         tokenAddress,
         this.abortController.signal,
+        { timeout: 5000 },
       );
       return token;
     } catch (error) {


### PR DESCRIPTION
- CHANGED:

  - Change the timeout for the fetch of tokenMetadata from token-api.metaswap.codefi.network from 10 seconds to 5 seconds, because this call stalls when querying token addresses it does not know.


In the most recent `controllers` release a query to the <api> was added in the `addTokens` flow: https://github.com/MetaMask/controllers/commit/4c1df4f924134ac28b269d51d47f3731e54726f5#diff-49200b6dedba3600208082eb048fcb111f5898b373c650b92c966b61409d60cfR271

This query has a timeout of 10 seconds which, when the token is unknown to the API, resulted in very long loading times before a response to hide the loading indicator for [just adding a tokens via the `wallet_watchAsset` API].(https://github.com/MetaMask/metamask-extension/pull/14906#discussion_r921192789) 