### PR TITLE
Remove unused network client configuration

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -318,13 +318,7 @@ export class NetworkController extends BaseControllerV2<
     this.#previousNetworkSpecifier = this.state.providerConfig.type;
   }
 
-  #configureProvider(
-    type: NetworkType,
-    rpcUrl?: string,
-    chainId?: string,
-    ticker?: string,
-    nickname?: string,
-  ) {
+  #configureProvider(type: NetworkType, rpcUrl?: string, chainId?: string) {
     switch (type) {
       case NetworkType.mainnet:
       case NetworkType.goerli:
@@ -335,8 +329,7 @@ export class NetworkController extends BaseControllerV2<
         this.#setupStandardProvider(LOCALHOST_RPC_URL);
         break;
       case NetworkType.rpc:
-        rpcUrl &&
-          this.#setupStandardProvider(rpcUrl, chainId, ticker, nickname);
+        rpcUrl && this.#setupStandardProvider(rpcUrl, chainId);
         break;
       default:
         throw new Error(`Unrecognized network type: '${type}'`);
@@ -359,8 +352,8 @@ export class NetworkController extends BaseControllerV2<
       state.networkStatus = NetworkStatus.Unknown;
       state.networkDetails = {};
     });
-    const { rpcUrl, type, chainId, ticker } = this.state.providerConfig;
-    this.#configureProvider(type, rpcUrl, chainId, ticker);
+    const { rpcUrl, type, chainId } = this.state.providerConfig;
+    this.#configureProvider(type, rpcUrl, chainId);
     await this.lookupNetwork();
   }
 
@@ -383,17 +376,10 @@ export class NetworkController extends BaseControllerV2<
     this.#updateProvider(provider, blockTracker);
   }
 
-  #setupStandardProvider(
-    rpcUrl: string,
-    chainId?: string,
-    ticker?: string,
-    nickname?: string,
-  ) {
+  #setupStandardProvider(rpcUrl: string, chainId?: string) {
     const { provider, blockTracker } = createNetworkClient({
       chainId,
-      nickname,
       rpcUrl,
-      ticker,
       type: NetworkClientType.Custom,
     });
 
@@ -428,9 +414,8 @@ export class NetworkController extends BaseControllerV2<
    *
    */
   async initializeProvider() {
-    const { type, rpcUrl, chainId, ticker, nickname } =
-      this.state.providerConfig;
-    this.#configureProvider(type, rpcUrl, chainId, ticker, nickname);
+    const { type, rpcUrl, chainId } = this.state.providerConfig;
+    this.#configureProvider(type, rpcUrl, chainId);
     this.#registerProvider();
     await this.lookupNetwork();
   }

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -20,8 +20,6 @@ export enum NetworkClientType {
 type CustomNetworkConfiguration = {
   chainId?: string;
   rpcUrl: string;
-  nickname?: string;
-  ticker?: string;
   type: NetworkClientType.Custom;
 };
 

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -475,9 +475,7 @@ describe('NetworkController', () => {
 
             expect(createNetworkClientMock).toHaveBeenCalledWith({
               chainId: undefined,
-              nickname: undefined,
               rpcUrl: 'http://localhost:8545',
-              ticker: undefined,
               type: NetworkClientType.Custom,
             });
             const { provider } = controller.getProviderAndBlockTracker();
@@ -686,9 +684,7 @@ describe('NetworkController', () => {
 
               expect(createNetworkClientMock).toHaveBeenCalledWith({
                 chainId: '123',
-                nickname: 'some cool network',
                 rpcUrl: 'http://example.com',
-                ticker: 'ABC',
                 type: NetworkClientType.Custom,
               });
               const { provider } = controller.getProviderAndBlockTracker();
@@ -3549,9 +3545,7 @@ describe('NetworkController', () => {
 
           expect(createNetworkClientMock).toHaveBeenCalledWith({
             chainId: undefined,
-            nickname: undefined,
             rpcUrl: 'http://localhost:8545',
-            ticker: undefined,
             type: NetworkClientType.Custom,
           });
           const { provider } = controller.getProviderAndBlockTracker();
@@ -3807,9 +3801,7 @@ describe('NetworkController', () => {
 
           expect(createNetworkClientMock).toHaveBeenCalledWith({
             chainId: '0xtest',
-            nickname: undefined,
             rpcUrl: 'https://mock-rpc-url',
-            ticker: 'TEST',
             type: NetworkClientType.Custom,
           });
           const { provider } = controller.getProviderAndBlockTracker();


### PR DESCRIPTION
## Description

When constructing a non-Infura network client, the network `nickname` and `ticker` configuration properties were passed on down to `web3-provider-engine`. However these were entirely unused. There are no references to these in the `web3-provider-engine` package.

## Changes

None

## References

Relates to #1116

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
