### PR TITLE
Move lookup network tests to helper function

### DIFF
--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -496,26 +496,20 @@ describe('NetworkController', () => {
       });
     });
 
-    [NetworkType.mainnet, NetworkType.goerli, NetworkType.sepolia].forEach(
-      (networkType) => {
-        describe(`when the provider config in state contains a network type of "${networkType}"`, () => {
-          lookupNetworkTests(
-            buildProviderConfig({ type: networkType }),
-            async (controller: NetworkController) => {
-              await controller.lookupNetwork();
-            },
-          );
-        });
-      },
-    );
-
-    describe('when the provider config in state contains a network type of "rpc"', () => {
-      lookupNetworkTests(
-        buildProviderConfig({ type: NetworkType.rpc }),
-        async (controller: NetworkController) => {
-          await controller.lookupNetwork();
-        },
-      );
+    [
+      NetworkType.mainnet,
+      NetworkType.goerli,
+      NetworkType.sepolia,
+      NetworkType.rpc,
+    ].forEach((networkType) => {
+      describe(`when the provider config in state contains a network type of "${networkType}"`, () => {
+        lookupNetworkTests(
+          buildProviderConfig({ type: networkType }),
+          async (controller: NetworkController) => {
+            await controller.lookupNetwork();
+          },
+        );
+      });
     });
 
     describe('if lookupNetwork is called multiple times in quick succession', () => {

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -4682,9 +4682,7 @@ function lookupNetworkTests(
 
             await operation(controller);
 
-            expect(controller.state.networkStatus).toBe(
-              NetworkStatus.Unknown,
-            );
+            expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
           },
         );
       });
@@ -4776,9 +4774,7 @@ function lookupNetworkTests(
 
             await operation(controller);
 
-            expect(controller.state.networkStatus).toBe(
-              NetworkStatus.Blocked,
-            );
+            expect(controller.state.networkStatus).toBe(NetworkStatus.Blocked);
           },
         );
       });
@@ -4873,9 +4869,7 @@ function lookupNetworkTests(
 
           await operation(controller);
 
-          expect(controller.state.networkStatus).toBe(
-            NetworkStatus.Unknown,
-          );
+          expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
         },
       );
     });
@@ -5005,9 +4999,7 @@ function lookupNetworkTests(
 
           await operation(controller);
 
-          expect(controller.state.networkStatus).toBe(
-            NetworkStatus.Unknown,
-          );
+          expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
         },
       );
     });
@@ -5285,9 +5277,7 @@ function lookupNetworkTests(
 
             await operation(controller);
 
-            expect(controller.state.networkStatus).toBe(
-              NetworkStatus.Unknown,
-            );
+            expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
           },
         );
       });
@@ -5388,9 +5378,7 @@ function lookupNetworkTests(
 
             await operation(controller);
 
-            expect(controller.state.networkStatus).toBe(
-              NetworkStatus.Blocked,
-            );
+            expect(controller.state.networkStatus).toBe(NetworkStatus.Blocked);
           },
         );
       });
@@ -5493,9 +5481,7 @@ function lookupNetworkTests(
 
           await operation(controller);
 
-          expect(controller.state.networkStatus).toBe(
-            NetworkStatus.Unknown,
-          );
+          expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
         },
       );
     });


### PR DESCRIPTION
## Description

Most of the lookup network unit tests have been moved to a helper function, so that we can use them to test other methods in a later PR.

## Changes

None

## References

Relates to #1210

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
