### PR TITLE
Remove `isCustomNetwork`

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -107,7 +107,6 @@ export type NetworkId = `${number}`;
  *
  * Network controller state
  * @property network - Network ID as per net_version of the currently connected network
- * @property isCustomNetwork - Identifies if the currently connected network is a custom network
  * @property providerConfig - RPC URL and network name provider settings of the currently connected network
  * @property properties - an additional set of network properties for the currently connected network
  * @property networkConfigurations - the full list of configured networks either preloaded or added by the user.
@@ -115,7 +114,6 @@ export type NetworkId = `${number}`;
 export type NetworkState = {
   networkId: NetworkId | null;
   networkStatus: NetworkStatus;
-  isCustomNetwork: boolean;
   providerConfig: ProviderConfig;
   networkDetails: NetworkDetails;
   networkConfigurations: Record<string, NetworkConfiguration & { id: string }>;
@@ -182,7 +180,6 @@ export type NetworkControllerOptions = {
 export const defaultState: NetworkState = {
   networkId: null,
   networkStatus: NetworkStatus.Unknown,
-  isCustomNetwork: false,
   providerConfig: {
     type: NetworkType.mainnet,
     chainId: NetworksChainId.mainnet,
@@ -247,10 +244,6 @@ export class NetworkController extends BaseControllerV2<
           persist: true,
           anonymous: false,
         },
-        isCustomNetwork: {
-          persist: true,
-          anonymous: false,
-        },
         networkDetails: {
           persist: true,
           anonymous: false,
@@ -293,10 +286,6 @@ export class NetworkController extends BaseControllerV2<
     ticker?: string,
     nickname?: string,
   ) {
-    this.update((state) => {
-      state.isCustomNetwork = this.#getIsCustomNetwork(chainId);
-    });
-
     switch (type) {
       case NetworkType.mainnet:
       case NetworkType.goerli:

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -351,15 +351,6 @@ export class NetworkController extends BaseControllerV2<
     this.#updateProvider(createMetamaskProvider(config));
   }
 
-  #getIsCustomNetwork(chainId?: string) {
-    return (
-      chainId !== NetworksChainId.mainnet &&
-      chainId !== NetworksChainId.goerli &&
-      chainId !== NetworksChainId.sepolia &&
-      chainId !== NetworksChainId.localhost
-    );
-  }
-
   #setupStandardProvider(
     rpcTarget: string,
     chainId?: string,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -151,7 +151,6 @@ const MOCK_NETWORK: MockNetwork = {
   state: {
     networkId: '5',
     networkStatus: NetworkStatus.Available,
-    isCustomNetwork: false,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
       type: NetworkType.goerli,
@@ -167,7 +166,6 @@ const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
   state: {
     networkId: '5',
     networkStatus: NetworkStatus.Available,
-    isCustomNetwork: false,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
       type: NetworkType.goerli,
@@ -182,7 +180,6 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
   state: {
     networkId: '1',
     networkStatus: NetworkStatus.Available,
-    isCustomNetwork: false,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
       type: NetworkType.mainnet,
@@ -198,7 +195,6 @@ const MOCK_CUSTOM_NETWORK: MockNetwork = {
   state: {
     networkId: '11297108109',
     networkStatus: NetworkStatus.Available,
-    isCustomNetwork: true,
     networkDetails: { isEIP1559Compatible: false },
     providerConfig: {
       type: NetworkType.rpc,

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1001,7 +1001,8 @@ export class TransactionController extends BaseController<
       typeof providedGasPrice === 'undefined'
         ? await query(this.ethQuery, 'gasPrice')
         : providedGasPrice;
-    const { isCustomNetwork } = this.getNetworkState();
+    const { providerConfig } = this.getNetworkState();
+    const isCustomNetwork = providerConfig.type === NetworkType.rpc;
     // 1. If gas is already defined on the transaction, use it
     if (typeof gas !== 'undefined') {
       return { gas, gasPrice };


### PR DESCRIPTION
## Description

The network controller state `isCustomNetwork` has been removed. This state was redundant; you can determine whether the current selected network is custom or not by checking the `providerConfig` state.

The one usage of this state in other packages was the transaction controller. It has been updated to use the provider configuration state instead.

## Changes

- **BREAKING**: Remove `isCustomNetwork` state
  - To check whether the current selected network is a custom network or not, check the `providerConfig.type` property. If it's set to `NetworkType.rpc` then it's a custom network, otherwise it's a built-in network.

## References

Closes #1020

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
