### PR TITLE
API-125 - Migrated from metaswap to metafi subdomain for proxy and token icons

### DIFF
--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -602,14 +602,14 @@ describe('NftDetectionController', () => {
     getOpenSeaApiKeyStub.mockImplementation(() => 'FAKE API KEY');
     nftController.setApiKey('FAKE API KEY');
 
-    nock('https://proxy.metaswap.codefi.network:443', {
+    nock('https://proxy.metafi.codefi.network:443', {
       encodedQueryParams: true,
     })
       .get('/opensea/v1/api/v1/assets')
       .query({ owner: selectedAddress, offset: '0', limit: '50' })
       .replyWithError(new Error('Failed to fetch'));
 
-    nock('https://proxy.metaswap.codefi.network:443', {
+    nock('https://proxy.metafi.codefi.network:443', {
       encodedQueryParams: true,
     })
       .get('/opensea/v1/api/v1/assets')
@@ -690,7 +690,7 @@ describe('NftDetectionController', () => {
 
   it('should rethrow error when OpenSea proxy server fails with error other than fetch failure', async () => {
     const selectedAddress = '0x4';
-    nock('https://proxy.metaswap.codefi.network:443', {
+    nock('https://proxy.metafi.codefi.network:443', {
       encodedQueryParams: true,
     })
       .get('/opensea/v1/api/v1/assets')

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -74,7 +74,7 @@ const sampleTokenA: Token = {
   symbol: tokenAFromList.symbol,
   decimals: tokenAFromList.decimals,
   image:
-    'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
+    'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
   isERC721: false,
   aggregators: formattedSampleAggregators,
 };
@@ -83,7 +83,7 @@ const sampleTokenB: Token = {
   symbol: tokenBFromList.symbol,
   decimals: tokenBFromList.decimals,
   image:
-    'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.png',
+    'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.png',
   isERC721: false,
   aggregators: formattedSampleAggregators,
 };

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -26,7 +26,7 @@ const sampleMainnetTokenList = [
     occurrences: 11,
     name: 'Synthetix',
     iconUrl:
-      'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png',
+      'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png',
     aggregators: [
       'Aave',
       'Bancor',
@@ -49,7 +49,7 @@ const sampleMainnetTokenList = [
     occurrences: 11,
     name: 'Chainlink',
     iconUrl:
-      'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
+      'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
     aggregators: [
       'Aave',
       'Bancor',
@@ -71,7 +71,7 @@ const sampleMainnetTokenList = [
     occurrences: 11,
     name: 'Bancor',
     iconUrl:
-      'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.png',
+      'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.png',
     aggregators: [
       'Bancor',
       'CMC',
@@ -102,7 +102,7 @@ const sampleWithDuplicateSymbols = [
     occurrences: 11,
     name: 'Bancor',
     iconUrl:
-      'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.png',
+      'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.png',
     aggregators: [
       'Bancor',
       'CMC',
@@ -131,7 +131,7 @@ const sampleWithLessThan3OccurencesResponse = [
     occurrences: 2,
     name: 'Synthetix',
     iconUrl:
-      'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png',
+      'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png',
     aggregators: [
       'Aave',
       'Bancor',
@@ -154,7 +154,7 @@ const sampleWithLessThan3OccurencesResponse = [
     occurrences: 11,
     name: 'Chainlink',
     iconUrl:
-      'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
+      'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
     aggregators: [
       'Aave',
       'Bancor',
@@ -194,7 +194,7 @@ const sampleBinanceTokenList = [
       'Paraswap',
     ],
     iconUrl:
-      'https://static.metaswap.codefi.network/api/v1/tokenIcons/56/0x7083609fce4d1d8dc0c979aab8c869ea2c873402.png',
+      'https://static.metafi.codefi.network/api/v1/tokenIcons/56/0x7083609fce4d1d8dc0c979aab8c869ea2c873402.png',
   },
   {
     address: '0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3',
@@ -211,7 +211,7 @@ const sampleBinanceTokenList = [
       'Paraswap',
     ],
     iconUrl:
-      'https://static.metaswap.codefi.network/api/v1/tokenIcons/56/0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3.png',
+      'https://static.metafi.codefi.network/api/v1/tokenIcons/56/0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3.png',
   },
 ];
 const sampleSingleChainState = {
@@ -223,7 +223,7 @@ const sampleSingleChainState = {
       occurrences: 11,
       name: 'Synthetix',
       iconUrl:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png',
       aggregators: [
         'Aave',
         'Bancor',
@@ -246,7 +246,7 @@ const sampleSingleChainState = {
       occurrences: 11,
       name: 'Chainlink',
       iconUrl:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
       aggregators: [
         'Aave',
         'Bancor',
@@ -268,7 +268,7 @@ const sampleSingleChainState = {
       occurrences: 11,
       name: 'Bancor',
       iconUrl:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.png',
       aggregators: [
         'Bancor',
         'CMC',
@@ -314,7 +314,7 @@ const sampleTwoChainState = {
         'Paraswap',
       ],
       iconUrl:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/56/0x7083609fce4d1d8dc0c979aab8c869ea2c873402.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/56/0x7083609fce4d1d8dc0c979aab8c869ea2c873402.png',
     },
     '0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3': {
       address: '0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3',
@@ -331,7 +331,7 @@ const sampleTwoChainState = {
         'Paraswap',
       ],
       iconUrl:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/56/0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/56/0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3.png',
     },
   },
   tokensChainsCache: {
@@ -355,7 +355,7 @@ const existingState = {
       occurrences: 11,
       name: 'Chainlink',
       iconUrl:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
       aggregators: [
         'Aave',
         'Bancor',
@@ -389,7 +389,7 @@ const outdatedExistingState = {
       occurrences: 11,
       name: 'Chainlink',
       iconUrl:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
       aggregators: [
         'Aave',
         'Bancor',
@@ -423,7 +423,7 @@ const expiredCacheExistingState: TokenListState = {
       occurrences: 9,
       name: 'Chainlink',
       iconUrl:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
       aggregators: [
         'Aave',
         'Bancor',
@@ -450,7 +450,7 @@ const expiredCacheExistingState: TokenListState = {
           occurrences: 11,
           name: 'Chainlink',
           iconUrl:
-            'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
           aggregators: [
             'Aave',
             'Bancor',
@@ -559,7 +559,7 @@ describe('TokenListController', () => {
           occurrences: 11,
           name: 'Chainlink',
           iconUrl:
-            'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
           aggregators: [
             'Aave',
             'Bancor',
@@ -946,7 +946,7 @@ describe('TokenListController', () => {
         occurrences: 11,
         name: 'Bancor',
         iconUrl:
-          'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.png',
+          'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.png',
         aggregators: [
           'Bancor',
           'CMC',

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -95,7 +95,7 @@ describe('TokensController', () => {
       address: '0x01',
       decimals: 2,
       image:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x01.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x01.png',
       symbol: 'bar',
       isERC721: false,
       aggregators: [],
@@ -105,7 +105,7 @@ describe('TokensController', () => {
       address: '0x01',
       decimals: 2,
       image:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x01.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x01.png',
       symbol: 'baz',
       isERC721: false,
       aggregators: [],
@@ -250,7 +250,7 @@ describe('TokensController', () => {
       address: '0x01',
       decimals: 2,
       image:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x01.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x01.png',
       symbol: 'bar',
       isERC721: false,
       aggregators: [],
@@ -275,7 +275,7 @@ describe('TokensController', () => {
       address: '0x01',
       decimals: 2,
       image:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/11155111/0x01.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/11155111/0x01.png',
       symbol: 'bar',
       isERC721: false,
       aggregators: [],
@@ -307,7 +307,7 @@ describe('TokensController', () => {
       address: '0x02',
       decimals: 2,
       image:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x02.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x02.png',
       symbol: 'baz',
       isERC721: false,
       aggregators: [],
@@ -332,7 +332,7 @@ describe('TokensController', () => {
       address: '0x02',
       decimals: 2,
       image:
-        'https://static.metaswap.codefi.network/api/v1/tokenIcons/11155111/0x02.png',
+        'https://static.metafi.codefi.network/api/v1/tokenIcons/11155111/0x02.png',
       symbol: 'baz',
       isERC721: false,
       aggregators: [],
@@ -471,7 +471,7 @@ describe('TokensController', () => {
         address: '0x01',
         decimals: 4,
         image:
-          'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x01.png',
+          'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x01.png',
         isERC721: false,
         symbol: 'A',
         aggregators: [],
@@ -480,7 +480,7 @@ describe('TokensController', () => {
         address: '0x02',
         decimals: 5,
         image:
-          'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x02.png',
+          'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x02.png',
         isERC721: false,
         symbol: 'B',
         aggregators: [],
@@ -593,7 +593,7 @@ describe('TokensController', () => {
             symbol: 'REST',
             isERC721: true,
             image:
-              'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0xda5584cc586d07c7141aa427224a4bd58e64af7d.png',
+              'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0xda5584cc586d07c7141aa427224a4bd58e64af7d.png',
             decimals: 4,
             aggregators: [],
           },
@@ -634,7 +634,7 @@ describe('TokensController', () => {
             symbol: 'LEST',
             isERC721: false,
             image:
-              'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0xda5584cc586d07c7141aa427224a4bd58e64af7d.png',
+              'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0xda5584cc586d07c7141aa427224a4bd58e64af7d.png',
             decimals: 5,
             aggregators: [],
           },
@@ -686,7 +686,7 @@ describe('TokensController', () => {
       const dummyAddedToken: Token = {
         ...dummyDetectedToken,
         image:
-          'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x01.png',
+          'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x01.png',
       };
 
       await tokensController.addDetectedTokens([dummyDetectedToken]);
@@ -725,7 +725,7 @@ describe('TokensController', () => {
         aggregators: [],
         isERC721: false,
         image:
-          'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x01.png',
+          'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x01.png',
       };
 
       const directlyAddedToken: Token = {
@@ -733,7 +733,7 @@ describe('TokensController', () => {
         decimals: 5,
         symbol: 'B',
         image:
-          'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x02.png',
+          'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x02.png',
         isERC721: false,
         aggregators: [],
       };
@@ -1091,7 +1091,7 @@ describe('TokensController', () => {
           address: '0x01',
           decimals: 4,
           image:
-            'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x01.png',
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x01.png',
           isERC721: false,
           symbol: 'A',
           aggregators: [],
@@ -1100,7 +1100,7 @@ describe('TokensController', () => {
           address: '0x02',
           decimals: 5,
           image:
-            'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x02.png',
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x02.png',
           isERC721: false,
           symbol: 'B',
           aggregators: [],
@@ -1112,7 +1112,7 @@ describe('TokensController', () => {
           address: '0x03',
           decimals: 6,
           image:
-            'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x03.png',
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x03.png',
           isERC721: false,
           symbol: 'C',
           aggregators: [],
@@ -1149,7 +1149,7 @@ describe('TokensController', () => {
           address: '0x01',
           decimals: 4,
           image:
-            'https://static.metaswap.codefi.network/api/v1/tokenIcons/11155111/0x01.png',
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/11155111/0x01.png',
           isERC721: false,
           symbol: 'A',
           aggregators: [],
@@ -1158,7 +1158,7 @@ describe('TokensController', () => {
           address: '0x02',
           decimals: 5,
           image:
-            'https://static.metaswap.codefi.network/api/v1/tokenIcons/11155111/0x02.png',
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/11155111/0x02.png',
           isERC721: false,
           symbol: 'B',
           aggregators: [],
@@ -1170,7 +1170,7 @@ describe('TokensController', () => {
           address: '0x03',
           decimals: 4,
           image:
-            'https://static.metaswap.codefi.network/api/v1/tokenIcons/5/0x03.png',
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/5/0x03.png',
           isERC721: false,
           symbol: 'C',
           aggregators: [],
@@ -1179,7 +1179,7 @@ describe('TokensController', () => {
           address: '0x04',
           decimals: 5,
           image:
-            'https://static.metaswap.codefi.network/api/v1/tokenIcons/5/0x04.png',
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/5/0x04.png',
           isERC721: false,
           symbol: 'D',
           aggregators: [],

--- a/packages/assets-controllers/src/assetsUtil.test.ts
+++ b/packages/assets-controllers/src/assetsUtil.test.ts
@@ -118,7 +118,7 @@ describe('assetsUtil', () => {
         chainId: NetworksChainId.mainnet,
         tokenAddress: linkTokenAddress,
       });
-      const expectedValue = `https://static.metaswap.codefi.network/api/v1/tokenIcons/${NetworksChainId.mainnet}/${linkTokenAddress}.png`;
+      const expectedValue = `https://static.metafi.codefi.network/api/v1/tokenIcons/${NetworksChainId.mainnet}/${linkTokenAddress}.png`;
       expect(formattedIconUrl).toStrictEqual(expectedValue);
     });
 
@@ -128,7 +128,7 @@ describe('assetsUtil', () => {
         chainId: `0x${Number(NetworksChainId.mainnet).toString(16)}`,
         tokenAddress: linkTokenAddress,
       });
-      const expectedValue = `https://static.metaswap.codefi.network/api/v1/tokenIcons/${NetworksChainId.mainnet}/${linkTokenAddress}.png`;
+      const expectedValue = `https://static.metafi.codefi.network/api/v1/tokenIcons/${NetworksChainId.mainnet}/${linkTokenAddress}.png`;
       expect(formattedIconUrl).toStrictEqual(expectedValue);
     });
   });

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -98,7 +98,7 @@ export const formatIconUrlWithProxy = ({
   tokenAddress: string;
 }) => {
   const chainIdDecimal = convertHexToDecimal(chainId).toString();
-  return `https://static.metaswap.codefi.network/api/v1/tokenIcons/${chainIdDecimal}/${tokenAddress.toLowerCase()}.png`;
+  return `https://static.metafi.codefi.network/api/v1/tokenIcons/${chainIdDecimal}/${tokenAddress.toLowerCase()}.png`;
 };
 
 /**

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -50,6 +50,6 @@ export const TESTNET_NETWORK_TYPE_TO_TICKER_SYMBOL: {
 
 // APIs
 export const OPENSEA_PROXY_URL =
-  'https://proxy.metaswap.codefi.network/opensea/v1/api/v1';
+  'https://proxy.metafi.codefi.network/opensea/v1/api/v1';
 export const OPENSEA_API_URL = 'https://api.opensea.io/api/v1';
 export const OPENSEA_TEST_API_URL = 'https://testnets-api.opensea.io/api/v1';


### PR DESCRIPTION
**PR Title**

- Migrates from *.metaswap.codefi.network  to *.metafi.codefi.network for `proxy` and `static` subdomains. MetaMask Platform API team is migrating from metaswap aws accounts to their own.

**Description**

_Itemize the changes you have made into the categories below_

- BREAKING:

  - Uses new subdomains for providing the opensea proxy and token icons cache.

- CHANGED:

  - Uses new subdomains for providing the opensea proxy and token icons cache.
  - New infrastructure enables a new mechanism to handle support requests for changes to token icons. Now https://github.com/MetaMask/contract-metadata will be the priority provider of icons, such that changes there will overwrite any existing token icons we're fetching and caching from other providers.