### PR TITLE
Remove unnecessary internal provider property

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -221,8 +221,6 @@ export class NetworkController extends BaseControllerV2<
 
   #previousNetworkSpecifier: NetworkType | NetworkConfigurationId | null;
 
-  #provider: Provider | undefined;
-
   #providerProxy: ProviderProxy | undefined;
 
   #blockTrackerProxy: BlockTrackerProxy | undefined;
@@ -379,7 +377,7 @@ export class NetworkController extends BaseControllerV2<
   }
 
   #updateProvider(provider: Provider) {
-    this.#safelyStopProvider(this.#provider);
+    this.#safelyStopProvider();
     assert(
       hasProperty(provider, '_blockTracker'),
       'Provider is missing block tracker.',
@@ -391,9 +389,9 @@ export class NetworkController extends BaseControllerV2<
     this.#registerProvider();
   }
 
-  #safelyStopProvider(provider: Provider | undefined) {
+  #safelyStopProvider() {
     setTimeout(() => {
-      provider?.stop();
+      this.#providerProxy?.stop();
     }, 500);
   }
 
@@ -608,7 +606,6 @@ export class NetworkController extends BaseControllerV2<
     } else {
       this.#providerProxy = createEventEmitterProxy(provider);
     }
-    this.#provider = provider;
 
     if (this.#blockTrackerProxy) {
       this.#blockTrackerProxy.setTarget(blockTracker);


### PR DESCRIPTION
## Description

The network controller internal `#provider` property has been removed. This was only used in one place, and was easily replaced by the provider proxy.


## Changes

None

## References

This helps reduce the scope of #1116

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
