### PR TITLE
Refresh network when connection is reset

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -560,10 +560,11 @@ export class NetworkController extends BaseControllerV2<
     return isEIP1559Compatible;
   }
 
+  /**
+   * Re-initializes the provider and block tracker for the current network.
+   */
   resetConnection() {
-    const { type, rpcTarget, chainId, ticker, nickname } =
-      this.state.providerConfig;
-    this.#configureProvider(type, rpcTarget, chainId, ticker, nickname);
+    this.#refreshNetwork();
   }
 
   #setProviderAndBlockTracker({


### PR DESCRIPTION
## Description

The `resetConnction` method has been updated to match the extension more closely. We now refresh the network when this is called, rather than just reconstructing the provider and checking EIP1559 status.

Unit tests have been updated to align more closely with the extension as well.

## Changes

- CHANGED: Update `resetConnection` to perform network lookup (refresh network id and status) 

## References

This was done to unblock #1203, but it also relates to #1023 and #1176

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
