### PR TITLE
Make `verifyNetwork` async

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -363,8 +363,10 @@ export class NetworkController extends BaseControllerV2<
     }, 500);
   }
 
-  private verifyNetwork() {
-    this.state.network === 'loading' && this.lookupNetwork();
+  private async verifyNetwork() {
+    if (this.state.network === 'loading') {
+      await this.lookupNetwork();
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

The internal method `verifyNetwork` is now async. It performed an async call but didn't `await` it.

This method is only invoked as an internal event handler, so this didn't require any changes outside of that function (not even to tests). Effectively this is not a functional change in any way.

## Changes

N/A

## References

This relates to https://github.com/MetaMask/core/issues/1176

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
