### PR TITLE
feat: add security provider request to AbstractMessageManager

### DIFF
--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -60,7 +60,7 @@ describe('AbstractTestManager', () => {
 
   it('should add a valid message', async () => {
     const controller = new AbstractTestManager();
-    controller.addMessage({
+    await controller.addMessage({
       id: messageId,
       messageParams: {
         data: typedMessage,
@@ -84,15 +84,15 @@ describe('AbstractTestManager', () => {
 
   it('adds a valid message with provider security response', async () => {
     const securityProviderResponseMock = { flagAsDangerous: 2 };
-    const securityProviderRequest: SecurityProviderRequest = jest
+    const securityProviderRequestMock: SecurityProviderRequest = jest
       .fn()
       .mockResolvedValue(securityProviderResponseMock);
     const controller = new AbstractTestManager(
       undefined,
       undefined,
-      securityProviderRequest,
+      securityProviderRequestMock,
     );
-    controller.addMessage({
+    await controller.addMessage({
       id: messageId,
       messageParams: {
         data: typedMessage,
@@ -102,9 +102,6 @@ describe('AbstractTestManager', () => {
       time: messageTime,
       type: messageType,
     });
-
-    // Wait for the securityProviderRequest Promise to resolve
-    await new Promise((resolve) => setTimeout(resolve, 100));
 
     const message = controller.getMessage(messageId);
     if (!message) {
@@ -116,12 +113,14 @@ describe('AbstractTestManager', () => {
     expect(message.time).toBe(messageTime);
     expect(message.status).toBe(messageStatus);
     expect(message.type).toBe(messageType);
+    expect(securityProviderRequestMock).toHaveBeenCalled();
+    expect(message).toHaveProperty('securityProviderResponse');
     expect(message.securityProviderResponse).toBe(securityProviderResponseMock);
   });
 
-  it('should reject a message', () => {
+  it('should reject a message', async () => {
     const controller = new AbstractTestManager();
-    controller.addMessage({
+    await controller.addMessage({
       id: messageId,
       messageParams: {
         data: typedMessage,
@@ -139,9 +138,9 @@ describe('AbstractTestManager', () => {
     expect(message.status).toBe('rejected');
   });
 
-  it('should sign a message', () => {
+  it('should sign a message', async () => {
     const controller = new AbstractTestManager();
-    controller.addMessage({
+    await controller.addMessage({
       id: messageId,
       messageParams: {
         data: typedMessage,
@@ -160,7 +159,7 @@ describe('AbstractTestManager', () => {
     expect(message.rawSig).toBe('rawSig');
   });
 
-  it('should get correct unapproved messages', () => {
+  it('should get correct unapproved messages', async () => {
     const firstMessageData = [
       {
         name: 'Message',
@@ -200,8 +199,8 @@ describe('AbstractTestManager', () => {
       type: 'eth_signTypedData',
     };
     const controller = new AbstractTestManager();
-    controller.addMessage(firstMessage);
-    controller.addMessage(secondMessage);
+    await controller.addMessage(firstMessage);
+    await controller.addMessage(secondMessage);
     expect(controller.getUnapprovedMessagesCount()).toStrictEqual(2);
     expect(controller.getUnapprovedMessages()).toStrictEqual({
       [firstMessage.id]: firstMessage,
@@ -213,7 +212,7 @@ describe('AbstractTestManager', () => {
     const controller = new AbstractTestManager();
     const firstMessage = { from: '0xfoO', data: typedMessage };
     const version = 'V1';
-    controller.addMessage({
+    await controller.addMessage({
       id: messageId,
       messageParams: firstMessage,
       status: messageStatus,
@@ -234,9 +233,9 @@ describe('AbstractTestManager', () => {
   });
 
   describe('setMessageStatus', () => {
-    it('should set the given message status', () => {
+    it('should set the given message status', async () => {
       const controller = new AbstractTestManager();
-      controller.addMessage({
+      await controller.addMessage({
         id: messageId,
         messageParams: { from: '0x1234', data: 'test' },
         status: 'status',

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -91,7 +91,7 @@ export abstract class AbstractMessageManager<
 > extends BaseController<BaseConfig, MessageManagerState<M>> {
   protected messages: M[];
 
-  protected securityProviderRequest: SecurityProviderRequest | undefined;
+  private securityProviderRequest: SecurityProviderRequest | undefined;
 
   /**
    * Saves the unapproved messages, and their count to state.

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -4,6 +4,7 @@ import {
   BaseConfig,
   BaseState,
 } from '@metamask/base-controller';
+import { Json } from '@metamask/controller-utils';
 
 /**
  * @type OriginalRequest
@@ -23,6 +24,7 @@ export interface OriginalRequest {
  * @property type - The json-prc signing method for which a signature request has been made.
  * A 'Message' which always has a signing type
  * @property rawSig - Raw data of the signature request
+ * @property securityProviderResponse - Response from a security provider, whether it is malicious or not
  */
 export interface AbstractMessage {
   id: string;
@@ -30,6 +32,7 @@ export interface AbstractMessage {
   status: string;
   type: string;
   rawSig?: string;
+  securityProviderResponse?: Json;
 }
 
 /**
@@ -71,6 +74,14 @@ export interface MessageManagerState<M extends AbstractMessage>
 }
 
 /**
+ * A function for verifying a message, whether it is malicious or not
+ */
+export type SecurityProviderRequest = (
+  requestData: AbstractMessage,
+  messageType: string,
+) => Promise<Json>;
+
+/**
  * Controller in charge of managing - storing, adding, removing, updating - Messages.
  */
 export abstract class AbstractMessageManager<
@@ -79,6 +90,8 @@ export abstract class AbstractMessageManager<
   PM extends AbstractMessageParamsMetamask,
 > extends BaseController<BaseConfig, MessageManagerState<M>> {
   protected messages: M[];
+
+  protected securityProviderRequest: SecurityProviderRequest | undefined;
 
   /**
    * Saves the unapproved messages, and their count to state.
@@ -140,10 +153,12 @@ export abstract class AbstractMessageManager<
    *
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
+   * @param securityProviderRequest - A function for verifying a message, whether it is malicious or not.
    */
   constructor(
     config?: Partial<BaseConfig>,
     state?: Partial<MessageManagerState<M>>,
+    securityProviderRequest?: SecurityProviderRequest,
   ) {
     super(config, state);
     this.defaultState = {
@@ -151,6 +166,7 @@ export abstract class AbstractMessageManager<
       unapprovedMessagesCount: 0,
     };
     this.messages = [];
+    this.securityProviderRequest = securityProviderRequest;
     this.initialize();
   }
 
@@ -179,13 +195,26 @@ export abstract class AbstractMessageManager<
 
   /**
    * Adds a passed Message to this.messages, and calls this.saveMessageList() to save
-   * the unapproved Messages from that list to this.messages.
+   * the unapproved Messages from that list to this.messages. If a security provider
+   * is provided, the method will check if the Message is malicious or not.
    *
    * @param message - The Message to add to this.messages.
    */
   addMessage(message: M) {
-    this.messages.push(message);
-    this.saveMessageList();
+    if (this.securityProviderRequest) {
+      this.securityProviderRequest(message, message.type).then(
+        (securityProviderResponse) => {
+          this.messages.push({
+            ...message,
+            securityProviderResponse,
+          });
+          this.saveMessageList();
+        },
+      );
+    } else {
+      this.messages.push(message);
+      this.saveMessageList();
+    }
   }
 
   /**

--- a/packages/message-manager/src/MessageManager.test.ts
+++ b/packages/message-manager/src/MessageManager.test.ts
@@ -1,8 +1,17 @@
 import { MessageManager } from './MessageManager';
 
-describe('PersonalMessageManager', () => {
+describe('MessageManager', () => {
+  let controller: MessageManager;
+
+  const fromMock = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+  const dataMock = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
+  const messageIdMock = 'message-id-mocked';
+  const rawSigMock = '0xsignaturemocked';
+  beforeEach(() => {
+    controller = new MessageManager();
+  });
+
   it('should set default state', () => {
-    const controller = new MessageManager();
     expect(controller.state).toStrictEqual({
       unapprovedMessages: {},
       unapprovedMessagesCount: 0,
@@ -10,19 +19,17 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should set default config', () => {
-    const controller = new MessageManager();
     expect(controller.config).toStrictEqual({});
   });
 
   it('should add a valid message', async () => {
-    const controller = new MessageManager();
     const messageId = '1';
     const from = '0x0123';
     const messageData = '0x123';
     const messageTime = Date.now();
     const messageStatus = 'unapproved';
     const messageType = 'eth_sign';
-    controller.addMessage({
+    await controller.addMessage({
       id: messageId,
       messageParams: {
         data: messageData,
@@ -44,60 +51,72 @@ describe('PersonalMessageManager', () => {
     expect(message.type).toBe(messageType);
   });
 
-  it('should reject a message', async () => {
-    const controller = new MessageManager();
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-    const result = controller.addUnapprovedMessageAsync({
-      data,
-      from,
+  describe('addUnapprovedMessageAsync', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(controller, 'addUnapprovedMessage')
+        .mockImplementation()
+        .mockResolvedValue(messageIdMock);
     });
-    const unapprovedMessages = controller.getUnapprovedMessages();
-    const keys = Object.keys(unapprovedMessages);
-    controller.hub.once(`${keys[0]}:finished`, () => {
-      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
-      expect(unapprovedMessages[keys[0]].status).toBe('rejected');
-    });
-    controller.rejectMessage(keys[0]);
-    await expect(result).rejects.toThrow('User denied message signature');
-  });
 
-  it('should sign a message', async () => {
-    const controller = new MessageManager();
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-    const rawSig = '0x5f7a0';
-    const result = controller.addUnapprovedMessageAsync({
-      data,
-      from,
+    afterAll(() => {
+      jest.spyOn(controller, 'addUnapprovedMessage').mockClear();
     });
-    const unapprovedMessages = controller.getUnapprovedMessages();
-    const keys = Object.keys(unapprovedMessages);
-    controller.hub.once(`${keys[0]}:finished`, () => {
-      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
-      expect(unapprovedMessages[keys[0]].status).toBe('signed');
-    });
-    controller.setMessageStatusSigned(keys[0], rawSig);
-    const sig = await result;
-    expect(sig).toBe(rawSig);
-  });
+    it('signs the message when status is "signed"', async () => {
+      const promise = controller.addUnapprovedMessageAsync({
+        data: dataMock,
+        from: fromMock,
+      });
 
-  it('should throw when unapproved finishes', async () => {
-    const controller = new MessageManager();
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-    const result = controller.addUnapprovedMessageAsync({
-      data,
-      from,
+      setTimeout(() => {
+        controller.hub.emit(`${messageIdMock}:finished`, {
+          status: 'signed',
+          rawSig: rawSigMock,
+        });
+      }, 100);
+
+      expect(await promise).toStrictEqual(rawSigMock);
     });
-    const unapprovedMessages = controller.getUnapprovedMessages();
-    const keys = Object.keys(unapprovedMessages);
-    controller.hub.emit(`${keys[0]}:finished`, unapprovedMessages[keys[0]]);
-    await expect(result).rejects.toThrow('Unknown problem');
+
+    it('rejects with an error when status is "rejected"', async () => {
+      const promise = controller.addUnapprovedMessageAsync({
+        data: dataMock,
+        from: fromMock,
+      });
+
+      setTimeout(() => {
+        controller.hub.emit(`${messageIdMock}:finished`, {
+          status: 'rejected',
+        });
+      }, 100);
+
+      await expect(() => promise).rejects.toThrow(
+        'MetaMask Message Signature: User denied message signature.',
+      );
+    });
+
+    it('rejects with an error when unapproved finishes', async () => {
+      const promise = controller.addUnapprovedMessageAsync({
+        data: dataMock,
+        from: fromMock,
+      });
+
+      setTimeout(() => {
+        controller.hub.emit(`${messageIdMock}:finished`, {
+          status: 'unknown',
+        });
+      }, 100);
+
+      await expect(() => promise).rejects.toThrow(
+        `MetaMask Message Signature: Unknown problem: ${JSON.stringify({
+          data: dataMock,
+          from: fromMock,
+        })}`,
+      );
+    });
   });
 
   it('should add a valid unapproved message', async () => {
-    const controller = new MessageManager();
     const messageStatus = 'unapproved';
     const messageType = 'eth_sign';
     const messageParams = {
@@ -105,7 +124,7 @@ describe('PersonalMessageManager', () => {
       from: '0xfoO',
     };
     const originalRequest = { origin: 'origin' };
-    const messageId = controller.addUnapprovedMessage(
+    const messageId = await controller.addUnapprovedMessage(
       messageParams,
       originalRequest,
     );
@@ -124,7 +143,6 @@ describe('PersonalMessageManager', () => {
   it('should throw when adding invalid message', async () => {
     const from = 'foo';
     const messageData = '0x123';
-    const controller = new MessageManager();
     await expect(
       controller.addUnapprovedMessageAsync({
         data: messageData,
@@ -133,7 +151,7 @@ describe('PersonalMessageManager', () => {
     ).rejects.toThrow('Invalid "from" address:');
   });
 
-  it('should get correct unapproved messages', () => {
+  it('should get correct unapproved messages', async () => {
     const firstMessage = {
       id: '1',
       messageParams: { from: '0x1', data: '0x123' },
@@ -148,9 +166,8 @@ describe('PersonalMessageManager', () => {
       time: 123,
       type: 'eth_sign',
     };
-    const controller = new MessageManager();
-    controller.addMessage(firstMessage);
-    controller.addMessage(secondMessage);
+    await controller.addMessage(firstMessage);
+    await controller.addMessage(secondMessage);
     expect(controller.getUnapprovedMessagesCount()).toStrictEqual(2);
     expect(controller.getUnapprovedMessages()).toStrictEqual({
       [firstMessage.id]: firstMessage,
@@ -159,9 +176,8 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should approve message', async () => {
-    const controller = new MessageManager();
     const firstMessage = { from: 'foo', data: '0x123' };
-    const messageId = controller.addUnapprovedMessage(firstMessage);
+    const messageId = await controller.addUnapprovedMessage(firstMessage);
     const messageParams = await controller.approveMessage({
       ...firstMessage,
       metamaskId: messageId,
@@ -174,11 +190,10 @@ describe('PersonalMessageManager', () => {
     expect(message.status).toStrictEqual('approved');
   });
 
-  it('should set message status signed', () => {
-    const controller = new MessageManager();
+  it('should set message status signed', async () => {
     const firstMessage = { from: 'foo', data: '0x123' };
     const rawSig = '0x5f7a0';
-    const messageId = controller.addUnapprovedMessage(firstMessage);
+    const messageId = await controller.addUnapprovedMessage(firstMessage);
 
     controller.setMessageStatusSigned(messageId, rawSig);
     const message = controller.getMessage(messageId);
@@ -189,10 +204,9 @@ describe('PersonalMessageManager', () => {
     expect(message.status).toStrictEqual('signed');
   });
 
-  it('should reject message', () => {
-    const controller = new MessageManager();
+  it('should reject message', async () => {
     const firstMessage = { from: 'foo', data: '0x123' };
-    const messageId = controller.addUnapprovedMessage(firstMessage);
+    const messageId = await controller.addUnapprovedMessage(firstMessage);
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
     if (!message) {

--- a/packages/message-manager/src/MessageManager.ts
+++ b/packages/message-manager/src/MessageManager.ts
@@ -70,13 +70,13 @@ export class MessageManager extends AbstractMessageManager<
    * @param req - The original request object possibly containing the origin.
    * @returns Promise resolving to the raw data of the signature request.
    */
-  addUnapprovedMessageAsync(
+  async addUnapprovedMessageAsync(
     messageParams: MessageParams,
     req?: OriginalRequest,
   ): Promise<string> {
+    validateSignMessageData(messageParams);
+    const messageId = await this.addUnapprovedMessage(messageParams, req);
     return new Promise((resolve, reject) => {
-      validateSignMessageData(messageParams);
-      const messageId = this.addUnapprovedMessage(messageParams, req);
       this.hub.once(`${messageId}:finished`, (data: Message) => {
         switch (data.status) {
           case 'signed':
@@ -110,7 +110,10 @@ export class MessageManager extends AbstractMessageManager<
    * @param req - The original request object possibly containing the origin.
    * @returns The id of the newly created message.
    */
-  addUnapprovedMessage(messageParams: MessageParams, req?: OriginalRequest) {
+  async addUnapprovedMessage(
+    messageParams: MessageParams,
+    req?: OriginalRequest,
+  ): Promise<string> {
     if (req) {
       messageParams.origin = req.origin;
     }
@@ -123,7 +126,7 @@ export class MessageManager extends AbstractMessageManager<
       time: Date.now(),
       type: 'eth_sign',
     };
-    this.addMessage(messageData);
+    await this.addMessage(messageData);
     this.hub.emit(`unapprovedMessage`, {
       ...messageParams,
       ...{ metamaskId: messageId },

--- a/packages/message-manager/src/PersonalMessageManager.test.ts
+++ b/packages/message-manager/src/PersonalMessageManager.test.ts
@@ -20,14 +20,19 @@ const siweMockFound = {
 } as SIWEMessage;
 
 describe('PersonalMessageManager', () => {
-  const detectSIWEMock = detectSIWE as jest.MockedFunction<typeof detectSIWE>;
+  let controller: PersonalMessageManager;
 
+  const detectSIWEMock = detectSIWE as jest.MockedFunction<typeof detectSIWE>;
+  const fromMock = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+  const dataMock = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
+  const messageIdMock = 'message-id-mocked';
+  const rawSigMock = '0xsignaturemocked';
   beforeEach(() => {
+    controller = new PersonalMessageManager();
     detectSIWEMock.mockReturnValue(siweMockNotFound);
   });
 
   it('should set default state', () => {
-    const controller = new PersonalMessageManager();
     expect(controller.state).toStrictEqual({
       unapprovedMessages: {},
       unapprovedMessagesCount: 0,
@@ -35,19 +40,83 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should set default config', () => {
-    const controller = new PersonalMessageManager();
     expect(controller.config).toStrictEqual({});
   });
 
+  describe('addUnapprovedMessageAsync', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(controller, 'addUnapprovedMessage')
+        .mockImplementation()
+        .mockResolvedValue(messageIdMock);
+    });
+
+    afterAll(() => {
+      jest.spyOn(controller, 'addUnapprovedMessage').mockClear();
+    });
+    it('signs the message when status is "signed"', async () => {
+      const promise = controller.addUnapprovedMessageAsync({
+        data: dataMock,
+        from: fromMock,
+      });
+
+      setTimeout(() => {
+        controller.hub.emit(`${messageIdMock}:finished`, {
+          status: 'signed',
+          rawSig: rawSigMock,
+        });
+      }, 100);
+
+      expect(await promise).toStrictEqual(rawSigMock);
+    });
+
+    it('rejects with an error when status is "rejected"', async () => {
+      const promise = controller.addUnapprovedMessageAsync({
+        data: dataMock,
+        from: fromMock,
+      });
+
+      setTimeout(() => {
+        controller.hub.emit(`${messageIdMock}:finished`, {
+          status: 'rejected',
+        });
+      }, 100);
+
+      await expect(() => promise).rejects.toThrow(
+        'MetaMask Personal Message Signature: User denied message signature.',
+      );
+    });
+
+    it('rejects with an error when unapproved finishes', async () => {
+      const promise = controller.addUnapprovedMessageAsync({
+        data: dataMock,
+        from: fromMock,
+      });
+
+      setTimeout(() => {
+        controller.hub.emit(`${messageIdMock}:finished`, {
+          status: 'unknown',
+        });
+      }, 100);
+
+      await expect(() => promise).rejects.toThrow(
+        `MetaMask Personal Message Signature: Unknown problem: ${JSON.stringify(
+          {
+            data: dataMock,
+            from: fromMock,
+          },
+        )}`,
+      );
+    });
+  });
   it('should add a valid message', async () => {
-    const controller = new PersonalMessageManager();
     const messageId = '1';
     const from = '0x0123';
     const messageData = '0x123';
     const messageTime = Date.now();
     const messageStatus = 'unapproved';
     const messageType = 'personal_sign';
-    controller.addMessage({
+    await controller.addMessage({
       id: messageId,
       messageParams: {
         data: messageData,
@@ -69,60 +138,7 @@ describe('PersonalMessageManager', () => {
     expect(message.type).toBe(messageType);
   });
 
-  it('should reject a message', async () => {
-    const controller = new PersonalMessageManager();
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-    const result = controller.addUnapprovedMessageAsync({
-      data,
-      from,
-    });
-    const unapprovedMessages = controller.getUnapprovedMessages();
-    const keys = Object.keys(unapprovedMessages);
-    controller.hub.once(`${keys[0]}:finished`, () => {
-      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
-      expect(unapprovedMessages[keys[0]].status).toBe('rejected');
-    });
-    controller.rejectMessage(keys[0]);
-    await expect(result).rejects.toThrow('User denied message signature');
-  });
-
-  it('should sign a message', async () => {
-    const controller = new PersonalMessageManager();
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-    const rawSig = '0x5f7a0';
-    const result = controller.addUnapprovedMessageAsync({
-      data,
-      from,
-    });
-    const unapprovedMessages = controller.getUnapprovedMessages();
-    const keys = Object.keys(unapprovedMessages);
-    controller.hub.once(`${keys[0]}:finished`, () => {
-      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
-      expect(unapprovedMessages[keys[0]].status).toBe('signed');
-    });
-    controller.setMessageStatusSigned(keys[0], rawSig);
-    const sig = await result;
-    expect(sig).toBe(rawSig);
-  });
-
-  it('should throw when unapproved finishes', async () => {
-    const controller = new PersonalMessageManager();
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-    const result = controller.addUnapprovedMessageAsync({
-      data,
-      from,
-    });
-    const unapprovedMessages = controller.getUnapprovedMessages();
-    const keys = Object.keys(unapprovedMessages);
-    controller.hub.emit(`${keys[0]}:finished`, unapprovedMessages[keys[0]]);
-    await expect(result).rejects.toThrow('Unknown problem');
-  });
-
   it('should add a valid unapproved message', async () => {
-    const controller = new PersonalMessageManager();
     const messageStatus = 'unapproved';
     const messageType = 'personal_sign';
     const messageParams = {
@@ -130,7 +146,7 @@ describe('PersonalMessageManager', () => {
       from: '0xfoO',
     };
     const originalRequest = { origin: 'origin' };
-    const messageId = controller.addUnapprovedMessage(
+    const messageId = await controller.addUnapprovedMessage(
       messageParams,
       originalRequest,
     );
@@ -149,7 +165,6 @@ describe('PersonalMessageManager', () => {
   it('should throw when adding invalid message', async () => {
     const from = 'foo';
     const messageData = '0x123';
-    const controller = new PersonalMessageManager();
     await expect(
       controller.addUnapprovedMessageAsync({
         data: messageData,
@@ -158,7 +173,7 @@ describe('PersonalMessageManager', () => {
     ).rejects.toThrow('Invalid "from" address:');
   });
 
-  it('should get correct unapproved messages', () => {
+  it('should get correct unapproved messages', async () => {
     const firstMessage = {
       id: '1',
       messageParams: { from: '0x1', data: '0x123' },
@@ -173,9 +188,8 @@ describe('PersonalMessageManager', () => {
       time: 123,
       type: 'personal_sign',
     };
-    const controller = new PersonalMessageManager();
-    controller.addMessage(firstMessage);
-    controller.addMessage(secondMessage);
+    await controller.addMessage(firstMessage);
+    await controller.addMessage(secondMessage);
     expect(controller.getUnapprovedMessagesCount()).toStrictEqual(2);
     expect(controller.getUnapprovedMessages()).toStrictEqual({
       [firstMessage.id]: firstMessage,
@@ -184,9 +198,8 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should approve message', async () => {
-    const controller = new PersonalMessageManager();
     const firstMessage = { from: 'foo', data: '0x123' };
-    const messageId = controller.addUnapprovedMessage(firstMessage);
+    const messageId = await controller.addUnapprovedMessage(firstMessage);
     const messageParams = await controller.approveMessage({
       ...firstMessage,
       metamaskId: messageId,
@@ -199,11 +212,10 @@ describe('PersonalMessageManager', () => {
     expect(message.status).toStrictEqual('approved');
   });
 
-  it('should set message status signed', () => {
-    const controller = new PersonalMessageManager();
+  it('should set message status signed', async () => {
     const firstMessage = { from: 'foo', data: '0x123' };
     const rawSig = '0x5f7a0';
-    const messageId = controller.addUnapprovedMessage(firstMessage);
+    const messageId = await controller.addUnapprovedMessage(firstMessage);
 
     controller.setMessageStatusSigned(messageId, rawSig);
     const message = controller.getMessage(messageId);
@@ -214,10 +226,9 @@ describe('PersonalMessageManager', () => {
     expect(message.status).toStrictEqual('signed');
   });
 
-  it('should reject message', () => {
-    const controller = new PersonalMessageManager();
+  it('should reject message', async () => {
     const firstMessage = { from: 'foo', data: '0x123' };
-    const messageId = controller.addUnapprovedMessage(firstMessage);
+    const messageId = await controller.addUnapprovedMessage(firstMessage);
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
     if (!message) {
@@ -228,9 +239,8 @@ describe('PersonalMessageManager', () => {
 
   it('should add message including Ethereum sign in data', async () => {
     detectSIWEMock.mockReturnValue(siweMockFound);
-    const controller = new PersonalMessageManager();
     const firstMessage = { from: 'foo', data: '0x123' };
-    const messageId = controller.addUnapprovedMessage(firstMessage);
+    const messageId = await controller.addUnapprovedMessage(firstMessage);
     const message = controller.getMessage(messageId);
     if (!message) {
       throw new Error('"message" is falsy');

--- a/packages/message-manager/src/PersonalMessageManager.ts
+++ b/packages/message-manager/src/PersonalMessageManager.ts
@@ -73,13 +73,13 @@ export class PersonalMessageManager extends AbstractMessageManager<
    * @param req - The original request object possibly containing the origin.
    * @returns Promise resolving to the raw data of the signature request.
    */
-  addUnapprovedMessageAsync(
+  async addUnapprovedMessageAsync(
     messageParams: PersonalMessageParams,
     req?: OriginalRequest,
   ): Promise<string> {
+    validateSignMessageData(messageParams);
+    const messageId = await this.addUnapprovedMessage(messageParams, req);
     return new Promise((resolve, reject) => {
-      validateSignMessageData(messageParams);
-      const messageId = this.addUnapprovedMessage(messageParams, req);
       this.hub.once(`${messageId}:finished`, (data: PersonalMessage) => {
         switch (data.status) {
           case 'signed':
@@ -113,10 +113,10 @@ export class PersonalMessageManager extends AbstractMessageManager<
    * @param req - The original request object possibly containing the origin.
    * @returns The id of the newly created message.
    */
-  addUnapprovedMessage(
+  async addUnapprovedMessage(
     messageParams: PersonalMessageParams,
     req?: OriginalRequest,
-  ) {
+  ): Promise<string> {
     if (req) {
       messageParams.origin = req.origin;
     }
@@ -133,7 +133,7 @@ export class PersonalMessageManager extends AbstractMessageManager<
       time: Date.now(),
       type: 'personal_sign',
     };
-    this.addMessage(messageData);
+    await this.addMessage(messageData);
     this.hub.emit(`unapprovedMessage`, {
       ...finalMsgParams,
       ...{ metamaskId: messageId },

--- a/packages/message-manager/src/TypedMessageManager.ts
+++ b/packages/message-manager/src/TypedMessageManager.ts
@@ -89,20 +89,24 @@ export class TypedMessageManager extends AbstractMessageManager<
    * @param req - The original request object possibly containing the origin.
    * @returns Promise resolving to the raw data of the signature request.
    */
-  addUnapprovedMessageAsync(
+  async addUnapprovedMessageAsync(
     messageParams: TypedMessageParams,
     version: string,
     req?: OriginalRequest,
   ): Promise<string> {
-    return new Promise((resolve, reject) => {
-      if (version === 'V1') {
-        validateTypedSignMessageDataV1(messageParams);
-      }
+    if (version === 'V1') {
+      validateTypedSignMessageDataV1(messageParams);
+    }
 
-      if (version === 'V3') {
-        validateTypedSignMessageDataV3(messageParams);
-      }
-      const messageId = this.addUnapprovedMessage(messageParams, version, req);
+    if (version === 'V3') {
+      validateTypedSignMessageDataV3(messageParams);
+    }
+    const messageId = await this.addUnapprovedMessage(
+      messageParams,
+      version,
+      req,
+    );
+    return new Promise((resolve, reject) => {
       this.hub.once(`${messageId}:finished`, (data: TypedMessage) => {
         switch (data.status) {
           case 'signed':
@@ -141,11 +145,11 @@ export class TypedMessageManager extends AbstractMessageManager<
    * @param req - The original request object possibly containing the origin.
    * @returns The id of the newly created TypedMessage.
    */
-  addUnapprovedMessage(
+  async addUnapprovedMessage(
     messageParams: TypedMessageParams,
     version: string,
     req?: OriginalRequest,
-  ) {
+  ): Promise<string> {
     const messageId = random();
     const messageParamsMetamask = {
       ...messageParams,


### PR DESCRIPTION
**Add security provider request to AbstractMessageManager**

**Description**

This PR aims to move the security provider request from `SignController` in the extension to `AbstractMessageManager`, and support it in a generic way here in the core and potentially in mobile. 

NOTE: There will be a following PR for the extension to delete the duplicated code within the extension, and potentially following that a PR moving the  `securityProviderCheck` from the extension to core utils.

See the patched changes in the extension (ci): [branch](https://github.com/MetaMask/metamask-extension/tree/poc/security-provider) 

- CHANGED:

  - Included a new param `securityProviderRequest` 
  - Created a method `securityProviderCheck` to be called whenever an unapproved message is added if securityProviderRequest is defined.
  - added a call to the `securityProviderCheck`  into the `addMessage` whenever security provided is provided, the method will check if the Message is malicious or not. 
  - Changed `addMessage` and `addUnapprovedMessage` to asynchronous 

- ADDED:

  - Unit test to cover the changes to support the security provider

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Resolves https://github.com/MetaMask/MetaMask-planning/issues/391
