### PR TITLE
Add nonce tracker to transactions controller

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -100,7 +100,7 @@ export type ProviderProxy = SwappableProxy<Provider>;
 
 type BlockTracker = any;
 
-type BlockTrackerProxy = SwappableProxy<BlockTracker>;
+export type BlockTrackerProxy = SwappableProxy<BlockTracker>;
 
 export type NetworkControllerStateChangeEvent = {
   type: `NetworkController:stateChange`;

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -40,6 +40,7 @@
     "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.0",
     "ethereumjs-util": "^7.0.10",
+    "nonce-tracker": "^1.1.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1,6 +1,5 @@
 import * as sinon from 'sinon';
 import HttpProvider from 'ethjs-provider-http';
-// import uuid from 'uuid';
 import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
 import type { NetworkState } from '@metamask/network-controller';
 import { ESTIMATE_GAS_ERROR } from './utils';
@@ -150,7 +149,6 @@ const GOERLI_PROVIDER = new HttpProvider(
 const MAINNET_PROVIDER = new HttpProvider(
   'https://mainnet.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035',
 );
-// const PALM_PROVIDER = new HttpProvider('https://mainnet.optimism.io');
 const PALM_PROVIDER = new HttpProvider(
   'https://palm-mainnet.infura.io/v3/3a961d6501e54add9a41aa53f15de99b',
 );
@@ -302,14 +300,9 @@ describe('TransactionController', () => {
     for (const key in mockFlags) {
       mockFlags[key] = null;
     }
-    // jest
-    //   .spyOn(uuid, 'v1')
-    //   .mockImplementationOnce(() => 'aaaab1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d')
-    //   .mockImplementationOnce(() => 'bbbb1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d');
   });
 
   afterEach(() => {
-    // jest.resetModules();
     jest.clearAllMocks();
     sinon.restore();
   });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -12,7 +12,11 @@ import {
   BaseConfig,
   BaseState,
 } from '@metamask/base-controller';
-import type { NetworkState, ProviderProxy } from '@metamask/network-controller';
+import type {
+  NetworkState,
+  ProviderProxy,
+  BlockTrackerProxy,
+} from '@metamask/network-controller';
 import {
   BNToHex,
   fractionBN,
@@ -23,7 +27,9 @@ import {
   NetworkType,
   RPC,
 } from '@metamask/controller-utils';
+import NonceTracker from 'nonce-tracker';
 import {
+  formatTxForNonceTracker,
   normalizeTransaction,
   validateTransaction,
   handleTransactionFetch,
@@ -267,7 +273,11 @@ export class TransactionController extends BaseController<
 > {
   private ethQuery: any;
 
+  private nonceTracker: NonceTracker;
+
   private registry: any;
+
+  private provider: ProviderProxy;
 
   private handle?: ReturnType<typeof setTimeout>;
 
@@ -410,7 +420,8 @@ export class TransactionController extends BaseController<
    * @param options - The controller options.
    * @param options.getNetworkState - Gets the state of the network controller.
    * @param options.onNetworkStateChange - Allows subscribing to network controller state changes.
-   * @param options.getProvider - Returns a provider for the current network.
+   * @param options.provider - The provider used to create the underlying EthQuery instance.
+   * @param options.blockTracker - The block tracker used to poll for new blocks data.
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
    */
@@ -418,11 +429,13 @@ export class TransactionController extends BaseController<
     {
       getNetworkState,
       onNetworkStateChange,
-      getProvider,
+      provider,
+      blockTracker,
     }: {
       getNetworkState: () => NetworkState;
       onNetworkStateChange: (listener: (state: NetworkState) => void) => void;
-      getProvider: () => ProviderProxy;
+      provider: ProviderProxy;
+      blockTracker: BlockTrackerProxy;
     },
     config?: Partial<TransactionConfig>,
     state?: Partial<TransactionState>,
@@ -438,14 +451,34 @@ export class TransactionController extends BaseController<
       transactions: [],
     };
     this.initialize();
-    const provider = getProvider();
+    this.provider = provider;
     this.getNetworkState = getNetworkState;
     this.ethQuery = new EthQuery(provider);
     this.registry = new MethodRegistry({ provider });
+    this.nonceTracker = new NonceTracker({
+      provider,
+      blockTracker,
+      getPendingTransactions: (address) => {
+        return formatTxForNonceTracker(
+          this.state.transactions.filter(
+            ({ status, transaction: { from } }) =>
+              status === TransactionStatus.submitted &&
+              (address ? from.toLowerCase() === address.toLowerCase() : true),
+          ),
+        );
+      },
+      getConfirmedTransactions: () => {
+        return formatTxForNonceTracker(
+          this.state.transactions.filter(
+            ({ status }) => status === TransactionStatus.confirmed,
+          ),
+        );
+      },
+    });
+
     onNetworkStateChange(() => {
-      const newProvider = getProvider();
-      this.ethQuery = new EthQuery(newProvider);
-      this.registry = new MethodRegistry({ provider: newProvider });
+      this.ethQuery = new EthQuery(this.provider);
+      this.registry = new MethodRegistry({ provider: this.provider });
     });
     this.poll();
   }
@@ -625,10 +658,11 @@ export class TransactionController extends BaseController<
     const { chainId: currentChainId } = providerConfig;
     const index = transactions.findIndex(({ id }) => transactionID === id);
     const transactionMeta = transactions[index];
-    const { nonce } = transactionMeta.transaction;
-
+    const {
+      transaction: { nonce, from },
+    } = transactionMeta;
+    let nonceLock;
     try {
-      const { from } = transactionMeta.transaction;
       if (!this.sign) {
         releaseLock();
         this.failTransaction(
@@ -644,21 +678,21 @@ export class TransactionController extends BaseController<
 
       const chainId = parseInt(currentChainId, undefined);
       const { approved: status } = TransactionStatus;
-
-      const txNonce =
-        nonce ||
-        (await query(this.ethQuery, 'getTransactionCount', [from, 'pending']));
+      let nonceToUse = nonce;
+      // if a nonce already exists on the transactionMeta it means this is a speedup or cancel transaction
+      // so we want to reuse that nonce and hope that it beats the previous attempt to chain. Otherwise use a new locked nonce
+      if (!nonceToUse) {
+        nonceLock = await this.nonceTracker.getNonceLock(from);
+        nonceToUse = nonceLock.nextNonce.toString(16);
+      }
 
       transactionMeta.status = status;
-      transactionMeta.transaction.nonce = txNonce;
+      transactionMeta.transaction.nonce = addHexPrefix(nonceToUse);
       transactionMeta.transaction.chainId = chainId;
 
       const baseTxParams = {
         ...transactionMeta.transaction,
         gasLimit: transactionMeta.transaction.gas,
-        chainId,
-        nonce: txNonce,
-        status,
       };
 
       const isEIP1559 = isEIP1559Transaction(transactionMeta.transaction);
@@ -698,6 +732,10 @@ export class TransactionController extends BaseController<
     } catch (error: any) {
       this.failTransaction(transactionMeta, error);
     } finally {
+      // must set transaction to submitted/failed before releasing lock
+      if (nonceLock) {
+        nonceLock.releaseLock();
+      }
       releaseLock();
     }
   }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -679,11 +679,11 @@ export class TransactionController extends BaseController<
       // so we want to reuse that nonce and hope that it beats the previous attempt to chain. Otherwise use a new locked nonce
       if (!nonceToUse) {
         nonceLock = await this.nonceTracker.getNonceLock(from);
-        nonceToUse = nonceLock.nextNonce.toString(16);
+        nonceToUse = addHexPrefix(nonceLock.nextNonce.toString(16));
       }
 
       transactionMeta.status = status;
-      transactionMeta.transaction.nonce = addHexPrefix(nonceToUse);
+      transactionMeta.transaction.nonce = nonceToUse;
       transactionMeta.transaction.chainId = chainId;
 
       const baseTxParams = {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -29,7 +29,7 @@ import {
 } from '@metamask/controller-utils';
 import NonceTracker from 'nonce-tracker';
 import {
-  formatTxForNonceTracker,
+  getAndFormatTransactionsForNonceTracker,
   normalizeTransaction,
   validateTransaction,
   handleTransactionFetch,
@@ -458,22 +458,18 @@ export class TransactionController extends BaseController<
     this.nonceTracker = new NonceTracker({
       provider,
       blockTracker,
-      getPendingTransactions: (address) => {
-        return formatTxForNonceTracker(
-          this.state.transactions.filter(
-            ({ status, transaction: { from } }) =>
-              status === TransactionStatus.submitted &&
-              (address ? from.toLowerCase() === address.toLowerCase() : true),
-          ),
-        );
-      },
-      getConfirmedTransactions: () => {
-        return formatTxForNonceTracker(
-          this.state.transactions.filter(
-            ({ status }) => status === TransactionStatus.confirmed,
-          ),
-        );
-      },
+      getPendingTransactions: (address) =>
+        getAndFormatTransactionsForNonceTracker(
+          address,
+          TransactionStatus.submitted,
+          this.state.transactions,
+        ),
+      getConfirmedTransactions: (address) =>
+        getAndFormatTransactionsForNonceTracker(
+          address,
+          TransactionStatus.confirmed,
+          this.state.transactions,
+        ),
     });
 
     onNetworkStateChange(() => {

--- a/packages/transaction-controller/src/utils.test.ts
+++ b/packages/transaction-controller/src/utils.test.ts
@@ -1,9 +1,13 @@
+import type { Transaction as NonceTrackerTransaction } from 'nonce-tracker/dist/NonceTracker';
 import {
   Transaction,
   GasPriceValue,
   FeeMarketEIP1559Values,
+  TransactionStatus,
 } from './TransactionController';
 import * as util from './utils';
+import type { TransactionMeta } from './TransactionController';
+import { formatTxForNonceTracker } from './utils';
 
 const MAX_FEE_PER_GAS = 'maxFeePerGas';
 const MAX_PRIORITY_FEE_PER_GAS = 'maxPriorityFeePerGas';
@@ -279,6 +283,60 @@ describe('utils', () => {
       expect(() =>
         util.validateMinimumIncrease('0x7162a5ca', '0x5916a6d6'),
       ).not.toThrow(Error);
+    });
+  });
+
+  describe('formatTxForNonceTracker', () => {
+    it('should return an array of formatted NonceTrackerTransaction objects', () => {
+      const inputTransactions: TransactionMeta[] = [
+        {
+          id: '1',
+          time: 123456,
+          transaction: {
+            from: '0x123',
+            gas: '0x100',
+            value: '0x200',
+            nonce: '0x1',
+          },
+          status: TransactionStatus.confirmed,
+        },
+        {
+          id: '2',
+          time: 123457,
+          transaction: {
+            from: '',
+            gas: '',
+            value: '',
+            nonce: '',
+          },
+          status: TransactionStatus.submitted,
+        },
+      ];
+      const expectedResult: NonceTrackerTransaction[] = [
+        {
+          status: TransactionStatus.confirmed,
+          history: [{}],
+          txParams: {
+            from: '0x123',
+            gas: '0x100',
+            value: '0x200',
+            nonce: '0x1',
+          },
+        },
+        {
+          status: TransactionStatus.submitted,
+          history: [{}],
+          txParams: {
+            from: '',
+            gas: '',
+            value: '',
+            nonce: '',
+          },
+        },
+      ];
+
+      const result = formatTxForNonceTracker(inputTransactions);
+      expect(result).toStrictEqual(expectedResult);
     });
   });
 });

--- a/packages/transaction-controller/src/utils.test.ts
+++ b/packages/transaction-controller/src/utils.test.ts
@@ -7,7 +7,7 @@ import {
 } from './TransactionController';
 import * as util from './utils';
 import type { TransactionMeta } from './TransactionController';
-import { formatTxForNonceTracker } from './utils';
+import { getAndFormatTransactionsForNonceTracker } from './utils';
 
 const MAX_FEE_PER_GAS = 'maxFeePerGas';
 const MAX_PRIORITY_FEE_PER_GAS = 'maxPriorityFeePerGas';
@@ -286,14 +286,15 @@ describe('utils', () => {
     });
   });
 
-  describe('formatTxForNonceTracker', () => {
-    it('should return an array of formatted NonceTrackerTransaction objects', () => {
+  describe('getAndFormatTransactionsForNonceTracker', () => {
+    it('should return an array of formatted NonceTrackerTransaction objects filtered by fromAddress and transactionStatus', () => {
+      const fromAddress = '0x123';
       const inputTransactions: TransactionMeta[] = [
         {
           id: '1',
           time: 123456,
           transaction: {
-            from: '0x123',
+            from: fromAddress,
             gas: '0x100',
             value: '0x200',
             nonce: '0x1',
@@ -304,38 +305,44 @@ describe('utils', () => {
           id: '2',
           time: 123457,
           transaction: {
-            from: '',
-            gas: '',
-            value: '',
-            nonce: '',
+            from: '0x124',
+            gas: '0x101',
+            value: '0x201',
+            nonce: '0x2',
           },
           status: TransactionStatus.submitted,
         },
+        {
+          id: '3',
+          time: 123458,
+          transaction: {
+            from: fromAddress,
+            gas: '0x102',
+            value: '0x202',
+            nonce: '0x3',
+          },
+          status: TransactionStatus.approved,
+        },
       ];
+
       const expectedResult: NonceTrackerTransaction[] = [
         {
           status: TransactionStatus.confirmed,
           history: [{}],
           txParams: {
-            from: '0x123',
+            from: fromAddress,
             gas: '0x100',
             value: '0x200',
             nonce: '0x1',
           },
         },
-        {
-          status: TransactionStatus.submitted,
-          history: [{}],
-          txParams: {
-            from: '',
-            gas: '',
-            value: '',
-            nonce: '',
-          },
-        },
       ];
 
-      const result = formatTxForNonceTracker(inputTransactions);
+      const result = getAndFormatTransactionsForNonceTracker(
+        fromAddress,
+        TransactionStatus.confirmed,
+        inputTransactions,
+      );
       expect(result).toStrictEqual(expectedResult);
     });
   });

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -5,12 +5,14 @@ import {
   handleFetch,
   isValidHexAddress,
 } from '@metamask/controller-utils';
+import type { Transaction as NonceTrackerTransaction } from 'nonce-tracker/dist/NonceTracker';
 import {
   Transaction,
   FetchAllOptions,
   GasPriceValue,
   FeeMarketEIP1559Values,
 } from './TransactionController';
+import type { TransactionMeta } from './TransactionController';
 
 export const ESTIMATE_GAS_ERROR = 'eth_estimateGas rpc method error';
 
@@ -260,4 +262,32 @@ export function validateMinimumIncrease(proposed: string, min: string) {
   }
   const errorMsg = `The proposed value: ${proposedDecimal} should meet or exceed the minimum value: ${minDecimal}`;
   throw new Error(errorMsg);
+}
+
+/**
+ * Helper Method to format transactions for the nonce tracker.
+ *
+ * @param transactions - Array of transactionMeta objects that have been prefiltered.
+ * @returns Array of transactions formatted for the nonce tracker.
+ */
+export function formatTxForNonceTracker(
+  transactions: TransactionMeta[],
+): NonceTrackerTransaction[] {
+  return transactions.map(
+    ({ status, transaction: { from, gas, value, nonce } }) => {
+      // the only value we care about is the nonce
+      // but we need to return the other values to satisfy the type
+      // TODO: refactor nonceTracker to not require this
+      return {
+        status,
+        history: [{}],
+        txParams: {
+          from: from ?? '',
+          gas: gas ?? '',
+          value: value ?? '',
+          nonce: nonce ?? '',
+        },
+      };
+    },
+  );
 }

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -266,7 +266,7 @@ export function validateMinimumIncrease(proposed: string, min: string) {
 }
 
 /**
- * Helper Method to format transactions for the nonce tracker.
+ * Helper function to filter and format transactions for the nonce tracker.
  *
  * @param fromAddress - Address of the account from which the transactions to filter from are sent.
  * @param transactionStatus - Status of the transactions for which to filter.

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -11,6 +11,7 @@ import {
   FetchAllOptions,
   GasPriceValue,
   FeeMarketEIP1559Values,
+  TransactionStatus,
 } from './TransactionController';
 import type { TransactionMeta } from './TransactionController';
 
@@ -267,14 +268,23 @@ export function validateMinimumIncrease(proposed: string, min: string) {
 /**
  * Helper Method to format transactions for the nonce tracker.
  *
+ * @param fromAddress - Address of the account from which the transactions to filter from are sent.
+ * @param transactionStatus - Status of the transactions for which to filter.
  * @param transactions - Array of transactionMeta objects that have been prefiltered.
  * @returns Array of transactions formatted for the nonce tracker.
  */
-export function formatTxForNonceTracker(
+export function getAndFormatTransactionsForNonceTracker(
+  fromAddress: string,
+  transactionStatus: TransactionStatus,
   transactions: TransactionMeta[],
 ): NonceTrackerTransaction[] {
-  return transactions.map(
-    ({ status, transaction: { from, gas, value, nonce } }) => {
+  return transactions
+    .filter(
+      ({ status, transaction: { from } }) =>
+        status === transactionStatus &&
+        from.toLowerCase() === fromAddress.toLowerCase(),
+    )
+    .map(({ status, transaction: { from, gas, value, nonce } }) => {
       // the only value we care about is the nonce
       // but we need to return the other values to satisfy the type
       // TODO: refactor nonceTracker to not require this
@@ -288,6 +298,5 @@ export function formatTxForNonceTracker(
           nonce: nonce ?? '',
         },
       };
-    },
-  );
+    });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,6 +2045,7 @@ __metadata:
     ethereumjs-util: ^7.0.10
     ethjs-provider-http: ^0.1.6
     jest: ^26.4.2
+    nonce-tracker: ^1.1.0
     sinon: ^9.2.4
     ts-jest: ^26.5.2
     typedoc: ^0.22.15
@@ -3189,6 +3190,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assert@npm:^1.4.1":
+  version: 1.5.0
+  resolution: "assert@npm:1.5.0"
+  dependencies:
+    object-assign: ^4.1.1
+    util: 0.10.3
+  checksum: 9be48435f726029ae7020c5888a3566bf4d617687aab280827f2e4029644b6515a9519ea10d018b342147c02faf73d9e9419e780e8937b3786ee4945a0ca71e5
+  languageName: node
+  linkType: hard
+
 "assert@npm:^2.0.0":
   version: 2.0.0
   resolution: "assert@npm:2.0.0"
@@ -3283,6 +3294,13 @@ __metadata:
   version: 1.0.5
   resolution: "available-typed-arrays@npm:1.0.5"
   checksum: 20eb47b3cefd7db027b9bbb993c658abd36d4edd3fe1060e83699a03ee275b0c9b216cc076ff3f2db29073225fb70e7613987af14269ac1fe2a19803ccc97f1a
+  languageName: node
+  linkType: hard
+
+"await-semaphore@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "await-semaphore@npm:0.1.3"
+  checksum: 334c86541e446378dd832168de431327a77146f70cd80b57c99cd483ce5996e3bfdadea9d795e36f0b4faacb5121f5f7a99d94297ac2bdafbc690e5b0aa5cc32
   languageName: node
   linkType: hard
 
@@ -5541,6 +5559,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ethjs-query@npm:^0.3.8":
+  version: 0.3.8
+  resolution: "ethjs-query@npm:0.3.8"
+  dependencies:
+    babel-runtime: ^6.26.0
+    ethjs-format: 0.2.7
+    ethjs-rpc: 0.2.0
+    promise-to-callback: ^1.0.0
+  checksum: 6673167101e793dfdbb212f3ee2e7449a7c1eb7f4d72aba04a1c504eb36d9148f18c42a702839ebce7534709d821f32adcca84c56b7900788b2875cba8a371f1
+  languageName: node
+  linkType: hard
+
 "ethjs-rpc@npm:0.2.0":
   version: 0.2.0
   resolution: "ethjs-rpc@npm:0.2.0"
@@ -6739,6 +6769,13 @@ __metadata:
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
+  languageName: node
+  linkType: hard
+
+"inherits@npm:2.0.1":
+  version: 2.0.1
+  resolution: "inherits@npm:2.0.1"
+  checksum: 6536b9377296d4ce8ee89c5c543cb75030934e61af42dba98a428e7d026938c5985ea4d1e3b87743a5b834f40ed1187f89c2d7479e9d59e41d2d1051aefba07b
   languageName: node
   linkType: hard
 
@@ -9029,6 +9066,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nonce-tracker@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "nonce-tracker@npm:1.1.0"
+  dependencies:
+    assert: ^1.4.1
+    await-semaphore: ^0.1.3
+    ethjs-query: ^0.3.8
+  checksum: fbed4eac51a5df3922a9ee93f2d40f700d3c86e03ac02acc5c7983e9fd5c9d97278f1f5d8422f2dad0f0108c09a2d880145906cae19604717cc898d385bbdff9
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^5.0.0":
   version: 5.0.0
   resolution: "nopt@npm:5.0.0"
@@ -9148,7 +9196,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4.1.0":
+"object-assign@npm:^4.1.0, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
@@ -11832,6 +11880,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"util@npm:0.10.3":
+  version: 0.10.3
+  resolution: "util@npm:0.10.3"
+  dependencies:
+    inherits: 2.0.1
+  checksum: bd800f5d237a82caddb61723a6cbe45297d25dd258651a31335a4d5d981fd033cb4771f82db3d5d59b582b187cb69cfe727dc6f4d8d7826f686ee6c07ce611e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves: #1070 

- ADDED
   - Adds `NonceTracker` package to transaction approval flow to manage transaction nonces. This functionality was previously handled by middleware in `web3-provider-engine which is slated to be removed. [#123](https://github.com/metamask/controllers/pull/123)
