### PR TITLE
Use Set to improve lookup performance

### DIFF
--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -270,11 +270,14 @@ export class PhishingController extends BaseController<
       configs.push(metamaskConfig);
     }
 
+    // Create Set from metamaskConfig.blocklist to improve look up performance when used within filter.
+    const mmConfigBlocklist = new Set(metamaskConfig.blocklist);
+
     // Correctly shaping PhishFort config.
     const phishfortConfig: EthPhishingDetectConfig = {
       allowlist: [],
       blocklist: (phishfortHotlist || []).filter(
-        (i) => !metamaskConfig.blocklist.includes(i),
+        (i) => !mmConfigBlocklist.has(i),
       ), // Removal of duplicates.
       fuzzylist: [],
       tolerance: 0,


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Improve lookup time in PhishingController**

This PR creates a Set from `metamaskConfig.blocklist` in the `PhishingController`. The blocklist Set is later used as a lookup inside of a filter method. As a result, look up performance is significantly improved by using a `Set` + `has` method instead of `includes` method from an Array.

**Description**

_Itemize the changes you have made into the categories below_

- CHANGED:

  - `PhishingController.updatePhishingLists`
    - Create a `Set` from `metamaskConfig.blocklist` to be used as lookup.

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Resolves https://github.com/metamask/metamask-mobile/issues/5382
