### PR TITLE
Exclude types from rate limiting in approval controller

### DIFF
--- a/packages/approval-controller/src/ApprovalController.test.ts
+++ b/packages/approval-controller/src/ApprovalController.test.ts
@@ -224,6 +224,30 @@ describe('approval controller', () => {
         }),
       ).toThrow(getOriginTypeCollisionError('bar.baz', 'myType'));
     });
+
+    it('does not throw on origin and type collision if type excluded', () => {
+      approvalController = new ApprovalController({
+        messenger: getRestrictedMessenger(),
+        showApprovalRequest,
+        typesExcludedFromRateLimiting: ['myType'],
+      });
+
+      expect(() =>
+        approvalController.add({
+          id: 'foo',
+          origin: 'bar.baz',
+          type: 'myType',
+        }),
+      ).not.toThrow();
+
+      expect(() =>
+        approvalController.add({
+          id: 'foo1',
+          origin: 'bar.baz',
+          type: 'myType',
+        }),
+      ).not.toThrow();
+    });
   });
 
   // otherwise tested by 'add' above

--- a/packages/approval-controller/src/ApprovalController.ts
+++ b/packages/approval-controller/src/ApprovalController.ts
@@ -562,14 +562,15 @@ export class ApprovalController extends BaseControllerV2<
    * @param type - The type associated with the approval request.
    */
   private _addPendingApprovalOrigin(origin: string, type: string): void {
-    const originMap = this._origins.get(origin) || new Map();
-    const currentValue = originMap.get(type) || 0;
+    let originMap = this._origins.get(origin);
 
-    originMap.set(type, currentValue + 1);
-
-    if (!this._origins.has(origin)) {
+    if (!originMap) {
+      originMap = new Map();
       this._origins.set(origin, originMap);
     }
+
+    const currentValue = originMap.get(type) || 0;
+    originMap.set(type, currentValue + 1);
   }
 
   /**


### PR DESCRIPTION
## Description

Currently all approval requests created by the `ApprovalController` are rate limited to a single pending approval request for each approval type and origin combination.

This is not yet required for some existing approval flows being migrated to use the `ApprovalController` hence the need for a way to exclude specific approval types from rate limiting to avoid any regressions in functionality and user expectation.

## Changes

- **ADDED**: Optional `typesExcludedFromRateLimiting` parameter to the `ApprovalController` constructor to disable rate limiting for specific approval types.
- **CHANGED**: Data structure of `_origins` property to support multiple requests with same origin and type.

## References

[[Bug]: Approval request with id not found.](https://github.com/MetaMask/metamask-extension/issues/18553)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
