### PR TITLE
Update NftController tests to not create networkController instance

### DIFF
--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -14,7 +14,6 @@ import {
   OPENSEA_API_URL,
   ERC721,
   NetworksChainId,
-  NetworkType,
 } from '@metamask/controller-utils';
 import { Network } from '@ethersproject/providers';
 import { AssetsContractController } from './AssetsContractController';
@@ -47,8 +46,8 @@ const DEPRESSIONIST_CLOUDFLARE_IPFS_SUBDOMAIN_PATH = getFormattedIpfsUrl(
   true,
 );
 
-const SEPOLIA = { chainId: '11155111', type: 'SEPOLIA' as NetworkType };
-const GOERLI = { chainId: '5', type: 'goerli' as NetworkType };
+const SEPOLIA = { chainId: '11155111', type: 'sepolia' as const };
+const GOERLI = { chainId: '5', type: 'goerli' as const };
 
 // Mock out detectNetwork function for cleaner tests, Ethers calls this a bunch of times because the Web3Provider is paranoid.
 jest.mock('@ethersproject/providers', () => {
@@ -787,8 +786,6 @@ describe('NftController', () => {
     });
 
     it('should add NFT by provider type', async () => {
-      const firstNetworkType = 'SEPOLIA';
-      const secondNetworkType = 'GOERLI';
       const { nftController, changeNetwork } = setupController();
       const { selectedAddress } = nftController.config;
       sinon
@@ -802,13 +799,13 @@ describe('NftController', () => {
 
       expect(
         nftController.state.allNfts[selectedAddress]?.[
-          NetworksChainId[secondNetworkType]
+          NetworksChainId[GOERLI.type]
         ],
       ).toBeUndefined();
 
       expect(
         nftController.state.allNfts[selectedAddress][
-          NetworksChainId[firstNetworkType]
+          NetworksChainId[SEPOLIA.type]
         ][0],
       ).toStrictEqual({
         address: '0x01',


### PR DESCRIPTION
**No NetworkController in tests**

**Description**:
Mocking the behaviour of the network controller makes the tests more flexible, and lessens the burden of cleanup / maintainability of the tests. This PR removes the `NetworkController` from the `NftController` tests. 

Relates to #1051 