### PR TITLE
`importAccountWithStrategy` shouldn't select address

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -365,6 +365,15 @@ describe('KeyringController', () => {
           expect(keyringState).toStrictEqual(modifiedState);
           expect(importedAccountAddress).toBe(address);
         });
+
+        it('should not select imported account', async () => {
+          const somePassword = 'holachao123';
+          await keyringController.importAccountWithStrategy(
+            AccountImportStrategy.json,
+            [input, somePassword],
+          );
+          expect(preferences.setSelectedAddress.called).toBe(false);
+        });
       });
 
       describe('when wrong data is provided', () => {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -431,7 +431,6 @@ export class KeyringController extends BaseController<
     const accounts = await newKeyring.getAccounts();
     const allAccounts = await this.#keyring.getAccounts();
     this.updateIdentities(allAccounts);
-    this.setSelectedAddress(accounts[0]);
     return {
       keyringState: await this.fullUpdate(),
       importedAccountAddress: accounts[0],


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR refactors the `importAccountWithStrategy` method from KeyringController to not select the imported account.

As a new test case has been added, I took the chance to refactor tests groups for the `importAccountWithStrategy`.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **CHANGED**: `KeyringController.importAccountWithStrategy` to not select imported address

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes #1249

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
