### PR TITLE
Make `refreshNetwork` async

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -288,14 +288,14 @@ export class NetworkController extends BaseControllerV2<
     };
   }
 
-  private refreshNetwork() {
+  private async refreshNetwork() {
     this.update((state) => {
       state.network = 'loading';
       state.networkDetails = {};
     });
     const { rpcTarget, type, chainId, ticker } = this.state.providerConfig;
     this.configureProvider(type, rpcTarget, chainId, ticker);
-    this.lookupNetwork();
+    await this.lookupNetwork();
   }
 
   private registerProvider() {


### PR DESCRIPTION
## Description

The internal method `refreshNetwork` has been made async. The method already called an asynchronous method internally, but it was not `await`-ed. Now it is.

This method is only being called from within synchronous functions. They will be made async in later PRs.

Because the async call was the last operation, this change effectively has no functional impact.

## Changes

N/A

## References

This relates to https://github.com/MetaMask/core/issues/1176

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
