### PR TITLE
Rename `rpcTarget` to `rpcUrl`

### DIFF
--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -1036,7 +1036,7 @@ describe('TokenListController', () => {
     controllerMessenger.publish('NetworkController:providerConfigChange', {
       type: NetworkType.rpc,
       chainId: '56',
-      rpcTarget: 'http://localhost:8545',
+      rpcUrl: 'http://localhost:8545',
     });
 
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 500));
@@ -1138,7 +1138,7 @@ describe('TokenListController', () => {
       controllerMessenger.publish('NetworkController:providerConfigChange', {
         type: NetworkType.rpc,
         chainId: '56',
-        rpcTarget: 'http://localhost:8545',
+        rpcUrl: 'http://localhost:8545',
       });
     });
   });

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -320,7 +320,7 @@ describe('GasFeeController', () => {
               providerConfig: {
                 type: NetworkType.rpc,
                 chainId: '1337',
-                rpcTarget: 'http://some/url',
+                rpcUrl: 'http://some/url',
               },
             },
             clientId: '99999',
@@ -375,7 +375,7 @@ describe('GasFeeController', () => {
               providerConfig: {
                 type: NetworkType.rpc,
                 chainId: '1337',
-                rpcTarget: 'http://some/url',
+                rpcUrl: 'http://some/url',
               },
             },
             clientId: '99999',
@@ -685,7 +685,7 @@ describe('GasFeeController', () => {
             providerConfig: {
               type: NetworkType.rpc,
               chainId: '1337',
-              rpcTarget: 'http://some/url',
+              rpcUrl: 'http://some/url',
             },
           },
           clientId: '99999',
@@ -796,7 +796,7 @@ describe('GasFeeController', () => {
             providerConfig: {
               type: NetworkType.rpc,
               chainId: '1337',
-              rpcTarget: 'http://some/url',
+              rpcUrl: 'http://some/url',
             },
           },
           clientId: '99999',

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -37,7 +37,7 @@ const log = createModuleLogger(projectLogger, 'NetworkController');
  * @type ProviderConfig
  *
  * Configuration passed to web3-provider-engine
- * @property rpcTarget - RPC target URL.
+ * @property rpcUrl - RPC target URL.
  * @property type - Human-readable network name.
  * @property chainId - Network ID as per EIP-155.
  * @property ticker - Currency ticker.
@@ -45,7 +45,7 @@ const log = createModuleLogger(projectLogger, 'NetworkController');
  * @property id - Network Configuration Id.
  */
 export type ProviderConfig = {
-  rpcTarget?: string;
+  rpcUrl?: string;
   type: NetworkType;
   chainId: string;
   ticker?: string;
@@ -65,7 +65,7 @@ export type NetworkDetails = {
 /**
  * Custom RPC network information
  *
- * @property rpcTarget - RPC target URL.
+ * @property rpcUrl - RPC target URL.
  * @property chainId - Network ID as per EIP-155
  * @property nickname - Personalized network name.
  * @property ticker - Currency ticker.
@@ -320,7 +320,7 @@ export class NetworkController extends BaseControllerV2<
 
   #configureProvider(
     type: NetworkType,
-    rpcTarget?: string,
+    rpcUrl?: string,
     chainId?: string,
     ticker?: string,
     nickname?: string,
@@ -335,8 +335,8 @@ export class NetworkController extends BaseControllerV2<
         this.#setupStandardProvider(LOCALHOST_RPC_URL);
         break;
       case NetworkType.rpc:
-        rpcTarget &&
-          this.#setupStandardProvider(rpcTarget, chainId, ticker, nickname);
+        rpcUrl &&
+          this.#setupStandardProvider(rpcUrl, chainId, ticker, nickname);
         break;
       default:
         throw new Error(`Unrecognized network type: '${type}'`);
@@ -359,8 +359,8 @@ export class NetworkController extends BaseControllerV2<
       state.networkStatus = NetworkStatus.Unknown;
       state.networkDetails = {};
     });
-    const { rpcTarget, type, chainId, ticker } = this.state.providerConfig;
-    this.#configureProvider(type, rpcTarget, chainId, ticker);
+    const { rpcUrl, type, chainId, ticker } = this.state.providerConfig;
+    this.#configureProvider(type, rpcUrl, chainId, ticker);
     await this.lookupNetwork();
   }
 
@@ -384,7 +384,7 @@ export class NetworkController extends BaseControllerV2<
   }
 
   #setupStandardProvider(
-    rpcTarget: string,
+    rpcUrl: string,
     chainId?: string,
     ticker?: string,
     nickname?: string,
@@ -392,7 +392,7 @@ export class NetworkController extends BaseControllerV2<
     const { provider, blockTracker } = createNetworkClient({
       chainId,
       nickname,
-      rpcUrl: rpcTarget,
+      rpcUrl,
       ticker,
       type: NetworkClientType.Custom,
     });
@@ -428,9 +428,9 @@ export class NetworkController extends BaseControllerV2<
    *
    */
   async initializeProvider() {
-    const { type, rpcTarget, chainId, ticker, nickname } =
+    const { type, rpcUrl, chainId, ticker, nickname } =
       this.state.providerConfig;
-    this.#configureProvider(type, rpcTarget, chainId, ticker, nickname);
+    this.#configureProvider(type, rpcUrl, chainId, ticker, nickname);
     this.#registerProvider();
     await this.lookupNetwork();
   }
@@ -576,7 +576,7 @@ export class NetworkController extends BaseControllerV2<
       state.providerConfig.ticker = ticker;
       state.providerConfig.chainId = NetworksChainId[type];
       state.providerConfig.rpcPrefs = BUILT_IN_NETWORKS[type].rpcPrefs;
-      state.providerConfig.rpcTarget = undefined;
+      state.providerConfig.rpcUrl = undefined;
       state.providerConfig.nickname = undefined;
       state.providerConfig.id = undefined;
     });
@@ -602,7 +602,7 @@ export class NetworkController extends BaseControllerV2<
 
     this.update((state) => {
       state.providerConfig.type = NetworkType.rpc;
-      state.providerConfig.rpcTarget = targetNetwork.rpcUrl;
+      state.providerConfig.rpcUrl = targetNetwork.rpcUrl;
       state.providerConfig.chainId = targetNetwork.chainId;
       state.providerConfig.ticker = targetNetwork.ticker;
       state.providerConfig.nickname = targetNetwork.nickname;

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -453,7 +453,7 @@ describe('NetworkController', () => {
                 type: NetworkType.localhost,
                 chainId: '123',
                 nickname: 'some cool network',
-                rpcTarget: 'http://doesntmatter.com',
+                rpcUrl: 'http://doesntmatter.com',
                 ticker: 'ABC',
               }),
             },
@@ -664,7 +664,7 @@ describe('NetworkController', () => {
                   type: NetworkType.rpc,
                   chainId: '123',
                   nickname: 'some cool network',
-                  rpcTarget: 'http://example.com',
+                  rpcUrl: 'http://example.com',
                   ticker: 'ABC',
                 },
               },
@@ -714,7 +714,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: NetworkType.rpc,
-                  rpcTarget: 'http://example.com',
+                  rpcUrl: 'http://example.com',
                 }),
               },
             },
@@ -747,7 +747,7 @@ describe('NetworkController', () => {
                   state: {
                     providerConfig: buildProviderConfig({
                       type: NetworkType.rpc,
-                      rpcTarget: 'http://example.com',
+                      rpcUrl: 'http://example.com',
                     }),
                   },
                 },
@@ -816,7 +816,7 @@ describe('NetworkController', () => {
                   state: {
                     providerConfig: buildProviderConfig({
                       type: NetworkType.rpc,
-                      rpcTarget: 'http://example.com',
+                      rpcUrl: 'http://example.com',
                     }),
                   },
                 },
@@ -879,7 +879,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: NetworkType.rpc,
-                  rpcTarget: undefined,
+                  rpcUrl: undefined,
                 }),
               },
             },
