### PR TITLE
Add DecryptMessageManager

### DIFF
--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -8,6 +8,8 @@ import {
   SecurityProviderRequest,
 } from './AbstractMessageManager';
 
+jest.mock('events');
+
 class AbstractTestManager extends AbstractMessageManager<
   TypedMessage,
   TypedMessageParams,
@@ -281,6 +283,27 @@ describe('AbstractTestManager', () => {
       expect(() => controller.setMessageStatus(messageId, 'newstatus')).toThrow(
         'AbstractMessageManager: Message not found for id: 1.',
       );
+    });
+  });
+
+  describe('setMessageStatusAndResult', () => {
+    it('emits updateBadge once', async () => {
+      const controller = new AbstractTestManager();
+      await controller.addMessage({
+        id: messageId,
+        messageParams: { from: '0x1234', data: 'test' },
+        status: 'status',
+        time: 10,
+        type: 'type',
+      });
+      const messageBefore = controller.getMessage(messageId);
+      expect(messageBefore?.status).toStrictEqual('status');
+
+      controller.setMessageStatusAndResult(messageId, 'newRawSig', 'newstatus');
+      const messageAfter = controller.getMessage(messageId);
+
+      expect(controller.hub.emit).toHaveBeenNthCalledWith(1, 'updateBadge');
+      expect(messageAfter?.status).toStrictEqual('newstatus');
     });
   });
 });

--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -257,40 +257,6 @@ describe('AbstractTestManager', () => {
     expect(message.status).toStrictEqual('approved');
   });
 
