### PR TITLE
Widen format of networkDetails

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -71,7 +71,6 @@ export type NetworkDetails = {
   EIPS: {
     [eipNumber: number]: boolean;
   };
-  [otherProperty: string]: any;
 };
 
 /**

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -60,8 +60,18 @@ export type Block = {
   baseFeePerGas?: string;
 };
 
+/**
+ * Information about the network not held by any other part of state. Currently
+ * only used to capture whether a network supports EIP-1559.
+ */
 export type NetworkDetails = {
-  isEIP1559Compatible?: boolean;
+  /**
+   * EIPs supported by the network.
+   */
+  EIPS: {
+    [eipNumber: number]: boolean;
+  };
+  [otherProperty: string]: any;
 };
 
 /**
@@ -220,7 +230,11 @@ export const defaultState: NetworkState = {
     type: NetworkType.mainnet,
     chainId: NetworksChainId.mainnet,
   },
-  networkDetails: { isEIP1559Compatible: false },
+  networkDetails: {
+    EIPS: {
+      1559: false,
+    },
+  },
   networkConfigurations: {},
 };
 
@@ -356,7 +370,9 @@ export class NetworkController extends BaseControllerV2<
     this.update((state) => {
       state.networkId = null;
       state.networkStatus = NetworkStatus.Unknown;
-      state.networkDetails = {};
+      state.networkDetails = {
+        EIPS: {},
+      };
     });
     const { rpcUrl, type, chainId } = this.state.providerConfig;
     this.#configureProvider(type, rpcUrl, chainId);
@@ -610,18 +626,18 @@ export class NetworkController extends BaseControllerV2<
   }
 
   async getEIP1559Compatibility() {
-    const { networkDetails = {} } = this.state;
+    const { networkDetails = { EIPS: {} } } = this.state;
 
-    if (networkDetails.isEIP1559Compatible || !this.#ethQuery) {
+    if (networkDetails.EIPS[1559] || !this.#ethQuery) {
       return true;
     }
 
     const latestBlock = await this.#getLatestBlock();
     const isEIP1559Compatible =
       typeof latestBlock.baseFeePerGas !== 'undefined';
-    if (networkDetails.isEIP1559Compatible !== isEIP1559Compatible) {
+    if (networkDetails.EIPS[1559] !== isEIP1559Compatible) {
       this.update((state) => {
-        state.networkDetails.isEIP1559Compatible = isEIP1559Compatible;
+        state.networkDetails.EIPS[1559] = isEIP1559Compatible;
       });
     }
     return isEIP1559Compatible;

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -644,8 +644,10 @@ describe('NetworkController', () => {
 
                   await controller.lookupNetwork();
 
-                  await expect(controller.state.networkDetails).toStrictEqual({
-                    isEIP1559Compatible: true,
+                  expect(controller.state.networkDetails).toStrictEqual({
+                    EIPS: {
+                      1559: true,
+                    },
                   });
                 },
               );

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -172,7 +172,11 @@ describe('NetworkController', () => {
           networkId: null,
           networkStatus: NetworkStatus.Unknown,
           providerConfig: { type: NetworkType.mainnet, chainId: '1' },
-          networkDetails: { isEIP1559Compatible: false },
+          networkDetails: {
+            EIPS: {
+              1559: false,
+            },
+          },
         });
       });
     });
@@ -181,7 +185,11 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            networkDetails: { isEIP1559Compatible: true },
+            networkDetails: {
+              EIPS: {
+                1559: false,
+              },
+            },
           },
         },
         ({ controller }) => {
@@ -190,7 +198,11 @@ describe('NetworkController', () => {
             networkId: null,
             networkStatus: NetworkStatus.Unknown,
             providerConfig: { type: NetworkType.mainnet, chainId: '1' },
-            networkDetails: { isEIP1559Compatible: true },
+            networkDetails: {
+              EIPS: {
+                1559: false,
+              },
+            },
           });
         },
       );
@@ -394,7 +406,7 @@ describe('NetworkController', () => {
       });
     });
 
-    it('updates networkDetails.isEIP1559Compatible in state based on the latest block (assuming that the request for eth_getBlockByNumber is made successfully)', async () => {
+    it('updates networkDetails.EIPS in state based on the latest block (assuming that the request for eth_getBlockByNumber is made successfully)', async () => {
       await withController(
         {
           state: {
@@ -420,15 +432,13 @@ describe('NetworkController', () => {
 
           await waitForStateChanges({
             messenger,
-            propertyPath: ['networkDetails', 'isEIP1559Compatible'],
+            propertyPath: ['networkDetails', 'EIPS', '1559'],
             produceStateChanges: async () => {
               await controller.initializeProvider();
             },
           });
 
-          expect(controller.state.networkDetails.isEIP1559Compatible).toBe(
-            true,
-          );
+          expect(controller.state.networkDetails.EIPS[1559]).toBe(true);
         },
       );
     });
@@ -564,7 +574,11 @@ describe('NetworkController', () => {
               await withController(
                 {
                   state: {
-                    networkDetails: { isEIP1559Compatible: false },
+                    networkDetails: {
+                      EIPS: {
+                        1559: false,
+                      },
+                    },
                     providerConfig,
                   },
                 },
@@ -589,7 +603,9 @@ describe('NetworkController', () => {
                   await controller.lookupNetwork();
 
                   expect(controller.state.networkDetails).toStrictEqual({
-                    isEIP1559Compatible: true,
+                    EIPS: {
+                      1559: true,
+                    },
                   });
                 },
               );
@@ -601,7 +617,11 @@ describe('NetworkController', () => {
               await withController(
                 {
                   state: {
-                    networkDetails: { isEIP1559Compatible: true },
+                    networkDetails: {
+                      EIPS: {
+                        1559: true,
+                      },
+                    },
                     providerConfig,
                   },
                 },
@@ -2003,7 +2023,7 @@ describe('NetworkController', () => {
           );
         });
 
-        it('updates networkDetails.isEIP1559Compatible in state based on the latest block (assuming that the request for eth_getBlockByNumber is made successfully)', async () => {
+        it('updates networkDetails.EIPS in state based on the latest block (assuming that the request for eth_getBlockByNumber is made successfully)', async () => {
           await withController({}, async ({ controller }) => {
             const fakeProvider = buildFakeProvider([
               {
@@ -2023,9 +2043,7 @@ describe('NetworkController', () => {
 
             await controller.setProviderType(networkType);
 
-            expect(controller.state.networkDetails.isEIP1559Compatible).toBe(
-              true,
-            );
+            expect(controller.state.networkDetails.EIPS[1559]).toBe(true);
           });
         });
 
@@ -2096,7 +2114,7 @@ describe('NetworkController', () => {
         });
       });
 
-      it('does not update networkDetails.isEIP1559Compatible in state', async () => {
+      it('does not update networkDetails.EIPS in state', async () => {
         await withController(async ({ controller }) => {
           const fakeProvider = buildFakeProvider([
             {
@@ -2120,9 +2138,7 @@ describe('NetworkController', () => {
             // catch the rejection (it is tested above)
           }
 
-          expect(
-            controller.state.networkDetails.isEIP1559Compatible,
-          ).toBeUndefined();
+          expect(controller.state.networkDetails.EIPS[1559]).toBeUndefined();
         });
       });
     });
@@ -2233,7 +2249,7 @@ describe('NetworkController', () => {
       );
     });
 
-    it('updates networkDetails.isEIP1559Compatible in state based on the latest block (assuming that the request for eth_getBlockByNumber is made successfully)', async () => {
+    it('updates networkDetails.EIPS in state based on the latest block (assuming that the request for eth_getBlockByNumber is made successfully)', async () => {
       await withController(
         {
           state: {
@@ -2268,9 +2284,7 @@ describe('NetworkController', () => {
 
           await controller.setActiveNetwork('testNetworkConfigurationId');
 
-          expect(controller.state.networkDetails.isEIP1559Compatible).toBe(
-            true,
-          );
+          expect(controller.state.networkDetails.EIPS[1559]).toBe(true);
         },
       );
     });
@@ -2428,7 +2442,7 @@ describe('NetworkController', () => {
     describe('if the state does not have a "networkDetails" property', () => {
       describe('if no error is thrown while fetching the latest block', () => {
         describe('if the block has a "baseFeePerGas" property', () => {
-          it('updates isEIP1559Compatible in state to true', async () => {
+          it('updates EIPS[1559] in state to true', async () => {
             await withController(
               {
                 state: {
@@ -2455,15 +2469,13 @@ describe('NetworkController', () => {
 
                 await waitForStateChanges({
                   messenger,
-                  propertyPath: ['networkDetails', 'isEIP1559Compatible'],
+                  propertyPath: ['networkDetails', 'EIPS', '1559'],
                   produceStateChanges: async () => {
                     await controller.getEIP1559Compatibility();
                   },
                 });
 
-                expect(
-                  controller.state.networkDetails.isEIP1559Compatible,
-                ).toBe(true);
+                expect(controller.state.networkDetails.EIPS['1559']).toBe(true);
               },
             );
           });
@@ -2503,7 +2515,7 @@ describe('NetworkController', () => {
         });
 
         describe('if the block does not have a "baseFeePerGas" property', () => {
-          it('does not change networkDetails.isEIP1559Compatible in state', async () => {
+          it('does not change networkDetails.EIPS in state', async () => {
             await withController(
               {
                 state: {
@@ -2530,7 +2542,7 @@ describe('NetworkController', () => {
                 const promiseForIsEIP1559CompatibleChanges =
                   waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkDetails', 'isEIP1559Compatible'],
+                    propertyPath: ['networkDetails', 'EIPS', '1559'],
                   });
 
                 await controller.getEIP1559Compatibility();
@@ -2578,7 +2590,7 @@ describe('NetworkController', () => {
       });
 
       describe('if an error is thrown while fetching the latest block', () => {
-        it('does not change networkDetails.isEIP1559Compatible in state', async () => {
+        it('does not change networkDetails.EIPS in state', async () => {
           await withController(
             {
               state: {
@@ -2602,7 +2614,7 @@ describe('NetworkController', () => {
               });
               const promiseForIsEIP1559CompatibleChanges = waitForStateChanges({
                 messenger,
-                propertyPath: ['networkDetails', 'isEIP1559Compatible'],
+                propertyPath: ['networkDetails', 'EIPS', '1559'],
               });
 
               try {
@@ -2653,15 +2665,16 @@ describe('NetworkController', () => {
       });
     });
 
-    describe('if the state has a "networkDetails" property, but it does not have an "isEIP1559Compatible" property', () => {
+    describe('if the state has a "networkDetails" property, but it does not have an "EIPS[1559]" property', () => {
       describe('if no error is thrown while fetching the latest block', () => {
         describe('if the block has a "baseFeePerGas" property', () => {
-          it('updates isEIP1559Compatible in state to true', async () => {
+          it('updates EIPS[1559] in state to true', async () => {
             await withController(
               {
                 state: {
                   networkDetails: {
-                    // no "isEIP1559Compatible" property
+                    // no "EIPS[1559]" property
+                    EIPS: {},
                   },
                 },
               },
@@ -2685,15 +2698,13 @@ describe('NetworkController', () => {
 
                 await waitForStateChanges({
                   messenger,
-                  propertyPath: ['networkDetails', 'isEIP1559Compatible'],
+                  propertyPath: ['networkDetails', 'EIPS', '1559'],
                   produceStateChanges: async () => {
                     await controller.getEIP1559Compatibility();
                   },
                 });
 
-                expect(
-                  controller.state.networkDetails.isEIP1559Compatible,
-                ).toBe(true);
+                expect(controller.state.networkDetails.EIPS[1559]).toBe(true);
               },
             );
           });
@@ -2703,7 +2714,8 @@ describe('NetworkController', () => {
               {
                 state: {
                   networkDetails: {
-                    // no "isEIP1559Compatible" property
+                    // no "EIPS[1559]" property
+                    EIPS: {},
                   },
                 },
               },
@@ -2735,12 +2747,13 @@ describe('NetworkController', () => {
         });
 
         describe('if the block does not have a "baseFeePerGas" property', () => {
-          it('updates isEIP1559Compatible in state to false', async () => {
+          it('updates EIPS[1559] in state to false', async () => {
             await withController(
               {
                 state: {
                   networkDetails: {
-                    // no "isEIP1559Compatible" property
+                    // no "EIPS[1559]" property
+                    EIPS: {},
                   },
                 },
               },
@@ -2764,15 +2777,13 @@ describe('NetworkController', () => {
 
                 await waitForStateChanges({
                   messenger,
-                  propertyPath: ['networkDetails', 'isEIP1559Compatible'],
+                  propertyPath: ['networkDetails', 'EIPS', '1559'],
                   produceStateChanges: async () => {
                     await controller.getEIP1559Compatibility();
                   },
                 });
 
-                expect(
-                  controller.state.networkDetails.isEIP1559Compatible,
-                ).toBe(false);
+                expect(controller.state.networkDetails.EIPS[1559]).toBe(false);
               },
             );
           });
@@ -2782,7 +2793,8 @@ describe('NetworkController', () => {
               {
                 state: {
                   networkDetails: {
-                    // no "isEIP1559Compatible" property
+                    // no "EIPS[1559]" property
+                    EIPS: {},
                   },
                 },
               },
@@ -2815,12 +2827,13 @@ describe('NetworkController', () => {
       });
 
       describe('if an error is thrown while fetching the latest block', () => {
-        it('does not change networkDetails.isEIP1559Compatible in state', async () => {
+        it('does not change networkDetails.EIPS in state', async () => {
           await withController(
             {
               state: {
                 networkDetails: {
-                  // no "isEIP1559Compatible" property
+                  // no "EIPS[1559]" property
+                  EIPS: {},
                 },
               },
             },
@@ -2841,7 +2854,7 @@ describe('NetworkController', () => {
               });
               const promiseForIsEIP1559CompatibleChanges = waitForStateChanges({
                 messenger,
-                propertyPath: ['networkDetails', 'isEIP1559Compatible'],
+                propertyPath: ['networkDetails', 'EIPS', '1559'],
               });
 
               try {
@@ -2862,7 +2875,8 @@ describe('NetworkController', () => {
             {
               state: {
                 networkDetails: {
-                  // no "isEIP1559Compatible" property
+                  // no "EIPS[1559]" property
+                  EIPS: {},
                 },
               },
             },
@@ -2894,15 +2908,17 @@ describe('NetworkController', () => {
       });
     });
 
-    describe('if isEIP1559Compatible in state is set to false', () => {
+    describe('if EIPS[1559] in state is set to false', () => {
       describe('if no error is thrown while fetching the latest block', () => {
         describe('if the block has a "baseFeePerGas" property', () => {
-          it('updates isEIP1559Compatible in state to true', async () => {
+          it('updates EIPS[1559] in state to true', async () => {
             await withController(
               {
                 state: {
                   networkDetails: {
-                    isEIP1559Compatible: false,
+                    EIPS: {
+                      1559: false,
+                    },
                   },
                 },
               },
@@ -2926,15 +2942,13 @@ describe('NetworkController', () => {
 
                 await waitForStateChanges({
                   messenger,
-                  propertyPath: ['networkDetails', 'isEIP1559Compatible'],
+                  propertyPath: ['networkDetails', 'EIPS', '1559'],
                   produceStateChanges: async () => {
                     await controller.getEIP1559Compatibility();
                   },
                 });
 
-                expect(
-                  controller.state.networkDetails.isEIP1559Compatible,
-                ).toBe(true);
+                expect(controller.state.networkDetails.EIPS[1559]).toBe(true);
               },
             );
           });
@@ -2944,7 +2958,9 @@ describe('NetworkController', () => {
               {
                 state: {
                   networkDetails: {
-                    isEIP1559Compatible: false,
+                    EIPS: {
+                      1559: false,
+                    },
                   },
                 },
               },
@@ -2976,12 +2992,14 @@ describe('NetworkController', () => {
         });
 
         describe('if the block does not have a "baseFeePerGas" property', () => {
-          it('does not change networkDetails.isEIP1559Compatible in state', async () => {
+          it('does not change networkDetails.EIPS in state', async () => {
             await withController(
               {
                 state: {
                   networkDetails: {
-                    isEIP1559Compatible: false,
+                    EIPS: {
+                      1559: false,
+                    },
                   },
                 },
               },
@@ -3005,7 +3023,7 @@ describe('NetworkController', () => {
                 const promiseForIsEIP1559CompatibleChanges =
                   waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkDetails', 'isEIP1559Compatible'],
+                    propertyPath: ['networkDetails', 'EIPS', '1559'],
                   });
 
                 await controller.getEIP1559Compatibility();
@@ -3022,7 +3040,9 @@ describe('NetworkController', () => {
               {
                 state: {
                   networkDetails: {
-                    isEIP1559Compatible: false,
+                    EIPS: {
+                      1559: false,
+                    },
                   },
                 },
               },
@@ -3055,12 +3075,14 @@ describe('NetworkController', () => {
       });
 
       describe('if an error is thrown while fetching the latest block', () => {
-        it('does not change networkDetails.isEIP1559Compatible in state', async () => {
+        it('does not change networkDetails.EIPS in state', async () => {
           await withController(
             {
               state: {
                 networkDetails: {
-                  isEIP1559Compatible: false,
+                  EIPS: {
+                    1559: false,
+                  },
                 },
               },
             },
@@ -3081,7 +3103,7 @@ describe('NetworkController', () => {
               });
               const promiseForIsEIP1559CompatibleChanges = waitForStateChanges({
                 messenger,
-                propertyPath: ['networkDetails', 'isEIP1559Compatible'],
+                propertyPath: ['networkDetails', 'EIPS', '1559'],
               });
 
               try {
@@ -3102,7 +3124,9 @@ describe('NetworkController', () => {
             {
               state: {
                 networkDetails: {
-                  isEIP1559Compatible: false,
+                  EIPS: {
+                    1559: false,
+                  },
                 },
               },
             },
@@ -3134,13 +3158,15 @@ describe('NetworkController', () => {
       });
     });
 
-    describe('if isEIP1559Compatible in state is set to true', () => {
-      it('does not change networkDetails.isEIP1559Compatible in state', async () => {
+    describe('if EIPS[1559] in state is set to true', () => {
+      it('does not change networkDetails.EIPS in state', async () => {
         await withController(
           {
             state: {
               networkDetails: {
-                isEIP1559Compatible: true,
+                EIPS: {
+                  1559: true,
+                },
               },
             },
           },
@@ -3150,7 +3176,7 @@ describe('NetworkController', () => {
             });
             const promiseForIsEIP1559CompatibleChanges = waitForStateChanges({
               messenger,
-              propertyPath: ['networkDetails', 'isEIP1559Compatible'],
+              propertyPath: ['networkDetails', 'EIPS', '1559'],
             });
 
             await controller.getEIP1559Compatibility();
@@ -3165,7 +3191,9 @@ describe('NetworkController', () => {
           {
             state: {
               networkDetails: {
-                isEIP1559Compatible: true,
+                EIPS: {
+                  1559: true,
+                },
               },
             },
           },
@@ -3290,7 +3318,9 @@ describe('NetworkController', () => {
                 createNetworkClientMock.mockReturnValue(fakeNetworkClient);
                 await controller.initializeProvider();
                 expect(controller.state.networkDetails).toStrictEqual({
-                  isEIP1559Compatible: false,
+                  EIPS: {
+                    1559: false,
+                  },
                 });
 
                 await waitForStateChanges({
@@ -3306,7 +3336,9 @@ describe('NetworkController', () => {
                   },
                 });
 
-                expect(controller.state.networkDetails).toStrictEqual({});
+                expect(controller.state.networkDetails).toStrictEqual({
+                  EIPS: {},
+                });
               },
             );
           });
@@ -3423,7 +3455,9 @@ describe('NetworkController', () => {
                     chainId: '9999999',
                   },
                   networkDetails: {
-                    isEIP1559Compatible: false,
+                    EIPS: {
+                      1559: false,
+                    },
                   },
                 },
               },
@@ -3444,7 +3478,9 @@ describe('NetworkController', () => {
                 await controller.resetConnection();
 
                 expect(controller.state.networkDetails).toStrictEqual({
-                  isEIP1559Compatible: true,
+                  EIPS: {
+                    1559: true,
+                  },
                 });
               },
             );
@@ -3524,7 +3560,9 @@ describe('NetworkController', () => {
                 chainId: '1337',
               },
               networkDetails: {
-                isEIP1559Compatible: false,
+                EIPS: {
+                  1559: false,
+                },
               },
             },
           },
@@ -3556,7 +3594,9 @@ describe('NetworkController', () => {
             createNetworkClientMock.mockReturnValue(fakeNetworkClient);
             await controller.initializeProvider();
             expect(controller.state.networkDetails).toStrictEqual({
-              isEIP1559Compatible: false,
+              EIPS: {
+                1559: false,
+              },
             });
 
             await waitForStateChanges({
@@ -3572,7 +3612,9 @@ describe('NetworkController', () => {
               },
             });
 
-            expect(controller.state.networkDetails).toStrictEqual({});
+            expect(controller.state.networkDetails).toStrictEqual({
+              EIPS: {},
+            });
           },
         );
       });
@@ -3704,7 +3746,9 @@ describe('NetworkController', () => {
                 chainId: '1337',
               },
               networkDetails: {
-                isEIP1559Compatible: false,
+                EIPS: {
+                  1559: false,
+                },
               },
             },
           },
@@ -3725,7 +3769,9 @@ describe('NetworkController', () => {
             await controller.resetConnection();
 
             expect(controller.state.networkDetails).toStrictEqual({
-              isEIP1559Compatible: true,
+              EIPS: {
+                1559: true,
+              },
             });
           },
         );
@@ -4664,7 +4710,7 @@ describe('NetworkController', () => {
           );
         });
 
-        it('resets isEIP1559Compatible and sets network to "unknown" for the network before emitting NetworkController:providerConfigChange', async () => {
+        it('resets EIPS[1559] and sets network to "unknown" for the network before emitting NetworkController:providerConfigChange', async () => {
           const networkConfiguration = {
             rpcUrl: 'https://mock-rpc-url',
             chainId: '0x1338',
@@ -4733,7 +4779,9 @@ describe('NetworkController', () => {
 
               await controller.setActiveNetwork('testNetworkConfigurationId');
               expect(controller.state.networkDetails).toStrictEqual({
-                isEIP1559Compatible: true,
+                EIPS: {
+                  1559: true,
+                },
               });
 
               await waitForStateChanges({
@@ -4751,7 +4799,9 @@ describe('NetworkController', () => {
                 NetworkStatus.Unknown,
               );
               expect(controller.state.networkDetails).toStrictEqual({
-                isEIP1559Compatible: false,
+                EIPS: {
+                  1559: false,
+                },
               });
             },
           );
@@ -5166,7 +5216,9 @@ describe('NetworkController', () => {
             createNetworkClientMock.mockReturnValue(fakeNetworkClient);
             await controller.setActiveNetwork('testNetworkConfigurationId1');
             expect(controller.state.networkDetails).toStrictEqual({
-              isEIP1559Compatible: true,
+              EIPS: {
+                1559: true,
+              },
             });
             expect(controller.state.networkStatus).toStrictEqual(
               NetworkStatus.Available,
@@ -5187,7 +5239,9 @@ describe('NetworkController', () => {
             expect(controller.state.networkStatus).toStrictEqual(
               NetworkStatus.Unknown,
             );
-            expect(controller.state.networkDetails).toStrictEqual({});
+            expect(controller.state.networkDetails).toStrictEqual({
+              EIPS: {},
+            });
           },
         );
       });

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -187,7 +187,7 @@ describe('NetworkController', () => {
           state: {
             networkDetails: {
               EIPS: {
-                1559: false,
+                1559: true,
               },
             },
           },
@@ -200,7 +200,7 @@ describe('NetworkController', () => {
             providerConfig: { type: NetworkType.mainnet, chainId: '1' },
             networkDetails: {
               EIPS: {
-                1559: false,
+                1559: true,
               },
             },
           });

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -172,7 +172,7 @@ const MOCK_NETWORK: MockNetwork = {
   state: {
     networkId: '5',
     networkStatus: NetworkStatus.Available,
-    networkDetails: { isEIP1559Compatible: false },
+    networkDetails: { EIPS: { 1559: false } },
     providerConfig: {
       type: NetworkType.goerli,
       chainId: NetworksChainId.goerli,
@@ -187,7 +187,7 @@ const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
   state: {
     networkId: '5',
     networkStatus: NetworkStatus.Available,
-    networkDetails: { isEIP1559Compatible: false },
+    networkDetails: { EIPS: { 1559: false } },
     providerConfig: {
       type: NetworkType.goerli,
     } as NetworkState['providerConfig'],
@@ -201,7 +201,7 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
   state: {
     networkId: '1',
     networkStatus: NetworkStatus.Available,
-    networkDetails: { isEIP1559Compatible: false },
+    networkDetails: { EIPS: { 1559: false } },
     providerConfig: {
       type: NetworkType.mainnet,
       chainId: NetworksChainId.mainnet,
@@ -216,7 +216,7 @@ const MOCK_CUSTOM_NETWORK: MockNetwork = {
   state: {
     networkId: '11297108109',
     networkStatus: NetworkStatus.Available,
-    networkDetails: { isEIP1559Compatible: false },
+    networkDetails: { EIPS: { 1559: false } },
     providerConfig: {
       type: NetworkType.rpc,
       chainId: '11297108109',


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR changes the type of the `networkDetails` state property, using an `EIPS` object instead of `isEIP1559Compatible`

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **BREAKING**: Changed shape of `networkDetails` state property type
  - Replace references to `networkDetails.isEIP1559Compatible` with `networkDetails.EIPS.1559`

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes #1218

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
