### PR TITLE
Remove unnecessary ESLint ignore comments

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -725,7 +725,6 @@ export class NetworkController extends BaseControllerV2<
     }
 
     try {
-      // eslint-disable-next-line no-new
       new URL(rpcUrl);
     } catch (e: any) {
       if (e.message.includes('Invalid URL')) {

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -202,8 +202,7 @@ describe('NetworkController', () => {
     it('throws if the infura project ID is missing', async () => {
       expect(
         () =>
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
+          // @ts-expect-error Required parameter intentionally omitted
           new NetworkController({
             messenger: buildNetworkControllerMessenger(),
             trackMetaMetricsEvent: jest.fn(),
@@ -217,8 +216,7 @@ describe('NetworkController', () => {
           new NetworkController({
             messenger: buildNetworkControllerMessenger(),
             trackMetaMetricsEvent: jest.fn(),
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
+            // @ts-expect-error Required parameter intentionally omitted
             infuraProjectId: 10,
           }),
       ).toThrow('Invalid Infura project ID');
@@ -5755,17 +5753,15 @@ describe('NetworkController', () => {
 
     it('throws if an options object is not passed as a second argument', async () => {
       await withController(async ({ controller }) => {
-        await expect(
-          async () =>
-            // @ts-expect-error - we want to test the case where no second arg is passed.
-            controller.upsertNetworkConfiguration({
-              chainId: '0x5',
-              nickname: 'RPC',
-              rpcPrefs: { blockExplorerUrl: 'test-block-explorer.com' },
-              rpcUrl: 'https://mock-rpc-url',
-            }),
-          // eslint-disable-next-line
-        ).rejects.toThrow();
+        await expect(async () =>
+          // @ts-expect-error - we want to test the case where no second arg is passed.
+          controller.upsertNetworkConfiguration({
+            chainId: '0x5',
+            nickname: 'RPC',
+            rpcPrefs: { blockExplorerUrl: 'test-block-explorer.com' },
+            rpcUrl: 'https://mock-rpc-url',
+          }),
+        ).rejects.toThrow('Cannot read properties of undefined');
       });
     });
 

--- a/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
@@ -188,7 +188,7 @@ export const testsForRpcMethodsThatCheckForBlockHashInResponse = (
   }
 
   for (const paramIndex of [...Array(numberOfParameters).keys()]) {
-    it(`does not reuse the result of a previous request with a valid blockHash if parameter at index "${paramIndex}" differs`, async () => { // eslint-disable-line
+    it(`does not reuse the result of a previous request with a valid blockHash if parameter at index "${paramIndex}" differs`, async () => {
       const firstMockParams = [
         ...new Array(numberOfParameters).fill('some value'),
       ];

--- a/packages/network-controller/tests/provider-api-tests/block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-param.ts
@@ -69,7 +69,7 @@ export const testsForRpcMethodSupportingBlockParam = (
         continue;
       }
 
-      it(`does not reuse the result of a previous request if parameter at index "${paramIndex}" differs`, async () => {// eslint-disable-line
+      it(`does not reuse the result of a previous request if parameter at index "${paramIndex}" differs`, async () => {
         const firstMockParams = [
           ...new Array(numberOfParameters).fill('some value'),
         ];
@@ -1316,7 +1316,7 @@ export const testsForRpcMethodSupportingBlockParam = (
         continue;
       }
 
-      it(`does not reuse the result of a previous request if parameter at index "${paramIndex}" differs`, async () => {// eslint-disable-line
+      it(`does not reuse the result of a previous request if parameter at index "${paramIndex}" differs`, async () => {
         const firstMockParams = [
           ...new Array(numberOfParameters).fill('some value'),
         ];

--- a/packages/network-controller/tests/provider-api-tests/helpers.ts
+++ b/packages/network-controller/tests/provider-api-tests/helpers.ts
@@ -54,7 +54,6 @@ function debug(...args: any) {
       console.error(args[0]);
       return;
     }
-    // eslint-disable-next-line
     console.log(...args);
   }
 }
@@ -90,14 +89,12 @@ const mockNextBlockTrackerRequest = ({
   blockNumber = DEFAULT_LATEST_BLOCK_NUMBER,
   block = DEFAULT_BLOCK,
 }: MockBlockTrackerRequestOptions) => {
-  // eslint-disable-next-line
   mockRpcCall({
     nockScope,
     request: { method: 'eth_blockNumber', params: [] },
     response: { result: blockNumber },
   });
 
-  // eslint-disable-next-line
   mockRpcCall({
     nockScope,
     request: { method: 'eth_getBlockByNumber', params: [blockNumber, false] },
@@ -113,7 +110,7 @@ const mockAllBlockTrackerRequests = ({
   block = DEFAULT_BLOCK,
 }: MockBlockTrackerRequestOptions) => {
   (
-    mockRpcCall({ // eslint-disable-line
+    mockRpcCall({
       nockScope,
       request: { method: 'eth_blockNumber', params: [] },
       response: { result: blockNumber },
@@ -121,7 +118,7 @@ const mockAllBlockTrackerRequests = ({
   ).persist();
 
   (
-    mockRpcCall({ // eslint-disable-line
+    mockRpcCall({
       nockScope,
       request: { method: 'eth_getBlockByNumber', params: [blockNumber, false] },
       response: {
@@ -168,14 +165,36 @@ type MockRpcCallOptions = {
 
 type MockRpcCallResult = nock.Interceptor | nock.Scope;
 
-const mockRpcCall = ({
+/**
+ * Mocks a JSON-RPC request sent to the provider with the given response.
+ * Provider type is inferred from the base url set on the nockScope.
+ *
+ * @param args - The arguments.
+ * @param args.nockScope - A nock scope (a set of mocked requests scoped to a
+ * certain base URL).
+ * @param args.request - The request data.
+ * @param args.response - Information concerning the response that the request
+ * should have. If a `body` property is present, this is taken as the complete
+ * response body. If an `httpStatus` property is present, then it is taken as
+ * the HTTP status code to respond with. Properties other than these two are
+ * used to build a complete response body (including `id` and `jsonrpc`
+ * properties).
+ * @param args.error - An error to throw while making the request. Takes
+ * precedence over `response`.
+ * @param args.delay - The amount of time that should pass before the request
+ * resolves with the response.
+ * @param args.times - The number of times that the request is expected to be
+ * made.
+ * @returns The nock scope.
+ */
+function mockRpcCall({
   nockScope,
   request,
   response,
   error,
   delay,
   times,
-}: MockRpcCallOptions): MockRpcCallResult => {
+}: MockRpcCallOptions): MockRpcCallResult {
   // eth-query always passes `params`, so even if we don't supply this property,
   // for consistency with makeRpcCall, assume that the `body` contains it
   const { method, params = [], ...rest } = request;
@@ -241,7 +260,7 @@ const mockRpcCall = ({
     });
   }
   return nockRequest;
-};
+}
 
 const makeRpcCall = (
   ethQuery: EthQuery,


### PR DESCRIPTION
## Description

All unnecessary ESLint ignore comments have been removed from the network controller package. Most of these were added before we had decent types setup for the network client tests.

The `mockRpcCall` function was converted from an arrow function to a function declaration to address lint errors, so the description was copied over from the extension.

## Changes

None

## References

Relates to #1116

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
