### PR TITLE
Extract network client construction from NetworkController

### DIFF
--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -1,13 +1,31 @@
 /**
- * Human-readable network name
+ * Ethereum networks that can be used to create an Infura network client.
  */
-export enum NetworkType {
-  localhost = 'localhost',
-  mainnet = 'mainnet',
-  goerli = 'goerli',
-  sepolia = 'sepolia',
-  rpc = 'rpc',
-}
+export const InfuraNetworkType = {
+  mainnet: 'mainnet',
+  goerli: 'goerli',
+  sepolia: 'sepolia',
+} as const;
+
+/**
+ * Ethereum networks that can be used to create an Infura network client.
+ */
+export type InfuraNetworkType =
+  typeof InfuraNetworkType[keyof typeof InfuraNetworkType];
+
+/**
+ * Networks that can be used to create a network client.
+ */
+export const NetworkType = {
+  ...InfuraNetworkType,
+  localhost: 'localhost',
+  rpc: 'rpc',
+} as const;
+
+/**
+ * Networks that can be used to create a network client.
+ */
+export type NetworkType = typeof NetworkType[keyof typeof NetworkType];
 
 /**
  * A helper to determine whether a given input is NetworkType.

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -1,6 +1,5 @@
 /**
- * The names of built-in Infura-supported networks that can be used to create an
- * Infura-specific network client.
+ * The names of built-in Infura networks
  */
 export const InfuraNetworkType = {
   mainnet: 'mainnet',
@@ -8,17 +7,11 @@ export const InfuraNetworkType = {
   sepolia: 'sepolia',
 } as const;
 
-/**
- * The name of a built-in Infura-supported network that can be used to create an
- * Infura-specific network client.
- */
 export type InfuraNetworkType =
   typeof InfuraNetworkType[keyof typeof InfuraNetworkType];
 
 /**
- * Symbols that can be used to create a network client: either names of
- * built-in Infura-supported networks, "localhost" for a locally operated custom network,
- * or "rpc" for a remotely operated custom network.
+ * The "network type"; either the name of a built-in network, or "rpc" for custom networks.
  */
 export const NetworkType = {
   ...InfuraNetworkType,
@@ -26,11 +19,6 @@ export const NetworkType = {
   rpc: 'rpc',
 } as const;
 
-/**
- * A symbol that can be used to create a network client: either names of
- * built-in Infura-supported networks, "localhost" for a locally operated custom
- * network, or "rpc" for a remotely operated custom network.
- */
 export type NetworkType = typeof NetworkType[keyof typeof NetworkType];
 
 /**

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -45,10 +45,13 @@
   "devDependencies": {
     "@json-rpc-specification/meta-schema": "^1.0.6",
     "@metamask/auto-changelog": "^3.1.0",
+    "@metamask/eth-json-rpc-provider": "^1.0.0",
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.191",
     "deepmerge": "^4.2.2",
+    "eth-block-tracker": "^7.0.1",
     "jest": "^27.5.1",
+    "json-rpc-engine": "^6.1.0",
     "lodash": "^4.17.21",
     "nock": "^13.0.7",
     "sinon": "^9.2.4",

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -19,7 +19,6 @@ import {
   isNetworkType,
 } from '@metamask/controller-utils';
 import {
-  assert,
   assertIsStrictHexString,
   hasProperty,
   isPlainObject,

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -1,0 +1,104 @@
+import Subprovider from 'web3-provider-engine/subproviders/provider';
+import createInfuraProvider from 'eth-json-rpc-infura/src/createProvider';
+import createMetamaskProvider from 'web3-provider-engine/zero';
+import { InfuraNetworkType } from '@metamask/controller-utils';
+import { assert, hasProperty } from '@metamask/utils';
+import type { BlockTracker, Provider } from './types';
+
+/**
+ * The type of network client that can be created.
+ */
+export enum NetworkClientType {
+  Custom = 'custom',
+  Infura = 'infura',
+}
+
+/**
+ * A configuration object that can be used to create a provider engine for a
+ * custom network.
+ */
+type CustomNetworkConfiguration = {
+  chainId?: string;
+  rpcUrl: string;
+  nickname?: string;
+  ticker?: string;
+  type: NetworkClientType.Custom;
+};
+
+/**
+ * A configuration object that can be used to create a provider engine for an
+ * Infura network.
+ */
+type InfuraNetworkConfiguration = {
+  network: InfuraNetworkType;
+  infuraProjectId: string;
+  type: NetworkClientType.Infura;
+};
+
+/**
+ * Create a JSON-RPC network client for a specific network.
+ *
+ * @param networkConfig - The network configuration.
+ * @returns The network client.
+ */
+export function createNetworkClient(
+  networkConfig: CustomNetworkConfiguration | InfuraNetworkConfiguration,
+): { provider: Provider; blockTracker: BlockTracker } {
+  const providerConfig =
+    networkConfig.type === NetworkClientType.Infura
+      ? buildInfuraNetworkProviderConfig(networkConfig)
+      : buildCustomNetworkProviderConfig(networkConfig);
+
+  // Cast needed because the `web3-provider-engine` type for `sendAsync`
+  // incorrectly suggests that an array is accepted as the first parameter
+  // of `sendAsync`. This (along with the bad type) will go away when we replace
+  // `web3-provider-engine`.
+  const provider = createMetamaskProvider(providerConfig) as Provider;
+
+  assert(
+    hasProperty(provider, '_blockTracker'),
+    'Provider is missing block tracker.',
+  );
+
+  return { provider, blockTracker: provider._blockTracker };
+}
+
+/**
+ * Construct the configuration object for a provider engine that can be used to
+ * interface with an Infura network.
+ *
+ * @param networkConfig - Network configuration.
+ * @returns The complete provider engine configuration object.
+ */
+function buildInfuraNetworkProviderConfig(
+  networkConfig: InfuraNetworkConfiguration,
+) {
+  const infuraProvider = createInfuraProvider({
+    network: networkConfig.network,
+    projectId: networkConfig.infuraProjectId,
+  });
+  const infuraSubprovider = new Subprovider(infuraProvider);
+  return {
+    dataSubprovider: infuraSubprovider,
+    engineParams: {
+      blockTrackerProvider: infuraProvider,
+      pollingInterval: 12000,
+    },
+  };
+}
+
+/**
+ * Construct the configuration object for a provider engine that can be used to
+ * interface with a custom network.
+ *
+ * @param networkConfig - Network configuration.
+ * @returns The complete provider engine configuration object.
+ */
+function buildCustomNetworkProviderConfig(
+  networkConfig: CustomNetworkConfiguration,
+) {
+  return {
+    ...networkConfig,
+    engineParams: { pollingInterval: 12000 },
+  };
+}

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -49,11 +49,7 @@ export function createNetworkClient(
       ? buildInfuraNetworkProviderConfig(networkConfig)
       : buildCustomNetworkProviderConfig(networkConfig);
 
-  // Cast needed because the `web3-provider-engine` type for `sendAsync`
-  // incorrectly suggests that an array is accepted as the first parameter
-  // of `sendAsync`. This (along with the bad type) will go away when we replace
-  // `web3-provider-engine`.
-  const provider = createMetamaskProvider(providerConfig) as Provider;
+  const provider = createMetamaskProvider(providerConfig);
 
   assert(
     hasProperty(provider, '_blockTracker'),

--- a/packages/network-controller/src/index.ts
+++ b/packages/network-controller/src/index.ts
@@ -1,2 +1,3 @@
 export * from './NetworkController';
 export * from './constants';
+export type { Provider } from './types';

--- a/packages/network-controller/src/types.ts
+++ b/packages/network-controller/src/types.ts
@@ -1,6 +1,5 @@
-import type EventEmitter from 'events';
-import type { Provider as EthQueryProvider } from 'eth-query';
+import type { ProviderEngine } from 'web3-provider-engine';
 
-export type Provider = EventEmitter & EthQueryProvider & { stop: () => void };
+export type Provider = ProviderEngine;
 
 export type BlockTracker = any;

--- a/packages/network-controller/src/types.ts
+++ b/packages/network-controller/src/types.ts
@@ -1,0 +1,6 @@
+import type EventEmitter from 'events';
+import type { Provider as EthQueryProvider } from 'eth-query';
+
+export type Provider = EventEmitter & EthQueryProvider & { stop: () => void };
+
+export type BlockTracker = any;

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -26,7 +26,7 @@ import {
   NetworkState,
   ProviderConfig,
 } from '../src/NetworkController';
-import type { Provider } from '../src/NetworkController';
+import type { Provider } from '../src/types';
 import { NetworkStatus } from '../src/constants';
 import { BUILT_IN_NETWORKS } from '../../controller-utils/src/constants';
 import { FakeProviderEngine, FakeProviderStub } from './fake-provider-engine';

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -903,6 +903,7 @@ describe('NetworkController', () => {
             async ({ controller }) => {
               const fakeProvider = buildFakeProvider();
               const fakeNetworkClient = buildFakeClient(fakeProvider);
+              createNetworkClientMock.mockReturnValue(fakeNetworkClient);
 
               await controller.initializeProvider();
 
@@ -3621,6 +3622,7 @@ describe('NetworkController', () => {
         await withController(async ({ controller }) => {
           const fakeProvider = buildFakeProvider();
           const fakeNetworkClient = buildFakeClient(fakeProvider);
+          createNetworkClientMock.mockReturnValue(fakeNetworkClient);
 
           await controller.setProviderType(NetworkType.rpc);
 

--- a/packages/network-controller/tests/create-network-client.test.ts
+++ b/packages/network-controller/tests/create-network-client.test.ts
@@ -1,0 +1,7 @@
+import { NetworkClientType } from '../src/create-network-client';
+import { testsForProviderType } from './provider-api-tests/shared-tests';
+
+describe('createNetworkClient', () => {
+  testsForProviderType(NetworkClientType.Infura);
+  testsForProviderType(NetworkClientType.Custom);
+});

--- a/packages/network-controller/tests/customNetworkClient.test.ts
+++ b/packages/network-controller/tests/customNetworkClient.test.ts
@@ -1,5 +1,0 @@
-import { testsForProviderType } from './provider-api-tests/shared-tests';
-
-describe('customNetworkClient', () => {
-  testsForProviderType('custom');
-});

--- a/packages/network-controller/tests/fake-block-tracker.ts
+++ b/packages/network-controller/tests/fake-block-tracker.ts
@@ -1,0 +1,19 @@
+import { PollingBlockTracker } from 'eth-block-tracker';
+import { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider/dist/safe-event-emitter-provider';
+import { JsonRpcEngine } from 'json-rpc-engine';
+
+/**
+ * Acts like a PollingBlockTracker, but doesn't start the polling loop or
+ * make any requests.
+ */
+export class FakeBlockTracker extends PollingBlockTracker {
+  constructor() {
+    super({
+      provider: new SafeEventEmitterProvider({ engine: new JsonRpcEngine() }),
+    });
+  }
+
+  async _start() {
+    // do nothing
+  }
+}

--- a/types/web3-provider-engine.d.ts
+++ b/types/web3-provider-engine.d.ts
@@ -13,8 +13,8 @@ declare module 'web3-provider-engine' {
     jsonrpc: Y['jsonrpc'];
     result: V | undefined;
     error?: {
-      message: unknown;
-      code: number;
+      message: any;
+      code?: number;
     };
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,6 +1608,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-json-rpc-provider@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@metamask/eth-json-rpc-provider@npm:1.0.0"
+  dependencies:
+    "@metamask/safe-event-emitter": ^2.0.0
+    json-rpc-engine: ^6.1.0
+  checksum: 27865d84d90030db1a9e5a66bc0b0ae079706fb7be635ec1e9bd4f64771e819aae78f0a026c6629d3a1a2eb277fcd51977315c049c47a70df1dd95d1d4106982
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-keyring-controller@npm:^10.0.1":
   version: 10.0.1
   resolution: "@metamask/eth-keyring-controller@npm:10.0.1"
@@ -1759,6 +1769,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
+    "@metamask/eth-json-rpc-provider": ^1.0.0
     "@metamask/swappable-obj-proxy": ^2.1.0
     "@metamask/utils": ^5.0.2
     "@types/jest": ^27.4.1
@@ -1766,11 +1777,13 @@ __metadata:
     async-mutex: ^0.2.6
     babel-runtime: ^6.26.0
     deepmerge: ^4.2.2
+    eth-block-tracker: ^7.0.1
     eth-json-rpc-infura: ^5.1.0
     eth-query: ^2.1.2
     eth-rpc-errors: ^4.0.2
     immer: ^9.0.6
     jest: ^27.5.1
+    json-rpc-engine: ^6.1.0
     lodash: ^4.17.21
     nock: ^13.0.7
     sinon: ^9.2.4
@@ -1904,6 +1917,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/safe-event-emitter@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/safe-event-emitter@npm:3.0.0"
+  checksum: 8dc58a76f9f75bf2405931465fc311c68043d851e6b8ebe9f82ae339073a08a83430dba9338f8e3adc4bfc8067607125074bcafa32baee3a5157f42343dc89e5
+  languageName: node
+  linkType: hard
+
 "@metamask/scure-bip39@npm:^2.0.3":
   version: 2.1.0
   resolution: "@metamask/scure-bip39@npm:2.1.0"
@@ -1970,7 +1990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^5.0.2":
+"@metamask/utils@npm:^5.0.1, @metamask/utils@npm:^5.0.2":
   version: 5.0.2
   resolution: "@metamask/utils@npm:5.0.2"
   dependencies:
@@ -4448,6 +4468,19 @@ __metadata:
     json-rpc-random-id: ^1.0.1
     pify: ^3.0.0
   checksum: 83b2dd28fb7f12d644f1c1bc72011fb6bb683012489973e31171d445a34ddf6a1c167be4e4232bf7eb65144f08d92705795cf6b371c5aa6a8e78ebf48e4d5654
+  languageName: node
+  linkType: hard
+
+"eth-block-tracker@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "eth-block-tracker@npm:7.0.1"
+  dependencies:
+    "@metamask/eth-json-rpc-provider": ^1.0.0
+    "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^5.0.1
+    json-rpc-random-id: ^1.0.1
+    pify: ^3.0.0
+  checksum: b8ecdaebed26423fa8444a779ecf34fb102f873fd1a29135189a3c553f679e34c19151f6b8d1cbbe180fdcc9ba967a7a55af6a72678140d6e3c8e725e630771e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

The NetworkController will construct a provider that is designed to interface with either an Infura network or a custom RPC endpoint, depending on state, along with a block tracker. We call this pair the network client, and in the extension we have extracted its construction to a separate file. This commit follows the same pattern so that when we replace `web3-provider-engine` we don't have to introduce so many changes. It also consolidates the network client tests (which we still call the provider API tests, though that will be renamed at some point).

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **ADDED:** [`@metamask/controller-utils`] Add `InfuraNetworkType`

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Reduces the scope of #1116.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
