### PR TITLE
BREAKING: Make the EIP-1559 endpoint a required argument for the GasFeeController

### DIFF
--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -23,7 +23,6 @@ import {
 import determineGasFeeCalculations from './determineGasFeeCalculations';
 import fetchGasEstimatesViaEthFeeHistory from './fetchGasEstimatesViaEthFeeHistory';
 
-const GAS_FEE_API = 'https://mock-gas-server.herokuapp.com/';
 export const LEGACY_GAS_PRICES_API_URL = `https://api.metaswap.codefi.network/gasPrices`;
 
 export type unknownString = 'unknown';
@@ -279,8 +278,7 @@ export class GasFeeController extends BaseControllerV2<
    * network state change event.
    * @param options.legacyAPIEndpoint - The legacy gas price API URL. This option is primarily for
    * testing purposes.
-   * @param options.EIP1559APIEndpoint - The EIP-1559 gas price API URL. This option is primarily
-   * for testing purposes.
+   * @param options.EIP1559APIEndpoint - The EIP-1559 gas price API URL.
    * @param options.clientId - The client ID used to identify to the gas estimation API who is
    * asking for estimates.
    */
@@ -295,7 +293,7 @@ export class GasFeeController extends BaseControllerV2<
     getProvider,
     onNetworkStateChange,
     legacyAPIEndpoint = LEGACY_GAS_PRICES_API_URL,
-    EIP1559APIEndpoint = GAS_FEE_API,
+    EIP1559APIEndpoint,
     clientId,
   }: {
     interval?: number;
@@ -308,7 +306,7 @@ export class GasFeeController extends BaseControllerV2<
     getProvider: () => NetworkController['provider'];
     onNetworkStateChange?: (listener: (state: NetworkState) => void) => void;
     legacyAPIEndpoint?: string;
-    EIP1559APIEndpoint?: string;
+    EIP1559APIEndpoint: string;
     clientId?: string;
   }) {
     super({


### PR DESCRIPTION
**[GasFeeController] Make the EIP-1559 gas fee endpoint a required argument**

-  This PR removes the default value given to the `EIP1559APIEndpoint` parameter of the GasFeeController. This server is no longer maintained, and consumers of this package should pass in their own gas fee endpoint. All MetaMask products already currently pass in their own API endpoint, and no additional changes are needed on their end.
 
**Description**

_Itemize the changes you have made into the categories below_

- BREAKING:

  - `EIP1559APIEndpoint` argument for the gas fee controller is now required.

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented
