### PR TITLE
Convert the ENS controller to the BaseController v2 API

### DIFF
--- a/packages/ens-controller/src/EnsController.test.ts
+++ b/packages/ens-controller/src/EnsController.test.ts
@@ -1,3 +1,4 @@
+import { ControllerMessenger } from '@metamask/base-controller';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { EnsController } from './EnsController';
 
@@ -11,14 +12,47 @@ const address1Checksum = toChecksumHexAddress(address1);
 const address2Checksum = toChecksumHexAddress(address2);
 const address3Checksum = toChecksumHexAddress(address3);
 
+const name = 'EnsController';
+
+/**
+ * Constructs a unrestricted controller messenger.
+ *
+ * @returns A unrestricted controller messenger.
+ */
+function getUnrestrictedMessenger() {
+  return new ControllerMessenger<never, never>();
+}
+
+/**
+ * Constructs a restricted controller messenger.
+ *
+ * @param controllerMessenger - An optional unrestricted messenger
+ * @returns A restricted controller messenger.
+ */
+function getRestrictedMessenger(
+  controllerMessenger = getUnrestrictedMessenger(),
+) {
+  return controllerMessenger.getRestricted<typeof name, never, never>({
+    name,
+  });
+}
+
 describe('EnsController', () => {
   it('should set default state', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.state).toStrictEqual({ ensEntries: {} });
   });
 
   it('should add a new ENS entry and return true', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
@@ -34,7 +68,11 @@ describe('EnsController', () => {
   });
 
   it('should add a new ENS entry with null address and return true', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, null)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
@@ -50,7 +88,11 @@ describe('EnsController', () => {
   });
 
   it('should update an ENS entry and return true', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.set('1', name1, address2)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
@@ -67,7 +109,11 @@ describe('EnsController', () => {
   });
 
   it('should update an ENS entry with null address and return true', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.set('1', name1, null)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
@@ -84,7 +130,11 @@ describe('EnsController', () => {
   });
 
   it('should not update an ENS entry if the address is the same (valid address) and return false', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.set('1', name1, address1)).toStrictEqual(false);
     expect(controller.state).toStrictEqual({
@@ -101,7 +151,11 @@ describe('EnsController', () => {
   });
 
   it('should not update an ENS entry if the address is the same (null) and return false', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, null)).toStrictEqual(true);
     expect(controller.set('1', name1, null)).toStrictEqual(false);
     expect(controller.state).toStrictEqual({
@@ -118,7 +172,11 @@ describe('EnsController', () => {
   });
 
   it('should add multiple ENS entries and update without side effects', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.set('1', name2, address2)).toStrictEqual(true);
     expect(controller.set('2', name1, address1)).toStrictEqual(true);
@@ -149,7 +207,11 @@ describe('EnsController', () => {
   });
 
   it('should get ENS entry by chainId and ensName', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.get('1', name1)).toStrictEqual({
       address: address1Checksum,
@@ -159,19 +221,31 @@ describe('EnsController', () => {
   });
 
   it('should return null when getting nonexistent name', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.get('1', name2)).toBeNull();
   });
 
   it('should return null when getting nonexistent chainId', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.get('2', name1)).toBeNull();
   });
 
   it('should throw on attempt to set invalid ENS entry: chainId', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(() => {
       controller.set('a', name1, address1);
     }).toThrow(
@@ -181,7 +255,11 @@ describe('EnsController', () => {
   });
 
   it('should throw on attempt to set invalid ENS entry: ENS name', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(() => {
       controller.set('1', 'foo.eth', address1);
     }).toThrow('Invalid ENS name: foo.eth');
@@ -189,7 +267,11 @@ describe('EnsController', () => {
   });
 
   it('should throw on attempt to set invalid ENS entry: address', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(() => {
       controller.set('1', name1, 'foo');
     }).toThrow(
@@ -199,14 +281,22 @@ describe('EnsController', () => {
   });
 
   it('should remove an ENS entry and return true', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.delete('1', name1)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({ ensEntries: {} });
   });
 
   it('should return false if an ENS entry was NOT deleted', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     controller.set('1', name1, address1);
     expect(controller.delete('1', 'bar')).toStrictEqual(false);
     expect(controller.delete('2', 'bar')).toStrictEqual(false);
@@ -224,7 +314,11 @@ describe('EnsController', () => {
   });
 
   it('should add multiple ENS entries and remove without side effects', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.set('1', name2, address2)).toStrictEqual(true);
     expect(controller.set('2', name1, address1)).toStrictEqual(true);
@@ -250,7 +344,11 @@ describe('EnsController', () => {
   });
 
   it('should clear all ENS entries', () => {
-    const controller = new EnsController();
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+    const controller = new EnsController({
+      messenger,
+    });
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.set('1', name2, address2)).toStrictEqual(true);
     expect(controller.set('2', name1, address1)).toStrictEqual(true);

--- a/packages/ens-controller/src/EnsController.test.ts
+++ b/packages/ens-controller/src/EnsController.test.ts
@@ -15,32 +15,19 @@ const address3Checksum = toChecksumHexAddress(address3);
 const name = 'EnsController';
 
 /**
- * Constructs a unrestricted controller messenger.
- *
- * @returns A unrestricted controller messenger.
- */
-function getUnrestrictedMessenger() {
-  return new ControllerMessenger<never, never>();
-}
-
-/**
  * Constructs a restricted controller messenger.
  *
- * @param controllerMessenger - An optional unrestricted messenger
  * @returns A restricted controller messenger.
  */
-function getRestrictedMessenger(
-  controllerMessenger = getUnrestrictedMessenger(),
-) {
-  return controllerMessenger.getRestricted<typeof name, never, never>({
+function getMessenger() {
+  return new ControllerMessenger().getRestricted<typeof name, never, never>({
     name,
   });
 }
 
 describe('EnsController', () => {
   it('should set default state', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -48,8 +35,7 @@ describe('EnsController', () => {
   });
 
   it('should add a new ENS entry and return true', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -68,8 +54,7 @@ describe('EnsController', () => {
   });
 
   it('should add a new ENS entry with null address and return true', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -88,8 +73,7 @@ describe('EnsController', () => {
   });
 
   it('should update an ENS entry and return true', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -109,8 +93,7 @@ describe('EnsController', () => {
   });
 
   it('should update an ENS entry with null address and return true', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -130,8 +113,7 @@ describe('EnsController', () => {
   });
 
   it('should not update an ENS entry if the address is the same (valid address) and return false', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -151,8 +133,7 @@ describe('EnsController', () => {
   });
 
   it('should not update an ENS entry if the address is the same (null) and return false', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -172,8 +153,7 @@ describe('EnsController', () => {
   });
 
   it('should add multiple ENS entries and update without side effects', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -207,8 +187,7 @@ describe('EnsController', () => {
   });
 
   it('should get ENS entry by chainId and ensName', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -221,8 +200,7 @@ describe('EnsController', () => {
   });
 
   it('should return null when getting nonexistent name', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -231,8 +209,7 @@ describe('EnsController', () => {
   });
 
   it('should return null when getting nonexistent chainId', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -241,8 +218,7 @@ describe('EnsController', () => {
   });
 
   it('should throw on attempt to set invalid ENS entry: chainId', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -255,8 +231,7 @@ describe('EnsController', () => {
   });
 
   it('should throw on attempt to set invalid ENS entry: ENS name', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -267,8 +242,7 @@ describe('EnsController', () => {
   });
 
   it('should throw on attempt to set invalid ENS entry: address', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -281,8 +255,7 @@ describe('EnsController', () => {
   });
 
   it('should remove an ENS entry and return true', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -292,8 +265,7 @@ describe('EnsController', () => {
   });
 
   it('should return false if an ENS entry was NOT deleted', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -314,8 +286,7 @@ describe('EnsController', () => {
   });
 
   it('should add multiple ENS entries and remove without side effects', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });
@@ -344,8 +315,7 @@ describe('EnsController', () => {
   });
 
   it('should clear all ENS entries', () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const messenger = getMessenger();
     const controller = new EnsController({
       messenger,
     });

--- a/packages/ens-controller/src/EnsController.ts
+++ b/packages/ens-controller/src/EnsController.ts
@@ -18,19 +18,19 @@ const name = 'EnsController';
  * @property ensName - The ENS name
  * @property address - Hex address with the ENS name, or null
  */
-export interface EnsEntry {
+export type EnsEntry = {
   chainId: string;
   ensName: string;
   address: string | null;
-}
+};
 
 /**
- * @type EnsState
+ * @type EnsControllerState
  *
  * ENS controller state
  * @property ensEntries - Object of ENS entry objects
  */
-export type EnsState = {
+export type EnsControllerState = {
   ensEntries: {
     [chainId: string]: {
       [ensName: string]: EnsEntry;
@@ -60,11 +60,11 @@ const defaultState = {
  */
 export class EnsController extends BaseControllerV2<
   typeof name,
-  EnsState,
+  EnsControllerState,
   EnsControllerMessenger
 > {
   /**
-   * Creates a EnsController instance.
+   * Creates an EnsController instance.
    *
    * @param options - Constructor options.
    * @param options.messenger - A reference to the messaging system.
@@ -75,7 +75,7 @@ export class EnsController extends BaseControllerV2<
     state,
   }: {
     messenger: EnsControllerMessenger;
-    state?: Partial<EnsState>;
+    state?: Partial<EnsControllerState>;
   }) {
     super({
       name,
@@ -114,15 +114,12 @@ export class EnsController extends BaseControllerV2<
       return false;
     }
 
-    const ensEntries = Object.assign({}, this.state.ensEntries);
-    delete ensEntries[chainId][normalizedEnsName];
-
-    if (Object.keys(ensEntries[chainId]).length === 0) {
-      delete ensEntries[chainId];
-    }
-
     this.update((state) => {
-      state.ensEntries = ensEntries;
+      delete state.ensEntries[chainId][normalizedEnsName];
+
+      if (Object.keys(state.ensEntries[chainId]).length === 0) {
+        delete state.ensEntries[chainId];
+      }
     });
     return true;
   }


### PR DESCRIPTION
This PR migrate the ens controller to new base api
Related issue [#1130](https://github.com/MetaMask/core/issues/1130)