### PR TITLE
Add network change events

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -162,6 +162,25 @@ export type NetworkControllerStateChangeEvent = {
 };
 
 /**
+ * `networkWillChange` is published when the current network is about to be
+ * switched, but the new provider has not been created and no state changes have
+ * occurred yet.
+ */
+export type NetworkControllerNetworkWillChangeEvent = {
+  type: 'NetworkController:networkWillChange';
+  payload: [];
+};
+
+/**
+ * `networkDidChange` is published after a provider has been created for a newly
+ * switched network (but before the network has been confirmed to be available).
+ */
+export type NetworkControllerNetworkDidChangeEvent = {
+  type: 'NetworkController:networkDidChange';
+  payload: [];
+};
+
+/**
  * `infuraIsBlocked` is published after the network is switched to an Infura
  * network, but when Infura returns an error blocking the user based on their
  * location.
@@ -183,6 +202,8 @@ export type NetworkControllerInfuraIsUnblockedEvent = {
 
 export type NetworkControllerEvents =
   | NetworkControllerStateChangeEvent
+  | NetworkControllerNetworkWillChangeEvent
+  | NetworkControllerNetworkDidChangeEvent
   | NetworkControllerInfuraIsBlockedEvent
   | NetworkControllerInfuraIsUnblockedEvent;
 
@@ -365,6 +386,7 @@ export class NetworkController extends BaseControllerV2<
   }
 
   async #refreshNetwork() {
+    this.messagingSystem.publish('NetworkController:networkWillChange');
     this.update((state) => {
       state.networkId = null;
       state.networkStatus = NetworkStatus.Unknown;
@@ -374,6 +396,7 @@ export class NetworkController extends BaseControllerV2<
     });
     const { rpcUrl, type, chainId } = this.state.providerConfig;
     this.#configureProvider(type, rpcUrl, chainId);
+    this.messagingSystem.publish('NetworkController:networkDidChange');
     await this.lookupNetwork();
   }
 

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -2353,7 +2353,6 @@ describe('NetworkController', () => {
                   },
                 },
               },
-              infuraProjectId: 'some-infura-project-id',
             },
             async ({ controller, messenger }) => {
               const fakeProvider = buildFakeProvider();
@@ -2397,7 +2396,6 @@ describe('NetworkController', () => {
                   },
                 },
               },
-              infuraProjectId: 'some-infura-project-id',
             },
             async ({ controller, messenger }) => {
               const fakeProvider = buildFakeProvider();
@@ -2988,7 +2986,6 @@ describe('NetworkController', () => {
                 chainId: '1337',
               }),
             },
-            infuraProjectId: 'some-infura-project-id',
           },
           async ({ controller, messenger }) => {
             const fakeProvider = buildFakeProvider();
@@ -3021,7 +3018,6 @@ describe('NetworkController', () => {
                 chainId: '1337',
               }),
             },
-            infuraProjectId: 'some-infura-project-id',
           },
           async ({ controller, messenger }) => {
             const fakeProvider = buildFakeProvider();
@@ -3615,7 +3611,6 @@ function refreshNetworkTests({
   it('emits networkWillChange', async () => {
     await withController(
       {
-        infuraProjectId: 'infura-project-id',
         state: initialState,
       },
       async ({ controller, messenger }) => {
@@ -3641,7 +3636,6 @@ function refreshNetworkTests({
   it('emits networkDidChange', async () => {
     await withController(
       {
-        infuraProjectId: 'infura-project-id',
         state: initialState,
       },
       async ({ controller, messenger }) => {

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -2338,7 +2338,6 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: networkType,
-                  ...BUILT_IN_NETWORKS[networkType],
                 }),
                 networkConfigurations: {
                   testNetworkConfiguration: {
@@ -2381,7 +2380,6 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: networkType,
-                  ...BUILT_IN_NETWORKS[networkType],
                 }),
                 networkConfigurations: {
                   testNetworkConfiguration: {
@@ -2982,8 +2980,6 @@ describe('NetworkController', () => {
             state: {
               providerConfig: buildProviderConfig({
                 type: NetworkType.rpc,
-                rpcUrl: 'https://mock-rpc-url',
-                chainId: '1337',
               }),
             },
           },
@@ -3014,8 +3010,6 @@ describe('NetworkController', () => {
             state: {
               providerConfig: buildProviderConfig({
                 type: NetworkType.rpc,
-                rpcUrl: 'https://mock-rpc-url',
-                chainId: '1337',
               }),
             },
           },

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -2332,6 +2332,94 @@ describe('NetworkController', () => {
   describe('rollbackToPreviousProvider', () => {
     for (const { networkType } of INFURA_NETWORKS) {
       describe(`if the previous provider configuration had a type of "${networkType}"`, () => {
+        it('emits networkWillChange', async () => {
+          await withController(
+            {
+              state: {
+                providerConfig: buildProviderConfig({
+                  type: networkType,
+                  ...BUILT_IN_NETWORKS[networkType],
+                }),
+                networkConfigurations: {
+                  testNetworkConfiguration: {
+                    id: 'testNetworkConfiguration',
+                    rpcUrl: 'https://mock-rpc-url',
+                    chainId: '0x1337',
+                    ticker: 'TEST',
+                    nickname: 'test network',
+                    rpcPrefs: {
+                      blockExplorerUrl: 'https://test-block-explorer.com',
+                    },
+                  },
+                },
+              },
+              infuraProjectId: 'some-infura-project-id',
+            },
+            async ({ controller, messenger }) => {
+              const fakeProvider = buildFakeProvider();
+              const fakeNetworkClient = buildFakeClient(fakeProvider);
+              mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
+              await controller.setActiveNetwork('testNetworkConfiguration');
+
+              const networkWillChange = await waitForPublishedEvents({
+                messenger,
+                eventType: 'NetworkController:networkWillChange',
+                operation: () => {
+                  // Intentionally not awaited because we're capturing an event
+                  // emitted partway through the operation
+                  controller.rollbackToPreviousProvider();
+                },
+              });
+
+              expect(networkWillChange).toStrictEqual([[]]);
+            },
+          );
+        });
+
+        it('emits networkDidChange', async () => {
+          await withController(
+            {
+              state: {
+                providerConfig: buildProviderConfig({
+                  type: networkType,
+                  ...BUILT_IN_NETWORKS[networkType],
+                }),
+                networkConfigurations: {
+                  testNetworkConfiguration: {
+                    id: 'testNetworkConfiguration',
+                    rpcUrl: 'https://mock-rpc-url',
+                    chainId: '0x1337',
+                    ticker: 'TEST',
+                    nickname: 'test network',
+                    rpcPrefs: {
+                      blockExplorerUrl: 'https://test-block-explorer.com',
+                    },
+                  },
+                },
+              },
+              infuraProjectId: 'some-infura-project-id',
+            },
+            async ({ controller, messenger }) => {
+              const fakeProvider = buildFakeProvider();
+              const fakeNetworkClient = buildFakeClient(fakeProvider);
+              mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
+              await controller.setActiveNetwork('testNetworkConfiguration');
+
+              const networkDidChange = await waitForPublishedEvents({
+                messenger,
+                eventType: 'NetworkController:networkDidChange',
+                operation: () => {
+                  // Intentionally not awaited because we're capturing an event
+                  // emitted partway through the operation
+                  controller.rollbackToPreviousProvider();
+                },
+              });
+
+              expect(networkDidChange).toStrictEqual([[]]);
+            },
+          );
+        });
+
         it('overwrites the the current provider configuration with the previous provider configuration', async () => {
           await withController(
             {
@@ -2890,6 +2978,72 @@ describe('NetworkController', () => {
     }
 
     describe(`if the previous provider configuration had a type of "rpc"`, () => {
+      it('emits networkWillChange', async () => {
+        await withController(
+          {
+            state: {
+              providerConfig: buildProviderConfig({
+                type: NetworkType.rpc,
+                rpcUrl: 'https://mock-rpc-url',
+                chainId: '1337',
+              }),
+            },
+            infuraProjectId: 'some-infura-project-id',
+          },
+          async ({ controller, messenger }) => {
+            const fakeProvider = buildFakeProvider();
+            const fakeNetworkClient = buildFakeClient(fakeProvider);
+            mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
+            await controller.setProviderType(InfuraNetworkType.goerli);
+
+            const networkWillChange = await waitForPublishedEvents({
+              messenger,
+              eventType: 'NetworkController:networkWillChange',
+              operation: () => {
+                // Intentionally not awaited because we're capturing an event
+                // emitted partway through the operation
+                controller.rollbackToPreviousProvider();
+              },
+            });
+
+            expect(networkWillChange).toStrictEqual([[]]);
+          },
+        );
+      });
+
+      it('emits networkDidChange', async () => {
+        await withController(
+          {
+            state: {
+              providerConfig: buildProviderConfig({
+                type: NetworkType.rpc,
+                rpcUrl: 'https://mock-rpc-url',
+                chainId: '1337',
+              }),
+            },
+            infuraProjectId: 'some-infura-project-id',
+          },
+          async ({ controller, messenger }) => {
+            const fakeProvider = buildFakeProvider();
+            const fakeNetworkClient = buildFakeClient(fakeProvider);
+            mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
+            await controller.setProviderType(InfuraNetworkType.goerli);
+
+            const networkDidChange = await waitForPublishedEvents({
+              messenger,
+              eventType: 'NetworkController:networkDidChange',
+              operation: () => {
+                // Intentionally not awaited because we're capturing an event
+                // emitted partway through the operation
+                controller.rollbackToPreviousProvider();
+              },
+            });
+
+            expect(networkDidChange).toStrictEqual([[]]);
+          },
+        );
+      });
+
       it('overwrites the the current provider configuration with the previous provider configuration', async () => {
         await withController(
           {
@@ -3458,6 +3612,58 @@ function refreshNetworkTests({
   initialState?: Partial<NetworkState>;
   operation: (controller: NetworkController) => Promise<void>;
 }) {
+  it('emits networkWillChange', async () => {
+    await withController(
+      {
+        infuraProjectId: 'infura-project-id',
+        state: initialState,
+      },
+      async ({ controller, messenger }) => {
+        const fakeProvider = buildFakeProvider();
+        const fakeNetworkClient = buildFakeClient(fakeProvider);
+        mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
+
+        const networkWillChange = await waitForPublishedEvents({
+          messenger,
+          eventType: 'NetworkController:networkWillChange',
+          operation: () => {
+            // Intentionally not awaited because we're capturing an event
+            // emitted partway through the operation
+            operation(controller);
+          },
+        });
+
+        expect(networkWillChange).toStrictEqual([[]]);
+      },
+    );
+  });
+
+  it('emits networkDidChange', async () => {
+    await withController(
+      {
+        infuraProjectId: 'infura-project-id',
+        state: initialState,
+      },
+      async ({ controller, messenger }) => {
+        const fakeProvider = buildFakeProvider();
+        const fakeNetworkClient = buildFakeClient(fakeProvider);
+        mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
+
+        const networkDidChange = await waitForPublishedEvents({
+          messenger,
+          eventType: 'NetworkController:networkDidChange',
+          operation: () => {
+            // Intentionally not awaited because we're capturing an event
+            // emitted partway through the operation
+            operation(controller);
+          },
+        });
+
+        expect(networkDidChange).toStrictEqual([[]]);
+      },
+    );
+  });
+
   it('clears network id from state', async () => {
     await withController(
       {
@@ -4979,6 +5185,8 @@ function buildNetworkControllerMessenger(messenger = buildMessenger()) {
       'NetworkController:stateChange',
       'NetworkController:infuraIsBlocked',
       'NetworkController:infuraIsUnblocked',
+      'NetworkController:networkDidChange',
+      'NetworkController:networkWillChange',
     ],
   });
 }


### PR DESCRIPTION
## Description

The network controller now emits the events `networkWillChange` and `networkDidChange` when the network is being refreshed. The event `networkWillChange` is emitted before the switch begins (before the network status is cleared), and the `networkDidChange` event is emitted after the new provider is setup (but before it has finished initializing).

## Changes

- ADDED: The events `networkWillChange` and `networkDidChange` are emitted during `setProviderType`, `setActiveNetwork`, `resetConnection`, and `rollbackToPreviousProvider`
  - The `networkWillChange` event is emitted before the network is switched (before the network status is cleared),
  - The `networkDidChange` event is emitted after the new provider is setup (but before it has finished initializing).

## References

Closes #1210

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
