### PR TITLE
Require Infura project ID

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -37,6 +37,7 @@ const setupControllers = () => {
       allowedActions: [],
     });
   const network = new NetworkController({
+    infuraProjectId: 'infura-project-id',
     messenger,
     trackMetaMetricsEvent: jest.fn(),
   });

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -216,7 +216,11 @@ describe('TokenRatesController', () => {
   });
 
   it('should update all rates', async () => {
-    new NetworkController({ messenger, trackMetaMetricsEvent: jest.fn() });
+    new NetworkController({
+      infuraProjectId: 'infura-project-id',
+      messenger,
+      trackMetaMetricsEvent: jest.fn(),
+    });
     const preferences = new PreferencesController();
     const tokensController = new TokensController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -173,7 +173,7 @@ export type NetworkControllerMessenger = RestrictedControllerMessenger<
 export type NetworkControllerOptions = {
   messenger: NetworkControllerMessenger;
   trackMetaMetricsEvent: () => void;
-  infuraProjectId?: string;
+  infuraProjectId: string;
   state?: Partial<NetworkState>;
 };
 
@@ -213,7 +213,7 @@ export class NetworkController extends BaseControllerV2<
 > {
   #ethQuery: EthQuery;
 
-  #infuraProjectId: string | undefined;
+  #infuraProjectId: string;
 
   #trackMetaMetricsEvent: (event: MetaMetricsEventPayload) => void;
 
@@ -260,6 +260,9 @@ export class NetworkController extends BaseControllerV2<
       messenger,
       state: { ...defaultState, ...state },
     });
+    if (!infuraProjectId || typeof infuraProjectId !== 'string') {
+      throw new Error('Invalid Infura project ID');
+    }
     this.#infuraProjectId = infuraProjectId;
     this.#trackMetaMetricsEvent = trackMetaMetricsEvent;
     this.messagingSystem.registerActionHandler(

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -162,6 +162,35 @@ describe('NetworkController', () => {
         },
       );
     });
+
+    it('throws if the infura project ID is missing', async () => {
+      const messenger = buildMessenger();
+
+      expect(
+        () =>
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          new NetworkController({
+            messenger,
+            trackMetaMetricsEvent: jest.fn(),
+          }),
+      ).toThrow('Invalid Infura project ID');
+    });
+
+    it('throws if the infura project ID is not a string', async () => {
+      const messenger = buildMessenger();
+
+      expect(
+        () =>
+          new NetworkController({
+            messenger,
+            trackMetaMetricsEvent: jest.fn(),
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            infuraProjectId: 10,
+          }),
+      ).toThrow('Invalid Infura project ID');
+    });
   });
 
   describe('initializeProvider', () => {
@@ -235,7 +264,6 @@ describe('NetworkController', () => {
                     type: networkType,
                   }),
                 },
-                infuraProjectId: 'infura-project-id',
               },
               async ({ controller }) => {
                 const fakeInfuraProvider = buildFakeInfuraProvider();
@@ -273,7 +301,6 @@ describe('NetworkController', () => {
                         type: networkType,
                       }),
                     },
-                    infuraProjectId: 'infura-project-id',
                   },
                   async ({ controller }) => {
                     const fakeInfuraProvider = buildFakeInfuraProvider();
@@ -351,7 +378,6 @@ describe('NetworkController', () => {
                         type: networkType,
                       }),
                     },
-                    infuraProjectId: 'infura-project-id',
                   },
                   async ({ controller }) => {
                     const fakeInfuraProvider = buildFakeInfuraProvider();
@@ -3325,7 +3351,6 @@ describe('NetworkController', () => {
                     chainId: '0x9999999',
                   },
                 },
-                infuraProjectId: 'infura-project-id',
               },
               async ({ controller }) => {
                 const fakeInfuraProvider = buildFakeInfuraProvider();
@@ -5673,6 +5698,7 @@ async function withController<ReturnValue>(
   const controller = new NetworkController({
     messenger,
     trackMetaMetricsEvent: jest.fn(),
+    infuraProjectId: 'infura-project-id',
     ...rest,
   });
   try {


### PR DESCRIPTION
## Description

The network controller now requires an Infura project ID to be provided upon construction. This brings the network controller more in-line with the extension. Runtime validation has been added for the sake of making the merge with the extension network controller easier.

## Changes

### `@metamask/network-controller`

- **BREAKING:** The `infuraProjectId` constructor parameter is now required

## References

Closes #1201

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
