### PR TITLE
Refactor `lookupNetworkTests` helper function

### DIFF
--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -508,7 +508,7 @@ describe('NetworkController', () => {
           initialState: {
             providerConfig: buildProviderConfig({ type: networkType }),
           },
-          operation: async (controller: NetworkController) => {
+          operation: async (controller) => {
             await controller.lookupNetwork();
           },
         });


### PR DESCRIPTION
## Description

The `lookupNetworkTests` helper function has been updated to distinguish between the initial state and the expected provider config at the end of the operation under test.

Previously the `providerConfig` passed in was used as part of the initial state _and_ as the expected end state. This worked for operations like `resetConnection` and `lookupNetwork` where the network doesn't change, but it was incompatible with functions that change the active network.

## Changes

None

## References

Relates to #1210

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
