### PR TITLE
Ledger account missing on password reset 

### DIFF
--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -786,6 +786,17 @@ export class KeyringController extends BaseController<
   }
 
   /**
+   * Restores the Ledger Keyring. This is only used at the time the user resets the account's password at the moment.
+   *
+   * @param keyringSerialized - The serialized keyring;
+   */
+  async restoreLedgerKeyring(keyringSerialized: any): Promise<void> {
+    (await this.getLedgerKeyring()).deserialize(keyringSerialized);
+    this.updateIdentities(await this.#keyring.getAccounts());
+    await this.fullUpdate();
+  }
+
+  /**
    * Connects to the ledger device by requesting some metadata from it.
    *
    * @param transport - The transport to use to connect to the device


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**PR Title**
Ledger account missing on password reset 

- A brief description of changes. If the PR has breaking changes add `BREAKING:`
  to the start of the PR title.

**Description**
This PR fixes the bug where the Ledger account is missing on password reset 

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented


Resolves [#5721](https://github.com/MetaMask/metamask-mobile/issues/5721)