### PR TITLE
Eliminate console error when running test

### DIFF
--- a/packages/network-controller/tests/provider-api-tests/block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-param.ts
@@ -250,6 +250,8 @@ export const testsForRpcMethodSupportingBlockParam = (
         // block-cache middleware will request the latest block number
         // through the block tracker to determine the cache key.
         comms.mockNextBlockTrackerRequest();
+        // A second block tracker request is made for some reason
+        comms.mockNextBlockTrackerRequest();
         comms.mockRpcCall({
           delay: 100,
           request: buildRequestWithReplacedBlockParam(

--- a/packages/network-controller/tests/provider-api-tests/no-block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/no-block-param.ts
@@ -77,7 +77,7 @@ export const testsForRpcMethodAssumingNoBlockParam = (
   });
 
   for (const paramIndex of [...Array(numberOfParameters).keys()]) {
-    it(`does not reuse the result of a previous request if parameter at index "${paramIndex}" differs`, async () => {// eslint-disable-line
+    it(`does not reuse the result of a previous request if parameter at index "${paramIndex}" differs`, async () => {
       const firstMockParams = [
         ...new Array(numberOfParameters).fill('some value'),
       ];
@@ -214,6 +214,8 @@ export const testsForRpcMethodAssumingNoBlockParam = (
       // The first time a block-cacheable request is made, the latest block
       // number is retrieved through the block tracker first. It doesn't
       // matter what this is — it's just used as a cache key.
+      comms.mockNextBlockTrackerRequest();
+      // A second block tracker request is made for some reason
       comms.mockNextBlockTrackerRequest();
       comms.mockRpcCall({
         request: requests[0],


### PR DESCRIPTION
## Description

The network client test "queues requests while a previous identical call is still pending..." was emitting a console error due to an unmocked block tracker network call.

That call is now mocked, eliminating the error.

I am unsure why the second call is made during this test, but we suspect that it's because the first block tracker call isn't being cached until after the RPC call that triggered it has been resolved.

To reproduce, use `.only` on that test and run this command:

`yarn workspace @metamask/network-controller jest --coverage=false --verbose=false`

Before this change, that command should produce console errors. After this change, there will be none (though there are still lots of warnings).

## Changes

N/A

## References

This relates to #1178

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
