### PR TITLE
Add Ledger Keyring

### DIFF
--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -30,6 +30,8 @@
   },
   "dependencies": {
     "@keystonehq/metamask-airgapped-keyring": "^0.6.1",
+    "@ledgerhq/hw-transport": "^6.24.1",
+    "@ledgerhq/metamask-keyring": "0.3.1",
     "@metamask/base-controller": "workspace:^",
     "@metamask/controller-utils": "workspace:^",
     "@metamask/message-manager": "workspace:^",

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -1,4 +1,4 @@
-import { bufferToHex } from 'ethereumjs-util';
+import { BN, bufferToHex } from 'ethereumjs-util';
 import {
   recoverPersonalSignature,
   recoverTypedSignature,
@@ -10,6 +10,7 @@ import Common from '@ethereumjs/common';
 import { TransactionFactory } from '@ethereumjs/tx';
 import { MetaMaskKeyring as QRKeyring } from '@keystonehq/metamask-airgapped-keyring';
 import { CryptoHDKey, ETHSignature } from '@keystonehq/bc-ur-registry-eth';
+import LedgerKeyring from '@ledgerhq/metamask-keyring';
 import * as uuid from 'uuid';
 import { PreferencesController } from '@metamask/preferences-controller';
 import { MAINNET } from '@metamask/controller-utils';
@@ -52,7 +53,7 @@ describe('KeyringController', () => {
     keyringTypes: string[];
     keyrings: Keyring[];
   };
-  const additionalKeyrings = [QRKeyring];
+  const additionalKeyrings = [QRKeyring, LedgerKeyring];
   const baseConfig: Partial<KeyringConfig> = {
     encryptor: new MockEncryptor(),
     keyringTypes: additionalKeyrings,
@@ -758,6 +759,7 @@ describe('KeyringController', () => {
         },
         baseConfig,
       );
+
       await signProcessKeyringController.createNewVaultAndKeychain(password);
       const qrkeyring = await signProcessKeyringController.getOrAddQRKeyring();
       qrkeyring.forgetDevice();
@@ -1107,6 +1109,266 @@ describe('KeyringController', () => {
       cancelSignRequestStub.resolves();
       await signProcessKeyringController.cancelQRSignRequest();
       expect(cancelSignRequestStub.called).toBe(true);
+    });
+  });
+
+  describe('Ledger Keyring', () => {
+    let ledgerKeyring: LedgerKeyring;
+    preferences = new PreferencesController();
+
+    beforeEach(async () => {
+      keyringController = new KeyringController(
+        {
+          setAccountLabel: preferences.setAccountLabel.bind(preferences),
+          removeIdentity: preferences.removeIdentity.bind(preferences),
+          syncIdentities: preferences.syncIdentities.bind(preferences),
+          updateIdentities: preferences.updateIdentities.bind(preferences),
+          setSelectedAddress: preferences.setSelectedAddress.bind(preferences),
+        },
+        baseConfig,
+      );
+
+      await keyringController.createNewVaultAndKeychain(password);
+      ledgerKeyring = await keyringController.getLedgerKeyring();
+
+      ledgerKeyring.setApp({
+        signTransaction: sinon.stub(),
+        getAddress: sinon.stub().resolves({
+          address: '0xe908e4378431418759b4f87b4bf7966e8aaa5cf2',
+        }),
+        signEIP712HashedMessage: sinon.stub(),
+        signPersonalMessage: sinon.stub(),
+      });
+
+      await keyringController.unlockLedgerDefaultAccount();
+    });
+
+    it('should unlock default account from Ledger', async () => {
+      const defaultAccount =
+        await keyringController.unlockLedgerDefaultAccount();
+      expect(defaultAccount.address).toBe(
+        '0xe908e4378431418759b4f87b4bf7966e8aaa5cf2',
+      );
+      expect(defaultAccount.balance).toBe('0x0');
+    });
+
+    it('should sign a message with a Ledger keyring', async () => {
+      const confirmSignatureStub = sinon.stub(ledgerKeyring, 'signMessage');
+
+      confirmSignatureStub.resolves(
+        '4cb25933c5225f9f92fc9b487451b93bc3646c6aa01b72b01065b8509ac4fd6c37798695d0d5c0949ed10c5e102800ea2b62c2b670729c5631c81b0c52002a641b',
+      );
+
+      const data =
+        '0x879a053d4800c6354e76c7985a865d2922c82fb5b3f4577b2fe08b998954f2e0';
+
+      const account = await ledgerKeyring?.getDefaultAccount();
+      const signature = await keyringController.signMessage({
+        data,
+        from: account,
+      });
+      expect(signature).toBe(
+        '4cb25933c5225f9f92fc9b487451b93bc3646c6aa01b72b01065b8509ac4fd6c37798695d0d5c0949ed10c5e102800ea2b62c2b670729c5631c81b0c52002a641b',
+      );
+
+      confirmSignatureStub.reset();
+    });
+
+    it('should sign a personal message with a Ledger keyring', async () => {
+      const confirmSignatureStub = sinon.stub(
+        ledgerKeyring,
+        'signPersonalMessage',
+      );
+
+      confirmSignatureStub.resolves(
+        '4cb25933c5225f9f92fc9b487451b93bc3646c6aa01b72b01065b8509ac4fd6c37798695d0d5c0949ed10c5e102800ea2b62c2b670729c5631c81b0c52002a641b',
+      );
+
+      const data =
+        '0x879a053d4800c6354e76c7985a865d2922c82fb5b3f4577b2fe08b998954f2e0';
+
+      const account = await ledgerKeyring?.getDefaultAccount();
+      const signature = await keyringController.signPersonalMessage({
+        data,
+        from: account,
+      });
+      expect(signature).toBe(
+        '4cb25933c5225f9f92fc9b487451b93bc3646c6aa01b72b01065b8509ac4fd6c37798695d0d5c0949ed10c5e102800ea2b62c2b670729c5631c81b0c52002a641b',
+      );
+
+      confirmSignatureStub.reset();
+    });
+
+    it('should sign transaction with Ledger keyring', async () => {
+      const tx = TransactionFactory.fromTxData(
+        {
+          accessList: [],
+          chainId: '0x4',
+          data: '0x',
+          gasLimit: '0x5208',
+          maxFeePerGas: '0x2540be400',
+          maxPriorityFeePerGas: '0x3b9aca00',
+          nonce: '0x68',
+          r: undefined,
+          s: undefined,
+          to: '0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb',
+          v: undefined,
+          value: '0x0',
+          type: 2,
+        },
+        {
+          common: Common.forCustomChain(
+            MAINNET,
+            {
+              name: 'rinkeby',
+              chainId: parseInt('4'),
+              networkId: parseInt('4'),
+            },
+            'london',
+          ),
+        },
+      );
+
+      const confirmSignatureStub = sinon.stub(ledgerKeyring, 'signTransaction');
+
+      confirmSignatureStub.resolves({
+        ...tx,
+        r: new BN('1'),
+        s: new BN('2'),
+        v: new BN('3'),
+      } as any);
+
+      const account = await ledgerKeyring?.getDefaultAccount();
+
+      const { r, s, v } = await keyringController.signTransaction(tx, account);
+      expect(r.toString()).toBe('1');
+      expect(s.toString()).toBe('2');
+      expect(v.toString()).toBe('3');
+
+      confirmSignatureStub.reset();
+    });
+
+    it('should throw if typed data verions is not V4', async () => {
+      const typedMsgParams = [
+        {
+          name: 'Message',
+          type: 'string',
+          value: 'Hi, Alice!',
+        },
+        {
+          name: 'A number',
+          type: 'uint32',
+          value: '1337',
+        },
+      ];
+      const account = await ledgerKeyring.getDefaultAccount();
+
+      const signature = keyringController.signTypedMessage(
+        { data: typedMsgParams, from: account },
+        SignTypedDataVersion.V1,
+      );
+
+      await expect(signature).rejects.toThrow(
+        'Ledger: Only version 4 of typed data signing is supported',
+      );
+
+      const signature2 = keyringController.signTypedMessage(
+        { data: typedMsgParams, from: account },
+        SignTypedDataVersion.V3,
+      );
+
+      await expect(signature2).rejects.toThrow(
+        'Ledger: Only version 4 of typed data signing is supported',
+      );
+    });
+
+    it('should sign typed data for V4 with Ledger Keyring', async () => {
+      const msgParams = {
+        domain: {
+          chainId: 1,
+          name: 'Ether Mail',
+          verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+          version: '1',
+        },
+        message: {
+          contents: 'Hello, Bob!',
+          attachedMoneyInEth: 4.2,
+          from: {
+            name: 'Cow',
+            wallets: [
+              '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+              '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+            ],
+          },
+          to: [
+            {
+              name: 'Bob',
+              wallets: [
+                '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+                '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
+                '0xB0B0b0b0b0b0B000000000000000000000000000',
+              ],
+            },
+          ],
+        },
+        primaryType: 'Mail',
+        types: {
+          EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+          ],
+          Group: [
+            { name: 'name', type: 'string' },
+            { name: 'members', type: 'Person[]' },
+          ],
+          Mail: [
+            { name: 'from', type: 'Person' },
+            { name: 'to', type: 'Person[]' },
+            { name: 'contents', type: 'string' },
+          ],
+          Person: [
+            { name: 'name', type: 'string' },
+            { name: 'wallets', type: 'address[]' },
+          ],
+        },
+      };
+
+      const confirmSignatureStub = sinon.stub(ledgerKeyring, 'signTypedData');
+
+      confirmSignatureStub.resolves(
+        '0xafb6e247b1c490e284053c87ab5f6b59e219d51f743f7a4d83e400782bc7e4b9479a268e0e0acd4de3f1e28e4fac2a6b32a4195e8dfa9d19147abe8807aa6f6400',
+      );
+
+      const account = await ledgerKeyring.getDefaultAccount();
+      const signature = await keyringController.signTypedMessage(
+        { data: JSON.stringify(msgParams), from: account },
+        SignTypedDataVersion.V4,
+      );
+      const recovered = recoverTypedSignature_v4({
+        data: msgParams as any,
+        sig: signature as string,
+      });
+      expect(account).toBe(recovered);
+    });
+
+    it('should forget Ledger Keyring', async () => {
+      const accounts = await ledgerKeyring.getAccounts();
+      expect(accounts).toHaveLength(1);
+
+      await keyringController.forgetLedger();
+      expect(keyringController.state.keyrings[1].accounts).toHaveLength(0);
+    });
+
+    it('should return Ledger Keyring for corresponding account', async () => {
+      const ledgerAccount = '0xe908e4378431418759b4f87b4bf7966e8aaa5cf2';
+
+      const keyring = await keyringController.getAccountKeyringType(
+        ledgerAccount,
+      );
+
+      expect(keyring).toBe(KeyringTypes.ledger);
     });
   });
 });

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -18,6 +18,8 @@ import {
   MetaMaskKeyring as QRKeyring,
   IKeyringState as IQRKeyringState,
 } from '@keystonehq/metamask-airgapped-keyring';
