### PR TITLE
API-217 - Refactored to new long-running phishing-detection API for phishing list updates

### DIFF
--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -3,6 +3,7 @@ import * as sinon from 'sinon';
 import nock from 'nock';
 import DEFAULT_PHISHING_RESPONSE from 'eth-phishing-detect/src/config.json';
 import {
+  ListNames,
   METAMASK_HOTLIST_DIFF_FILE,
   METAMASK_STALELIST_FILE,
   PhishingController,
@@ -34,7 +35,7 @@ describe('PhishingController', () => {
         blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
         fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
         tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
-        name: `MetaMask`,
+        name: ListNames.MetaMask,
         version: DEFAULT_PHISHING_RESPONSE.version,
         lastUpdated: 0,
       },
@@ -442,7 +443,7 @@ describe('PhishingController', () => {
     expect(controller.test('metamask.io')).toMatchObject({
       result: false,
       type: 'allowlist',
-      name: 'MetaMask',
+      name: ListNames.MetaMask,
     });
   });
 
@@ -467,7 +468,7 @@ describe('PhishingController', () => {
     expect(controller.test('etnerscan.io')).toMatchObject({
       result: true,
       type: 'blocklist',
-      name: 'MetaMask',
+      name: ListNames.MetaMask,
     });
   });
 
@@ -476,7 +477,7 @@ describe('PhishingController', () => {
     expect(controller.test('myetherẉalletṭ.com')).toMatchObject({
       result: true,
       type: 'blocklist',
-      name: 'MetaMask',
+      name: ListNames.MetaMask,
     });
   });
 
@@ -485,7 +486,7 @@ describe('PhishingController', () => {
     expect(controller.test('xn--myetherallet-4k5fwn.com')).toMatchObject({
       result: true,
       type: 'blocklist',
-      name: `MetaMask`,
+      name: ListNames.MetaMask,
     });
   });
 
@@ -514,7 +515,7 @@ describe('PhishingController', () => {
     expect(controller.test('metamask.io')).toMatchObject({
       result: false,
       type: 'allowlist',
-      name: 'MetaMask',
+      name: ListNames.MetaMask,
     });
   });
 
@@ -602,7 +603,7 @@ describe('PhishingController', () => {
     expect(controller.test('etnerscan.io')).toMatchObject({
       result: true,
       type: 'blocklist',
-      name: 'MetaMask',
+      name: ListNames.MetaMask,
     });
   });
 
@@ -631,7 +632,7 @@ describe('PhishingController', () => {
     expect(controller.test('myetherẉalletṭ.com')).toMatchObject({
       result: true,
       type: 'blocklist',
-      name: 'MetaMask',
+      name: ListNames.MetaMask,
     });
   });
 
@@ -676,7 +677,7 @@ describe('PhishingController', () => {
     expect(controller.test('xn--myetherallet-4k5fwn.com')).toMatchObject({
       result: true,
       type: 'blocklist',
-      name: 'MetaMask',
+      name: ListNames.MetaMask,
     });
   });
 
@@ -716,7 +717,7 @@ describe('PhishingController', () => {
     ).toMatchObject({
       result: true,
       type: 'blocklist',
-      name: 'MetaMask',
+      name: ListNames.MetaMask,
     });
   });
 
@@ -727,7 +728,7 @@ describe('PhishingController', () => {
         data: {
           eth_phishing_detect_config: {
             allowlist: [],
-            blocklist: ['xn--myetherallet-4k5fwn.com'],
+            blocklist: [],
             fuzzylist: [],
           },
           phishfort_hotlist: {
@@ -776,7 +777,7 @@ describe('PhishingController', () => {
     expect(controller.test('opensea.io')).toMatchObject({
       result: false,
       type: 'allowlist',
-      name: 'MetaMask',
+      name: ListNames.MetaMask,
     });
   });
 
@@ -805,7 +806,7 @@ describe('PhishingController', () => {
     expect(controller.test('ohpensea.io')).toMatchObject({
       result: true,
       type: 'fuzzy',
-      name: 'MetaMask',
+      name: ListNames.MetaMask,
     });
   });
 
@@ -1035,7 +1036,7 @@ describe('PhishingController', () => {
           fuzzylist: [],
           tolerance: 0,
           lastUpdated: 2,
-          name: 'MetaMask',
+          name: ListNames.MetaMask,
           version: 0,
         },
         {
@@ -1044,7 +1045,7 @@ describe('PhishingController', () => {
           fuzzylist: [],
           tolerance: 0,
           lastUpdated: 1,
-          name: 'Phishfort',
+          name: ListNames.Phishfort,
           version: 0,
         },
       ]);
@@ -1099,7 +1100,7 @@ describe('PhishingController', () => {
           tolerance: 0,
           version: 0,
           lastUpdated: 2,
-          name: 'MetaMask',
+          name: ListNames.MetaMask,
         },
         {
           blocklist: [],
@@ -1108,7 +1109,7 @@ describe('PhishingController', () => {
           tolerance: 0,
           version: 0,
           lastUpdated: 1,
-          name: 'Phishfort',
+          name: ListNames.Phishfort,
         },
       ]);
     });
@@ -1123,7 +1124,7 @@ describe('PhishingController', () => {
           blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
           fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
           tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
-          name: `MetaMask`,
+          name: ListNames.MetaMask,
           version: DEFAULT_PHISHING_RESPONSE.version,
           lastUpdated: 0,
         },
@@ -1140,7 +1141,7 @@ describe('PhishingController', () => {
           blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
           fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
           tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
-          name: `MetaMask`,
+          name: ListNames.MetaMask,
           version: DEFAULT_PHISHING_RESPONSE.version,
           lastUpdated: 0,
         },
@@ -1163,7 +1164,7 @@ describe('PhishingController', () => {
           blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
           fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
           tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
-          name: `MetaMask`,
+          name: ListNames.MetaMask,
           version: DEFAULT_PHISHING_RESPONSE.version,
           lastUpdated: 0,
         },
@@ -1186,7 +1187,7 @@ describe('PhishingController', () => {
           blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
           fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
           tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
-          name: `MetaMask`,
+          name: ListNames.MetaMask,
           version: DEFAULT_PHISHING_RESPONSE.version,
           lastUpdated: 0,
         },
@@ -1308,7 +1309,7 @@ describe('PhishingController', () => {
           ],
           fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
           tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
-          name: `MetaMask`,
+          name: ListNames.MetaMask,
           version: DEFAULT_PHISHING_RESPONSE.version,
           lastUpdated: 1,
         },

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -9,7 +9,7 @@ import {
   PHISHING_CONFIG_BASE_URL,
 } from './PhishingController';
 
-const defaultHotlistRefreshInterval = 15 * 60;
+const defaultHotlistRefreshInterval = 30 * 60;
 const defaultStalelistRefreshInterval = 4 * 24 * 60 * 60;
 
 describe('PhishingController', () => {
@@ -1031,20 +1031,20 @@ describe('PhishingController', () => {
       expect(controller.state.phishingLists).toStrictEqual([
         {
           allowlist: [],
-          blocklist: [],
-          fuzzylist: [],
-          tolerance: 0,
-          lastUpdated: 1,
-          name: 'Phishfort',
-          version: 0,
-        },
-        {
-          allowlist: [],
           blocklist: [exampleBlockedUrl, exampleBlockedUrlOne],
           fuzzylist: [],
           tolerance: 0,
           lastUpdated: 2,
           name: 'MetaMask',
+          version: 0,
+        },
+        {
+          allowlist: [],
+          blocklist: [],
+          fuzzylist: [],
+          tolerance: 0,
+          lastUpdated: 1,
+          name: 'Phishfort',
           version: 0,
         },
       ]);
@@ -1093,15 +1093,6 @@ describe('PhishingController', () => {
 
       expect(controller.state.phishingLists).toStrictEqual([
         {
-          blocklist: [],
-          allowlist: [],
-          fuzzylist: [],
-          tolerance: 0,
-          version: 0,
-          lastUpdated: 1,
-          name: 'Phishfort',
-        },
-        {
           allowlist: [],
           blocklist: [exampleBlockedUrlTwo],
           fuzzylist: [],
@@ -1109,6 +1100,15 @@ describe('PhishingController', () => {
           version: 0,
           lastUpdated: 2,
           name: 'MetaMask',
+        },
+        {
+          blocklist: [],
+          allowlist: [],
+          fuzzylist: [],
+          tolerance: 0,
+          version: 0,
+          lastUpdated: 1,
+          name: 'Phishfort',
         },
       ]);
     });

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -1315,5 +1315,20 @@ describe('PhishingController', () => {
         },
       ]);
     });
+    it('should not update phishing lists if hotlist fetch returns 400', async () => {
+      nock(PHISHING_CONFIG_BASE_URL)
+        .get(`${METAMASK_HOTLIST_DIFF_FILE}/${0}`)
+        .reply(404);
+
+      const controller = new PhishingController();
+      await controller.updateHotlist();
+
+      expect(controller.state.phishingLists).toStrictEqual([
+        {
+          ...controller.state.phishingLists[0],
+          lastUpdated: 0,
+        },
+      ]);
+    });
   });
 });

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -10,6 +10,13 @@ import { safelyExecute } from '@metamask/controller-utils';
 import { applyDiffs, fetchTimeNow } from './utils';
 
 /**
+ * @type ListTypes
+ *
+ * The lit
+ */
+export type ListTypes = 'fuzzylist' | 'blocklist' | 'allowlist';
+
+/**
  * @type EthPhishingResponse
  *
  * Configuration response from the eth-phishing-detect package
@@ -40,9 +47,14 @@ export interface EthPhishingResponse {
  * @property version - Stalelist data structure iteration.
  */
 export interface PhishingStalelist {
-  allowlist: string[];
-  blocklist: string[];
-  fuzzylist: string[];
+  eth_phishing_detect_config: {
+    allowlist: string[];
+    blocklist: string[];
+    fuzzylist: string[];
+  };
+  phishfort_hotlist: {
+    blocklist: string[];
+  };
   tolerance: number;
   version: number;
   lastUpdated: number;
@@ -58,6 +70,7 @@ export interface PhishingStalelist {
  * @property tolerance - Fuzzy match tolerance level
  * @property lastUpdated - Timestamp of last update.
  * @property version - Version of the phishing list state.
+ * @property name - Name of the list. Used for attribution.
  */
 export interface PhishingListState {
   allowlist: string[];
@@ -99,8 +112,12 @@ export interface EthPhishingDetectResult {
 export interface HotlistDiff {
   url: string;
   timestamp: number;
-  targetList: 'fuzzylist' | 'blocklist' | 'allowlist';
+  targetList: `${ListKeys}.${ListTypes}`;
   isRemoval?: boolean;
+}
+
+export interface DataResultWrapper<T> {
+  data: T;
 }
 
 /**
@@ -134,25 +151,42 @@ export interface PhishingConfig extends BaseConfig {
  * @property whitelist - array of temporarily-approved origins
  */
 export interface PhishingState extends BaseState {
-  listState: PhishingListState;
+  phishingLists: PhishingListState[];
   whitelist: string[];
   hotlistLastFetched: number;
   stalelistLastFetched: number;
 }
 
 export const PHISHING_CONFIG_BASE_URL =
-  'https://static.metafi.codefi.network/api/v1/lists';
+  'https://phishing-detection.metafi.codefi.network';
 
-export const METAMASK_STALELIST_FILE = '/stalelist.json';
+export const METAMASK_STALELIST_FILE = '/v1/stalelist';
 
-export const METAMASK_HOTLIST_DIFF_FILE = '/hotlist.json';
+export const METAMASK_HOTLIST_DIFF_FILE = '/v1/diffsSince';
 
-export const HOTLIST_REFRESH_INTERVAL = 30 * 60; // 30 mins in seconds
+export const HOTLIST_REFRESH_INTERVAL = 15 * 60; // 15 mins in seconds
 export const STALELIST_REFRESH_INTERVAL = 4 * 24 * 60 * 60; // 4 days in seconds
 
 export const METAMASK_STALELIST_URL = `${PHISHING_CONFIG_BASE_URL}${METAMASK_STALELIST_FILE}`;
 export const METAMASK_HOTLIST_DIFF_URL = `${PHISHING_CONFIG_BASE_URL}${METAMASK_HOTLIST_DIFF_FILE}`;
 
+export enum ListKeys {
+  PhishfortHotlist = 'phishfort_hotlist',
+  EthPhishingDetectConfig = 'eth_phishing_detect_config',
+}
+export enum ListNames {
+  MetaMask = 'MetaMask',
+  Phishfort = 'Phishfort',
+}
+
+const phishingListNameKeyMap = {
+  [ListNames.Phishfort]: ListKeys.PhishfortHotlist,
+  [ListNames.MetaMask]: ListKeys.EthPhishingDetectConfig,
+};
+export const phishingListKeyNameMap = {
+  [ListKeys.EthPhishingDetectConfig]: ListNames.MetaMask,
+  [ListKeys.PhishfortHotlist]: ListNames.Phishfort,
+};
 /**
  * Controller that manages community-maintained lists of approved and unapproved website origins.
  */
@@ -188,15 +222,17 @@ export class PhishingController extends BaseController<
     };
 
     this.defaultState = {
-      listState: {
-        allowlist: DEFAULT_PHISHING_RESPONSE.whitelist,
-        blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
-        fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
-        tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
-        version: DEFAULT_PHISHING_RESPONSE.version,
-        name: 'MetaMask',
-        lastUpdated: 0,
-      },
+      phishingLists: [
+        {
+          allowlist: DEFAULT_PHISHING_RESPONSE.whitelist,
+          blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
+          fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
+          tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
+          version: DEFAULT_PHISHING_RESPONSE.version,
+          name: 'MetaMask',
+          lastUpdated: 0,
+        },
+      ],
       whitelist: [],
       hotlistLastFetched: 0,
       stalelistLastFetched: 0,
@@ -210,16 +246,7 @@ export class PhishingController extends BaseController<
    * Updates this.detector with an instance of PhishingDetector using the current state.
    */
   updatePhishingDetector() {
-    this.detector = new PhishingDetector([
-      {
-        allowlist: this.state.listState.allowlist,
-        blocklist: this.state.listState.blocklist,
-        fuzzylist: this.state.listState.fuzzylist,
-        tolerance: this.state.listState.tolerance,
-        name: `MetaMask`,
-        version: this.state.listState.version,
-      },
-    ]);
+    this.detector = new PhishingDetector(this.state.phishingLists);
   }
 
   /**
@@ -371,13 +398,20 @@ export class PhishingController extends BaseController<
       return;
     }
 
-    let stalelist;
-    let hotlistDiffs;
+    let stalelistResponse;
+    let hotlistDiffsResponse;
     try {
-      [stalelist, hotlistDiffs] = await Promise.all([
-        this.queryConfig<PhishingStalelist>(METAMASK_STALELIST_URL),
-        this.queryConfig<Hotlist>(METAMASK_HOTLIST_DIFF_URL),
-      ]);
+      stalelistResponse = await this.queryConfig<
+        DataResultWrapper<PhishingStalelist>
+      >(METAMASK_STALELIST_URL).then((d) => d);
+
+      // Fetching hotlist diffs relies on having a lastUpdated timestamp to do `GET /v1/diffsSince/:timestamp`,
+      // so it doesn't make sense to call if there is not a timestamp to begin with.
+      if (stalelistResponse && stalelistResponse.data.lastUpdated > 0) {
+        hotlistDiffsResponse = await this.queryConfig<
+          DataResultWrapper<Hotlist>
+        >(`${METAMASK_HOTLIST_DIFF_URL}/${stalelistResponse.data.lastUpdated}`);
+      }
     } finally {
       // Set `stalelistLastFetched` and `hotlistLastFetched` even for failed requests to prevent server
       // from being overwhelmed with traffic after a network disruption.
@@ -388,14 +422,39 @@ export class PhishingController extends BaseController<
       });
     }
 
-    if (!stalelist || !hotlistDiffs) {
+    if (!stalelistResponse || !hotlistDiffsResponse) {
       return;
     }
+
+    const { phishfort_hotlist, eth_phishing_detect_config, ...partialState } =
+      stalelistResponse.data;
+
+    const phishfortList: PhishingListState = {
+      ...phishfort_hotlist,
+      ...partialState,
+      fuzzylist: [], // Phishfort hotlist doesn't contain a fuzzylist
+      allowlist: [], // Phishfort hotlist doesn't contain an allowlist
+      name: phishingListKeyNameMap.phishfort_hotlist,
+    };
+    const metamaskList: PhishingListState = {
+      ...eth_phishing_detect_config,
+      ...partialState,
+      name: phishingListKeyNameMap.eth_phishing_detect_config,
+    };
     // Correctly shaping eth-phishing-detect state by applying hotlist diffs to the stalelist.
-    const newListState: PhishingListState = applyDiffs(stalelist, hotlistDiffs);
+    const newPhishfortListState: PhishingListState = applyDiffs(
+      phishfortList,
+      hotlistDiffsResponse.data,
+      ListKeys.PhishfortHotlist,
+    );
+    const newMetaMaskListState: PhishingListState = applyDiffs(
+      metamaskList,
+      hotlistDiffsResponse.data,
+      ListKeys.EthPhishingDetectConfig,
+    );
 
     this.update({
-      listState: newListState,
+      phishingLists: [newPhishfortListState, newMetaMaskListState],
     });
     this.updatePhishingDetector();
   }
@@ -410,29 +469,39 @@ export class PhishingController extends BaseController<
     if (this.disabled) {
       return;
     }
+    const lastDiffTimestamp = Math.max(
+      ...this.state.phishingLists.map(({ lastUpdated }) => lastUpdated),
+    );
 
-    let hotlistDiffs;
-    try {
-      hotlistDiffs = await this.queryConfig<Hotlist>(METAMASK_HOTLIST_DIFF_URL);
-    } finally {
-      // Set `stalelistLastFetched` even for failed requests to prevent server from being overwhelmed with
-      // traffic after a network disruption.
-      this.update({
-        hotlistLastFetched: fetchTimeNow(),
+    const hotlistResponse = await this.queryConfig<DataResultWrapper<Hotlist>>(
+      `${METAMASK_HOTLIST_DIFF_URL}/${lastDiffTimestamp}`,
+    )
+      .then((d) => d)
+      .finally(() => {
+        // Set `stalelistLastFetched` even for failed requests to prevent server from being overwhelmed with
+        // traffic after a network disruption.
+        this.update({
+          hotlistLastFetched: fetchTimeNow(),
+        });
       });
-    }
-
-    if (!hotlistDiffs) {
+    if (
+      !hotlistResponse ||
+      !hotlistResponse.data ||
+      hotlistResponse.data.length === 0
+    ) {
       return;
     }
-    // Correctly shaping MetaMask config.
-    const newListState: PhishingListState = applyDiffs(
-      this.state.listState,
-      hotlistDiffs,
+    // Correctly shaping new phishing detection config objects.
+    const newPhishingLists = this.state.phishingLists.map((phishingList) =>
+      applyDiffs(
+        phishingList,
+        hotlistResponse.data,
+        phishingListNameKeyMap[phishingList.name as ListNames],
+      ),
     );
 
     this.update({
-      listState: newListState,
+      phishingLists: newPhishingLists,
     });
     this.updatePhishingDetector();
   }

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -497,21 +497,22 @@ export class PhishingController extends BaseController<
       });
     }
 
-    if (hotlistResponse?.data && hotlistResponse?.data?.length > 0) {
-      const hotlist = hotlistResponse?.data;
-      const newPhishingLists = this.state.phishingLists.map((phishingList) =>
-        applyDiffs(
-          phishingList,
-          hotlist,
-          phishingListNameKeyMap[phishingList.name],
-        ),
-      );
-
-      this.update({
-        phishingLists: newPhishingLists,
-      });
-      this.updatePhishingDetector();
+    if (!hotlistResponse?.data) {
+      return;
     }
+    const hotlist = hotlistResponse.data;
+    const newPhishingLists = this.state.phishingLists.map((phishingList) =>
+      applyDiffs(
+        phishingList,
+        hotlist,
+        phishingListNameKeyMap[phishingList.name],
+      ),
+    );
+
+    this.update({
+      phishingLists: newPhishingLists,
+    });
+    this.updatePhishingDetector();
   }
 
   private async queryConfig<ResponseType>(

--- a/packages/phishing-controller/src/utils.test.ts
+++ b/packages/phishing-controller/src/utils.test.ts
@@ -1,5 +1,5 @@
 import sinon from 'sinon';
-import { ListKeys } from './PhishingController';
+import { ListKeys, ListNames } from './PhishingController';
 import { applyDiffs, fetchTimeNow } from './utils';
 
 const exampleBlockedUrl = 'https://example-blocked-website.com';
@@ -17,7 +17,7 @@ const exampleListState = {
   tolerance: 2,
   allowlist: exampleAllowlist,
   version: 0,
-  name: 'MetaMask',
+  name: ListNames.MetaMask,
   lastUpdated: 0,
 };
 
@@ -99,6 +99,39 @@ describe('applyDiffs', () => {
     expect(result).toStrictEqual({
       ...exampleListState,
       blocklist: [...exampleListState.blocklist, exampleBlockedUrlTwo],
+      lastUpdated: 1674773009,
+    });
+  });
+
+  it('does not add an addition diff to the state if it does not contain the same targetlist listkey.', () => {
+    const testTime = 1674773005000;
+    sinon.useFakeTimers(testTime);
+    const testExistingState = { ...exampleListState, lastUpdated: 1674773005 };
+    const result = applyDiffs(
+      testExistingState,
+      [exampleAddDiff],
+      ListKeys.PhishfortHotlist,
+    );
+    expect(result).toStrictEqual(testExistingState);
+  });
+
+  it('does not remove a url from the state if it does not contain the same targetlist listkey.', () => {
+    const testTime = 1674773005000;
+    sinon.useFakeTimers(testTime);
+    const testExistingState = {
+      ...exampleListState,
+      lastUpdated: 1674773005,
+    };
+    const result = applyDiffs(
+      testExistingState,
+      [
+        { ...exampleAddDiff, timestamp: 1674773009 },
+        { ...exampleRemoveDiff, timestamp: 1674773004 },
+      ],
+      ListKeys.PhishfortHotlist,
+    );
+    expect(result).toStrictEqual({
+      ...exampleListState,
       lastUpdated: 1674773009,
     });
   });

--- a/packages/phishing-controller/src/utils.test.ts
+++ b/packages/phishing-controller/src/utils.test.ts
@@ -1,4 +1,5 @@
 import sinon from 'sinon';
+import { ListKeys } from './PhishingController';
 import { applyDiffs, fetchTimeNow } from './utils';
 
 const exampleBlockedUrl = 'https://example-blocked-website.com';
@@ -21,13 +22,13 @@ const exampleListState = {
 };
 
 const exampleAddDiff = {
-  targetList: 'blocklist' as const,
+  targetList: 'eth_phishing_detect_config.blocklist' as const,
   url: exampleBlockedUrlTwo,
   timestamp: 1000000000,
 };
 
 const exampleRemoveDiff = {
-  targetList: 'blocklist' as const,
+  targetList: 'eth_phishing_detect_config.blocklist' as const,
   url: exampleBlockedUrlTwo,
   timestamp: 1000000000,
   isRemoval: true,
@@ -43,27 +44,28 @@ describe('fetchTimeNow', () => {
 });
 
 describe('applyDiffs', () => {
-  it('adds a valid addition diff to the state', () => {
-    const testTime = 1674773005000;
-    sinon.useFakeTimers(testTime);
-    const result = applyDiffs(exampleListState, [exampleAddDiff]);
+  it('adds a valid addition diff to the state then sets lastUpdated to be the time of the latest diff', () => {
+    const result = applyDiffs(
+      exampleListState,
+      [exampleAddDiff],
+      ListKeys.EthPhishingDetectConfig,
+    );
     expect(result).toStrictEqual({
       ...exampleListState,
       blocklist: [...exampleListState.blocklist, exampleBlockedUrlTwo],
-      lastUpdated: 1674773005,
+      lastUpdated: exampleAddDiff.timestamp,
     });
   });
 
-  it('removes a valid removal diff to the state', () => {
-    const testTime = 1674773005000;
-    sinon.useFakeTimers(testTime);
-    const result = applyDiffs(exampleListState, [
-      exampleAddDiff,
-      exampleRemoveDiff,
-    ]);
+  it('removes a valid removal diff to the state then sets lastUpdated to be the time of the latest diff', () => {
+    const result = applyDiffs(
+      exampleListState,
+      [exampleAddDiff, exampleRemoveDiff],
+      ListKeys.EthPhishingDetectConfig,
+    );
     expect(result).toStrictEqual({
       ...exampleListState,
-      lastUpdated: 1674773005,
+      lastUpdated: exampleRemoveDiff.timestamp,
     });
   });
 
@@ -71,7 +73,11 @@ describe('applyDiffs', () => {
     const testTime = 1674773005000;
     sinon.useFakeTimers(testTime);
     const testExistingState = { ...exampleListState, lastUpdated: 1674773005 };
-    const result = applyDiffs(testExistingState, [exampleAddDiff]);
+    const result = applyDiffs(
+      testExistingState,
+      [exampleAddDiff],
+      ListKeys.EthPhishingDetectConfig,
+    );
     expect(result).toStrictEqual(testExistingState);
   });
 
@@ -82,14 +88,18 @@ describe('applyDiffs', () => {
       ...exampleListState,
       lastUpdated: 1674773005,
     };
-    const result = applyDiffs(testExistingState, [
-      { ...exampleAddDiff, timestamp: 1674773009 },
-      { ...exampleRemoveDiff, timestamp: 1674773004 },
-    ]);
+    const result = applyDiffs(
+      testExistingState,
+      [
+        { ...exampleAddDiff, timestamp: 1674773009 },
+        { ...exampleRemoveDiff, timestamp: 1674773004 },
+      ],
+      ListKeys.EthPhishingDetectConfig,
+    );
     expect(result).toStrictEqual({
       ...exampleListState,
       blocklist: [...exampleListState.blocklist, exampleBlockedUrlTwo],
-      lastUpdated: 1674773005,
+      lastUpdated: 1674773009,
     });
   });
 });

--- a/packages/phishing-controller/src/utils.test.ts
+++ b/packages/phishing-controller/src/utils.test.ts
@@ -112,7 +112,10 @@ describe('applyDiffs', () => {
       [exampleAddDiff],
       ListKeys.PhishfortHotlist,
     );
-    expect(result).toStrictEqual(testExistingState);
+    expect(result).toStrictEqual({
+      ...testExistingState,
+      name: ListNames.Phishfort,
+    });
   });
 
   it('does not remove a url from the state if it does not contain the same targetlist listkey.', () => {
@@ -131,8 +134,8 @@ describe('applyDiffs', () => {
       ListKeys.PhishfortHotlist,
     );
     expect(result).toStrictEqual({
-      ...exampleListState,
-      lastUpdated: 1674773009,
+      ...testExistingState,
+      name: ListNames.Phishfort,
     });
   });
 });

--- a/packages/phishing-controller/src/utils.ts
+++ b/packages/phishing-controller/src/utils.ts
@@ -1,7 +1,6 @@
 import {
   Hotlist,
   ListKeys,
-  ListTypes,
   phishingListKeyNameMap,
   PhishingListState,
 } from './PhishingController';
@@ -11,6 +10,22 @@ import {
  * @returns the Date.now() time in seconds instead of miliseconds. backend files rely on timestamps in seconds since epoch.
  */
 export const fetchTimeNow = (): number => Math.round(Date.now() / 1000);
+
+/**
+ * Split a string into two pieces, using the first period as the delimiter.
+ *
+ * @param stringToSplit - The string to split.
+ * @returns An array of length two containing the beginning and end of the string.
+ */
+const splitStringByPeriod = <Start extends string, End extends string>(
+  stringToSplit: `${Start}.${End}`,
+): [Start, End] => {
+  const periodIndex = stringToSplit.indexOf('.');
+  return [
+    stringToSplit.slice(0, periodIndex) as Start,
+    stringToSplit.slice(periodIndex + 1) as End,
+  ];
+};
 
 /**
  * Determines which diffs are applicable to the listState, then applies those diffs.
@@ -30,7 +45,7 @@ export const applyDiffs = (
   const diffsToApply = hotlistDiffs.filter(
     ({ timestamp, targetList }) =>
       timestamp > listState.lastUpdated &&
-      (targetList.split('.')[0] as ListKeys) === listKey,
+      splitStringByPeriod(targetList)[0] === listKey,
   );
 
   // the reason behind using latestDiffTimestamp as the lastUpdated time
@@ -45,7 +60,7 @@ export const applyDiffs = (
     fuzzylist: new Set(listState.fuzzylist),
   };
   for (const { isRemoval, targetList, url, timestamp } of diffsToApply) {
-    const targetListType = targetList.split('.')[1] as ListTypes;
+    const targetListType = splitStringByPeriod(targetList)[1];
     if (timestamp > latestDiffTimestamp) {
       latestDiffTimestamp = timestamp;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Refactor to new long-running phishing-detection API for phishing list updates**

- Refactors phishing-controller to use new curated experiences phishing list updates API for `GET /v1/diffsSince/:timestamp` to maximally reduce data transfer.

**Description**

_Itemize the changes you have made into the categories below_

- FIXED:

  - Re-added eth-phishing-detect attribution by drawing out `diff.targetList` from list type (`'fuzzylist' | 'blocklist' | 'allowlist'`) to a composed `${sourceList}.${listType}` like `'eth_phishing_detect_config.blocklist'`, then splitting client side to re-allow for multiple phishing-lists to be passed into the [eth-phishing-detect detector](https://github.com/MetaMask/core/pull/1123/files#diff-73fbecd61d9f85b57fee9c8377652f5563d90e026e54fa105ca91fcc2cbc076fR249).

- CHANGED:

  - Refactored from static.metafi.codefi.network subdomain to phishing-detection.metafi.codefi.network.
  - New hotlist updates don't fetch 8 days worth of diffs every 30 minutes, it fetches exactly what the end client needs (diffs since a last update's timestamp), massively reducing data transfer associated with this service.

- ADDED:

  - Refactored from static object storage on the backend to a dynamic API service to serve exactly the data that is needed to end clients.

**Checklist**
- [x] Production API release
- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Resolves API-217 (MetaMask API Platform Team Card)
