### PR TITLE
bump contract metadata package version

### DIFF
--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -34,7 +34,7 @@
     "@ethersproject/providers": "^5.7.0",
     "@metamask/abi-utils": "^1.1.0",
     "@metamask/base-controller": "workspace:^",
-    "@metamask/contract-metadata": "^2.1.0",
+    "@metamask/contract-metadata": "^2.3.1",
     "@metamask/controller-utils": "workspace:^",
     "@metamask/metamask-eth-abis": "3.0.0",
     "@metamask/network-controller": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1452,7 +1452,7 @@ __metadata:
     "@metamask/abi-utils": ^1.1.0
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:^"
-    "@metamask/contract-metadata": ^2.1.0
+    "@metamask/contract-metadata": ^2.3.1
     "@metamask/controller-utils": "workspace:^"
     "@metamask/metamask-eth-abis": 3.0.0
     "@metamask/network-controller": "workspace:^"
@@ -1544,10 +1544,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/contract-metadata@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@metamask/contract-metadata@npm:2.1.0"
-  checksum: eebe2fb7c16c0f585f08e0de446efe5c7866316e3f663b409691aaf69333deead53fcc9f3f0a67db7d0d84309dc52a620512c441b5d020ad08baf2fed7ed773f
+"@metamask/contract-metadata@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "@metamask/contract-metadata@npm:2.3.1"
+  checksum: 95dcc27f661a3e380c0cca8c6d90fb1777e31ab3fe16909fd5c67844125510e3f8e9eca05c9069fde34c77df3b66e56111c7a908a07623e88052ef147eff4315
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Bump contract metadata package version**

**Description**

Bumping contract-metadata version following up on:

https://github.com/MetaMask/contract-metadata/pull/1169
https://github.com/MetaMask/contract-metadata/pull/1173

This PR is a blocker for [this other PR on the extension](https://github.com/MetaMask/metamask-extension/pull/18278) due to deduplication warnings.

- CHANGED:

  - Bumped contract metadata package version

