### PR TITLE
Remove unnecessary mock from provider API test helper

### DIFF
--- a/packages/network-controller/tests/provider-api-tests/helpers.ts
+++ b/packages/network-controller/tests/provider-api-tests/helpers.ts
@@ -407,12 +407,6 @@ export const withNetworkClient = async (
     trackMetaMetricsEvent: jest.fn(),
   });
 
-  const getEIP1559CompatibilityMock = jest
-    .spyOn(controller, 'getEIP1559Compatibility')
-    .mockImplementation(async () => {
-      return true;
-    });
-
   const lookupNetworkMock = jest
     .spyOn(controller, 'lookupNetwork')
     .mockImplementation(() => {
@@ -456,7 +450,6 @@ export const withNetworkClient = async (
   try {
     return await fn(client);
   } finally {
-    getEIP1559CompatibilityMock.mockRestore();
     lookupNetworkMock.mockRestore();
     blockTracker.removeAllListeners();
     provider?.stop();


### PR DESCRIPTION
## Description

An unnecessary mock has been removed from a helper function used by network client tests. The `getEIP1559Compatibility` function is only called as part of `lookupNetwork` (which is also mocked) as of #1236, so this has been redundant since then.

Relates to #1116

## Changes

None

## References

Relates to #1116

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
