### PR TITLE
Make `upsertNetworkConfiguration` async

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -577,14 +577,14 @@ export class NetworkController extends BaseControllerV2<
    * @param options.source - Where the upsertNetwork event originated (i.e. from a dapp or from the network form) - used for event metrics.
    * @returns id for the added or updated network configuration
    */
-  upsertNetworkConfiguration(
+  async upsertNetworkConfiguration(
     { rpcUrl, chainId, ticker, nickname, rpcPrefs }: NetworkConfiguration,
     {
       setActive = false,
       referrer,
       source,
     }: { setActive?: boolean; referrer: string; source: string },
-  ): string {
+  ): Promise<string> {
     assertIsStrictHexString(chainId);
 
     if (!isSafeChainId(parseInt(chainId, 16))) {
@@ -664,7 +664,7 @@ export class NetworkController extends BaseControllerV2<
     }
 
     if (setActive) {
-      this.setActiveNetwork(newNetworkConfigurationId);
+      await this.setActiveNetwork(newNetworkConfigurationId);
     }
 
     return newNetworkConfigurationId;

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -3907,7 +3907,7 @@ describe('NetworkController', () => {
 
         expect(controller.state.networkConfigurations).toStrictEqual({});
 
-        controller.upsertNetworkConfiguration(rpcUrlNetwork, {
+        await controller.upsertNetworkConfiguration(rpcUrlNetwork, {
           referrer: 'https://test-dapp.com',
           source: 'dapp',
         });
@@ -3944,7 +3944,7 @@ describe('NetworkController', () => {
           },
         },
         async ({ controller }) => {
-          controller.upsertNetworkConfiguration(
+          await controller.upsertNetworkConfiguration(
             {
               rpcUrl: 'https://rpc-url.com',
               ticker: 'new_rpc_ticker',
@@ -3975,7 +3975,7 @@ describe('NetworkController', () => {
     it('throws if the given chain ID is not a 0x-prefixed hex number', async () => {
       const invalidChainId = '1';
       await withController(async ({ controller }) => {
-        expect(() =>
+        await expect(async () =>
           controller.upsertNetworkConfiguration(
             {
               chainId: invalidChainId,
@@ -3989,7 +3989,7 @@ describe('NetworkController', () => {
               source: 'dapp',
             },
           ),
-        ).toThrow(
+        ).rejects.toThrow(
           new Error('Value must be a hexadecimal string, starting with "0x".'),
         );
       });
@@ -3997,7 +3997,7 @@ describe('NetworkController', () => {
 
     it('throws if the given chain ID is greater than the maximum allowed ID', async () => {
       await withController(async ({ controller }) => {
-        expect(() =>
+        await expect(async () =>
           controller.upsertNetworkConfiguration(
             {
               chainId: '0xFFFFFFFFFFFFFFFF',
@@ -4011,7 +4011,7 @@ describe('NetworkController', () => {
               source: 'dapp',
             },
           ),
-        ).toThrow(
+        ).rejects.toThrow(
           new Error(
             'Invalid chain ID "0xFFFFFFFFFFFFFFFF": numerical value greater than max safe value.',
           ),
@@ -4021,7 +4021,7 @@ describe('NetworkController', () => {
 
     it('throws if rpcUrl passed is not a valid Url', async () => {
       await withController(async ({ controller }) => {
-        expect(() =>
+        await expect(async () =>
           controller.upsertNetworkConfiguration(
             {
               chainId: '0x9999',
@@ -4035,13 +4035,13 @@ describe('NetworkController', () => {
               source: 'dapp',
             },
           ),
-        ).toThrow(new Error('rpcUrl must be a valid URL'));
+        ).rejects.toThrow(new Error('rpcUrl must be a valid URL'));
       });
     });
 
     it('throws if the no (or a falsy) ticker is passed', async () => {
       await withController(async ({ controller }) => {
-        expect(() =>
+        await expect(async () =>
           controller.upsertNetworkConfiguration(
             // @ts-expect-error - we want to test the case where no ticker is present.
             {
@@ -4055,7 +4055,7 @@ describe('NetworkController', () => {
               source: 'dapp',
             },
           ),
-        ).toThrow(
+        ).rejects.toThrow(
           new Error(
             'A ticker is required to add or update networkConfiguration',
           ),
@@ -4065,8 +4065,8 @@ describe('NetworkController', () => {
 
     it('throws if an options object is not passed as a second argument', async () => {
       await withController(async ({ controller }) => {
-        expect(
-          () =>
+        await expect(
+          async () =>
             // @ts-expect-error - we want to test the case where no second arg is passed.
             controller.upsertNetworkConfiguration({
               chainId: '0x5',
@@ -4075,7 +4075,7 @@ describe('NetworkController', () => {
               rpcUrl: 'https://mock-rpc-url',
             }),
           // eslint-disable-next-line
-        ).toThrow();
+        ).rejects.toThrow();
       });
     });
 
@@ -4114,10 +4114,10 @@ describe('NetworkController', () => {
             rpcPrefs: { blockExplorerUrl: 'https://block-explorer' },
           };
 
-          expect(() =>
+          await expect(async () =>
             // @ts-expect-error - we want to test the case where the options object is empty.
             controller.upsertNetworkConfiguration(newNetworkConfiguration, {}),
-          ).toThrow(
+          ).rejects.toThrow(
             'referrer and source are required arguments for adding or updating a network configuration',
           );
         },
@@ -4139,7 +4139,7 @@ describe('NetworkController', () => {
             ticker: 'test_ticker',
           };
 
-          controller.upsertNetworkConfiguration(rpcUrlNetwork, {
+          await controller.upsertNetworkConfiguration(rpcUrlNetwork, {
             referrer: 'https://test-dapp.com',
             source: 'dapp',
           });
@@ -4177,7 +4177,7 @@ describe('NetworkController', () => {
             invalidKey2: {},
           };
 
-          controller.upsertNetworkConfiguration(rpcUrlNetwork, {
+          await controller.upsertNetworkConfiguration(rpcUrlNetwork, {
             referrer: 'https://test-dapp.com',
             source: 'dapp',
           });
@@ -4226,7 +4226,7 @@ describe('NetworkController', () => {
             ticker: 'RPC',
           };
 
-          controller.upsertNetworkConfiguration(rpcUrlNetwork, {
+          await controller.upsertNetworkConfiguration(rpcUrlNetwork, {
             referrer: 'https://test-dapp.com',
             source: 'dapp',
           });
@@ -4275,7 +4275,7 @@ describe('NetworkController', () => {
             rpcPrefs: { blockExplorerUrl: 'alternativetestchainscan.io' },
             chainId: '0x1',
           };
-          controller.upsertNetworkConfiguration(updatedConfiguration, {
+          await controller.upsertNetworkConfiguration(updatedConfiguration, {
             referrer: 'https://test-dapp.com',
             source: 'dapp',
           });
@@ -4320,7 +4320,7 @@ describe('NetworkController', () => {
           },
         },
         async ({ controller }) => {
-          controller.upsertNetworkConfiguration(
+          await controller.upsertNetworkConfiguration(
             {
               rpcUrl: 'https://test-rpc-url',
               ticker: 'new-ticker',
@@ -4390,7 +4390,7 @@ describe('NetworkController', () => {
             ticker: 'test_ticker',
           };
 
-          controller.upsertNetworkConfiguration(rpcUrlNetwork, {
+          await controller.upsertNetworkConfiguration(rpcUrlNetwork, {
             referrer: 'https://test-dapp.com',
             source: 'dapp',
           });
@@ -4437,7 +4437,7 @@ describe('NetworkController', () => {
             ticker: 'test_ticker',
           };
 
-          controller.upsertNetworkConfiguration(rpcUrlNetwork, {
+          await controller.upsertNetworkConfiguration(rpcUrlNetwork, {
             setActive: true,
             referrer: 'https://test-dapp.com',
             source: 'dapp',
@@ -4493,7 +4493,7 @@ describe('NetworkController', () => {
             rpcPrefs: { blockExplorerUrl: 'https://block-explorer' },
           };
 
-          controller.upsertNetworkConfiguration(newNetworkConfiguration, {
+          await controller.upsertNetworkConfiguration(newNetworkConfiguration, {
             referrer: 'https://test-dapp.com',
             source: 'dapp',
           });

--- a/packages/network-controller/tests/provider-api-tests/helpers.ts
+++ b/packages/network-controller/tests/provider-api-tests/helpers.ts
@@ -402,7 +402,7 @@ export const withNetworkClient = async (
   if (providerType === 'infura') {
     await controller.setProviderType(infuraNetwork);
   } else {
-    controller.upsertNetworkConfiguration(
+    await controller.upsertNetworkConfiguration(
       {
         rpcUrl: customRpcUrl,
         chainId: '0x9999',


### PR DESCRIPTION
## Description

The network controller method `upsertNetworkConfiguration` is now async. If the option `setActive` is false, the flow of execution should be the same as before (apart from the change in return type). But if `setActive` is `true`, the method will not resolve until the network switch has completed (previously it would initiate the switch without waiting for it to complete).

## Changes

- **BREAKING**: `upsertNetworkConfiguration` is now async

## References

This relates to #1176

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
