### PR TITLE
Replace network/isCustomNetwork with networkStatus

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -18,8 +18,8 @@ module.exports = merge(baseConfig, {
     global: {
       branches: 81.51,
       functions: 98.86,
-      lines: 95.79,
-      statements: 95.97,
+      lines: 95.54,
+      statements: 95.73,
     },
   },
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1,6 +1,7 @@
 import * as sinon from 'sinon';
 import HttpProvider from 'ethjs-provider-http';
 import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
+import { NetworkStatus } from '@metamask/network-controller';
 import type { NetworkState } from '@metamask/network-controller';
 import { ESTIMATE_GAS_ERROR } from './utils';
 import {
@@ -131,8 +132,7 @@ const MAINNET_PROVIDER = new HttpProvider(
 const MOCK_NETWORK = {
   getProvider: () => PROVIDER,
   state: {
-    network: '5',
-    isCustomNetwork: false,
+    networkStatus: NetworkStatus.active,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
       type: 'goerli' as NetworkType,
@@ -144,8 +144,7 @@ const MOCK_NETWORK = {
 const MOCK_NETWORK_CUSTOM = {
   getProvider: () => PROVIDER,
   state: {
-    network: '10',
-    isCustomNetwork: true,
+    networkStatus: NetworkStatus.active,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
       type: 'rpc' as NetworkType,
@@ -156,15 +155,18 @@ const MOCK_NETWORK_CUSTOM = {
 };
 const MOCK_NETWORK_WITHOUT_CHAIN_ID = {
   getProvider: () => PROVIDER,
-  isCustomNetwork: false,
-  state: { network: '5', providerConfig: { type: 'goerli' as NetworkType } },
+  state: {
+    networkStatus: NetworkStatus.active,
+    providerConfig: {
+      type: 'goerli' as NetworkType,
+    },
+  },
   subscribe: () => undefined,
 };
 const MOCK_MAINNET_NETWORK = {
   getProvider: () => MAINNET_PROVIDER,
   state: {
-    network: '1',
-    isCustomNetwork: false,
+    networkStatus: NetworkStatus.active,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
       type: 'mainnet' as NetworkType,
@@ -176,8 +178,7 @@ const MOCK_MAINNET_NETWORK = {
 const MOCK_CUSTOM_NETWORK = {
   getProvider: () => MAINNET_PROVIDER,
   state: {
-    network: '80001',
-    isCustomNetwork: true,
+    networkStatus: NetworkStatus.active,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
       type: 'rpc' as NetworkType,
@@ -502,9 +503,6 @@ describe('TransactionController', () => {
       to: from,
     });
     expect(controller.state.transactions[0].transaction.from).toBe(from);
-    expect(controller.state.transactions[0].networkID).toBe(
-      MOCK_NETWORK.state.network,
-    );
 
     expect(controller.state.transactions[0].chainId).toBe(
       MOCK_NETWORK.state.providerConfig.chainId,
@@ -541,9 +539,6 @@ describe('TransactionController', () => {
       to: from,
     });
     expect(controller.state.transactions[0].transaction.from).toBe(from);
-    expect(controller.state.transactions[0].networkID).toBe(
-      MOCK_MAINNET_NETWORK.state.network,
-    );
 
     expect(controller.state.transactions[0].chainId).toBe(
       MOCK_MAINNET_NETWORK.state.providerConfig.chainId,
@@ -580,9 +575,6 @@ describe('TransactionController', () => {
       to: from,
     });
     expect(controller.state.transactions[0].transaction.from).toBe(from);
-    expect(controller.state.transactions[0].networkID).toBe(
-      MOCK_NETWORK_CUSTOM.state.network,
-    );
 
     expect(controller.state.transactions[0].chainId).toBe(
       MOCK_NETWORK_CUSTOM.state.providerConfig.chainId,
@@ -634,25 +626,6 @@ describe('TransactionController', () => {
       from,
       to: from,
     });
-    controller.wipeTransactions();
-    expect(controller.state.transactions).toHaveLength(0);
-  });
-
-  // This tests the fallback to networkID only when there is no chainId present. Should be removed when networkID is completely removed.
-  it('should wipe transactions using networkID when there is no chainId', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      getProvider: MOCK_NETWORK.getProvider,
-    });
-    controller.wipeTransactions();
-    controller.state.transactions.push({
-      from: MOCK_PRFERENCES.state.selectedAddress,
-      id: 'foo',
-      networkID: '5',
-      status: TransactionStatus.submitted,
-      transactionHash: '1337',
-    } as any);
     controller.wipeTransactions();
     expect(controller.state.transactions).toHaveLength(0);
   });
@@ -853,43 +826,7 @@ describe('TransactionController', () => {
       controller.state.transactions.push({
         from: MOCK_PRFERENCES.state.selectedAddress,
         id: 'foo',
-        networkID: '5',
         chainId: '5',
-        status: TransactionStatus.submitted,
-        transactionHash: '1337',
-      } as any);
-      controller.state.transactions.push({} as any);
-
-      controller.hub.once(
-        `${controller.state.transactions[0].id}:confirmed`,
-        () => {
-          expect(controller.state.transactions[0].status).toBe(
-            TransactionStatus.confirmed,
-          );
-          resolve('');
-        },
-      );
-      controller.queryTransactionStatuses();
-    });
-  });
-
-  // This tests the fallback to networkID only when there is no chainId present. Should be removed when networkID is completely removed.
-  it('should query transaction statuses with networkID only when there is no chainId', async () => {
-    await new Promise((resolve) => {
-      const controller = new TransactionController(
-        {
-          getNetworkState: () => MOCK_NETWORK.state,
-          onNetworkStateChange: MOCK_NETWORK.subscribe,
-          getProvider: MOCK_NETWORK.getProvider,
-        },
-        {
-          sign: async (transaction: any) => transaction,
-        },
-      );
-      controller.state.transactions.push({
-        from: MOCK_PRFERENCES.state.selectedAddress,
-        id: 'foo',
-        networkID: '5',
         status: TransactionStatus.submitted,
         transactionHash: '1337',
       } as any);


### PR DESCRIPTION
The network controller contains two related state properties: `network`
and `isCustomNetwork`.

The first property is strange: it can either be a number, which
represents the version of the network as obtained via `net_version`, or
"loading", which is a sort of null state that either means we don't have
a network to connect to, or we do but it's not accessible. In any case,
the `net_version` RPC method, much less the idea of a network version,
is no longer standard, so we don't need to store it.

The second property is unnecessary, as we can already obtain whether a
network is "custom" (i.e. not one of the ones we know about by default)
by looking at the `type` within the provider config object.

Therefore, we can remove these state properties and replace them with a
simple property that merely tracks whether we have an accessible network
or not.

Fixes #1020.