### PR TITLE
Add `describe` block per network client type

### DIFF
--- a/packages/network-controller/tests/create-network-client.test.ts
+++ b/packages/network-controller/tests/create-network-client.test.ts
@@ -1,7 +1,8 @@
 import { NetworkClientType } from '../src/create-network-client';
 import { testsForProviderType } from './provider-api-tests/shared-tests';
 
-describe('createNetworkClient', () => {
-  testsForProviderType(NetworkClientType.Infura);
-  testsForProviderType(NetworkClientType.Custom);
-});
+for (const clientType of Object.values(NetworkClientType)) {
+  describe(`createNetworkClient - ${clientType}`, () => {
+    testsForProviderType(clientType);
+  });
+}


### PR DESCRIPTION
## Description

The tests for each network client type now use a separate `describe` block, ensuring that it's clear which type of client was being tested when a test fails.

## Changes

None

## References

Not related to any issues

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
