### PR TITLE
Replace `network` state with `networkId` and `networkStatus`

### DIFF
--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -37,6 +37,7 @@
     "babel-runtime": "^6.26.0",
     "eth-json-rpc-infura": "^5.1.0",
     "eth-query": "^2.1.2",
+    "eth-rpc-errors": "^4.0.0",
     "immer": "^9.0.6",
     "uuid": "^8.3.2",
     "web3-provider-engine": "^16.0.3"

--- a/packages/network-controller/src/constants.ts
+++ b/packages/network-controller/src/constants.ts
@@ -13,7 +13,7 @@ export enum NetworkStatus {
    */
   Available = 'available',
   /**
-   * The network is unable to receive and respond to requests for unknown
+   * The network was unable to receive and respond to requests for unknown
    * reasons.
    */
   Unavailable = 'unavailable',

--- a/packages/network-controller/src/constants.ts
+++ b/packages/network-controller/src/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Represents the availability state of the currently selected network.
+ */
+export enum NetworkStatus {
+  /**
+   * The network may or may not be able to receive requests, but either no
+   * attempt has been made to determine this, or an attempt was made but was
+   * unsuccessful.
+   */
+  Unknown = 'unknown',
+  /**
+   * The network is able to receive and respond to requests.
+   */
+  Available = 'available',
+  /**
+   * The network is unable to receive and respond to requests for unknown
+   * reasons.
+   */
+  Unavailable = 'unavailable',
+}

--- a/packages/network-controller/src/index.ts
+++ b/packages/network-controller/src/index.ts
@@ -1,1 +1,2 @@
 export * from './NetworkController';
+export * from './constants';

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2,7 +2,7 @@ import * as sinon from 'sinon';
 import HttpProvider from 'ethjs-provider-http';
 import NonceTracker from 'nonce-tracker';
 import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
-import type { NetworkState, NetworkId } from '@metamask/network-controller';
+import type { NetworkState } from '@metamask/network-controller';
 import { NetworkStatus } from '@metamask/network-controller';
 import { ESTIMATE_GAS_ERROR } from './utils';
 import {
@@ -138,11 +138,18 @@ const PALM_PROVIDER = new HttpProvider(
   'https://palm-mainnet.infura.io/v3/3a961d6501e54add9a41aa53f15de99b',
 );
 
-const MOCK_NETWORK = {
+type MockNetwork = {
+  provider: typeof HttpProvider;
+  blockTracker: { getLatestBlock: () => string };
+  state: NetworkState;
+  subscribe: (listener: (state: NetworkState) => void) => void;
+};
+
+const MOCK_NETWORK: MockNetwork = {
   provider: MAINNET_PROVIDER,
   blockTracker: { getLatestBlock: () => '0x102833C' },
   state: {
-    networkId: '5' as NetworkId,
+    networkId: '5',
     networkStatus: NetworkStatus.Available,
     isCustomNetwork: false,
     networkDetails: { isEIP1559Compatible: false },
@@ -154,23 +161,26 @@ const MOCK_NETWORK = {
   },
   subscribe: () => undefined,
 };
-const MOCK_NETWORK_WITHOUT_CHAIN_ID = {
+const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
   provider: GOERLI_PROVIDER,
   blockTracker: { getLatestBlock: () => '0x102833C' },
-  isCustomNetwork: false,
   state: {
-    networkId: '5' as NetworkId,
+    networkId: '5',
     networkStatus: NetworkStatus.Available,
-    providerConfig: { type: NetworkType.goerli },
+    isCustomNetwork: false,
+    networkDetails: { isEIP1559Compatible: false },
+    providerConfig: {
+      type: NetworkType.goerli,
+    } as NetworkState['providerConfig'],
     networkConfigurations: {},
   },
   subscribe: () => undefined,
 };
-const MOCK_MAINNET_NETWORK = {
+const MOCK_MAINNET_NETWORK: MockNetwork = {
   provider: MAINNET_PROVIDER,
   blockTracker: { getLatestBlock: () => '0x102833C' },
   state: {
-    networkId: '1' as NetworkId,
+    networkId: '1',
     networkStatus: NetworkStatus.Available,
     isCustomNetwork: false,
     networkDetails: { isEIP1559Compatible: false },
@@ -182,11 +192,11 @@ const MOCK_MAINNET_NETWORK = {
   },
   subscribe: () => undefined,
 };
-const MOCK_CUSTOM_NETWORK = {
+const MOCK_CUSTOM_NETWORK: MockNetwork = {
   provider: PALM_PROVIDER,
   blockTracker: { getLatestBlock: () => '0xA6EDFC' },
   state: {
-    networkId: '11297108109' as NetworkId,
+    networkId: '11297108109',
     networkStatus: NetworkStatus.Available,
     isCustomNetwork: true,
     networkDetails: { isEIP1559Compatible: false },

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2,7 +2,8 @@ import * as sinon from 'sinon';
 import HttpProvider from 'ethjs-provider-http';
 import NonceTracker from 'nonce-tracker';
 import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
-import type { NetworkState } from '@metamask/network-controller';
+import type { NetworkState, NetworkId } from '@metamask/network-controller';
+import { NetworkStatus } from '@metamask/network-controller';
 import { ESTIMATE_GAS_ERROR } from './utils';
 import {
   TransactionController,
@@ -141,7 +142,8 @@ const MOCK_NETWORK = {
   provider: MAINNET_PROVIDER,
   blockTracker: { getLatestBlock: () => '0x102833C' },
   state: {
-    network: '5',
+    networkId: '5' as NetworkId,
+    networkStatus: NetworkStatus.Available,
     isCustomNetwork: false,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
@@ -157,7 +159,8 @@ const MOCK_NETWORK_WITHOUT_CHAIN_ID = {
   blockTracker: { getLatestBlock: () => '0x102833C' },
   isCustomNetwork: false,
   state: {
-    network: '5',
+    networkId: '5' as NetworkId,
+    networkStatus: NetworkStatus.Available,
     providerConfig: { type: NetworkType.goerli },
     networkConfigurations: {},
   },
@@ -167,7 +170,8 @@ const MOCK_MAINNET_NETWORK = {
   provider: MAINNET_PROVIDER,
   blockTracker: { getLatestBlock: () => '0x102833C' },
   state: {
-    network: '1',
+    networkId: '1' as NetworkId,
+    networkStatus: NetworkStatus.Available,
     isCustomNetwork: false,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
@@ -182,7 +186,8 @@ const MOCK_CUSTOM_NETWORK = {
   provider: PALM_PROVIDER,
   blockTracker: { getLatestBlock: () => '0xA6EDFC' },
   state: {
-    network: '11297108109',
+    networkId: '11297108109' as NetworkId,
+    networkStatus: NetworkStatus.Available,
     isCustomNetwork: true,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
@@ -527,7 +532,7 @@ describe('TransactionController', () => {
     });
     expect(controller.state.transactions[0].transaction.from).toBe(from);
     expect(controller.state.transactions[0].networkID).toBe(
-      MOCK_NETWORK.state.network,
+      MOCK_NETWORK.state.networkId,
     );
 
     expect(controller.state.transactions[0].chainId).toBe(
@@ -567,7 +572,7 @@ describe('TransactionController', () => {
     });
     expect(controller.state.transactions[0].transaction.from).toBe(from);
     expect(controller.state.transactions[0].networkID).toBe(
-      MOCK_MAINNET_NETWORK.state.network,
+      MOCK_MAINNET_NETWORK.state.networkId,
     );
 
     expect(controller.state.transactions[0].chainId).toBe(
@@ -607,7 +612,7 @@ describe('TransactionController', () => {
     });
     expect(controller.state.transactions[0].transaction.from).toBe(from);
     expect(controller.state.transactions[0].networkID).toBe(
-      MOCK_CUSTOM_NETWORK.state.network,
+      MOCK_CUSTOM_NETWORK.state.networkId,
     );
 
     expect(controller.state.transactions[0].chainId).toBe(

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -534,14 +534,14 @@ export class TransactionController extends BaseController<
     origin?: string,
     deviceConfirmedOn?: WalletDevice,
   ): Promise<Result> {
-    const { providerConfig, network } = this.getNetworkState();
+    const { providerConfig, networkId } = this.getNetworkState();
     const { transactions } = this.state;
     transaction = normalizeTransaction(transaction);
     validateTransaction(transaction);
 
     const transactionMeta: TransactionMeta = {
       id: random(),
-      networkID: network,
+      networkID: networkId ?? undefined,
       chainId: providerConfig.chainId,
       origin,
       status: TransactionStatus.unapproved as TransactionStatus.unapproved,
@@ -618,7 +618,7 @@ export class TransactionController extends BaseController<
 
   getCommonConfiguration(): Common {
     const {
-      network: networkId,
+      networkId,
       providerConfig: { type: chain, chainId, nickname: name },
     } = this.getNetworkState();
 
@@ -629,7 +629,7 @@ export class TransactionController extends BaseController<
     const customChainParams = {
       name,
       chainId: parseInt(chainId, undefined),
-      networkId: parseInt(networkId, undefined),
+      networkId: networkId === null ? NaN : parseInt(networkId, undefined),
     };
 
     return Common.forCustomChain(
@@ -1070,7 +1070,7 @@ export class TransactionController extends BaseController<
    */
   async queryTransactionStatuses() {
     const { transactions } = this.state;
-    const { providerConfig, network: currentNetworkID } =
+    const { providerConfig, networkId: currentNetworkID } =
       this.getNetworkState();
     const { chainId: currentChainId } = providerConfig;
     let gotUpdates = false;
@@ -1131,7 +1131,7 @@ export class TransactionController extends BaseController<
       this.update({ transactions: [] });
       return;
     }
-    const { providerConfig, network: currentNetworkID } =
+    const { providerConfig, networkId: currentNetworkID } =
       this.getNetworkState();
     const { chainId: currentChainId } = providerConfig;
     const newTransactions = this.state.transactions.filter(
@@ -1162,14 +1162,17 @@ export class TransactionController extends BaseController<
     address: string,
     opt?: FetchAllOptions,
   ): Promise<string | void> {
-    const { providerConfig, network: currentNetworkID } =
+    const { providerConfig, networkId: currentNetworkID } =
       this.getNetworkState();
     const { chainId: currentChainId, type: networkType } = providerConfig;
     const { transactions } = this.state;
 
     const supportedNetworkIds = ['1', '5', '11155111'];
     /* istanbul ignore next */
-    if (supportedNetworkIds.indexOf(currentNetworkID) === -1) {
+    if (
+      currentNetworkID === null ||
+      supportedNetworkIds.indexOf(currentNetworkID) === -1
+    ) {
       return undefined;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,6 +1853,7 @@ __metadata:
     deepmerge: ^4.2.2
     eth-json-rpc-infura: ^5.1.0
     eth-query: ^2.1.2
+    eth-rpc-errors: ^4.0.0
     immer: ^9.0.6
     jest: ^26.4.2
     lodash: ^4.17.21


### PR DESCRIPTION
## Description

The network controller `network` state used to be set to `loading` if the network was loading or uninitialized, or to the network ID if the network had finished loading. Effectively it was tracking both the network ID for the current selected network, and the network status.

This state property has been split in two; now we track the network ID of the current selected network separately from the network status. The network status has been expanded to include more states as well.

## Changes

- **BREAKING**: The `network` state has been replaced by `networkId` and `networkStatus`
  - If you were using `network` to access the network ID, use `networkId` now instead. It will be set to `null` rather than `loading` if the network is not currently available.
  - If you were using `network` to see if the network was currently available, use `networkStatus` instead. It will be set to `NetworkStatus.Available` if the network is available.
  - When the network is unavailable, we now have two different states to represent that: "Unknown" and "Unavailable". Unavailable means that we know the network is not currently available, whereas unknown is used for unknown errors and for cases where we don't yet know the network status (e.g. before initialization, or while the network is loading).

## References

Relates to #1020

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate