### PR TITLE
Release 46.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "45.0.0",
+  "version": "46.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.1.0]
-### Uncategorized
-- Exclude types from rate limiting in approval controller ([#1185](https://github.com/MetaMask/core/pull/1185))
+### Added
+- Option to exclude types from rate limiting ([#1185](https://github.com/MetaMask/core/pull/1185))
 
 ## [2.0.0]
 ### Removed

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0]
+### Uncategorized
+- Exclude types from rate limiting in approval controller ([#1185](https://github.com/MetaMask/core/pull/1185))
+
 ## [2.0.0]
 ### Removed
 - **BREAKING:** Remove `isomorphic-fetch` ([#1106](https://github.com/MetaMask/controllers/pull/1106))
@@ -31,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@2.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@2.1.0...HEAD
+[2.1.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@2.0.0...@metamask/approval-controller@2.1.0
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@1.1.0...@metamask/approval-controller@2.0.0
 [1.1.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@1.0.1...@metamask/approval-controller@1.1.0
 [1.0.1]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@1.0.0...@metamask/approval-controller@1.0.1

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/approval-controller",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Manages requests that require user approval",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
Non-breaking changes to the `ApprovalController` needed for an extension bug.

Adds an option to exclude types from rate limiting.
