### PR TITLE
addNewAccount doesn't select new account

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -110,6 +110,7 @@ describe('KeyringController', () => {
           currentKeyringMemState.keyrings[0].accounts,
         ),
       ).toBe(true);
+      expect(preferences.setSelectedAddress.called).toBe(false);
     });
   });
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -226,7 +226,6 @@ export class KeyringController extends BaseController<
     const addedAccountAddress = newAccounts.find(
       (selectedAddress: string) => !oldAccounts.includes(selectedAddress),
     );
-    this.setSelectedAddress(addedAccountAddress);
     return {
       keyringState: await this.fullUpdate(),
       addedAccountAddress,


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR changes the behaviour of KeyringController's `addNewAccount` method: whenever a new account is created, it will not be selected.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **CHANGED**: `addNewAccount` implementation

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes: #1244

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
