### PR TITLE
Simplify type of custom Jest matcher

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -3,8 +3,7 @@ declare global {
   // defined.
   /* eslint-disable-next-line @typescript-eslint/no-namespace */
   namespace jest {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/ban-types
-    interface Matchers<R, T = {}> {
+    interface Matchers<R> {
       toNeverResolve(): Promise<R>;
     }
   }


### PR DESCRIPTION
The `toNeverResolve` custom matcher is now registered using a simpler type declaration. This also lets us remove an ESLint ignore comment.
