### PR TITLE
updated the previously owned state for nft

### DIFF
--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -619,7 +619,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
           nftMetadata,
           existingEntry,
         );
-        if (differentMetadata) {
+        if (differentMetadata || !existingEntry.isCurrentlyOwned) {
           // TODO: Switch to indexToUpdate
           const indexToRemove = nfts.findIndex(
             (nft) =>


### PR DESCRIPTION
Fixes [17206](https://github.com/MetaMask/metamask-extension/issues/17206)

Ideally, when a user previously owned an NFT, and then received the same one back, we'd put that NFT back into its own group. With the current implementation, the NFT is always stuck in the Previously Owned category, even when imported again. This PR is to update the Nft Controllers to add the NFT back to its own group if we are re-importing it.
