### PR TITLE
[BREAKING] TokenRatesController performance improvement

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -118,6 +118,7 @@ describe('TokenRatesController', () => {
       onTokensStateChange: sinon.stub(),
       onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
+      onPreferencesStateChange: sinon.stub(),
     });
     expect(controller.state).toStrictEqual({
       contractExchangeRates: {},
@@ -129,6 +130,7 @@ describe('TokenRatesController', () => {
       onTokensStateChange: sinon.stub(),
       onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
+      onPreferencesStateChange: sinon.stub(),
     });
     expect(controller.config).toStrictEqual({
       disabled: false,
@@ -137,6 +139,9 @@ describe('TokenRatesController', () => {
       chainId: '',
       tokens: [],
       threshold: 21600000,
+      exchangeRateNativeCurrency: '',
+      selectedAddress: '',
+      lastSelectedAddress: '',
     });
   });
 
@@ -145,6 +150,7 @@ describe('TokenRatesController', () => {
       onTokensStateChange: sinon.stub(),
       onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
+      onPreferencesStateChange: sinon.stub(),
     });
     expect(() => console.log(controller.tokens)).toThrow(
       'Property only used for setting',
@@ -160,6 +166,7 @@ describe('TokenRatesController', () => {
         onTokensStateChange: jest.fn(),
         onCurrencyRateStateChange: jest.fn(),
         onNetworkStateChange: jest.fn(),
+        onPreferencesStateChange: jest.fn(),
       },
       {
         interval,
@@ -182,6 +189,7 @@ describe('TokenRatesController', () => {
         onTokensStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
+        onPreferencesStateChange: sinon.stub(),
       },
       {
         interval: 10,
@@ -200,6 +208,7 @@ describe('TokenRatesController', () => {
         onTokensStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
+        onPreferencesStateChange: sinon.stub(),
       },
       { interval: 1337 },
     );
@@ -226,6 +235,7 @@ describe('TokenRatesController', () => {
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: (listener) =>
           messenger.subscribe('NetworkController:stateChange', listener),
+        onPreferencesStateChange: sinon.stub(),
       },
       { interval: 10, chainId: '1' },
     );
@@ -252,6 +262,7 @@ describe('TokenRatesController', () => {
         onTokensStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
+        onPreferencesStateChange: sinon.stub(),
       },
       { interval: 10 },
     );
@@ -275,11 +286,13 @@ describe('TokenRatesController', () => {
     });
     const onCurrencyRateStateChange = sinon.stub();
     const onNetworkStateChange = sinon.stub();
+    const onPreferencesStateChange = sinon.stub();
     const controller = new TokenRatesController(
       {
         onTokensStateChange,
         onCurrencyRateStateChange,
         onNetworkStateChange,
+        onPreferencesStateChange,
       },
       { interval: 10 },
     );
@@ -289,9 +302,13 @@ describe('TokenRatesController', () => {
       'updateExchangeRates',
     );
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    tokenStateChangeListener!({ tokens: [], detectedTokens: [] });
-    // FIXME: This is now being called twice
-    expect(updateExchangeRatesStub.callCount).toStrictEqual(2);
+    tokenStateChangeListener!({
+      tokens: [],
+      detectedTokens: [],
+    });
+    // FIXME: This is now being called three times when the tokens array is empty
+    // It's called two times when the token array isn't empty
+    expect(updateExchangeRatesStub.callCount).toStrictEqual(3);
   });
 
   it('should update exchange rates when native currency changes', async () => {
@@ -301,11 +318,13 @@ describe('TokenRatesController', () => {
       currencyRateStateChangeListener = listener;
     });
     const onNetworkStateChange = sinon.stub();
+    const onPreferencesStateChange = sinon.stub();
     const controller = new TokenRatesController(
       {
         onTokensStateChange,
         onCurrencyRateStateChange,
         onNetworkStateChange,
+        onPreferencesStateChange,
       },
       { interval: 10 },
     );
@@ -355,6 +374,7 @@ describe('TokenRatesController', () => {
         onTokensStateChange,
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange,
+        onPreferencesStateChange: sinon.stub(),
       },
       { interval: 10 },
     );
@@ -388,7 +408,7 @@ describe('TokenRatesController', () => {
     );
   });
 
-  it('should clear contractExchangeRates state when network is changed', async () => {
+  it('should not clear contractExchangeRates state when network is changed', async () => {
     nock(COINGECKO_API)
       .get(`${COINGECKO_ETH_PATH}`)
       .query({ contract_addresses: '0x02,0x03', vs_currencies: 'eth' })
@@ -417,6 +437,7 @@ describe('TokenRatesController', () => {
         onTokensStateChange,
         onNetworkStateChange,
         onCurrencyRateStateChange: sinon.stub(),
+        onPreferencesStateChange: sinon.stub(),
       },
       { interval: 10 },
     );
@@ -462,7 +483,10 @@ describe('TokenRatesController', () => {
       detectedTokens: [],
     });
 
-    expect(controller.state.contractExchangeRates).toStrictEqual({});
+    expect(controller.state.contractExchangeRates).toStrictEqual({
+      '0x02': 0.001,
+      '0x03': 0.002,
+    });
   });
 
   it('should update exchange rates when detected tokens are added', async () => {
@@ -489,6 +513,7 @@ describe('TokenRatesController', () => {
         onTokensStateChange,
         onNetworkStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),
+        onPreferencesStateChange: sinon.stub(),
       },
       { interval: 10, chainId: '1', nativeCurrency: 'ETH' },
     );


### PR DESCRIPTION
**PR Title**

**Description**
This PR aims to analyze and study a better way to fetch the exchange rates from the coin gecko API. It's been an issue so far because we are trying to call the endpoint too many times and the API returns 429 error (too many requests).

This will be a draft since it's yet to be worked on for a better solution, but the patch applied to the mobile contains the first commit of this PR.

We can find on this [notion document](https://www.notion.so/Controllers-Performance-Investigation-116b9f1a040145bca86ea1ef35443cd6) what was happening with the token rates controller and the mobile app


- BREAKING:
The TokenRatesController so far needed to know what was the last selected address to know if it was supposed to fetch new exchange rates, what was happening was that it was calling when the token list changed and when the selected address change, and if the chain Id changed it would be called as well, making this too many requests.

- FIXED:

  - _Describe the fix/bug addressed_

- CHANGED:

  - _Describe the change you have made to existing functionality_

- REMOVED:

  - _Describe functionality removed and why_

- ADDED:

  - _Describe functionality added and why_

- DEPRECATED:

  - _Describe what was deprecated and why_

- SECURITY:

  - _These should not be in a standard PR and addressed using the Security Advisory process_

**Checklist**

- [ ] Tests are included if applicable
- [ ] Any added code is fully documented

**Issue**

Resolves #???
