### PR TITLE
Make `setActiveNetwork` async

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -474,7 +474,7 @@ export class NetworkController extends BaseControllerV2<
    *
    * @param networkConfigurationId - The unique id for the network configuration to set as the active provider.
    */
-  setActiveNetwork(networkConfigurationId: string) {
+  async setActiveNetwork(networkConfigurationId: string) {
     this.#setCurrentAsPreviousProvider();
 
     const targetNetwork =
@@ -496,7 +496,7 @@ export class NetworkController extends BaseControllerV2<
       state.providerConfig.id = targetNetwork.id;
     });
 
-    this.refreshNetwork();
+    await this.refreshNetwork();
   }
 
   #getLatestBlock(): Promise<Block> {

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -2345,12 +2345,7 @@ describe('NetworkController', () => {
           const fakeMetamaskProvider = buildFakeMetamaskProvider();
           createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
 
-          await waitForStateChanges(messenger, {
-            propertyPath: ['network'],
-            produceStateChanges: () => {
-              controller.setActiveNetwork('testNetworkConfigurationId');
-            },
-          });
+          await controller.setActiveNetwork('testNetworkConfigurationId');
 
           expect(controller.state.providerConfig).toStrictEqual({
             type: 'rpc',
@@ -2388,12 +2383,7 @@ describe('NetworkController', () => {
           const fakeMetamaskProvider = buildFakeMetamaskProvider();
           createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
 
-          await waitForStateChanges(messenger, {
-            propertyPath: ['isCustomNetwork'],
-            produceStateChanges: () => {
-              controller.setActiveNetwork('testNetworkConfigurationId');
-            },
-          });
+          await controller.setActiveNetwork('testNetworkConfigurationId');
 
           expect(controller.state.isCustomNetwork).toBe(true);
         },
@@ -2431,7 +2421,7 @@ describe('NetworkController', () => {
           ]);
           createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
 
-          controller.setActiveNetwork('testNetworkConfigurationId');
+          await controller.setActiveNetwork('testNetworkConfigurationId');
 
           expect(createMetamaskProviderMock).toHaveBeenCalledWith({
             rpcUrl: 'https://mock-rpc-url',
@@ -2487,12 +2477,7 @@ describe('NetworkController', () => {
           ]);
           createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
 
-          await waitForStateChanges(messenger, {
-            propertyPath: ['networkDetails', 'isEIP1559Compatible'],
-            produceStateChanges: () => {
-              controller.setActiveNetwork('testNetworkConfigurationId');
-            },
-          });
+          await controller.setActiveNetwork('testNetworkConfigurationId');
 
           expect(controller.state.networkDetails.isEIP1559Compatible).toBe(
             true,
@@ -2519,7 +2504,7 @@ describe('NetworkController', () => {
             },
           },
         },
-        ({ controller }) => {
+        async ({ controller }) => {
           const fakeMetamaskProviders = [
             buildFakeMetamaskProvider(),
             buildFakeMetamaskProvider(),
@@ -2529,8 +2514,8 @@ describe('NetworkController', () => {
             .mockImplementationOnce(() => fakeMetamaskProviders[0])
             .mockImplementationOnce(() => fakeMetamaskProviders[1]);
 
-          controller.setActiveNetwork('testNetworkConfigurationId');
-          controller.setActiveNetwork('testNetworkConfigurationId');
+          await controller.setActiveNetwork('testNetworkConfigurationId');
+          await controller.setActiveNetwork('testNetworkConfigurationId');
           assert(controller.getProviderAndBlockTracker().provider);
           jest.runAllTimers();
 
@@ -2571,12 +2556,7 @@ describe('NetworkController', () => {
           ]);
           createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
 
-          await waitForStateChanges(messenger, {
-            propertyPath: ['network'],
-            produceStateChanges: () => {
-              controller.setActiveNetwork('testNetworkConfigurationId');
-            },
-          });
+          await controller.setActiveNetwork('testNetworkConfigurationId');
 
           expect(controller.state.network).toBe('42');
         },
@@ -2624,16 +2604,7 @@ describe('NetworkController', () => {
               ]);
               createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
 
-              await waitForPublishedEvents(
-                messenger,
-                'NetworkController:providerConfigChange',
-                {
-                  produceEvents: () => {
-                    controller.setActiveNetwork('testNetworkConfigurationId');
-                    assert(controller.getProviderAndBlockTracker().provider);
-                  },
-                },
-              );
+              await controller.setActiveNetwork('testNetworkConfigurationId');
 
               await waitForStateChanges(messenger, {
                 propertyPath: ['network'],
@@ -2689,16 +2660,7 @@ describe('NetworkController', () => {
               ]);
               createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
 
-              await waitForPublishedEvents(
-                messenger,
-                'NetworkController:providerConfigChange',
-                {
-                  produceEvents: () => {
-                    controller.setActiveNetwork('testNetworkConfigurationId');
-                    assert(controller.getProviderAndBlockTracker().provider);
-                  },
-                },
-              );
+              await controller.setActiveNetwork('testNetworkConfigurationId');
 
               await waitForStateChanges(messenger, {
                 propertyPath: ['network'],
@@ -4834,7 +4796,7 @@ describe('NetworkController', () => {
             async ({ controller }) => {
               const fakeMetamaskProvider = buildFakeMetamaskProvider();
               createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-              controller.setActiveNetwork('testNetworkConfigurationId');
+              await controller.setActiveNetwork('testNetworkConfigurationId');
               expect(controller.state.providerConfig).toStrictEqual({
                 ...customNetworkConfiguration,
                 rpcTarget: rpcUrlOrTarget,
@@ -4878,7 +4840,7 @@ describe('NetworkController', () => {
             async ({ controller }) => {
               const fakeMetamaskProvider = buildFakeMetamaskProvider();
               createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-              controller.setActiveNetwork('testNetworkConfigurationId');
+              await controller.setActiveNetwork('testNetworkConfigurationId');
               const promiseForProviderConfigChange =
                 await waitForPublishedEvents(
                   messenger,
@@ -4963,13 +4925,7 @@ describe('NetworkController', () => {
               ]);
 
               createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-              await waitForStateChanges(messenger, {
-                propertyPath: ['network'],
-                count: 1,
-                produceStateChanges: () => {
-                  controller.setActiveNetwork('testNetworkConfigurationId');
-                },
-              });
+              await controller.setActiveNetwork('testNetworkConfigurationId');
               expect(controller.state.networkDetails).toStrictEqual({
                 isEIP1559Compatible: true,
               });
@@ -5030,13 +4986,7 @@ describe('NetworkController', () => {
               ]);
 
               createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-              await waitForStateChanges(messenger, {
-                propertyPath: ['network'],
-                count: 1,
-                produceStateChanges: () => {
-                  controller.setActiveNetwork('testNetworkConfigurationId');
-                },
-              });
+              await controller.setActiveNetwork('testNetworkConfigurationId');
               await waitForStateChanges(messenger, {
                 propertyPath: ['network'],
                 count: 1,
@@ -5088,13 +5038,7 @@ describe('NetworkController', () => {
               const fakeMetamaskProvider = buildFakeMetamaskProvider();
 
               createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-              await waitForStateChanges(messenger, {
-                propertyPath: ['network'],
-                count: 1,
-                produceStateChanges: () => {
-                  controller.setActiveNetwork('testNetworkConfigurationId');
-                },
-              });
+              await controller.setActiveNetwork('testNetworkConfigurationId');
               const { provider: providerBefore } =
                 controller.getProviderAndBlockTracker();
 
@@ -5162,13 +5106,7 @@ describe('NetworkController', () => {
               ]);
 
               createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-              await waitForStateChanges(messenger, {
-                propertyPath: ['network'],
-                count: 1,
-                produceStateChanges: () => {
-                  controller.setActiveNetwork('testNetworkConfigurationId');
-                },
-              });
+              await controller.setActiveNetwork('testNetworkConfigurationId');
               expect(controller.state.network).toStrictEqual('999');
 
               await waitForStateChanges(messenger, {
@@ -5283,7 +5221,7 @@ describe('NetworkController', () => {
           async ({ controller }) => {
             const fakeMetamaskProvider = buildFakeMetamaskProvider();
             createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-            controller.setActiveNetwork('testNetworkConfigurationId2');
+            await controller.setActiveNetwork('testNetworkConfigurationId2');
             expect(controller.state.providerConfig).toStrictEqual({
               ...networkConfiguration2,
               rpcTarget: rpcUrlOrTarget2,
@@ -5336,7 +5274,7 @@ describe('NetworkController', () => {
           async ({ controller }) => {
             const fakeMetamaskProvider = buildFakeMetamaskProvider();
             createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-            controller.setActiveNetwork('testNetworkConfigurationId1');
+            await controller.setActiveNetwork('testNetworkConfigurationId1');
             const promiseForProviderConfigChange = await waitForPublishedEvents(
               messenger,
               'NetworkController:providerConfigChange',
@@ -5414,13 +5352,7 @@ describe('NetworkController', () => {
               },
             ]);
             createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-            await waitForStateChanges(messenger, {
-              propertyPath: ['network'],
-              count: 1,
-              produceStateChanges: () => {
-                controller.setActiveNetwork('testNetworkConfigurationId1');
-              },
-            });
+            await controller.setActiveNetwork('testNetworkConfigurationId1');
             expect(controller.state.networkDetails).toStrictEqual({
               isEIP1559Compatible: true,
             });
@@ -5489,13 +5421,7 @@ describe('NetworkController', () => {
             ]);
 
             createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-            await waitForStateChanges(messenger, {
-              propertyPath: ['network'],
-              count: 1,
-              produceStateChanges: () => {
-                controller.setActiveNetwork('testNetworkConfigurationId1');
-              },
-            });
+            await controller.setActiveNetwork('testNetworkConfigurationId1');
             await waitForStateChanges(messenger, {
               propertyPath: ['network'],
               count: 1,
@@ -5558,13 +5484,7 @@ describe('NetworkController', () => {
             const fakeMetamaskProvider = buildFakeMetamaskProvider();
 
             createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-            await waitForStateChanges(messenger, {
-              propertyPath: ['network'],
-              count: 1,
-              produceStateChanges: () => {
-                controller.setActiveNetwork('testNetworkConfigurationId1');
-              },
-            });
+            await controller.setActiveNetwork('testNetworkConfigurationId1');
             const { provider: providerBefore } =
               controller.getProviderAndBlockTracker();
 
@@ -5641,13 +5561,7 @@ describe('NetworkController', () => {
             ]);
 
             createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-            await waitForStateChanges(messenger, {
-              propertyPath: ['network'],
-              count: 1,
-              produceStateChanges: () => {
-                controller.setActiveNetwork('testNetworkConfigurationId1');
-              },
-            });
+            await controller.setActiveNetwork('testNetworkConfigurationId1');
             expect(controller.state.network).toStrictEqual('999');
 
             await waitForStateChanges(messenger, {
@@ -5696,7 +5610,7 @@ describe('NetworkController', () => {
         async ({ controller }) => {
           const fakeMetamaskProvider = buildFakeMetamaskProvider();
           createMetamaskProviderMock.mockReturnValue(fakeMetamaskProvider);
-          controller.setActiveNetwork('testNetworkConfigurationId');
+          await controller.setActiveNetwork('testNetworkConfigurationId');
           expect(controller.state.providerConfig).toStrictEqual({
             ...networkConfiguration,
             rpcTarget: rpcUrlOrTarget,


### PR DESCRIPTION
## Description

The network controller method `setActiveNetwork` is now async. It will not resolve until the network switch has completed.

## Changes

- **BREAKING**: `setActiveNetwork` is now async

## References

This relates to https://github.com/MetaMask/core/issues/1176

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
