### PR TITLE
Check imported prv key length

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -281,6 +281,13 @@ describe('KeyringController', () => {
       ).rejects.toThrow(
         'Expected private key to be an Uint8Array with length 32',
       );
+
+      await expect(
+        keyringController.importAccountWithStrategy(
+          AccountImportStrategy.privateKey,
+          [privateKey.slice(1)],
+        ),
+      ).rejects.toThrow('Cannot import invalid private key.');
     });
 
     it('should import account with strategy json', async () => {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -4,6 +4,7 @@ import {
   isValidPrivate,
   toBuffer,
   stripHexPrefix,
+  getBinarySize,
 } from 'ethereumjs-util';
 import {
   normalize as normalizeAddress,
@@ -374,7 +375,11 @@ export class KeyringController extends BaseController<
         }
 
         /* istanbul ignore if */
-        if (!isValidPrivate(bufferedPrivateKey)) {
+        if (
+          !isValidPrivate(bufferedPrivateKey) ||
+          // ensures that the key is 64 bytes long
+          getBinarySize(prefixed) !== 64 + '0x'.length
+        ) {
           throw new Error('Cannot import invalid private key.');
         }
 


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR ports the private key length check added by [this PR](https://github.com/MetaMask/metamask-extension/pull/17763) on metamask-extension, to the KeyringController's `importAccountWithStrategy` method. 

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **ADDED**: check on `importAccountWithStrategy` for strategy `privateKey`

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes #1247

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
