### PR TITLE
Remove redundant test suite

### DIFF
--- a/packages/network-controller/tests/infuraNetworkClient.test.ts
+++ b/packages/network-controller/tests/infuraNetworkClient.test.ts
@@ -1,5 +1,0 @@
-import { testsForProviderType } from './provider-api-tests/shared-tests';
-
-describe('infuraNetworkClient', () => {
-  testsForProviderType('infura');
-});


### PR DESCRIPTION
## Description

The Infura network client tests are covered by the `create-network-client.test.ts` module. This additional module is redundant.

## Changes

Done

## References

This was accidentally left behind in #1285

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
