### PR TITLE
Improve types used for network client test helpers

### DIFF
--- a/packages/network-controller/tests/provider-api-tests/helpers.ts
+++ b/packages/network-controller/tests/provider-api-tests/helpers.ts
@@ -8,7 +8,7 @@ import {
   JSONRPCResponseResult,
 } from '@json-rpc-specification/meta-schema';
 import { ControllerMessenger } from '@metamask/base-controller';
-import { NetworkType } from '@metamask/controller-utils';
+import { InfuraNetworkType } from '@metamask/controller-utils';
 import {
   NetworkController,
   NetworkControllerMessenger,
@@ -289,7 +289,7 @@ export type ProviderType = 'infura' | 'custom';
 
 export type MockOptions = {
   providerType: ProviderType;
-  infuraNetwork?: NetworkType;
+  infuraNetwork?: InfuraNetworkType;
   customRpcUrl?: string;
 };
 
@@ -298,13 +298,13 @@ export type MockCommunications = {
   mockAllBlockTrackerRequests: (options?: any) => void;
   mockRpcCall: (arg0: CurriedMockRpcCallOptions) => MockRpcCallResult;
   rpcUrl: string;
-  infuraNetwork: NetworkType;
+  infuraNetwork: InfuraNetworkType;
 };
 
 export const withMockedCommunications = async (
   {
     providerType,
-    infuraNetwork = NetworkType.mainnet,
+    infuraNetwork = InfuraNetworkType.mainnet,
     customRpcUrl = MOCK_RPC_URL,
   }: MockOptions,
   fn: (comms: MockCommunications) => Promise<void>,
@@ -387,7 +387,7 @@ export const waitForPromiseToBeFulfilledAfterRunningAllTimers = async (
 export const withNetworkClient = async (
   {
     providerType,
-    infuraNetwork = NetworkType.mainnet,
+    infuraNetwork = InfuraNetworkType.mainnet,
     customRpcUrl = MOCK_RPC_URL,
   }: MockOptions,
   fn: (client: MockNetworkClient) => Promise<any>,


### PR DESCRIPTION
## Description

The types used for the network client test helpers have been made more specific; the network type passed in is now required at a type-level to be an Infura network.

This was a type-only change because we were already only passing in Infura neworks for this option. This was done to make a later refactor PR simpler.

## Changes

None

## References

Relates to #1116

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
