### PR TITLE
BREAKING Adds messenger to token controller

### DIFF
--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -33,6 +33,7 @@
     "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@metamask/abi-utils": "^1.1.0",
+    "@metamask/approval-controller": "workspace:^",
     "@metamask/base-controller": "workspace:^",
     "@metamask/contract-metadata": "^2.3.1",
     "@metamask/controller-utils": "workspace:^",
@@ -68,6 +69,7 @@
     "typescript": "~4.6.3"
   },
   "peerDependencies": {
+    "@metamask/approval-controller": "workspace:^",
     "@metamask/network-controller": "workspace:^"
   },
   "engines": {

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -14,6 +14,13 @@ import {
   TokenBalancesController,
 } from './TokenBalancesController';
 
+const TokensControllerMessenger = new ControllerMessenger<
+  never,
+  never
+>().getRestricted<'TokensController', never, never>({
+  name: 'TokensController',
+});
+
 const stubCreateEthers = (ctrl: TokensController, res: boolean) => {
   return sinon.stub(ctrl, '_createEthersContract').callsFake(() => {
     return {
@@ -142,7 +149,7 @@ describe('TokenBalancesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
-      messenger: undefined as any,
+      messenger: TokensControllerMessenger,
     });
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
     const tokenBalances = new TokenBalancesController(
@@ -178,7 +185,7 @@ describe('TokenBalancesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
-      messenger: undefined as any,
+      messenger: TokensControllerMessenger,
     });
     const errorMsg = 'Failed to get balance';
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
@@ -231,7 +238,7 @@ describe('TokenBalancesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
-      messenger: undefined as any,
+      messenger: TokensControllerMessenger,
     });
 
     const stub = stubCreateEthers(tokensController, false);

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -6,20 +6,16 @@ import {
 } from '@metamask/network-controller';
 import { PreferencesController } from '@metamask/preferences-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
-import { TokensController } from './TokensController';
+import {
+  TokensController,
+  TokensControllerMessenger,
+} from './TokensController';
 import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
 import {
   BN as exportedBn,
   TokenBalancesController,
 } from './TokenBalancesController';
-
-const TokensControllerMessenger = new ControllerMessenger<
-  never,
-  never
->().getRestricted<'TokensController', never, never>({
-  name: 'TokensController',
-});
 
 const stubCreateEthers = (ctrl: TokensController, res: boolean) => {
   return sinon.stub(ctrl, '_createEthersContract').callsFake(() => {
@@ -149,7 +145,7 @@ describe('TokenBalancesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
-      messenger: TokensControllerMessenger,
+      messenger: undefined as unknown as TokensControllerMessenger,
     });
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
     const tokenBalances = new TokenBalancesController(
@@ -185,7 +181,7 @@ describe('TokenBalancesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
-      messenger: TokensControllerMessenger,
+      messenger: undefined as unknown as TokensControllerMessenger,
     });
     const errorMsg = 'Failed to get balance';
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
@@ -238,7 +234,7 @@ describe('TokenBalancesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
-      messenger: TokensControllerMessenger,
+      messenger: undefined as unknown as TokensControllerMessenger,
     });
 
     const stub = stubCreateEthers(tokensController, false);

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -142,6 +142,7 @@ describe('TokenBalancesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
+      messenger: undefined as any,
     });
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
     const tokenBalances = new TokenBalancesController(
@@ -177,6 +178,7 @@ describe('TokenBalancesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
+      messenger: undefined as any,
     });
     const errorMsg = 'Failed to get balance';
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
@@ -229,6 +231,7 @@ describe('TokenBalancesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
+      messenger: undefined as any,
     });
 
     const stub = stubCreateEthers(tokensController, false);

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -11,7 +11,10 @@ import {
 import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
 import { PreferencesController } from '@metamask/preferences-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
-import { TokensController } from './TokensController';
+import {
+  TokensController,
+  TokensControllerMessenger,
+} from './TokensController';
 import { TokenDetectionController } from './TokenDetectionController';
 import {
   TokenListController,
@@ -165,13 +168,7 @@ describe('TokenDetectionController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         onNetworkStateChangeListeners.push(listener),
-      messenger: new ControllerMessenger<never, never>().getRestricted<
-        'TokensController',
-        never,
-        never
-      >({
-        name: 'TokensController',
-      }),
+      messenger: undefined as unknown as TokensControllerMessenger,
     });
 
     const tokenListSetup = setupTokenListController(controllerMessenger);

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -165,6 +165,7 @@ describe('TokenDetectionController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         onNetworkStateChangeListeners.push(listener),
+      messenger: undefined as any,
     });
 
     const tokenListSetup = setupTokenListController(controllerMessenger);

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -165,7 +165,13 @@ describe('TokenDetectionController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         onNetworkStateChangeListeners.push(listener),
-      messenger: undefined as any,
+      messenger: new ControllerMessenger<never, never>().getRestricted<
+        'TokensController',
+        never,
+        never
+      >({
+        name: 'TokensController',
+      }),
     });
 
     const tokenListSetup = setupTokenListController(controllerMessenger);

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -219,6 +219,7 @@ describe('TokenRatesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
+      messenger: undefined as any,
     });
     const controller = new TokenRatesController(
       {

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -219,7 +219,13 @@ describe('TokenRatesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
-      messenger: undefined as any,
+      messenger: new ControllerMessenger<never, never>().getRestricted<
+        'TokensController',
+        never,
+        never
+      >({
+        name: 'TokensController',
+      }),
     });
     const controller = new TokenRatesController(
       {

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -7,7 +7,10 @@ import {
 } from '@metamask/network-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
 import { TokenRatesController } from './TokenRatesController';
-import { TokensController } from './TokensController';
+import {
+  TokensController,
+  TokensControllerMessenger,
+} from './TokensController';
 
 const COINGECKO_API = 'https://api.coingecko.com/api/v3';
 const COINGECKO_ETH_PATH = '/simple/token_price/ethereum';
@@ -219,13 +222,7 @@ describe('TokenRatesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
-      messenger: new ControllerMessenger<never, never>().getRestricted<
-        'TokensController',
-        never,
-        never
-      >({
-        name: 'TokensController',
-      }),
+      messenger: undefined as unknown as TokensControllerMessenger,
     });
     const controller = new TokenRatesController(
       {

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -876,6 +876,7 @@ describe('TokensController', () => {
   describe('on watchAsset', function () {
     let asset: any, type: any;
     const interactingAddress = '0x2';
+    const requestId = '12345';
 
     let createEthersStub: sinon.SinonStub;
     beforeEach(function () {
@@ -973,7 +974,7 @@ describe('TokensController', () => {
       const clock = sinon.useFakeTimers(1);
       const generateRandomIdStub = sinon
         .stub(tokensController, '_generateRandomId')
-        .callsFake(() => '12345');
+        .callsFake(() => requestId);
       type = 'ERC20';
 
       const callActionSpy = jest.spyOn(messenger, 'call').mockResolvedValue({});
@@ -981,7 +982,7 @@ describe('TokensController', () => {
       await tokensController.watchAsset(asset, type);
       expect(tokensController.state.suggestedAssets).toStrictEqual([
         {
-          id: '12345',
+          id: requestId,
           status: 'pending',
           time: 1, // uses the fakeTimers clock
           type: 'ERC20',
@@ -993,9 +994,19 @@ describe('TokensController', () => {
       expect(callActionSpy).toHaveBeenCalledWith(
         'ApprovalController:addRequest',
         {
-          id: '12345',
+          id: requestId,
           origin: ORIGIN_METAMASK,
           type: WATCH_ASSET_METHOD_NAME,
+          requestData: {
+            id: requestId,
+            interactingAddress: '0x1',
+            asset: {
+              address: asset.address,
+              decimals: asset.decimals,
+              symbol: asset.symbol,
+              image: asset.image,
+            },
+          },
         },
         true,
       );
@@ -1008,7 +1019,7 @@ describe('TokensController', () => {
       const clock = sinon.useFakeTimers(1);
       const generateRandomIdStub = sinon
         .stub(tokensController, '_generateRandomId')
-        .callsFake(() => '12345');
+        .callsFake(() => requestId);
       type = 'ERC20';
 
       const callActionSpy = jest.spyOn(messenger, 'call').mockResolvedValue({});
@@ -1016,7 +1027,7 @@ describe('TokensController', () => {
       await tokensController.watchAsset(asset, type, interactingAddress);
       expect(tokensController.state.suggestedAssets).toStrictEqual([
         {
-          id: '12345',
+          id: requestId,
           status: 'pending',
           interactingAddress,
           time: 1, // uses the fakeTimers clock
@@ -1028,9 +1039,19 @@ describe('TokensController', () => {
       expect(callActionSpy).toHaveBeenCalledWith(
         'ApprovalController:addRequest',
         {
-          id: '12345',
+          id: requestId,
           origin: ORIGIN_METAMASK,
           type: WATCH_ASSET_METHOD_NAME,
+          requestData: {
+            id: requestId,
+            interactingAddress,
+            asset: {
+              address: asset.address,
+              decimals: asset.decimals,
+              symbol: asset.symbol,
+              image: asset.image,
+            },
+          },
         },
         true,
       );
@@ -1047,7 +1068,7 @@ describe('TokensController', () => {
       async function (_, approvalControllerCallResolves: boolean) {
         const generateRandomIdStub = sinon
           .stub(tokensController, '_generateRandomId')
-          .callsFake(() => '12345');
+          .callsFake(() => requestId);
         type = 'ERC20';
 
         let calledOnce = false;
@@ -1063,7 +1084,7 @@ describe('TokensController', () => {
             });
 
         await tokensController.watchAsset(asset, type);
-        await tokensController.acceptWatchAsset('12345');
+        await tokensController.acceptWatchAsset(requestId);
 
         expect(tokensController.state.suggestedAssets).toStrictEqual([]);
         expect(tokensController.state.tokens).toHaveLength(1);
@@ -1079,9 +1100,19 @@ describe('TokensController', () => {
         expect(callActionSpy).toHaveBeenCalledWith(
           'ApprovalController:addRequest',
           {
-            id: '12345',
+            id: requestId,
             origin: ORIGIN_METAMASK,
             type: WATCH_ASSET_METHOD_NAME,
+            requestData: {
+              id: requestId,
+              interactingAddress: '0x1',
+              asset: {
+                address: asset.address,
+                decimals: asset.decimals,
+                symbol: asset.symbol,
+                image: asset.image,
+              },
+            },
           },
           true,
         );
@@ -1097,13 +1128,13 @@ describe('TokensController', () => {
     it('should store token correctly under interacting address if user confirms', async function () {
       const generateRandomIdStub = sinon
         .stub(tokensController, '_generateRandomId')
-        .callsFake(() => '12345');
+        .callsFake(() => requestId);
       type = 'ERC20';
 
       const callActionSpy = jest.spyOn(messenger, 'call').mockResolvedValue({});
 
       await tokensController.watchAsset(asset, type, interactingAddress);
-      await tokensController.acceptWatchAsset('12345');
+      await tokensController.acceptWatchAsset(requestId);
 
       expect(tokensController.state.suggestedAssets).toStrictEqual([]);
       expect(tokensController.state.tokens).toHaveLength(0);
@@ -1129,9 +1160,19 @@ describe('TokensController', () => {
       expect(callActionSpy).toHaveBeenCalledWith(
         'ApprovalController:addRequest',
         {
-          id: '12345',
+          id: requestId,
           origin: ORIGIN_METAMASK,
           type: WATCH_ASSET_METHOD_NAME,
+          requestData: {
+            id: requestId,
+            interactingAddress,
+            asset: {
+              address: asset.address,
+              decimals: asset.decimals,
+              symbol: asset.symbol,
+              image: asset.image,
+            },
+          },
         },
         true,
       );
@@ -1195,9 +1236,19 @@ describe('TokensController', () => {
         expect(callActionSpy).toHaveBeenCalledWith(
           'ApprovalController:addRequest',
           {
-            id: expect.any(String),
+            id: suggestedAssetMeta.id,
             origin: ORIGIN_METAMASK,
             type: WATCH_ASSET_METHOD_NAME,
+            requestData: {
+              id: suggestedAssetMeta.id,
+              interactingAddress: suggestedAssetMeta.interactingAddress,
+              asset: {
+                address: suggestedAssetMeta.asset.address,
+                decimals: suggestedAssetMeta.asset.decimals,
+                symbol: suggestedAssetMeta.asset.symbol,
+                image: null,
+              },
+            },
           },
           true,
         );
@@ -1227,9 +1278,19 @@ describe('TokensController', () => {
       expect(callActionSpy).toHaveBeenCalledWith(
         'ApprovalController:addRequest',
         {
-          id: expect.any(String),
+          id: suggestedAssetMeta.id,
           origin: ORIGIN_METAMASK,
           type: WATCH_ASSET_METHOD_NAME,
+          requestData: {
+            id: suggestedAssetMeta.id,
+            interactingAddress: suggestedAssetMeta.interactingAddress,
+            asset: {
+              address: suggestedAssetMeta.asset.address,
+              decimals: suggestedAssetMeta.asset.decimals,
+              symbol: suggestedAssetMeta.asset.symbol,
+              image: null,
+            },
+          },
         },
         true,
       );
@@ -1283,9 +1344,19 @@ describe('TokensController', () => {
         expect(callActionSpy).toHaveBeenCalledWith(
           'ApprovalController:addRequest',
           {
-            id: expect.any(String),
+            id: suggestedAssetMeta.id,
             origin: ORIGIN_METAMASK,
             type: WATCH_ASSET_METHOD_NAME,
+            requestData: {
+              id: suggestedAssetMeta.id,
+              interactingAddress: suggestedAssetMeta.interactingAddress,
+              asset: {
+                address: suggestedAssetMeta.asset.address,
+                decimals: suggestedAssetMeta.asset.decimals,
+                symbol: suggestedAssetMeta.asset.symbol,
+                image: null,
+              },
+            },
           },
           true,
         );

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -746,13 +746,16 @@ export class TokensController extends BaseController<
             image,
             suggestedAssetMeta?.interactingAddress || selectedAddress,
           );
-          suggestedAssetMeta.status = SuggestedAssetStatus.accepted;
 
           this._acceptApproval(suggestedAssetID);
 
+          const acceptedSuggestedAssetMeta = {
+            ...suggestedAssetMeta,
+            status: SuggestedAssetStatus.accepted,
+          };
           this.hub.emit(
             `${suggestedAssetMeta.id}:finished`,
-            suggestedAssetMeta,
+            acceptedSuggestedAssetMeta,
           );
           break;
         default:
@@ -787,8 +790,14 @@ export class TokensController extends BaseController<
     if (!suggestedAssetMeta) {
       return;
     }
-    suggestedAssetMeta.status = SuggestedAssetStatus.rejected;
-    this.hub.emit(`${suggestedAssetMeta.id}:finished`, suggestedAssetMeta);
+    const rejectedSuggestedAssetMeta = {
+      ...suggestedAssetMeta,
+      status: SuggestedAssetStatus.rejected,
+    };
+    this.hub.emit(
+      `${suggestedAssetMeta.id}:finished`,
+      rejectedSuggestedAssetMeta,
+    );
     const newSuggestedAssets = suggestedAssets.filter(
       ({ id }) => id !== suggestedAssetID,
     );

--- a/packages/assets-controllers/tsconfig.build.json
+++ b/packages/assets-controllers/tsconfig.build.json
@@ -6,6 +6,7 @@
     "rootDir": "./src"
   },
   "references": [
+    { "path": "../approval-controller/tsconfig.build.json" },
     { "path": "../base-controller/tsconfig.build.json" },
     { "path": "../controller-utils/tsconfig.build.json" },
     { "path": "../network-controller/tsconfig.build.json" },

--- a/packages/assets-controllers/tsconfig.json
+++ b/packages/assets-controllers/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": "./"
   },
   "references": [
+    { "path": "../approval-controller" },
     { "path": "../base-controller" },
     { "path": "../controller-utils" },
     { "path": "../network-controller" },

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -84,3 +84,6 @@ export const OPENSEA_PROXY_URL =
   'https://proxy.metafi.codefi.network/opensea/v1/api/v1';
 export const OPENSEA_API_URL = 'https://api.opensea.io/api/v1';
 export const OPENSEA_TEST_API_URL = 'https://testnets-api.opensea.io/api/v1';
+
+// Default origin for controllers
+export const ORIGIN_METAMASK = 'metamask';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,6 +1450,7 @@ __metadata:
     "@ethersproject/contracts": ^5.7.0
     "@ethersproject/providers": ^5.7.0
     "@metamask/abi-utils": ^1.1.0
+    "@metamask/approval-controller": "workspace:^"
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:^"
     "@metamask/contract-metadata": ^2.3.1
@@ -1482,6 +1483,7 @@ __metadata:
     typescript: ~4.6.3
     uuid: ^8.3.2
   peerDependencies:
+    "@metamask/approval-controller": "workspace:^"
     "@metamask/network-controller": "workspace:^"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
**BREAKING Adds messenger to token controller**

**Description**

Adds a messenger to `TokensController` so that the confirmation can be triggered by sending a message to `ApprovalController`.

- BREAKING:

  - The new messenger field in the constructor introduces a breaking change.

- CHANGED:

  - It uses `ApprovalController` messages to initiate and complete the request instead of an event.

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Resolves https://github.com/MetaMask/MetaMask-planning/issues/409