+import Transport from '@ledgerhq/hw-transport';
+import LedgerKeyring from '@ledgerhq/metamask-keyring';
 import {
   BaseController,
   BaseConfig,
@@ -38,6 +40,7 @@ export enum KeyringTypes {
   simple = 'Simple Key Pair',
   hd = 'HD Key Tree',
   qr = 'QR Hardware Wallet Device',
+  ledger = 'Ledger',
 }
 
 /**
@@ -458,6 +461,14 @@ export class KeyringController extends BaseController<
   ) {
     try {
       const address = normalizeAddress(messageParams.from);
+
+      const ledgerKeyring = await this.getLedgerKeyring();
+      const isLedgerAccount = await ledgerKeyring.managesAccount(address);
+
+      if (isLedgerAccount) {
+        return this.#keyring.signTypedMessage(messageParams, { version });
+      }
+
       const qrKeyring = await this.getOrAddQRKeyring();
       const qrAccounts = await qrKeyring.getAccounts();
       if (
@@ -745,6 +756,114 @@ export class KeyringController extends BaseController<
     accounts.forEach((account) => {
       this.setSelectedAddress(account);
     });
+    await this.#keyring.persistAllKeyrings();
+    await this.fullUpdate();
+  }
+
+  // Ledger Related methods
+
+  private async addLedgerKeyring(): Promise<LedgerKeyring> {
+    return await this.#keyring.addNewKeyring(KeyringTypes.ledger);
+  }
+
+  /**
+   * Retrieve the existing LedgerKeyring or create a new one.
+   *
+   * @returns The stored Ledger Keyring
+   */
+  async getLedgerKeyring(): Promise<LedgerKeyring> {
+    const keyring = this.#keyring.getKeyringsByType(KeyringTypes.ledger)[0];
+
+    if (keyring) {
+      return keyring;
+    }
+
+    return await this.addLedgerKeyring();
+  }
+
+  /**
+   * Connects to the ledger device by requesting some metadata from it.
+   *
+   * @param transport - The transport to use to connect to the device
+   * @param deviceId - The device ID to connect to
+   * @returns The name of the currently open application on the device
+   */
+  async connectLedgerHardware(
+    transport: Transport,
+    deviceId: string,
+  ): Promise<string> {
+    const keyring = await this.getLedgerKeyring();
+    keyring.setTransport(transport, deviceId);
+
+    const { appName } = await keyring.getAppAndVersion();
+
+    return appName;
+  }
+
+  /**
+   * Retrieve the first account from the Ledger device.
+   *
+   * @returns The default (first) account on the device
+   */
+  async unlockLedgerDefaultAccount(): Promise<{
+    address: string;
+    balance: string;
+  }> {
+    const keyring = await this.getLedgerKeyring();
+    const oldAccounts = await this.#keyring.getAccounts();
+    await this.#keyring.addNewAccount(keyring);
+    const newAccounts = await this.#keyring.getAccounts();
+
+    this.updateIdentities(newAccounts);
+    newAccounts.forEach((address: string, index: number) => {
+      if (!oldAccounts.includes(address)) {
+        if (this.setAccountLabel) {
+          this.setAccountLabel(address, `${keyring.getName()} ${index + 1}`);
+        }
+        this.setSelectedAddress(address);
+      }
+    });
+    await this.#keyring.persistAllKeyrings();
+    this.fullUpdate();
+
+    const address = await keyring.getDefaultAccount();
+    return {
+      address,
+      balance: `0x0`,
+    };
+  }
+
+  /**
+   * Automatically opens the Ethereum app on the Ledger device.
+   */
+  async openEthereumApp(): Promise<void> {
+    const keyring = await this.getLedgerKeyring();
+    await keyring.openEthApp();
+  }
+
+  /**
+   * Automatically closes the current app on the Ledger device.
+   */
+  async closeRunningApp(): Promise<void> {
+    const keyring = await this.getLedgerKeyring();
+    const { appName } = await keyring.getAppAndVersion();
+
+    // BOLOS means we are on the dashboard we don't need to close anything
+    if (appName !== 'BOLOS') {
+      await keyring.quitApp();
+    }
+  }
+
+  /**
+   * Forgets the ledger keyring's previous device specific state.
+   */
+  async forgetLedger(): Promise<void> {
+    const keyring = await this.getLedgerKeyring();
+    keyring.forgetDevice();
+
+    const accounts: string[] = await this.#keyring.getAccounts();
+    this.setSelectedAddress(accounts[0]);
+
     await this.#keyring.persistAllKeyrings();
     await this.fullUpdate();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,7 +615,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/common@npm:^2.6.3":
+"@ethereumjs/common@npm:^2.6.3, @ethereumjs/common@npm:^2.6.4":
   version: 2.6.5
   resolution: "@ethereumjs/common@npm:2.6.5"
   dependencies:
@@ -664,6 +664,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethereumjs/tx@npm:^3.5.0":
+  version: 3.5.2
+  resolution: "@ethereumjs/tx@npm:3.5.2"
+  dependencies:
+    "@ethereumjs/common": ^2.6.4
+    ethereumjs-util: ^7.1.5
+  checksum: a34a7228a623b40300484d15875b9f31f0a612cfeab64a845f6866cf0bfe439519e9455ac6396149f29bc527cf0ee277ace082ae013a1075dcbf7193220a0146
+  languageName: node
+  linkType: hard
+
 "@ethereumjs/util@npm:^8.0.0":
   version: 8.0.0
   resolution: "@ethereumjs/util@npm:8.0.0"
@@ -674,7 +684,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/abi@npm:^5.7.0":
+"@ethersproject/abi@npm:^5.5.0, @ethersproject/abi@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/abi@npm:5.7.0"
   dependencies:
@@ -888,7 +898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/rlp@npm:^5.7.0":
+"@ethersproject/rlp@npm:^5.5.0, @ethersproject/rlp@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/rlp@npm:5.7.0"
   dependencies:
@@ -1332,6 +1342,94 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ledgerhq/cryptoassets@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@ledgerhq/cryptoassets@npm:7.0.0"
+  dependencies:
+    invariant: 2
+  checksum: 1df72e6372f82689f11e7c93cfc6bc23102e6001fc0eae5a190e4ab99bfc4d40b1bd1c1b2415f5abbec18e6f89bffc4401df22a9fe054c7829001900587b8777
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/devices@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "@ledgerhq/devices@npm:7.0.5"
+  dependencies:
+    "@ledgerhq/errors": ^6.12.1
+    "@ledgerhq/logs": ^6.10.1
+    rxjs: 6
+    semver: ^7.3.5
+  checksum: 9af8ea36fa971fdf9a35c42e5be93387a48db71f0cd9d0b38ec0664b03df3016a9602ebe94cb4155c83afb7aff73b1474b67b43021e871cd5f4c5b81dc1cb661
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/errors@npm:^6.12.1":
+  version: 6.12.1
+  resolution: "@ledgerhq/errors@npm:6.12.1"
+  checksum: a729d0933221cd54f3293e6d64f22b8b191bc65577a5aefc14fd42c32ef427634ea3835a86154c7d0072a46363ef15afc638eba8761ced422eb8bd0fbf26d9e7
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/hw-app-eth@npm:^6.26.1":
+  version: 6.30.2
+  resolution: "@ledgerhq/hw-app-eth@npm:6.30.2"
+  dependencies:
+    "@ethersproject/abi": ^5.5.0
+    "@ethersproject/rlp": ^5.5.0
+    "@ledgerhq/cryptoassets": ^7.0.0
+    "@ledgerhq/errors": ^6.12.1
+    "@ledgerhq/hw-transport": ^6.27.8
+    "@ledgerhq/hw-transport-mocker": ^6.27.8
+    "@ledgerhq/logs": ^6.10.1
+    axios: ^0.26.1
+    bignumber.js: ^9.1.0
+    crypto-js: ^4.1.1
+  checksum: 9c87ee5a91397ebcb9bf5462b1265773d4d85321f147e3ad44f0f9b7bdb765d86fa5c5808318b22c3ae16fb0f85f9a01db7c3cba365303894f3b82256e22cd3f
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/hw-transport-mocker@npm:^6.27.8":
+  version: 6.27.8
+  resolution: "@ledgerhq/hw-transport-mocker@npm:6.27.8"
+  dependencies:
+    "@ledgerhq/hw-transport": ^6.27.8
+    "@ledgerhq/logs": ^6.10.1
+  checksum: a6676ae4f3b79e79dd5b3c6b20f0daecce62a2e65c557de4b7395c1da320a9fca720108d5aa64ba9428d15f7567d9500165a3a8fb3b936c07f5fa2722b84f123
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/hw-transport@npm:^6.24.1, @ledgerhq/hw-transport@npm:^6.27.8":
+  version: 6.27.8
+  resolution: "@ledgerhq/hw-transport@npm:6.27.8"
+  dependencies:
+    "@ledgerhq/devices": ^7.0.5
+    "@ledgerhq/errors": ^6.12.1
+    events: ^3.3.0
+  checksum: 28f923833edaf1c3a0560d21ffed507c0a9117d8f4f0789027d409a38bbe6229f8315019c5560ab2b15cb7ba34adafe0f3711c1989110f0dd805baa293cc690b
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/logs@npm:^6.10.1":
+  version: 6.10.1
+  resolution: "@ledgerhq/logs@npm:6.10.1"
+  checksum: 4dde46557d9daa6028f7040d26585aaa7260445212ad8348ae4a01463b7d76a1592dfc36921e47f5fc477c50b5d73e840070ac167e3cbe5b45123f36a4f96b08
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/metamask-keyring@npm:0.3.1":
+  version: 0.3.1
+  resolution: "@ledgerhq/metamask-keyring@npm:0.3.1"
+  dependencies:
+    "@ethereumjs/tx": ^3.5.0
+    "@ledgerhq/hw-app-eth": ^6.26.1
+    "@ledgerhq/hw-transport": ^6.24.1
+    buffer: ^6.0.3
+    eth-sig-util: ^3.0.1
+    ethereumjs-util: ^7.1.4
+  checksum: 6f3a40ec5b38e6086f2bd8d7d4a299fc431b77bcb6f1f3a099f62f958daa7459a099438e196ddabe93608acd638506267b8194d71262be3100077393ef6ac158
+  languageName: node
+  linkType: hard
+
 "@metamask/action-utils@npm:^0.0.2":
   version: 0.0.2
   resolution: "@metamask/action-utils@npm:0.0.2"
@@ -1723,6 +1821,8 @@ __metadata:
     "@ethereumjs/tx": ^3.2.1
     "@keystonehq/bc-ur-registry-eth": ^0.9.0
     "@keystonehq/metamask-airgapped-keyring": ^0.6.1
+    "@ledgerhq/hw-transport": ^6.24.1
+    "@ledgerhq/metamask-keyring": 0.3.1
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
@@ -3173,6 +3273,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^0.26.1":
+  version: 0.26.1
+  resolution: "axios@npm:0.26.1"
+  dependencies:
+    follow-redirects: ^1.14.8
+  checksum: d9eb58ff4bc0b36a04783fc9ff760e9245c829a5a1052ee7ca6013410d427036b1d10d04e7380c02f3508c5eaf3485b1ae67bd2adbfec3683704745c8d7a6e1a
+  languageName: node
+  linkType: hard
+
 "babel-jest@npm:^26.3.0":
   version: 26.3.0
   resolution: "babel-jest@npm:26.3.0"
@@ -3349,6 +3458,13 @@ __metadata:
   version: 9.0.2
   resolution: "bignumber.js@npm:9.0.2"
   checksum: 8637b71d0a99104b20413c47578953970006fec6b4df796b9dcfd9835ea9c402ea0e727eba9a5ca9f9a393c1d88b6168c5bbe0887598b708d4f8b4870ad62e1f
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:^9.1.0":
+  version: 9.1.1
+  resolution: "bignumber.js@npm:9.1.1"
+  checksum: ad243b7e2f9120b112d670bb3d674128f0bd2ca1745b0a6c9df0433bd2c0252c43e6315d944c2ac07b4c639e7496b425e46842773cf89c6a2dcd4f31e5c4b11e
   languageName: node
   linkType: hard
 
@@ -3599,6 +3715,16 @@ __metadata:
     base64-js: ^1.0.2
     ieee754: ^1.1.4
   checksum: ca8b2b7dce2dccd049182cf886772b09c9b4b52f3557557513c6130c721c10fe4c8dea08bbaca1ad8a10a69055266526d601be47d77103ca70959f668cf02b0d
+  languageName: node
+  linkType: hard
+
+"buffer@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: ^1.3.1
+    ieee754: ^1.2.1
+  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
   languageName: node
   linkType: hard
 
@@ -4070,6 +4196,13 @@ __metadata:
     shebang-command: ^2.0.0
     which: ^2.0.1
   checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
+  languageName: node
+  linkType: hard
+
+"crypto-js@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "crypto-js@npm:4.1.1"
+  checksum: b3747c12ee3a7632fab3b3e171ea50f78b182545f0714f6d3e7e2858385f0f4101a15f2517e033802ce9d12ba50a391575ff4638c9de3dd9b2c4bc47768d5425
   languageName: node
   linkType: hard
 
@@ -5542,6 +5675,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"events@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
+  languageName: node
+  linkType: hard
+
 "evp_bytestokey@npm:^1.0.3":
   version: 1.0.3
   resolution: "evp_bytestokey@npm:1.0.3"
@@ -5873,6 +6013,16 @@ __metadata:
   version: 3.1.1
   resolution: "flatted@npm:3.1.1"
   checksum: 508935e3366d95444131f0aaa801a4301f24ea5bcb900d12764e7335b46b910730cc1b5bcfcfb8eccb7c8db261ba0671c6a7ca30d10870ff7a7756dc7e731a7a
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.14.8":
+  version: 1.15.2
+  resolution: "follow-redirects@npm:1.15.2"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
   languageName: node
   linkType: hard
 
@@ -6524,7 +6674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13":
+"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
@@ -6651,6 +6801,15 @@ __metadata:
     has: ^1.0.3
     side-channel: ^1.0.4
   checksum: 1944f92e981e47aebc98a88ff0db579fd90543d937806104d0b96557b10c1f170c51fb777b97740a8b6ddeec585fca8c39ae99fd08a8e058dfc8ab70937238bf
+  languageName: node
+  linkType: hard
+
+"invariant@npm:2":
+  version: 2.2.4
+  resolution: "invariant@npm:2.2.4"
+  dependencies:
+    loose-envify: ^1.0.0
+  checksum: cc3182d793aad82a8d1f0af697b462939cb46066ec48bbf1707c150ad5fad6406137e91a262022c269702e01621f35ef60269f6c0d7fd178487959809acdfb14
   languageName: node
   linkType: hard
 
@@ -7787,7 +7946,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-tokens@npm:^4.0.0":
+"js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: 8a95213a5a77deb6cbe94d86340e8d9ace2b93bc367790b260101d2f36a2eaf4e4e22d9fa9cf459b38af3a32fb4190e638024cf82ec95ef708680e405ea7cc78
@@ -8231,6 +8390,17 @@ __metadata:
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+  languageName: node
+  linkType: hard
+
+"loose-envify@npm:^1.0.0":
+  version: 1.4.0
+  resolution: "loose-envify@npm:1.4.0"
+  dependencies:
+    js-tokens: ^3.0.0 || ^4.0.0
+  bin:
+    loose-envify: cli.js
+  checksum: 6517e24e0cad87ec9888f500c5b5947032cdfe6ef65e1c1936a0c48a524b81e65542c9c3edc91c97d5bddc806ee2a985dbc79be89215d613b1de5db6d1cfe6f4
   languageName: node
   linkType: hard
 
@@ -10192,6 +10362,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rxjs@npm:6":
+  version: 6.6.7
+  resolution: "rxjs@npm:6.6.7"
+  dependencies:
+    tslib: ^1.9.0
+  checksum: bc334edef1bb8bbf56590b0b25734ba0deaf8825b703256a93714308ea36dff8a11d25533671adf8e104e5e8f256aa6fdfe39b2e248cdbd7a5f90c260acbbd1b
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.1":
   version: 5.2.0
   resolution: "safe-buffer@npm:5.2.0"
@@ -11314,6 +11493,13 @@ __metadata:
   version: 1.10.0
   resolution: "tslib@npm:1.10.0"
   checksum: 1d0450dc6f64b918b14acaf3b956ebe1c72d7401c632adce932a60e3cd8d2a70f6040ceef6a7c3561146c3f29bcf584c41c2e09a5d20a27d6c3057f0d5f2a836
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^1.9.0":
+  version: 1.14.1
+  resolution: "tslib@npm:1.14.1"
+  checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Add Ledger Keyring**

This PR expands the responsibility of the `KeyringController` to support the `LedgerKeyring` from `@ledgerhq/metamask-keyring`.

Use the previous PR (https://github.com/MetaMask/core/pull/862) as a reference.

**Description**

_Itemize the changes you have made into the categories below_

- CHANGED:

  - KeyringController.signTypedMessage
    - Added support to check if the account is a ledger device and if so, propagate the signing request to the device.

- ADDED:

  - `KeyringController.getLedgerKeyring`
    - Method to retrieve the keyring for ledger.
  - `KeyringController.connectLedgerHardware`
    - Method to connect to a device using a `Transport` object.
  - `KeyringController.unlockLedgerDefaultAccount`
    - Method to retrieve the first account from the Ledger device.
  - `KeyringController.openEthereumApp`
    - Method to open the Ethereum app on the Ledger device
  - `KeyringController.closeRunningApp`
    - Method to close the current app on the Ledger device.
  - `KeyringController.forgetLedger`
    - Method to reset the state of the keyring.

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Resolves https://github.com/MetaMask/mobile-planning/issues/567