-  it('sets rawData of message', async () => {
-    const mockedRawData = 'rawData';
-    const controller = new AbstractTestManager();
-    const firstMessage = { from: '0xfoO', data: typedMessage };
-    await controller.addMessage({
-      id: messageId,
-      messageParams: firstMessage,
-      status: messageStatus,
-      time: messageTime,
-      type: messageType,
-    });
-    controller.updateMessageDataInline(messageId, mockedRawData);
-    expect(controller.getMessage(messageId)?.rawData).toStrictEqual(
-      mockedRawData,
-    );
-  });
-
-  it('sets error of message', async () => {
-    const mockedErrorMessage = 'errorMessage';
-    const controller = new AbstractTestManager();
-    const firstMessage = { from: '0xfoO', data: typedMessage };
-    await controller.addMessage({
-      id: messageId,
-      messageParams: firstMessage,
-      status: messageStatus,
-      time: messageTime,
-      type: messageType,
-    });
-    controller.updateMessageErrorInline(messageId, mockedErrorMessage);
-    expect(controller.getMessage(messageId)?.error).toStrictEqual(
-      mockedErrorMessage,
-    );
-  });
-
   describe('setMessageStatus', () => {
     it('should set the given message status', async () => {
       const controller = new AbstractTestManager();

--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -150,6 +150,27 @@ describe('AbstractTestManager', () => {
       time: messageTime,
       type: messageType,
     });
+    controller.setMessageStatusDecrypted(messageId, 'rawSig');
+    const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.status).toBe('decrypted');
+    expect(message.rawSig).toBe('rawSig');
+  });
+
+  it('decrypts a message', () => {
+    const controller = new AbstractTestManager();
+    controller.addMessage({
+      id: messageId,
+      messageParams: {
+        data: typedMessage,
+        from,
+      },
+      status: messageStatus,
+      time: messageTime,
+      type: messageType,
+    });
     controller.setMessageStatusSigned(messageId, 'rawSig');
     const message = controller.getMessage(messageId);
     if (!message) {

--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -159,28 +159,6 @@ describe('AbstractTestManager', () => {
     expect(message.rawSig).toBe('rawSig');
   });
 
-  it('sets message to one of the allowed statuses', () => {
-    const controller = new AbstractTestManager(undefined, undefined, [
-      'received',
-    ]);
-    controller.addMessage({
-      id: messageId,
-      messageParams: {
-        data: typedMessage,
-        from,
-      },
-      status: messageStatus,
-      time: messageTime,
-      type: messageType,
-    });
-    controller.setMessageStatusAndResult(messageId, 'rawSig', 'received');
-    const message = controller.getMessage(messageId);
-    if (!message) {
-      throw new Error('"message" is falsy');
-    }
-    expect(message.status).toBe('received');
-  });
-
   it('sets message to one of the allowed statuses', async () => {
     const controller = new AbstractTestManager(
       undefined,
@@ -279,11 +257,11 @@ describe('AbstractTestManager', () => {
     expect(message.status).toStrictEqual('approved');
   });
 
-  it('sets rawData of message', () => {
+  it('sets rawData of message', async () => {
     const mockedRawData = 'rawData';
     const controller = new AbstractTestManager();
     const firstMessage = { from: '0xfoO', data: typedMessage };
-    controller.addMessage({
+    await controller.addMessage({
       id: messageId,
       messageParams: firstMessage,
       status: messageStatus,
@@ -296,11 +274,11 @@ describe('AbstractTestManager', () => {
     );
   });
 
-  it('sets error of message', () => {
+  it('sets error of message', async () => {
     const mockedErrorMessage = 'errorMessage';
     const controller = new AbstractTestManager();
     const firstMessage = { from: '0xfoO', data: typedMessage };
-    controller.addMessage({
+    await controller.addMessage({
       id: messageId,
       messageParams: firstMessage,
       status: messageStatus,

--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -279,6 +279,40 @@ describe('AbstractTestManager', () => {
     expect(message.status).toStrictEqual('approved');
   });
 
+  it('sets rawData of message', () => {
+    const mockedRawData = 'rawData';
+    const controller = new AbstractTestManager();
+    const firstMessage = { from: '0xfoO', data: typedMessage };
+    controller.addMessage({
+      id: messageId,
+      messageParams: firstMessage,
+      status: messageStatus,
+      time: messageTime,
+      type: messageType,
+    });
+    controller.updateMessageDataInline(messageId, mockedRawData);
+    expect(controller.getMessage(messageId)?.rawData).toStrictEqual(
+      mockedRawData,
+    );
+  });
+
+  it('sets error of message', () => {
+    const mockedErrorMessage = 'errorMessage';
+    const controller = new AbstractTestManager();
+    const firstMessage = { from: '0xfoO', data: typedMessage };
+    controller.addMessage({
+      id: messageId,
+      messageParams: firstMessage,
+      status: messageStatus,
+      time: messageTime,
+      type: messageType,
+    });
+    controller.updateMessageErrorInline(messageId, mockedErrorMessage);
+    expect(controller.getMessage(messageId)?.error).toStrictEqual(
+      mockedErrorMessage,
+    );
+  });
+
   describe('setMessageStatus', () => {
     it('should set the given message status', async () => {
       const controller = new AbstractTestManager();

--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -150,17 +150,19 @@ describe('AbstractTestManager', () => {
       time: messageTime,
       type: messageType,
     });
-    controller.setMessageStatusDecrypted(messageId, 'rawSig');
+    controller.setMessageStatusSigned(messageId, 'rawSig');
     const message = controller.getMessage(messageId);
     if (!message) {
       throw new Error('"message" is falsy');
     }
-    expect(message.status).toBe('decrypted');
+    expect(message.status).toBe('signed');
     expect(message.rawSig).toBe('rawSig');
   });
 
-  it('decrypts a message', () => {
-    const controller = new AbstractTestManager();
+  it('sets message to one of the allowed statuses', () => {
+    const controller = new AbstractTestManager(undefined, undefined, [
+      'received',
+    ]);
     controller.addMessage({
       id: messageId,
       messageParams: {
@@ -171,13 +173,12 @@ describe('AbstractTestManager', () => {
       time: messageTime,
       type: messageType,
     });
-    controller.setMessageStatusSigned(messageId, 'rawSig');
+    controller.setMessageStatusAndResult(messageId, 'rawSig', 'received');
     const message = controller.getMessage(messageId);
     if (!message) {
       throw new Error('"message" is falsy');
     }
-    expect(message.status).toBe('signed');
-    expect(message.rawSig).toBe('rawSig');
+    expect(message.status).toBe('received');
   });
 
   it('sets message to one of the allowed statuses', async () => {

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -33,6 +33,8 @@ export interface AbstractMessage {
   type: string;
   rawSig?: string;
   securityProviderResponse?: Map<string, Json>;
+  rawData?: string;
+  error?: string;
 }
 
 /**
@@ -299,6 +301,38 @@ export abstract class AbstractMessageManager<
     message.rawSig = rawSig;
     this.updateMessage(message);
     this.setMessageStatus(messageId, status);
+  }
+
+  /**
+   * Updates the message rawData without changing the status.
+   *
+   * @param messageId - The id of the Message to sign.
+   * @param rawData - The data to update rawData in the message.
+   */
+  updateMessageDataInline(messageId: string, rawData: string) {
+    const message = this.getMessage(messageId);
+    /* istanbul ignore if */
+    if (!message) {
+      return;
+    }
+    message.rawData = rawData;
+    this.updateMessage(message);
+  }
+
+  /**
+   * Updates the message error without changing the status.
+   *
+   * @param messageId - The id of the Message to sign.
+   * @param error - The data to update error in the message.
+   */
+  updateMessageErrorInline(messageId: string, error: string) {
+    const message = this.getMessage(messageId);
+    /* istanbul ignore if */
+    if (!message) {
+      return;
+    }
+    message.error = error;
+    this.updateMessage(message);
   }
 
   /**

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -23,6 +23,7 @@ export interface OriginalRequest {
  * @property id - An id to track and identify the message object
  * @property type - The json-prc signing method for which a signature request has been made.
  * A 'Message' which always has a signing type
+ * @property rawSig - Raw data of the signature request
  * @property securityProviderResponse - Response from a security provider, whether it is malicious or not
  */
 export interface AbstractMessage {
@@ -32,7 +33,6 @@ export interface AbstractMessage {
   type: string;
   rawSig?: string;
   securityProviderResponse?: Map<string, Json>;
-  error?: string;
 }
 
 /**
@@ -298,15 +298,15 @@ export abstract class AbstractMessageManager<
    * Sets the message result.
    *
    * @param messageId - The id of the Message to sign.
-   * @param rawSig - The data to update rawSig in the message.
+   * @param result - The data to update result in the message.
    */
-  setResult(messageId: string, rawSig: string) {
+  setResult(messageId: string, result: string) {
     const message = this.getMessage(messageId);
     /* istanbul ignore if */
     if (!message) {
       return;
     }
-    message.rawSig = rawSig;
+    message.rawSig = result;
     this.updateMessage(message);
   }
 

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -23,7 +23,6 @@ export interface OriginalRequest {
  * @property id - An id to track and identify the message object
  * @property type - The json-prc signing method for which a signature request has been made.
  * A 'Message' which always has a signing type
- * @property rawSig - Raw data of the signature request
  * @property securityProviderResponse - Response from a security provider, whether it is malicious or not
  */
 export interface AbstractMessage {
@@ -33,7 +32,6 @@ export interface AbstractMessage {
   type: string;
   rawSig?: string;
   securityProviderResponse?: Map<string, Json>;
-  rawData?: string;
   error?: string;
 }
 
@@ -285,53 +283,30 @@ export abstract class AbstractMessageManager<
   }
 
   /**
-   * Sets the message to a new status via a call to this.setMsgStatus and
-   * updates the rawSig field in this.messages.
+   * Sets the message via a call to this.setResult and updates status of the message.
    *
    * @param messageId - The id of the Message to sign.
    * @param rawSig - The data to update rawSig in the message.
    * @param status - The new message status.
    */
   setMessageStatusAndResult(messageId: string, rawSig: string, status: string) {
+    this.setResult(messageId, rawSig);
+    this.setMessageStatus(messageId, status);
+  }
+
+  /**
+   * Sets the message result.
+   *
+   * @param messageId - The id of the Message to sign.
+   * @param rawSig - The data to update rawSig in the message.
+   */
+  setResult(messageId: string, rawSig: string) {
     const message = this.getMessage(messageId);
     /* istanbul ignore if */
     if (!message) {
       return;
     }
     message.rawSig = rawSig;
-    this.updateMessage(message);
-    this.setMessageStatus(messageId, status);
-  }
-
-  /**
-   * Updates the message rawData without changing the status.
-   *
-   * @param messageId - The id of the Message to sign.
-   * @param rawData - The data to update rawData in the message.
-   */
-  updateMessageDataInline(messageId: string, rawData: string) {
-    const message = this.getMessage(messageId);
-    /* istanbul ignore if */
-    if (!message) {
-      return;
-    }
-    message.rawData = rawData;
-    this.updateMessage(message);
-  }
-
-  /**
-   * Updates the message error without changing the status.
-   *
-   * @param messageId - The id of the Message to sign.
-   * @param error - The data to update error in the message.
-   */
-  updateMessageErrorInline(messageId: string, error: string) {
-    const message = this.getMessage(messageId);
-    /* istanbul ignore if */
-    if (!message) {
-      return;
-    }
-    message.error = error;
     this.updateMessage(message);
   }
 

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -135,14 +135,17 @@ export abstract class AbstractMessageManager<
    * Then saves the unapprovedMessage list to storage.
    *
    * @param message - A Message that will replace an existing Message (with the id) in this.messages.
+   * @param emitUpdate - Whether to emit the updateBadge event.
    */
-  protected updateMessage(message: M) {
+  protected updateMessage(message: M, emitUpdate = true) {
     const index = this.messages.findIndex((msg) => message.id === msg.id);
     /* istanbul ignore next */
     if (index !== -1) {
       this.messages[index] = message;
     }
-    this.saveMessageList();
+    if (emitUpdate) {
+      this.saveMessageList();
+    }
   }
 
   /**
@@ -307,7 +310,7 @@ export abstract class AbstractMessageManager<
       return;
     }
     message.rawSig = result;
-    this.updateMessage(message);
+    this.updateMessage(message, false);
   }
 
   /**

--- a/packages/message-manager/src/DecryptMessageManager.test.ts
+++ b/packages/message-manager/src/DecryptMessageManager.test.ts
@@ -163,7 +163,9 @@ describe('DecryptMessageManager', () => {
         from,
         data: dataMock,
       }),
-    ).rejects.toThrow(`Invalid "from" address: ${from} must be a valid string.`);
+    ).rejects.toThrow(
+      `Invalid "from" address: ${from} must be a valid string.`,
+    );
   });
 
   it('gets correct unapproved messages', async () => {

--- a/packages/message-manager/src/DecryptMessageManager.test.ts
+++ b/packages/message-manager/src/DecryptMessageManager.test.ts
@@ -163,7 +163,7 @@ describe('DecryptMessageManager', () => {
         from,
         data: dataMock,
       }),
-    ).rejects.toThrow(`Invalid address: ${from} must be a valid string.`);
+    ).rejects.toThrow(`Invalid "from" address: ${from} must be a valid string.`);
   });
 
   it('gets correct unapproved messages', async () => {

--- a/packages/message-manager/src/DecryptMessageManager.test.ts
+++ b/packages/message-manager/src/DecryptMessageManager.test.ts
@@ -134,7 +134,6 @@ describe('DecryptMessageManager', () => {
         })}`,
       );
     });
-
   });
 
   it('adds a valid unapproved message', async () => {

--- a/packages/message-manager/src/DecryptMessageManager.test.ts
+++ b/packages/message-manager/src/DecryptMessageManager.test.ts
@@ -1,0 +1,178 @@
+import { DecryptMessageManager } from './DecryptMessageManager';
+
+describe('DecryptMessageManager', () => {
+  it('sets default state', () => {
+    const controller = new DecryptMessageManager();
+    expect(controller.state).toStrictEqual({
+      unapprovedMessages: {},
+      unapprovedMessagesCount: 0,
+    });
+  });
+
+  it('sets default config', () => {
+    const controller = new DecryptMessageManager();
+    expect(controller.config).toStrictEqual({});
+  });
+
+  it('adds a valid message', async () => {
+    const controller = new DecryptMessageManager();
+    const messageId = '1';
+    const from = '0x0123';
+    const messageData = '0x123';
+    const messageTime = Date.now();
+    const messageStatus = 'unapproved';
+    const messageType = 'eth_decrypt';
+    controller.addMessage({
+      id: messageId,
+      messageParams: {
+        data: messageData,
+        from,
+      },
+      status: messageStatus,
+      time: messageTime,
+      type: messageType,
+    });
+    const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.id).toBe(messageId);
+    expect(message.messageParams.from).toBe(from);
+    expect(message.messageParams.data).toBe(messageData);
+    expect(message.time).toBe(messageTime);
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
+  });
+
+  it('approves message', async () => {
+    const controller = new DecryptMessageManager();
+    const from = '0x0123';
+    const data = '0x0123';
+    const messageParams = { from, data };
+    const messageId = controller.addUnapprovedMessage(messageParams);
+    const approvedMessageParams = await controller.approveMessage({
+      from,
+      data: from,
+      metamaskId: messageId,
+    });
+    const message = controller.getMessage(messageId);
+    expect(messageParams).toStrictEqual(approvedMessageParams);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.status).toStrictEqual('approved');
+  });
+
+  it('throws error if message dont have from', async () => {
+    const controller = new DecryptMessageManager();
+    const result = controller.addUnapprovedMessageAsync({
+      data: '0x123',
+    } as any);
+    await expect(result).rejects.toThrow(
+      'MetaMask Decryption: from field is required.',
+    );
+  });
+
+  it('sets message to decrypted', async () => {
+    const controller = new DecryptMessageManager();
+    const from = '0x0123';
+    const rawSig = '0x123';
+    const data = '0x12345';
+    const result = controller.addUnapprovedMessageAsync({
+      from,
+      data,
+    });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('decrypted');
+    });
+    controller.setMessageStatusAndResult(keys[0], rawSig, 'decrypted');
+    expect(await result).toStrictEqual(rawSig);
+  });
+
+  it('rejects a message', async () => {
+    const controller = new DecryptMessageManager();
+    const from = '0x0123';
+    const result = controller.addUnapprovedMessageAsync({
+      from,
+      data: '0x123',
+    });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('rejected');
+    });
+
+    controller.rejectMessage(keys[0]);
+    await expect(result).rejects.toThrow(
+      'MetaMask Decryption: User denied message decryption.',
+    );
+  });
+
+  it('throws error if message is not decrypted and errored', async () => {
+    const controller = new DecryptMessageManager();
+    const from = '0x0123';
+    const rawSig = '0x123';
+    const result = controller.addUnapprovedMessageAsync({
+      from,
+      data: '0x123',
+    });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('errored');
+    });
+
+    controller.setMessageStatusAndResult(keys[0], rawSig, 'errored');
+    await expect(result).rejects.toThrow(
+      'MetaMask Decryption: This message cannot be decrypted.',
+    );
+  });
+
+  it('throws error if status is unknown', async () => {
+    const controller = new DecryptMessageManager();
+    const from = '0x0123';
+    const rawSig = '0x123';
+    const result = controller.addUnapprovedMessageAsync({
+      from,
+      data: '0x123',
+    });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('signed');
+    });
+
+    controller.setMessageStatusAndResult(keys[0], rawSig, 'signed');
+    await expect(result).rejects.toThrow(
+      'MetaMask Decryption: Unknown problem: {"from":"0x0123","data":"0x123"',
+    );
+  });
+
+  it('adds valid unapproved message', async () => {
+    const controller = new DecryptMessageManager();
+    const from = '0x0123';
+    const data = '0x12345';
+    const originalRequest = { origin: 'origin' };
+    const messageParams = {
+      from,
+      data,
+    };
+    const messageId = controller.addUnapprovedMessage(
+      messageParams,
+      originalRequest,
+    );
+    const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.messageParams.from).toBe(messageParams.from);
+    expect(message.messageParams.data).toBe(messageParams.data);
+    expect(message.status).toBe('unapproved');
+  });
+});

--- a/packages/message-manager/src/DecryptMessageManager.test.ts
+++ b/packages/message-manager/src/DecryptMessageManager.test.ts
@@ -74,7 +74,9 @@ describe('DecryptMessageManager', () => {
   });
 
   it('sets message to decrypted', async () => {
-    const controller = new DecryptMessageManager();
+    const controller = new DecryptMessageManager(undefined, undefined, [
+      'decrypted',
+    ]);
     const from = '0x0123';
     const rawSig = '0x123';
     const data = '0x12345';

--- a/packages/message-manager/src/DecryptMessageManager.test.ts
+++ b/packages/message-manager/src/DecryptMessageManager.test.ts
@@ -163,7 +163,7 @@ describe('DecryptMessageManager', () => {
         from,
         data: dataMock,
       }),
-    ).rejects.toThrow('Invalid "from" address:');
+    ).rejects.toThrow(`Invalid address: ${from} must be a valid string.`);
   });
 
   it('gets correct unapproved messages', async () => {

--- a/packages/message-manager/src/DecryptMessageManager.test.ts
+++ b/packages/message-manager/src/DecryptMessageManager.test.ts
@@ -135,23 +135,6 @@ describe('DecryptMessageManager', () => {
       );
     });
 
-    // it('rejects a message', async () => {
-    //   const result = controller.addUnapprovedMessageAsync({
-    //     from: fromMock,
-    //     data: '0x123',
-    //   });
-    //   const unapprovedMessages = controller.getUnapprovedMessages();
-    //   const keys = Object.keys(unapprovedMessages);
-    //   controller.hub.once(`${keys[0]}:finished`, () => {
-    //     expect(unapprovedMessages[keys[0]].messageParams.from).toBe(fromMock);
-    //     expect(unapprovedMessages[keys[0]].status).toBe('rejected');
-    //   });
-
-    //   controller.rejectMessage(keys[0]);
-    //   await expect(result).rejects.toThrow(
-    //     'MetaMask Decryption: User denied message decryption.',
-    //   );
-    // });
   });
 
   it('adds a valid unapproved message', async () => {

--- a/packages/message-manager/src/DecryptMessageManager.ts
+++ b/packages/message-manager/src/DecryptMessageManager.ts
@@ -21,8 +21,6 @@ import {
  */
 export interface DecryptMessage extends AbstractMessage {
   messageParams: DecryptMessageParams;
-  rawData?: string;
-  error?: string;
 }
 
 /**

--- a/packages/message-manager/src/DecryptMessageManager.ts
+++ b/packages/message-manager/src/DecryptMessageManager.ts
@@ -17,7 +17,6 @@ import {
  * @property messageParams - The parameters to pass to the eth_decrypt method once the request is approved
  * @property type - The json-prc signing method for which a signature request has been made.
  * A 'DecryptMessage' which always has a 'eth_decrypt' type
- * @property rawData - Raw data of the signature request
  */
 export interface DecryptMessage extends AbstractMessage {
   messageParams: DecryptMessageParams;

--- a/packages/message-manager/src/DecryptMessageManager.ts
+++ b/packages/message-manager/src/DecryptMessageManager.ts
@@ -1,5 +1,5 @@
 import { v1 as random } from 'uuid';
-import { normalizeMessageData } from './utils';
+import { normalizeMessageData, validateDecryptedMessageData } from './utils';
 import {
   AbstractMessageManager,
   AbstractMessage,
@@ -69,35 +69,34 @@ export class DecryptMessageManager extends AbstractMessageManager<
    * @param req - The original request object possibly containing the origin.
    * @returns Promise resolving to the raw data of the signature request.
    */
-  addUnapprovedMessageAsync(
+  async addUnapprovedMessageAsync(
     messageParams: DecryptMessageParams,
     req?: OriginalRequest,
   ): Promise<string> {
-    return new Promise((resolve, reject) => {
-      if (!messageParams.from) {
-        reject(new Error('MetaMask Decryption: from field is required.'));
-        return;
-      }
-      const messageId = this.addUnapprovedMessage(messageParams, req);
+    validateDecryptedMessageData(messageParams);
+    const messageId = await this.addUnapprovedMessage(messageParams, req);
 
+    return new Promise((resolve, reject) => {
       this.hub.once(`${messageId}:finished`, (data: DecryptMessage) => {
         switch (data.status) {
           case 'decrypted':
             return resolve(data.rawSig as string);
           case 'rejected':
             return reject(
-              new Error('MetaMask Decryption: User denied message decryption.'),
+              new Error(
+                'MetaMask DecryptMessage: User denied message decryption.',
+              ),
             );
           case 'errored':
             return reject(
               new Error(
-                'MetaMask Decryption: This message cannot be decrypted.',
+                'MetaMask DecryptMessage: This message cannot be decrypted.',
               ),
             );
           default:
             return reject(
               new Error(
-                `MetaMask Decryption: Unknown problem: ${JSON.stringify(
+                `MetaMask DecryptMessage: Unknown problem: ${JSON.stringify(
                   messageParams,
                 )}`,
               ),
@@ -117,7 +116,7 @@ export class DecryptMessageManager extends AbstractMessageManager<
    * @param req - The original request object possibly containing the origin.
    * @returns The id of the newly created message.
    */
-  addUnapprovedMessage(
+  async addUnapprovedMessage(
     messageParams: DecryptMessageParams,
     req?: OriginalRequest,
   ) {
@@ -133,7 +132,7 @@ export class DecryptMessageManager extends AbstractMessageManager<
       time: Date.now(),
       type: 'eth_decrypt',
     };
-    this.addMessage(messageData);
+    await this.addMessage(messageData);
     this.hub.emit(`unapprovedMessage`, {
       ...messageParams,
       ...{ metamaskId: messageId },

--- a/packages/message-manager/src/DecryptMessageManager.ts
+++ b/packages/message-manager/src/DecryptMessageManager.ts
@@ -21,6 +21,8 @@ import {
  */
 export interface DecryptMessage extends AbstractMessage {
   messageParams: DecryptMessageParams;
+  rawData?: string;
+  error?: string;
 }
 
 /**

--- a/packages/message-manager/src/DecryptMessageManager.ts
+++ b/packages/message-manager/src/DecryptMessageManager.ts
@@ -1,0 +1,157 @@
+import { v1 as random } from 'uuid';
+import { normalizeMessageData } from './utils';
+import {
+  AbstractMessageManager,
+  AbstractMessage,
+  AbstractMessageParams,
+  AbstractMessageParamsMetamask,
+  OriginalRequest,
+} from './AbstractMessageManager';
+
+/**
+ * @type DecryptMessage
+ *
+ * Represents and contains data about a 'eth_decrypt' type signature request.
+ * These are created when a signature for an eth_decrypt call is requested.
+ * @property id - An id to track and identify the message object
+ * @property messageParams - The parameters to pass to the eth_decrypt method once the request is approved
+ * @property type - The json-prc signing method for which a signature request has been made.
+ * A 'DecryptMessage' which always has a 'eth_decrypt' type
+ * @property rawData - Raw data of the signature request
+ */
+export interface DecryptMessage extends AbstractMessage {
+  messageParams: DecryptMessageParams;
+}
+
+/**
+ * @type DecryptMessageParams
+ *
+ * Represents the parameters to pass to the eth_decrypt method once the request is approved.
+ * @property data - A hex string conversion of the raw buffer data of the signature request
+ */
+export interface DecryptMessageParams extends AbstractMessageParams {
+  data: string;
+}
+
+/**
+ * @type DecryptMessageParamsMetamask
+ *
+ * Represents the parameters to pass to the eth_decrypt method once the request is approved
+ * plus data added by MetaMask.
+ * @property metamaskId - Added for tracking and identification within MetaMask
+ * @property data - A hex string conversion of the raw buffer data of the signature request
+ * @property from - Address to sign this message from
+ * @property origin? - Added for request origin identification
+ */
+export interface DecryptMessageParamsMetamask
+  extends AbstractMessageParamsMetamask {
+  data: string;
+}
+
+/**
+ * Controller in charge of managing - storing, adding, removing, updating - DecryptMessages.
+ */
+export class DecryptMessageManager extends AbstractMessageManager<
+  DecryptMessage,
+  DecryptMessageParams,
+  DecryptMessageParamsMetamask
+> {
+  /**
+   * Name of this controller used during composition
+   */
+  override name = 'DecryptMessageManager';
+
+  /**
+   * Creates a new Message with an 'unapproved' status using the passed messageParams.
+   * this.addMessage is called to add the new Message to this.messages, and to save the unapproved Messages.
+   *
+   * @param messageParams - The params for the personal_sign call to be made after the message is approved.
+   * @param req - The original request object possibly containing the origin.
+   * @returns Promise resolving to the raw data of the signature request.
+   */
+  addUnapprovedMessageAsync(
+    messageParams: DecryptMessageParams,
+    req?: OriginalRequest,
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      if (!messageParams.from) {
+        reject(new Error('MetaMask Decryption: from field is required.'));
+        return;
+      }
+      const messageId = this.addUnapprovedMessage(messageParams, req);
+
+      this.hub.once(`${messageId}:finished`, (data: DecryptMessage) => {
+        switch (data.status) {
+          case 'decrypted':
+            return resolve(data.rawSig as string);
+          case 'rejected':
+            return reject(
+              new Error('MetaMask Decryption: User denied message decryption.'),
+            );
+          case 'errored':
+            return reject(
+              new Error(
+                'MetaMask Decryption: This message cannot be decrypted.',
+              ),
+            );
+          default:
+            return reject(
+              new Error(
+                `MetaMask Decryption: Unknown problem: ${JSON.stringify(
+                  messageParams,
+                )}`,
+              ),
+            );
+        }
+      });
+    });
+  }
+
+  /**
+   * Creates a new Message with an 'unapproved' status using the passed messageParams.
+   * this.addMessage is called to add the new Message to this.messages, and to save the
+   * unapproved Messages.
+   *
+   * @param messageParams - The params for the personal_sign call to be made after the message
+   * is approved.
+   * @param req - The original request object possibly containing the origin.
+   * @returns The id of the newly created message.
+   */
+  addUnapprovedMessage(
+    messageParams: DecryptMessageParams,
+    req?: OriginalRequest,
+  ) {
+    if (req) {
+      messageParams.origin = req.origin;
+    }
+    messageParams.data = normalizeMessageData(messageParams.data);
+    const messageId = random();
+    const messageData: DecryptMessage = {
+      id: messageId,
+      messageParams,
+      status: 'unapproved',
+      time: Date.now(),
+      type: 'eth_decrypt',
+    };
+    this.addMessage(messageData);
+    this.hub.emit(`unapprovedMessage`, {
+      ...messageParams,
+      ...{ metamaskId: messageId },
+    });
+    return messageId;
+  }
+
+  /**
+   * Removes the metamaskId property from passed messageParams and returns a promise which
+   * resolves the updated messageParams.
+   *
+   * @param messageParams - The messageParams to modify.
+   * @returns Promise resolving to the messageParams with the metamaskId property removed.
+   */
+  prepMessageForSigning(
+    messageParams: DecryptMessageParamsMetamask,
+  ): Promise<DecryptMessageParams> {
+    delete messageParams.metamaskId;
+    return Promise.resolve(messageParams);
+  }
+}

--- a/packages/message-manager/src/EncryptionPublicKeyManager.test.ts
+++ b/packages/message-manager/src/EncryptionPublicKeyManager.test.ts
@@ -142,7 +142,9 @@ describe('EncryptionPublicKeyManager', () => {
       controller.addUnapprovedMessageAsync({
         from,
       }),
-    ).rejects.toThrow(`Invalid "from" address: ${from} must be a valid string.`);
+    ).rejects.toThrow(
+      `Invalid "from" address: ${from} must be a valid string.`,
+    );
   });
 
   it('gets correct unapproved messages', async () => {

--- a/packages/message-manager/src/EncryptionPublicKeyManager.test.ts
+++ b/packages/message-manager/src/EncryptionPublicKeyManager.test.ts
@@ -142,7 +142,7 @@ describe('EncryptionPublicKeyManager', () => {
       controller.addUnapprovedMessageAsync({
         from,
       }),
-    ).rejects.toThrow('Invalid "from" address:');
+    ).rejects.toThrow(`Invalid address: ${from} must be a valid string.`);
   });
 
   it('gets correct unapproved messages', async () => {

--- a/packages/message-manager/src/EncryptionPublicKeyManager.test.ts
+++ b/packages/message-manager/src/EncryptionPublicKeyManager.test.ts
@@ -142,7 +142,7 @@ describe('EncryptionPublicKeyManager', () => {
       controller.addUnapprovedMessageAsync({
         from,
       }),
-    ).rejects.toThrow(`Invalid address: ${from} must be a valid string.`);
+    ).rejects.toThrow(`Invalid "from" address: ${from} must be a valid string.`);
   });
 
   it('gets correct unapproved messages', async () => {

--- a/packages/message-manager/src/MessageManager.test.ts
+++ b/packages/message-manager/src/MessageManager.test.ts
@@ -148,7 +148,7 @@ describe('MessageManager', () => {
         data: messageData,
         from,
       }),
-    ).rejects.toThrow(`Invalid address: ${from} must be a valid string.`);
+    ).rejects.toThrow(`Invalid "from" address: ${from} must be a valid string.`);
   });
 
   it('should get correct unapproved messages', async () => {

--- a/packages/message-manager/src/MessageManager.test.ts
+++ b/packages/message-manager/src/MessageManager.test.ts
@@ -148,7 +148,7 @@ describe('MessageManager', () => {
         data: messageData,
         from,
       }),
-    ).rejects.toThrow('Invalid "from" address:');
+    ).rejects.toThrow(`Invalid address: ${from} must be a valid string.`);
   });
 
   it('should get correct unapproved messages', async () => {

--- a/packages/message-manager/src/MessageManager.test.ts
+++ b/packages/message-manager/src/MessageManager.test.ts
@@ -148,7 +148,9 @@ describe('MessageManager', () => {
         data: messageData,
         from,
       }),
-    ).rejects.toThrow(`Invalid "from" address: ${from} must be a valid string.`);
+    ).rejects.toThrow(
+      `Invalid "from" address: ${from} must be a valid string.`,
+    );
   });
 
   it('should get correct unapproved messages', async () => {

--- a/packages/message-manager/src/PersonalMessageManager.test.ts
+++ b/packages/message-manager/src/PersonalMessageManager.test.ts
@@ -170,7 +170,9 @@ describe('PersonalMessageManager', () => {
         data: messageData,
         from,
       }),
-    ).rejects.toThrow(`Invalid "from" address: ${from} must be a valid string.`);
+    ).rejects.toThrow(
+      `Invalid "from" address: ${from} must be a valid string.`,
+    );
   });
 
   it('should get correct unapproved messages', async () => {

--- a/packages/message-manager/src/PersonalMessageManager.test.ts
+++ b/packages/message-manager/src/PersonalMessageManager.test.ts
@@ -170,7 +170,7 @@ describe('PersonalMessageManager', () => {
         data: messageData,
         from,
       }),
-    ).rejects.toThrow('Invalid "from" address:');
+    ).rejects.toThrow(`Invalid address: ${from} must be a valid string.`);
   });
 
   it('should get correct unapproved messages', async () => {

--- a/packages/message-manager/src/PersonalMessageManager.test.ts
+++ b/packages/message-manager/src/PersonalMessageManager.test.ts
@@ -170,7 +170,7 @@ describe('PersonalMessageManager', () => {
         data: messageData,
         from,
       }),
-    ).rejects.toThrow(`Invalid address: ${from} must be a valid string.`);
+    ).rejects.toThrow(`Invalid "from" address: ${from} must be a valid string.`);
   });
 
   it('should get correct unapproved messages', async () => {

--- a/packages/message-manager/src/index.ts
+++ b/packages/message-manager/src/index.ts
@@ -2,3 +2,4 @@ export * from './MessageManager';
 export * from './PersonalMessageManager';
 export * from './TypedMessageManager';
 export * from './EncryptionPublicKeyManager';
+export * from './DecryptMessageManager';

--- a/packages/message-manager/src/utils.test.ts
+++ b/packages/message-manager/src/utils.test.ts
@@ -18,7 +18,7 @@ describe('utils', () => {
         util.validateSignMessageData({
           data: '0x879a05',
         } as any),
-      ).toThrow(`Invalid address: undefined must be a valid string.`);
+      ).toThrow(`Invalid "from" address: undefined must be a valid string.`);
     });
 
     it('should throw if invalid from address', () => {
@@ -28,7 +28,7 @@ describe('utils', () => {
           data: '0x879a05',
           from,
         } as any),
-      ).toThrow(`Invalid address: ${from} must be a valid string.`);
+      ).toThrow(`Invalid "from" address: ${from} must be a valid string.`);
     });
 
     it('should throw if invalid type from address', () => {
@@ -38,7 +38,7 @@ describe('utils', () => {
           data: '0x879a05',
           from,
         } as any),
-      ).toThrow(`Invalid address: ${from} must be a valid string.`);
+      ).toThrow(`Invalid "from" address: ${from} must be a valid string.`);
     });
 
     it('should throw if no data', () => {
@@ -46,7 +46,7 @@ describe('utils', () => {
         util.validateSignMessageData({
           data: '0x879a05',
         } as any),
-      ).toThrow(`Invalid address: undefined must be a valid string.`);
+      ).toThrow(`Invalid "from" address: undefined must be a valid string.`);
     });
 
     it('should throw if invalid tyoe data', () => {
@@ -65,7 +65,7 @@ describe('utils', () => {
         util.validateTypedSignMessageDataV1({
           data: [],
         } as any),
-      ).toThrow(`Invalid address: undefined must be a valid string.`);
+      ).toThrow(`Invalid "from" address: undefined must be a valid string.`);
     });
 
     it('should throw if invalid from address', () => {
@@ -75,7 +75,7 @@ describe('utils', () => {
           data: [],
           from,
         } as any),
-      ).toThrow(`Invalid address: ${from} must be a valid string.`);
+      ).toThrow(`Invalid "from" address: ${from} must be a valid string.`);
     });
 
     it('should throw if invalid type from address', () => {
@@ -85,7 +85,7 @@ describe('utils', () => {
           data: [],
           from,
         } as any),
-      ).toThrow(`Invalid address: ${from} must be a valid string.`);
+      ).toThrow(`Invalid "from" address: ${from} must be a valid string.`);
     });
 
     it('should throw if incorrect data', () => {
@@ -124,7 +124,7 @@ describe('utils', () => {
         util.validateTypedSignMessageDataV3({
           data: '0x879a05',
         } as any),
-      ).toThrow(`Invalid address: undefined must be a valid string.`);
+      ).toThrow(`Invalid "from" address: undefined must be a valid string.`);
     });
 
     it('should throw if invalid from address', () => {
@@ -134,7 +134,7 @@ describe('utils', () => {
           data: '0x879a05',
           from,
         } as any),
-      ).toThrow(`Invalid address: ${from} must be a valid string.`);
+      ).toThrow(`Invalid "from" address: ${from} must be a valid string.`);
     });
 
     it('should throw if invalid type from address', () => {
@@ -144,7 +144,7 @@ describe('utils', () => {
           data: '0x879a05',
           from: 123,
         } as any),
-      ).toThrow(`Invalid address: ${from} must be a valid string.`);
+      ).toThrow(`Invalid "from" address: ${from} must be a valid string.`);
     });
 
     it('should throw if array data', () => {
@@ -196,7 +196,7 @@ describe('utils', () => {
     it('should throw if no from address', () => {
       expect(() =>
         util.validateEncryptionPublicKeyMessageData({} as any),
-      ).toThrow(`Invalid address: undefined must be a valid string.`);
+      ).toThrow(`Invalid "from" address: undefined must be a valid string.`);
     });
 
     it('should throw if invalid from address', () => {
@@ -205,7 +205,7 @@ describe('utils', () => {
         util.validateEncryptionPublicKeyMessageData({
           from,
         } as any),
-      ).toThrow(`Invalid address: ${from} must be a valid string.`);
+      ).toThrow(`Invalid "from" address: ${from} must be a valid string.`);
     });
 
     it('should throw if invalid type from address', () => {
@@ -214,7 +214,7 @@ describe('utils', () => {
         util.validateEncryptionPublicKeyMessageData({
           from: 123,
         } as any),
-      ).toThrow(`Invalid address: ${from} must be a valid string.`);
+      ).toThrow(`Invalid "from" address: ${from} must be a valid string.`);
     });
 
     it('should not throw if from address is correct', () => {
@@ -229,7 +229,7 @@ describe('utils', () => {
   describe('validateDecryptedMessageData', () => {
     it('should throw if no from address', () => {
       expect(() => util.validateDecryptedMessageData({} as any)).toThrow(
-        'Invalid address: undefined must be a valid string.',
+        'Invalid "from" address: undefined must be a valid string.',
       );
     });
 
@@ -239,7 +239,7 @@ describe('utils', () => {
         util.validateDecryptedMessageData({
           from,
         } as any),
-      ).toThrow(`Invalid address: ${from} must be a valid string.`);
+      ).toThrow(`Invalid "from" address: ${from} must be a valid string.`);
     });
 
     it('should throw if invalid type from address', () => {
@@ -248,7 +248,7 @@ describe('utils', () => {
         util.validateDecryptedMessageData({
           from,
         } as any),
-      ).toThrow(`Invalid address: ${from} must be a valid string.`);
+      ).toThrow(`Invalid "from" address: ${from} must be a valid string.`);
     });
 
     it('should not throw if from address is correct', () => {

--- a/packages/message-manager/src/utils.test.ts
+++ b/packages/message-manager/src/utils.test.ts
@@ -18,25 +18,27 @@ describe('utils', () => {
         util.validateSignMessageData({
           data: '0x879a05',
         } as any),
-      ).toThrow('Invalid "from" address: undefined must be a valid string.');
+      ).toThrow(`Invalid address: undefined must be a valid string.`);
     });
 
     it('should throw if invalid from address', () => {
+      const from = '01';
       expect(() =>
         util.validateSignMessageData({
           data: '0x879a05',
-          from: '01',
+          from,
         } as any),
-      ).toThrow('Invalid "from" address: 01 must be a valid string.');
+      ).toThrow(`Invalid address: ${from} must be a valid string.`);
     });
 
     it('should throw if invalid type from address', () => {
+      const from = 123;
       expect(() =>
         util.validateSignMessageData({
           data: '0x879a05',
-          from: 123,
+          from,
         } as any),
-      ).toThrow('Invalid "from" address: 123 must be a valid string.');
+      ).toThrow(`Invalid address: ${from} must be a valid string.`);
     });
 
     it('should throw if no data', () => {
@@ -44,7 +46,7 @@ describe('utils', () => {
         util.validateSignMessageData({
           data: '0x879a05',
         } as any),
-      ).toThrow('Invalid "from" address: undefined must be a valid string.');
+      ).toThrow(`Invalid address: undefined must be a valid string.`);
     });
 
     it('should throw if invalid tyoe data', () => {
@@ -63,25 +65,27 @@ describe('utils', () => {
         util.validateTypedSignMessageDataV1({
           data: [],
         } as any),
-      ).toThrow('Invalid "from" address:');
+      ).toThrow(`Invalid address: undefined must be a valid string.`);
     });
 
     it('should throw if invalid from address', () => {
+      const from = '3244e191f1b4903970224322180f1';
       expect(() =>
         util.validateTypedSignMessageDataV1({
           data: [],
-          from: '3244e191f1b4903970224322180f1fbbc415696b',
+          from,
         } as any),
-      ).toThrow('Expected EIP712 typed data.');
+      ).toThrow(`Invalid address: ${from} must be a valid string.`);
     });
 
     it('should throw if invalid type from address', () => {
+      const from = 123;
       expect(() =>
         util.validateTypedSignMessageDataV1({
           data: [],
-          from: 123,
+          from,
         } as any),
-      ).toThrow('Invalid "from" address:');
+      ).toThrow(`Invalid address: ${from} must be a valid string.`);
     });
 
     it('should throw if incorrect data', () => {
@@ -120,25 +124,27 @@ describe('utils', () => {
         util.validateTypedSignMessageDataV3({
           data: '0x879a05',
         } as any),
-      ).toThrow('Invalid "from" address:');
+      ).toThrow(`Invalid address: undefined must be a valid string.`);
     });
 
     it('should throw if invalid from address', () => {
+      const from = '3244e191f1b4903970224322180f1fb';
       expect(() =>
         util.validateTypedSignMessageDataV3({
           data: '0x879a05',
-          from: '3244e191f1b4903970224322180f1fbbc415696b',
+          from,
         } as any),
-      ).toThrow('Data must be passed as a valid JSON string.');
+      ).toThrow(`Invalid address: ${from} must be a valid string.`);
     });
 
     it('should throw if invalid type from address', () => {
+      const from = 123;
       expect(() =>
         util.validateTypedSignMessageDataV3({
           data: '0x879a05',
           from: 123,
         } as any),
-      ).toThrow('Invalid "from" address:');
+      ).toThrow(`Invalid address: ${from} must be a valid string.`);
     });
 
     it('should throw if array data', () => {
@@ -190,23 +196,25 @@ describe('utils', () => {
     it('should throw if no from address', () => {
       expect(() =>
         util.validateEncryptionPublicKeyMessageData({} as any),
-      ).toThrow('Invalid "from" address: undefined must be a valid string.');
+      ).toThrow(`Invalid address: undefined must be a valid string.`);
     });
 
     it('should throw if invalid from address', () => {
+      const from = '01';
       expect(() =>
         util.validateEncryptionPublicKeyMessageData({
-          from: '01',
+          from,
         } as any),
-      ).toThrow('Invalid "from" address: 01 must be a valid string.');
+      ).toThrow(`Invalid address: ${from} must be a valid string.`);
     });
 
     it('should throw if invalid type from address', () => {
+      const from = 123;
       expect(() =>
         util.validateEncryptionPublicKeyMessageData({
           from: 123,
         } as any),
-      ).toThrow('Invalid "from" address: 123 must be a valid string.');
+      ).toThrow(`Invalid address: ${from} must be a valid string.`);
     });
 
     it('should not throw if from address is correct', () => {
@@ -221,24 +229,26 @@ describe('utils', () => {
   describe('validateDecryptedMessageData', () => {
     it('should throw if no from address', () => {
       expect(() => util.validateDecryptedMessageData({} as any)).toThrow(
-        'Invalid "from" address: undefined must be a valid string.',
+        'Invalid address: undefined must be a valid string.',
       );
     });
 
     it('should throw if invalid from address', () => {
+      const from = '01';
       expect(() =>
         util.validateDecryptedMessageData({
-          from: '01',
+          from,
         } as any),
-      ).toThrow('Invalid "from" address: 01 must be a valid string.');
+      ).toThrow(`Invalid address: ${from} must be a valid string.`);
     });
 
     it('should throw if invalid type from address', () => {
+      const from = 123;
       expect(() =>
         util.validateDecryptedMessageData({
-          from: 123,
+          from,
         } as any),
-      ).toThrow('Invalid "from" address: 123 must be a valid string.');
+      ).toThrow(`Invalid address: ${from} must be a valid string.`);
     });
 
     it('should not throw if from address is correct', () => {

--- a/packages/message-manager/src/utils.test.ts
+++ b/packages/message-manager/src/utils.test.ts
@@ -217,4 +217,36 @@ describe('utils', () => {
       ).not.toThrow();
     });
   });
+
+  describe('validateDecryptedMessageData', () => {
+    it('should throw if no from address', () => {
+      expect(() => util.validateDecryptedMessageData({} as any)).toThrow(
+        'Invalid "from" address: undefined must be a valid string.',
+      );
+    });
+
+    it('should throw if invalid from address', () => {
+      expect(() =>
+        util.validateDecryptedMessageData({
+          from: '01',
+        } as any),
+      ).toThrow('Invalid "from" address: 01 must be a valid string.');
+    });
+
+    it('should throw if invalid type from address', () => {
+      expect(() =>
+        util.validateDecryptedMessageData({
+          from: 123,
+        } as any),
+      ).toThrow('Invalid "from" address: 123 must be a valid string.');
+    });
+
+    it('should not throw if from address is correct', () => {
+      expect(() =>
+        util.validateDecryptedMessageData({
+          from: '0x3244e191f1b4903970224322180f1fbbc415696b',
+        } as any),
+      ).not.toThrow();
+    });
+  });
 });

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -6,6 +6,7 @@ import { MessageParams } from './MessageManager';
 import { PersonalMessageParams } from './PersonalMessageManager';
 import { TypedMessageParams } from './TypedMessageManager';
 import { EncryptionPublicKeyParams } from './EncryptionPublicKeyManager';
+import { DecryptMessageParams } from './DecryptMessageManager';
 
 const hexRe = /^[0-9A-Fa-f]+$/gu;
 
@@ -126,6 +127,21 @@ export function validateTypedSignMessageDataV3(
  */
 export function validateEncryptionPublicKeyMessageData(
   messageData: EncryptionPublicKeyParams,
+) {
+  const { from } = messageData;
+  if (!from || typeof from !== 'string' || !isValidHexAddress(from)) {
+    throw new Error(`Invalid "from" address: ${from} must be a valid string.`);
+  }
+}
+
+/**
+ * Validates messageData for the eth_decrypt message and throws in
+ * the event of any validation error.
+ *
+ * @param messageData - address string to validate.
+ */
+export function validateDecryptedMessageData(
+  messageData: DecryptMessageParams,
 ) {
   const { from } = messageData;
   if (!from || typeof from !== 'string' || !isValidHexAddress(from)) {

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -14,9 +14,9 @@ const hexRe = /^[0-9A-Fa-f]+$/gu;
  *
  * @param address - The address to validate.
  */
-function validateAddress(address: string) {
+function validateAddress(address: string, propertyName: string) {
   if (!address || typeof address !== 'string' || !isValidHexAddress(address)) {
-    throw new Error(`Invalid address: ${address} must be a valid string.`);
+    throw new Error(`Invalid "${propertyName}" address: ${address} must be a valid string.`);
   }
 }
 
@@ -49,7 +49,7 @@ export function validateSignMessageData(
   messageData: PersonalMessageParams | MessageParams,
 ) {
   const { from, data } = messageData;
-  validateAddress(from);
+  validateAddress(from, "from");
 
   if (!data || typeof data !== 'string') {
     throw new Error(`Invalid message "data": ${data} must be a valid string.`);
@@ -65,7 +65,7 @@ export function validateSignMessageData(
 export function validateTypedSignMessageDataV1(
   messageData: TypedMessageParams,
 ) {
-  validateAddress(messageData.from);
+  validateAddress(messageData.from, "from");
 
   if (!messageData.data || !Array.isArray(messageData.data)) {
     throw new Error(
@@ -90,7 +90,7 @@ export function validateTypedSignMessageDataV1(
 export function validateTypedSignMessageDataV3(
   messageData: TypedMessageParams,
 ) {
-  validateAddress(messageData.from);
+  validateAddress(messageData.from, "from");
 
   if (!messageData.data || typeof messageData.data !== 'string') {
     throw new Error(
@@ -121,7 +121,7 @@ export function validateEncryptionPublicKeyMessageData(
   messageData: EncryptionPublicKeyParams,
 ) {
   const { from } = messageData;
-  validateAddress(from);
+  validateAddress(from, "from");
 }
 
 /**
@@ -134,5 +134,5 @@ export function validateDecryptedMessageData(
   messageData: DecryptMessageParams,
 ) {
   const { from } = messageData;
-  validateAddress(from);
+  validateAddress(from, "from");
 }

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -9,6 +9,16 @@ import { EncryptionPublicKeyParams } from './EncryptionPublicKeyManager';
 import { DecryptMessageParams } from './DecryptMessageManager';
 
 const hexRe = /^[0-9A-Fa-f]+$/gu;
+/**
+ * Validates an address string and throws in the event of any validation error.
+ *
+ * @param address - The address to validate.
+ */
+function validateAddress(address: string) {
+  if (!address || typeof address !== 'string' || !isValidHexAddress(address)) {
+    throw new Error(`Invalid address: ${address} must be a valid string.`);
+  }
+}
 
 /**
  * A helper function that converts rawmessageData buffer data to a hex, or just returns the data if
@@ -39,9 +49,7 @@ export function validateSignMessageData(
   messageData: PersonalMessageParams | MessageParams,
 ) {
   const { from, data } = messageData;
-  if (!from || typeof from !== 'string' || !isValidHexAddress(from)) {
-    throw new Error(`Invalid "from" address: ${from} must be a valid string.`);
-  }
+  validateAddress(from);
 
   if (!data || typeof data !== 'string') {
     throw new Error(`Invalid message "data": ${data} must be a valid string.`);
@@ -57,15 +65,7 @@ export function validateSignMessageData(
 export function validateTypedSignMessageDataV1(
   messageData: TypedMessageParams,
 ) {
-  if (
-    !messageData.from ||
-    typeof messageData.from !== 'string' ||
-    !isValidHexAddress(messageData.from)
-  ) {
-    throw new Error(
-      `Invalid "from" address: ${messageData.from} must be a valid string.`,
-    );
-  }
+  validateAddress(messageData.from);
 
   if (!messageData.data || !Array.isArray(messageData.data)) {
     throw new Error(
@@ -90,15 +90,7 @@ export function validateTypedSignMessageDataV1(
 export function validateTypedSignMessageDataV3(
   messageData: TypedMessageParams,
 ) {
-  if (
-    !messageData.from ||
-    typeof messageData.from !== 'string' ||
-    !isValidHexAddress(messageData.from)
-  ) {
-    throw new Error(
-      `Invalid "from" address: ${messageData.from} must be a valid string.`,
-    );
-  }
+  validateAddress(messageData.from);
 
   if (!messageData.data || typeof messageData.data !== 'string') {
     throw new Error(
@@ -129,9 +121,7 @@ export function validateEncryptionPublicKeyMessageData(
   messageData: EncryptionPublicKeyParams,
 ) {
   const { from } = messageData;
-  if (!from || typeof from !== 'string' || !isValidHexAddress(from)) {
-    throw new Error(`Invalid "from" address: ${from} must be a valid string.`);
-  }
+  validateAddress(from);
 }
 
 /**
@@ -144,7 +134,5 @@ export function validateDecryptedMessageData(
   messageData: DecryptMessageParams,
 ) {
   const { from } = messageData;
-  if (!from || typeof from !== 'string' || !isValidHexAddress(from)) {
-    throw new Error(`Invalid "from" address: ${from} must be a valid string.`);
-  }
+  validateAddress(from);
 }

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -13,10 +13,13 @@ const hexRe = /^[0-9A-Fa-f]+$/gu;
  * Validates an address string and throws in the event of any validation error.
  *
  * @param address - The address to validate.
+ * @param propertyName - The name of the property source to use in the error message.
  */
 function validateAddress(address: string, propertyName: string) {
   if (!address || typeof address !== 'string' || !isValidHexAddress(address)) {
-    throw new Error(`Invalid "${propertyName}" address: ${address} must be a valid string.`);
+    throw new Error(
+      `Invalid "${propertyName}" address: ${address} must be a valid string.`,
+    );
   }
 }
 
@@ -49,7 +52,7 @@ export function validateSignMessageData(
   messageData: PersonalMessageParams | MessageParams,
 ) {
   const { from, data } = messageData;
-  validateAddress(from, "from");
+  validateAddress(from, 'from');
 
   if (!data || typeof data !== 'string') {
     throw new Error(`Invalid message "data": ${data} must be a valid string.`);
@@ -65,7 +68,7 @@ export function validateSignMessageData(
 export function validateTypedSignMessageDataV1(
   messageData: TypedMessageParams,
 ) {
-  validateAddress(messageData.from, "from");
+  validateAddress(messageData.from, 'from');
 
   if (!messageData.data || !Array.isArray(messageData.data)) {
     throw new Error(
@@ -90,7 +93,7 @@ export function validateTypedSignMessageDataV1(
 export function validateTypedSignMessageDataV3(
   messageData: TypedMessageParams,
 ) {
-  validateAddress(messageData.from, "from");
+  validateAddress(messageData.from, 'from');
 
   if (!messageData.data || typeof messageData.data !== 'string') {
     throw new Error(
@@ -121,7 +124,7 @@ export function validateEncryptionPublicKeyMessageData(
   messageData: EncryptionPublicKeyParams,
 ) {
   const { from } = messageData;
-  validateAddress(from, "from");
+  validateAddress(from, 'from');
 }
 
 /**
@@ -134,5 +137,5 @@ export function validateDecryptedMessageData(
   messageData: DecryptMessageParams,
 ) {
   const { from } = messageData;
-  validateAddress(from, "from");
+  validateAddress(from, 'from');
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Add `DecryptMessageManager` to message managers**

**Description**

- CHANGED:

  - Extends `AbstractMessageManager` adds `decrypted`

- ADDED:

  - Adds `DecryptMessageManager` in order to consume it at `DecryptMessageController` on extension

**Checklist**

- [X] Tests are included if applicable
- [X] Any added code is fully documented
