### PR TITLE
Change importAccountWithStrategy return

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -254,15 +254,17 @@ describe('KeyringController', () => {
 
       const address = '0x51253087e6f8358b5f10c0a94315d69db3357859';
       const newKeyring = { accounts: [address], type: 'Simple Key Pair' };
-      const obj = await keyringController.importAccountWithStrategy(
-        AccountImportStrategy.privateKey,
-        [privateKey],
-      );
+      const { keyringState, importedAccountAddress } =
+        await keyringController.importAccountWithStrategy(
+          AccountImportStrategy.privateKey,
+          [privateKey],
+        );
       const modifiedState = {
         ...initialState,
         keyrings: [initialState.keyrings[0], newKeyring],
       };
-      expect(obj).toStrictEqual(modifiedState);
+      expect(keyringState).toStrictEqual(modifiedState);
+      expect(importedAccountAddress).toBe(address);
     });
 
     it('should not import account with strategy privateKey if wrong data is provided', async () => {
@@ -295,17 +297,19 @@ describe('KeyringController', () => {
 
       const address = '0xb97c80fab7a3793bbe746864db80d236f1345ea7';
 
-      const obj = await keyringController.importAccountWithStrategy(
-        AccountImportStrategy.json,
-        [input, somePassword],
-      );
+      const { keyringState, importedAccountAddress } =
+        await keyringController.importAccountWithStrategy(
+          AccountImportStrategy.json,
+          [input, somePassword],
+        );
 
       const newKeyring = { accounts: [address], type: 'Simple Key Pair' };
       const modifiedState = {
         ...initialState,
         keyrings: [initialState.keyrings[0], newKeyring],
       };
-      expect(obj).toStrictEqual(modifiedState);
+      expect(keyringState).toStrictEqual(modifiedState);
+      expect(importedAccountAddress).toBe(address);
     });
 
     it('should throw when passed an unrecognized strategy', async () => {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -351,7 +351,8 @@ export class KeyringController extends BaseController<
    * @param strategy - Import strategy name.
    * @param args - Array of arguments to pass to the underlying stategy.
    * @throws Will throw when passed an unrecognized strategy.
-   * @returns Promise resolving to current state when the import is complete.
+   * @returns Promise resolving to keyring current state and imported account
+   * address.
    */
   async importAccountWithStrategy(
     strategy: AccountImportStrategy,

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -356,7 +356,10 @@ export class KeyringController extends BaseController<
   async importAccountWithStrategy(
     strategy: AccountImportStrategy,
     args: any[],
-  ): Promise<KeyringMemState> {
+  ): Promise<{
+    keyringState: KeyringMemState;
+    importedAccountAddress: string;
+  }> {
     let privateKey;
     switch (strategy) {
       case 'privateKey':
@@ -400,7 +403,10 @@ export class KeyringController extends BaseController<
     const allAccounts = await this.#keyring.getAccounts();
     this.updateIdentities(allAccounts);
     this.setSelectedAddress(accounts[0]);
-    return this.fullUpdate();
+    return {
+      keyringState: await this.fullUpdate(),
+      importedAccountAddress: accounts[0],
+    };
   }
 
   /**


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR changes the returned object of `importAccountWithStrategy` method from KeyringController. The method now returns the imported account address along with the keyring current mem state.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **BREAKING**: Changed `importAccountWithStrategy` returned object

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes #1248

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
