### PR TITLE
Use package import over relative import in test

### DIFF
--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -6,7 +6,7 @@ import * as ethQueryModule from 'eth-query';
 import { Patch } from 'immer';
 import { v4 } from 'uuid';
 import { ethErrors } from 'eth-rpc-errors';
-import { NetworkType } from '@metamask/controller-utils';
+import { BUILT_IN_NETWORKS, NetworkType } from '@metamask/controller-utils';
 import { waitForResult } from '../../../tests/helpers';
 import {
   NetworkController,
@@ -19,7 +19,6 @@ import {
 } from '../src/NetworkController';
 import type { Provider } from '../src/types';
 import { NetworkStatus } from '../src/constants';
-import { BUILT_IN_NETWORKS } from '../../controller-utils/src/constants';
 import {
   createNetworkClient,
   NetworkClientType,


### PR DESCRIPTION
## Description

The network controller unit tests have been updated to avoid importing a constants file from another package using a relative path import. As a general rule we should be using package imports whenever referencing modules in other packages.

## Changes

None

## References

This reduces the scope of #1116

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
