### PR TITLE
Added disabledRpcMethodPreferences state to PreferencesController

### DIFF
--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -231,7 +231,7 @@ describe('PreferencesController', () => {
 
   it('should set disabledRpcMethodPreferences', () => {
     const controller = new PreferencesController();
-    controller.setDisabledRpcMethodPreferences('eth_sign', true);
+    controller.setDisabledRpcMethodPreference('eth_sign', true);
     expect(
       controller.state.disabledRpcMethodPreferences.eth_sign,
     ).toStrictEqual(true);

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -13,6 +13,9 @@ describe('PreferencesController', () => {
       useTokenDetection: true,
       useNftDetection: false,
       openSeaEnabled: false,
+      disabledRpcMethodPreferences: {
+        eth_sign: false
+      },
     });
   });
 
@@ -225,4 +228,10 @@ describe('PreferencesController', () => {
     controller.setUseNftDetection(true);
     expect(controller.state.useNftDetection).toStrictEqual(true);
   });
+
+  it('should set disabledRpcMethodPreferences', () => {
+    const controller = new PreferencesController();
+    controller.setDisabledRpcMethodPreferences("eth_sign", true);
+    expect(controller.state.disabledRpcMethodPreferences.eth_sign).toStrictEqual(true);
+  })
 });

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -14,7 +14,7 @@ describe('PreferencesController', () => {
       useNftDetection: false,
       openSeaEnabled: false,
       disabledRpcMethodPreferences: {
-        eth_sign: false
+        eth_sign: false,
       },
     });
   });
@@ -231,7 +231,9 @@ describe('PreferencesController', () => {
 
   it('should set disabledRpcMethodPreferences', () => {
     const controller = new PreferencesController();
-    controller.setDisabledRpcMethodPreferences("eth_sign", true);
-    expect(controller.state.disabledRpcMethodPreferences.eth_sign).toStrictEqual(true);
-  })
+    controller.setDisabledRpcMethodPreferences('eth_sign', true);
+    expect(
+      controller.state.disabledRpcMethodPreferences.eth_sign,
+    ).toStrictEqual(true);
+  });
 });

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -66,7 +66,7 @@ export interface PreferencesState extends BaseState {
   openSeaEnabled: boolean;
   disabledRpcMethodPreferences: {
     [methodName: string]: boolean;
-  }
+  };
 }
 
 /**
@@ -346,10 +346,10 @@ export class PreferencesController extends BaseController<
   }
 
   /**
-   * A setter for the user preferences to enable/disable rpc methods
+   * A setter for the user preferences to enable/disable rpc methods.
    *
-   * @param {string} methodName - The RPC method name to change the setting of
-   * @param {bool} isEnabled - true to enable the rpc method
+   * @param methodName - The RPC method name to change the setting of.
+   * @param isEnabled - true to enable the rpc method, false to disable it.
    */
   setDisabledRpcMethodPreferences(methodName: string, isEnabled: boolean) {
     const { disabledRpcMethodPreferences } = this.state;

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -351,7 +351,7 @@ export class PreferencesController extends BaseController<
    * @param methodName - The RPC method name to change the setting of.
    * @param isEnabled - true to enable the rpc method, false to disable it.
    */
-  setDisabledRpcMethodPreferences(methodName: string, isEnabled: boolean) {
+  setDisabledRpcMethodPreference(methodName: string, isEnabled: boolean) {
     const { disabledRpcMethodPreferences } = this.state;
     const newDisabledRpcMethods = {
       ...disabledRpcMethodPreferences,

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -64,6 +64,9 @@ export interface PreferencesState extends BaseState {
   useTokenDetection: boolean;
   useNftDetection: boolean;
   openSeaEnabled: boolean;
+  disabledRpcMethodPreferences: {
+    [methodName: string]: boolean;
+  }
 }
 
 /**
@@ -96,6 +99,9 @@ export class PreferencesController extends BaseController<
       useTokenDetection: true,
       useNftDetection: false,
       openSeaEnabled: false,
+      disabledRpcMethodPreferences: {
+        eth_sign: false,
+      },
     };
     this.initialize();
   }
@@ -337,6 +343,21 @@ export class PreferencesController extends BaseController<
     if (!openSeaEnabled) {
       this.update({ useNftDetection: false });
     }
+  }
+
+  /**
+   * A setter for the user preferences to enable/disable rpc methods
+   *
+   * @param {string} methodName - The RPC method name to change the setting of
+   * @param {bool} isEnabled - true to enable the rpc method
+   */
+  setDisabledRpcMethodPreferences(methodName: string, isEnabled: boolean) {
+    const { disabledRpcMethodPreferences } = this.state;
+    const newDisabledRpcMethods = {
+      ...disabledRpcMethodPreferences,
+      [methodName]: isEnabled,
+    };
+    this.update({ disabledRpcMethodPreferences: newDisabledRpcMethods });
   }
 }
 


### PR DESCRIPTION

**PR Title**

Added disabledRpcMethodPreferences state to PreferencesController

- ADDED:

  - Added a new key for storing which rpc methods we've deprecated, but want the user to be able to specify if they want to enable it again.


**Checklist**

- [x] Tests are included
- [x] Any added code is fully documented

**Issue**

Related to https://github.com/MetaMask/metamask-mobile/issues/5676
