### PR TITLE
replace web3-provider-engine

### DIFF
--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -13,7 +13,7 @@ import {
   ERC1155,
   OPENSEA_API_URL,
   ERC721,
-  NetworksChainId,
+  NetworksChainId
 } from '@metamask/controller-utils';
 import { Network } from '@ethersproject/providers';
 import { AssetsContractController } from './AssetsContractController';
@@ -787,6 +787,7 @@ describe('NftController', () => {
 
     it('should add NFT by provider type', async () => {
       const { nftController, changeNetwork } = setupController();
+
       const { selectedAddress } = nftController.config;
       sinon
         .stub(nftController, 'getNftInformation' as any)
@@ -799,13 +800,13 @@ describe('NftController', () => {
 
       expect(
         nftController.state.allNfts[selectedAddress]?.[
-          NetworksChainId[GOERLI.type]
+        NetworksChainId[GOERLI.type]
         ],
       ).toBeUndefined();
 
       expect(
         nftController.state.allNfts[selectedAddress][
-          NetworksChainId[SEPOLIA.type]
+        NetworksChainId[SEPOLIA.type]
         ][0],
       ).toStrictEqual({
         address: '0x01',

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -400,7 +400,7 @@ describe('NftDetectionController', () => {
 
     expect(
       nftController.state.allNfts[nftDetection.config.selectedAddress]?.[
-        chainId
+      chainId
       ],
     ).toBeUndefined();
   });

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -254,7 +254,10 @@ export class TokensController extends BaseController<
     });
   }
 
-  _instantiateNewEthersProvider(): any {
+  _instantiateNewEthersProvider(): Web3Provider | undefined {
+    if (this.config.provider === undefined) {
+      return undefined;
+    }
     return new Web3Provider(this.config?.provider);
   }
 

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -1,4 +1,4 @@
-import { NetworkType } from './types';
+import { NetworksChainId, NetworkType } from './types';
 
 export const MAINNET = 'mainnet';
 export const RPC = 'rpc';

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -31,17 +31,21 @@
   "dependencies": {
     "@metamask/base-controller": "workspace:^",
     "@metamask/controller-utils": "workspace:^",
+    "@metamask/eth-json-rpc-infura": "^7.0.0",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "async-mutex": "^0.2.6",
     "babel-runtime": "^6.26.0",
+    "eth-block-tracker": "^6.1.0",
     "eth-json-rpc-infura": "^5.1.0",
+    "eth-json-rpc-middleware": "^9.0.1",
     "eth-query": "^2.1.2",
     "immer": "^9.0.6",
-    "web3-provider-engine": "^16.0.3"
+    "json-rpc-engine": "^6.1.0"
   },
   "devDependencies": {
     "@json-rpc-specification/meta-schema": "^1.0.6",
     "@metamask/auto-changelog": "^3.1.0",
+    "@metamask/safe-event-emitter": "^2.0.0",
     "@types/jest": "^26.0.22",
     "@types/lodash": "^4.14.191",
     "deepmerge": "^4.2.2",

--- a/packages/network-controller/src/clients/createInfuraClient.ts
+++ b/packages/network-controller/src/clients/createInfuraClient.ts
@@ -1,0 +1,91 @@
+import {
+  createScaffoldMiddleware,
+  JsonRpcMiddleware,
+  mergeMiddleware,
+} from 'json-rpc-engine';
+import {
+  createBlockRefMiddleware,
+  createRetryOnEmptyMiddleware,
+  createBlockCacheMiddleware,
+  createInflightCacheMiddleware,
+  createBlockTrackerInspectorMiddleware,
+  providerFromMiddleware,
+} from 'eth-json-rpc-middleware';
+
+import { createInfuraMiddleware } from '@metamask/eth-json-rpc-infura';
+import { PollingBlockTracker } from 'eth-block-tracker';
+
+import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
+import { CreateClientResult } from './types';
+
+export type InfuraNetworkType =
+  | 'kovan'
+  | 'mainnet'
+  | 'rinkeby'
+  | 'goerli'
+  | 'ropsten';
+
+/**
+ * Create client middleware for infura.
+ *
+ * @param network - the network name.
+ * @param projectId - infura project id.
+ * @returns The network middleware and the block tracker.
+ */
+export default function createInfuraClient(
+  network: InfuraNetworkType,
+  projectId: string,
+): CreateClientResult {
+  const infuraMiddleware = createInfuraMiddleware({
+    network,
+    projectId,
+    maxAttempts: 5,
+    source: 'metamask',
+  });
+  const infuraProvider = providerFromMiddleware(infuraMiddleware);
+  // there is a type mismatch for Provider & SafeEventEmitter.
+  const blockTracker = new PollingBlockTracker({
+    provider: infuraProvider,
+  });
+
+  const networkMiddleware = mergeMiddleware([
+    createNetworkAndChainIdMiddleware(network),
+    createBlockCacheMiddleware({ blockTracker: blockTracker as any }) as any, // something wrong with typing
+    createInflightCacheMiddleware(),
+    createBlockRefMiddleware({
+      blockTracker: blockTracker as any,
+      provider: infuraProvider,
+    }),
+    createRetryOnEmptyMiddleware({
+      blockTracker: blockTracker as any,
+      provider: infuraProvider,
+    }),
+    createBlockTrackerInspectorMiddleware({
+      blockTracker: blockTracker as any,
+    }),
+    infuraMiddleware,
+  ]);
+  return { networkMiddleware, blockTracker };
+}
+
+/**
+ * Create middleware that will trap calls to get network or chain id.
+ *
+ * @param network - network type that we are connecting to.
+ * @returns json-rpc-engine middleware
+ */
+function createNetworkAndChainIdMiddleware(
+  network: NetworkType,
+): JsonRpcMiddleware<any, any> {
+  const chainId = NetworksChainId[network] === undefined;
+
+  if (typeof chainId === undefined) {
+    throw new Error(`createInfuraClient - unknown network "${network}"`);
+  }
+
+  // For infura networks, networkId is always the same as chainId.
+  return createScaffoldMiddleware({
+    eth_chainId: chainId,
+    net_version: chainId,
+  });
+}

--- a/packages/network-controller/src/clients/createInfuraClient.ts
+++ b/packages/network-controller/src/clients/createInfuraClient.ts
@@ -12,7 +12,9 @@ import {
   providerFromMiddleware,
 } from 'eth-json-rpc-middleware';
 
-import { createInfuraMiddleware } from '@metamask/eth-json-rpc-infura';
+import { createInfuraMiddleware, CreateInfuraMiddlewareOptions } from '@metamask/eth-json-rpc-infura';
+
+import { InfuraJsonRpcSupportedNetwork } from '@metamask/eth-json-rpc-infura/dist/types'; // todo: export this from main?
 import { PollingBlockTracker } from 'eth-block-tracker';
 
 import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
@@ -33,11 +35,11 @@ export type InfuraNetworkType =
  * @returns The network middleware and the block tracker.
  */
 export default function createInfuraClient(
-  network: InfuraNetworkType,
-  projectId: string,
+  network: NetworkType,
+  projectId: CreateInfuraMiddlewareOptions["projectId"],
 ): CreateClientResult {
   const infuraMiddleware = createInfuraMiddleware({
-    network,
+    network: network as InfuraJsonRpcSupportedNetwork,
     projectId,
     maxAttempts: 5,
     source: 'metamask',
@@ -49,7 +51,7 @@ export default function createInfuraClient(
   });
 
   const networkMiddleware = mergeMiddleware([
-    createNetworkAndChainIdMiddleware(network),
+    createNetworkAndChainIdMiddleware(network as NetworkType),
     createBlockCacheMiddleware({ blockTracker: blockTracker as any }) as any, // something wrong with typing
     createInflightCacheMiddleware(),
     createBlockRefMiddleware({
@@ -77,7 +79,7 @@ export default function createInfuraClient(
 function createNetworkAndChainIdMiddleware(
   network: NetworkType,
 ): JsonRpcMiddleware<any, any> {
-  const chainId = NetworksChainId[network] === undefined;
+  const chainId = NetworksChainId[network];
 
   if (typeof chainId === undefined) {
     throw new Error(`createInfuraClient - unknown network "${network}"`);

--- a/packages/network-controller/src/clients/createJsonRpcClient.ts
+++ b/packages/network-controller/src/clients/createJsonRpcClient.ts
@@ -1,0 +1,50 @@
+import { createScaffoldMiddleware, mergeMiddleware } from 'json-rpc-engine';
+import {
+  createFetchMiddleware,
+  createBlockRefRewriteMiddleware,
+  createBlockCacheMiddleware,
+  createInflightCacheMiddleware,
+  createBlockTrackerInspectorMiddleware,
+  providerFromMiddleware,
+} from 'eth-json-rpc-middleware';
+import { PollingBlockTracker } from 'eth-block-tracker';
+import { CreateClientResult } from './types';
+
+/**
+ * Create client middleware for a custom rpc endpoint.
+ *
+ * @param rpcUrl - url of the rpc endpoint.
+ * @param chainId - the chain id for the rpc endpoint. This value will always be returned by eth_chainId.
+ * @returns The network middleware and the block tracker.
+ */
+export default function createJsonRpcClient(
+  rpcUrl: string,
+  chainId?: string,
+): CreateClientResult {
+  const fetchMiddleware = createFetchMiddleware({ rpcUrl });
+  const blockProvider = providerFromMiddleware(fetchMiddleware);
+  const blockTracker = new PollingBlockTracker({
+    provider: blockProvider as any,
+  });
+
+  const scaffolded = [];
+
+  if (chainId !== undefined) {
+    scaffolded.push(createScaffoldMiddleware({ eth_chainId: chainId }));
+  }
+
+  const networkMiddleware = mergeMiddleware([
+    ...scaffolded,
+    createBlockRefRewriteMiddleware({
+      blockTracker: blockTracker as any,
+    }) as any,
+    createBlockCacheMiddleware({ blockTracker: blockTracker as any }),
+    createInflightCacheMiddleware(),
+    createBlockTrackerInspectorMiddleware({
+      blockTracker: blockTracker as any,
+    }),
+    fetchMiddleware,
+  ]);
+
+  return { networkMiddleware, blockTracker };
+}

--- a/packages/network-controller/src/clients/types.ts
+++ b/packages/network-controller/src/clients/types.ts
@@ -1,0 +1,7 @@
+import { PollingBlockTracker } from 'eth-block-tracker';
+import { JsonRpcMiddleware } from 'json-rpc-engine';
+
+export type CreateClientResult = {
+  networkMiddleware: JsonRpcMiddleware<any, any>;
+  blockTracker: PollingBlockTracker;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1705,6 +1705,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-json-rpc-infura@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@metamask/eth-json-rpc-infura@npm:7.0.0"
+  dependencies:
+    "@metamask/utils": ^3.0.1
+    eth-json-rpc-middleware: ^8.1.0
+    eth-rpc-errors: ^4.0.3
+    json-rpc-engine: ^6.1.0
+    node-fetch: ^2.6.7
+  checksum: 6230cb289b66db39d27f08ffc72cfb79274e632e4e14eb52ca72d19167d17bbf22c58718d80f801818058631dec0638bcc21ef4b229fa8d53e7f9328be870fc6
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-keyring-controller@npm:^10.0.0":
   version: 10.0.0
   resolution: "@metamask/eth-keyring-controller@npm:10.0.0"
@@ -1718,7 +1731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-sig-util@npm:5.0.2, @metamask/eth-sig-util@npm:^5.0.1, @metamask/eth-sig-util@npm:^5.0.2":
+"@metamask/eth-sig-util@npm:5.0.2, @metamask/eth-sig-util@npm:^5.0.0, @metamask/eth-sig-util@npm:^5.0.1, @metamask/eth-sig-util@npm:^5.0.2":
   version: 5.0.2
   resolution: "@metamask/eth-sig-util@npm:5.0.2"
   dependencies:
@@ -1842,16 +1855,21 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
+    "@metamask/eth-json-rpc-infura": ^7.0.0
+    "@metamask/safe-event-emitter": ^2.0.0
     "@metamask/swappable-obj-proxy": ^2.1.0
     "@types/jest": ^26.0.22
     "@types/lodash": ^4.14.191
     async-mutex: ^0.2.6
     babel-runtime: ^6.26.0
     deepmerge: ^4.2.2
+    eth-block-tracker: ^6.1.0
     eth-json-rpc-infura: ^5.1.0
+    eth-json-rpc-middleware: ^9.0.1
     eth-query: ^2.1.2
     immer: ^9.0.6
     jest: ^26.4.2
+    json-rpc-engine: ^6.1.0
     lodash: ^4.17.21
     nock: ^13.0.7
     sinon: ^9.2.4
@@ -1859,7 +1877,6 @@ __metadata:
     typedoc: ^0.22.15
     typedoc-plugin-missing-exports: ^0.22.6
     typescript: ~4.6.3
-    web3-provider-engine: ^16.0.3
   languageName: unknown
   linkType: soft
 
@@ -2054,6 +2071,18 @@ __metadata:
   version: 1.1.0
   resolution: "@metamask/types@npm:1.1.0"
   checksum: 500e8c076a2b0a6d688c8c465101256f090547d99c9a5585efe3d1db7a494b6b2712b127043fb316912caffc4fff78976b9a7780780abb68305e8a3bf812689c
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^3.0.1":
+  version: 3.6.0
+  resolution: "@metamask/utils@npm:3.6.0"
+  dependencies:
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    semver: ^7.3.8
+    superstruct: ^1.0.3
+  checksum: 1ebc6677bb017e4d09d4af143621fe27194d8ed815234cfd76469c3c734dc1db2ea7b577c01a2096c21c04d8c9c4d721d3035b5353fe2ded3b4737f326755e43
   languageName: node
   linkType: hard
 
@@ -5043,6 +5072,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eth-block-tracker@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eth-block-tracker@npm:5.0.1"
+  dependencies:
+    "@metamask/safe-event-emitter": ^2.0.0
+    json-rpc-random-id: ^1.0.1
+    pify: ^3.0.0
+  checksum: 83b2dd28fb7f12d644f1c1bc72011fb6bb683012489973e31171d445a34ddf6a1c167be4e4232bf7eb65144f08d92705795cf6b371c5aa6a8e78ebf48e4d5654
+  languageName: node
+  linkType: hard
+
+"eth-block-tracker@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "eth-block-tracker@npm:6.1.0"
+  dependencies:
+    "@metamask/safe-event-emitter": ^2.0.0
+    "@metamask/utils": ^3.0.1
+    json-rpc-random-id: ^1.0.1
+    pify: ^3.0.0
+  checksum: 33ee6375a26822649d1e9ac24a3c39d70338eb505715f72b9102fb82e40d7a48902b4a7dd4a33bb4f121b79707c5ab045777507a2881cfcdb385c8ccbb3ac2a0
+  languageName: node
+  linkType: hard
+
 "eth-ens-namehash@npm:^2.0.8":
   version: 2.0.8
   resolution: "eth-ens-namehash@npm:2.0.8"
@@ -5098,6 +5150,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eth-json-rpc-middleware@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "eth-json-rpc-middleware@npm:8.1.0"
+  dependencies:
+    "@metamask/safe-event-emitter": ^2.0.0
+    btoa: ^1.2.1
+    clone: ^2.1.1
+    eth-block-tracker: ^5.0.1
+    eth-rpc-errors: ^4.0.3
+    eth-sig-util: ^1.4.2
+    json-rpc-engine: ^6.1.0
+    json-stable-stringify: ^1.0.1
+    node-fetch: ^2.6.7
+    pify: ^3.0.0
+  checksum: ec10bbc04e3b7696f82db2db528b052c8f6de811c90a12d4eb32f23cbe6ea198d86656afa5b53c52de06b631fef633cf29409bb56c04a16f173da94ee1d89ab6
+  languageName: node
+  linkType: hard
+
+"eth-json-rpc-middleware@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "eth-json-rpc-middleware@npm:9.0.1"
+  dependencies:
+    "@metamask/eth-sig-util": ^5.0.0
+    "@metamask/safe-event-emitter": ^2.0.0
+    "@metamask/utils": ^3.0.3
+    btoa: ^1.2.1
+    clone: ^2.1.1
+    eth-block-tracker: ^5.0.1
+    eth-rpc-errors: ^4.0.3
+    json-rpc-engine: ^6.1.0
+    json-stable-stringify: ^1.0.1
+    node-fetch: ^2.6.7
+    pify: ^3.0.0
+  checksum: 9512829a6958df6ef739b891a0c0804b51a140407fd2e3ddaaa6b18d975796646cfcf7f7305a18beb7903db09e0c7a91b06dc5434b6bd2d6cdb85d992d9fd3ab
+  languageName: node
+  linkType: hard
+
 "eth-method-registry@npm:1.1.0":
   version: 1.1.0
   resolution: "eth-method-registry@npm:1.1.0"
@@ -5150,6 +5239,15 @@ __metadata:
   dependencies:
     fast-safe-stringify: ^2.0.6
   checksum: 1dbdee8f416090f1d318e17bdee2251d174d73c8faa4286fa364bc51ae9105672045f2d078ec23ca6a2b4b92af7cfbe7fa1ba17ad49e591fc653a363bf8cbab2
+  languageName: node
+  linkType: hard
+
+"eth-rpc-errors@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "eth-rpc-errors@npm:4.0.3"
+  dependencies:
+    fast-safe-stringify: ^2.0.6
+  checksum: 5fa31d1a10fdb340733b9a55e38e7687222c501052ca20743cef4d0c911a9bbcc0cad54aa6bf3e4b428604c071ff519803060e1cbc79ddb7c9257c11d407d32a
   languageName: node
   linkType: hard
 
@@ -10533,7 +10631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.7":
+"semver@npm:^7.3.7, semver@npm:^7.3.8":
   version: 7.3.8
   resolution: "semver@npm:7.3.8"
   dependencies:
@@ -11202,6 +11300,13 @@ __metadata:
   version: 0.16.7
   resolution: "superstruct@npm:0.16.7"
   checksum: c8c855ff6945da8a41048c6d236de7b1af5d4d9c31742b3ee54d65647c31597488620281f65e095d5efc9e2fbdaad529b8c8f2506c12569d428467c835a21477
+  languageName: node
+  linkType: hard
+
+"superstruct@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "superstruct@npm:1.0.3"
+  checksum: 761790bb111e6e21ddd608299c252f3be35df543263a7ebbc004e840d01fcf8046794c274bcb351bdf3eae4600f79d317d085cdbb19ca05803a4361840cc9bb1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Replace web3-provider-engine**

Use the network clients from extension. 

**Description**

 - networkControllers.provider is now typed better than `any`


- BREAKING:


- FIXED:

  - _Describe the fix/bug addressed_

- CHANGED:

  - _Describe the change you have made to existing functionality_

- REMOVED:

  - _Describe functionality removed and why_

- ADDED:
  - Provider change event - fired immediately after `networkController.provider` is sete

- DEPRECATED:

  - _Describe what was deprecated and why_

- SECURITY:

  - _These should not be in a standard PR and addressed using the Security Advisory process_

**Checklist**

- [ ] Tests are included if applicable
- [ ] Any added code is fully documented

**Issue**

Resolves #???
