### PR TITLE
keyring-controller: validate from-address in signTypedMessage

### DIFF
--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -7,6 +7,10 @@ import {
   getBinarySize,
 } from 'ethereumjs-util';
 import {
+  isValidHexAddress,
+  toChecksumHexAddress,
+} from '@metamask/controller-utils';
+import {
   normalize as normalizeAddress,
   signTypedData,
 } from '@metamask/eth-sig-util';
@@ -28,7 +32,6 @@ import {
   PersonalMessageParams,
   TypedMessageParams,
 } from '@metamask/message-manager';
-import { toChecksumHexAddress } from '@metamask/controller-utils';
 
 /**
  * Available keyring types
@@ -493,7 +496,7 @@ export class KeyringController extends BaseController<
   ) {
     try {
       const address = normalizeAddress(messageParams.from);
-      if (!address?.length) {
+      if (!address || !isValidHexAddress(address)) {
         throw new Error(
           `Missing or invalid address ${JSON.stringify(messageParams.from)}`,
         );


### PR DESCRIPTION
The `normalizeAddress` function is can return `undefined` even if the interface says otherwise.

This adds explicit handling of that case in `keyring-controller`. Required for #1289 .