### PR TITLE
WIP Changed NetworkController events and actions

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -18,6 +18,7 @@ import { PreferencesController } from './user/PreferencesController';
 import {
   NetworkController,
   NetworkControllerMessenger,
+  NetworkControllerProviderConfigChangeEvent,
   NetworkControllerStateChangeEvent,
   NetworksChainId,
 } from './network/NetworkController';
@@ -94,19 +95,26 @@ class BarController extends BaseController<never, BarControllerState> {
 const setupControllers = () => {
   const mainMessenger = new ControllerMessenger<
     never,
-    NetworkControllerStateChangeEvent
+    | NetworkControllerStateChangeEvent
+    | NetworkControllerProviderConfigChangeEvent
   >();
 
   const messenger: NetworkControllerMessenger = mainMessenger.getRestricted({
     name: 'NetworkController',
-    allowedEvents: ['NetworkController:stateChange'],
+    allowedEvents: [
+      'NetworkController:stateChange',
+      'NetworkController:providerConfigChange',
+    ],
     allowedActions: [],
   });
 
   const composableMessenger: ComposableControllerRestrictedMessenger =
     mainMessenger.getRestricted({
       name: 'ComposableController',
-      allowedEvents: ['NetworkController:stateChange'],
+      allowedEvents: [
+        'NetworkController:stateChange',
+        'NetworkController:providerConfigChange',
+      ],
       allowedActions: [],
     });
 
@@ -119,15 +127,15 @@ const setupControllers = () => {
   const assetContractController = new AssetsContractController({
     onPreferencesStateChange: (listener) =>
       preferencesController.subscribe(listener),
-    onNetworkStateChange: (listener) =>
-      messenger.subscribe('NetworkController:stateChange', listener),
+    onNetworkProviderConfigChange: (listener) =>
+      messenger.subscribe('NetworkController:providerConfigChange', listener),
   });
 
   const collectiblesController = new CollectiblesController({
     onPreferencesStateChange: (listener) =>
       preferencesController.subscribe(listener),
-    onNetworkStateChange: (listener) =>
-      messenger.subscribe('NetworkController:stateChange', listener),
+    onNetworkProviderConfigChange: (listener) =>
+      messenger.subscribe('NetworkController:providerConfigChange', listener),
     getERC721AssetName: assetContractController.getERC721AssetName.bind(
       assetContractController,
     ),
@@ -152,8 +160,8 @@ const setupControllers = () => {
   const tokensController = new TokensController({
     onPreferencesStateChange: (listener) =>
       preferencesController.subscribe(listener),
-    onNetworkStateChange: (listener) =>
-      messenger.subscribe('NetworkController:stateChange', listener),
+    onNetworkProviderConfigChange: (listener) =>
+      messenger.subscribe('NetworkController:providerConfigChange', listener),
   });
 
   return {
@@ -237,6 +245,9 @@ describe('ComposableController', () => {
       });
 
       messenger.clearEventSubscriptions('NetworkController:stateChange');
+      messenger.clearEventSubscriptions(
+        'NetworkController:providerConfigChange',
+      );
     });
 
     it('should compose flat controller state', () => {
@@ -291,6 +302,9 @@ describe('ComposableController', () => {
       });
 
       messenger.clearEventSubscriptions('NetworkController:stateChange');
+      messenger.clearEventSubscriptions(
+        'NetworkController:providerConfigChange',
+      );
     });
 
     it('should set initial state', () => {

--- a/src/assets/AssetsContractController.test.ts
+++ b/src/assets/AssetsContractController.test.ts
@@ -30,7 +30,7 @@ const setupControllers = () => {
   const messenger: NetworkControllerMessenger =
     new ControllerMessenger().getRestricted({
       name: 'NetworkController',
-      allowedEvents: ['NetworkController:stateChange'],
+      allowedEvents: ['NetworkController:providerConfigChange'],
       allowedActions: [],
     });
   const network = new NetworkController({
@@ -39,8 +39,8 @@ const setupControllers = () => {
   const preferences = new PreferencesController();
   const assetsContract = new AssetsContractController({
     onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-    onNetworkStateChange: (listener) =>
-      messenger.subscribe('NetworkController:stateChange', listener),
+    onNetworkProviderConfigChange: (listener) =>
+      messenger.subscribe('NetworkController:providerConfigChange', listener),
   });
 
   return { messenger, network, preferences, assetsContract };
@@ -54,7 +54,7 @@ describe('AssetsContractController', () => {
       ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,
       provider: undefined,
     });
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should update the ipfsGateWay config value when this value is changed in the preferences controller', () => {
@@ -72,7 +72,7 @@ describe('AssetsContractController', () => {
       provider: undefined,
     });
 
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should throw when provider property is accessed', () => {
@@ -80,7 +80,7 @@ describe('AssetsContractController', () => {
     expect(() => console.log(assetsContract.provider)).toThrow(
       'Property only used for setting',
     );
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should throw missing provider error when getting ERC-20 token balance when missing provider', async () => {
@@ -92,7 +92,7 @@ describe('AssetsContractController', () => {
         TEST_ACCOUNT_PUBLIC_ADDRESS,
       ),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should throw missing provider error when getting ERC-20 token decimal when missing provider', async () => {
@@ -101,7 +101,7 @@ describe('AssetsContractController', () => {
     await expect(
       assetsContract.getERC20TokenDecimals(ERC20_UNI_ADDRESS),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get balance of ERC-20 token contract correctly', async () => {
@@ -117,7 +117,7 @@ describe('AssetsContractController', () => {
     );
     expect(UNIBalance.toNumber()).not.toStrictEqual(0);
     expect(UNINoBalance.toNumber()).toStrictEqual(0);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get ERC-721 collectible tokenId correctly', async () => {
@@ -129,7 +129,7 @@ describe('AssetsContractController', () => {
       0,
     );
     expect(tokenId).not.toStrictEqual(0);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should throw missing provider error when getting ERC-721 token standard and details when missing provider', async () => {
@@ -141,7 +141,7 @@ describe('AssetsContractController', () => {
         TEST_ACCOUNT_PUBLIC_ADDRESS,
       ),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should throw contract standard error when getting ERC-20 token standard and details when provided with invalid ERC-20 address', async () => {
@@ -154,7 +154,7 @@ describe('AssetsContractController', () => {
         TEST_ACCOUNT_PUBLIC_ADDRESS,
       ),
     ).rejects.toThrow(error);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get ERC-721 token standard and details', async () => {
@@ -165,7 +165,7 @@ describe('AssetsContractController', () => {
       TEST_ACCOUNT_PUBLIC_ADDRESS,
     );
     expect(standardAndDetails.standard).toStrictEqual('ERC721');
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get ERC-1155 token standard and details', async () => {
@@ -176,7 +176,7 @@ describe('AssetsContractController', () => {
       TEST_ACCOUNT_PUBLIC_ADDRESS,
     );
     expect(standardAndDetails.standard).toStrictEqual('ERC1155');
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get ERC-20 token standard and details', async () => {
@@ -187,7 +187,7 @@ describe('AssetsContractController', () => {
       TEST_ACCOUNT_PUBLIC_ADDRESS,
     );
     expect(standardAndDetails.standard).toStrictEqual('ERC20');
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get ERC-721 collectible tokenURI correctly', async () => {
@@ -198,7 +198,7 @@ describe('AssetsContractController', () => {
       '0',
     );
     expect(tokenId).toStrictEqual('https://api.godsunchained.com/card/0');
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should throw an error when address given is not an ERC-721 collectible', async () => {
@@ -213,7 +213,7 @@ describe('AssetsContractController', () => {
 
     const error = 'Contract does not support ERC721 metadata interface.';
     await expect(result).rejects.toThrow(error);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get ERC-721 collectible name', async () => {
@@ -221,7 +221,7 @@ describe('AssetsContractController', () => {
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const name = await assetsContract.getERC721AssetName(ERC721_GODS_ADDRESS);
     expect(name).toStrictEqual('Gods Unchained');
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get ERC-721 collectible symbol', async () => {
@@ -231,7 +231,7 @@ describe('AssetsContractController', () => {
       ERC721_GODS_ADDRESS,
     );
     expect(symbol).toStrictEqual('GODS');
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should throw missing provider error when getting ERC-721 collectible symbol when missing provider', async () => {
@@ -239,7 +239,7 @@ describe('AssetsContractController', () => {
     await expect(
       assetsContract.getERC721AssetSymbol(ERC721_GODS_ADDRESS),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get ERC-20 token decimals', async () => {
@@ -249,7 +249,7 @@ describe('AssetsContractController', () => {
       ERC20_DAI_ADDRESS,
     );
     expect(Number(decimals)).toStrictEqual(18);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get ERC-721 collectible ownership', async () => {
@@ -260,7 +260,7 @@ describe('AssetsContractController', () => {
       '148332',
     );
     expect(tokenId).not.toStrictEqual('');
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should throw missing provider error when getting ERC-721 collectible ownership', async () => {
@@ -268,7 +268,7 @@ describe('AssetsContractController', () => {
     await expect(
       assetsContract.getERC721OwnerOf(ERC721_GODS_ADDRESS, '148332'),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get balance of ERC-20 token in a single call on network with token detection support', async () => {
@@ -279,7 +279,7 @@ describe('AssetsContractController', () => {
       [ERC20_DAI_ADDRESS],
     );
     expect(balances[ERC20_DAI_ADDRESS]).not.toBeUndefined();
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should not have balance in a single call after switching to network without token detection support', async () => {
@@ -301,7 +301,7 @@ describe('AssetsContractController', () => {
       [ERC20_DAI_ADDRESS],
     );
     expect(noBalances).toStrictEqual({});
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should throw missing provider error when transfering single ERC-1155 when missing provider', async () => {
@@ -316,7 +316,7 @@ describe('AssetsContractController', () => {
         '1',
       ),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get the balance of a ERC-1155 collectible for a given address', async () => {
@@ -328,7 +328,7 @@ describe('AssetsContractController', () => {
       ERC1155_ID,
     );
     expect(Number(balance)).toBeGreaterThan(0);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should throw missing provider error when getting the balance of a ERC-1155 collectible when missing provider', async () => {
@@ -340,7 +340,7 @@ describe('AssetsContractController', () => {
         ERC1155_ID,
       ),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should get the URI of a ERC-1155 collectible', async () => {
@@ -352,6 +352,6 @@ describe('AssetsContractController', () => {
       ERC1155_ID,
     );
     expect(uri.toLowerCase()).toStrictEqual(expectedUri);
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 });

--- a/src/assets/AssetsContractController.ts
+++ b/src/assets/AssetsContractController.ts
@@ -5,7 +5,7 @@ import { BaseController, BaseConfig, BaseState } from '../BaseController';
 import type { PreferencesState } from '../user/PreferencesController';
 import { IPFS_DEFAULT_GATEWAY_URL } from '../constants';
 import { SupportedTokenDetectionNetworks } from '../util';
-import { NetworkState } from '../network/NetworkController';
+import { ProviderConfig } from '../network/NetworkController';
 import { ERC721Standard } from './Standards/CollectibleStandards/ERC721/ERC721Standard';
 import { ERC1155Standard } from './Standards/CollectibleStandards/ERC1155/ERC1155Standard';
 import { ERC20Standard } from './Standards/ERC20Standard';
@@ -77,20 +77,20 @@ export class AssetsContractController extends BaseController<
    *
    * @param options - The controller options.
    * @param options.onPreferencesStateChange - Allows subscribing to preference controller state changes.
-   * @param options.onNetworkStateChange - Allows subscribing to network controller state changes.
+   * @param options.onNetworkProviderConfigChange - Allows subscribing to network controller ProviderConfig changes.
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
    */
   constructor(
     {
       onPreferencesStateChange,
-      onNetworkStateChange,
+      onNetworkProviderConfigChange,
     }: {
       onPreferencesStateChange: (
         listener: (preferencesState: PreferencesState) => void,
       ) => void;
-      onNetworkStateChange: (
-        listener: (networkState: NetworkState) => void,
+      onNetworkProviderConfigChange: (
+        listener: (providerConfig: ProviderConfig) => void,
       ) => void;
     },
     config?: Partial<AssetsContractConfig>,
@@ -108,10 +108,10 @@ export class AssetsContractController extends BaseController<
       this.configure({ ipfsGateway });
     });
 
-    onNetworkStateChange((networkState) => {
-      if (this.config.chainId !== networkState.provider.chainId) {
+    onNetworkProviderConfigChange((providerConfig: ProviderConfig) => {
+      if (this.config.chainId !== providerConfig.chainId) {
         this.configure({
-          chainId: networkState.provider.chainId,
+          chainId: providerConfig.chainId,
         });
       }
     });

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -34,7 +34,7 @@ describe('CollectibleDetectionController', () => {
   beforeEach(async () => {
     messenger = new ControllerMessenger().getRestricted({
       name: 'NetworkController',
-      allowedEvents: ['NetworkController:stateChange'],
+      allowedEvents: ['NetworkController:providerConfigChange'],
       allowedActions: [],
     });
 
@@ -45,14 +45,14 @@ describe('CollectibleDetectionController', () => {
     preferences = new PreferencesController();
     assetsContract = new AssetsContractController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) =>
-        messenger.subscribe('NetworkController:stateChange', listener),
+      onNetworkProviderConfigChange: (listener) =>
+        messenger.subscribe('NetworkController:providerConfigChange', listener),
     });
 
     collectiblesController = new CollectiblesController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) =>
-        messenger.subscribe('NetworkController:stateChange', listener),
+      onNetworkProviderConfigChange: (listener) =>
+        messenger.subscribe('NetworkController:providerConfigChange', listener),
       getERC721AssetName:
         assetsContract.getERC721AssetName.bind(assetsContract),
       getERC721AssetSymbol:
@@ -70,8 +70,8 @@ describe('CollectibleDetectionController', () => {
       onCollectiblesStateChange: (listener) =>
         collectiblesController.subscribe(listener),
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) =>
-        messenger.subscribe('NetworkController:stateChange', listener),
+      onNetworkProviderConfigChange: (listener) =>
+        messenger.subscribe('NetworkController:providerConfigChange', listener),
       getOpenSeaApiKey: getOpenSeaApiKeyStub,
       addCollectible: collectiblesController.addCollectible.bind(
         collectiblesController,
@@ -242,8 +242,11 @@ describe('CollectibleDetectionController', () => {
               collectiblesController.subscribe(listener),
             onPreferencesStateChange: (listener) =>
               preferences.subscribe(listener),
-            onNetworkStateChange: (listener) =>
-              messenger.subscribe('NetworkController:stateChange', listener),
+            onNetworkProviderConfigChange: (listener) =>
+              messenger.subscribe(
+                'NetworkController:providerConfigChange',
+                listener,
+              ),
             getOpenSeaApiKey: () => collectiblesController.openSeaApiKey,
             addCollectible: collectiblesController.addCollectible.bind(
               collectiblesController,
@@ -281,8 +284,11 @@ describe('CollectibleDetectionController', () => {
             collectiblesController.subscribe(listener),
           onPreferencesStateChange: (listener) =>
             preferences.subscribe(listener),
-          onNetworkStateChange: (listener) =>
-            messenger.subscribe('NetworkController:stateChange', listener),
+          onNetworkProviderConfigChange: (listener) =>
+            messenger.subscribe(
+              'NetworkController:providerConfigChange',
+              listener,
+            ),
           getOpenSeaApiKey: () => collectiblesController.openSeaApiKey,
           addCollectible: collectiblesController.addCollectible.bind(
             collectiblesController,

--- a/src/assets/CollectibleDetectionController.ts
+++ b/src/assets/CollectibleDetectionController.ts
@@ -1,5 +1,5 @@
 import { BaseController, BaseConfig, BaseState } from '../BaseController';
-import type { NetworkState, NetworkType } from '../network/NetworkController';
+import type { NetworkType, ProviderConfig } from '../network/NetworkController';
 import type { PreferencesState } from '../user/PreferencesController';
 import { fetchWithErrorHandling, toChecksumHexAddress } from '../util';
 import { MAINNET, OPENSEA_PROXY_URL, OPENSEA_API_URL } from '../constants';
@@ -203,7 +203,7 @@ export class CollectibleDetectionController extends BaseController<
    * @param options - The controller options.
    * @param options.onCollectiblesStateChange - Allows subscribing to assets controller state changes.
    * @param options.onPreferencesStateChange - Allows subscribing to preferences controller state changes.
-   * @param options.onNetworkStateChange - Allows subscribing to network controller state changes.
+   * @param options.onNetworkProviderConfigChange - Allows subscribing to network controller ProviderConfig changes.
    * @param options.getOpenSeaApiKey - Gets the OpenSea API key, if one is set.
    * @param options.addCollectible - Add a collectible.
    * @param options.getCollectiblesState - Gets the current state of the Assets controller.
@@ -213,7 +213,7 @@ export class CollectibleDetectionController extends BaseController<
   constructor(
     {
       onPreferencesStateChange,
-      onNetworkStateChange,
+      onNetworkProviderConfigChange,
       getOpenSeaApiKey,
       addCollectible,
       getCollectiblesState,
@@ -224,8 +224,8 @@ export class CollectibleDetectionController extends BaseController<
       onPreferencesStateChange: (
         listener: (preferencesState: PreferencesState) => void,
       ) => void;
-      onNetworkStateChange: (
-        listener: (networkState: NetworkState) => void,
+      onNetworkProviderConfigChange: (
+        listener: (providerConfig: ProviderConfig) => void,
       ) => void;
       getOpenSeaApiKey: () => string | undefined;
       addCollectible: CollectiblesController['addCollectible'];
@@ -264,10 +264,11 @@ export class CollectibleDetectionController extends BaseController<
       }
     });
 
-    onNetworkStateChange(({ provider }) => {
+    onNetworkProviderConfigChange((providerConfig: ProviderConfig) => {
       this.configure({
-        networkType: provider.type,
-        chainId: provider.chainId as CollectibleDetectionConfig['chainId'],
+        networkType: providerConfig.type,
+        chainId:
+          providerConfig.chainId as CollectibleDetectionConfig['chainId'],
       });
     });
     this.getOpenSeaApiKey = getOpenSeaApiKey;

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -59,7 +59,7 @@ function setupController({
   const messenger: NetworkControllerMessenger =
     new ControllerMessenger().getRestricted({
       name: 'NetworkController',
-      allowedEvents: ['NetworkController:stateChange'],
+      allowedEvents: ['NetworkController:providerConfigChange'],
       allowedActions: [],
     });
   const preferences = new PreferencesController();
@@ -69,8 +69,8 @@ function setupController({
   });
   const assetsContract = new AssetsContractController({
     onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-    onNetworkStateChange: (listener) =>
-      messenger.subscribe('NetworkController:stateChange', listener),
+    onNetworkProviderConfigChange: (listener) =>
+      messenger.subscribe('NetworkController:providerConfigChange', listener),
   });
   const onCollectibleAddedSpy = includeOnCollectibleAdded
     ? jest.fn()
@@ -78,8 +78,8 @@ function setupController({
 
   const collectiblesController = new CollectiblesController({
     onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-    onNetworkStateChange: (listener) =>
-      messenger.subscribe('NetworkController:stateChange', listener),
+    onNetworkProviderConfigChange: (listener) =>
+      messenger.subscribe('NetworkController:providerConfigChange', listener),
     getERC721AssetName: assetsContract.getERC721AssetName.bind(assetsContract),
     getERC721AssetSymbol:
       assetsContract.getERC721AssetSymbol.bind(assetsContract),

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -4,7 +4,7 @@ import { Mutex } from 'async-mutex';
 
 import { BaseController, BaseConfig, BaseState } from '../BaseController';
 import type { PreferencesState } from '../user/PreferencesController';
-import type { NetworkState, NetworkType } from '../network/NetworkController';
+import type { NetworkType, ProviderConfig } from '../network/NetworkController';
 import {
   safelyExecute,
   handleFetch,
@@ -914,7 +914,7 @@ export class CollectiblesController extends BaseController<
    *
    * @param options - The controller options.
    * @param options.onPreferencesStateChange - Allows subscribing to preference controller state changes.
-   * @param options.onNetworkStateChange - Allows subscribing to network controller state changes.
+   * @param options.onNetworkProviderConfigChange - Allows subscribing to network controller ProviderConfig changes.
    * @param options.getERC721AssetName - Gets the name of the asset at the given address.
    * @param options.getERC721AssetSymbol - Gets the symbol of the asset at the given address.
    * @param options.getERC721TokenURI - Gets the URI of the ERC721 token at the given address, with the given ID.
@@ -929,7 +929,7 @@ export class CollectiblesController extends BaseController<
   constructor(
     {
       onPreferencesStateChange,
-      onNetworkStateChange,
+      onNetworkProviderConfigChange,
       getERC721AssetName,
       getERC721AssetSymbol,
       getERC721TokenURI,
@@ -941,8 +941,8 @@ export class CollectiblesController extends BaseController<
       onPreferencesStateChange: (
         listener: (preferencesState: PreferencesState) => void,
       ) => void;
-      onNetworkStateChange: (
-        listener: (networkState: NetworkState) => void,
+      onNetworkProviderConfigChange: (
+        listener: (providerConfig: ProviderConfig) => void,
       ) => void;
       getERC721AssetName: AssetsContractController['getERC721AssetName'];
       getERC721AssetSymbol: AssetsContractController['getERC721AssetSymbol'];
@@ -991,8 +991,8 @@ export class CollectiblesController extends BaseController<
       },
     );
 
-    onNetworkStateChange(({ provider }) => {
-      const { chainId } = provider;
+    onNetworkProviderConfigChange((providerConfig: ProviderConfig) => {
+      const { chainId } = providerConfig;
       this.configure({ chainId });
     });
   }

--- a/src/assets/TokenBalancesController.test.ts
+++ b/src/assets/TokenBalancesController.test.ts
@@ -123,7 +123,10 @@ describe('TokenBalancesController', () => {
     const messenger: NetworkControllerMessenger =
       new ControllerMessenger().getRestricted({
         name: 'NetworkController',
-        allowedEvents: ['NetworkController:stateChange'],
+        allowedEvents: [
+          'NetworkController:stateChange',
+          'NetworkController:providerConfigChange',
+        ],
         allowedActions: [],
       });
 
@@ -139,8 +142,8 @@ describe('TokenBalancesController', () => {
     const { messenger, preferences } = setupControllers();
     const assets = new TokensController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) =>
-        messenger.subscribe('NetworkController:stateChange', listener),
+      onNetworkProviderConfigChange: (listener) =>
+        messenger.subscribe('NetworkController:providerConfigChange', listener),
     });
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
     const tokenBalances = new TokenBalancesController(
@@ -174,8 +177,8 @@ describe('TokenBalancesController', () => {
     const { messenger, preferences } = setupControllers();
     const assets = new TokensController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) =>
-        messenger.subscribe('NetworkController:stateChange', listener),
+      onNetworkProviderConfigChange: (listener) =>
+        messenger.subscribe('NetworkController:providerConfigChange', listener),
     });
     const errorMsg = 'Failed to get balance';
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
@@ -214,20 +217,20 @@ describe('TokenBalancesController', () => {
       tokenBalances.state.contractBalances[address].toNumber(),
     ).toBeGreaterThan(0);
 
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should subscribe to new sibling assets controllers', async () => {
     const { messenger, preferences } = setupControllers();
     const assetsContract = new AssetsContractController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) =>
-        messenger.subscribe('NetworkController:stateChange', listener),
+      onNetworkProviderConfigChange: (listener) =>
+        messenger.subscribe('NetworkController:providerConfigChange', listener),
     });
     const tokensController = new TokensController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) =>
-        messenger.subscribe('NetworkController:stateChange', listener),
+      onNetworkProviderConfigChange: (listener) =>
+        messenger.subscribe('NetworkController:providerConfigChange', listener),
     });
 
     const stub = stubCreateEthers(tokensController, false);
@@ -250,6 +253,7 @@ describe('TokenBalancesController', () => {
 
     stub.restore();
     messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should update token balances when detected tokens are added', async () => {

--- a/src/assets/TokenDetectionController.ts
+++ b/src/assets/TokenDetectionController.ts
@@ -1,5 +1,5 @@
 import { BaseController, BaseConfig, BaseState } from '../BaseController';
-import type { NetworkState } from '../network/NetworkController';
+import type { ProviderConfig } from '../network/NetworkController';
 import type { PreferencesState } from '../user/PreferencesController';
 import {
   safelyExecute,
@@ -58,13 +58,13 @@ export class TokenDetectionController extends BaseController<
    *
    * @param options - The controller options.
    * @param options.onPreferencesStateChange - Allows subscribing to preferences controller state changes.
-   * @param options.onNetworkStateChange - Allows subscribing to network controller state changes.
+   * @param options.onNetworkProviderConfigChange - Allows subscribing to network controller ProviderConfig changes.
    * @param options.onTokenListStateChange - Allows subscribing to token list controller state changes.
    * @param options.getBalancesInSingleCall - Gets the balances of a list of tokens for the given address.
    * @param options.addDetectedTokens - Add a list of detected tokens.
    * @param options.getTokenListState - Gets the current state of the TokenList controller.
    * @param options.getTokensState - Gets the current state of the Tokens controller.
-   * @param options.getNetworkState - Gets the state of the network controller.
+   * @param options.getNetworkProviderConfig - Gets the ProviderConfig the network controller.
    * @param options.getPreferencesState - Gets the state of the preferences controller.
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
@@ -72,20 +72,20 @@ export class TokenDetectionController extends BaseController<
   constructor(
     {
       onPreferencesStateChange,
-      onNetworkStateChange,
+      onNetworkProviderConfigChange,
       onTokenListStateChange,
       getBalancesInSingleCall,
       addDetectedTokens,
       getTokenListState,
       getTokensState,
-      getNetworkState,
+      getNetworkProviderConfig,
       getPreferencesState,
     }: {
       onPreferencesStateChange: (
         listener: (preferencesState: PreferencesState) => void,
       ) => void;
-      onNetworkStateChange: (
-        listener: (networkState: NetworkState) => void,
+      onNetworkProviderConfigChange: (
+        listener: (providerConfig: ProviderConfig) => void,
       ) => void;
       onTokenListStateChange: (
         listener: (tokenListState: TokenListState) => void,
@@ -94,15 +94,13 @@ export class TokenDetectionController extends BaseController<
       addDetectedTokens: TokensController['addDetectedTokens'];
       getTokenListState: () => TokenListState;
       getTokensState: () => TokensState;
-      getNetworkState: () => NetworkState;
+      getNetworkProviderConfig: () => ProviderConfig;
       getPreferencesState: () => PreferencesState;
     },
     config?: Partial<TokenDetectionConfig>,
     state?: Partial<BaseState>,
   ) {
-    const {
-      provider: { chainId: defaultChainId },
-    } = getNetworkState();
+    const { chainId: defaultChainId } = getNetworkProviderConfig();
     const { useTokenDetection: defaultUseTokenDetection } =
       getPreferencesState();
 
@@ -155,8 +153,10 @@ export class TokenDetectionController extends BaseController<
       }
     });
 
-    onNetworkStateChange(({ provider: { chainId } }) => {
+    onNetworkProviderConfigChange((providerConfig: ProviderConfig) => {
       const { chainId: currentChainId } = this.config;
+      const { chainId } = providerConfig;
+
       const isDetectionEnabledForNetwork =
         isTokenDetectionSupportedForNetwork(chainId);
       const isChainIdChanged = currentChainId !== chainId;

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -4,7 +4,8 @@ import { TOKEN_END_POINT_API } from '../apis/token-service';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
   NetworkController,
-  NetworkControllerProviderChangeEvent,
+  NetworkControllerGetProviderConfigAction,
+  NetworkControllerProviderConfigChangeEvent,
   NetworksChainId,
 } from '../network/NetworkController';
 import {
@@ -472,8 +473,8 @@ const expiredCacheExistingState: TokenListState = {
 };
 
 type MainControllerMessenger = ControllerMessenger<
-  GetTokenListState,
-  TokenListStateChange | NetworkControllerProviderChangeEvent
+  GetTokenListState | NetworkControllerGetProviderConfigAction,
+  TokenListStateChange | NetworkControllerProviderConfigChangeEvent
 >;
 
 const getControllerMessenger = (): MainControllerMessenger => {
@@ -485,8 +486,8 @@ const setupNetworkController = (
 ) => {
   const networkMessenger = controllerMessenger.getRestricted({
     name: 'NetworkController',
-    allowedEvents: ['NetworkController:providerChange'],
-    allowedActions: [],
+    allowedEvents: ['NetworkController:providerConfigChange'],
+    allowedActions: ['NetworkController:getProviderConfig'],
   });
 
   const network = new NetworkController({
@@ -502,10 +503,10 @@ const getRestrictedMessenger = (
 ) => {
   const messenger = controllerMessenger.getRestricted({
     name,
-    allowedActions: [],
+    allowedActions: ['NetworkController:getProviderConfig'],
     allowedEvents: [
       'TokenListController:stateChange',
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     ],
   });
 
@@ -523,7 +524,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
     });
@@ -536,7 +536,7 @@ describe('TokenListController', () => {
 
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -545,7 +545,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: existingState,
@@ -586,7 +585,7 @@ describe('TokenListController', () => {
 
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -595,7 +594,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       messenger,
     });
 
@@ -607,7 +605,7 @@ describe('TokenListController', () => {
 
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -616,7 +614,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -627,7 +624,7 @@ describe('TokenListController', () => {
 
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -641,7 +638,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -656,7 +652,7 @@ describe('TokenListController', () => {
 
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -670,7 +666,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -687,7 +682,7 @@ describe('TokenListController', () => {
 
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -702,7 +697,6 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger(controllerMessenger);
 
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -722,7 +716,7 @@ describe('TokenListController', () => {
     expect(tokenListMock.calledThrice).toBe(true);
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -736,7 +730,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -748,7 +741,7 @@ describe('TokenListController', () => {
     expect(tokenListMock.called).toBe(true);
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -759,10 +752,11 @@ describe('TokenListController', () => {
     );
 
     const controllerMessenger = getControllerMessenger();
-    setupNetworkController(controllerMessenger);
+    const { network } = setupNetworkController(controllerMessenger);
+
+    network.setProviderType('localhost');
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.localhost,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -776,7 +770,7 @@ describe('TokenListController', () => {
     controller.destroy();
     tokenListMock.restore();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -790,7 +784,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
     });
@@ -813,7 +806,7 @@ describe('TokenListController', () => {
     );
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -832,7 +825,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       interval: 100,
@@ -850,7 +842,7 @@ describe('TokenListController', () => {
     );
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -859,7 +851,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: existingState,
@@ -877,7 +868,7 @@ describe('TokenListController', () => {
     );
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -891,7 +882,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
     });
@@ -924,7 +914,7 @@ describe('TokenListController', () => {
     ).toStrictEqual(sampleWithDuplicateSymbolsTokensChainsCache);
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -938,7 +928,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
     });
@@ -952,7 +941,7 @@ describe('TokenListController', () => {
     ).toStrictEqual(sampleWith3OrMoreOccurrences);
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -966,7 +955,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: outdatedExistingState,
@@ -984,7 +972,7 @@ describe('TokenListController', () => {
     );
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -998,7 +986,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: expiredCacheExistingState,
@@ -1019,7 +1006,7 @@ describe('TokenListController', () => {
     );
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -1037,7 +1024,6 @@ describe('TokenListController', () => {
     const { network } = setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: existingState,
@@ -1085,7 +1071,7 @@ describe('TokenListController', () => {
 
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -1094,7 +1080,6 @@ describe('TokenListController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: existingState,
@@ -1107,7 +1092,7 @@ describe('TokenListController', () => {
 
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerChange',
+      'NetworkController:providerConfigChange',
     );
   });
 
@@ -1123,9 +1108,9 @@ describe('TokenListController', () => {
 
     const controllerMessenger = getControllerMessenger();
     const { network } = setupNetworkController(controllerMessenger);
+    network.setProviderType('ropsten');
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.ropsten,
       preventPollingOnNetworkRestart: true,
       messenger,
       interval: 100,
@@ -1164,7 +1149,7 @@ describe('TokenListController', () => {
         messenger.clearEventSubscriptions('TokenListController:stateChange');
         controller.destroy();
         controllerMessenger.clearEventSubscriptions(
-          'NetworkController:providerChange',
+          'NetworkController:providerConfigChange',
         );
         resolve();
       });

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -1,7 +1,7 @@
 import { BaseController, BaseConfig, BaseState } from '../BaseController';
 import { safelyExecute, handleFetch, toChecksumHexAddress } from '../util';
 
-import type { NetworkState } from '../network/NetworkController';
+import type { ProviderConfig } from '../network/NetworkController';
 import { FALL_BACK_VS_CURRENCY } from '../constants';
 import { fetchExchangeRate as fetchNativeExchangeRate } from '../apis/crypto-compare';
 import type { TokensState } from './TokensController';
@@ -159,7 +159,7 @@ export class TokenRatesController extends BaseController<
    * @param options - The controller options.
    * @param options.onTokensStateChange - Allows subscribing to token controller state changes.
    * @param options.onCurrencyRateStateChange - Allows subscribing to currency rate controller state changes.
-   * @param options.onNetworkStateChange - Allows subscribing to network state changes.
+   * @param options.onNetworkProviderConfigChange - Allows subscribing to network controller ProviderConfig changes.
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
    */
@@ -167,7 +167,7 @@ export class TokenRatesController extends BaseController<
     {
       onTokensStateChange,
       onCurrencyRateStateChange,
-      onNetworkStateChange,
+      onNetworkProviderConfigChange,
     }: {
       onTokensStateChange: (
         listener: (tokensState: TokensState) => void,
@@ -175,8 +175,8 @@ export class TokenRatesController extends BaseController<
       onCurrencyRateStateChange: (
         listener: (currencyRateState: CurrencyRateState) => void,
       ) => void;
-      onNetworkStateChange: (
-        listener: (networkState: NetworkState) => void,
+      onNetworkProviderConfigChange: (
+        listener: (providerConfig: ProviderConfig) => void,
       ) => void;
     },
     config?: Partial<TokenRatesConfig>,
@@ -205,8 +205,8 @@ export class TokenRatesController extends BaseController<
       this.configure({ nativeCurrency: currencyRateState.nativeCurrency });
     });
 
-    onNetworkStateChange(({ provider }) => {
-      const { chainId } = provider;
+    onNetworkProviderConfigChange((providerConfig) => {
+      const { chainId } = providerConfig;
       this.update({ contractExchangeRates: {} });
       this.configure({ chainId });
     });

--- a/src/assets/TokensController.test.ts
+++ b/src/assets/TokensController.test.ts
@@ -32,10 +32,7 @@ describe('TokensController', () => {
   beforeEach(() => {
     messenger = new ControllerMessenger().getRestricted({
       name: 'NetworkController',
-      allowedEvents: [
-        'NetworkController:stateChange',
-        'NetworkController:providerChange',
-      ],
+      allowedEvents: ['NetworkController:providerConfigChange'],
       allowedActions: [],
     });
     preferences = new PreferencesController();
@@ -46,15 +43,8 @@ describe('TokensController', () => {
 
     tokensController = new TokensController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) =>
-        messenger.subscribe('NetworkController:stateChange', (state, patch) => {
-          const touchesProviderConfig = patch.find(
-            (p) => p.path[0] === 'provider',
-          );
-          if (touchesProviderConfig) {
-            listener(state);
-          }
-        }),
+      onNetworkProviderConfigChange: (listener) =>
+        messenger.subscribe('NetworkController:providerConfigChange', listener),
       config: {
         chainId: NetworksChainId.mainnet,
       },
@@ -67,7 +57,7 @@ describe('TokensController', () => {
 
   afterEach(() => {
     instEthProvStub.restore();
-    messenger.clearEventSubscriptions('NetworkController:stateChange');
+    messenger.clearEventSubscriptions('NetworkController:providerConfigChange');
   });
 
   it('should set default state', () => {

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -8,7 +8,7 @@ import { Web3Provider } from '@ethersproject/providers';
 import { AbortController } from 'abort-controller';
 import { BaseController, BaseConfig, BaseState } from '../BaseController';
 import type { PreferencesState } from '../user/PreferencesController';
-import type { NetworkState, NetworkType } from '../network/NetworkController';
+import type { ProviderConfig, NetworkType } from '../network/NetworkController';
 import { validateTokenToWatch, toChecksumHexAddress } from '../util';
 import { MAINNET, ERC721_INTERFACE_ID } from '../constants';
 import {
@@ -172,21 +172,21 @@ export class TokensController extends BaseController<
    *
    * @param options - The controller options.
    * @param options.onPreferencesStateChange - Allows subscribing to preference controller state changes.
-   * @param options.onNetworkStateChange - Allows subscribing to network controller state changes.
+   * @param options.onNetworkProviderConfigChange - Allows subscribing to network controller ProviderConfig changes.
    * @param options.config - Initial options used to configure this controller.
    * @param options.state - Initial state to set on this controller.
    */
   constructor({
     onPreferencesStateChange,
-    onNetworkStateChange,
+    onNetworkProviderConfigChange,
     config,
     state,
   }: {
     onPreferencesStateChange: (
       listener: (preferencesState: PreferencesState) => void,
     ) => void;
-    onNetworkStateChange: (
-      listener: (networkState: NetworkState) => void,
+    onNetworkProviderConfigChange: (
+      listener: (providerConfig: ProviderConfig) => void,
     ) => void;
     config?: Partial<TokensConfig>;
     state?: Partial<TokensState>;
@@ -226,10 +226,10 @@ export class TokensController extends BaseController<
       });
     });
 
-    onNetworkStateChange(({ provider }) => {
+    onNetworkProviderConfigChange((providerConfig) => {
       const { allTokens, allIgnoredTokens, allDetectedTokens } = this.state;
       const { selectedAddress } = this.config;
-      const { chainId } = provider;
+      const { chainId } = providerConfig;
       this.abortController.abort();
       this.abortController = new AbortController();
       this.configure({ chainId });

--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -16,6 +16,8 @@ import {
   GasFeeStateFeeMarket,
   GasFeeStateLegacy,
   GetGasFeeState,
+  GasFeeControllerActions,
+  GasFeeControllerEvents,
 } from './GasFeeController';
 import determineGasFeeCalculations from './determineGasFeeCalculations';
 
@@ -29,10 +31,8 @@ const mockedDetermineGasFeeCalculations = mocked(
 const name = 'GasFeeController';
 
 type MainControllerMessenger = ControllerMessenger<
-  | GetGasFeeState
-  | NetworkControllerGetProviderConfigAction
-  | NetworkControllerGetEthQueryAction,
-  GasFeeStateChange | NetworkControllerProviderChangeEvent
+  GasFeeControllerActions,
+  GasFeeControllerEvents
 >;
 
 const getControllerMessenger = (): MainControllerMessenger => {
@@ -44,10 +44,13 @@ const setupNetworkController = (
 ) => {
   const networkMessenger = controllerMessenger.getRestricted({
     name: 'NetworkController',
-    allowedEvents: ['NetworkController:providerChange'],
+    allowedEvents: [
+      'NetworkController:providerConfigChange',
+      'NetworkController:ethQueryChange'
+    ],
     allowedActions: [
       'NetworkController:getProviderConfig',
-      'NetworkController:getEthQuery',
+      'NetworkController:getEthQuery'
     ],
   });
 
@@ -64,11 +67,14 @@ const getRestrictedMessenger = (
 ) => {
   const messenger = controllerMessenger.getRestricted({
     name,
+    allowedEvents: [
+      'NetworkController:providerConfigChange',
+      'NetworkController:ethQueryChange'
+    ],
     allowedActions: [
       'NetworkController:getProviderConfig',
-      'NetworkController:getEthQuery',
+      'NetworkController:getEthQuery'
     ],
-    allowedEvents: ['NetworkController:providerChange'],
   });
 
   return messenger;

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -349,6 +349,16 @@ export class GasFeeController extends BaseController<
         }
       },
     );
+
+    this.messagingSystem.subscribe(
+      'NetworkController:eip1559CompatibilityChange',
+      async (eip1559Compatible: boolean) => {
+        if (this.currentChainId !== providerConfig.chainId) {
+          this.currentChainId = providerConfig.chainId;
+          await this.resetPolling();
+        }
+      },
+    );
   }
 
   async resetPolling() {

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -30,7 +30,6 @@ const setupController = (
     messenger,
   };
   const controller = new NetworkController(networkControllerOpts);
-  controller.providerConfig = {} as ProviderConfig;
   return controller;
 };
 
@@ -109,7 +108,6 @@ describe('NetworkController', () => {
       messenger,
     };
     const controller = new NetworkController(networkControllerOpts);
-    controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
 
@@ -127,7 +125,6 @@ describe('NetworkController', () => {
 
   it('should create a provider instance for optimism network', () => {
     const networkControllerOpts: NetworkControllerOptions = {
-      infuraProjectId: 'foo',
       state: {
         network: '0',
         provider: {
@@ -140,14 +137,12 @@ describe('NetworkController', () => {
       messenger,
     };
     const controller = new NetworkController(networkControllerOpts);
-    controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
     expect(controller.state.isCustomNetwork).toBe(true);
   });
 
   it('should create a provider instance for rpc network', () => {
     const networkControllerOpts: NetworkControllerOptions = {
-      infuraProjectId: 'foo',
       state: {
         network: '0',
         provider: {
@@ -159,20 +154,19 @@ describe('NetworkController', () => {
       messenger,
     };
     const controller = new NetworkController(networkControllerOpts);
-    controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
     expect(controller.state.isCustomNetwork).toBe(false);
   });
 
   it('should set new RPC target', () => {
-    const controller = new NetworkController({ messenger });
+    const controller = new NetworkController({messenger});
     controller.setRpcTarget(RPC_TARGET, NetworksChainId.rpc);
     expect(controller.state.provider.rpcTarget).toBe(RPC_TARGET);
     expect(controller.state.isCustomNetwork).toBe(false);
   });
 
   it('should set new provider type', () => {
-    const controller = new NetworkController({ messenger });
+    const controller = new NetworkController({messenger});
     controller.setProviderType('localhost');
     expect(controller.state.provider.type).toBe('localhost');
     expect(controller.state.isCustomNetwork).toBe(false);
@@ -201,7 +195,10 @@ describe('NetworkController', () => {
   });
 
   it('should throw when setting an unrecognized provider type', () => {
-    const controller = new NetworkController({ messenger });
+    const controller = new NetworkController({
+      messenger,
+      infuraProjectId: 'foo'
+    });
     expect(() => controller.setProviderType('junk' as NetworkType)).toThrow(
       "Unrecognized network type: 'junk'",
     );
@@ -215,7 +212,6 @@ describe('NetworkController', () => {
         network: 'loading',
       },
     });
-    controller.providerConfig = {} as ProviderConfig;
     controller.lookupNetwork = sinon.stub();
     controller.provider.emit('error', {});
     expect((controller.lookupNetwork as any).called).toBe(true);
@@ -240,7 +236,7 @@ describe('NetworkController', () => {
       };
       messenger.subscribe(event, handleProviderChange);
 
-      controller.providerConfig = {} as ProviderConfig;
+      controller.setProviderType('mainnet');
     });
   });
 
@@ -264,7 +260,7 @@ describe('NetworkController', () => {
       messenger.subscribe(event, handleEip1559Change);
 
       const controller = new NetworkController(testConfig);
-      controller.providerConfig = {} as ProviderConfig;
+      controller.setProviderType('mainnet');
     });
   });
 

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -42,6 +42,7 @@ describe('NetworkController', () => {
       name: 'NetworkController',
       allowedEvents: [
         'NetworkController:providerChange',
+        'NetworkController:providerConfigChange',
         'NetworkController:networkIdChange',
         'NetworkController:eip1559CompatibilityChange',
       ],
@@ -264,6 +265,52 @@ describe('NetworkController', () => {
 
       const controller = new NetworkController(testConfig);
       controller.providerConfig = {} as ProviderConfig;
+    });
+  });
+
+  describe('providerConfigChange event', () => {
+    it('fires when setRpcTarget is called', async () => {
+      expect.assertions(1);
+
+      await new Promise((resolve, _) => {
+        const testConfig = {
+          infuraProjectId: 'foo',
+          messenger,
+        };
+
+        const event = 'NetworkController:providerConfigChange';
+        const handle = (providerConfig: ProviderConfig) => {
+          messenger.unsubscribe(event, handle);
+          expect(providerConfig.type).toBe('rpc');
+          resolve('');
+        };
+        messenger.subscribe(event, handle);
+
+        const controller = new NetworkController(testConfig);
+        controller.setRpcTarget(RPC_TARGET, NetworksChainId.rpc);
+      });
+    });
+
+    it('fires when setProviderType is called', async () => {
+      expect.assertions(1);
+
+      await new Promise((resolve, _) => {
+        const testConfig = {
+          infuraProjectId: 'foo',
+          messenger,
+        };
+
+        const event = 'NetworkController:providerConfigChange';
+        const handle = (providerConfig: ProviderConfig) => {
+          messenger.unsubscribe(event, handle);
+          expect(providerConfig.type).toBe('rpc');
+          resolve('');
+        };
+        messenger.subscribe(event, handle);
+
+        const controller = new NetworkController(testConfig);
+        controller.setProviderType('rpc');
+      });
     });
   });
 });

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -58,6 +58,8 @@ export type Block = {
 
 export type NetworkProperties = {
   isEIP1559Compatible?: boolean;
+  chainId: string;
+  networkId: string;
 };
 
 /**
@@ -65,12 +67,10 @@ export type NetworkProperties = {
  *
  * Network controller state
  * @property network - Network ID as per net_version
- * @property isCustomNetwork - Identifies if the network is a custom network
  * @property provider - RPC URL and network name provider settings
  */
 export type NetworkState = {
   network: string;
-  isCustomNetwork: boolean;
   provider: ProviderConfig;
   properties: NetworkProperties;
 };
@@ -154,10 +154,8 @@ export type NetworkControllerOptions = {
 };
 
 const defaultState: NetworkState = {
-  network: 'loading',
-  isCustomNetwork: false,
-  provider: { type: MAINNET, chainId: NetworksChainId.mainnet },
-  properties: { isEIP1559Compatible: false },
+  providerConfig: { type: MAINNET, chainId: NetworksChainId.mainnet },
+  properties: { isEIP1559Compatible: false, isCustomNetwork: false },
 };
 
 /**
@@ -168,10 +166,6 @@ export class NetworkController extends BaseController<
   NetworkState,
   NetworkControllerMessenger
 > {
-  private ethQuery: EthQuery;
-
-  private internalProviderConfig: ProviderConfig = {} as ProviderConfig;
-
   private infuraProjectId: string | undefined;
 
   private mutex = new Mutex();

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -221,6 +221,10 @@ export class NetworkController extends BaseController<
         return this.ethQuery;
       },
     );
+
+    if (this.infuraProjectId || this.state.provider.type === 'rpc' ||  this.state.provider.type === 'localhost') {
+      this.refreshNetwork();
+    }
   }
 
   private initializeProvider(
@@ -253,16 +257,16 @@ export class NetworkController extends BaseController<
         throw new Error(`Unrecognized network type: '${type}'`);
     }
     this.getEIP1559Compatibility();
+    this.lookupNetwork();
   }
 
   private refreshNetwork() {
     this.update((state) => {
       state.network = 'loading';
-      state.properties = {};
+      state.properties = { ...defaultState.properties };
     });
     const { rpcTarget, type, chainId, ticker } = this.state.provider;
     this.initializeProvider(type, rpcTarget, chainId, ticker);
-    this.lookupNetwork();
   }
 
   private registerProvider() {
@@ -347,25 +351,6 @@ export class NetworkController extends BaseController<
    * Ethereum provider object for the current network
    */
   provider: any;
-
-  /**
-   * Sets a new configuration for web3-provider-engine.
-   *
-   * TODO: Replace this wth a method.
-   *
-   * @param providerConfig - The web3-provider-engine configuration.
-   */
-  set providerConfig(providerConfig: ProviderConfig) {
-    this.internalProviderConfig = providerConfig;
-    const { type, rpcTarget, chainId, ticker, nickname } = this.state.provider;
-    this.initializeProvider(type, rpcTarget, chainId, ticker, nickname);
-    this.registerProvider();
-    this.lookupNetwork();
-  }
-
-  get providerConfig() {
-    throw new Error('Property only used for setting');
-  }
 
   /**
    * Refreshes the current network code.


### PR DESCRIPTION
WIP

**Change the events and actions provided by NetworkController**

- A brief description of changes. If the PR has breaking changes add `BREAKING:`
  to the start of the PR title.

**Description**

also add tests for eip1559 compatibility checking

- BREAKING:

 - NetworkController:providerChange now returns `networkController.provider` (eip1193). Use `NetworkController:providerConfigChange` to receive updates when the config has changed.
 - `onNetworkStateChange` -> `onNetworkProviderConfigChange` for the following controller's contructor interface:
   - AssetContractController
   - CollectibleDetectionController
   - CollectiblesController
   - TokenDetectionController
   - TokenListController
   - TokenRatesController
   - TokensController
- `TokenDetectionController` contructor `getNetworkState` -> `getNetworkProviderConfig` 
- `TokenListController` contructor no longer takes `chainId`, uses `messagingSystem.call('NetworkController:getNetworkProviderConfig')` instead. 

- FIXED:

  - _Describe the fix/bug addressed_

- CHANGED:

  - _Describe the change you have made to existing functionality_

- REMOVED:

  - _Describe functionality removed and why_

- ADDED:

  - `NetworkController:networkIdChange`: fires when the networkid is set (calling rpc's `net_version` to get networkId)
  - `NetworkController:eip1559CompatibilityChange`: fires when the eip1559 compat of the rpc has been changed.

- DEPRECATED:

  - _Describe what was deprecated and why_

- SECURITY:

  - _These should not be in a standard PR and addressed using the Security Advisory process_

**Checklist**

- [ ] Tests are included if applicable
- [ ] Any added code is fully documented

**Issue**

Resolves #???
