### PR TITLE
Support watching assets on a specific account

### DIFF
--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -841,6 +841,8 @@ describe('TokensController', () => {
 
   describe('on watchAsset', function () {
     let asset: any, type: any;
+    const defaultSelectedAddress = '0x1';
+    const interactingAddress = '0x2';
 
     let createEthersStub: sinon.SinonStub;
     beforeEach(function () {
@@ -945,6 +947,28 @@ describe('TokensController', () => {
         {
           id: '12345',
           status: 'pending',
+          time: 1, // uses the fakeTimers clock
+          type: 'ERC20',
+          asset,
+        },
+      ]);
+
+      generateRandomIdStub.restore();
+      clock.restore();
+    });
+
+    it('should handle ERC20 type and add to suggestedAssets with interacting address', async function () {
+      const clock = sinon.useFakeTimers(1);
+      const generateRandomIdStub = sinon
+        .stub(tokensController, '_generateRandomId')
+        .callsFake(() => '12345');
+      type = 'ERC20';
+      await tokensController.watchAsset(asset, type, interactingAddress);
+      expect(tokensController.state.suggestedAssets).toStrictEqual([
+        {
+          id: '12345',
+          status: 'pending',
+          interactingAddress,
           time: 1, // uses the fakeTimers clock
           type: 'ERC20',
           asset,

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -43,6 +43,7 @@ describe('TokensController', () => {
   };
 
   beforeEach(() => {
+    const defaultSelectedAddress = '0x1';
     preferences = new PreferencesController();
     tokensController = new TokensController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
@@ -50,6 +51,7 @@ describe('TokensController', () => {
         (onNetworkStateChangeListener = listener),
       config: {
         chainId: NetworksChainId.mainnet,
+        selectedAddress: defaultSelectedAddress,
       },
     });
 
@@ -841,7 +843,6 @@ describe('TokensController', () => {
 
   describe('on watchAsset', function () {
     let asset: any, type: any;
-    const defaultSelectedAddress = '0x1';
     const interactingAddress = '0x2';
 
     let createEthersStub: sinon.SinonStub;
@@ -950,6 +951,7 @@ describe('TokensController', () => {
           time: 1, // uses the fakeTimers clock
           type: 'ERC20',
           asset,
+          interactingAddress: '0x1',
         },
       ]);
 
@@ -1006,10 +1008,6 @@ describe('TokensController', () => {
         .stub(tokensController, '_generateRandomId')
         .callsFake(() => '12345');
       type = 'ERC20';
-      tokensController.configure({
-        selectedAddress: defaultSelectedAddress,
-        chainId: NetworksChainId.mainnet,
-      });
       await tokensController.watchAsset(asset, type, interactingAddress);
       await tokensController.acceptWatchAsset('12345');
 

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -1001,6 +1001,42 @@ describe('TokensController', () => {
       generateRandomIdStub.restore();
     });
 
+    it('should store token correctly under interacting address if user confirms', async function () {
+      const generateRandomIdStub = sinon
+        .stub(tokensController, '_generateRandomId')
+        .callsFake(() => '12345');
+      type = 'ERC20';
+      tokensController.configure({
+        selectedAddress: defaultSelectedAddress,
+        chainId: NetworksChainId.mainnet,
+      });
+      await tokensController.watchAsset(asset, type, interactingAddress);
+      await tokensController.acceptWatchAsset('12345');
+
+      expect(tokensController.state.suggestedAssets).toStrictEqual([]);
+      expect(tokensController.state.tokens).toHaveLength(0);
+      expect(tokensController.state.tokens).toStrictEqual([]);
+      expect(
+        tokensController.state.allTokens[NetworksChainId.mainnet][
+          interactingAddress
+        ],
+      ).toHaveLength(1);
+      expect(
+        tokensController.state.allTokens[NetworksChainId.mainnet][
+          interactingAddress
+        ],
+      ).toStrictEqual([
+        {
+          isERC721: false,
+          aggregators: [],
+          ...asset,
+          image: 'image',
+        },
+      ]);
+
+      generateRandomIdStub.restore();
+    });
+
     it('should fail an invalid type suggested asset via watchAsset', async () => {
       await expect(
         tokensController.watchAsset(

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -663,6 +663,7 @@ export class TokensController extends BaseController<
    * @param suggestedAssetID - The ID of the suggestedAsset to accept.
    */
   async acceptWatchAsset(suggestedAssetID: string): Promise<void> {
+    const { selectedAddress } = this.config;
     const { suggestedAssets } = this.state;
     const index = suggestedAssets.findIndex(
       ({ id }) => suggestedAssetID === id,
@@ -672,7 +673,13 @@ export class TokensController extends BaseController<
       switch (suggestedAssetMeta.type) {
         case 'ERC20':
           const { address, symbol, decimals, image } = suggestedAssetMeta.asset;
-          await this.addToken(address, symbol, decimals, image);
+          await this.addToken(
+            address,
+            symbol,
+            decimals,
+            image,
+            suggestedAssetMeta?.interactingAddress || selectedAddress,
+          );
           suggestedAssetMeta.status = SuggestedAssetStatus.accepted;
           this.hub.emit(
             `${suggestedAssetMeta.id}:finished`,

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -79,6 +79,7 @@ export type SuggestedAssetMetaBase = {
  * @property time - Timestamp associated with this this suggested asset
  * @property type - Type type this suggested asset
  * @property asset - Asset suggested object
+ * @property interactingAddress - Account address that requested watch asset
  */
 export type SuggestedAssetMeta =
   | (SuggestedAssetMetaBase & {
@@ -628,16 +629,17 @@ export class TokensController extends BaseController<
     type: string,
     interactingAddress?: string,
   ): Promise<AssetSuggestionResult> {
+    const { selectedAddress } = this.config;
+
     const suggestedAssetMeta: SuggestedAssetMeta = {
       asset,
       id: this._generateRandomId(),
       status: SuggestedAssetStatus.pending as SuggestedAssetStatus.pending,
       time: Date.now(),
       type,
+      interactingAddress: interactingAddress || selectedAddress,
     };
-    if (interactingAddress) {
-      suggestedAssetMeta.interactingAddress = interactingAddress;
-    }
+
     try {
       switch (type) {
         case 'ERC20':

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -598,16 +598,24 @@ export class TokensController extends BaseController<
    *
    * @param asset - The asset to be watched. For now only ERC20 tokens are accepted.
    * @param type - The asset type.
+   * @param interactingAddress - The address of the account that is requesting to watch the asset.
    * @returns Object containing a Promise resolving to the suggestedAsset address if accepted.
    */
-  async watchAsset(asset: Token, type: string): Promise<AssetSuggestionResult> {
-    const suggestedAssetMeta = {
+  async watchAsset(
+    asset: Token,
+    type: string,
+    interactingAddress?: string,
+  ): Promise<AssetSuggestionResult> {
+    const suggestedAssetMeta: SuggestedAssetMeta = {
       asset,
       id: this._generateRandomId(),
       status: SuggestedAssetStatus.pending as SuggestedAssetStatus.pending,
       time: Date.now(),
       type,
     };
+    if (interactingAddress) {
+      suggestedAssetMeta.interactingAddress = interactingAddress;
+    }
     try {
       switch (type) {
         case 'ERC20':

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -66,6 +66,7 @@ export type SuggestedAssetMetaBase = {
   time: number;
   type: string;
   asset: Token;
+  interactingAddress?: string;
 };
 
 /**

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -333,7 +333,7 @@ export class TokensController extends BaseController<
           newTokens,
           newIgnoredTokens,
           newDetectedTokens,
-          detectionAddress: accountAddress,
+          interactingAddress: accountAddress,
         });
 
       let newState: Partial<TokensState> = {
@@ -518,15 +518,17 @@ export class TokensController extends BaseController<
         }
       });
 
-      const { selectedAddress: detectionAddress, chainId: detectionChainId } =
-        detectionDetails || {};
+      const {
+        selectedAddress: interactingAddress,
+        chainId: interactingChainId,
+      } = detectionDetails || {};
 
       const { newAllTokens, newAllDetectedTokens } = this._getNewAllTokensState(
         {
           newTokens,
           newDetectedTokens,
-          detectionAddress,
-          detectionChainId,
+          interactingAddress,
+          interactingChainId,
         },
       );
 
@@ -751,29 +753,29 @@ export class TokensController extends BaseController<
    * @param params.newTokens - The new tokens to set for the current network and selected account.
    * @param params.newIgnoredTokens - The new ignored tokens to set for the current network and selected account.
    * @param params.newDetectedTokens - The new detected tokens to set for the current network and selected account.
-   * @param params.detectionAddress - The address on which the detected tokens to add were detected.
-   * @param params.detectionChainId - The chainId on which the detected tokens to add were detected.
+   * @param params.interactingAddress - The account address to use to store the tokens.
+   * @param params.interactingChainId - The chainId to use to store the tokens.
    * @returns The updated `allTokens` and `allIgnoredTokens` state.
    */
   _getNewAllTokensState(params: {
     newTokens?: Token[];
     newIgnoredTokens?: string[];
     newDetectedTokens?: Token[];
-    detectionAddress?: string;
-    detectionChainId?: string;
+    interactingAddress?: string;
+    interactingChainId?: string;
   }) {
     const {
       newTokens,
       newIgnoredTokens,
       newDetectedTokens,
-      detectionAddress,
-      detectionChainId,
+      interactingAddress,
+      interactingChainId,
     } = params;
     const { allTokens, allIgnoredTokens, allDetectedTokens } = this.state;
     const { chainId, selectedAddress } = this.config;
 
-    const userAddressToAddTokens = detectionAddress ?? selectedAddress;
-    const chainIdToAddTokens = detectionChainId ?? chainId;
+    const userAddressToAddTokens = interactingAddress ?? selectedAddress;
+    const chainIdToAddTokens = interactingChainId ?? chainId;
 
     let newAllTokens = allTokens;
     if (


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Support watching assets on a specific account**

The purpose of the changes to is allow a user to store a watched asset to the token states in the `TokensController`. Why is this needed? The introduction of the Permission System on mobile now allows users to interact with Dapps using accounts that are different than what is active on their wallet screen. This dynamic makes it possible for users to watch assets under the active Dapp account, which may be different than the active wallet account. As a result, we needed to enable passing of an account address to both the `watchAsset` and `addToken` method, that would allow for storing of tokens under specific account addresses. All of the listed changes below is backwards compatible and code that uses the `TokensController` will not need to change.

**Description**

- CHANGED:

  - `TokensController.watchAsset`
    - Added optional `interactingAddress: string` parameter with the definition of `The address of the account that is requesting to watch the asset.`
  - `TokensController.acceptWatchAsset`
    - Now passes an account address (`interactingAddress: string || selectedAddress: string`) into `TokensController.addToken` under the `ERC20` switch condition.
  - `TokensController.addToken`
    -  If `interactingAddress` is defined and is not equal to `selectedAddress`, this method will function the same way but will not update `tokens`, `ignoredTokens`, `detectedTokens` token states.
    - If `interactingAddress` is not defined, this method will use the `selectedAddress` and function the same way.
  - `SuggestedAssetMeta` type
    -  Added optional `interactingAddress?: string` property. This is only populated if `interactingAddress` is passed into `TokensController.watchAsset`.

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Resolves #???
