### PR TITLE
Restrict certain permissions by subject type

### DIFF
--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -2,6 +2,7 @@ import { Json } from '@metamask/types';
 import { nanoid } from 'nanoid';
 import { NonEmptyArray } from '@metamask/controller-utils';
 import { ActionConstraint, EventConstraint } from '@metamask/base-controller';
+import { SubjectType } from './SubjectMetadataController';
 import { CaveatConstraint } from './Caveat';
 
 import type {
@@ -482,6 +483,11 @@ type PermissionSpecificationBase<Type extends PermissionType> = {
    * If the side-effect action fails, the permission that triggered it is revoked.
    */
   sideEffect?: PermissionSideEffect<any, any>;
+
+  /**
+   * The Permission may be available to only a subset of the subject types. If so, specify the subject types as an array.
+   */
+  subjectTypes?: SubjectType[];
 };
 
 /**

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -2,7 +2,7 @@ import { Json } from '@metamask/types';
 import { nanoid } from 'nanoid';
 import { NonEmptyArray } from '@metamask/controller-utils';
 import { ActionConstraint, EventConstraint } from '@metamask/base-controller';
-import { SubjectType } from './SubjectMetadataController';
+import type { SubjectType } from './SubjectMetadataController';
 import { CaveatConstraint } from './Caveat';
 
 import type {

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -486,6 +486,9 @@ type PermissionSpecificationBase<Type extends PermissionType> = {
 
   /**
    * The Permission may be available to only a subset of the subject types. If so, specify the subject types as an array.
+   * If a subject with a type not in this array tries to request the permission, the call will fail.
+   *
+   * Leaving this as undefined uses default behaviour where the permission is available to request for all subject types.
    */
   subjectTypes?: readonly SubjectType[];
 };

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -487,7 +487,7 @@ type PermissionSpecificationBase<Type extends PermissionType> = {
   /**
    * The Permission may be available to only a subset of the subject types. If so, specify the subject types as an array.
    */
-  subjectTypes?: SubjectType[];
+  subjectTypes?: readonly SubjectType[];
 };
 
 /**

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -8,10 +8,7 @@ import {
 } from '@metamask/approval-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
 import { Json, hasProperty, isPlainObject } from '@metamask/controller-utils';
-import {
-  GetSubjectMetadata,
-  SubjectType,
-} from './SubjectMetadataController';
+import { GetSubjectMetadata, SubjectType } from './SubjectMetadataController';
 import * as errors from './errors';
 import { EndowmentGetterParams } from './Permission';
 import {

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -11,7 +11,7 @@ import { Json, hasProperty, isPlainObject } from '@metamask/controller-utils';
 import {
   GetSubjectMetadata,
   SubjectType,
-} from '@metamask/subject-metadata-controller';
+} from './SubjectMetadataController';
 import * as errors from './errors';
 import { EndowmentGetterParams } from './Permission';
 import {

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -25,6 +25,7 @@ import {
   Json,
   NonEmptyArray,
 } from '@metamask/controller-utils';
+import { GetSubjectMetadata } from './SubjectMetadataController';
 import {
   CaveatConstraint,
   CaveatSpecificationConstraint,
@@ -333,7 +334,8 @@ type AllowedActions =
   | AddApprovalRequest
   | HasApprovalRequest
   | AcceptApprovalRequest
-  | RejectApprovalRequest;
+  | RejectApprovalRequest
+  | GetSubjectMetadata;
 
 /**
  * The messenger of the {@link PermissionController}.
@@ -851,6 +853,25 @@ export class PermissionController<
     const specification = this.getPermissionSpecification(targetKey);
     if (!hasSpecificationType(specification, permissionType)) {
       throw failureError;
+    }
+
+    if (specification.subjectTypes) {
+      if (!origin) {
+        throw failureError;
+      }
+
+      const metadata = this.messagingSystem.call(
+        'SubjectMetadataController:getSubjectMetadata',
+        origin,
+      );
+
+      if (
+        !metadata ||
+        metadata.subjectType === null ||
+        !specification.subjectTypes.includes(metadata.subjectType)
+      ) {
+        throw failureError;
+      }
     }
 
     return specification;

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -1720,7 +1720,10 @@ export class PermissionController<
   ): void {
     const { allowedCaveats, validator } = specification;
 
-    if (specification.subjectTypes && specification.subjectTypes.length > 0) {
+    if (
+      specification.subjectTypes?.length &&
+      specification.subjectTypes.length > 0
+    ) {
       const metadata = this.messagingSystem.call(
         'SubjectMetadataController:getSubjectMetadata',
         origin,

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -1686,6 +1686,7 @@ export class PermissionController<
 
   /**
    * Validates the specified permission by:
+   * - Ensuring that if `subjectTypes` is specified, the subject requesting the permission is of a type in the list.
    * - Ensuring that its `caveats` property is either `null` or a non-empty array.
    * - Ensuring that it only includes caveats allowed by its specification.
    * - Ensuring that it includes no duplicate caveats (by caveat type).


### PR DESCRIPTION
## Description

Adds a `subjectTypes` field to permission specifications, allowing certain permissions to be limited to access from certain subject types. 

If a request for permissions is made from a non-matching subject type we throw a method or endowment not found error.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **Added**: Added `subjectTypes` field to permission specifications
   - This field can be used to limit which subject types can request a given permission


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
