### PR TITLE
Export `isEIP1559Transaction` function

### DIFF
--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -1,1 +1,2 @@
 export * from './TransactionController';
+export { isEIP1559Transaction } from './utils';


### PR DESCRIPTION
This function is used in mobile. It was exported prior to the monorepo release.
