### PR TITLE
NetworkController: Remove providerConfigChange event

### DIFF
--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -2,7 +2,6 @@ import * as sinon from 'sinon';
 import nock from 'nock';
 import { BN } from 'ethereumjs-util';
 import {
-  NetworkControllerProviderConfigChangeEvent,
   NetworkControllerStateChangeEvent,
   defaultState as defaultNetworkState,
   NetworkState,
@@ -89,9 +88,7 @@ const sampleTokenB: Token = {
 
 type MainControllerMessenger = ControllerMessenger<
   GetTokenListState,
-  | TokenListStateChange
-  | NetworkControllerProviderConfigChangeEvent
-  | NetworkControllerStateChangeEvent
+  TokenListStateChange | NetworkControllerStateChangeEvent
 >;
 
 const getControllerMessenger = (): MainControllerMessenger => {
@@ -106,7 +103,7 @@ const setupTokenListController = (
     allowedActions: [],
     allowedEvents: [
       'TokenListController:stateChange',
-      'NetworkController:providerConfigChange',
+      'NetworkController:stateChange',
     ],
   });
 

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -2,8 +2,9 @@ import * as sinon from 'sinon';
 import nock from 'nock';
 import { ControllerMessenger } from '@metamask/base-controller';
 import {
-  NetworkControllerProviderConfigChangeEvent,
+  NetworkControllerStateChangeEvent,
   NetworkState,
+  NetworkStatus,
   ProviderConfig,
 } from '@metamask/network-controller';
 import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
@@ -474,7 +475,7 @@ const expiredCacheExistingState: TokenListState = {
 
 type MainControllerMessenger = ControllerMessenger<
   GetTokenListState,
-  TokenListStateChange | NetworkControllerProviderConfigChangeEvent
+  TokenListStateChange | NetworkControllerStateChangeEvent
 >;
 
 const getControllerMessenger = (): MainControllerMessenger => {
@@ -489,12 +490,32 @@ const getRestrictedMessenger = (
     allowedActions: [],
     allowedEvents: [
       'TokenListController:stateChange',
-      'NetworkController:providerConfigChange',
+      'NetworkController:stateChange',
     ],
   });
 
   return messenger;
 };
+
+/**
+ * Builds an object that satisfies the NetworkState shape using the given
+ * provider config. This can be used to return a complete value for the
+ * `NetworkController:stateChange` event.
+ *
+ * @param providerConfig - The provider config to use.
+ * @returns A complete state object for NetworkController.
+ */
+function buildNetworkControllerStateWithProviderConfig(
+  providerConfig: ProviderConfig,
+): NetworkState {
+  return {
+    providerConfig,
+    networkId: '1',
+    networkStatus: NetworkStatus.Available,
+    networkDetails: {},
+    networkConfigurations: {},
+  };
+}
 
 describe('TokenListController', () => {
   afterEach(() => {
@@ -519,7 +540,7 @@ describe('TokenListController', () => {
 
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerConfigChange',
+      'NetworkController:stateChange',
     );
   });
 
@@ -568,7 +589,7 @@ describe('TokenListController', () => {
 
     controller.destroy();
     controllerMessenger.clearEventSubscriptions(
-      'NetworkController:providerConfigChange',
+      'NetworkController:stateChange',
     );
   });
 
@@ -613,9 +634,7 @@ describe('TokenListController', () => {
 
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
-    let onNetworkStateChangeCallback!: (
-      state: NetworkState | ProviderConfig,
-    ) => void;
+    let onNetworkStateChangeCallback!: (state: NetworkState) => void;
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       onNetworkStateChange: (cb) => (onNetworkStateChangeCallback = cb),
@@ -628,10 +647,12 @@ describe('TokenListController', () => {
     expect(controller.state.tokenList).toStrictEqual(
       sampleSingleChainState.tokenList,
     );
-    onNetworkStateChangeCallback({
-      chainId: NetworksChainId.goerli,
-      type: NetworkType.goerli,
-    });
+    onNetworkStateChangeCallback(
+      buildNetworkControllerStateWithProviderConfig({
+        chainId: NetworksChainId.goerli,
+        type: NetworkType.goerli,
+      }),
+    );
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 500));
 
     expect(controller.state.tokenList).toStrictEqual({});
@@ -1019,10 +1040,14 @@ describe('TokenListController', () => {
       sampleTwoChainState.tokensChainsCache[NetworksChainId.mainnet].data,
     );
 
-    controllerMessenger.publish('NetworkController:providerConfigChange', {
-      type: NetworkType.goerli,
-      chainId: NetworksChainId.goerli,
-    });
+    controllerMessenger.publish(
+      'NetworkController:stateChange',
+      buildNetworkControllerStateWithProviderConfig({
+        type: NetworkType.goerli,
+        chainId: NetworksChainId.goerli,
+      }),
+      [],
+    );
 
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 500));
 
@@ -1033,11 +1058,15 @@ describe('TokenListController', () => {
       sampleTwoChainState.tokensChainsCache[NetworksChainId.mainnet].data,
     );
 
-    controllerMessenger.publish('NetworkController:providerConfigChange', {
-      type: NetworkType.rpc,
-      chainId: '56',
-      rpcUrl: 'http://localhost:8545',
-    });
+    controllerMessenger.publish(
+      'NetworkController:stateChange',
+      buildNetworkControllerStateWithProviderConfig({
+        type: NetworkType.rpc,
+        chainId: '56',
+        rpcUrl: 'http://localhost:8545',
+      }),
+      [],
+    );
 
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 500));
     expect(controller.state.tokenList).toStrictEqual(
@@ -1094,10 +1123,14 @@ describe('TokenListController', () => {
       interval: 100,
     });
     await controller.start();
-    controllerMessenger.publish('NetworkController:providerConfigChange', {
-      type: NetworkType.mainnet,
-      chainId: NetworksChainId.mainnet,
-    });
+    controllerMessenger.publish(
+      'NetworkController:stateChange',
+      buildNetworkControllerStateWithProviderConfig({
+        type: NetworkType.mainnet,
+        chainId: NetworksChainId.mainnet,
+      }),
+      [],
+    );
 
     expect(controller.state).toStrictEqual({
       tokenList: {},
@@ -1130,16 +1163,20 @@ describe('TokenListController', () => {
         messenger.clearEventSubscriptions('TokenListController:stateChange');
         controller.destroy();
         controllerMessenger.clearEventSubscriptions(
-          'NetworkController:providerConfigChange',
+          'NetworkController:stateChange',
         );
         resolve();
       });
 
-      controllerMessenger.publish('NetworkController:providerConfigChange', {
-        type: NetworkType.rpc,
-        chainId: '56',
-        rpcUrl: 'http://localhost:8545',
-      });
+      controllerMessenger.publish(
+        'NetworkController:stateChange',
+        buildNetworkControllerStateWithProviderConfig({
+          type: NetworkType.rpc,
+          chainId: '56',
+          rpcUrl: 'http://localhost:8545',
+        }),
+        [],
+      );
     });
   });
 });

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -512,7 +512,9 @@ function buildNetworkControllerStateWithProviderConfig(
     providerConfig,
     networkId: '1',
     networkStatus: NetworkStatus.Available,
-    networkDetails: {},
+    networkDetails: {
+      EIPS: {},
+    },
     networkConfigurations: {},
   };
 }

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -3,9 +3,8 @@ import * as sinon from 'sinon';
 import { ControllerMessenger } from '@metamask/base-controller';
 import {
   NetworkController,
-  NetworkControllerGetEthQueryAction,
-  NetworkControllerGetProviderConfigAction,
-  NetworkControllerProviderConfigChangeEvent,
+  NetworkControllerGetStateAction,
+  NetworkControllerStateChangeEvent,
   NetworkState,
 } from '@metamask/network-controller';
 import EthQuery from 'eth-query';
@@ -40,10 +39,8 @@ const mockedDetermineGasFeeCalculations =
 const name = 'GasFeeController';
 
 type MainControllerMessenger = ControllerMessenger<
-  | GetGasFeeState
-  | NetworkControllerGetProviderConfigAction
-  | NetworkControllerGetEthQueryAction,
-  GasFeeStateChange | NetworkControllerProviderConfigChangeEvent
+  GetGasFeeState | NetworkControllerGetStateAction,
+  GasFeeStateChange | NetworkControllerStateChangeEvent
 >;
 
 const getControllerMessenger = (): MainControllerMessenger => {
@@ -61,11 +58,8 @@ const setupNetworkController = async ({
 }) => {
   const restrictedMessenger = unrestrictedMessenger.getRestricted({
     name: 'NetworkController',
-    allowedEvents: ['NetworkController:providerConfigChange'],
-    allowedActions: [
-      'NetworkController:getProviderConfig',
-      'NetworkController:getEthQuery',
-    ],
+    allowedActions: ['NetworkController:getState'],
+    allowedEvents: ['NetworkController:stateChange'],
   });
 
   const networkController = new NetworkController({
@@ -89,11 +83,8 @@ const getRestrictedMessenger = (
 ) => {
   const messenger = controllerMessenger.getRestricted({
     name,
-    allowedActions: [
-      'NetworkController:getProviderConfig',
-      'NetworkController:getEthQuery',
-    ],
-    allowedEvents: ['NetworkController:providerConfigChange'],
+    allowedActions: ['NetworkController:getState'],
+    allowedEvents: ['NetworkController:stateChange'],
   });
 
   return messenger;

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -153,11 +153,6 @@ export type NetworkControllerStateChangeEvent = {
   payload: [NetworkState, Patch[]];
 };
 
-export type NetworkControllerProviderConfigChangeEvent = {
-  type: `NetworkController:providerConfigChange`;
-  payload: [ProviderConfig];
-};
-
 /**
  * `infuraIsBlocked` is published after the network is switched to an Infura
  * network, but when Infura returns an error blocking the user based on their
@@ -180,9 +175,13 @@ export type NetworkControllerInfuraIsUnblockedEvent = {
 
 export type NetworkControllerEvents =
   | NetworkControllerStateChangeEvent
-  | NetworkControllerProviderConfigChangeEvent
   | NetworkControllerInfuraIsBlockedEvent
   | NetworkControllerInfuraIsUnblockedEvent;
+
+export type NetworkControllerGetStateAction = {
+  type: `NetworkController:getState`;
+  handler: () => NetworkState;
+};
 
 export type NetworkControllerGetProviderConfigAction = {
   type: `NetworkController:getProviderConfig`;
@@ -195,12 +194,13 @@ export type NetworkControllerGetEthQueryAction = {
 };
 
 export type NetworkControllerActions =
+  | NetworkControllerGetStateAction
   | NetworkControllerGetProviderConfigAction
   | NetworkControllerGetEthQueryAction;
 
 export type NetworkControllerMessenger = RestrictedControllerMessenger<
   typeof name,
-  NetworkControllerGetProviderConfigAction | NetworkControllerGetEthQueryAction,
+  NetworkControllerActions,
   NetworkControllerEvents,
   string,
   string
@@ -513,11 +513,6 @@ export class NetworkController extends BaseControllerV2<
         // previously connected to an Infura network that was blocked
         this.messagingSystem.publish('NetworkController:infuraIsUnblocked');
       }
-
-      this.messagingSystem.publish(
-        `NetworkController:providerConfigChange`,
-        this.state.providerConfig,
-      );
     } finally {
       releaseLock();
     }


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

Despite its name, the `providerConfigChange` event in NetworkController doesn't get emitted whenever the `providerConfig` property in state is changed. Rather, it gets updated as the very last step in `lookupNetwork`. This method is called:

- When the provider is initialized
- When the network is switched
- When the network is rolled back to the previous setting
- When `resetConnection` is called

`lookupNetwork` can also be called on its own.

If this were not enough, we already provide a way to listen for changes to a particular property in state: by passing a selector function to the `subscribe` method on the controller messenger.

So, this commit removes the `providerConfigChange` event from NetworkController. Instead of the following code:

```
messenger.subscribe(
  'NetworkController:providerConfigChange',
  (providerConfig) => {
    // do something with the providerConfig
  },
)
```

consumers should be able to say:

```
messenger.subscribe(
  'NetworkController:stateChange',
  (providerConfig) => {
    // do something with the providerConfig
  },
  (networkControllerState) => networkControllerState.providerConfig,
)
```

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **BREAKING**: [`@metamask/network-controller`] Update `initializeProvider`, `lookupNetwork`, `setProviderType`, `setActiveNetwork`, `rollbackToPreviousProvider`, and `resetConnection` so that `NetworkController:providerConfigChange` is no longer emitted; remove this event entirely from the set of allowed events along with the `NetworkControllerProviderConfigChangeEvent` type
  - Consumers are encouraged to subscribe to `NetworkController:stateChange` with a selector function that returns `providerConfig` if they want to perform an action when `providerConfig` changes.
- **ADDED**: [`@metamask/network-controller`] Add `NetworkController:getState` to the set of allowed messenger actions, along with a `NetworkControllerGetStateAction` type
- **BREAKING:** [`@metamask/assets-controllers`] Update signature of `onNetworkStateChange` callback for TokenListController so that it must be given a NetworkController state change object; it will no longer also accept a provider config object
- **BREAKING:** [`@metamask/assets-controllers`] Update type of TokenListController messenger to require `NetworkController:stateChange` as an allowed event
- **BREAKING:** [`@metamask/gas-fee-controller`] Update type of GasFeeMessenger to require `NetworkController:getState` as an allowed event


## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Fixes #1205.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
