### PR TITLE
Correctly lint test helpers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,8 +11,22 @@ module.exports = {
   ],
   overrides: [
     {
-      files: ['*.test.ts', '*.test.js'],
+      files: ['*.test.{ts,js}', '**/tests/**/*.{ts,js}'],
       extends: ['@metamask/eslint-config-jest'],
+    },
+    {
+      // These files are test helpers, not tests. We still use the Jest ESLint
+      // config here to ensure that ESLint expects a test-like environment, but
+      // various rules meant just to apply to tests have been disabled.
+      files: ['**/tests/**/*.{ts,js}', '!*.test.{ts,js}'],
+      rules: {
+        'jest/no-export': 'off',
+        'jest/require-top-level-describe': 'off',
+        'jest/no-if': 'off',
+        'jest/no-test-return-statement': 'off',
+        // TODO: Re-enable this rule; we can accomodate this even in our test helpers
+        'jest/expect-expect': 'off',
+      },
     },
     {
       files: ['*.js'],

--- a/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-loop-func */
 import {
   ProviderType,
   waitForNextBlockTracker,

--- a/packages/network-controller/tests/provider-api-tests/block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-param.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-loop-func */
 import {
   buildMockParams,
   buildRequestWithReplacedBlockParam,

--- a/packages/network-controller/tests/provider-api-tests/no-block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/no-block-param.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-loop-func */
-
 import {
   MockCommunications,
   ProviderType,

--- a/packages/network-controller/tests/provider-api-tests/shared-tests.ts
+++ b/packages/network-controller/tests/provider-api-tests/shared-tests.ts
@@ -1,5 +1,3 @@
-/* eslint-disable jest/require-top-level-describe, jest/no-export, jest/no-identical-title, jest/no-if */
-
 import { NetworkType } from '@metamask/controller-utils';
 import { testsForRpcMethodsThatCheckForBlockHashInResponse } from './block-hash-in-response';
 import { testsForRpcMethodSupportingBlockParam } from './block-param';

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -6,13 +6,13 @@ const originalSetTimeout = global.setTimeout;
  * times) until it returns a value.
  *
  * @param expectedValue - The value that the function should return.
- * @param test - The function to call.
+ * @param operation - The function to call.
  * @returns A promise that either resolves to a successful result as soon as it
  * returns the expected value, or a failure result if that never happens.
  */
 export async function waitForResult(
   expectedValue: any,
-  test: () => any,
+  operation: () => any,
 ): Promise<{ pass: boolean; lastActualValue?: any }> {
   const approximateRunTime = 10000;
   const intervalBetweenRetries = 25;
@@ -22,7 +22,7 @@ export async function waitForResult(
   let lastActualValue: any;
 
   while (numIterations < maxNumIterations) {
-    const actualValue = test();
+    const actualValue = operation();
     if (actualValue === expectedValue) {
       return { pass: true };
     }


### PR DESCRIPTION
## Description

Our test helper modules have been covered by ESLint as though they were production code. This resulted in misleading coverage statistics and various erronous lint errors (which we've handled by disabling rules in affected files).

The ESLint configuration has been updated to consider any modules under a `tests` directory to be test helpers.

## Changes

None

## References

This helps reduce the scope of #1116


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
