### PR TITLE
[MMI] add setMsgInProgress method to AbstractMessageManager

### DIFF
--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -186,6 +186,31 @@ describe('AbstractTestManager', () => {
     expect(message.status).toBe('test-status');
   });
 
+  it('should set a status to inProgress', async () => {
+    const controller = new AbstractTestManager(
+      undefined,
+      undefined,
+      undefined,
+      ['test-status'],
+    );
+    await controller.addMessage({
+      id: messageId,
+      messageParams: {
+        data: typedMessage,
+        from,
+      },
+      status: messageStatus,
+      time: messageTime,
+      type: messageType,
+    });
+    controller.setMessageStatusInProgress(messageId);
+    const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.status).toBe('inProgress');
+  });
+
   it('should get correct unapproved messages', async () => {
     const firstMessageData = [
       {

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -282,6 +282,16 @@ export abstract class AbstractMessageManager<
   }
 
   /**
+   * Sets message status to inProgress in order to allow users to use extension
+   * while waiting for a custodian signature.
+   *
+   * @param messageId - The id of the message to set to inProgress
+   */
+  setMessageStatusInProgress(messageId: string) {
+    this.setMessageStatus(messageId, 'inProgress');
+  }
+
+  /**
    * Sets a Message status to 'signed' via a call to this.setMessageStatus and updates
    * that Message in this.messages by adding the raw signature data of the signature
    * request to the Message.

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -83,6 +83,7 @@ const createMessageManagerMock = <T>(prototype?: any): jest.Mocked<T> => {
     approveMessage: jest.fn(),
     setMessageStatusSigned: jest.fn(),
     setMessageStatusErrored: jest.fn(),
+    setMessageStatusInProgress: jest.fn(),
     rejectMessage: jest.fn(),
     subscribe: jest.fn(),
     update: jest.fn(),
@@ -735,6 +736,29 @@ describe('SignatureController', () => {
         unapprovedPersonalMsgCount: 0,
         unapprovedTypedMessagesCount: 5,
       });
+    });
+  });
+  describe('setPersonalMessageInProgress', () => {
+    it('calls the message manager', async () => {
+      signatureController.setPersonalMessageInProgress(
+        messageParamsMock.metamaskId,
+      );
+
+      expect(
+        personalMessageManagerMock.setMessageStatusInProgress,
+      ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setTypedMessageInProgress', () => {
+    it('calls the message manager', async () => {
+      signatureController.setTypedMessageInProgress(
+        messageParamsMock.metamaskId,
+      );
+
+      expect(
+        typedMessageManagerMock.setMessageStatusInProgress,
+      ).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -675,4 +675,12 @@ export class SignatureController extends BaseControllerV2<
       data: JSON.parse(messageParams.data),
     };
   }
+
+  setTypedMessageInProgress(messageId: string) {
+    this.#typedMessageManager.setMessageStatusInProgress(messageId);
+  }
+
+  setPersonalMessageInProgress(messageId: string) {
+    this.#personalMessageManager.setMessageStatusInProgress(messageId);
+  }
 }


### PR DESCRIPTION
## Description

Some messages (for example in MMI) have an intermediate state after being approved where they are not signed, due to the implicit delay in custodial signing.

This adds an `inProgress` status to messages which allows the user to continue using the extension while the message is being signed.

The method is also exposed via the Signature Controller.

## Changes

- **<ADDED>**: Added a method to set a message status to "inProgress"

## References

- Issue #1341 
- This [code-fencing PR](https://github.com/MetaMask/metamask-extension/pull/18770#discussion_r1185210107) is a dependent of this message.

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [X] I've highlighted breaking changes using the "BREAKING" category above as appropriate
