### PR TITLE
add rollbackToPreviousProvider method

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -1,5 +1,8 @@
 import HttpProvider from 'ethjs-provider-http';
-import { IPFS_DEFAULT_GATEWAY_URL } from '@metamask/controller-utils';
+import {
+  IPFS_DEFAULT_GATEWAY_URL,
+  NetworkType,
+} from '@metamask/controller-utils';
 import { PreferencesController } from '@metamask/preferences-controller';
 import {
   NetworkController,
@@ -295,7 +298,7 @@ describe('AssetsContractController', () => {
     );
     expect(balances[ERC20_DAI_ADDRESS]).not.toBeUndefined();
 
-    network.setProviderType('localhost');
+    network.setProviderType(NetworkType.localhost);
 
     const noBalances = await assetsContract.getBalancesInSingleCall(
       ERC20_DAI_ADDRESS,

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -14,6 +14,7 @@ import {
   OPENSEA_API_URL,
   ERC721,
   NetworksChainId,
+  NetworkType,
 } from '@metamask/controller-utils';
 import { Network } from '@ethersproject/providers';
 import { AssetsContractController } from './AssetsContractController';
@@ -46,8 +47,8 @@ const DEPRESSIONIST_CLOUDFLARE_IPFS_SUBDOMAIN_PATH = getFormattedIpfsUrl(
   true,
 );
 
-const SEPOLIA = { chainId: '11155111', type: 'sepolia' as const };
-const GOERLI = { chainId: '5', type: 'goerli' as const };
+const SEPOLIA = { chainId: '11155111', type: NetworkType.sepolia };
+const GOERLI = { chainId: '5', type: NetworkType.goerli };
 
 // Mock out detectNetwork function for cleaner tests, Ethers calls this a bunch of times because the Web3Provider is paranoid.
 jest.mock('@ethersproject/providers', () => {

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -14,7 +14,6 @@ import {
   toChecksumHexAddress,
   BNToHex,
   fetchWithErrorHandling,
-  MAINNET,
   IPFS_DEFAULT_GATEWAY_URL,
   ERC721,
   ERC1155,
@@ -911,7 +910,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
   ) {
     super(config, state);
     this.defaultConfig = {
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress: '',
       chainId: '',
       ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -1,14 +1,12 @@
 import * as sinon from 'sinon';
 import nock from 'nock';
 import { PreferencesController } from '@metamask/preferences-controller';
-import { OPENSEA_PROXY_URL } from '@metamask/controller-utils';
+import { OPENSEA_PROXY_URL, NetworkType } from '@metamask/controller-utils';
 import { NftController } from './NftController';
 import { AssetsContractController } from './AssetsContractController';
 import { NftDetectionController } from './NftDetectionController';
 
 const DEFAULT_INTERVAL = 180000;
-const MAINNET = 'mainnet';
-const GOERLI = 'goerli';
 
 describe('NftDetectionController', () => {
   let nftDetection: NftDetectionController;
@@ -236,9 +234,9 @@ describe('NftDetectionController', () => {
   });
 
   it('should detect mainnet correctly', () => {
-    nftDetection.configure({ networkType: MAINNET });
+    nftDetection.configure({ networkType: NetworkType.mainnet });
     expect(nftDetection.isMainnet()).toStrictEqual(true);
-    nftDetection.configure({ networkType: GOERLI });
+    nftDetection.configure({ networkType: NetworkType.goerli });
     expect(nftDetection.isMainnet()).toStrictEqual(false);
   });
 
@@ -258,7 +256,7 @@ describe('NftDetectionController', () => {
           addNft: nftController.addNft.bind(nftController),
           getNftState: () => nftController.state,
         },
-        { interval: 10, networkType: GOERLI },
+        { interval: 10, networkType: NetworkType.goerli },
       );
       expect(mockNfts.called).toBe(false);
       resolve('');
@@ -269,12 +267,12 @@ describe('NftDetectionController', () => {
     const selectedAddress = '0x1';
 
     nftDetection.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress,
     });
 
     nftController.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress,
     });
     const { chainId } = nftDetection.config;
@@ -299,7 +297,7 @@ describe('NftDetectionController', () => {
   it('should detect, add NFTs and do nor remove not detected NFTs correctly', async () => {
     const selectedAddress = '0x1';
     nftDetection.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress,
     });
     nftController.configure({ selectedAddress });
@@ -348,7 +346,7 @@ describe('NftDetectionController', () => {
   it('should not autodetect NFTs that exist in the ignoreList', async () => {
     const selectedAddress = '0x2';
     nftDetection.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress: '0x2',
     });
     nftController.configure({ selectedAddress });
@@ -375,7 +373,7 @@ describe('NftDetectionController', () => {
   it('should not detect and add NFTs if there is no selectedAddress', async () => {
     const selectedAddress = '';
     nftDetection.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress,
     });
     const { chainId } = nftDetection.config;
@@ -386,7 +384,7 @@ describe('NftDetectionController', () => {
 
   it('should not detect and add NFTs to the wrong selectedAddress', async () => {
     nftDetection.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress: '0x9',
     });
     const { chainId } = nftDetection.config;
@@ -409,7 +407,7 @@ describe('NftDetectionController', () => {
     preferences.setUseNftDetection(false);
     const selectedAddress = '0x9';
     nftDetection.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress,
     });
     const { chainId } = nftController.config;
@@ -423,7 +421,7 @@ describe('NftDetectionController', () => {
     preferences.setOpenSeaEnabled(false);
     const selectedAddress = '0x9';
     nftDetection.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress,
     });
     const { chainId } = nftController.config;
@@ -492,12 +490,12 @@ describe('NftDetectionController', () => {
     const selectedAddress = '0x1';
     nftDetection.configure({
       selectedAddress,
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
     });
 
     nftController.configure({
       selectedAddress,
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
     });
 
     const { chainId } = nftDetection.config;
@@ -660,12 +658,12 @@ describe('NftDetectionController', () => {
       });
 
     nftDetection.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress,
     });
 
     nftController.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress,
     });
 
@@ -698,12 +696,12 @@ describe('NftDetectionController', () => {
       .replyWithError(new Error('UNEXPECTED ERROR'));
 
     nftDetection.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress,
     });
 
     nftController.configure({
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress,
     });
 

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -6,7 +6,6 @@ import {
 import type { NetworkState } from '@metamask/network-controller';
 import type { PreferencesState } from '@metamask/preferences-controller';
 import {
-  MAINNET,
   OPENSEA_PROXY_URL,
   OPENSEA_API_URL,
   NetworkType,
@@ -240,7 +239,7 @@ export class NftDetectionController extends BaseController<
     super(config, state);
     this.defaultConfig = {
       interval: DEFAULT_INTERVAL,
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       chainId: '1',
       selectedAddress: '',
       disabled: true,
@@ -320,7 +319,7 @@ export class NftDetectionController extends BaseController<
    *
    * @returns Whether current network is mainnet.
    */
-  isMainnet = (): boolean => this.config.networkType === MAINNET;
+  isMainnet = (): boolean => this.config.networkType === NetworkType.mainnet;
 
   /**
    * Triggers asset ERC721 token auto detection on mainnet. Any newly detected NFTs are

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -8,11 +8,7 @@ import {
   NetworkState,
   ProviderConfig,
 } from '@metamask/network-controller';
-import {
-  NetworksChainId,
-  MAINNET,
-  NetworkType,
-} from '@metamask/controller-utils';
+import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
 import { PreferencesController } from '@metamask/preferences-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
 import { TokensController } from './TokensController';
@@ -142,7 +138,7 @@ describe('TokenDetectionController', () => {
   };
   const mainnet = {
     chainId: NetworksChainId.mainnet,
-    type: MAINNET as NetworkType,
+    type: NetworkType.mainnet,
   };
 
   beforeEach(async () => {

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -6,7 +6,7 @@ import {
   NetworkState,
   ProviderConfig,
 } from '@metamask/network-controller';
-import { NetworksChainId } from '@metamask/controller-utils';
+import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
 import {
   TokenListController,
   TokenListStateChange,
@@ -629,8 +629,8 @@ describe('TokenListController', () => {
       sampleSingleChainState.tokenList,
     );
     onNetworkStateChangeCallback({
-      chainId: '5',
-      type: 'rpc',
+      chainId: NetworksChainId.goerli,
+      type: NetworkType.goerli,
     });
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 500));
 
@@ -1020,7 +1020,7 @@ describe('TokenListController', () => {
     );
 
     controllerMessenger.publish('NetworkController:providerConfigChange', {
-      type: 'goerli',
+      type: NetworkType.goerli,
       chainId: NetworksChainId.goerli,
     });
 
@@ -1034,7 +1034,7 @@ describe('TokenListController', () => {
     );
 
     controllerMessenger.publish('NetworkController:providerConfigChange', {
-      type: 'rpc',
+      type: NetworkType.rpc,
       chainId: '56',
       rpcTarget: 'http://localhost:8545',
     });
@@ -1095,7 +1095,7 @@ describe('TokenListController', () => {
     });
     await controller.start();
     controllerMessenger.publish('NetworkController:providerConfigChange', {
-      type: 'mainnet',
+      type: NetworkType.mainnet,
       chainId: NetworksChainId.mainnet,
     });
 
@@ -1136,7 +1136,7 @@ describe('TokenListController', () => {
       });
 
       controllerMessenger.publish('NetworkController:providerConfigChange', {
-        type: 'rpc',
+        type: NetworkType.rpc,
         chainId: '56',
         rpcTarget: 'http://localhost:8545',
       });

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -2,7 +2,7 @@ import * as sinon from 'sinon';
 import nock from 'nock';
 import contractMaps from '@metamask/contract-metadata';
 import { PreferencesController } from '@metamask/preferences-controller';
-import { NetworksChainId } from '@metamask/controller-utils';
+import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
 import {
   NetworkState,
   ProviderConfig,
@@ -27,8 +27,8 @@ const stubCreateEthers = (ctrl: TokensController, res: boolean) => {
   });
 };
 
-const SEPOLIA = { chainId: '11155111', type: 'sepolia' as const };
-const GOERLI = { chainId: '5', type: 'goerli' as const };
+const SEPOLIA = { chainId: '11155111', type: NetworkType.sepolia };
+const GOERLI = { chainId: '5', type: NetworkType.goerli };
 
 describe('TokensController', () => {
   let tokensController: TokensController;

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -16,7 +16,6 @@ import type { NetworkState } from '@metamask/network-controller';
 import {
   NetworkType,
   toChecksumHexAddress,
-  MAINNET,
   ERC721_INTERFACE_ID,
 } from '@metamask/controller-utils';
 import type { Token } from './TokenRatesController';
@@ -206,7 +205,7 @@ export class TokensController extends BaseController<
     super(config, state);
 
     this.defaultConfig = {
-      networkType: MAINNET,
+      networkType: NetworkType.mainnet,
       selectedAddress: '',
       chainId: '',
       provider: undefined,

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -1,6 +1,5 @@
-import { NetworkType } from './types';
+import { NetworkType, NetworksTicker, NetworksChainId } from './types';
 
-export const MAINNET = 'mainnet';
 export const RPC = 'rpc';
 export const FALL_BACK_VS_CURRENCY = 'ETH';
 export const IPFS_DEFAULT_GATEWAY_URL = 'https://cloudflare-ipfs.com/ipfs/';
@@ -42,16 +41,43 @@ export const TESTNET_TICKER_SYMBOLS = {
   GOERLI: 'GoerliETH',
   SEPOLIA: 'SepoliaETH',
 };
-// TYPED NetworkType TICKER SYMBOLS
-export const TESTNET_NETWORK_TYPE_TO_TICKER_SYMBOL: {
-  [K in NetworkType]: string;
-} = {
-  goerli: 'GoerliETH',
-  sepolia: 'SepoliaETH',
-  mainnet: '',
-  rpc: '',
-  localhost: '',
-};
+
+/**
+ * Map of all build-in Infura networks to their network, ticker and chain IDs.
+ */
+export const BUILT_IN_NETWORKS = {
+  [NetworkType.goerli]: {
+    chainId: NetworksChainId.goerli,
+    ticker: NetworksTicker.goerli,
+    rpcPrefs: {
+      blockExplorerUrl: `https://${NetworkType.goerli}.etherscan.io`,
+    },
+  },
+  [NetworkType.sepolia]: {
+    chainId: NetworksChainId.sepolia,
+    ticker: NetworksTicker.sepolia,
+    rpcPrefs: {
+      blockExplorerUrl: `https://${NetworkType.sepolia}.etherscan.io`,
+    },
+  },
+  [NetworkType.mainnet]: {
+    chainId: NetworksChainId.mainnet,
+    ticker: NetworksTicker.mainnet,
+    rpcPrefs: {
+      blockExplorerUrl: 'https://etherscan.io',
+    },
+  },
+  [NetworkType.localhost]: {
+    chainId: NetworksChainId.localhost,
+    blockExplorerUrl: undefined,
+    rpcPrefs: undefined,
+  },
+  [NetworkType.rpc]: {
+    chainId: undefined,
+    blockExplorerUrl: undefined,
+    rpcPrefs: undefined,
+  },
+} as const;
 
 // APIs
 export const OPENSEA_PROXY_URL =

--- a/packages/controller-utils/src/types.test.ts
+++ b/packages/controller-utils/src/types.test.ts
@@ -1,0 +1,16 @@
+import { NetworkType } from '@metamask/controller-utils';
+import { isNetworkType } from './types';
+
+describe('types', () => {
+  it('isNetworkType', () => {
+    expect(isNetworkType({})).toBe(false);
+    expect(isNetworkType(1)).toBe(false);
+    expect(isNetworkType('test')).toBe(false);
+    expect(isNetworkType('mainnet')).toBe(true);
+    expect(isNetworkType(NetworkType.mainnet)).toBe(true);
+    expect(isNetworkType(NetworkType.goerli)).toBe(true);
+    expect(isNetworkType(NetworkType.sepolia)).toBe(true);
+    expect(isNetworkType(NetworkType.localhost)).toBe(true);
+    expect(isNetworkType(NetworkType.rpc)).toBe(true);
+  });
+});

--- a/packages/controller-utils/src/types.test.ts
+++ b/packages/controller-utils/src/types.test.ts
@@ -1,5 +1,4 @@
-import { NetworkType } from '@metamask/controller-utils';
-import { isNetworkType } from './types';
+import { isNetworkType, NetworkType } from './types';
 
 describe('types', () => {
   it('isNetworkType', () => {

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -1,17 +1,36 @@
 /**
  * Human-readable network name
  */
-export type NetworkType =
-  | 'localhost'
-  | 'mainnet'
-  | 'goerli'
-  | 'sepolia'
-  | 'rpc';
+export enum NetworkType {
+  localhost = 'localhost',
+  mainnet = 'mainnet',
+  goerli = 'goerli',
+  sepolia = 'sepolia',
+  rpc = 'rpc',
+}
+
+/**
+ * A helper to determine whether a given input is NetworkType.
+ *
+ * @param val - the value to check whether it is NetworkType or not.
+ * @returns boolean indicating whether or not the argument is NetworkType.
+ */
+export function isNetworkType(val: any): val is NetworkType {
+  return Object.values(NetworkType).includes(val);
+}
 
 export enum NetworksChainId {
   mainnet = '1',
   goerli = '5',
   sepolia = '11155111',
+  localhost = '',
+  rpc = '',
+}
+
+export enum NetworksTicker {
+  mainnet = 'ETH',
+  goerli = 'GoerliETH',
+  sepolia = 'SepoliaETH',
   localhost = '',
   rpc = '',
 }

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -11,7 +11,7 @@ import { MetaMaskKeyring as QRKeyring } from '@keystonehq/metamask-airgapped-key
 import { CryptoHDKey, ETHSignature } from '@keystonehq/bc-ur-registry-eth';
 import * as uuid from 'uuid';
 import { PreferencesController } from '@metamask/preferences-controller';
-import { MAINNET } from '@metamask/controller-utils';
+import { NetworkType } from '@metamask/controller-utils';
 import { keyringBuilderFactory } from '@metamask/eth-keyring-controller';
 import MockEncryptor from '../tests/mocks/mockEncryptor';
 import {
@@ -991,7 +991,7 @@ describe('KeyringController', () => {
         },
         {
           common: Common.forCustomChain(
-            MAINNET,
+            NetworkType.mainnet,
             {
               name: 'goerli',
               chainId: parseInt('5'),

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -2359,6 +2359,7 @@ describe('NetworkController', () => {
               chainId: '99999',
               ticker: 'something existing',
               nickname: 'something existing',
+              rpcPrefs: undefined,
             },
             networkConfigurations: {
               testNetworkConfigurationId: {
@@ -2366,6 +2367,7 @@ describe('NetworkController', () => {
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
+                rpcPrefs: undefined,
               },
               testNetworkConfigurationId2: {
                 rpcUrl: 'http://somethingexisting.com',
@@ -2373,6 +2375,7 @@ describe('NetworkController', () => {
                 ticker: 'something existing',
                 nickname: 'something existing',
                 id: 'testNetworkConfigurationId2',
+                rpcPrefs: undefined,
               },
             },
           },
@@ -2395,6 +2398,7 @@ describe('NetworkController', () => {
             ticker: 'TEST',
             id: 'testNetworkConfigurationId',
             nickname: undefined,
+            rpcPrefs: undefined,
           });
         },
       );
@@ -2413,6 +2417,8 @@ describe('NetworkController', () => {
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
+                nickname: undefined,
+                rpcPrefs: undefined,
               },
             },
           },
@@ -2445,6 +2451,8 @@ describe('NetworkController', () => {
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
+                nickname: undefined,
+                rpcPrefs: undefined,
               },
             },
           },
@@ -2496,6 +2504,8 @@ describe('NetworkController', () => {
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
+                nickname: undefined,
+                rpcPrefs: undefined,
               },
             },
           },
@@ -2542,6 +2552,8 @@ describe('NetworkController', () => {
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
+                nickname: undefined,
+                rpcPrefs: undefined,
               },
             },
           },
@@ -2578,6 +2590,8 @@ describe('NetworkController', () => {
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
+                nickname: undefined,
+                rpcPrefs: undefined,
               },
             },
           },
@@ -2622,6 +2636,8 @@ describe('NetworkController', () => {
                     chainId: '0xtest',
                     ticker: 'TEST',
                     id: 'testNetworkConfigurationId',
+                    nickname: undefined,
+                    rpcPrefs: undefined,
                   },
                 },
               },
@@ -2685,6 +2701,8 @@ describe('NetworkController', () => {
                     chainId: '0xtest',
                     ticker: 'TEST',
                     id: 'testNetworkConfigurationId',
+                    nickname: undefined,
+                    rpcPrefs: undefined,
                   },
                 },
               },
@@ -3767,6 +3785,8 @@ describe('NetworkController', () => {
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
+                nickname: undefined,
+                rpcPrefs: undefined,
               },
             },
           },
@@ -4044,6 +4064,8 @@ describe('NetworkController', () => {
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
+                nickname: undefined,
+                rpcPrefs: undefined,
               },
             },
           },
@@ -4078,6 +4100,8 @@ describe('NetworkController', () => {
               chainId: '0xtest',
               ticker: 'TEST',
               id: 'testNetworkConfigurationId',
+              nickname: undefined,
+              rpcPrefs: undefined,
             },
             networkConfigurations: {
               testNetworkConfigurationId: {
@@ -4085,6 +4109,8 @@ describe('NetworkController', () => {
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
+                nickname: undefined,
+                rpcPrefs: undefined,
               },
             },
           },
@@ -4111,6 +4137,7 @@ describe('NetworkController', () => {
             ticker: 'test_ticker',
             id: 'networkConfigurationId',
             nickname: undefined,
+            rpcPrefs: undefined,
           });
         },
       );
@@ -4128,6 +4155,8 @@ describe('NetworkController', () => {
               chainId: '0xtest',
               ticker: 'TEST',
               id: 'testNetworkConfigurationId',
+              nickname: undefined,
+              rpcPrefs: undefined,
             },
             networkConfigurations: {
               testNetworkConfigurationId: {
@@ -4135,6 +4164,8 @@ describe('NetworkController', () => {
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
+                nickname: undefined,
+                rpcPrefs: undefined,
               },
             },
           },
@@ -4162,6 +4193,8 @@ describe('NetworkController', () => {
               chainId: '0xtest',
               ticker: 'TEST',
               id: 'testNetworkConfigurationId',
+              nickname: undefined,
+              rpcPrefs: undefined,
             },
             {
               ...newNetworkConfiguration,
@@ -4251,7 +4284,7 @@ describe('NetworkController', () => {
         nickname: 'Mainnet',
         networkType: NetworkType.mainnet,
         chainId: NetworksChainId.mainnet,
-        ticker: 'ETH',
+        ticker: NetworksTicker.mainnet,
         blockExplorerUrl: `https://etherscan.io`,
         networkVersion: '1',
       },
@@ -4260,7 +4293,7 @@ describe('NetworkController', () => {
         nickname: 'Goerli',
         networkType: NetworkType.goerli,
         chainId: NetworksChainId.goerli,
-        ticker: 'GoerliETH',
+        ticker: NetworksTicker.goerli,
         blockExplorerUrl: `https://goerli.etherscan.io`,
         networkVersion: '5',
       },
@@ -4268,7 +4301,7 @@ describe('NetworkController', () => {
         nickname: 'Sepolia',
         networkType: NetworkType.sepolia,
         chainId: NetworksChainId.sepolia,
-        ticker: 'SepoliaETH',
+        ticker: NetworksTicker.sepolia,
         blockExplorerUrl: `https://sepolia.etherscan.io`,
         networkVersion: '11155111',
       },
@@ -4288,8 +4321,8 @@ describe('NetworkController', () => {
       describe(`if the previous provider configuration had a type of "${chainName}"`, () => {
         it('overwrites the the current provider configuration with the previous provider configuration', async () => {
           const messenger = buildMessenger();
+          const rpcUrlOrTarget = 'https://mock-rpc-url-1';
           const customNetworkConfiguration = {
-            rpcUrl: 'https://mock-rpc-url-1',
             chainId: '0xtest',
             nickname: 'test-chain',
             ticker: 'TEST',
@@ -4316,7 +4349,10 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: initialProviderConfig,
                 networkConfigurations: {
-                  testNetworkConfigurationId: customNetworkConfiguration,
+                  testNetworkConfigurationId: {
+                    ...customNetworkConfiguration,
+                    rpcUrl: rpcUrlOrTarget,
+                  },
                 },
               },
             },
@@ -4326,6 +4362,7 @@ describe('NetworkController', () => {
               controller.setActiveNetwork('testNetworkConfigurationId');
               expect(controller.state.providerConfig).toStrictEqual({
                 ...customNetworkConfiguration,
+                rpcTarget: rpcUrlOrTarget,
                 type: NetworkType.rpc,
               });
               controller.rollbackToPreviousProvider();
@@ -4338,13 +4375,6 @@ describe('NetworkController', () => {
 
         it('emits NetworkController:providerConfigChange via the messenger', async () => {
           const messenger = buildMessenger();
-          const networkConfiguration = {
-            rpcUrl: 'https://mock-rpc-url',
-            chainId: '0xtest',
-            ticker: 'TEST',
-            nickname: undefined,
-            id: 'testNetworkConfigurationId',
-          };
 
           const initialProviderConfig = {
             ...buildProviderConfig({
@@ -4359,7 +4389,13 @@ describe('NetworkController', () => {
               messenger,
               state: {
                 networkConfigurations: {
-                  testNetworkConfigurationId: networkConfiguration,
+                  testNetworkConfigurationId: {
+                    chainId: '0xtest',
+                    ticker: 'TEST',
+                    nickname: undefined,
+                    id: 'testNetworkConfigurationId',
+                    rpcUrl: 'https://mock-rpc-url',
+                  },
                 },
                 providerConfig: initialProviderConfig,
               },
@@ -4387,7 +4423,7 @@ describe('NetworkController', () => {
                     rpcPrefs: { blockExplorerUrl },
                     id: undefined,
                     nickname: undefined,
-                    rpcUrl: undefined,
+                    rpcTarget: undefined,
                   },
                 ],
               ]);
@@ -4482,8 +4518,9 @@ describe('NetworkController', () => {
             rpcUrl: 'https://mock-rpc-url',
             chainId: '0xtest',
             ticker: 'TEST',
-            nickname: undefined,
             id: 'testNetworkConfigurationId',
+            nickname: undefined,
+            rpcPrefs: undefined,
           };
 
           const initialProviderConfig = {
@@ -4676,8 +4713,8 @@ describe('NetworkController', () => {
     describe(`if the previous provider configuration had a type of "rpc"`, () => {
       it('should overwrite the current provider with the previous provider when current provider has type "mainnet" and previous provider has type "rpc"', async () => {
         const messenger = buildMessenger();
+        const rpcUrlOrTarget = 'https://mock-rpc-url';
         const networkConfiguration = {
-          rpcUrl: 'https://mock-rpc-url',
           chainId: '0xtest',
           ticker: 'TEST',
           id: 'testNetworkConfigurationId',
@@ -4696,7 +4733,10 @@ describe('NetworkController', () => {
             messenger,
             state: {
               networkConfigurations: {
-                testNetworkConfigurationId: networkConfiguration,
+                testNetworkConfigurationId: {
+                  ...networkConfiguration,
+                  rpcUrl: rpcUrlOrTarget,
+                },
               },
               providerConfig: initialProviderConfig,
             },
@@ -4709,12 +4749,13 @@ describe('NetworkController', () => {
               type: NetworkType.mainnet,
               ...BUILT_IN_NETWORKS.mainnet,
               nickname: undefined,
-              rpcUrl: undefined,
+              rpcTarget: undefined,
               id: undefined,
             });
             controller.rollbackToPreviousProvider();
             expect(controller.state.providerConfig).toStrictEqual({
               ...networkConfiguration,
+              rpcTarget: rpcUrlOrTarget,
               type: NetworkType.rpc,
             });
           },
@@ -4723,8 +4764,9 @@ describe('NetworkController', () => {
 
       it('should overwrite the current provider with the previous provider when current provider has type "rpc" and previous provider has type "rpc"', async () => {
         const messenger = buildMessenger();
+        const rpcUrlOrTarget1 = 'https://mock-rpc-url';
+        const rpcUrlOrTarget2 = 'https://mock-rpc-url-2';
         const networkConfiguration1 = {
-          rpcUrl: 'https://mock-rpc-url',
           chainId: '0xtest',
           ticker: 'TEST',
           id: 'testNetworkConfigurationId',
@@ -4733,7 +4775,6 @@ describe('NetworkController', () => {
         };
 
         const networkConfiguration2 = {
-          rpcUrl: 'https://mock-rpc-url-2',
           chainId: '0xtest2',
           ticker: 'TEST2',
           id: 'testNetworkConfigurationId2',
@@ -4752,8 +4793,14 @@ describe('NetworkController', () => {
             messenger,
             state: {
               networkConfigurations: {
-                testNetworkConfigurationId: networkConfiguration1,
-                testNetworkConfigurationId2: networkConfiguration2,
+                testNetworkConfigurationId: {
+                  ...networkConfiguration1,
+                  rpcUrl: rpcUrlOrTarget1,
+                },
+                testNetworkConfigurationId2: {
+                  ...networkConfiguration2,
+                  rpcUrl: rpcUrlOrTarget2,
+                },
               },
               providerConfig: initialProviderConfig,
             },
@@ -4764,20 +4811,22 @@ describe('NetworkController', () => {
             controller.setActiveNetwork('testNetworkConfigurationId2');
             expect(controller.state.providerConfig).toStrictEqual({
               ...networkConfiguration2,
+              rpcTarget: rpcUrlOrTarget2,
               type: NetworkType.rpc,
             });
             controller.rollbackToPreviousProvider();
-            expect(controller.state.providerConfig).toStrictEqual(
-              initialProviderConfig,
-            );
+            expect(controller.state.providerConfig).toStrictEqual({
+              ...initialProviderConfig,
+              rpcTarget: rpcUrlOrTarget1,
+            });
           },
         );
       });
 
       it('emits NetworkController:providerConfigChange via the messenger', async () => {
         const messenger = buildMessenger();
+        const rpcUrlOrTarget = 'https://mock-rpc-url-2';
         const initialProviderConfigNetworkConfiguration = {
-          rpcUrl: 'https://mock-rpc-url-2',
           chainId: '0x1337',
           ticker: 'TEST2',
           id: 'testNetworkConfigurationId2',
@@ -4802,8 +4851,10 @@ describe('NetworkController', () => {
                   ticker: 'TEST',
                   id: 'testNetworkConfigurationId1',
                 },
-                testNetworkConfigurationId2:
-                  initialProviderConfigNetworkConfiguration,
+                testNetworkConfigurationId2: {
+                  ...initialProviderConfigNetworkConfiguration,
+                  rpcUrl: rpcUrlOrTarget,
+                },
               },
             },
           },
@@ -4821,7 +4872,7 @@ describe('NetworkController', () => {
               },
             );
             expect(promiseForProviderConfigChange).toStrictEqual([
-              [initialProviderConfig],
+              [{ ...initialProviderConfig, rpcTarget: rpcUrlOrTarget }],
             ]);
           },
         );
@@ -5139,13 +5190,13 @@ describe('NetworkController', () => {
 
     it('should overwrite the current provider with the previous provider when current provider has type "rpc" and previous provider has type "mainnet"', async () => {
       const networkConfiguration = {
-        rpcUrl: 'https://mock-rpc-url',
         chainId: '0xtest',
         ticker: 'TEST',
         id: 'testNetworkConfigurationId',
         nickname: undefined,
         rpcPrefs: undefined,
       };
+      const rpcUrlOrTarget = 'https://mock-rpc-url';
 
       const initialProviderConfig = {
         ...buildProviderConfig({
@@ -5159,7 +5210,10 @@ describe('NetworkController', () => {
           messenger,
           state: {
             networkConfigurations: {
-              testNetworkConfigurationId: networkConfiguration,
+              testNetworkConfigurationId: {
+                ...networkConfiguration,
+                rpcUrl: rpcUrlOrTarget,
+              },
             },
             providerConfig: initialProviderConfig,
           },
@@ -5170,9 +5224,11 @@ describe('NetworkController', () => {
           controller.setActiveNetwork('testNetworkConfigurationId');
           expect(controller.state.providerConfig).toStrictEqual({
             ...networkConfiguration,
+            rpcTarget: rpcUrlOrTarget,
             type: NetworkType.rpc,
           });
           controller.rollbackToPreviousProvider();
+
           expect(controller.state.providerConfig).toStrictEqual(
             initialProviderConfig,
           );
@@ -5290,7 +5346,7 @@ function buildProviderConfig(config: Partial<ProviderConfig> = {}) {
     chainId: '1337',
     id: undefined,
     nickname: undefined,
-    rpcUrl: undefined,
+    rpcTarget: undefined,
     ...config,
   };
 }

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -10,7 +10,11 @@ import type { ProviderEngine } from 'web3-provider-engine';
 import createMetamaskProvider from 'web3-provider-engine/zero';
 import { Patch } from 'immer';
 import { v4 } from 'uuid';
-import { NetworkType } from '@metamask/controller-utils';
+import {
+  NetworkType,
+  NetworksChainId,
+  NetworksTicker,
+} from '@metamask/controller-utils';
 import { waitForResult } from '../../../tests/helpers';
 import {
   NetworkController,
@@ -22,6 +26,7 @@ import {
   NetworkState,
   ProviderConfig,
 } from '../src/NetworkController';
+import { BUILT_IN_NETWORKS } from '../../controller-utils/src/constants';
 import { FakeProviderEngine, FakeProviderStub } from './fake-provider-engine';
 
 jest.mock('eth-query', () => {
@@ -49,6 +54,51 @@ const originalSetTimeout = global.setTimeout;
 const SubproviderMock = mocked(Subprovider);
 const createInfuraProviderMock = mocked(createInfuraProvider);
 const createMetamaskProviderMock = mocked(createMetamaskProvider);
+
+/**
+ * A dummy block that matches the pre-EIP-1559 format (i.e. it doesn't have the
+ * `baseFeePerGas` property).
+ */
+const PRE_1559_BLOCK = {
+  difficulty: '0x0',
+  extraData: '0x',
+  gasLimit: '0x1c9c380',
+  gasUsed: '0x598c9b',
+  hash: '0xfb2086eb924ffce4061f94c3b65f303e0351f8e7deff185fe1f5e9001ff96f63',
+  logsBloom:
+    '0x7034820113921800018e8070900006316040002225c04a0624110010841018a2109040401004112a4c120f00220a2119020000714b143a04004106120130a8450080433129401068ed22000a54a48221a1020202524204045421b883882530009a1800b08a1309408008828403010d530440001a40003c0006240291008c0404c211610c690b00f1985e000009c02503240040010989c01cf2806840043815498e90012103e06084051542c0094002494008044c24a0a13281e0009601481073010800130402464202212202a8088210442a8ec81b080430075629e60a00a082005a3988400940a4009012a204011a0018a00903222a60420428888144210802',
+  miner: '0xffee087852cb4898e6c3532e776e68bc68b1143b',
+  mixHash: '0xb17ba50cd7261e77a213fb75704dcfd8a28fbcd78d100691a112b7cc2893efa2',
+  nonce: '0x0000000000000000',
+  number: '0x2', // number set to "2" to simplify tests
+  parentHash:
+    '0x31406d1bf1a2ca12371ce5b3ecb20568d6a8b9bf05b49b71b93ba33f317d5a82',
+  receiptsRoot:
+    '0x5ba97ece1afbac2a8fe0344f9022fe808342179b26ea3ecc2e0b8c4b46b7f8cd',
+  sha3Uncles:
+    '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',
+  size: '0x70f4',
+  stateRoot:
+    '0x36bfb7ca106d41c4458292669126e091011031c5af612dee1c2e6424ef92b080',
+  timestamp: '0x639b6d9b',
+  totalDifficulty: '0xc70d815d562d3cfa955',
+  transactions: [
+    // reduced to a single transaction to make fixture less verbose
+    '0x2761e939dc822f64141bd00bc7ef8cee16201af10e862469212396664cee81ce',
+  ],
+  transactionsRoot:
+    '0x98bbdfbe1074bc3aa72a77a281f16d6ba7e723d68f15937d80954fb34d323369',
+  uncles: [],
+};
+
+/**
+ * A dummy block that matches the pre-EIP-1559 format (i.e. it has the
+ * `baseFeePerGas` property).
+ */
+const POST_1559_BLOCK = {
+  ...PRE_1559_BLOCK,
+  baseFeePerGas: '0x63c498a46',
+};
 
 //                                                                                     setProviderType            setActiveNetwork
 //                                                                                            └───────────┬────────────┘
@@ -86,7 +136,7 @@ describe('NetworkController', () => {
           networkConfigurations: {},
           network: 'loading',
           isCustomNetwork: false,
-          providerConfig: { type: 'mainnet' as const, chainId: '1' },
+          providerConfig: { type: NetworkType.mainnet, chainId: '1' },
           networkDetails: { isEIP1559Compatible: false },
         });
       });
@@ -105,7 +155,7 @@ describe('NetworkController', () => {
             networkConfigurations: {},
             network: 'loading',
             isCustomNetwork: true,
-            providerConfig: { type: 'mainnet', chainId: '1' },
+            providerConfig: { type: NetworkType.mainnet, chainId: '1' },
             networkDetails: { isEIP1559Compatible: true },
           });
         },
@@ -184,259 +234,263 @@ describe('NetworkController', () => {
         });
       });
 
-      (['mainnet', 'goerli', 'sepolia'] as const).forEach((networkType) => {
-        describe(`when the provider config in state contains a network type of "${networkType}"`, () => {
-          it(`sets the provider to an Infura provider pointed to ${networkType}`, async () => {
-            await withController(
-              {
-                state: {
-                  providerConfig: buildProviderConfig({
-                    type: networkType,
-                  }),
+      [NetworkType.mainnet, NetworkType.goerli, NetworkType.sepolia].forEach(
+        (networkType) => {
+          describe(`when the provider config in state contains a network type of "${networkType}"`, () => {
+            it(`sets the provider to an Infura provider pointed to ${networkType}`, async () => {
+              await withController(
+                {
+                  state: {
+                    providerConfig: buildProviderConfig({
+                      type: networkType,
+                    }),
+                  },
+                  infuraProjectId: 'infura-project-id',
                 },
-                infuraProjectId: 'infura-project-id',
-              },
-              async ({ controller }) => {
-                const fakeInfuraProvider = buildFakeInfuraProvider();
-                createInfuraProviderMock.mockReturnValue(fakeInfuraProvider);
-                const fakeInfuraSubprovider = buildFakeInfuraSubprovider();
-                SubproviderMock.mockReturnValue(fakeInfuraSubprovider);
-                const fakeMetamaskProvider = buildFakeMetamaskProvider([
-                  {
-                    request: {
-                      method: 'eth_chainId',
+                async ({ controller }) => {
+                  const fakeInfuraProvider = buildFakeInfuraProvider();
+                  createInfuraProviderMock.mockReturnValue(fakeInfuraProvider);
+                  const fakeInfuraSubprovider = buildFakeInfuraSubprovider();
+                  SubproviderMock.mockReturnValue(fakeInfuraSubprovider);
+                  const fakeMetamaskProvider = buildFakeMetamaskProvider([
+                    {
+                      request: {
+                        method: 'eth_chainId',
+                      },
+                      response: {
+                        result: '0x1337',
+                      },
                     },
-                    response: {
-                      result: '0x1337',
+                  ]);
+                  createMetamaskProviderMock.mockReturnValue(
+                    fakeMetamaskProvider,
+                  );
+
+                  controller.providerConfig = {
+                    // NOTE: Neither the type nor chainId needs to match the
+                    // values in state, or match each other
+                    type: NetworkType.mainnet,
+                    chainId: '99999',
+                    nickname: 'some nickname',
+                  };
+
+                  expect(createInfuraProviderMock).toHaveBeenCalledWith({
+                    network: networkType,
+                    projectId: 'infura-project-id',
+                  });
+                  expect(createMetamaskProviderMock).toHaveBeenCalledWith({
+                    type: NetworkType.mainnet,
+                    chainId: '99999',
+                    nickname: 'some nickname',
+                    dataSubprovider: fakeInfuraSubprovider,
+                    engineParams: {
+                      blockTrackerProvider: fakeInfuraProvider,
+                      pollingInterval: 12000,
                     },
-                  },
-                ]);
-                createMetamaskProviderMock.mockReturnValue(
-                  fakeMetamaskProvider,
-                );
-
-                controller.providerConfig = {
-                  // NOTE: Neither the type nor chainId needs to match the
-                  // values in state, or match each other
-                  type: 'mainnet',
-                  chainId: '99999',
-                  nickname: 'some nickname',
-                };
-
-                expect(createInfuraProviderMock).toHaveBeenCalledWith({
-                  network: networkType,
-                  projectId: 'infura-project-id',
-                });
-                expect(createMetamaskProviderMock).toHaveBeenCalledWith({
-                  type: 'mainnet',
-                  chainId: '99999',
-                  nickname: 'some nickname',
-                  dataSubprovider: fakeInfuraSubprovider,
-                  engineParams: {
-                    blockTrackerProvider: fakeInfuraProvider,
-                    pollingInterval: 12000,
-                  },
-                });
-                const { provider } = controller.getProviderAndBlockTracker();
-                assert(provider, 'Provider is not set');
-                const promisifiedSendAsync = promisify(provider.sendAsync).bind(
-                  provider,
-                );
-                const chainIdResult = await promisifiedSendAsync({
-                  id: 1,
-                  jsonrpc: '2.0',
-                  method: 'eth_chainId',
-                });
-                expect(chainIdResult.result).toBe('0x1337');
-              },
-            );
-          });
-
-          it('ensures that the existing provider is stopped while replacing it', async () => {
-            await withController(
-              {
-                state: {
-                  providerConfig: buildProviderConfig({
-                    type: networkType,
-                  }),
+                  });
+                  const { provider } = controller.getProviderAndBlockTracker();
+                  assert(provider, 'Provider is not set');
+                  const promisifiedSendAsync = promisify(
+                    provider.sendAsync,
+                  ).bind(provider);
+                  const chainIdResult = await promisifiedSendAsync({
+                    id: 1,
+                    jsonrpc: '2.0',
+                    method: 'eth_chainId',
+                  });
+                  expect(chainIdResult.result).toBe('0x1337');
                 },
-                infuraProjectId: 'infura-project-id',
-              },
-              ({ controller }) => {
-                const fakeInfuraProvider = buildFakeInfuraProvider();
-                createInfuraProviderMock.mockReturnValue(fakeInfuraProvider);
-                const fakeInfuraSubprovider = buildFakeInfuraSubprovider();
-                SubproviderMock.mockReturnValue(fakeInfuraSubprovider);
-                const fakeMetamaskProviders = [
-                  buildFakeMetamaskProvider(),
-                  buildFakeMetamaskProvider(),
-                ];
-                jest.spyOn(fakeMetamaskProviders[0], 'stop');
-                createMetamaskProviderMock
-                  .mockImplementationOnce(() => fakeMetamaskProviders[0])
-                  .mockImplementationOnce(() => fakeMetamaskProviders[1]);
-
-                controller.providerConfig = buildProviderConfig();
-                controller.providerConfig = buildProviderConfig();
-                assert(controller.getProviderAndBlockTracker().provider);
-                jest.runAllTimers();
-
-                expect(fakeMetamaskProviders[0].stop).toHaveBeenCalled();
-              },
-            );
-          });
-
-          describe('when an "error" event occurs on the new provider', () => {
-            describe('if the network version could not be retrieved while providerConfig was being set', () => {
-              it('retrieves the network version twice more (due to the "error" event being listened to twice) and, assuming success, persists it to state', async () => {
-                const messenger = buildMessenger();
-                await withController(
-                  {
-                    messenger,
-                    state: {
-                      providerConfig: buildProviderConfig({
-                        type: networkType,
-                      }),
-                    },
-                    infuraProjectId: 'infura-project-id',
-                  },
-                  async ({ controller }) => {
-                    const fakeInfuraProvider = buildFakeInfuraProvider();
-                    createInfuraProviderMock.mockReturnValue(
-                      fakeInfuraProvider,
-                    );
-                    const fakeInfuraSubprovider = buildFakeInfuraSubprovider();
-                    SubproviderMock.mockReturnValue(fakeInfuraSubprovider);
-                    const fakeMetamaskProvider = buildFakeMetamaskProvider([
-                      {
-                        request: {
-                          method: 'net_version',
-                        },
-                        response: {
-                          error: 'oops',
-                        },
-                      },
-                      {
-                        request: {
-                          method: 'net_version',
-                        },
-                        response: {
-                          result: '1',
-                        },
-                      },
-                      {
-                        request: {
-                          method: 'net_version',
-                        },
-                        response: {
-                          result: '2',
-                        },
-                      },
-                    ]);
-                    createMetamaskProviderMock.mockReturnValue(
-                      fakeMetamaskProvider,
-                    );
-
-                    await waitForPublishedEvents(
-                      messenger,
-                      'NetworkController:providerConfigChange',
-                      {
-                        produceEvents: () => {
-                          controller.providerConfig = buildProviderConfig();
-                          assert(
-                            controller.getProviderAndBlockTracker().provider,
-                          );
-                        },
-                      },
-                    );
-
-                    await waitForStateChanges(messenger, {
-                      propertyPath: ['network'],
-                      count: 2,
-                      produceStateChanges: () => {
-                        controller
-                          .getProviderAndBlockTracker()
-                          .provider.emit('error', { some: 'error' });
-                      },
-                    });
-                    expect(controller.state.network).toBe('2');
-                  },
-                );
-              });
+              );
             });
 
-            describe('if the network version could be retrieved while providerConfig was being set', () => {
-              it('does not retrieve the network version again', async () => {
-                const messenger = buildMessenger();
-                await withController(
-                  {
-                    messenger,
-                    state: {
-                      providerConfig: buildProviderConfig({
-                        type: networkType,
-                      }),
-                    },
-                    infuraProjectId: 'infura-project-id',
+            it('ensures that the existing provider is stopped while replacing it', async () => {
+              await withController(
+                {
+                  state: {
+                    providerConfig: buildProviderConfig({
+                      type: networkType,
+                    }),
                   },
-                  async ({ controller }) => {
-                    const fakeInfuraProvider = buildFakeInfuraProvider();
-                    createInfuraProviderMock.mockReturnValue(
-                      fakeInfuraProvider,
-                    );
-                    const fakeInfuraSubprovider = buildFakeInfuraSubprovider();
-                    SubproviderMock.mockReturnValue(fakeInfuraSubprovider);
-                    const fakeMetamaskProvider = buildFakeMetamaskProvider([
-                      {
-                        request: {
-                          method: 'net_version',
-                        },
-                        response: {
-                          result: '1',
-                        },
-                      },
-                      {
-                        request: {
-                          method: 'net_version',
-                        },
-                        response: {
-                          result: '2',
-                        },
-                      },
-                    ]);
-                    createMetamaskProviderMock.mockReturnValue(
-                      fakeMetamaskProvider,
-                    );
+                  infuraProjectId: 'infura-project-id',
+                },
+                ({ controller }) => {
+                  const fakeInfuraProvider = buildFakeInfuraProvider();
+                  createInfuraProviderMock.mockReturnValue(fakeInfuraProvider);
+                  const fakeInfuraSubprovider = buildFakeInfuraSubprovider();
+                  SubproviderMock.mockReturnValue(fakeInfuraSubprovider);
+                  const fakeMetamaskProviders = [
+                    buildFakeMetamaskProvider(),
+                    buildFakeMetamaskProvider(),
+                  ];
+                  jest.spyOn(fakeMetamaskProviders[0], 'stop');
+                  createMetamaskProviderMock
+                    .mockImplementationOnce(() => fakeMetamaskProviders[0])
+                    .mockImplementationOnce(() => fakeMetamaskProviders[1]);
 
-                    await waitForPublishedEvents(
+                  controller.providerConfig = buildProviderConfig();
+                  controller.providerConfig = buildProviderConfig();
+                  assert(controller.getProviderAndBlockTracker().provider);
+                  jest.runAllTimers();
+
+                  expect(fakeMetamaskProviders[0].stop).toHaveBeenCalled();
+                },
+              );
+            });
+
+            describe('when an "error" event occurs on the new provider', () => {
+              describe('if the network version could not be retrieved while providerConfig was being set', () => {
+                it('retrieves the network version twice more (due to the "error" event being listened to twice) and, assuming success, persists it to state', async () => {
+                  const messenger = buildMessenger();
+                  await withController(
+                    {
                       messenger,
-                      'NetworkController:providerConfigChange',
-                      {
-                        produceEvents: () => {
-                          controller.providerConfig = buildProviderConfig();
-                          assert(
-                            controller.getProviderAndBlockTracker().provider,
-                          );
+                      state: {
+                        providerConfig: buildProviderConfig({
+                          type: networkType,
+                        }),
+                      },
+                      infuraProjectId: 'infura-project-id',
+                    },
+                    async ({ controller }) => {
+                      const fakeInfuraProvider = buildFakeInfuraProvider();
+                      createInfuraProviderMock.mockReturnValue(
+                        fakeInfuraProvider,
+                      );
+                      const fakeInfuraSubprovider =
+                        buildFakeInfuraSubprovider();
+                      SubproviderMock.mockReturnValue(fakeInfuraSubprovider);
+                      const fakeMetamaskProvider = buildFakeMetamaskProvider([
+                        {
+                          request: {
+                            method: 'net_version',
+                          },
+                          response: {
+                            error: 'oops',
+                          },
                         },
-                      },
-                    );
+                        {
+                          request: {
+                            method: 'net_version',
+                          },
+                          response: {
+                            result: '1',
+                          },
+                        },
+                        {
+                          request: {
+                            method: 'net_version',
+                          },
+                          response: {
+                            result: '2',
+                          },
+                        },
+                      ]);
+                      createMetamaskProviderMock.mockReturnValue(
+                        fakeMetamaskProvider,
+                      );
 
-                    await waitForStateChanges(messenger, {
-                      propertyPath: ['network'],
-                      count: 0,
-                      produceStateChanges: () => {
-                        controller
-                          .getProviderAndBlockTracker()
-                          .provider.emit('error', { some: 'error' });
+                      await waitForPublishedEvents(
+                        messenger,
+                        'NetworkController:providerConfigChange',
+                        {
+                          produceEvents: () => {
+                            controller.providerConfig = buildProviderConfig();
+                            assert(
+                              controller.getProviderAndBlockTracker().provider,
+                            );
+                          },
+                        },
+                      );
+
+                      await waitForStateChanges(messenger, {
+                        propertyPath: ['network'],
+                        count: 2,
+                        produceStateChanges: () => {
+                          controller
+                            .getProviderAndBlockTracker()
+                            .provider.emit('error', { some: 'error' });
+                        },
+                      });
+                      expect(controller.state.network).toBe('2');
+                    },
+                  );
+                });
+              });
+
+              describe('if the network version could be retrieved while providerConfig was being set', () => {
+                it('does not retrieve the network version again', async () => {
+                  const messenger = buildMessenger();
+                  await withController(
+                    {
+                      messenger,
+                      state: {
+                        providerConfig: buildProviderConfig({
+                          type: networkType,
+                        }),
                       },
-                    });
-                    expect(controller.state.network).toBe('1');
-                  },
-                );
+                      infuraProjectId: 'infura-project-id',
+                    },
+                    async ({ controller }) => {
+                      const fakeInfuraProvider = buildFakeInfuraProvider();
+                      createInfuraProviderMock.mockReturnValue(
+                        fakeInfuraProvider,
+                      );
+                      const fakeInfuraSubprovider =
+                        buildFakeInfuraSubprovider();
+                      SubproviderMock.mockReturnValue(fakeInfuraSubprovider);
+                      const fakeMetamaskProvider = buildFakeMetamaskProvider([
+                        {
+                          request: {
+                            method: 'net_version',
+                          },
+                          response: {
+                            result: '1',
+                          },
+                        },
+                        {
+                          request: {
+                            method: 'net_version',
+                          },
+                          response: {
+                            result: '2',
+                          },
+                        },
+                      ]);
+                      createMetamaskProviderMock.mockReturnValue(
+                        fakeMetamaskProvider,
+                      );
+
+                      await waitForPublishedEvents(
+                        messenger,
+                        'NetworkController:providerConfigChange',
+                        {
+                          produceEvents: () => {
+                            controller.providerConfig = buildProviderConfig();
+                            assert(
+                              controller.getProviderAndBlockTracker().provider,
+                            );
+                          },
+                        },
+                      );
+
+                      await waitForStateChanges(messenger, {
+                        propertyPath: ['network'],
+                        count: 0,
+                        produceStateChanges: () => {
+                          controller
+                            .getProviderAndBlockTracker()
+                            .provider.emit('error', { some: 'error' });
+                        },
+                      });
+                      expect(controller.state.network).toBe('1');
+                    },
+                  );
+                });
               });
             });
           });
-        });
-      });
+        },
+      );
 
       describe(`when the provider config in state contains a network type of "localhost"`, () => {
         it('sets the provider to a custom RPC provider pointed to localhost, initialized with the configured chain ID, nickname, and ticker', async () => {
@@ -444,7 +498,7 @@ describe('NetworkController', () => {
             {
               state: {
                 providerConfig: buildProviderConfig({
-                  type: 'localhost',
+                  type: NetworkType.localhost,
                   chainId: '66666',
                   nickname: "doesn't matter",
                   rpcTarget: 'http://doesntmatter.com',
@@ -467,11 +521,11 @@ describe('NetworkController', () => {
 
               controller.providerConfig = buildProviderConfig({
                 // NOTE: The type does not need to match the type in state
-                type: 'mainnet',
+                type: NetworkType.mainnet,
               });
 
               expect(createMetamaskProviderMock).toHaveBeenCalledWith({
-                type: 'mainnet',
+                type: NetworkType.mainnet,
                 chainId: undefined,
                 engineParams: { pollingInterval: 12000 },
                 nickname: undefined,
@@ -495,7 +549,7 @@ describe('NetworkController', () => {
             {
               state: {
                 providerConfig: buildProviderConfig({
-                  type: 'localhost',
+                  type: NetworkType.localhost,
                 }),
               },
             },
@@ -528,7 +582,7 @@ describe('NetworkController', () => {
                   messenger,
                   state: {
                     providerConfig: buildProviderConfig({
-                      type: 'localhost',
+                      type: NetworkType.localhost,
                     }),
                   },
                 },
@@ -599,7 +653,7 @@ describe('NetworkController', () => {
                   messenger,
                   state: {
                     providerConfig: buildProviderConfig({
-                      type: 'localhost',
+                      type: NetworkType.localhost,
                     }),
                   },
                 },
@@ -663,7 +717,7 @@ describe('NetworkController', () => {
               {
                 state: {
                   providerConfig: {
-                    type: 'rpc',
+                    type: NetworkType.rpc,
                     chainId: '123',
                     nickname: 'some cool network',
                     rpcTarget: 'http://example.com',
@@ -688,11 +742,11 @@ describe('NetworkController', () => {
 
                 controller.providerConfig = buildProviderConfig({
                   // NOTE: The type does not need to match the type in state
-                  type: 'mainnet',
+                  type: NetworkType.mainnet,
                 });
 
                 expect(createMetamaskProviderMock).toHaveBeenCalledWith({
-                  type: 'mainnet',
+                  type: NetworkType.mainnet,
                   chainId: '123',
                   engineParams: { pollingInterval: 12000 },
                   nickname: 'some cool network',
@@ -716,7 +770,7 @@ describe('NetworkController', () => {
               {
                 state: {
                   providerConfig: buildProviderConfig({
-                    type: 'rpc',
+                    type: NetworkType.rpc,
                     rpcTarget: 'http://example.com',
                   }),
                 },
@@ -750,7 +804,7 @@ describe('NetworkController', () => {
                     messenger,
                     state: {
                       providerConfig: buildProviderConfig({
-                        type: 'rpc',
+                        type: NetworkType.rpc,
                         rpcTarget: 'http://example.com',
                       }),
                     },
@@ -822,7 +876,7 @@ describe('NetworkController', () => {
                     messenger,
                     state: {
                       providerConfig: buildProviderConfig({
-                        type: 'rpc',
+                        type: NetworkType.rpc,
                         rpcTarget: 'http://example.com',
                       }),
                     },
@@ -886,7 +940,7 @@ describe('NetworkController', () => {
               {
                 state: {
                   providerConfig: buildProviderConfig({
-                    type: 'rpc',
+                    type: NetworkType.rpc,
                   }),
                 },
               },
@@ -1016,7 +1070,7 @@ describe('NetworkController', () => {
               messenger,
               state: {
                 providerConfig: {
-                  type: 'mainnet',
+                  type: NetworkType.mainnet,
                   chainId: '1',
                 },
               },
@@ -1045,7 +1099,7 @@ describe('NetworkController', () => {
               expect(providerConfigChanges).toStrictEqual([
                 [
                   {
-                    type: 'mainnet',
+                    type: NetworkType.mainnet,
                     chainId: '1',
                   },
                 ],
@@ -1143,7 +1197,7 @@ describe('NetworkController', () => {
               messenger,
               state: {
                 providerConfig: {
-                  type: 'mainnet',
+                  type: NetworkType.mainnet,
                   chainId: '1',
                 },
               },
@@ -1172,7 +1226,7 @@ describe('NetworkController', () => {
               expect(providerConfigChanges).toStrictEqual([
                 [
                   {
-                    type: 'mainnet',
+                    type: NetworkType.mainnet,
                     chainId: '1',
                   },
                 ],
@@ -1244,7 +1298,7 @@ describe('NetworkController', () => {
             messenger,
             state: {
               providerConfig: {
-                type: 'localhost',
+                type: NetworkType.localhost,
                 rpcTarget: 'http://somethingexisting.com',
                 chainId: '99999',
                 ticker: 'something existing',
@@ -1263,16 +1317,16 @@ describe('NetworkController', () => {
             await waitForStateChanges(messenger, {
               propertyPath: ['network'],
               produceStateChanges: () => {
-                controller.setProviderType('mainnet' as const);
+                controller.setProviderType(NetworkType.mainnet);
               },
             });
 
             expect(controller.state.providerConfig).toStrictEqual({
-              type: 'mainnet',
-              ticker: 'ETH',
-              chainId: '1',
+              type: NetworkType.mainnet,
+              ...BUILT_IN_NETWORKS.mainnet,
               rpcTarget: undefined,
               nickname: undefined,
+              id: undefined,
             });
           },
         );
@@ -1299,7 +1353,7 @@ describe('NetworkController', () => {
             await waitForStateChanges(messenger, {
               propertyPath: ['isCustomNetwork'],
               produceStateChanges: () => {
-                controller.setProviderType('mainnet' as const);
+                controller.setProviderType(NetworkType.mainnet);
               },
             });
 
@@ -1330,10 +1384,10 @@ describe('NetworkController', () => {
             ]);
             createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
 
-            controller.setProviderType('mainnet' as const);
+            controller.setProviderType(NetworkType.mainnet);
 
             expect(createInfuraProviderMock).toHaveBeenCalledWith({
-              network: 'mainnet',
+              network: NetworkType.mainnet,
               projectId: 'infura-project-id',
             });
             expect(createMetamaskProviderMock).toHaveBeenCalledWith({
@@ -1384,7 +1438,7 @@ describe('NetworkController', () => {
             await waitForStateChanges(messenger, {
               propertyPath: ['networkDetails', 'isEIP1559Compatible'],
               produceStateChanges: () => {
-                controller.setProviderType('mainnet' as const);
+                controller.setProviderType(NetworkType.mainnet);
               },
             });
 
@@ -1410,8 +1464,8 @@ describe('NetworkController', () => {
             .mockImplementationOnce(() => fakeMetamaskProviders[0])
             .mockImplementationOnce(() => fakeMetamaskProviders[1]);
 
-          controller.setProviderType('mainnet' as const);
-          controller.setProviderType('mainnet' as const);
+          controller.setProviderType(NetworkType.mainnet);
+          controller.setProviderType(NetworkType.mainnet);
           assert(controller.getProviderAndBlockTracker().provider);
           jest.runAllTimers();
 
@@ -1442,7 +1496,7 @@ describe('NetworkController', () => {
           await waitForStateChanges(messenger, {
             propertyPath: ['network'],
             produceStateChanges: () => {
-              controller.setProviderType('mainnet' as const);
+              controller.setProviderType(NetworkType.mainnet);
             },
           });
 
@@ -1484,7 +1538,7 @@ describe('NetworkController', () => {
                 'NetworkController:providerConfigChange',
                 {
                   produceEvents: () => {
-                    controller.setProviderType('mainnet' as const);
+                    controller.setProviderType(NetworkType.mainnet);
                     assert(controller.getProviderAndBlockTracker().provider);
                   },
                 },
@@ -1536,7 +1590,7 @@ describe('NetworkController', () => {
                 'NetworkController:providerConfigChange',
                 {
                   produceEvents: () => {
-                    controller.setProviderType('mainnet' as const);
+                    controller.setProviderType(NetworkType.mainnet);
                     assert(controller.getProviderAndBlockTracker().provider);
                   },
                 },
@@ -1561,19 +1615,17 @@ describe('NetworkController', () => {
     (
       [
         {
-          networkType: 'goerli',
-          ticker: 'GoerliETH',
-          chainId: '5',
-          networkName: 'Goerli',
+          networkType: NetworkType.goerli,
+          ticker: NetworksTicker.goerli,
+          chainId: NetworksChainId.goerli,
         },
         {
-          networkType: 'sepolia',
-          ticker: 'SepoliaETH',
-          chainId: '11155111',
-          networkName: 'Sepolia',
+          networkType: NetworkType.sepolia,
+          ticker: NetworksTicker.sepolia,
+          chainId: NetworksChainId.sepolia,
         },
       ] as const
-    ).forEach(({ networkType, ticker, chainId, networkName }) => {
+    ).forEach(({ networkType }) => {
       describe(`given a network type of "${networkType}"`, () => {
         it('updates the provider config in state with the network type, the corresponding chain ID, and a special ticker, clearing any existing RPC target and nickname', async () => {
           const messenger = buildMessenger();
@@ -1582,7 +1634,7 @@ describe('NetworkController', () => {
               messenger,
               state: {
                 providerConfig: {
-                  type: 'localhost',
+                  type: NetworkType.localhost,
                   rpcTarget: 'http://somethingexisting.com',
                   chainId: '99999',
                   ticker: 'something existing',
@@ -1607,10 +1659,10 @@ describe('NetworkController', () => {
 
               expect(controller.state.providerConfig).toStrictEqual({
                 type: networkType,
-                ticker,
-                chainId,
+                ...BUILT_IN_NETWORKS[networkType],
                 rpcTarget: undefined,
                 nickname: undefined,
+                id: undefined,
               });
             },
           );
@@ -1645,7 +1697,7 @@ describe('NetworkController', () => {
           );
         });
 
-        it(`sets the provider to an Infura provider pointed to ${networkName}`, async () => {
+        it(`sets the provider to an Infura provider pointed to ${networkType}`, async () => {
           await withController(
             {
               infuraProjectId: 'infura-project-id',
@@ -1908,7 +1960,7 @@ describe('NetworkController', () => {
             messenger,
             state: {
               providerConfig: {
-                type: 'localhost',
+                type: NetworkType.localhost,
                 rpcTarget: 'http://somethingexisting.com',
                 chainId: '99999',
                 ticker: 'something existing',
@@ -1923,16 +1975,18 @@ describe('NetworkController', () => {
             await waitForStateChanges(messenger, {
               propertyPath: ['providerConfig'],
               produceStateChanges: () => {
-                controller.setProviderType('rpc' as const);
+                controller.setProviderType(NetworkType.rpc);
               },
             });
 
             expect(controller.state.providerConfig).toStrictEqual({
-              type: 'rpc',
+              type: NetworkType.rpc,
               ticker: 'ETH',
               chainId: '',
               rpcTarget: undefined,
               nickname: undefined,
+              id: undefined,
+              rpcPrefs: undefined,
             });
           },
         );
@@ -1956,7 +2010,7 @@ describe('NetworkController', () => {
               { propertyPath: ['isCustomNetwork'] },
             );
 
-            controller.setProviderType('rpc' as const);
+            controller.setProviderType(NetworkType.rpc);
 
             await expect(promiseForIsCustomNetworkChange).toNeverResolve();
           },
@@ -1968,7 +2022,7 @@ describe('NetworkController', () => {
           const fakeMetamaskProvider = buildFakeMetamaskProvider();
           createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
 
-          controller.setProviderType('rpc' as const);
+          controller.setProviderType(NetworkType.rpc);
 
           expect(createMetamaskProviderMock).not.toHaveBeenCalled();
           expect(
@@ -2002,7 +2056,7 @@ describe('NetworkController', () => {
             await waitForStateChanges(messenger, {
               propertyPath: ['networkDetails', 'isEIP1559Compatible'],
               produceStateChanges: () => {
-                controller.setProviderType('rpc' as const);
+                controller.setProviderType(NetworkType.rpc);
               },
             });
 
@@ -2022,7 +2076,7 @@ describe('NetworkController', () => {
             messenger,
             state: {
               providerConfig: {
-                type: 'localhost',
+                type: NetworkType.localhost,
                 rpcTarget: 'http://somethingexisting.com',
                 chainId: '99999',
                 ticker: 'something existing',
@@ -2037,16 +2091,18 @@ describe('NetworkController', () => {
             await waitForStateChanges(messenger, {
               propertyPath: ['network'],
               produceStateChanges: () => {
-                controller.setProviderType('localhost' as const);
+                controller.setProviderType(NetworkType.localhost);
               },
             });
 
             expect(controller.state.providerConfig).toStrictEqual({
-              type: 'localhost',
+              type: NetworkType.localhost,
               ticker: 'ETH',
               chainId: '',
               rpcTarget: undefined,
               nickname: undefined,
+              id: undefined,
+              rpcPrefs: undefined,
             });
           },
         );
@@ -2068,7 +2124,7 @@ describe('NetworkController', () => {
             await waitForStateChanges(messenger, {
               propertyPath: ['isCustomNetwork'],
               produceStateChanges: () => {
-                controller.setProviderType('localhost' as const);
+                controller.setProviderType(NetworkType.localhost);
               },
             });
 
@@ -2091,7 +2147,7 @@ describe('NetworkController', () => {
           ]);
           createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
 
-          controller.setProviderType('localhost' as const);
+          controller.setProviderType(NetworkType.localhost);
 
           expect(createMetamaskProviderMock).toHaveBeenCalledWith({
             chainId: undefined,
@@ -2132,7 +2188,7 @@ describe('NetworkController', () => {
           await waitForStateChanges(messenger, {
             propertyPath: ['networkDetails', 'isEIP1559Compatible'],
             produceStateChanges: () => {
-              controller.setProviderType('localhost' as const);
+              controller.setProviderType(NetworkType.localhost);
             },
           });
 
@@ -2153,8 +2209,8 @@ describe('NetworkController', () => {
             .mockImplementationOnce(() => fakeMetamaskProviders[0])
             .mockImplementationOnce(() => fakeMetamaskProviders[1]);
 
-          controller.setProviderType('localhost' as const);
-          controller.setProviderType('localhost' as const);
+          controller.setProviderType(NetworkType.localhost);
+          controller.setProviderType(NetworkType.localhost);
           assert(controller.getProviderAndBlockTracker().provider);
           jest.runAllTimers();
 
@@ -2181,7 +2237,7 @@ describe('NetworkController', () => {
           await waitForStateChanges(messenger, {
             propertyPath: ['network'],
             produceStateChanges: () => {
-              controller.setProviderType('localhost' as const);
+              controller.setProviderType(NetworkType.localhost);
             },
           });
 
@@ -2219,7 +2275,7 @@ describe('NetworkController', () => {
                 'NetworkController:providerConfigChange',
                 {
                   produceEvents: () => {
-                    controller.setProviderType('localhost' as const);
+                    controller.setProviderType(NetworkType.localhost);
                     assert(controller.getProviderAndBlockTracker().provider);
                   },
                 },
@@ -2267,7 +2323,7 @@ describe('NetworkController', () => {
                 'NetworkController:providerConfigChange',
                 {
                   produceEvents: () => {
-                    controller.setProviderType('localhost' as const);
+                    controller.setProviderType(NetworkType.localhost);
                     assert(controller.getProviderAndBlockTracker().provider);
                   },
                 },
@@ -2298,7 +2354,7 @@ describe('NetworkController', () => {
           messenger,
           state: {
             providerConfig: {
-              type: 'localhost',
+              type: NetworkType.localhost,
               rpcTarget: 'http://somethingexisting.com',
               chainId: '99999',
               ticker: 'something existing',
@@ -3469,8 +3525,8 @@ describe('NetworkController', () => {
           messenger,
           state: {
             providerConfig: {
-              type: 'mainnet',
-              chainId: '1',
+              type: NetworkType.mainnet,
+              ...BUILT_IN_NETWORKS.mainnet,
             },
           },
         },
@@ -3480,8 +3536,8 @@ describe('NetworkController', () => {
           );
 
           expect(providerConfig).toStrictEqual({
-            type: 'mainnet',
-            chainId: '1',
+            type: NetworkType.mainnet,
+            ...BUILT_IN_NETWORKS.mainnet,
           });
         },
       );
@@ -3699,7 +3755,7 @@ describe('NetworkController', () => {
         {
           state: {
             providerConfig: {
-              type: 'rpc',
+              type: NetworkType.rpc,
               rpcTarget: 'https://mock-rpc-url',
               chainId: '0xtest',
               ticker: 'TEST',
@@ -4017,7 +4073,7 @@ describe('NetworkController', () => {
         {
           state: {
             providerConfig: {
-              type: 'rpc',
+              type: NetworkType.rpc,
               rpcTarget: 'https://mock-rpc-url',
               chainId: '0xtest',
               ticker: 'TEST',
@@ -4067,7 +4123,7 @@ describe('NetworkController', () => {
         {
           state: {
             providerConfig: {
-              type: 'rpc',
+              type: NetworkType.rpc,
               rpcTarget: 'https://mock-rpc-url',
               chainId: '0xtest',
               ticker: 'TEST',
@@ -4184,6 +4240,979 @@ describe('NetworkController', () => {
       );
     });
   });
+
+  describe('rollbackToPreviousProvider', () => {
+    /**
+     * The set of networks that, when specified, create an Infura provider as
+     * opposed to a "standard" provider (one suited for a custom RPC endpoint).
+     */
+    const INFURA_NETWORKS = {
+      mainnet: {
+        nickname: 'Mainnet',
+        networkType: NetworkType.mainnet,
+        chainId: NetworksChainId.mainnet,
+        ticker: 'ETH',
+        blockExplorerUrl: `https://etherscan.io`,
+        networkVersion: '1',
+      },
+
+      goerli: {
+        nickname: 'Goerli',
+        networkType: NetworkType.goerli,
+        chainId: NetworksChainId.goerli,
+        ticker: 'GoerliETH',
+        blockExplorerUrl: `https://goerli.etherscan.io`,
+        networkVersion: '5',
+      },
+      sepolia: {
+        nickname: 'Sepolia',
+        networkType: NetworkType.sepolia,
+        chainId: NetworksChainId.sepolia,
+        ticker: 'SepoliaETH',
+        blockExplorerUrl: `https://sepolia.etherscan.io`,
+        networkVersion: '11155111',
+      },
+    };
+
+    for (const [
+      chainName,
+      {
+        networkType: type,
+        chainId,
+        blockExplorerUrl,
+        ticker,
+        nickname,
+        networkVersion,
+      },
+    ] of Object.entries(INFURA_NETWORKS)) {
+      describe(`if the previous provider configuration had a type of "${chainName}"`, () => {
+        it('overwrites the the current provider configuration with the previous provider configuration', async () => {
+          const messenger = buildMessenger();
+          const customNetworkConfiguration = {
+            rpcUrl: 'https://mock-rpc-url-1',
+            chainId: '0xtest',
+            nickname: 'test-chain',
+            ticker: 'TEST',
+            rpcPrefs: {
+              blockExplorerUrl: 'test-block-explorer.com',
+            },
+            id: 'testNetworkConfigurationId',
+          };
+
+          const initialProviderConfig = {
+            ...buildProviderConfig({
+              type,
+              chainId,
+              ticker,
+              rpcPrefs: {
+                blockExplorerUrl,
+              },
+            }),
+          };
+
+          await withController(
+            {
+              messenger,
+              state: {
+                providerConfig: initialProviderConfig,
+                networkConfigurations: {
+                  testNetworkConfigurationId: customNetworkConfiguration,
+                },
+              },
+            },
+            async ({ controller }) => {
+              const fakeMetamaskProvider = buildFakeMetamaskProvider();
+              createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+              controller.setActiveNetwork('testNetworkConfigurationId');
+              expect(controller.state.providerConfig).toStrictEqual({
+                ...customNetworkConfiguration,
+                type: NetworkType.rpc,
+              });
+              controller.rollbackToPreviousProvider();
+              expect(controller.state.providerConfig).toStrictEqual(
+                initialProviderConfig,
+              );
+            },
+          );
+        });
+
+        it('emits NetworkController:providerConfigChange via the messenger', async () => {
+          const messenger = buildMessenger();
+          const networkConfiguration = {
+            rpcUrl: 'https://mock-rpc-url',
+            chainId: '0xtest',
+            ticker: 'TEST',
+            nickname: undefined,
+            id: 'testNetworkConfigurationId',
+          };
+
+          const initialProviderConfig = {
+            ...buildProviderConfig({
+              type,
+              chainId,
+              ticker,
+              rpcPrefs: { blockExplorerUrl },
+            }),
+          };
+          await withController(
+            {
+              messenger,
+              state: {
+                networkConfigurations: {
+                  testNetworkConfigurationId: networkConfiguration,
+                },
+                providerConfig: initialProviderConfig,
+              },
+            },
+            async ({ controller }) => {
+              const fakeMetamaskProvider = buildFakeMetamaskProvider();
+              createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+              controller.setActiveNetwork('testNetworkConfigurationId');
+              const promiseForProviderConfigChange =
+                await waitForPublishedEvents(
+                  messenger,
+                  'NetworkController:providerConfigChange',
+                  {
+                    produceEvents: () => {
+                      controller.rollbackToPreviousProvider();
+                    },
+                  },
+                );
+              expect(promiseForProviderConfigChange).toStrictEqual([
+                [
+                  {
+                    type,
+                    chainId,
+                    ticker,
+                    rpcPrefs: { blockExplorerUrl },
+                    id: undefined,
+                    nickname: undefined,
+                    rpcUrl: undefined,
+                  },
+                ],
+              ]);
+            },
+          );
+        });
+
+        it('resets isEIP1559Compatible and sets network to "loading" for the network before emitting NetworkController:providerConfigChange', async () => {
+          const networkConfiguration = {
+            rpcUrl: 'https://mock-rpc-url',
+            chainId: '0xtest',
+            ticker: 'TEST',
+            nickname: undefined,
+            id: 'testNetworkConfigurationId',
+          };
+
+          const initialProviderConfig = {
+            ...buildProviderConfig({
+              type,
+              chainId,
+              ticker,
+              rpcPrefs: { blockExplorerUrl },
+            }),
+          };
+          const messenger = buildMessenger();
+          await withController(
+            {
+              messenger,
+              state: {
+                networkConfigurations: {
+                  testNetworkConfigurationId: networkConfiguration,
+                },
+                providerConfig: initialProviderConfig,
+              },
+            },
+            async ({ controller }) => {
+              const fakeMetamaskProvider = buildFakeMetamaskProvider([
+                {
+                  request: {
+                    method: 'eth_getBlockByNumber',
+                  },
+                  response: {
+                    result: POST_1559_BLOCK,
+                  },
+                },
+                {
+                  request: {
+                    method: 'eth_getBlockByNumber',
+                  },
+                  response: {
+                    result: PRE_1559_BLOCK,
+                  },
+                },
+                {
+                  request: {
+                    method: 'net_version',
+                  },
+                  response: {
+                    result: '10000',
+                  },
+                },
+              ]);
+
+              createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+              await waitForStateChanges(messenger, {
+                propertyPath: ['network'],
+                count: 1,
+                produceStateChanges: () => {
+                  controller.setActiveNetwork('testNetworkConfigurationId');
+                },
+              });
+              expect(controller.state.networkDetails).toStrictEqual({
+                isEIP1559Compatible: true,
+              });
+              await waitForStateChanges(messenger, {
+                propertyPath: ['network'],
+                count: 1,
+                produceStateChanges: () => {
+                  controller.rollbackToPreviousProvider();
+                },
+              });
+              expect(controller.state.network).toStrictEqual('loading');
+              expect(controller.state.networkDetails).toStrictEqual({
+                isEIP1559Compatible: false,
+              });
+            },
+          );
+        });
+
+        it(`initializes a provider pointed to the ${nickname} Infura network (chainId: ${chainId})`, async () => {
+          const networkConfiguration = {
+            rpcUrl: 'https://mock-rpc-url',
+            chainId: '0xtest',
+            ticker: 'TEST',
+            nickname: undefined,
+            id: 'testNetworkConfigurationId',
+          };
+
+          const initialProviderConfig = {
+            ...buildProviderConfig({
+              type,
+              chainId,
+              ticker,
+              rpcPrefs: { blockExplorerUrl },
+            }),
+          };
+          const messenger = buildMessenger();
+          await withController(
+            {
+              messenger,
+              state: {
+                networkConfigurations: {
+                  testNetworkConfigurationId: networkConfiguration,
+                },
+                providerConfig: initialProviderConfig,
+              },
+            },
+            async ({ controller }) => {
+              const fakeMetamaskProvider = buildFakeMetamaskProvider([
+                {
+                  request: {
+                    method: 'eth_chainId',
+                  },
+                  response: {
+                    result: chainId,
+                  },
+                },
+              ]);
+
+              createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+              await waitForStateChanges(messenger, {
+                propertyPath: ['network'],
+                count: 1,
+                produceStateChanges: () => {
+                  controller.setActiveNetwork('testNetworkConfigurationId');
+                },
+              });
+              await waitForStateChanges(messenger, {
+                propertyPath: ['network'],
+                count: 1,
+                produceStateChanges: () => {
+                  controller.rollbackToPreviousProvider();
+                },
+              });
+              const { provider } = controller.getProviderAndBlockTracker();
+              const promisifiedSendAsync = promisify(provider.sendAsync).bind(
+                provider,
+              );
+              const { result: chainIdResult } = await promisifiedSendAsync({
+                method: 'eth_chainId',
+              });
+              expect(chainIdResult).toBe(chainId);
+            },
+          );
+        });
+
+        it('replaces the provider object underlying the provider proxy without creating a new instance of the proxy itself', async () => {
+          const networkConfiguration = {
+            rpcUrl: 'https://mock-rpc-url',
+            chainId: '0xtest',
+            ticker: 'TEST',
+            nickname: undefined,
+            id: 'testNetworkConfigurationId',
+          };
+
+          const initialProviderConfig = {
+            ...buildProviderConfig({
+              type,
+              chainId,
+              ticker,
+              rpcPrefs: { blockExplorerUrl },
+            }),
+          };
+          const messenger = buildMessenger();
+          await withController(
+            {
+              messenger,
+              state: {
+                networkConfigurations: {
+                  testNetworkConfigurationId: networkConfiguration,
+                },
+                providerConfig: initialProviderConfig,
+              },
+            },
+            async ({ controller }) => {
+              const fakeMetamaskProvider = buildFakeMetamaskProvider();
+
+              createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+              await waitForStateChanges(messenger, {
+                propertyPath: ['network'],
+                count: 1,
+                produceStateChanges: () => {
+                  controller.setActiveNetwork('testNetworkConfigurationId');
+                },
+              });
+              const { provider: providerBefore } =
+                controller.getProviderAndBlockTracker();
+
+              await waitForStateChanges(messenger, {
+                propertyPath: ['network'],
+                count: 1,
+                produceStateChanges: () => {
+                  controller.rollbackToPreviousProvider();
+                },
+              });
+              const { provider: providerAfter } =
+                controller.getProviderAndBlockTracker();
+
+              expect(providerBefore).toBe(providerAfter);
+            },
+          );
+        });
+
+        it(`persists "${networkVersion}" to state as the network version of ${nickname}`, async () => {
+          const networkConfiguration = {
+            rpcUrl: 'https://mock-rpc-url',
+            chainId: '0xtest',
+            ticker: 'TEST',
+            nickname: undefined,
+            id: 'testNetworkConfigurationId',
+          };
+
+          const initialProviderConfig = {
+            ...buildProviderConfig({
+              type,
+              chainId,
+              ticker,
+              rpcPrefs: { blockExplorerUrl },
+            }),
+          };
+          const messenger = buildMessenger();
+          await withController(
+            {
+              messenger,
+              state: {
+                networkConfigurations: {
+                  testNetworkConfigurationId: networkConfiguration,
+                },
+                providerConfig: initialProviderConfig,
+              },
+            },
+            async ({ controller }) => {
+              const fakeMetamaskProvider = buildFakeMetamaskProvider([
+                {
+                  request: {
+                    method: 'net_version',
+                  },
+                  response: {
+                    result: '999',
+                  },
+                },
+                {
+                  request: {
+                    method: 'net_version',
+                  },
+                  response: {
+                    result: '1',
+                  },
+                },
+              ]);
+
+              createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+              await waitForStateChanges(messenger, {
+                propertyPath: ['network'],
+                count: 1,
+                produceStateChanges: () => {
+                  controller.setActiveNetwork('testNetworkConfigurationId');
+                },
+              });
+              expect(controller.state.network).toStrictEqual('999');
+
+              await waitForStateChanges(messenger, {
+                propertyPath: ['network'],
+                count: 1,
+                produceStateChanges: () => {
+                  controller.rollbackToPreviousProvider();
+                },
+              });
+              expect(controller.state.network).toStrictEqual('1');
+            },
+          );
+        });
+      });
+    }
+
+    describe(`if the previous provider configuration had a type of "rpc"`, () => {
+      it('should overwrite the current provider with the previous provider when current provider has type "mainnet" and previous provider has type "rpc"', async () => {
+        const messenger = buildMessenger();
+        const networkConfiguration = {
+          rpcUrl: 'https://mock-rpc-url',
+          chainId: '0xtest',
+          ticker: 'TEST',
+          id: 'testNetworkConfigurationId',
+          nickname: undefined,
+          rpcPrefs: undefined,
+        };
+
+        const initialProviderConfig = {
+          ...buildProviderConfig({
+            ...networkConfiguration,
+          }),
+          type: NetworkType.rpc,
+        };
+        await withController(
+          {
+            messenger,
+            state: {
+              networkConfigurations: {
+                testNetworkConfigurationId: networkConfiguration,
+              },
+              providerConfig: initialProviderConfig,
+            },
+          },
+          async ({ controller }) => {
+            const fakeMetamaskProvider = buildFakeMetamaskProvider();
+            createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+            controller.setProviderType(NetworkType.mainnet);
+            expect(controller.state.providerConfig).toStrictEqual({
+              type: NetworkType.mainnet,
+              ...BUILT_IN_NETWORKS.mainnet,
+              nickname: undefined,
+              rpcUrl: undefined,
+              id: undefined,
+            });
+            controller.rollbackToPreviousProvider();
+            expect(controller.state.providerConfig).toStrictEqual({
+              ...networkConfiguration,
+              type: NetworkType.rpc,
+            });
+          },
+        );
+      });
+
+      it('should overwrite the current provider with the previous provider when current provider has type "rpc" and previous provider has type "rpc"', async () => {
+        const messenger = buildMessenger();
+        const networkConfiguration1 = {
+          rpcUrl: 'https://mock-rpc-url',
+          chainId: '0xtest',
+          ticker: 'TEST',
+          id: 'testNetworkConfigurationId',
+          nickname: 'test-network-1',
+          rpcPrefs: undefined,
+        };
+
+        const networkConfiguration2 = {
+          rpcUrl: 'https://mock-rpc-url-2',
+          chainId: '0xtest2',
+          ticker: 'TEST2',
+          id: 'testNetworkConfigurationId2',
+          nickname: 'test-network-2',
+          rpcPrefs: undefined,
+        };
+
+        const initialProviderConfig = {
+          ...buildProviderConfig({
+            ...networkConfiguration1,
+            type: NetworkType.rpc,
+          }),
+        };
+        await withController(
+          {
+            messenger,
+            state: {
+              networkConfigurations: {
+                testNetworkConfigurationId: networkConfiguration1,
+                testNetworkConfigurationId2: networkConfiguration2,
+              },
+              providerConfig: initialProviderConfig,
+            },
+          },
+          async ({ controller }) => {
+            const fakeMetamaskProvider = buildFakeMetamaskProvider();
+            createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+            controller.setActiveNetwork('testNetworkConfigurationId2');
+            expect(controller.state.providerConfig).toStrictEqual({
+              ...networkConfiguration2,
+              type: NetworkType.rpc,
+            });
+            controller.rollbackToPreviousProvider();
+            expect(controller.state.providerConfig).toStrictEqual(
+              initialProviderConfig,
+            );
+          },
+        );
+      });
+
+      it('emits NetworkController:providerConfigChange via the messenger', async () => {
+        const messenger = buildMessenger();
+        const initialProviderConfigNetworkConfiguration = {
+          rpcUrl: 'https://mock-rpc-url-2',
+          chainId: '0x1337',
+          ticker: 'TEST2',
+          id: 'testNetworkConfigurationId2',
+          rpcPrefs: { blockExplorerUrl: 'https://test-block-explorer.com' },
+        };
+
+        const initialProviderConfig = {
+          ...buildProviderConfig({
+            ...initialProviderConfigNetworkConfiguration,
+            type: NetworkType.rpc,
+          }),
+        };
+        await withController(
+          {
+            messenger,
+            state: {
+              providerConfig: initialProviderConfig,
+              networkConfigurations: {
+                testNetworkConfigurationId1: {
+                  rpcUrl: 'https://mock-rpc-url',
+                  chainId: '0xtest',
+                  ticker: 'TEST',
+                  id: 'testNetworkConfigurationId1',
+                },
+                testNetworkConfigurationId2:
+                  initialProviderConfigNetworkConfiguration,
+              },
+            },
+          },
+          async ({ controller }) => {
+            const fakeMetamaskProvider = buildFakeMetamaskProvider();
+            createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+            controller.setActiveNetwork('testNetworkConfigurationId1');
+            const promiseForProviderConfigChange = await waitForPublishedEvents(
+              messenger,
+              'NetworkController:providerConfigChange',
+              {
+                produceEvents: () => {
+                  controller.rollbackToPreviousProvider();
+                },
+              },
+            );
+            expect(promiseForProviderConfigChange).toStrictEqual([
+              [initialProviderConfig],
+            ]);
+          },
+        );
+      });
+
+      it('resets the network state to "loading" and the isEIP before emitting NetworkController:providerConfigChange', async () => {
+        const messenger = buildMessenger();
+        const initialProviderConfigNetworkConfiguration = {
+          rpcUrl: 'https://mock-rpc-url-2',
+          chainId: '0x1337',
+          ticker: 'TEST2',
+          id: 'testNetworkConfigurationId2',
+          rpcPrefs: { blockExplorerUrl: 'https://test-block-explorer.com' },
+        };
+
+        const initialProviderConfig = {
+          ...buildProviderConfig({
+            ...initialProviderConfigNetworkConfiguration,
+            type: NetworkType.rpc,
+          }),
+        };
+        await withController(
+          {
+            messenger,
+            state: {
+              providerConfig: initialProviderConfig,
+              networkConfigurations: {
+                testNetworkConfigurationId1: {
+                  rpcUrl: 'https://mock-rpc-url',
+                  chainId: '0xtest',
+                  ticker: 'TEST',
+                  id: 'testNetworkConfigurationId1',
+                },
+                testNetworkConfigurationId2:
+                  initialProviderConfigNetworkConfiguration,
+              },
+            },
+          },
+          async ({ controller }) => {
+            const fakeMetamaskProvider = buildFakeMetamaskProvider([
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                },
+                response: {
+                  result: POST_1559_BLOCK,
+                },
+              },
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                },
+                response: {
+                  result: PRE_1559_BLOCK,
+                },
+              },
+              {
+                request: {
+                  method: 'net_version',
+                },
+                response: {
+                  result: '10000',
+                },
+              },
+            ]);
+            createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+            await waitForStateChanges(messenger, {
+              propertyPath: ['network'],
+              count: 1,
+              produceStateChanges: () => {
+                controller.setActiveNetwork('testNetworkConfigurationId1');
+              },
+            });
+            expect(controller.state.networkDetails).toStrictEqual({
+              isEIP1559Compatible: true,
+            });
+            await waitForStateChanges(messenger, {
+              propertyPath: ['network'],
+              count: 1,
+              produceStateChanges: () => {
+                controller.rollbackToPreviousProvider();
+              },
+            });
+            expect(controller.state.network).toStrictEqual('loading');
+            expect(controller.state.networkDetails).toStrictEqual({
+              isEIP1559Compatible: false,
+            });
+          },
+        );
+      });
+
+      it('initializes a provider pointed to the given RPC URL whose chain ID matches the previously configured chain ID', async () => {
+        const networkConfiguration1 = {
+          rpcUrl: 'https://mock-rpc-url',
+          chainId: '0xtest',
+          ticker: 'TEST',
+          nickname: undefined,
+          id: 'testNetworkConfigurationId1',
+        };
+
+        const initialProviderConfigNetworkConfiguration = {
+          rpcUrl: 'https://mock-rpc-url-2',
+          chainId: '0x1337',
+          ticker: 'TEST2',
+          id: 'testNetworkConfigurationId2',
+          rpcPrefs: { blockExplorerUrl: 'https://test-block-explorer.com' },
+        };
+
+        const initialProviderConfig = {
+          ...buildProviderConfig({
+            ...initialProviderConfigNetworkConfiguration,
+            type: NetworkType.rpc,
+          }),
+        };
+
+        const messenger = buildMessenger();
+        await withController(
+          {
+            messenger,
+            state: {
+              networkConfigurations: {
+                testNetworkConfigurationId1: networkConfiguration1,
+                testNetworkConfigurationId2:
+                  initialProviderConfigNetworkConfiguration,
+              },
+              providerConfig: initialProviderConfig,
+            },
+          },
+          async ({ controller }) => {
+            const fakeMetamaskProvider = buildFakeMetamaskProvider([
+              {
+                request: {
+                  method: 'eth_chainId',
+                },
+                response: {
+                  result: initialProviderConfigNetworkConfiguration.chainId,
+                },
+              },
+            ]);
+
+            createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+            await waitForStateChanges(messenger, {
+              propertyPath: ['network'],
+              count: 1,
+              produceStateChanges: () => {
+                controller.setActiveNetwork('testNetworkConfigurationId1');
+              },
+            });
+            await waitForStateChanges(messenger, {
+              propertyPath: ['network'],
+              count: 1,
+              produceStateChanges: () => {
+                controller.rollbackToPreviousProvider();
+              },
+            });
+            const { provider } = controller.getProviderAndBlockTracker();
+            const promisifiedSendAsync = promisify(provider.sendAsync).bind(
+              provider,
+            );
+            const { result: chainIdResult } = await promisifiedSendAsync({
+              method: 'eth_chainId',
+            });
+            expect(chainIdResult).toBe(
+              initialProviderConfigNetworkConfiguration.chainId,
+            );
+          },
+        );
+      });
+
+      it('replaces the provider object underlying the provider proxy without creating a new instance of the proxy itself', async () => {
+        const networkConfiguration1 = {
+          rpcUrl: 'https://mock-rpc-url',
+          chainId: '0xtest',
+          ticker: 'TEST',
+          nickname: undefined,
+          id: 'testNetworkConfigurationId1',
+        };
+
+        const initialProviderConfigNetworkConfiguration = {
+          rpcUrl: 'https://mock-rpc-url-2',
+          chainId: '0x1337',
+          ticker: 'TEST2',
+          id: 'testNetworkConfigurationId2',
+          rpcPrefs: { blockExplorerUrl: 'https://test-block-explorer.com' },
+        };
+
+        const initialProviderConfig = {
+          ...buildProviderConfig({
+            ...initialProviderConfigNetworkConfiguration,
+            type: NetworkType.rpc,
+          }),
+        };
+
+        const messenger = buildMessenger();
+        await withController(
+          {
+            messenger,
+            state: {
+              networkConfigurations: {
+                testNetworkConfigurationId1: networkConfiguration1,
+                testNetworkConfigurationId2:
+                  initialProviderConfigNetworkConfiguration,
+              },
+              providerConfig: initialProviderConfig,
+            },
+          },
+          async ({ controller }) => {
+            const fakeMetamaskProvider = buildFakeMetamaskProvider();
+
+            createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+            await waitForStateChanges(messenger, {
+              propertyPath: ['network'],
+              count: 1,
+              produceStateChanges: () => {
+                controller.setActiveNetwork('testNetworkConfigurationId1');
+              },
+            });
+            const { provider: providerBefore } =
+              controller.getProviderAndBlockTracker();
+
+            await waitForStateChanges(messenger, {
+              propertyPath: ['network'],
+              count: 1,
+              produceStateChanges: () => {
+                controller.rollbackToPreviousProvider();
+              },
+            });
+            const { provider: providerAfter } =
+              controller.getProviderAndBlockTracker();
+
+            expect(providerBefore).toBe(providerAfter);
+          },
+        );
+      });
+
+      it('persists the network version to state (assuming that the request for net_version responds successfully)', async () => {
+        const networkConfiguration1 = {
+          rpcUrl: 'https://mock-rpc-url',
+          chainId: '0xtest',
+          ticker: 'TEST',
+          nickname: undefined,
+          id: 'testNetworkConfigurationId1',
+        };
+
+        const initialProviderConfigNetworkConfiguration = {
+          rpcUrl: 'https://mock-rpc-url-2',
+          chainId: '0x1337',
+          ticker: 'TEST2',
+          id: 'testNetworkConfigurationId2',
+          rpcPrefs: { blockExplorerUrl: 'https://test-block-explorer.com' },
+        };
+
+        const initialProviderConfig = {
+          ...buildProviderConfig({
+            ...initialProviderConfigNetworkConfiguration,
+            type: NetworkType.rpc,
+          }),
+        };
+
+        const messenger = buildMessenger();
+        await withController(
+          {
+            messenger,
+            state: {
+              networkConfigurations: {
+                testNetworkConfigurationId1: networkConfiguration1,
+                testNetworkConfigurationId2:
+                  initialProviderConfigNetworkConfiguration,
+              },
+              providerConfig: initialProviderConfig,
+            },
+          },
+          async ({ controller }) => {
+            const fakeMetamaskProvider = buildFakeMetamaskProvider([
+              {
+                request: {
+                  method: 'net_version',
+                },
+                response: {
+                  result: '999',
+                },
+              },
+              {
+                request: {
+                  method: 'net_version',
+                },
+                response: {
+                  result: '1',
+                },
+              },
+            ]);
+
+            createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+            await waitForStateChanges(messenger, {
+              propertyPath: ['network'],
+              count: 1,
+              produceStateChanges: () => {
+                controller.setActiveNetwork('testNetworkConfigurationId1');
+              },
+            });
+            expect(controller.state.network).toStrictEqual('999');
+
+            await waitForStateChanges(messenger, {
+              propertyPath: ['network'],
+              count: 1,
+              produceStateChanges: () => {
+                controller.rollbackToPreviousProvider();
+              },
+            });
+            expect(controller.state.network).toStrictEqual('1');
+          },
+        );
+      });
+    });
+
+    it('should overwrite the current provider with the previous provider when current provider has type "rpc" and previous provider has type "mainnet"', async () => {
+      const networkConfiguration = {
+        rpcUrl: 'https://mock-rpc-url',
+        chainId: '0xtest',
+        ticker: 'TEST',
+        id: 'testNetworkConfigurationId',
+        nickname: undefined,
+        rpcPrefs: undefined,
+      };
+
+      const initialProviderConfig = {
+        ...buildProviderConfig({
+          type: NetworkType.mainnet,
+          ...BUILT_IN_NETWORKS.mainnet,
+        }),
+      };
+      const messenger = buildMessenger();
+      await withController(
+        {
+          messenger,
+          state: {
+            networkConfigurations: {
+              testNetworkConfigurationId: networkConfiguration,
+            },
+            providerConfig: initialProviderConfig,
+          },
+        },
+        async ({ controller }) => {
+          const fakeMetamaskProvider = buildFakeMetamaskProvider();
+          createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+          controller.setActiveNetwork('testNetworkConfigurationId');
+          expect(controller.state.providerConfig).toStrictEqual({
+            ...networkConfiguration,
+            type: NetworkType.rpc,
+          });
+          controller.rollbackToPreviousProvider();
+          expect(controller.state.providerConfig).toStrictEqual(
+            initialProviderConfig,
+          );
+        },
+      );
+    });
+
+    it('should overwrite the current provider with the previous provider when current provider has type "mainnet" and previous provider has type "sepolia"', async () => {
+      const messenger = buildMessenger();
+      const initialProviderConfig = {
+        ...buildProviderConfig({
+          type: NetworkType.mainnet,
+          ...BUILT_IN_NETWORKS.mainnet,
+        }),
+      };
+      await withController(
+        {
+          messenger,
+          state: {
+            providerConfig: initialProviderConfig,
+          },
+        },
+        async ({ controller }) => {
+          const fakeMetamaskProvider = buildFakeMetamaskProvider();
+          createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
+          controller.setProviderType(NetworkType.sepolia);
+          expect(controller.state.providerConfig).toStrictEqual({
+            ...buildProviderConfig({
+              type: NetworkType.sepolia,
+              ...BUILT_IN_NETWORKS.sepolia,
+            }),
+          });
+          controller.rollbackToPreviousProvider();
+          expect(controller.state.providerConfig).toStrictEqual(
+            initialProviderConfig,
+          );
+        },
+      );
+    });
+  });
 });
 
 /**
@@ -4256,7 +5285,14 @@ async function withController<ReturnValue>(
  * @returns The complete ProviderConfig object.
  */
 function buildProviderConfig(config: Partial<ProviderConfig> = {}) {
-  return { type: 'localhost' as const, chainId: '1337', ...config };
+  return {
+    type: NetworkType.localhost,
+    chainId: '1337',
+    id: undefined,
+    nickname: undefined,
+    rpcUrl: undefined,
+    ...config,
+  };
 }
 
 /**

--- a/packages/network-controller/tests/provider-api-tests/helpers.ts
+++ b/packages/network-controller/tests/provider-api-tests/helpers.ts
@@ -284,7 +284,7 @@ export type MockCommunications = {
 export const withMockedCommunications = async (
   {
     providerType,
-    infuraNetwork = 'mainnet',
+    infuraNetwork = NetworkType.mainnet,
     customRpcUrl = MOCK_RPC_URL,
   }: MockOptions,
   fn: (comms: MockCommunications) => Promise<void>,
@@ -367,7 +367,7 @@ export const waitForPromiseToBeFulfilledAfterRunningAllTimers = async (
 export const withNetworkClient = async (
   {
     providerType,
-    infuraNetwork = 'mainnet',
+    infuraNetwork = NetworkType.mainnet,
     customRpcUrl = MOCK_RPC_URL,
   }: MockOptions,
   fn: (client: MockNetworkClient) => Promise<any>,

--- a/packages/network-controller/tests/provider-api-tests/shared-tests.ts
+++ b/packages/network-controller/tests/provider-api-tests/shared-tests.ts
@@ -1,5 +1,6 @@
 /* eslint-disable jest/require-top-level-describe, jest/no-export, jest/no-identical-title, jest/no-if */
 
+import { NetworkType } from '@metamask/controller-utils/src';
 import { testsForRpcMethodsThatCheckForBlockHashInResponse } from './block-hash-in-response';
 import { testsForRpcMethodSupportingBlockParam } from './block-param';
 import {
@@ -367,14 +368,14 @@ export const testsForProviderType = (providerType: ProviderType) => {
       describe('net_version', () => {
         it('does hit RPC endpoint to get net_version', async () => {
           await withMockedCommunications(
-            { providerType, infuraNetwork: 'goerli' },
+            { providerType, infuraNetwork: NetworkType.goerli },
             async (comms) => {
               comms.mockRpcCall({
                 request: { method: 'net_version' },
                 response: { result: '5' },
               });
               const networkId = await withNetworkClient(
-                { providerType, infuraNetwork: 'goerli' },
+                { providerType, infuraNetwork: NetworkType.goerli },
                 ({ makeRpcCall }) => {
                   return makeRpcCall({
                     method: 'net_version',

--- a/packages/network-controller/tests/provider-api-tests/shared-tests.ts
+++ b/packages/network-controller/tests/provider-api-tests/shared-tests.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jest/require-top-level-describe, jest/no-export, jest/no-identical-title, jest/no-if */
 
-import { NetworkType } from '@metamask/controller-utils/src';
+import { NetworkType } from '@metamask/controller-utils';
 import { testsForRpcMethodsThatCheckForBlockHashInResponse } from './block-hash-in-response';
 import { testsForRpcMethodSupportingBlockParam } from './block-param';
 import {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -135,7 +135,7 @@ const MOCK_NETWORK = {
     isCustomNetwork: false,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
-      type: 'goerli' as NetworkType,
+      type: NetworkType.goerli,
       chainId: NetworksChainId.goerli,
     },
     networkConfigurations: {},
@@ -149,7 +149,7 @@ const MOCK_NETWORK_CUSTOM = {
     isCustomNetwork: true,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
-      type: 'rpc' as NetworkType,
+      type: NetworkType.rpc,
       chainId: '10',
     },
     networkConfigurations: {},
@@ -161,7 +161,7 @@ const MOCK_NETWORK_WITHOUT_CHAIN_ID = {
   isCustomNetwork: false,
   state: {
     network: '5',
-    providerConfig: { type: 'goerli' as NetworkType },
+    providerConfig: { type: NetworkType.goerli },
     networkConfigurations: {},
   },
   subscribe: () => undefined,
@@ -173,7 +173,7 @@ const MOCK_MAINNET_NETWORK = {
     isCustomNetwork: false,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
-      type: 'mainnet' as NetworkType,
+      type: NetworkType.mainnet,
       chainId: NetworksChainId.mainnet,
     },
     networkConfigurations: {},
@@ -187,7 +187,7 @@ const MOCK_CUSTOM_NETWORK = {
     isCustomNetwork: true,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
-      type: 'rpc' as NetworkType,
+      type: NetworkType.rpc,
       chainId: '80001',
     },
     networkConfigurations: {},

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -20,7 +20,7 @@ import {
   safelyExecute,
   isSmartContractCode,
   query,
-  MAINNET,
+  NetworkType,
   RPC,
 } from '@metamask/controller-utils';
 import {
@@ -603,7 +603,11 @@ export class TransactionController extends BaseController<
       networkId: parseInt(networkId, undefined),
     };
 
-    return Common.forCustomChain(MAINNET, customChainParams, HARDFORK);
+    return Common.forCustomChain(
+      NetworkType.mainnet,
+      customChainParams,
+      HARDFORK,
+    );
   }
 
   /**

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -1,6 +1,6 @@
 import { addHexPrefix, isHexString } from 'ethereumjs-util';
 import {
-  MAINNET,
+  NetworkType,
   convertHexToDecimal,
   handleFetch,
   isValidHexAddress,
@@ -41,7 +41,7 @@ export function getEtherscanApiUrl(
   urlParams: any,
 ): string {
   let etherscanSubdomain = 'api';
-  if (networkType !== MAINNET) {
+  if (networkType !== NetworkType.mainnet) {
     etherscanSubdomain = `api-${networkType}`;
   }
   const apiUrl = `https://${etherscanSubdomain}.etherscan.io`;


### PR DESCRIPTION

- ADDED:

  - adds a `rollbackToPreviousProvider` method like the one that exists [on the extension side](https://github.com/MetaMask/metamask-extension/blob/7a421e05c37658820298ded50c8949df16fc1f3f/app/scripts/controllers/network/network-controller.js#L290) `NetworkController`


Resolves #1024 
