### PR TITLE
Remove duplicate `hasProperty` function

### DIFF
--- a/packages/controller-utils/src/util.test.ts
+++ b/packages/controller-utils/src/util.test.ts
@@ -525,16 +525,6 @@ describe('util', () => {
     });
   });
 
-  describe('hasProperty', () => {
-    it('returns false for non existing properties', () => {
-      expect(util.hasProperty({ foo: 'bar' }, 'property')).toBe(false);
-    });
-
-    it('returns true for existing properties', () => {
-      expect(util.hasProperty({ foo: 'bar' }, 'foo')).toBe(true);
-    });
-  });
-
   describe('isNonEmptyArray', () => {
     it('returns false non arrays', () => {
       // @ts-expect-error Invalid type for testing purposes

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -475,11 +475,6 @@ export function isPlainObject(value: unknown): value is PlainObject {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
-export const hasProperty = (
-  object: PlainObject,
-  key: string | number | symbol,
-) => Reflect.hasOwnProperty.call(object, key);
-
 /**
  * Like {@link Array}, but always non-empty.
  *

--- a/packages/ens-controller/src/EnsController.ts
+++ b/packages/ens-controller/src/EnsController.ts
@@ -7,14 +7,13 @@ import {
   ExternalProvider,
   JsonRpcFetchFunc,
 } from '@ethersproject/providers';
-import { createProjectLogger } from '@metamask/utils';
+import { createProjectLogger, hasProperty } from '@metamask/utils';
 import {
   normalizeEnsName,
   isValidHexAddress,
   toChecksumHexAddress,
   NETWORK_ID_TO_ETHERS_NETWORK_NAME_MAP,
   convertHexToDecimal,
-  hasProperty,
 } from '@metamask/controller-utils';
 import { toASCII } from 'punycode/';
 import ensNetworkMap from 'ethereum-ens-network-map';

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "workspace:^",
-    "@metamask/controller-utils": "workspace:^",
+    "@metamask/utils": "^5.0.2",
     "immer": "^9.0.6",
     "nanoid": "^3.1.31"
   },

--- a/packages/notification-controller/src/NotificationController.ts
+++ b/packages/notification-controller/src/NotificationController.ts
@@ -1,6 +1,6 @@
 import type { Patch } from 'immer';
 import { nanoid } from 'nanoid';
-import { hasProperty } from '@metamask/controller-utils';
+import { hasProperty } from '@metamask/utils';
 import {
   BaseControllerV2,
   RestrictedControllerMessenger,

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -33,6 +33,7 @@
     "@metamask/base-controller": "workspace:^",
     "@metamask/controller-utils": "workspace:^",
     "@metamask/types": "^1.1.0",
+    "@metamask/utils": "^5.0.2",
     "@types/deep-freeze-strict": "^1.1.0",
     "deep-freeze-strict": "^1.1.1",
     "eth-rpc-errors": "^4.0.2",

--- a/packages/permission-controller/src/Caveat.ts
+++ b/packages/permission-controller/src/Caveat.ts
@@ -1,5 +1,5 @@
 import { Json } from '@metamask/types';
-import { hasProperty } from '@metamask/controller-utils';
+import { hasProperty } from '@metamask/utils';
 import {
   CaveatSpecificationMismatchError,
   UnrecognizedCaveatTypeError,

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -7,7 +7,8 @@ import {
   RejectRequest as RejectApprovalRequest,
 } from '@metamask/approval-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
-import { Json, hasProperty, isPlainObject } from '@metamask/controller-utils';
+import { hasProperty } from '@metamask/utils';
+import { Json, isPlainObject } from '@metamask/controller-utils';
 import { GetSubjectMetadata, SubjectType } from './SubjectMetadataController';
 import * as errors from './errors';
 import { EndowmentGetterParams } from './Permission';

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -4,6 +4,7 @@ import deepFreeze from 'deep-freeze-strict';
 import { castDraft, Draft, Patch } from 'immer';
 import { nanoid } from 'nanoid';
 import { EthereumRpcError } from 'eth-rpc-errors';
+import { hasProperty } from '@metamask/utils';
 import {
   AcceptRequest as AcceptApprovalRequest,
   AddApprovalRequest,
@@ -18,7 +19,6 @@ import {
   EventConstraint,
 } from '@metamask/base-controller';
 import {
-  hasProperty,
   isNonEmptyArray,
   isPlainObject,
   isValidJson,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,7 +1775,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:^"
-    "@metamask/controller-utils": "workspace:^"
+    "@metamask/utils": ^5.0.2
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     immer: ^9.0.6
@@ -1807,6 +1807,7 @@ __metadata:
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
     "@metamask/types": ^1.1.0
+    "@metamask/utils": ^5.0.2
     "@types/deep-freeze-strict": ^1.1.0
     "@types/jest": ^27.4.1
     deep-freeze-strict: ^1.1.1


### PR DESCRIPTION
## Description

The `hasProperty` function in `@metamask/controller-utils` has been removed. Instead the `hasProperty` function from `@metamask/utils` is now used in its place. The `@metamask/utils` version of this function is functionally identical but has a better type signature.

## Changes

- **BREAKING:** Remove the `hasProperty` function

## References

Relates to #1204

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
