### PR TITLE
Skip vault creation if one already exists

### DIFF
--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -306,12 +306,12 @@ export class KeyringController extends BaseController<
     const releaseLock = await this.mutex.acquire();
     try {
       let vault;
-      const accounts = await this.#keyring.getAccounts();
+      const accounts = await this.getAccounts();
       if (accounts.length > 0) {
-        vault = await this.#keyring.fullUpdate();
+        vault = await this.fullUpdate();
       } else {
         vault = await this.#keyring.createNewVaultAndKeychain(password);
-        this.updateIdentities(await this.#keyring.getAccounts());
+        this.updateIdentities(await this.getAccounts());
         this.fullUpdate();
       }
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -305,9 +305,16 @@ export class KeyringController extends BaseController<
   async createNewVaultAndKeychain(password: string) {
     const releaseLock = await this.mutex.acquire();
     try {
-      const vault = await this.#keyring.createNewVaultAndKeychain(password);
-      this.updateIdentities(await this.#keyring.getAccounts());
-      this.fullUpdate();
+      let vault;
+      const accounts = await this.#keyring.getAccounts();
+      if (accounts.length > 0) {
+        vault = await this.#keyring.fullUpdate();
+      } else {
+        vault = await this.#keyring.createNewVaultAndKeychain(password);
+        this.updateIdentities(await this.#keyring.getAccounts());
+        this.fullUpdate();
+      }
+
       return vault;
     } finally {
       releaseLock();


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR changes the `KeyringController.createNewVaultAndRestore` method to not create a new vault if there is already an existing one. In this case, it will simply return the existing vault.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **CHANGED**: `createNewVaultAndRestore` from KeyringController, to not overwrite existing vault.

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes #1250

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
