### PR TITLE
Adds EncryptionPublicKeyManager

### DIFF
--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -120,7 +120,7 @@ describe('AbstractTestManager', () => {
     expect(message.rawSig).toBe('rawSig');
   });
 
-  it('should set message to one of the allowed statuses', () => {
+  it('sets message to one of the allowed statuses', () => {
     const controller = new AbstractTestManager(undefined, undefined, [
       'received',
     ]);

--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -120,6 +120,28 @@ describe('AbstractTestManager', () => {
     expect(message.rawSig).toBe('rawSig');
   });
 
+  it('should set message to one of the allowed statuses', () => {
+    const controller = new AbstractTestManager(undefined, undefined, [
+      'received',
+    ]);
+    controller.addMessage({
+      id: messageId,
+      messageParams: {
+        data: typedMessage,
+        from,
+      },
+      status: messageStatus,
+      time: messageTime,
+      type: messageType,
+    });
+    controller.setMessageStatusAndResult(messageId, 'rawSig', 'received');
+    const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.status).toBe('received');
+  });
+
   it('should get correct unapproved messages', () => {
     const firstMessageData = [
       {

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -80,6 +80,8 @@ export abstract class AbstractMessageManager<
 > extends BaseController<BaseConfig, MessageManagerState<M>> {
   protected messages: M[];
 
+  private additionalFinishStatuses: string[];
+
   /**
    * Saves the unapproved messages, and their count to state.
    *
@@ -109,7 +111,7 @@ export abstract class AbstractMessageManager<
       status === 'rejected' ||
       status === 'signed' ||
       status === 'errored' ||
-      status === 'received'
+      this.additionalFinishStatuses.includes(status)
     ) {
       this.hub.emit(`${messageId}:finished`, message);
     }
@@ -145,10 +147,12 @@ export abstract class AbstractMessageManager<
    *
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
+   * @param additionalFinishStatuses -
    */
   constructor(
     config?: Partial<BaseConfig>,
     state?: Partial<MessageManagerState<M>>,
+    additionalFinishStatuses?: string[],
   ) {
     super(config, state);
     this.defaultState = {
@@ -156,6 +160,7 @@ export abstract class AbstractMessageManager<
       unapprovedMessagesCount: 0,
     };
     this.messages = [];
+    this.additionalFinishStatuses = additionalFinishStatuses ?? [];
     this.initialize();
   }
 

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -105,7 +105,12 @@ export abstract class AbstractMessageManager<
     message.status = status;
     this.updateMessage(message);
     this.hub.emit(`${messageId}:${status}`, message);
-    if (status === 'rejected' || status === 'signed' || status === 'errored') {
+    if (
+      status === 'rejected' ||
+      status === 'signed' ||
+      status === 'errored' ||
+      status === 'received'
+    ) {
       this.hub.emit(`${messageId}:finished`, message);
     }
   }
@@ -240,6 +245,25 @@ export abstract class AbstractMessageManager<
     message.rawSig = rawSig;
     this.updateMessage(message);
     this.setMessageStatus(messageId, 'signed');
+  }
+
+  /**
+   * Sets a EncryptionPublicKey status to 'received' via a call to this.setMsgStatus and
+   * updates that EncryptionPublicKey in this.messages by adding the raw data of request
+   * to the EncryptionPublicKey.
+   *
+   * @param messageId - The id of the Message to sign.
+   * @param rawSig - The encryption public key of the request.
+   */
+  setMessageStatusReceived(messageId: string, rawSig: string) {
+    const message = this.getMessage(messageId);
+    /* istanbul ignore if */
+    if (!message) {
+      return;
+    }
+    message.rawSig = rawSig;
+    this.updateMessage(message);
+    this.setMessageStatus(messageId, 'received');
   }
 
   /**

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -36,7 +36,7 @@ export interface AbstractMessage {
  * @type MessageParams
  *
  * Represents the parameters to pass to the signing method once the signature request is approved.
- * @property from - Address to sign this message from
+ * @property from - Address from which the message is processed
  * @property origin? - Added for request origin identification
  */
 export interface AbstractMessageParams {
@@ -50,7 +50,7 @@ export interface AbstractMessageParams {
  * Represents the parameters to pass to the signing method once the signature request is approved
  * plus data added by MetaMask.
  * @property metamaskId - Added for tracking and identification within MetaMask
- * @property from - Address to sign this message from
+ * @property from - Address from which the message is processed
  * @property origin? - Added for request origin identification
  */
 export interface AbstractMessageParamsMetamask extends AbstractMessageParams {
@@ -242,25 +242,18 @@ export abstract class AbstractMessageManager<
    * @param rawSig - The raw data of the signature request.
    */
   setMessageStatusSigned(messageId: string, rawSig: string) {
-    const message = this.getMessage(messageId);
-    /* istanbul ignore if */
-    if (!message) {
-      return;
-    }
-    message.rawSig = rawSig;
-    this.updateMessage(message);
-    this.setMessageStatus(messageId, 'signed');
+    this.setMessageStatusAndResult(messageId, rawSig, 'signed');
   }
 
   /**
-   * Sets a EncryptionPublicKey status to 'received' via a call to this.setMsgStatus and
-   * updates that EncryptionPublicKey in this.messages by adding the raw data of request
-   * to the EncryptionPublicKey.
+   * Sets the message to a new status via a call to this.setMsgStatus and
+   * updates the rawSig field in this.messages.
    *
    * @param messageId - The id of the Message to sign.
-   * @param rawSig - The encryption public key of the request.
+   * @param rawSig - The data to update rawSig in the message.
+   * @param status - The new message status.
    */
-  setMessageStatusReceived(messageId: string, rawSig: string) {
+  setMessageStatusAndResult(messageId: string, rawSig: string, status: string) {
     const message = this.getMessage(messageId);
     /* istanbul ignore if */
     if (!message) {
@@ -268,7 +261,7 @@ export abstract class AbstractMessageManager<
     }
     message.rawSig = rawSig;
     this.updateMessage(message);
-    this.setMessageStatus(messageId, 'received');
+    this.setMessageStatus(messageId, status);
   }
 
   /**

--- a/packages/message-manager/src/EncryptionPublicKeyManager.test.ts
+++ b/packages/message-manager/src/EncryptionPublicKeyManager.test.ts
@@ -1,0 +1,199 @@
+import { EncryptionPublicKeyManager } from './EncryptionPublicKeyManager';
+
+describe('EncryptionPublicKeyManager', () => {
+  it('should set default state', () => {
+    const controller = new EncryptionPublicKeyManager();
+    expect(controller.state).toStrictEqual({
+      unapprovedMessages: {},
+      unapprovedMessagesCount: 0,
+    });
+  });
+
+  it('should set default config', () => {
+    const controller = new EncryptionPublicKeyManager();
+    expect(controller.config).toStrictEqual({});
+  });
+
+  it('should add a valid message', async () => {
+    const controller = new EncryptionPublicKeyManager();
+    const messageId = '1';
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const messageTime = Date.now();
+    const messageStatus = 'unapproved';
+    const messageType = 'eth_getEncryptionPublicKey';
+    controller.addMessage({
+      id: messageId,
+      messageParams: {
+        from,
+      },
+      status: messageStatus,
+      time: messageTime,
+      type: messageType,
+    });
+    const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.id).toBe(messageId);
+    expect(message.messageParams.from).toBe(from);
+    expect(message.time).toBe(messageTime);
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
+  });
+
+  it('should reject a message', async () => {
+    const controller = new EncryptionPublicKeyManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const result = controller.addUnapprovedMessageAsync({
+      from,
+    });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('rejected');
+    });
+    controller.rejectMessage(keys[0]);
+    await expect(result).rejects.toThrow(
+      'MetaMask EncryptionPublicKey: User denied message EncryptionPublicKey',
+    );
+  });
+
+  it('should set message to received', async () => {
+    const controller = new EncryptionPublicKeyManager(undefined, undefined, [
+      'received',
+    ]);
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const rawSig = '231124fe67213512=';
+    const result = controller.addUnapprovedMessageAsync({
+      from,
+    });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('received');
+    });
+    controller.setMessageStatusAndResult(keys[0], rawSig, 'received');
+    const publicKey = await result;
+    expect(publicKey).toBe(rawSig);
+  });
+
+  it('should throw when unapproved finishes', async () => {
+    const controller = new EncryptionPublicKeyManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const result = controller.addUnapprovedMessageAsync({
+      from,
+    });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.emit(`${keys[0]}:finished`, unapprovedMessages[keys[0]]);
+    await expect(result).rejects.toThrow('Unknown problem');
+  });
+
+  it('should add a valid unapproved message', async () => {
+    const controller = new EncryptionPublicKeyManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const messageStatus = 'unapproved';
+    const messageType = 'eth_getEncryptionPublicKey';
+    const messageParams = {
+      from,
+    };
+    const originalRequest = { origin: 'origin' };
+    const messageId = controller.addUnapprovedMessage(
+      messageParams,
+      originalRequest,
+    );
+    expect(messageId).not.toBeUndefined();
+    const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.messageParams.from).toBe(messageParams.from);
+    expect(message.time).not.toBeUndefined();
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
+  });
+
+  it('should throw when adding invalid message', async () => {
+    const from = 'foo';
+    const controller = new EncryptionPublicKeyManager();
+    await expect(
+      controller.addUnapprovedMessageAsync({
+        from,
+      }),
+    ).rejects.toThrow('Invalid "from" address:');
+  });
+
+  it('should get correct unapproved messages', () => {
+    const firstMessage = {
+      id: '1',
+      messageParams: { from: '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d' },
+      status: 'unapproved',
+      time: 123,
+      type: 'eth_getEncryptionPublicKey',
+    };
+    const secondMessage = {
+      id: '2',
+      messageParams: { from: '0x3244e191f1b4903970224322180f1fbbc415696b' },
+      status: 'unapproved',
+      time: 123,
+      type: 'eth_getEncryptionPublicKey',
+    };
+    const controller = new EncryptionPublicKeyManager();
+    controller.addMessage(firstMessage);
+    controller.addMessage(secondMessage);
+    expect(controller.getUnapprovedMessagesCount()).toStrictEqual(2);
+    expect(controller.getUnapprovedMessages()).toStrictEqual({
+      [firstMessage.id]: firstMessage,
+      [secondMessage.id]: secondMessage,
+    });
+  });
+
+  it('should approve message', async () => {
+    const controller = new EncryptionPublicKeyManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const firstMessage = { from };
+    const messageId = controller.addUnapprovedMessage(firstMessage);
+    const messageParams = await controller.approveMessage({
+      from,
+      data: from,
+      metamaskId: messageId,
+    });
+    const message = controller.getMessage(messageId);
+    expect(messageParams).toStrictEqual(firstMessage);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.status).toStrictEqual('approved');
+  });
+
+  it('should set message status received', () => {
+    const controller = new EncryptionPublicKeyManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const firstMessage = { from };
+    const rawSig = '231124fe67213512=';
+    const messageId = controller.addUnapprovedMessage(firstMessage);
+
+    controller.setMessageStatusAndResult(messageId, rawSig, 'received');
+    const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.rawSig).toStrictEqual(rawSig);
+    expect(message.status).toStrictEqual('received');
+  });
+
+  it('should reject message', () => {
+    const controller = new EncryptionPublicKeyManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const firstMessage = { from };
+    const messageId = controller.addUnapprovedMessage(firstMessage);
+    controller.rejectMessage(messageId);
+    const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.status).toStrictEqual('rejected');
+  });
+});

--- a/packages/message-manager/src/EncryptionPublicKeyManager.test.ts
+++ b/packages/message-manager/src/EncryptionPublicKeyManager.test.ts
@@ -1,7 +1,7 @@
 import { EncryptionPublicKeyManager } from './EncryptionPublicKeyManager';
 
 describe('EncryptionPublicKeyManager', () => {
-  it('should set default state', () => {
+  it('sets default state', () => {
     const controller = new EncryptionPublicKeyManager();
     expect(controller.state).toStrictEqual({
       unapprovedMessages: {},
@@ -9,12 +9,12 @@ describe('EncryptionPublicKeyManager', () => {
     });
   });
 
-  it('should set default config', () => {
+  it('sets default config', () => {
     const controller = new EncryptionPublicKeyManager();
     expect(controller.config).toStrictEqual({});
   });
 
-  it('should add a valid message', async () => {
+  it('adds a valid message', async () => {
     const controller = new EncryptionPublicKeyManager();
     const messageId = '1';
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
@@ -41,7 +41,7 @@ describe('EncryptionPublicKeyManager', () => {
     expect(message.type).toBe(messageType);
   });
 
-  it('should reject a message', async () => {
+  it('rejects a message', async () => {
     const controller = new EncryptionPublicKeyManager();
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const result = controller.addUnapprovedMessageAsync({
@@ -59,7 +59,7 @@ describe('EncryptionPublicKeyManager', () => {
     );
   });
 
-  it('should set message to received', async () => {
+  it('sets message to received', async () => {
     const controller = new EncryptionPublicKeyManager(undefined, undefined, [
       'received',
     ]);
@@ -79,7 +79,7 @@ describe('EncryptionPublicKeyManager', () => {
     expect(publicKey).toBe(rawSig);
   });
 
-  it('should throw when unapproved finishes', async () => {
+  it('throws when unapproved finishes', async () => {
     const controller = new EncryptionPublicKeyManager();
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const result = controller.addUnapprovedMessageAsync({
@@ -91,7 +91,7 @@ describe('EncryptionPublicKeyManager', () => {
     await expect(result).rejects.toThrow('Unknown problem');
   });
 
-  it('should add a valid unapproved message', async () => {
+  it('adds a valid unapproved message', async () => {
     const controller = new EncryptionPublicKeyManager();
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const messageStatus = 'unapproved';
@@ -115,7 +115,7 @@ describe('EncryptionPublicKeyManager', () => {
     expect(message.type).toBe(messageType);
   });
 
-  it('should throw when adding invalid message', async () => {
+  it('throws when adding invalid message', async () => {
     const from = 'foo';
     const controller = new EncryptionPublicKeyManager();
     await expect(
@@ -125,7 +125,7 @@ describe('EncryptionPublicKeyManager', () => {
     ).rejects.toThrow('Invalid "from" address:');
   });
 
-  it('should get correct unapproved messages', () => {
+  it('gets correct unapproved messages', () => {
     const firstMessage = {
       id: '1',
       messageParams: { from: '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d' },
@@ -150,7 +150,7 @@ describe('EncryptionPublicKeyManager', () => {
     });
   });
 
-  it('should approve message', async () => {
+  it('approves message', async () => {
     const controller = new EncryptionPublicKeyManager();
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const firstMessage = { from };
@@ -168,7 +168,7 @@ describe('EncryptionPublicKeyManager', () => {
     expect(message.status).toStrictEqual('approved');
   });
 
-  it('should set message status received', () => {
+  it('sets message status received', () => {
     const controller = new EncryptionPublicKeyManager();
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const firstMessage = { from };
@@ -184,7 +184,7 @@ describe('EncryptionPublicKeyManager', () => {
     expect(message.status).toStrictEqual('received');
   });
 
-  it('should reject message', () => {
+  it('rejects message', () => {
     const controller = new EncryptionPublicKeyManager();
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const firstMessage = { from };

--- a/packages/message-manager/src/EncryptionPublicKeyManager.ts
+++ b/packages/message-manager/src/EncryptionPublicKeyManager.ts
@@ -1,0 +1,149 @@
+import { v1 as random } from 'uuid';
+import {
+  AbstractMessageManager,
+  AbstractMessage,
+  AbstractMessageParams,
+  AbstractMessageParamsMetamask,
+  OriginalRequest,
+} from './AbstractMessageManager';
+import { validateEncryptionPublicKeyMessageData } from './utils';
+
+/**
+ * @type EncryptionPublicKey
+ *
+ * Represents and contains data about a 'eth_getEncryptionPublicKey' type request.
+ * These are created when an encryption public key is requested.
+ * @property id - An id to track and identify the message object
+ * @property messageParams - The parameters to pass to the eth_getEncryptionPublicKey method once the request is approved
+ * @property type - The json-prc method for which an encryption public key request has been made.
+ * A 'Message' which always has a 'eth_getEncryptionPublicKey' type
+ * @property rawSig - Encryption public key
+ */
+export interface EncryptionPublicKey extends AbstractMessage {
+  messageParams: EncryptionPublicKeyParams;
+}
+
+/**
+ * @type EncryptionPublicKeyParams
+ *
+ * Represents the parameters to pass to the method once the request is approved.
+ * @property from - Address from which to extract the encryption public key
+ * @property origin? - Added for request origin identification
+ */
+export type EncryptionPublicKeyParams = AbstractMessageParams;
+
+/**
+ * @type MessageParamsMetamask
+ *
+ * Represents the parameters to pass to the eth_getEncryptionPublicKey method once the request is approved
+ * plus data added by MetaMask.
+ * @property metamaskId - Added for tracking and identification within MetaMask
+ * @property data - Encryption public key
+ * @property from - Address from which to extract the encryption public key
+ * @property origin? - Added for request origin identification
+ */
+export interface EncryptionPublicKeyParamsMetamask
+  extends AbstractMessageParamsMetamask {
+  data: string;
+}
+
+/**
+ * Controller in charge of managing - storing, adding, removing, updating - Messages.
+ */
+export class EncryptionPublicKeyManager extends AbstractMessageManager<
+  EncryptionPublicKey,
+  EncryptionPublicKeyParams,
+  EncryptionPublicKeyParamsMetamask
+> {
+  /**
+   * Name of this controller used during composition
+   */
+  override name = 'EncryptionPublicKeyManager';
+
+  /**
+   * Creates a new Message with an 'unapproved' status using the passed messageParams.
+   * this.addMessage is called to add the new Message to this.messages, and to save the unapproved Messages.
+   *
+   * @param messageParams - The params for the eth_getEncryptionPublicKey call to be made after the message is approved.
+   * @param req - The original request object possibly containing the origin.
+   * @returns Promise resolving to the raw data of the request.
+   */
+  addUnapprovedMessageAsync(
+    messageParams: EncryptionPublicKeyParams,
+    req?: OriginalRequest,
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      validateEncryptionPublicKeyMessageData(messageParams);
+      const messageId = this.addUnapprovedMessage(messageParams, req);
+      this.hub.once(`${messageId}:finished`, (data: EncryptionPublicKey) => {
+        switch (data.status) {
+          case 'received':
+            return resolve(data.rawSig as string);
+          case 'rejected':
+            return reject(
+              new Error(
+                'MetaMask EncryptionPublicKey: User denied message EncryptionPublicKey.',
+              ),
+            );
+          default:
+            return reject(
+              new Error(
+                `MetaMask EncryptionPublicKey: Unknown problem: ${JSON.stringify(
+                  messageParams,
+                )}`,
+              ),
+            );
+        }
+      });
+    });
+  }
+
+  /**
+   * Creates a new Message with an 'unapproved' status using the passed messageParams.
+   * this.addMessage is called to add the new Message to this.messages, and to save the
+   * unapproved Messages.
+   *
+   * @param messageParams - The params for the eth_getEncryptionPublicKey call to be made after the message
+   * is approved.
+   * @param req - The original request object possibly containing the origin.
+   * @returns The id of the newly created message.
+   */
+  addUnapprovedMessage(
+    messageParams: EncryptionPublicKeyParams,
+    req?: OriginalRequest,
+  ) {
+    if (req) {
+      messageParams.origin = req.origin;
+    }
+    const messageId = random();
+    const messageData: EncryptionPublicKey = {
+      id: messageId,
+      messageParams,
+      status: 'unapproved',
+      time: Date.now(),
+      type: 'eth_getEncryptionPublicKey',
+    };
+    this.addMessage(messageData);
+    this.hub.emit(`unapprovedMessage`, {
+      ...messageParams,
+      ...{ metamaskId: messageId },
+    });
+    return messageId;
+  }
+
+  /**
+   * Removes the metamaskId property from passed messageParams and returns a promise which
+   * resolves the updated messageParams.
+   *
+   * @param messageParams - The messageParams to modify.
+   * @returns Promise resolving to the messageParams with the metamaskId property removed.
+   */
+  prepMessageForSigning(
+    messageParams: EncryptionPublicKeyParamsMetamask,
+  ): Promise<EncryptionPublicKeyParams> {
+    delete messageParams.metamaskId;
+    return Promise.resolve({ from: messageParams.data });
+  }
+}
+
+export default EncryptionPublicKeyManager;

--- a/packages/message-manager/src/index.ts
+++ b/packages/message-manager/src/index.ts
@@ -1,3 +1,4 @@
 export * from './MessageManager';
 export * from './PersonalMessageManager';
 export * from './TypedMessageManager';
+export * from './EncryptionPublicKeyManager';

--- a/packages/message-manager/src/utils.test.ts
+++ b/packages/message-manager/src/utils.test.ts
@@ -185,4 +185,36 @@ describe('utils', () => {
       ).not.toThrow();
     });
   });
+
+  describe('validateEncryptionPublicKeyMessageData', () => {
+    it('should throw if no from address', () => {
+      expect(() =>
+        util.validateEncryptionPublicKeyMessageData({} as any),
+      ).toThrow('Invalid "from" address: undefined must be a valid string.');
+    });
+
+    it('should throw if invalid from address', () => {
+      expect(() =>
+        util.validateEncryptionPublicKeyMessageData({
+          from: '01',
+        } as any),
+      ).toThrow('Invalid "from" address: 01 must be a valid string.');
+    });
+
+    it('should throw if invalid type from address', () => {
+      expect(() =>
+        util.validateEncryptionPublicKeyMessageData({
+          from: 123,
+        } as any),
+      ).toThrow('Invalid "from" address: 123 must be a valid string.');
+    });
+
+    it('should not throw if from address is correct', () => {
+      expect(() =>
+        util.validateEncryptionPublicKeyMessageData({
+          from: '0x3244e191f1b4903970224322180f1fbbc415696b',
+        } as any),
+      ).not.toThrow();
+    });
+  });
 });

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -5,6 +5,7 @@ import { isValidHexAddress } from '@metamask/controller-utils';
 import { MessageParams } from './MessageManager';
 import { PersonalMessageParams } from './PersonalMessageManager';
 import { TypedMessageParams } from './TypedMessageManager';
+import { EncryptionPublicKeyParams } from './EncryptionPublicKeyManager';
 
 const hexRe = /^[0-9A-Fa-f]+$/gu;
 
@@ -114,5 +115,20 @@ export function validateTypedSignMessageDataV3(
     throw new Error(
       'Data must conform to EIP-712 schema. See https://git.io/fNtcx.',
     );
+  }
+}
+
+/**
+ * Validates messageData for the eth_getEncryptionPublicKey message and throws in
+ * the event of any validation error.
+ *
+ * @param messageData - address string to validate.
+ */
+export function validateEncryptionPublicKeyMessageData(
+  messageData: EncryptionPublicKeyParams,
+) {
+  const { from } = messageData;
+  if (!from || typeof from !== 'string' || !isValidHexAddress(from)) {
+    throw new Error(`Invalid "from" address: ${from} must be a valid string.`);
   }
 }


### PR DESCRIPTION
**Adds EncryptionPublicKeyManager**

**Description**

- CHANGED:

  - Extends `AbstractMessageManager` so that it can support other actions

- ADDED:

  - Creates an `EncryptionPublicKeyManager` that will be used by `EncryptionPublicKeyController`.

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Resolves https://github.com/MetaMask/MetaMask-planning/issues/394
