### PR TITLE
Release 49.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "48.0.0",
+  "version": "49.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.1]
 ### Changed
-- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
+- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
 
 ## [2.1.0]
 ### Added
@@ -39,10 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@2.1.1...HEAD
-[2.1.1]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@2.1.0...@metamask/approval-controller@2.1.1
-[2.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@2.0.0...@metamask/approval-controller@2.1.0
-[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@1.1.0...@metamask/approval-controller@2.0.0
-[1.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@1.0.1...@metamask/approval-controller@1.1.0
-[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@1.0.0...@metamask/approval-controller@1.0.1
-[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/approval-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@2.1.1...HEAD
+[2.1.1]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@2.1.0...@metamask/approval-controller@2.1.1
+[2.1.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@2.0.0...@metamask/approval-controller@2.1.0
+[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@1.1.0...@metamask/approval-controller@2.0.0
+[1.1.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@1.0.1...@metamask/approval-controller@1.1.0
+[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@1.0.0...@metamask/approval-controller@1.0.1
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/approval-controller@1.0.0

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.1.1]
-### Uncategorized
-- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+### Changed
 - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
 
 ## [2.1.0]
@@ -26,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Rename this repository to `core` ([#1031](https://github.com/MetaMask/controllers/pull/1031))
-- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041)) 
+- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 
 ## [1.0.1]
 ### Changed

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1]
+### Uncategorized
+- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
+
 ## [2.1.0]
 ### Added
 - Option to exclude types from rate limiting ([#1185](https://github.com/MetaMask/core/pull/1185))
@@ -35,9 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@2.1.0...HEAD
-[2.1.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@2.0.0...@metamask/approval-controller@2.1.0
-[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@1.1.0...@metamask/approval-controller@2.0.0
-[1.1.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@1.0.1...@metamask/approval-controller@1.1.0
-[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@1.0.0...@metamask/approval-controller@1.0.1
-[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/approval-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@2.1.1...HEAD
+[2.1.1]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@2.1.0...@metamask/approval-controller@2.1.1
+[2.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@2.0.0...@metamask/approval-controller@2.1.0
+[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@1.1.0...@metamask/approval-controller@2.0.0
+[1.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@1.0.1...@metamask/approval-controller@1.1.0
+[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/approval-controller@1.0.0...@metamask/approval-controller@1.0.1
+[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/approval-controller@1.0.0

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/approval-controller",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Manages requests that require user approval",
   "keywords": [
     "MetaMask",

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.0]
 ### Changed
-- **BREAKING**: deps: @metamask/network-controller@6.0.0->8.0.0
-  - Adjust types to align with new version of `NetworkController` ([#1091](https://github.com/MetaMask/core/pull/1091))
+- **BREAKING**: peerDeps: @metamask/network-controller@6.0.0->8.0.0 ([#1196](https://github.com/MetaMask/core/pull/1196))
 
 ## [6.0.0]
 ### Changed

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0]
+### Changed
+- **BREAKING**: deps: @metamask/network-controller@6.0.0->8.0.0
+  - Adjust types to align with new version of `NetworkController` ([#1091](https://github.com/MetaMask/core/pull/1091))
+
 ## [6.0.0]
 ### Changed
 - **BREAKING:** Create approval requests using `@metamask/approval-controller` ([#1166](https://github.com/MetaMask/core/pull/1166))

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -96,7 +96,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use Ethers for AssetsContractController ([#845](https://github.com/MetaMask/core/pull/845))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@6.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@7.0.0...HEAD
+[7.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@6.0.0...@metamask/assets-controllers@7.0.0
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@5.1.0...@metamask/assets-controllers@6.0.0
 [5.1.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@5.0.1...@metamask/assets-controllers@5.1.0
 [5.0.1]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@5.0.0...@metamask/assets-controllers@5.0.1

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -96,8 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use Ethers for AssetsContractController ([#845](https://github.com/MetaMask/core/pull/845))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@7.0.0...HEAD
-[7.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@6.0.0...@metamask/assets-controllers@7.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@6.0.0...HEAD
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@5.1.0...@metamask/assets-controllers@6.0.0
 [5.1.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@5.0.1...@metamask/assets-controllers@5.1.0
 [5.0.1]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@5.0.0...@metamask/assets-controllers@5.0.1

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/assets-controllers",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Controllers which manage interactions involving ERC-20, ERC-721, and ERC-1155 tokens (including NFTs)",
   "keywords": [
     "MetaMask",

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0]
+### Uncategorized
+- add WalletConnect in approval type ([#1240](https://github.com/MetaMask/core.git/pull/1240))
+- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+
 ## [3.3.0]
 ### Added
 - Add Sign-in-with-Ethereum origin validation ([#1163](https://github.com/MetaMask/core/pull/1163))
@@ -82,10 +87,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@3.3.0...HEAD
-[3.3.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@3.2.0...@metamask/controller-utils@3.3.0
-[3.2.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@3.1.0...@metamask/controller-utils@3.2.0
-[3.1.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@3.0.0...@metamask/controller-utils@3.1.0
-[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@2.0.0...@metamask/controller-utils@3.0.0
-[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@1.0.0...@metamask/controller-utils@2.0.0
-[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/controller-utils@1.0.0
+[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@3.4.0...HEAD
+[3.4.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@3.3.0...@metamask/controller-utils@3.4.0
+[3.3.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@3.2.0...@metamask/controller-utils@3.3.0
+[3.2.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@3.1.0...@metamask/controller-utils@3.2.0
+[3.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@3.0.0...@metamask/controller-utils@3.1.0
+[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@2.0.0...@metamask/controller-utils@3.0.0
+[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@1.0.0...@metamask/controller-utils@2.0.0
+[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/controller-utils@1.0.0

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.4.0]
 ### Added
-- add WalletConnect in approval type ([#1240](https://github.com/MetaMask/core.git/pull/1240))
+- add WalletConnect in approval type ([#1240](https://github.com/MetaMask/core/pull/1240))
 
 ## [3.3.0]
 ### Added
@@ -86,11 +86,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@3.4.0...HEAD
-[3.4.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@3.3.0...@metamask/controller-utils@3.4.0
-[3.3.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@3.2.0...@metamask/controller-utils@3.3.0
-[3.2.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@3.1.0...@metamask/controller-utils@3.2.0
-[3.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@3.0.0...@metamask/controller-utils@3.1.0
-[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@2.0.0...@metamask/controller-utils@3.0.0
-[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/controller-utils@1.0.0...@metamask/controller-utils@2.0.0
-[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/controller-utils@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@3.4.0...HEAD
+[3.4.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@3.3.0...@metamask/controller-utils@3.4.0
+[3.3.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@3.2.0...@metamask/controller-utils@3.3.0
+[3.2.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@3.1.0...@metamask/controller-utils@3.2.0
+[3.1.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@3.0.0...@metamask/controller-utils@3.1.0
+[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@2.0.0...@metamask/controller-utils@3.0.0
+[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@1.0.0...@metamask/controller-utils@2.0.0
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/controller-utils@1.0.0

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [3.4.0]
-### Uncategorized
+### Added
 - add WalletConnect in approval type ([#1240](https://github.com/MetaMask/core.git/pull/1240))
-- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
 
 ## [3.3.0]
 ### Added

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/controller-utils",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Data and convenience functions shared by multiple packages",
   "keywords": [
     "MetaMask",

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.0]
 ### Changed
-- Merge extension ens controller ([#1170](https://github.com/MetaMask/core.git/pull/1170))
+- Merge extension ens controller ([#1170](https://github.com/MetaMask/core/pull/1170))
 
 ## [3.0.0]
 ### Changed
@@ -37,10 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@3.1.0...HEAD
-[3.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@3.0.0...@metamask/ens-controller@3.1.0
-[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@2.0.0...@metamask/ens-controller@3.0.0
-[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@1.0.2...@metamask/ens-controller@2.0.0
-[1.0.2]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@1.0.1...@metamask/ens-controller@1.0.2
-[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@1.0.0...@metamask/ens-controller@1.0.1
-[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/ens-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@3.1.0...HEAD
+[3.1.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@3.0.0...@metamask/ens-controller@3.1.0
+[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@2.0.0...@metamask/ens-controller@3.0.0
+[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@1.0.2...@metamask/ens-controller@2.0.0
+[1.0.2]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@1.0.1...@metamask/ens-controller@1.0.2
+[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@1.0.0...@metamask/ens-controller@1.0.1
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/ens-controller@1.0.0

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0]
+### Uncategorized
+- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+- Merge extension ens controller ([#1170](https://github.com/MetaMask/core.git/pull/1170))
+
 ## [3.0.0]
 ### Changed
 - **BREAKING:** Convert the ENS controller to the BaseController v2 API ([#1134](https://github.com/MetaMask/core/pull/1134))
@@ -33,9 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@3.0.0...HEAD
-[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@2.0.0...@metamask/ens-controller@3.0.0
-[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@1.0.2...@metamask/ens-controller@2.0.0
-[1.0.2]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@1.0.1...@metamask/ens-controller@1.0.2
-[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@1.0.0...@metamask/ens-controller@1.0.1
-[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/ens-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@3.1.0...HEAD
+[3.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@3.0.0...@metamask/ens-controller@3.1.0
+[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@2.0.0...@metamask/ens-controller@3.0.0
+[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@1.0.2...@metamask/ens-controller@2.0.0
+[1.0.2]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@1.0.1...@metamask/ens-controller@1.0.2
+[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/ens-controller@1.0.0...@metamask/ens-controller@1.0.1
+[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/ens-controller@1.0.0

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.0]
 ### Changed
-- Merge extension ens controller ([#1170](https://github.com/MetaMask/core/pull/1170))
+- Add support for reverse ENS address resolution ([#1170](https://github.com/MetaMask/core/pull/1170))
+  - This controller can now resolve a network address to an ENS address. This feature was ported from the extension ENS controller.
 
 ## [3.0.0]
 ### Changed

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [3.1.0]
-### Uncategorized
-- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+### Changed
 - Merge extension ens controller ([#1170](https://github.com/MetaMask/core.git/pull/1170))
 
 ## [3.0.0]
@@ -23,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2]
 ### Changed
 - Rename this repository to `core` ([#1031](https://github.com/MetaMask/controllers/pull/1031))
-- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041)) 
+- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 
 ## [1.0.1]
 ### Changed

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ens-controller",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Maps ENS names to their resolved addresses by chain id",
   "keywords": [
     "MetaMask",

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.0.0]
 ### Changed
 - **BREAKING**: peerDeps: @metamask/network-controller@6.0.0->8.0.0 ([#1196](https://github.com/MetaMask/core/pull/1196))
-  - Replace `network` state with `networkId` and `networkStatus`
 
 ## [4.0.1]
 - **BREAKING:** Update `@metamask/network-controller` peer dependency to v3 ([#1041](https://github.com/MetaMask/controllers/pull/1041))

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -11,11 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: peerDeps: @metamask/network-controller@6.0.0->8.0.0 ([#1196](https://github.com/MetaMask/core/pull/1196))
 
 ## [4.0.1]
-- **BREAKING:** Update `@metamask/network-controller` peer dependency to v3 ([#1041](https://github.com/MetaMask/controllers/pull/1041))
-### Changed
-- Adjust types to align with new version of `NetworkController` ([#1091](https://github.com/MetaMask/core/pull/1091))
-
-## [4.0.1]
 ### Changed
 - Adjust types to align with new version of `NetworkController` ([#1091](https://github.com/MetaMask/core/pull/1091))
 

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0]
+### Changed
+- **BREAKING**: peerDeps: @metamask/network-controller@6.0.0->8.0.0 ([#1196](https://github.com/MetaMask/core/pull/1196))
+  - Replace `network` state with `networkId` and `networkStatus`
+
+## [4.0.1]
+- **BREAKING:** Update `@metamask/network-controller` peer dependency to v3 ([#1041](https://github.com/MetaMask/controllers/pull/1041))
+### Changed
+- Adjust types to align with new version of `NetworkController` ([#1091](https://github.com/MetaMask/core/pull/1091))
+
 ## [4.0.1]
 ### Changed
 - Adjust types to align with new version of `NetworkController` ([#1091](https://github.com/MetaMask/core/pull/1091))
@@ -22,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING:** Update `@metamask/network-controller` peer dependency to v3 ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 - Rename this repository to `core` ([#1031](https://github.com/MetaMask/controllers/pull/1031))
-- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041)) 
+- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 
 ## [2.0.1]
 ### Fixed

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -46,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@4.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@5.0.0...HEAD
+[5.0.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@4.0.1...@metamask/gas-fee-controller@5.0.0
 [4.0.1]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@4.0.0...@metamask/gas-fee-controller@4.0.1
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@3.0.0...@metamask/gas-fee-controller@4.0.0
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@2.0.1...@metamask/gas-fee-controller@3.0.0

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/gas-fee-controller",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "Periodically calculates gas fee estimates based on various gas limits as well as other data displayed on transaction confirm screens",
   "keywords": [
     "MetaMask",

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0]
+### Uncategorized
+- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+- Stub PreferencesController in KeyringController tests ([#1194](https://github.com/MetaMask/core.git/pull/1194))
+- add rollbackToPreviousProvider method ([#1132](https://github.com/MetaMask/core.git/pull/1132))
+
 ## [4.0.0]
 ### Removed
 - **BREAKING:** Remove `isomorphic-fetch` ([#1106](https://github.com/MetaMask/controllers/pull/1106))
@@ -37,9 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@4.0.0...HEAD
-[4.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@3.0.0...@metamask/keyring-controller@4.0.0
-[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@2.0.0...@metamask/keyring-controller@3.0.0
-[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@1.0.1...@metamask/keyring-controller@2.0.0
-[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@1.0.0...@metamask/keyring-controller@1.0.1
-[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/keyring-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@4.1.0...HEAD
+[4.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@4.0.0...@metamask/keyring-controller@4.1.0
+[4.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@3.0.0...@metamask/keyring-controller@4.0.0
+[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@2.0.0...@metamask/keyring-controller@3.0.0
+[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@1.0.1...@metamask/keyring-controller@2.0.0
+[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@1.0.0...@metamask/keyring-controller@1.0.1
+[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/keyring-controller@1.0.0

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,9 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [4.1.0]
-### Uncategorized
-- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
-- Stub PreferencesController in KeyringController tests ([#1194](https://github.com/MetaMask/core.git/pull/1194))
+### Changed
 - add rollbackToPreviousProvider method ([#1132](https://github.com/MetaMask/core.git/pull/1132))
 
 ## [4.0.0]
@@ -29,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - This change was introduced by an indirect dependency on `ethereumjs/util` v8
 - Rename this repository to `core` ([#1031](https://github.com/MetaMask/controllers/pull/1031))
 - Update `@metamask/eth-sig-util` to v5 ([#914](https://github.com/MetaMask/controllers/pull/914))
-- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041)) 
+- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 
 ## [1.0.1]
 ### Changed

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.1.0]
-### Changed
-- add rollbackToPreviousProvider method ([#1132](https://github.com/MetaMask/core/pull/1132))
-
 ## [4.0.0]
 ### Removed
 - **BREAKING:** Remove `isomorphic-fetch` ([#1106](https://github.com/MetaMask/controllers/pull/1106))
@@ -17,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.0]
 ### Changed
-- **BREAKING:**: Bump eth-keyring-controller version to @metamask/eth-keyring-controller v10 ([#1072](https://github.com/MetaMask/core/pull/1072))
+- **BREAKING:**: Bump eth-keyring-controller version to @metamask/eth-keyring-controller v10 ([#1072](https://github.com/MetaMask/core.git/pull/1072))
   - `exportSeedPhrase` now returns a `Uint8Array` typed SRP (can be converted to a string using [this approach](https://github.com/MetaMask/eth-hd-keyring/blob/53b0570559595ba5b3fd8c80e900d847cd6dee3d/index.js#L40)).  It was previously a Buffer.
   - The HD keyring included with the keyring controller has been updated from v4 to v6. See [the `eth-hd-keyring` changelog entries for v5 and v6](https://github.com/MetaMask/eth-hd-keyring/blob/main/CHANGELOG.md#600) for further details on breaking changes.
 
@@ -27,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - This change was introduced by an indirect dependency on `ethereumjs/util` v8
 - Rename this repository to `core` ([#1031](https://github.com/MetaMask/controllers/pull/1031))
 - Update `@metamask/eth-sig-util` to v5 ([#914](https://github.com/MetaMask/controllers/pull/914))
-- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041))
+- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041)) 
 
 ## [1.0.1]
 ### Changed
@@ -41,8 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@4.1.0...HEAD
-[4.1.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@4.0.0...@metamask/keyring-controller@4.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@4.0.0...HEAD
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@3.0.0...@metamask/keyring-controller@4.0.0
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@2.0.0...@metamask/keyring-controller@3.0.0
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@1.0.1...@metamask/keyring-controller@2.0.0

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.1.0]
 ### Changed
-- add rollbackToPreviousProvider method ([#1132](https://github.com/MetaMask/core.git/pull/1132))
+- add rollbackToPreviousProvider method ([#1132](https://github.com/MetaMask/core/pull/1132))
 
 ## [4.0.0]
 ### Removed
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.0]
 ### Changed
-- **BREAKING:**: Bump eth-keyring-controller version to @metamask/eth-keyring-controller v10 ([#1072](https://github.com/MetaMask/core.git/pull/1072))
+- **BREAKING:**: Bump eth-keyring-controller version to @metamask/eth-keyring-controller v10 ([#1072](https://github.com/MetaMask/core/pull/1072))
   - `exportSeedPhrase` now returns a `Uint8Array` typed SRP (can be converted to a string using [this approach](https://github.com/MetaMask/eth-hd-keyring/blob/53b0570559595ba5b3fd8c80e900d847cd6dee3d/index.js#L40)).  It was previously a Buffer.
   - The HD keyring included with the keyring controller has been updated from v4 to v6. See [the `eth-hd-keyring` changelog entries for v5 and v6](https://github.com/MetaMask/eth-hd-keyring/blob/main/CHANGELOG.md#600) for further details on breaking changes.
 
@@ -41,10 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@4.1.0...HEAD
-[4.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@4.0.0...@metamask/keyring-controller@4.1.0
-[4.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@3.0.0...@metamask/keyring-controller@4.0.0
-[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@2.0.0...@metamask/keyring-controller@3.0.0
-[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@1.0.1...@metamask/keyring-controller@2.0.0
-[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/keyring-controller@1.0.0...@metamask/keyring-controller@1.0.1
-[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/keyring-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@4.1.0...HEAD
+[4.1.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@4.0.0...@metamask/keyring-controller@4.1.0
+[4.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@3.0.0...@metamask/keyring-controller@4.0.0
+[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@2.0.0...@metamask/keyring-controller@3.0.0
+[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@1.0.1...@metamask/keyring-controller@2.0.0
+[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@1.0.0...@metamask/keyring-controller@1.0.1
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/keyring-controller@1.0.0

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-controller",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Stores identities seen in the wallet and manages interactions such as signing",
   "keywords": [
     "MetaMask",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-controller",
-  "version": "4.1.0",
+  "version": "4.0.0",
   "description": "Stores identities seen in the wallet and manages interactions such as signing",
   "keywords": [
     "MetaMask",

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.1]
 ### Changed
-- fix: prevent setResult to emit updateBadge but state updates ([#1245](https://github.com/MetaMask/core.git/pull/1245))
+- fix: prevent setResult to emit updateBadge but state updates ([#1245](https://github.com/MetaMask/core/pull/1245))
 
 ## [3.1.0]
 ### Added
@@ -49,12 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@3.1.1...HEAD
-[3.1.1]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@3.1.0...@metamask/message-manager@3.1.1
-[3.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@3.0.0...@metamask/message-manager@3.1.0
-[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@2.1.0...@metamask/message-manager@3.0.0
-[2.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@2.0.0...@metamask/message-manager@2.1.0
-[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@1.0.2...@metamask/message-manager@2.0.0
-[1.0.2]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@1.0.1...@metamask/message-manager@1.0.2
-[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@1.0.0...@metamask/message-manager@1.0.1
-[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/message-manager@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/message-manager@3.1.1...HEAD
+[3.1.1]: https://github.com/MetaMask/core/compare/@metamask/message-manager@3.1.0...@metamask/message-manager@3.1.1
+[3.1.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@3.0.0...@metamask/message-manager@3.1.0
+[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@2.1.0...@metamask/message-manager@3.0.0
+[2.1.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@2.0.0...@metamask/message-manager@2.1.0
+[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@1.0.2...@metamask/message-manager@2.0.0
+[1.0.2]: https://github.com/MetaMask/core/compare/@metamask/message-manager@1.0.1...@metamask/message-manager@1.0.2
+[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/message-manager@1.0.0...@metamask/message-manager@1.0.1
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/message-manager@1.0.0

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.1]
 ### Fixed
-- Ensure message updates get saved in state even when they aren't emited right away  ([#1245](https://github.com/MetaMask/core/pull/1245))
+- Ensure message updates get saved in state even when they aren't emitted right away  ([#1245](https://github.com/MetaMask/core/pull/1245))
   - The `updateMessage` method included in each message manager accepted an `emitUpdate` boolean argument that would enable to caller to prevent that update from updating the badge (which displays the count of pending confirmations). Unfortunately this option would also prevent the update from being saved in state.
   - This method has been updated to ensure message updates are saved in state, even when the badge update event is suppressed
 

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -7,10 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [3.1.1]
-### Uncategorized
+### Changed
 - fix: prevent setResult to emit updateBadge but state updates ([#1245](https://github.com/MetaMask/core.git/pull/1245))
-- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
-- fix changelog ([#1232](https://github.com/MetaMask/core.git/pull/1232))
 
 ## [3.1.0]
 ### Added
@@ -36,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2]
 ### Changed
 - Rename this repository to `core` ([#1031](https://github.com/MetaMask/controllers/pull/1031))
-- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041)) 
+- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 
 ## [1.0.1]
 ### Changed

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1]
+### Uncategorized
+- fix: prevent setResult to emit updateBadge but state updates ([#1245](https://github.com/MetaMask/core.git/pull/1245))
+- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+- fix changelog ([#1232](https://github.com/MetaMask/core.git/pull/1232))
+
 ## [3.1.0]
 ### Added
 - Add DecryptMessageManager ([#1149](https://github.com/MetaMask/core/pull/1149))
@@ -45,11 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/message-manager@3.1.0...HEAD
-[3.1.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@3.0.0...@metamask/message-manager@3.1.0
-[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@2.1.0...@metamask/message-manager@3.0.0
-[2.1.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@2.0.0...@metamask/message-manager@2.1.0
-[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@1.0.2...@metamask/message-manager@2.0.0
-[1.0.2]: https://github.com/MetaMask/core/compare/@metamask/message-manager@1.0.1...@metamask/message-manager@1.0.2
-[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/message-manager@1.0.0...@metamask/message-manager@1.0.1
-[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/message-manager@1.0.0
+[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@3.1.1...HEAD
+[3.1.1]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@3.1.0...@metamask/message-manager@3.1.1
+[3.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@3.0.0...@metamask/message-manager@3.1.0
+[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@2.1.0...@metamask/message-manager@3.0.0
+[2.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@2.0.0...@metamask/message-manager@2.1.0
+[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@1.0.2...@metamask/message-manager@2.0.0
+[1.0.2]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@1.0.1...@metamask/message-manager@1.0.2
+[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/message-manager@1.0.0...@metamask/message-manager@1.0.1
+[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/message-manager@1.0.0

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [3.1.1]
-### Changed
-- fix: prevent setResult to emit updateBadge but state updates ([#1245](https://github.com/MetaMask/core/pull/1245))
+### Fixed
+- Ensure message updates get saved in state even when they aren't emited right away  ([#1245](https://github.com/MetaMask/core/pull/1245))
+  - The `updateMessage` method included in each message manager accepted an `emitUpdate` boolean argument that would enable to caller to prevent that update from updating the badge (which displays the count of pending confirmations). Unfortunately this option would also prevent the update from being saved in state.
+  - This method has been updated to ensure message updates are saved in state, even when the badge update event is suppressed
 
 ## [3.1.0]
 ### Added

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/message-manager",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Stores and manages interactions with signing requests",
   "keywords": [
     "MetaMask",

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.0.0]
 ### Changed
 - Update EIP-1559 compatibility during network lookup ([#1236](https://github.com/MetaMask/core/pull/1236))
-  - We still check for EIP-1559 compatibility upon initialization and after switching networks, the same as before. This change only impacts direct calls to `lookupNetwork`.
-  - `lookupNetwork` is now making two network calls instead of one, and it will ensure that the `networkDetails` state is up-to-date
+  - EIP-1559 compatibility check is still performed on initialization and after switching networks, like before. This change only impacts direct calls to `lookupNetwork`.
+  - `lookupNetwork` is now making two network calls instead of one, ensuring that the `networkDetails` state is up-to-date.
 - **BREAKING:** Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core/pull/1196))
-  - If you were using `network` to access the network ID, use `networkId` now instead. It will be set to `null` rather than `loading` if the network is not currently available.
+  - If you were using `network` to access the network ID, use `networkId` instead. It will be set to `null` rather than `loading` if the network is not currently available.
   - If you were using `network` to see if the network was currently available, use `networkStatus` instead. It will be set to `NetworkStatus.Available` if the network is available.
-  - When the network is unavailable, we now have two different states to represent that: "Unknown" and "Unavailable". Unavailable means that we know the network is not currently available, whereas unknown is used for unknown errors and for cases where we don't yet know the network status (e.g. before initialization, or while the network is loading).
+  - When the network is unavailable, we now have two different states to represent that: `unknown` and `unavailable`. `unavailable` means that the network was detected as not available, whereas `unknown` is used for unknown errors and cases where the network status is yet to be determined (e.g. before initialization, or while the network is loading).
 - Use JavaScript private fields rather than `private` TypeScript keyword for internal methods/fields ([#1189](https://github.com/MetaMask/core/pull/1189))
 - Export `BlockTrackerProxy` type ([#1147](https://github.com/MetaMask/core/pull/1147))
   - This is the type of the block tracker returned from the `getProviderAndBlockTracker` method

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use JavaScript private fields rather than `private` TypeScript keyword for internal methods/fields ([#1189](https://github.com/MetaMask/core/pull/1189))
 - Export `BlockTrackerProxy` type ([#1147](https://github.com/MetaMask/core/pull/1147))
   - This is the type of the block tracker returned from the `getProviderAndBlockTracker` method
-- Implement `resetConnection` method ([#1131](https://github.com/MetaMask/core/pull/1131), [#1235](https://github.com/MetaMask/core/pull/1235), [#1239](https://github.com/MetaMask/core/pull/1239))
 - **BREAKING:** Async refactor
   - Make `rollbackToPreviousProvider` async ([#1237](https://github.com/MetaMask/core/pull/1237))
   - Make `upsertNetworkConfiguration` async ([#1192](https://github.com/MetaMask/core/pull/1192))
@@ -31,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - deps: bump web3-provider-engine@16.0.3->16.0.5 ([#1212](https://github.com/MetaMask/core/pull/1212))
   - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
   - deps: bump @metamask/utils to 5.0.1 ([#1211](https://github.com/MetaMask/core/pull/1211))
+
+### Added
+- Implement `resetConnection` method ([#1131](https://github.com/MetaMask/core/pull/1131), [#1235](https://github.com/MetaMask/core/pull/1235), [#1239](https://github.com/MetaMask/core/pull/1239))
 
 ### Removed
 - **BREAKING:** Remove `isCustomNetwork` state ([#1199](https://github.com/MetaMask/core/pull/1199))

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [8.0.0]
+### Added
+- Implement `resetConnection` method ([#1131](https://github.com/MetaMask/core/pull/1131), [#1235](https://github.com/MetaMask/core/pull/1235), [#1239](https://github.com/MetaMask/core/pull/1239))
+
 ### Changed
 - Update EIP-1559 compatibility during network lookup ([#1236](https://github.com/MetaMask/core/pull/1236))
   - EIP-1559 compatibility check is still performed on initialization and after switching networks, like before. This change only impacts direct calls to `lookupNetwork`.
@@ -30,9 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - deps: bump web3-provider-engine@16.0.3->16.0.5 ([#1212](https://github.com/MetaMask/core/pull/1212))
   - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
   - deps: bump @metamask/utils to 5.0.1 ([#1211](https://github.com/MetaMask/core/pull/1211))
-
-### Added
-- Implement `resetConnection` method ([#1131](https://github.com/MetaMask/core/pull/1131), [#1235](https://github.com/MetaMask/core/pull/1235), [#1239](https://github.com/MetaMask/core/pull/1239))
 
 ### Removed
 - **BREAKING:** Remove `isCustomNetwork` state ([#1199](https://github.com/MetaMask/core/pull/1199))

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.0.0]
 ### Changed
 - Update EIP-1559 compatibility during network lookup ([#1236](https://github.com/MetaMask/core/pull/1236))
-- Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core/pull/1196))
+- **BREAKING:** Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core/pull/1196))
+  - If you were using `network` to access the network ID, use `networkId` now instead. It will be set to `null` rather than `loading` if the network is not currently available.
+  - If you were using `network` to see if the network was currently available, use `networkStatus` instead. It will be set to `NetworkStatus.Available` if the network is available.
+  - When the network is unavailable, we now have two different states to represent that: "Unknown" and "Unavailable". Unavailable means that we know the network is not currently available, whereas unknown is used for unknown errors and for cases where we don't yet know the network status (e.g. before initialization, or while the network is loading).
 - Use JavaScript private fields rather than `private` TypeScript keyword for internal methods/fields ([#1189](https://github.com/MetaMask/core/pull/1189))
 - Export `BlockTrackerProxy` type ([#1147](https://github.com/MetaMask/core/pull/1147))
   - This is the type of the block tracker returned from the `getProviderAndBlockTracker` method

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.0.0]
 ### Changed
 - Update EIP-1559 compatibility during network lookup ([#1236](https://github.com/MetaMask/core/pull/1236))
+  - We still check for EIP-1559 compatibility upon initialization and after switching networks, the same as before. This change only impacts direct calls to `lookupNetwork`.
+  - `lookupNetwork` is now making two network calls instead of one, and it will ensure that the `networkDetails` state is up-to-date
 - **BREAKING:** Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core/pull/1196))
   - If you were using `network` to access the network ID, use `networkId` now instead. It will be set to `null` rather than `loading` if the network is not currently available.
   - If you were using `network` to see if the network was currently available, use `networkStatus` instead. It will be set to `NetworkStatus.Available` if the network is available.
@@ -17,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Export `BlockTrackerProxy` type ([#1147](https://github.com/MetaMask/core/pull/1147))
   - This is the type of the block tracker returned from the `getProviderAndBlockTracker` method
 - Implement `resetConnection` method ([#1131](https://github.com/MetaMask/core/pull/1131), [#1235](https://github.com/MetaMask/core/pull/1235), [#1239](https://github.com/MetaMask/core/pull/1239))
-- Async refactor
+- **BREAKING:** Async refactor
   - Make `rollbackToPreviousProvider` async ([#1237](https://github.com/MetaMask/core/pull/1237))
   - Make `upsertNetworkConfiguration` async ([#1192](https://github.com/MetaMask/core/pull/1192))
   - Make `setActiveNetwork` async ([#1190](https://github.com/MetaMask/core/pull/1190))
@@ -31,7 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - deps: bump @metamask/utils to 5.0.1 ([#1211](https://github.com/MetaMask/core/pull/1211))
 
 ### Removed
-- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core/pull/1199))
+- **BREAKING:** Remove `isCustomNetwork` state ([#1199](https://github.com/MetaMask/core/pull/1199))
+  - The `providerConfig.type` state will be set to `'rpc'` if the current network is a custom network. Replace all references to the `isCustomNetwork` state by checking the provider config state instead.
 
 ## [7.0.0]
 ### Changed

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement resetConnection method in network controller ([#1131](https://github.com/MetaMask/core/pull/1131)) [#1239](https://github.com/MetaMask/core/pull/1239)
 - Async refactor
   - Make `rollbackToPreviousProvider` async ([#1237](https://github.com/MetaMask/core/pull/1237))
-  - Make `resetConnection` async ([#1239](https://github.com/MetaMask/core/pull/1239))
   - Make `upsertNetworkConfiguration` async ([#1192](https://github.com/MetaMask/core/pull/1192))
   - Make `setActiveNetwork` async ([#1190](https://github.com/MetaMask/core/pull/1190))
   - Make `setProviderType` async ([#1191](https://github.com/MetaMask/core/pull/1191))

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,30 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [8.0.0]
-### Uncategorized
-- Make `rollbackToPreviousProvider` async ([#1237](https://github.com/MetaMask/core.git/pull/1237))
-- Make `resetConnection` async ([#1239](https://github.com/MetaMask/core.git/pull/1239))
+### Changed
 - Update EIP-1559 compatibility during network lookup ([#1236](https://github.com/MetaMask/core.git/pull/1236))
-- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
 - Refresh network when connection is reset ([#1235](https://github.com/MetaMask/core.git/pull/1235))
-- deps: bump web3-provider-engine@16.0.3->16.0.5 ([#1212](https://github.com/MetaMask/core.git/pull/1212))
-- Simplify `setProviderType` unit tests ([#1222](https://github.com/MetaMask/core.git/pull/1222))
-- Consolidate `setProviderType` unit tests ([#1221](https://github.com/MetaMask/core.git/pull/1221))
-- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
-- deps: bump @metamask/utils to 5.0.1 ([#1211](https://github.com/MetaMask/core.git/pull/1211))
-- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core.git/pull/1199))
 - Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core.git/pull/1196))
-- Make `upsertNetworkConfiguration` async ([#1192](https://github.com/MetaMask/core.git/pull/1192))
 - Make network controller internal fields private ([#1189](https://github.com/MetaMask/core.git/pull/1189))
-- Make `setActiveNetwork` async ([#1190](https://github.com/MetaMask/core.git/pull/1190))
-- Make `setProviderType` async ([#1191](https://github.com/MetaMask/core.git/pull/1191))
-- Make `refreshNetwork` async ([#1182](https://github.com/MetaMask/core.git/pull/1182))
-- Make `initializeProvider` async ([#1180](https://github.com/MetaMask/core.git/pull/1180))
-- Make `verifyNetwork` async ([#1181](https://github.com/MetaMask/core.git/pull/1181))
-- Eliminate console error when running test ([#1179](https://github.com/MetaMask/core.git/pull/1179))
-- Fix test description ([#1175](https://github.com/MetaMask/core.git/pull/1175))
 - Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core.git/pull/1147))
 - Implement resetConnection method in network controller ([#1131](https://github.com/MetaMask/core.git/pull/1131))
+- Async refactor
+  - Make `rollbackToPreviousProvider` async ([#1237](https://github.com/MetaMask/core.git/pull/1237))
+  - Make `resetConnection` async ([#1239](https://github.com/MetaMask/core.git/pull/1239))
+  - Make `upsertNetworkConfiguration` async ([#1192](https://github.com/MetaMask/core.git/pull/1192))
+  - Make `setActiveNetwork` async ([#1190](https://github.com/MetaMask/core.git/pull/1190))
+  - Make `setProviderType` async ([#1191](https://github.com/MetaMask/core.git/pull/1191))
+  - Make `refreshNetwork` async ([#1182](https://github.com/MetaMask/core.git/pull/1182))
+  - Make `initializeProvider` async ([#1180](https://github.com/MetaMask/core.git/pull/1180))
+  - Make `verifyNetwork` async ([#1181](https://github.com/MetaMask/core.git/pull/1181))
+- Dependency updates
+  - deps: bump web3-provider-engine@16.0.3->16.0.5 ([#1212](https://github.com/MetaMask/core.git/pull/1212))
+  - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
+  - deps: bump @metamask/utils to 5.0.1 ([#1211](https://github.com/MetaMask/core.git/pull/1211))
+
+### Removed
+- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core.git/pull/1199))
 
 ## [7.0.0]
 ### Changed
@@ -76,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Make `lookupNetwork` block on completing the lookup ([#1063](https://github.com/MetaMask/controllers/pull/1063))
   - This function was always `async`, but it would return before completing any async work. Now it will not return until after the network lookup has been completed.
 - Rename this repository to `core` ([#1031](https://github.com/MetaMask/controllers/pull/1031))
-- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041)) 
+- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 
 ### Removed
 - **BREAKING:**: Drop support for Ropsten, Rinkeby, and Kovan as built-in Infura networks ([#1041](https://github.com/MetaMask/controllers/pull/1041))

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refresh network when connection is reset ([#1235](https://github.com/MetaMask/core/pull/1235))
 - Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core/pull/1196))
 - Make network controller internal fields private ([#1189](https://github.com/MetaMask/core/pull/1189))
-- Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core/pull/1147))
+- Export `BlockTrackerProxy` type ([#1147](https://github.com/MetaMask/core/pull/1147))
+  - This is the type of the block tracker returned from the `getProviderAndBlockTracker` method
 - Implement resetConnection method in network controller ([#1131](https://github.com/MetaMask/core/pull/1131))
 - Async refactor
   - Make `rollbackToPreviousProvider` async ([#1237](https://github.com/MetaMask/core/pull/1237))

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -8,28 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.0.0]
 ### Changed
-- Update EIP-1559 compatibility during network lookup ([#1236](https://github.com/MetaMask/core.git/pull/1236))
-- Refresh network when connection is reset ([#1235](https://github.com/MetaMask/core.git/pull/1235))
-- Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core.git/pull/1196))
-- Make network controller internal fields private ([#1189](https://github.com/MetaMask/core.git/pull/1189))
-- Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core.git/pull/1147))
-- Implement resetConnection method in network controller ([#1131](https://github.com/MetaMask/core.git/pull/1131))
+- Update EIP-1559 compatibility during network lookup ([#1236](https://github.com/MetaMask/core/pull/1236))
+- Refresh network when connection is reset ([#1235](https://github.com/MetaMask/core/pull/1235))
+- Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core/pull/1196))
+- Make network controller internal fields private ([#1189](https://github.com/MetaMask/core/pull/1189))
+- Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core/pull/1147))
+- Implement resetConnection method in network controller ([#1131](https://github.com/MetaMask/core/pull/1131))
 - Async refactor
-  - Make `rollbackToPreviousProvider` async ([#1237](https://github.com/MetaMask/core.git/pull/1237))
-  - Make `resetConnection` async ([#1239](https://github.com/MetaMask/core.git/pull/1239))
-  - Make `upsertNetworkConfiguration` async ([#1192](https://github.com/MetaMask/core.git/pull/1192))
-  - Make `setActiveNetwork` async ([#1190](https://github.com/MetaMask/core.git/pull/1190))
-  - Make `setProviderType` async ([#1191](https://github.com/MetaMask/core.git/pull/1191))
-  - Make `refreshNetwork` async ([#1182](https://github.com/MetaMask/core.git/pull/1182))
-  - Make `initializeProvider` async ([#1180](https://github.com/MetaMask/core.git/pull/1180))
-  - Make `verifyNetwork` async ([#1181](https://github.com/MetaMask/core.git/pull/1181))
+  - Make `rollbackToPreviousProvider` async ([#1237](https://github.com/MetaMask/core/pull/1237))
+  - Make `resetConnection` async ([#1239](https://github.com/MetaMask/core/pull/1239))
+  - Make `upsertNetworkConfiguration` async ([#1192](https://github.com/MetaMask/core/pull/1192))
+  - Make `setActiveNetwork` async ([#1190](https://github.com/MetaMask/core/pull/1190))
+  - Make `setProviderType` async ([#1191](https://github.com/MetaMask/core/pull/1191))
+  - Make `refreshNetwork` async ([#1182](https://github.com/MetaMask/core/pull/1182))
+  - Make `initializeProvider` async ([#1180](https://github.com/MetaMask/core/pull/1180))
+  - Make `verifyNetwork` async ([#1181](https://github.com/MetaMask/core/pull/1181))
 - Dependency updates
-  - deps: bump web3-provider-engine@16.0.3->16.0.5 ([#1212](https://github.com/MetaMask/core.git/pull/1212))
-  - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
-  - deps: bump @metamask/utils to 5.0.1 ([#1211](https://github.com/MetaMask/core.git/pull/1211))
+  - deps: bump web3-provider-engine@16.0.3->16.0.5 ([#1212](https://github.com/MetaMask/core/pull/1212))
+  - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
+  - deps: bump @metamask/utils to 5.0.1 ([#1211](https://github.com/MetaMask/core/pull/1211))
 
 ### Removed
-- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core.git/pull/1199))
+- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core/pull/1199))
 
 ## [7.0.0]
 ### Changed
@@ -95,12 +95,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@8.0.0...HEAD
-[8.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@7.0.0...@metamask/network-controller@8.0.0
-[7.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@6.0.0...@metamask/network-controller@7.0.0
-[6.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@5.0.0...@metamask/network-controller@6.0.0
-[5.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@4.0.0...@metamask/network-controller@5.0.0
-[4.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@3.0.0...@metamask/network-controller@4.0.0
-[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@2.0.0...@metamask/network-controller@3.0.0
-[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@1.0.0...@metamask/network-controller@2.0.0
-[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/network-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@8.0.0...HEAD
+[8.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@7.0.0...@metamask/network-controller@8.0.0
+[7.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@6.0.0...@metamask/network-controller@7.0.0
+[6.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@5.0.0...@metamask/network-controller@6.0.0
+[5.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@4.0.0...@metamask/network-controller@5.0.0
+[4.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@3.0.0...@metamask/network-controller@4.0.0
+[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@2.0.0...@metamask/network-controller@3.0.0
+[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@1.0.0...@metamask/network-controller@2.0.0
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/network-controller@1.0.0

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -6,6 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.0]
+### Uncategorized
+- Make `rollbackToPreviousProvider` async ([#1237](https://github.com/MetaMask/core.git/pull/1237))
+- Make `resetConnection` async ([#1239](https://github.com/MetaMask/core.git/pull/1239))
+- Update EIP-1559 compatibility during network lookup ([#1236](https://github.com/MetaMask/core.git/pull/1236))
+- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+- Refresh network when connection is reset ([#1235](https://github.com/MetaMask/core.git/pull/1235))
+- deps: bump web3-provider-engine@16.0.3->16.0.5 ([#1212](https://github.com/MetaMask/core.git/pull/1212))
+- Simplify `setProviderType` unit tests ([#1222](https://github.com/MetaMask/core.git/pull/1222))
+- Consolidate `setProviderType` unit tests ([#1221](https://github.com/MetaMask/core.git/pull/1221))
+- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
+- deps: bump @metamask/utils to 5.0.1 ([#1211](https://github.com/MetaMask/core.git/pull/1211))
+- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core.git/pull/1199))
+- Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core.git/pull/1196))
+- Make `upsertNetworkConfiguration` async ([#1192](https://github.com/MetaMask/core.git/pull/1192))
+- Make network controller internal fields private ([#1189](https://github.com/MetaMask/core.git/pull/1189))
+- Make `setActiveNetwork` async ([#1190](https://github.com/MetaMask/core.git/pull/1190))
+- Make `setProviderType` async ([#1191](https://github.com/MetaMask/core.git/pull/1191))
+- Make `refreshNetwork` async ([#1182](https://github.com/MetaMask/core.git/pull/1182))
+- Make `initializeProvider` async ([#1180](https://github.com/MetaMask/core.git/pull/1180))
+- Make `verifyNetwork` async ([#1181](https://github.com/MetaMask/core.git/pull/1181))
+- Eliminate console error when running test ([#1179](https://github.com/MetaMask/core.git/pull/1179))
+- Fix test description ([#1175](https://github.com/MetaMask/core.git/pull/1175))
+- Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core.git/pull/1147))
+- Implement resetConnection method in network controller ([#1131](https://github.com/MetaMask/core.git/pull/1131))
+
 ## [7.0.0]
 ### Changed
 - **BREAKING:** Replace `providerConfig` setter with a public `initializeProvider` method ([#1133](https://github.com/MetaMask/core/pull/1133))
@@ -70,11 +96,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@7.0.0...HEAD
-[7.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@6.0.0...@metamask/network-controller@7.0.0
-[6.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@5.0.0...@metamask/network-controller@6.0.0
-[5.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@4.0.0...@metamask/network-controller@5.0.0
-[4.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@3.0.0...@metamask/network-controller@4.0.0
-[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@2.0.0...@metamask/network-controller@3.0.0
-[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@1.0.0...@metamask/network-controller@2.0.0
-[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/network-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@8.0.0...HEAD
+[8.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@7.0.0...@metamask/network-controller@8.0.0
+[7.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@6.0.0...@metamask/network-controller@7.0.0
+[6.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@5.0.0...@metamask/network-controller@6.0.0
+[5.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@4.0.0...@metamask/network-controller@5.0.0
+[4.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@3.0.0...@metamask/network-controller@4.0.0
+[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@2.0.0...@metamask/network-controller@3.0.0
+[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/network-controller@1.0.0...@metamask/network-controller@2.0.0
+[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/network-controller@1.0.0

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update EIP-1559 compatibility during network lookup ([#1236](https://github.com/MetaMask/core/pull/1236))
 - Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core/pull/1196))
-- Make network controller internal fields private ([#1189](https://github.com/MetaMask/core/pull/1189))
+- Use JavaScript private fields rather than `private` TypeScript keyword for internal methods/fields ([#1189](https://github.com/MetaMask/core/pull/1189))
 - Export `BlockTrackerProxy` type ([#1147](https://github.com/MetaMask/core/pull/1147))
   - This is the type of the block tracker returned from the `getProviderAndBlockTracker` method
 - Implement `resetConnection` method ([#1131](https://github.com/MetaMask/core/pull/1131), [#1235](https://github.com/MetaMask/core/pull/1235), [#1239](https://github.com/MetaMask/core/pull/1239))

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make network controller internal fields private ([#1189](https://github.com/MetaMask/core/pull/1189))
 - Export `BlockTrackerProxy` type ([#1147](https://github.com/MetaMask/core/pull/1147))
   - This is the type of the block tracker returned from the `getProviderAndBlockTracker` method
-- Implement resetConnection method in network controller ([#1131](https://github.com/MetaMask/core/pull/1131))
+- Implement resetConnection method in network controller ([#1131](https://github.com/MetaMask/core/pull/1131)) [#1239](https://github.com/MetaMask/core/pull/1239)
 - Async refactor
   - Make `rollbackToPreviousProvider` async ([#1237](https://github.com/MetaMask/core/pull/1237))
   - Make `resetConnection` async ([#1239](https://github.com/MetaMask/core/pull/1239))

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -9,12 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [8.0.0]
 ### Changed
 - Update EIP-1559 compatibility during network lookup ([#1236](https://github.com/MetaMask/core/pull/1236))
-- Refresh network when connection is reset ([#1235](https://github.com/MetaMask/core/pull/1235))
 - Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core/pull/1196))
 - Make network controller internal fields private ([#1189](https://github.com/MetaMask/core/pull/1189))
 - Export `BlockTrackerProxy` type ([#1147](https://github.com/MetaMask/core/pull/1147))
   - This is the type of the block tracker returned from the `getProviderAndBlockTracker` method
-- Implement resetConnection method in network controller ([#1131](https://github.com/MetaMask/core/pull/1131)) [#1239](https://github.com/MetaMask/core/pull/1239)
+- Implement `resetConnection` method ([#1131](https://github.com/MetaMask/core/pull/1131), [#1235](https://github.com/MetaMask/core/pull/1235), [#1239](https://github.com/MetaMask/core/pull/1239))
 - Async refactor
   - Make `rollbackToPreviousProvider` async ([#1237](https://github.com/MetaMask/core/pull/1237))
   - Make `upsertNetworkConfiguration` async ([#1192](https://github.com/MetaMask/core/pull/1192))

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-controller",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Provides an interface to the currently selected network via a MetaMask-compatible provider object",
   "keywords": [
     "MetaMask",

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.2.0]
 ### Changed
-- Restrict certain permissions by subject type ([#1233](https://github.com/MetaMask/core.git/pull/1233))
-- Move `SubjectMetadataController` to permission-controller package ([#1234](https://github.com/MetaMask/core.git/pull/1234))
-- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
+- Restrict certain permissions by subject type ([#1233](https://github.com/MetaMask/core/pull/1233))
+- Move `SubjectMetadataController` to permission-controller package ([#1234](https://github.com/MetaMask/core/pull/1234))
+- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
 
 ## [3.1.0]
 ### Added
@@ -46,11 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@3.2.0...HEAD
-[3.2.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@3.1.0...@metamask/permission-controller@3.2.0
-[3.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@3.0.0...@metamask/permission-controller@3.1.0
-[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@2.0.0...@metamask/permission-controller@3.0.0
-[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@1.0.2...@metamask/permission-controller@2.0.0
-[1.0.2]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@1.0.1...@metamask/permission-controller@1.0.2
-[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@1.0.0...@metamask/permission-controller@1.0.1
-[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/permission-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@3.2.0...HEAD
+[3.2.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@3.1.0...@metamask/permission-controller@3.2.0
+[3.1.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@3.0.0...@metamask/permission-controller@3.1.0
+[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@2.0.0...@metamask/permission-controller@3.0.0
+[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@1.0.2...@metamask/permission-controller@2.0.0
+[1.0.2]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@1.0.1...@metamask/permission-controller@1.0.2
+[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@1.0.0...@metamask/permission-controller@1.0.1
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/permission-controller@1.0.0

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.0]
+## [3.2.0]
 ### Changed
 - Restrict certain permissions by subject type ([#1233](https://github.com/MetaMask/core.git/pull/1233))
 - Move `SubjectMetadataController` to permission-controller package ([#1234](https://github.com/MetaMask/core.git/pull/1234))
@@ -46,8 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@4.0.0...HEAD
-[4.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@3.1.0...@metamask/permission-controller@4.0.0
+[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@3.2.0...HEAD
+[3.2.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@3.1.0...@metamask/permission-controller@3.2.0
 [3.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@3.0.0...@metamask/permission-controller@3.1.0
 [3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@2.0.0...@metamask/permission-controller@3.0.0
 [2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@1.0.2...@metamask/permission-controller@2.0.0

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Restrict certain permissions by subject type ([#1233](https://github.com/MetaMask/core/pull/1233))
 - Move `SubjectMetadataController` to permission-controller package ([#1234](https://github.com/MetaMask/core/pull/1234))
-- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
+- Update minimum `eth-rpc-errors` version from `4.0.0` to `4.0.2` ([#1215](https://github.com/MetaMask/core/pull/1215))
 
 ## [3.1.0]
 ### Added

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -7,10 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [4.0.0]
-### Uncategorized
-- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+### Changed
 - Restrict certain permissions by subject type ([#1233](https://github.com/MetaMask/core.git/pull/1233))
-- BREAKING: Move `SubjectMetadataController` to permission-controller package ([#1234](https://github.com/MetaMask/core.git/pull/1234))
+- Move `SubjectMetadataController` to permission-controller package ([#1234](https://github.com/MetaMask/core.git/pull/1234))
 - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
 
 ## [3.1.0]
@@ -29,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING:** Update `@metamask/network-controller` peer dependency to v3 ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 - Rename this repository to `core` ([#1031](https://github.com/MetaMask/controllers/pull/1031))
-- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041)) 
+- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 
 ## [1.0.2]
 ### Fixed

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [3.2.0]
+### Added
+- Allow restricting permissions by subject type ([#1233](https://github.com/MetaMask/core/pull/1233))
+
 ### Changed
-- Restrict certain permissions by subject type ([#1233](https://github.com/MetaMask/core/pull/1233))
 - Move `SubjectMetadataController` to permission-controller package ([#1234](https://github.com/MetaMask/core/pull/1234))
 - Update minimum `eth-rpc-errors` version from `4.0.0` to `4.0.2` ([#1215](https://github.com/MetaMask/core/pull/1215))
 

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0]
+### Uncategorized
+- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+- Restrict certain permissions by subject type ([#1233](https://github.com/MetaMask/core.git/pull/1233))
+- BREAKING: Move `SubjectMetadataController` to permission-controller package ([#1234](https://github.com/MetaMask/core.git/pull/1234))
+- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
+
 ## [3.1.0]
 ### Added
 - Add side-effects to permissions ([#1069](https://github.com/MetaMask/core/pull/1069))
@@ -40,10 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@3.1.0...HEAD
-[3.1.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@3.0.0...@metamask/permission-controller@3.1.0
-[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@2.0.0...@metamask/permission-controller@3.0.0
-[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@1.0.2...@metamask/permission-controller@2.0.0
-[1.0.2]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@1.0.1...@metamask/permission-controller@1.0.2
-[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@1.0.0...@metamask/permission-controller@1.0.1
-[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/permission-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@4.0.0...HEAD
+[4.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@3.1.0...@metamask/permission-controller@4.0.0
+[3.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@3.0.0...@metamask/permission-controller@3.1.0
+[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@2.0.0...@metamask/permission-controller@3.0.0
+[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@1.0.2...@metamask/permission-controller@2.0.0
+[1.0.2]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@1.0.1...@metamask/permission-controller@1.0.2
+[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/permission-controller@1.0.0...@metamask/permission-controller@1.0.1
+[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/permission-controller@1.0.0

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/permission-controller",
-  "version": "4.0.0",
+  "version": "3.2.0",
   "description": "Mediates access to JSON-RPC methods, used to interact with pieces of the MetaMask stack, via middleware for json-rpc-engine",
   "keywords": [
     "MetaMask",

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/permission-controller",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Mediates access to JSON-RPC methods, used to interact with pieces of the MetaMask stack, via middleware for json-rpc-engine",
   "keywords": [
     "MetaMask",

--- a/packages/rate-limit-controller/CHANGELOG.md
+++ b/packages/rate-limit-controller/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.1]
 ### Changed
-- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
+- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
 
 ## [2.0.0]
 ### Removed
@@ -32,9 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/rate-limit-controller@2.0.1...HEAD
-[2.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/rate-limit-controller@2.0.0...@metamask/rate-limit-controller@2.0.1
-[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/rate-limit-controller@1.0.2...@metamask/rate-limit-controller@2.0.0
-[1.0.2]: https://github.com/MetaMask/core.git/compare/@metamask/rate-limit-controller@1.0.1...@metamask/rate-limit-controller@1.0.2
-[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/rate-limit-controller@1.0.0...@metamask/rate-limit-controller@1.0.1
-[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/rate-limit-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@2.0.1...HEAD
+[2.0.1]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@2.0.0...@metamask/rate-limit-controller@2.0.1
+[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@1.0.2...@metamask/rate-limit-controller@2.0.0
+[1.0.2]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@1.0.1...@metamask/rate-limit-controller@1.0.2
+[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@1.0.0...@metamask/rate-limit-controller@1.0.1
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/rate-limit-controller@1.0.0

--- a/packages/rate-limit-controller/CHANGELOG.md
+++ b/packages/rate-limit-controller/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1]
+### Uncategorized
+- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
+
 ## [2.0.0]
 ### Removed
 - **BREAKING:** Remove `isomorphic-fetch` ([#1106](https://github.com/MetaMask/controllers/pull/1106))
@@ -28,8 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@1.0.2...@metamask/rate-limit-controller@2.0.0
-[1.0.2]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@1.0.1...@metamask/rate-limit-controller@1.0.2
-[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@1.0.0...@metamask/rate-limit-controller@1.0.1
-[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/rate-limit-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/rate-limit-controller@2.0.1...HEAD
+[2.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/rate-limit-controller@2.0.0...@metamask/rate-limit-controller@2.0.1
+[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/rate-limit-controller@1.0.2...@metamask/rate-limit-controller@2.0.0
+[1.0.2]: https://github.com/MetaMask/core.git/compare/@metamask/rate-limit-controller@1.0.1...@metamask/rate-limit-controller@1.0.2
+[1.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/rate-limit-controller@1.0.0...@metamask/rate-limit-controller@1.0.1
+[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/rate-limit-controller@1.0.0

--- a/packages/rate-limit-controller/CHANGELOG.md
+++ b/packages/rate-limit-controller/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.1]
-### Uncategorized
-- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+### Changed
 - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
 
 ## [2.0.0]
@@ -19,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2]
 ### Changed
 - Rename this repository to `core` ([#1031](https://github.com/MetaMask/controllers/pull/1031))
-- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041)) 
+- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 
 ## [1.0.1]
 ### Changed

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rate-limit-controller",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Contains logic for rate-limiting API endpoints by requesting origin",
   "keywords": [
     "MetaMask",

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [4.1.0]
-### Uncategorized
-- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+### Changed
 - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
-- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core.git/pull/1199))
 - Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core.git/pull/1196))
 - Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core.git/pull/1147))
+
+### Removed
+- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core.git/pull/1199))
 
 ## [4.0.1]
 ### Changed
@@ -31,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING**: Drop Etherscan API support for Ropsten, Rinkeby, and Kovan ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 - Rename this repository to `core` ([#1031](https://github.com/MetaMask/controllers/pull/1031))
-- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041)) 
+- Update `@metamask/controller-utils` package ([#1041](https://github.com/MetaMask/controllers/pull/1041))
 
 ## [2.0.0]
 ### Changed

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0]
+### Uncategorized
+- Bump Jest to v27 ([#1198](https://github.com/MetaMask/core.git/pull/1198))
+- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
+- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core.git/pull/1199))
+- Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core.git/pull/1196))
+- Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core.git/pull/1147))
+
 ## [4.0.1]
 ### Changed
 - Use `NetworkType` enum for chain configuration ([#1132](https://github.com/MetaMask/core/pull/1132))
@@ -39,9 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@4.0.1...HEAD
-[4.0.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@4.0.0...@metamask/transaction-controller@4.0.1
-[4.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@3.0.0...@metamask/transaction-controller@4.0.0
-[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@2.0.0...@metamask/transaction-controller@3.0.0
-[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@1.0.0...@metamask/transaction-controller@2.0.0
-[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/transaction-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@4.1.0...HEAD
+[4.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@4.0.1...@metamask/transaction-controller@4.1.0
+[4.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@4.0.0...@metamask/transaction-controller@4.0.1
+[4.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@3.0.0...@metamask/transaction-controller@4.0.0
+[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@2.0.0...@metamask/transaction-controller@3.0.0
+[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@1.0.0...@metamask/transaction-controller@2.0.0
+[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/transaction-controller@1.0.0

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -6,17 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.1.0]
+## [5.0.0]
 ### Changed
+- **BREAKING**: deps: @metamask/network-controller@6.0.0->8.0.0 ([#1196](https://github.com/MetaMask/core/pull/1196))
+  - Replace `network` state with `networkId` and `networkStatus`
 - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
-- Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core/pull/1196))
 - Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core/pull/1147))
   - Previously this controller would get the next nonce by calling `eth_getTransactionCount` with a block reference of `pending`.  The next nonce would then be returned from our middleware (within `web3-provider-engine`).
   - Instead we're now using the nonce tracker to get the next nonce, dropping our reliance on this `eth_getTransactionCount` middleware. This will let us drop that middleware in a future update without impacting the transaction controller.
   - This should result in no functional changes, except that the nonce middleware is no longer required.
-
-### Removed
-- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core/pull/1199))
 
 ## [4.0.1]
 ### Changed

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
 - Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core/pull/1196))
 - Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core/pull/1147))
+  - Previously this controller would get the next nonce by calling `eth_getTransactionCount` with a block reference of `pending`.  The next nonce would then be returned from our middleware (within `web3-provider-engine`).
+  - Instead we're now using the nonce tracker to get the next nonce, dropping our reliance on this `eth_getTransactionCount` middleware. This will let us drop that middleware in a future update without impacting the transaction controller.
+  - This should result in no functional changes, except that the nonce middleware is no longer required.
 
 ### Removed
 - Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core/pull/1199))

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.0.0]
 ### Changed
 - **BREAKING**: peerDeps: @metamask/network-controller@6.0.0->8.0.0 ([#1196](https://github.com/MetaMask/core/pull/1196))
-  - Replace `network` state with `networkId` and `networkStatus`
 - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
 - Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core/pull/1147))
   - Previously this controller would get the next nonce by calling `eth_getTransactionCount` with a block reference of `pending`.  The next nonce would then be returned from our middleware (within `web3-provider-engine`).

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -48,8 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@4.1.0...HEAD
-[4.1.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@4.0.1...@metamask/transaction-controller@4.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@5.0.0...HEAD
+[5.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@4.0.1...@metamask/transaction-controller@5.0.0
 [4.0.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@4.0.0...@metamask/transaction-controller@4.0.1
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@3.0.0...@metamask/transaction-controller@4.0.0
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@2.0.0...@metamask/transaction-controller@3.0.0

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.0.0]
 ### Changed
-- **BREAKING**: deps: @metamask/network-controller@6.0.0->8.0.0 ([#1196](https://github.com/MetaMask/core/pull/1196))
+- **BREAKING**: peerDeps: @metamask/network-controller@6.0.0->8.0.0 ([#1196](https://github.com/MetaMask/core/pull/1196))
   - Replace `network` state with `networkId` and `networkStatus`
 - deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
 - Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core/pull/1147))

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -8,12 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.1.0]
 ### Changed
-- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core.git/pull/1215))
-- Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core.git/pull/1196))
-- Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core.git/pull/1147))
+- deps: eth-rpc-errors@4.0.0->4.0.2 ([#1215](https://github.com/MetaMask/core/pull/1215))
+- Replace `network` state with `networkId` and `networkStatus` ([#1196](https://github.com/MetaMask/core/pull/1196))
+- Add nonce tracker to transactions controller ([#1147](https://github.com/MetaMask/core/pull/1147))
 
 ### Removed
-- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core.git/pull/1199))
+- Remove `isCustomNetwork` ([#1199](https://github.com/MetaMask/core/pull/1199))
 
 ## [4.0.1]
 ### Changed
@@ -48,10 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@4.1.0...HEAD
-[4.1.0]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@4.0.1...@metamask/transaction-controller@4.1.0
-[4.0.1]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@4.0.0...@metamask/transaction-controller@4.0.1
-[4.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@3.0.0...@metamask/transaction-controller@4.0.0
-[3.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@2.0.0...@metamask/transaction-controller@3.0.0
-[2.0.0]: https://github.com/MetaMask/core.git/compare/@metamask/transaction-controller@1.0.0...@metamask/transaction-controller@2.0.0
-[1.0.0]: https://github.com/MetaMask/core.git/releases/tag/@metamask/transaction-controller@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@4.1.0...HEAD
+[4.1.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@4.0.1...@metamask/transaction-controller@4.1.0
+[4.0.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@4.0.0...@metamask/transaction-controller@4.0.1
+[4.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@3.0.0...@metamask/transaction-controller@4.0.0
+[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@2.0.0...@metamask/transaction-controller@3.0.0
+[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@1.0.0...@metamask/transaction-controller@2.0.0
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/transaction-controller@1.0.0

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Description

Release outstanding changes before bump to nodejs v16.

## Changes
### approval-controller
- 975a8c98 deps: eth-rpc-errors@4.0.0->4.0.2 (#1215)

### controller-utils
- d94a7029 add WalletConnect in approval type (#1240)

### ens-controller
- 7d5057b4 Merge extension ens controller (#1170)

### keyring-controller
- db046ee0 Stub PreferencesController in KeyringController tests (#1194)
- 99df8b57 add rollbackToPreviousProvider method (#1132)

### message-manager
- ced8c3c4 fix: prevent setResult to emit updateBadge but state updates (#1245)
- af9bb3c5 fix changelog (#1232)

### network-controller
- bd29cbc4 Make `rollbackToPreviousProvider` async (#1237)
- 11376760 Make `resetConnection` async (#1239)
- 383bcea2 Update EIP-1559 compatibility during network lookup (#1236)
- 360796a5 Refresh network when connection is reset (#1235)
- d7707a30 deps: bump web3-provider-engine@16.0.3->16.0.5 (#1212)
- 21e2a265 Simplify `setProviderType` unit tests (#1222)
- 68447061 Consolidate `setProviderType` unit tests (#1221)
- 975a8c98 deps: eth-rpc-errors@4.0.0->4.0.2 (#1215)
- eca9f254 deps: bump @metamask/utils to 5.0.1 (#1211)
- c8c9f389 Remove `isCustomNetwork` (#1199)
- d73498e4 Replace `network` state with `networkId` and `networkStatus` (#1196)
- aa00fae1 Make `upsertNetworkConfiguration` async (#1192)
- 7dc2b3dd Make network controller internal fields private (#1189)
- 269f4af3 Make `setActiveNetwork` async (#1190)
- 4ce47cae Make `setProviderType` async (#1191)
- 1d885651 Make `refreshNetwork` async (#1182)
- 364e2295 Make `initializeProvider` async (#1180)
- 5f1106ec Make `verifyNetwork` async (#1181)
- e8979627 Eliminate console error when running test (#1179)
- 49a502b7 Fix test description (#1175)
- e64e1817 Add nonce tracker to transactions controller (#1147)
- cb43d9e5 Implement resetConnection method in network controller (#1131)

### permission-controller
- b7f8a522 Restrict certain permissions by subject type (#1233)
- f5a16837 BREAKING: Move `SubjectMetadataController` to permission-controller package (#1234)
- 975a8c98 deps: eth-rpc-errors@4.0.0->4.0.2 (#1215)

### rate-limit-controller
- 975a8c98 deps: eth-rpc-errors@4.0.0->4.0.2 (#1215)

### transaction-controller
- 975a8c98 deps: eth-rpc-errors@4.0.0->4.0.2 (#1215)
- c8c9f389 Remove `isCustomNetwork` (#1199)
- d73498e4 Replace `network` state with `networkId` and `networkStatus` (#1196)
- e64e1817 Add nonce tracker to transactions controller (#1147)

## References


#1262