@@ -3201,7 +3201,7 @@ describe('NetworkController', () => {
                 state: {
                   providerConfig: {
                     type: NetworkType.localhost,
-                    rpcTarget: 'http://somethingexisting.com',
+                    rpcUrl: 'http://somethingexisting.com',
                     chainId: '99999',
                     ticker: 'something existing',
                     nickname: 'something existing',
@@ -3218,7 +3218,7 @@ describe('NetworkController', () => {
                 expect(controller.state.providerConfig).toStrictEqual({
                   type: networkType,
                   ...BUILT_IN_NETWORKS[networkType],
-                  rpcTarget: undefined,
+                  rpcUrl: undefined,
                   nickname: undefined,
                   id: undefined,
                 });
@@ -3428,7 +3428,7 @@ describe('NetworkController', () => {
             state: {
               providerConfig: {
                 type: NetworkType.localhost,
-                rpcTarget: 'http://somethingexisting.com',
+                rpcUrl: 'http://somethingexisting.com',
                 chainId: '99999',
                 ticker: 'something existing',
                 nickname: 'something existing',
@@ -3446,7 +3446,7 @@ describe('NetworkController', () => {
               type: NetworkType.rpc,
               ticker: 'ETH',
               chainId: '',
-              rpcTarget: undefined,
+              rpcUrl: undefined,
               nickname: undefined,
               id: undefined,
               rpcPrefs: undefined,
@@ -3504,7 +3504,7 @@ describe('NetworkController', () => {
             state: {
               providerConfig: {
                 type: NetworkType.localhost,
-                rpcTarget: 'http://somethingexisting.com',
+                rpcUrl: 'http://somethingexisting.com',
                 chainId: '99999',
                 ticker: 'something existing',
                 nickname: 'something existing',
@@ -3522,7 +3522,7 @@ describe('NetworkController', () => {
               type: NetworkType.localhost,
               ticker: 'ETH',
               chainId: '',
-              rpcTarget: undefined,
+              rpcUrl: undefined,
               nickname: undefined,
               id: undefined,
               rpcPrefs: undefined,
@@ -3723,13 +3723,13 @@ describe('NetworkController', () => {
   });
 
   describe('setActiveNetwork', () => {
-    it('updates the provider config in state with the rpcTarget and chainId, clearing the previous provider details', async () => {
+    it('updates the provider config in state with the rpcUrl and chainId, clearing the previous provider details', async () => {
       await withController(
         {
           state: {
             providerConfig: {
               type: NetworkType.localhost,
-              rpcTarget: 'http://somethingexisting.com',
+              rpcUrl: 'http://somethingexisting.com',
               chainId: '99999',
               ticker: 'something existing',
               nickname: 'something existing',
@@ -3763,7 +3763,7 @@ describe('NetworkController', () => {
 
           expect(controller.state.providerConfig).toStrictEqual({
             type: 'rpc',
-            rpcTarget: 'https://mock-rpc-url',
+            rpcUrl: 'https://mock-rpc-url',
             chainId: '0xtest',
             ticker: 'TEST',
             id: 'testNetworkConfigurationId',
@@ -5177,7 +5177,7 @@ describe('NetworkController', () => {
             state: {
               providerConfig: {
                 type: NetworkType.rpc,
-                rpcTarget: 'https://mock-rpc-url',
+                rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
               },
             },
@@ -5236,7 +5236,7 @@ describe('NetworkController', () => {
             state: {
               providerConfig: {
                 type: NetworkType.rpc,
-                rpcTarget: 'https://mock-rpc-url',
+                rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
               },
               networkDetails: {
@@ -5298,7 +5298,7 @@ describe('NetworkController', () => {
             state: {
               providerConfig: {
                 type: NetworkType.rpc,
-                rpcTarget: 'https://mock-rpc-url',
+                rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
@@ -5350,7 +5350,7 @@ describe('NetworkController', () => {
             state: {
               providerConfig: {
                 type: NetworkType.rpc,
-                rpcTarget: 'https://mock-rpc-url',
+                rpcUrl: 'https://mock-rpc-url',
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
@@ -5389,7 +5389,7 @@ describe('NetworkController', () => {
             state: {
               providerConfig: {
                 type: NetworkType.rpc,
-                rpcTarget: 'https://mock-rpc-url',
+                rpcUrl: 'https://mock-rpc-url',
                 chainId: '0xtest',
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
@@ -5423,7 +5423,7 @@ describe('NetworkController', () => {
             state: {
               providerConfig: {
                 type: NetworkType.rpc,
-                rpcTarget: 'https://mock-rpc-url',
+                rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
               },
             },
@@ -5449,7 +5449,7 @@ describe('NetworkController', () => {
             state: {
               providerConfig: {
                 type: NetworkType.rpc,
-                rpcTarget: 'https://mock-rpc-url',
+                rpcUrl: 'https://mock-rpc-url',
                 chainId: '0x1337',
               },
               networkDetails: {
@@ -5487,7 +5487,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: {
                   type: NetworkType.rpc,
-                  rpcTarget: 'https://mock-rpc-url',
+                  rpcUrl: 'https://mock-rpc-url',
                   chainId: '0xtest',
                   ticker: 'TEST',
                   id: 'testNetworkConfigurationId',
@@ -5777,7 +5777,7 @@ describe('NetworkController', () => {
           state: {
             providerConfig: {
               type: NetworkType.rpc,
-              rpcTarget: 'https://mock-rpc-url',
+              rpcUrl: 'https://mock-rpc-url',
               chainId: '0xtest',
               ticker: 'TEST',
               id: 'testNetworkConfigurationId',
@@ -6052,7 +6052,7 @@ describe('NetworkController', () => {
       (v4 as jest.Mock).mockImplementationOnce(() => 'networkConfigurationId');
       const originalProvider = {
         type: 'rpc' as NetworkType,
-        rpcTarget: 'https://mock-rpc-url',
+        rpcUrl: 'https://mock-rpc-url',
         chainId: '0xtest',
         ticker: 'TEST',
         id: 'testNetworkConfigurationId',
@@ -6099,7 +6099,7 @@ describe('NetworkController', () => {
           state: {
             providerConfig: {
               type: NetworkType.rpc,
-              rpcTarget: 'https://mock-rpc-url',
+              rpcUrl: 'https://mock-rpc-url',
               chainId: '0xtest',
               ticker: 'TEST',
               id: 'testNetworkConfigurationId',
@@ -6136,7 +6136,7 @@ describe('NetworkController', () => {
 
           expect(controller.state.providerConfig).toStrictEqual({
             type: 'rpc',
-            rpcTarget: 'https://test-rpc-url',
+            rpcUrl: 'https://test-rpc-url',
             chainId: '0x1',
             ticker: 'test_ticker',
             id: 'networkConfigurationId',
@@ -6155,7 +6155,7 @@ describe('NetworkController', () => {
           state: {
             providerConfig: {
               type: NetworkType.rpc,
-              rpcTarget: 'https://mock-rpc-url',
+              rpcUrl: 'https://mock-rpc-url',
               chainId: '0xtest',
               ticker: 'TEST',
               id: 'testNetworkConfigurationId',
@@ -6333,7 +6333,7 @@ describe('NetworkController', () => {
               await controller.setActiveNetwork('testNetworkConfigurationId');
               expect(controller.state.providerConfig).toStrictEqual({
                 ...customNetworkConfiguration,
-                rpcTarget: rpcUrlOrTarget,
+                rpcUrl: rpcUrlOrTarget,
                 type: NetworkType.rpc,
               });
 
@@ -6396,7 +6396,7 @@ describe('NetworkController', () => {
                     rpcPrefs: { blockExplorerUrl },
                     id: undefined,
                     nickname: undefined,
-                    rpcTarget: undefined,
+                    rpcUrl: undefined,
                   },
                 ],
               ]);
@@ -6700,7 +6700,7 @@ describe('NetworkController', () => {
               type: NetworkType.mainnet,
               ...BUILT_IN_NETWORKS.mainnet,
               nickname: undefined,
-              rpcTarget: undefined,
+              rpcUrl: undefined,
               id: undefined,
             });
 
@@ -6708,7 +6708,7 @@ describe('NetworkController', () => {
 
             expect(controller.state.providerConfig).toStrictEqual({
               ...networkConfiguration,
-              rpcTarget: rpcUrlOrTarget,
+              rpcUrl: rpcUrlOrTarget,
               type: NetworkType.rpc,
             });
           },
@@ -6763,7 +6763,7 @@ describe('NetworkController', () => {
             await controller.setActiveNetwork('testNetworkConfigurationId2');
             expect(controller.state.providerConfig).toStrictEqual({
               ...networkConfiguration2,
-              rpcTarget: rpcUrlOrTarget2,
+              rpcUrl: rpcUrlOrTarget2,
               type: NetworkType.rpc,
             });
 
@@ -6771,7 +6771,7 @@ describe('NetworkController', () => {
 
             expect(controller.state.providerConfig).toStrictEqual({
               ...initialProviderConfig,
-              rpcTarget: rpcUrlOrTarget1,
+              rpcUrl: rpcUrlOrTarget1,
             });
           },
         );
@@ -6827,7 +6827,7 @@ describe('NetworkController', () => {
             );
 
             expect(promiseForProviderConfigChange).toStrictEqual([
-              [{ ...initialProviderConfig, rpcTarget: rpcUrlOrTarget }],
+              [{ ...initialProviderConfig, rpcUrl: rpcUrlOrTarget }],
             ]);
           },
         );
@@ -7155,7 +7155,7 @@ describe('NetworkController', () => {
           await controller.setActiveNetwork('testNetworkConfigurationId');
           expect(controller.state.providerConfig).toStrictEqual({
             ...networkConfiguration,
-            rpcTarget: rpcUrlOrTarget,
+            rpcUrl: rpcUrlOrTarget,
             type: NetworkType.rpc,
           });
 
@@ -7297,7 +7297,7 @@ function buildProviderConfig(config: Partial<ProviderConfig> = {}) {
     chainId: '1337',
     id: undefined,
     nickname: undefined,
-    rpcTarget:
+    rpcUrl:
       config.type === NetworkType.rpc ? 'http://doesntmatter.com' : undefined,
     ...config,
   };


### PR DESCRIPTION
## Description

The network controller provider config property `rpcTarget` has been renamed to `rpcUrl`. This makes it consistent with what we call this value in the network configuration, and it makes this more consistent with the extension.

## Changes

- **BREAKING:** Rename provider configuration property `rpcTarget` to `rpcUrl`

## References

Closes #1219

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
