### PR TITLE
Generate source maps for type definition files

### DIFF
--- a/tsconfig.packages.build.json
+++ b/tsconfig.packages.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.packages.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "inlineSources": true,
     "sourceMap": true
   },


### PR DESCRIPTION
It is a frustrating experience to want to see the source code of a module that's being imported in one's editor only to be presented with the `.d.ts` file when the module is Cmd-clicked (or "Go to Definition" is otherwise invoked). To fix this, TypeScript needs to be configured to generate source maps alongside `.d.ts` files.

To test this, run `yarn:build`. All `.d.ts` files should have an accompanying `.d.ts.map` file.

## Changes

**CHANGED:**

  - Update `tsconfig.json` for all packages to enable `declarationMap`.

## Checklist

- [x] Tests are included if applicable
- [x] Any added code is fully documented

## References

References https://github.com/MetaMask/metamask-module-template/pull/182.
