### PR TITLE
Add validation when setting up custom provider

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -324,7 +324,14 @@ export class NetworkController extends BaseControllerV2<
         this.#setupInfuraProvider(type);
         break;
       case NetworkType.rpc:
-        rpcUrl && this.#setupStandardProvider(rpcUrl, chainId);
+        if (chainId === undefined) {
+          throw new Error('chainId must be provided for custom RPC endpoints');
+        }
+
+        if (rpcUrl === undefined) {
+          throw new Error('rpcUrl must be provided for custom RPC endpoints');
+        }
+        this.#setupStandardProvider(rpcUrl, chainId);
         break;
       default:
         throw new Error(`Unrecognized network type: '${type}'`);
@@ -371,7 +378,7 @@ export class NetworkController extends BaseControllerV2<
     this.#updateProvider(provider, blockTracker);
   }
 
-  #setupStandardProvider(rpcUrl: string, chainId?: string) {
+  #setupStandardProvider(rpcUrl: string, chainId: string) {
     const { provider, blockTracker } = createNetworkClient({
       chainId,
       rpcUrl,


### PR DESCRIPTION
## Description

Validation has been added to internal methods responsible for constructing a provider (upon initialization or after switching networks). They ensure that a custom provider has a chain ID and RPC URL set.

## Changes

- **BREAKING:** The methods `initializeProvider`, `setActiveNetwork`, and `resetConnection` will now throw if the provider config is of type `rpc` but is missing an RPC URL or a chain ID.
  - Previously the chain ID was not required to setup the provider.
  - Previously if the RPC URL was omitted, no error would be thrown but the provider would not be setup.
- **BREAKING:** The method `setProviderType` will now throw when passed the type `rpc`.
  - Previously no error would be thrown but the provider would not be setup.

## References

This reduces the scope of #1116

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
