### PR TITLE
Refactor refresh network tests

### DIFF
--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -3474,10 +3474,10 @@ function refreshNetworkTests({
           // Called during provider initialization
           {
             request: {
-              method: 'eth_getBlockByNumber',
+              method: 'net_version',
             },
             response: {
-              result: '0x1',
+              result: '1',
             },
           },
           // Called during network lookup after resetting connection.

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -3529,9 +3529,13 @@ function refreshNetworkTests({
             request: {
               method: 'net_version',
             },
-            response: {
-              result: '1',
+            response: SUCCESSFUL_NET_VERSION_RESPONSE,
+          },
+          {
+            request: {
+              method: 'eth_getBlockByNumber',
             },
+            response: SUCCESSFUL_ETH_GET_BLOCK_BY_NUMBER_RESPONSE,
           },
           // Called during network lookup after resetting connection.
           // Delayed to ensure that we can check the network status
@@ -3541,9 +3545,14 @@ function refreshNetworkTests({
             request: {
               method: 'net_version',
             },
-            response: {
-              result: '1',
+            response: SUCCESSFUL_NET_VERSION_RESPONSE,
+          },
+          {
+            delay: 1,
+            request: {
+              method: 'eth_getBlockByNumber',
             },
+            response: SUCCESSFUL_ETH_GET_BLOCK_BY_NUMBER_RESPONSE,
           },
         ]);
         const fakeNetworkClient = buildFakeClient(fakeProvider);

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -3737,7 +3737,24 @@ function refreshNetworkTests({
           buildFakeClient(fakeProviders[0]),
           buildFakeClient(fakeProviders[1]),
         ];
-        const networkClientOptions: Parameters<typeof createNetworkClient>[0] =
+        const initializationNetworkClientOptions: Parameters<
+          typeof createNetworkClient
+        >[0] =
+          controller.state.providerConfig.type === NetworkType.rpc
+            ? {
+                chainId: toHex(controller.state.providerConfig.chainId),
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                rpcUrl: controller.state.providerConfig.rpcUrl!,
+                type: NetworkClientType.Custom,
+              }
+            : {
+                network: controller.state.providerConfig.type,
+                infuraProjectId: 'infura-project-id',
+                type: NetworkClientType.Infura,
+              };
+        const operationNetworkClientOptions: Parameters<
+          typeof createNetworkClient
+        >[0] =
           expectedProviderConfig.type === NetworkType.rpc
             ? {
                 chainId: toHex(expectedProviderConfig.chainId),
@@ -3751,13 +3768,9 @@ function refreshNetworkTests({
                 type: NetworkClientType.Infura,
               };
         mockCreateNetworkClient()
-          .calledWith({
-            network: NetworkType.mainnet,
-            infuraProjectId: 'infura-project-id',
-            type: NetworkClientType.Infura,
-          })
+          .calledWith(initializationNetworkClientOptions)
           .mockReturnValue(fakeNetworkClients[0])
-          .calledWith(networkClientOptions)
+          .calledWith(operationNetworkClientOptions)
           .mockReturnValue(fakeNetworkClients[1]);
         await controller.initializeProvider();
         const { provider: providerBefore } =


### PR DESCRIPTION
## Description

The network controller unit tests have been refactored to use a helper function to test the effects of the refresh network step. This step happens during a variety of different functions, and has the same effects each time.

All tests related to the refresh network step have been consolidated in a helper function. This helper function is invoked separately for each method that internally calls `#refreshNetwork`. The one exception to this is `rollbackToPreviousProvider`, which is not tested using this helper function due to difficulties in abstracting the necessary test setup.
## Changes

None

## References

This relates to #1210

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
