### PR TITLE
Add handling of Infura "blocked" status

### DIFF
--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -1,13 +1,25 @@
 /**
- * Human-readable network name
+ * The names of built-in Infura networks
  */
-export enum NetworkType {
-  localhost = 'localhost',
-  mainnet = 'mainnet',
-  goerli = 'goerli',
-  sepolia = 'sepolia',
-  rpc = 'rpc',
-}
+export const InfuraNetworkType = {
+  mainnet: 'mainnet',
+  goerli: 'goerli',
+  sepolia: 'sepolia',
+} as const;
+
+export type InfuraNetworkType =
+  typeof InfuraNetworkType[keyof typeof InfuraNetworkType];
+
+/**
+ * The "network type"; either the name of a built-in network, or "rpc" for custom networks.
+ */
+export const NetworkType = {
+  ...InfuraNetworkType,
+  localhost: 'localhost',
+  rpc: 'rpc',
+} as const;
+
+export type NetworkType = typeof NetworkType[keyof typeof NetworkType];
 
 /**
  * A helper to determine whether a given input is NetworkType.

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -15,6 +15,7 @@ import {
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
 import {
+  InfuraNetworkType,
   NetworksChainId,
   NetworkType,
   isSafeChainId,
@@ -22,9 +23,16 @@ import {
   isNetworkType,
   BUILT_IN_NETWORKS,
 } from '@metamask/controller-utils';
-import { assert, assertIsStrictHexString, hasProperty } from '@metamask/utils';
+import {
+  assert,
+  assertIsStrictHexString,
+  hasProperty,
+  isPlainObject,
+} from '@metamask/utils';
+import { INFURA_BLOCKED_KEY, NetworkStatus } from './constants';
+import { projectLogger, createModuleLogger } from './logger';
 
-import { NetworkStatus } from './constants';
+const log = createModuleLogger(projectLogger, 'NetworkController');
 
 /**
  * @type ProviderConfig
@@ -100,6 +108,18 @@ function isErrorWithCode(error: unknown): error is { code: string | number } {
 }
 
 /**
+ * Returns whether the given argument is a type that our Infura middleware
+ * recognizes.
+ *
+ * @param type - A type to compare.
+ * @returns True or false, depending on whether the given type is one that our
+ * Infura middleware recognizes.
+ */
+function isInfuraProviderType(type: string): type is InfuraNetworkType {
+  return Object.keys(InfuraNetworkType).includes(type);
+}
+
+/**
  * The network ID of a network.
  */
 export type NetworkId = `${number}`;
@@ -143,9 +163,31 @@ export type NetworkControllerProviderConfigChangeEvent = {
   payload: [ProviderConfig];
 };
 
+/**
+ * `infuraIsBlocked` is published after the network is switched to an Infura
+ * network, but when Infura returns an error blocking the user based on their
+ * location.
+ */
+export type NetworkControllerInfuraIsBlockedEvent = {
+  type: 'NetworkController:infuraIsBlocked';
+  payload: [];
+};
+
+/**
+ * `infuraIsBlocked` is published either after the network is switched to an
+ * Infura network and Infura does not return an error blocking the user based on
+ * their location, or the network is switched to a non-Infura network.
+ */
+export type NetworkControllerInfuraIsUnblockedEvent = {
+  type: 'NetworkController:infuraIsUnblocked';
+  payload: [];
+};
+
 export type NetworkControllerEvents =
   | NetworkControllerStateChangeEvent
