### PR TITLE
Check if the 'tokenAddress' is a smart contract before querying further in getTokenStandardAndDetails

### DIFF
--- a/src/assets/AssetsContractController.test.ts
+++ b/src/assets/AssetsContractController.test.ts
@@ -4,6 +4,7 @@ import { SupportedTokenDetectionNetworks } from '../util';
 import { PreferencesController } from '../user/PreferencesController';
 import { NetworkController } from '../network/NetworkController';
 import {
+  NOT_SMART_CONTRACT_ERROR,
   AssetsContractController,
   MISSING_PROVIDER_ERROR,
 } from './AssetsContractController';
@@ -21,6 +22,7 @@ const ERC1155_ID =
 
 const TEST_ACCOUNT_PUBLIC_ADDRESS =
   '0x5a3CA5cD63807Ce5e4d7841AB32Ce6B6d9BbBa2D';
+
 describe('AssetsContractController', () => {
   let assetsContract: AssetsContractController;
   let preferences: PreferencesController;
@@ -62,6 +64,13 @@ describe('AssetsContractController', () => {
     expect(() => console.log(assetsContract.provider)).toThrow(
       'Property only used for setting',
     );
+  });
+
+  it('should throw not a smart contract error when attempting to get token standard and details for an EOA', async () => {
+    assetsContract.configure({ provider: MAINNET_PROVIDER });
+    await expect(
+      assetsContract.getTokenStandardAndDetails(TEST_ACCOUNT_PUBLIC_ADDRESS),
+    ).rejects.toThrow(NOT_SMART_CONTRACT_ERROR);
   });
 
   it('should throw missing provider error when getting ERC-20 token balance when missing provider', async () => {
@@ -117,13 +126,12 @@ describe('AssetsContractController', () => {
 
   it('should throw contract standard error when getting ERC-20 token standard and details when provided with invalid ERC-20 address', async () => {
     assetsContract.configure({ provider: MAINNET_PROVIDER });
-    const error = 'Unable to determine contract standard';
     await expect(
       assetsContract.getTokenStandardAndDetails(
         'BaDeRc20AdDrEsS',
         TEST_ACCOUNT_PUBLIC_ADDRESS,
       ),
-    ).rejects.toThrow(error);
+    ).rejects.toThrow(NOT_SMART_CONTRACT_ERROR);
   });
 
   it('should get ERC-721 token standard and details', async () => {

--- a/src/assets/AssetsContractController.ts
+++ b/src/assets/AssetsContractController.ts
@@ -32,6 +32,9 @@ export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID: Record<string, string> = {
 export const MISSING_PROVIDER_ERROR =
   'AssetsContractController failed to set the provider correctly. A provider must be set for this method to be available';
 
+export const NOT_SMART_CONTRACT_ERROR =
+  'The address passed is not a smart contract';
+
 /**
  * @type AssetsContractConfig
  *
@@ -227,7 +230,7 @@ export class AssetsContractController extends BaseController<
     );
 
     if (!isContractAddress) {
-      throw new Error('The address passed is not a smart contract');
+      throw new Error(NOT_SMART_CONTRACT_ERROR);
     }
 
     const { ipfsGateway } = this.config;

--- a/src/assets/assetsUtil.ts
+++ b/src/assets/assetsUtil.ts
@@ -1,4 +1,4 @@
-import { convertHexToDecimal } from '../util';
+import { convertHexToDecimal, query } from '../util';
 import { Collectible, CollectibleMetadata } from './CollectiblesController';
 
 /**
@@ -105,14 +105,16 @@ export const formatIconUrlWithProxy = ({
  * @param address - Address at which to query for code.
  * @returns an object containing the contract code if present and boolean value indicating whether the address points to smart contract
  */
-export const readAddressAsContract = async (ethQuery: any, address: string) => {
+export const readAddressAsContract = async (
+  ethQuery: any,
+  address: string,
+): Promise<{ contractCode: string | null; isContractAddress: boolean }> => {
   let contractCode;
   try {
-    contractCode = await ethQuery.getCode(address);
+    contractCode = await query(ethQuery, 'getCode', [address]);
   } catch (e) {
     contractCode = null;
   }
-
   const isContractAddress =
     contractCode && contractCode !== '0x' && contractCode !== '0x0';
   return { contractCode, isContractAddress };

--- a/src/assets/assetsUtil.ts
+++ b/src/assets/assetsUtil.ts
@@ -97,3 +97,23 @@ export const formatIconUrlWithProxy = ({
   const chainIdDecimal = convertHexToDecimal(chainId).toString();
   return `https://static.metaswap.codefi.network/api/v1/tokenIcons/${chainIdDecimal}/${tokenAddress.toLowerCase()}.png`;
 };
+
+/**
+ * Query for smart contract code at a given address.
+ *
+ * @param ethQuery - ethQuery rpc wrapper.
+ * @param address - Address at which to query for code.
+ * @returns an object containing the contract code if present and boolean value indicating whether the address points to smart contract
+ */
+export const readAddressAsContract = async (ethQuery: any, address: string) => {
+  let contractCode;
+  try {
+    contractCode = await ethQuery.getCode(address);
+  } catch (e) {
+    contractCode = null;
+  }
+
+  const isContractAddress =
+    contractCode && contractCode !== '0x' && contractCode !== '0x0';
+  return { contractCode, isContractAddress };
+};


### PR DESCRIPTION
We should make `getTokenStandardAndDetails` fail faster if passed an address that does not point to any smart contract code.