### PR TITLE
Improve return type of `toHex`

### DIFF
--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -9,6 +9,8 @@ import {
 import { fromWei, toWei } from 'ethjs-unit';
 import ensNamehash from 'eth-ens-namehash';
 import deepEqual from 'fast-deep-equal';
+import type { Hex } from '@metamask/utils';
+import { isStrictHexString } from '@metamask/utils';
 import type { Json } from './types';
 import { MAX_SAFE_CHAIN_ID } from './constants';
 
@@ -174,8 +176,8 @@ export function fromHex(value: string | BN): BN {
  * @param value - An integer, an integer encoded as a base-10 string, or a BN.
  * @returns The integer encoded as a hex string.
  */
-export function toHex(value: number | string | BN): string {
-  if (typeof value === 'string' && isHexString(value)) {
+export function toHex(value: number | string | BN): Hex {
+  if (typeof value === 'string' && isStrictHexString(value)) {
     return value;
   }
   const hexString = BN.isBN(value)


### PR DESCRIPTION
## Description

The `toHex` utility function now returns the `Hex` type rather than a `string`. The `Hex` type is a string that is guaranteed to start with `0x`.

This is a type-only change, there no no functional changes.

## Changes

- CHANGED: The `toHex` function now returns the type `Hex`, which guarantees that the returned string starts with `0x`.

## References

This was extracted from #1116, which addresses #970

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