-  | NetworkControllerProviderConfigChangeEvent;
+  | NetworkControllerProviderConfigChangeEvent
+  | NetworkControllerInfuraIsBlockedEvent
+  | NetworkControllerInfuraIsUnblockedEvent;
 
 export type NetworkControllerGetProviderConfigAction = {
   type: `NetworkController:getProviderConfig`;
@@ -164,8 +206,7 @@ export type NetworkControllerActions =
 export type NetworkControllerMessenger = RestrictedControllerMessenger<
   typeof name,
   NetworkControllerGetProviderConfigAction | NetworkControllerGetEthQueryAction,
-  | NetworkControllerStateChangeEvent
-  | NetworkControllerProviderConfigChangeEvent,
+  NetworkControllerEvents,
   string,
   string
 >;
@@ -444,14 +485,22 @@ export class NetworkController extends BaseControllerV2<
    * available, updates the network state with the network ID of the network and
    * stores whether the network supports EIP-1559; otherwise clears said
    * information about the network that may have been previously stored.
+   *
+   * @fires infuraIsBlocked if the network is Infura-supported and is blocking
+   * requests.
+   * @fires infuraIsUnblocked if the network is Infura-supported and is not
+   * blocking requests, or if the network is not Infura-supported.
    */
   async lookupNetwork() {
     if (!this.#ethQuery) {
       return;
     }
+    const isInfura = isInfuraProviderType(this.state.providerConfig.type);
     const releaseLock = await this.#mutex.acquire();
 
     try {
+      let updatedNetworkStatus: NetworkStatus;
+      let updatedNetworkId: NetworkId | null = null;
       try {
         const [networkId] = await Promise.all([
           this.#getNetworkId(),
@@ -460,20 +509,55 @@ export class NetworkController extends BaseControllerV2<
         if (this.state.networkId === networkId) {
           return;
         }
-
-        this.update((state) => {
-          state.networkId = networkId;
-          state.networkStatus = NetworkStatus.Available;
-        });
+        updatedNetworkStatus = NetworkStatus.Available;
+        updatedNetworkId = networkId;
       } catch (error) {
-        const networkStatus =
-          isErrorWithCode(error) && error.code !== errorCodes.rpc.internal
-            ? NetworkStatus.Unavailable
-            : NetworkStatus.Unknown;
-        this.update((state) => {
-          state.networkId = null;
-          state.networkStatus = networkStatus;
-        });
+        if (isErrorWithCode(error)) {
+          let responseBody;
+          if (
+            isInfura &&
+            hasProperty(error, 'message') &&
+            typeof error.message === 'string'
+          ) {
+            try {
+              responseBody = JSON.parse(error.message);
+            } catch {
+              // error.message must not be JSON
+            }
+          }
+
+          if (
+            isPlainObject(responseBody) &&
+            responseBody.error === INFURA_BLOCKED_KEY
+          ) {
+            updatedNetworkStatus = NetworkStatus.Blocked;
+          } else if (error.code === errorCodes.rpc.internal) {
+            updatedNetworkStatus = NetworkStatus.Unknown;
+          } else {
+            updatedNetworkStatus = NetworkStatus.Unavailable;
+          }
+        } else {
+          log('NetworkController - could not determine network status', error);
+          updatedNetworkStatus = NetworkStatus.Unknown;
+        }
+      }
+
+      this.update((state) => {
+        state.networkId = updatedNetworkId;
+        state.networkStatus = updatedNetworkStatus;
+      });
+
+      if (isInfura) {
+        if (updatedNetworkStatus === NetworkStatus.Available) {
+          this.messagingSystem.publish('NetworkController:infuraIsUnblocked');
+        } else if (updatedNetworkStatus === NetworkStatus.Blocked) {
+          this.messagingSystem.publish('NetworkController:infuraIsBlocked');
+        }
+      } else {
+        // Always publish infuraIsUnblocked regardless of network status to
+        // prevent consumers from being stuck in a blocked state if they were
+        // previously connected to an Infura network that was blocked
+        this.messagingSystem.publish('NetworkController:infuraIsUnblocked');
       }
 
       this.messagingSystem.publish(

--- a/packages/network-controller/src/constants.ts
+++ b/packages/network-controller/src/constants.ts
@@ -17,4 +17,12 @@ export enum NetworkStatus {
    * reasons.
    */
   Unavailable = 'unavailable',
+  /**
+   * The network is not only unavailable, but is also inaccessible for the user
+   * specifically based on their location. This state only applies to Infura
+   * networks.
+   */
+  Blocked = 'blocked',
 }
+
+export const INFURA_BLOCKED_KEY = 'countryBlocked';

--- a/packages/network-controller/src/logger.ts
+++ b/packages/network-controller/src/logger.ts
@@ -1,0 +1,5 @@
+import { createProjectLogger, createModuleLogger } from '@metamask/utils';
+
+export const projectLogger = createProjectLogger('network-controller');
+
+export { createModuleLogger };


### PR DESCRIPTION
## Description

The network controller has been updated to detect when connecting to an Infura network fails due to the user being blocked. A new status has been added to reflect this state, and two events have been added (one for when a user is blocked, and one for when they are unblocked).

This status and these events are used by the extension to better explain why the network is not working in this scenario.

## Changes

- **BREAKING:** The network status will now be "blocked" rather than "unavailable" when the user is blocked by Infura
- ADDED: The events "infuraIsBlocked" and "infuraIsUnblocked" have been added

## References

Fixes #1200

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
