### PR TITLE
docs/contributing: fix token scope

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,7 +25,7 @@ When developing changes to packages within this repository that a different proj
 
 If you're a MetaMask contributor, you can create these preview versions via draft pull requests:
 
-1. Navigate to your settings within GitHub and [create a classic access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic). Make sure to give this token the `packages:read` scope.
+1. Navigate to your settings within GitHub and [create a classic access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic). Make sure to give this token the `read:packages` scope.
 2. Switch to your project locally and add/edit the appropriate file with the following content, filling in the appropriate areas:
 
    - **Yarn 1 (classic) or NPM**
@@ -60,7 +60,7 @@ If you're a MetaMask contributor, you can create these preview versions via draf
 
 If you're a contributor and you've forked this repository, you can create preview versions for a branch via provided scripts:
 
-1. Navigate to your settings within GitHub and [create a **classic** access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic). Make sure to give this token the `packages:read` scope.
+1. Navigate to your settings within GitHub and [create a **classic** access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic). Make sure to give this token the `read:packages` scope.
 2. Switch to your project locally and add/edit the appropriate file with the following content, filling in the appropriate areas.
 
    - **Yarn 1 (classic) or NPM:**


### PR DESCRIPTION
**docs/contributing: fix token scope**

- Fixes scope typo. https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes

**Description**

- FIXED:

  - Changed token scope from `packages:read` to `read:packages`

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented