### PR TITLE
Always run `all-jobs-pass` to ensure all jobs have passed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,9 +47,26 @@ jobs:
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  all-jobs-pass:
-    name: All jobs pass
+  all-jobs-complete:
+    name: All jobs complete
     runs-on: ubuntu-latest
     needs: lint-build-test
+    outputs:
+      passed: ${{ steps.set-output.outputs.passed }}
     steps:
-      - run: echo "Great success!"
+      - name: Set passed output
+        id: set-output
+        run: echo "passed=true" >> "$GITHUB_OUTPUT"
+
+  all-jobs-pass:
+    name: All jobs pass
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: all-jobs-complete
+    steps:
+      - name: Check that all jobs have passed
+        run: |
+          passed="${{ needs.all-jobs-complete.outputs.passed }}"
+          if [[ $passed != "true" ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
**Always run `all-jobs-pass` to ensure all jobs have passed**

We require `all-jobs-pass` to complete for a PR to be merged. Currently if a job fails, `all-jobs-pass` shows up as "Skipped," bypassing the requirement. This PR changes it so `all-jobs-pass` always runs at the end of all other jobs, regardless of failures, and checks if a variable has been set, that only gets set when all jobs have passed.

For reference: https://github.com/MetaMask/snaps-monorepo/pull/1254#discussion_r1123523503

**Description**

- CHANGED:

  - Add new job that sets `passed` output.
  - The `all-jobs-pass` job now checks if `passed === 'true'`.