### PR TITLE
Make addNewAccount idempotent

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -93,7 +93,9 @@ describe('KeyringController', () => {
   describe('addNewAccount', () => {
     it('should add new account', async () => {
       const { keyringState: currentKeyringMemState, addedAccountAddress } =
-        await keyringController.addNewAccount();
+        await keyringController.addNewAccount(
+          initialState.keyrings[0].accounts.length,
+        );
       expect(initialState.keyrings).toHaveLength(1);
       expect(initialState.keyrings[0].accounts).not.toStrictEqual(
         currentKeyringMemState.keyrings[0].accounts,
@@ -111,6 +113,15 @@ describe('KeyringController', () => {
         ),
       ).toBe(true);
       expect(preferences.setSelectedAddress.called).toBe(false);
+    });
+
+    it('should not add a new account if called twice with the same accountCount param', async () => {
+      const accountCount = initialState.keyrings[0].accounts.length;
+      const { addedAccountAddress: firstAccountAdded } =
+        await keyringController.addNewAccount(accountCount);
+      const { addedAccountAddress: secondAccountAdded } =
+        await keyringController.addNewAccount(accountCount);
+      expect(firstAccountAdded).toBe(secondAccountAdded);
     });
   });
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -119,9 +119,10 @@ describe('KeyringController', () => {
       const accountCount = initialState.keyrings[0].accounts.length;
       const { addedAccountAddress: firstAccountAdded } =
         await keyringController.addNewAccount(accountCount);
-      const { addedAccountAddress: secondAccountAdded } =
+      const { keyringState, addedAccountAddress: secondAccountAdded } =
         await keyringController.addNewAccount(accountCount);
       expect(firstAccountAdded).toBe(secondAccountAdded);
+      expect(keyringState.keyrings[0].accounts).toHaveLength(accountCount + 1);
     });
   });
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -124,6 +124,13 @@ describe('KeyringController', () => {
       expect(firstAccountAdded).toBe(secondAccountAdded);
       expect(keyringState.keyrings[0].accounts).toHaveLength(accountCount + 1);
     });
+
+    it('should throw an error if passed accountCount param is out of sequence', async () => {
+      const accountCount = initialState.keyrings[0].accounts.length;
+      await expect(
+        keyringController.addNewAccount(accountCount + 1),
+      ).rejects.toThrow('Account out of sequence');
+    });
   });
 
   describe('addNewAccountWithoutUpdate', () => {

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -91,45 +91,73 @@ describe('KeyringController', () => {
   });
 
   describe('addNewAccount', () => {
-    it('should add new account', async () => {
-      const { keyringState: currentKeyringMemState, addedAccountAddress } =
-        await keyringController.addNewAccount(
-          initialState.keyrings[0].accounts.length,
-        );
-      expect(initialState.keyrings).toHaveLength(1);
-      expect(initialState.keyrings[0].accounts).not.toStrictEqual(
-        currentKeyringMemState.keyrings[0].accounts,
-      );
-      expect(currentKeyringMemState.keyrings[0].accounts).toHaveLength(2);
-      expect(initialState.keyrings[0].accounts).not.toContain(
-        addedAccountAddress,
-      );
-      expect(addedAccountAddress).toBe(
-        currentKeyringMemState.keyrings[0].accounts[1],
-      );
-      expect(
-        preferences.updateIdentities.calledWith(
+    describe('when accountCount is not provided', () => {
+      it('should add new account', async () => {
+        const { keyringState: currentKeyringMemState, addedAccountAddress } =
+          await keyringController.addNewAccount();
+        expect(initialState.keyrings).toHaveLength(1);
+        expect(initialState.keyrings[0].accounts).not.toStrictEqual(
           currentKeyringMemState.keyrings[0].accounts,
-        ),
-      ).toBe(true);
-      expect(preferences.setSelectedAddress.called).toBe(false);
+        );
+        expect(currentKeyringMemState.keyrings[0].accounts).toHaveLength(2);
+        expect(initialState.keyrings[0].accounts).not.toContain(
+          addedAccountAddress,
+        );
+        expect(addedAccountAddress).toBe(
+          currentKeyringMemState.keyrings[0].accounts[1],
+        );
+        expect(
+          preferences.updateIdentities.calledWith(
+            currentKeyringMemState.keyrings[0].accounts,
+          ),
+        ).toBe(true);
+        expect(preferences.setSelectedAddress.called).toBe(false);
+      });
     });
 
-    it('should not add a new account if called twice with the same accountCount param', async () => {
-      const accountCount = initialState.keyrings[0].accounts.length;
-      const { addedAccountAddress: firstAccountAdded } =
-        await keyringController.addNewAccount(accountCount);
-      const { keyringState, addedAccountAddress: secondAccountAdded } =
-        await keyringController.addNewAccount(accountCount);
-      expect(firstAccountAdded).toBe(secondAccountAdded);
-      expect(keyringState.keyrings[0].accounts).toHaveLength(accountCount + 1);
-    });
+    describe('when accountCount is provided', () => {
+      it('should add new account if accountCount is in sequence', async () => {
+        const { keyringState: currentKeyringMemState, addedAccountAddress } =
+          await keyringController.addNewAccount(
+            initialState.keyrings[0].accounts.length,
+          );
+        expect(initialState.keyrings).toHaveLength(1);
+        expect(initialState.keyrings[0].accounts).not.toStrictEqual(
+          currentKeyringMemState.keyrings[0].accounts,
+        );
+        expect(currentKeyringMemState.keyrings[0].accounts).toHaveLength(2);
+        expect(initialState.keyrings[0].accounts).not.toContain(
+          addedAccountAddress,
+        );
+        expect(addedAccountAddress).toBe(
+          currentKeyringMemState.keyrings[0].accounts[1],
+        );
+        expect(
+          preferences.updateIdentities.calledWith(
+            currentKeyringMemState.keyrings[0].accounts,
+          ),
+        ).toBe(true);
+        expect(preferences.setSelectedAddress.called).toBe(false);
+      });
 
-    it('should throw an error if passed accountCount param is out of sequence', async () => {
-      const accountCount = initialState.keyrings[0].accounts.length;
-      await expect(
-        keyringController.addNewAccount(accountCount + 1),
-      ).rejects.toThrow('Account out of sequence');
+      it('should throw an error if passed accountCount param is out of sequence', async () => {
+        const accountCount = initialState.keyrings[0].accounts.length;
+        await expect(
+          keyringController.addNewAccount(accountCount + 1),
+        ).rejects.toThrow('Account out of sequence');
+      });
+
+      it('should not add a new account if called twice with the same accountCount param', async () => {
+        const accountCount = initialState.keyrings[0].accounts.length;
+        const { addedAccountAddress: firstAccountAdded } =
+          await keyringController.addNewAccount(accountCount);
+        const { keyringState, addedAccountAddress: secondAccountAdded } =
+          await keyringController.addNewAccount(accountCount);
+        expect(firstAccountAdded).toBe(secondAccountAdded);
+        expect(keyringState.keyrings[0].accounts).toHaveLength(
+          accountCount + 1,
+        );
+      });
     });
   });
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -210,7 +210,7 @@ export class KeyringController extends BaseController<
    * @returns Promise resolving to keyring current state and added account
    * address.
    */
-  async addNewAccount(accountCount: number): Promise<{
+  async addNewAccount(accountCount?: number): Promise<{
     keyringState: KeyringMemState;
     addedAccountAddress: string;
   }> {
@@ -221,13 +221,15 @@ export class KeyringController extends BaseController<
     }
     const oldAccounts = await this.#keyring.getAccounts();
 
-    if (oldAccounts.length !== accountCount) {
-      // we return the last account added to the primary keyring
+    if (accountCount && oldAccounts.length !== accountCount) {
+      if (accountCount > oldAccounts.length) {
+        throw new Error('Account out of sequence');
+      }
+      // we return the account already existing at index `accountCount`
       const primaryKeyringAccounts = await primaryKeyring.getAccounts();
       return {
         keyringState: await this.fullUpdate(),
-        addedAccountAddress:
-          primaryKeyringAccounts[primaryKeyringAccounts.length - 1],
+        addedAccountAddress: primaryKeyringAccounts[accountCount],
       };
     }
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -205,10 +205,12 @@ export class KeyringController extends BaseController<
   /**
    * Adds a new account to the default (first) HD seed phrase keyring.
    *
+   * @param accountCount - Number of accounts before adding a new one, used to
+   * make the method idempotent.
    * @returns Promise resolving to keyring current state and added account
    * address.
    */
-  async addNewAccount(): Promise<{
+  async addNewAccount(accountCount: number): Promise<{
     keyringState: KeyringMemState;
     addedAccountAddress: string;
   }> {
@@ -218,6 +220,17 @@ export class KeyringController extends BaseController<
       throw new Error('No HD keyring found');
     }
     const oldAccounts = await this.#keyring.getAccounts();
+
+    if (oldAccounts.length !== accountCount) {
+      // we return the last account added to the primary keyring
+      const primaryKeyringAccounts = await primaryKeyring.getAccounts();
+      return {
+        keyringState: await this.fullUpdate(),
+        addedAccountAddress:
+          primaryKeyringAccounts[primaryKeyringAccounts.length - 1],
+      };
+    }
+
     await this.#keyring.addNewAccount(primaryKeyring);
     const newAccounts = await this.#keyring.getAccounts();
 


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR adds the `accountCount` parameter to the `addNewAccount` method of the KeyringController, and uses it to make the function call idempotent.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **BREAKING**: Added `accountCount: number` param to `addNewAccount` method

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes #1242

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
