### PR TITLE
Remove warning in NetworkController unit tests

### DIFF
--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -49,8 +49,9 @@ jest.mock('uuid', () => {
   };
 });
 
-// Store this up front so it doesn't get lost when it is stubbed
+// Store these up front so we can use them even when faking timers
 const originalSetTimeout = global.setTimeout;
+const originalClearTimeout = global.clearTimeout;
 
 const createNetworkClientMock = jest.mocked(createNetworkClient);
 
@@ -7514,7 +7515,7 @@ async function waitForPublishedEvents<E extends NetworkControllerEvents>(
        */
       function stopTimer() {
         if (timer) {
-          clearTimeout(timer);
+          originalClearTimeout(timer);
         }
       }
 


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

In the NetworkController unit tests we use `setTimeout` to wait for events to occur. We also use `clearTimeout` in the same context to stop waiting if need be. Because we use fake timers in these tests we need the original versions of these functions and not the fake versions. We already capture the original version of `setTimeout` up front, but we don't do the same for `clearTimeout`, and that leads to a warning being printed when we use it. This commit captures `clearTimeout` up front as well to prevent this warning.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

N/A

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Reduces scope of #1116

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
