### PR TITLE
Expose prev state in state change event payloads

### DIFF
--- a/packages/base-controller/src/BaseControllerV2.test.ts
+++ b/packages/base-controller/src/BaseControllerV2.test.ts
@@ -22,7 +22,7 @@ type CountControllerAction = {
 
 type CountControllerEvent = {
   type: `${typeof countControllerName}:stateChange`;
-  payload: [CountControllerState, Patch[]];
+  payload: [CountControllerState, Patch[], CountControllerState];
 };
 
 const countControllerStateMetadata = {
@@ -257,11 +257,13 @@ describe('BaseController', () => {
     expect(listener1.firstCall.args).toStrictEqual([
       { count: 1 },
       [{ op: 'replace', path: [], value: { count: 1 } }],
+      { count: 0 },
     ]);
 
     expect(listener1.secondCall.args).toStrictEqual([
       { count: 0 },
       [{ op: 'replace', path: [], value: { count: 0 } }],
+      { count: 1 },
     ]);
   });
 
@@ -289,11 +291,13 @@ describe('BaseController', () => {
     expect(listener1.firstCall.args).toStrictEqual([
       { count: 1 },
       [{ op: 'replace', path: [], value: { count: 1 } }],
+      { count: 0 },
     ]);
     expect(listener2.callCount).toStrictEqual(1);
     expect(listener2.firstCall.args).toStrictEqual([
       { count: 1 },
       [{ op: 'replace', path: [], value: { count: 1 } }],
+      { count: 0 },
     ]);
   });
 
@@ -321,6 +325,7 @@ describe('BaseController', () => {
     expect(listener1.firstCall.args).toStrictEqual([
       { count: 1 },
       [{ op: 'replace', path: [], value: { count: 1 } }],
+      { count: 0 },
     ]);
   });
 


### PR DESCRIPTION
- ADDED:

  - When listening for controller state changes, it is useful to be able to tell whether an individual property in state changed. However, this is not possible currently because the state change event only exposes the state _after_ it has been changed, not _before_. This commit adds a third argument to the `stateChange` listener so that the previous state can be accessed.

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented