### PR TITLE
Add submitEncryptionKey method

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -1601,12 +1601,13 @@ type WithControllerArgs<ReturnValue> =
   | [WithControllerOptions, WithControllerCallback<ReturnValue>];
 
 /**
- * Builds a controller based on the given options, and calls the given function
- * with that controller.
+ * Builds a controller based on the given options and creates a new vault
+ * and keychain, then calls the given function with that controller.
  *
  * @param args - Either a function, or an options bag + a function. The options
  * bag is equivalent to the options that KeyringController takes;
- * the function will be called with the built controller.
+ * the function will be called with the built controller, along with its
+ * preferences, encryptor and initial state.
  * @returns Whatever the callback returns.
  */
 async function withController<ReturnValue>(

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -706,177 +706,189 @@ describe('KeyringController', () => {
 
   describe('signTypedMessage', () => {
     it('should throw when given invalid version', async () => {
-      await withController(async ({ controller, initialState }) => {
-        const typedMsgParams = [
-          {
-            name: 'Message',
-            type: 'string',
-            value: 'Hi, Alice!',
-          },
-          {
-            name: 'A number',
-            type: 'uint32',
-            value: '1337',
-          },
-        ];
-        const account = initialState.keyrings[0].accounts[0];
-        await expect(
-          controller.signTypedMessage(
-            { data: typedMsgParams, from: account },
-            'junk' as SignTypedDataVersion,
-          ),
-        ).rejects.toThrow(
-          "Keyring Controller signTypedMessage: Error: Unexpected signTypedMessage version: 'junk'",
-        );
-      });
+      await withController(
+        { keyringBuilders: [keyringBuilderFactory(QRKeyring)] },
+        async ({ controller, initialState }) => {
+          const typedMsgParams = [
+            {
+              name: 'Message',
+              type: 'string',
+              value: 'Hi, Alice!',
+            },
+            {
+              name: 'A number',
+              type: 'uint32',
+              value: '1337',
+            },
+          ];
+          const account = initialState.keyrings[0].accounts[0];
+          await expect(
+            controller.signTypedMessage(
+              { data: typedMsgParams, from: account },
+              'junk' as SignTypedDataVersion,
+            ),
+          ).rejects.toThrow(
+            "Keyring Controller signTypedMessage: Error: Unexpected signTypedMessage version: 'junk'",
+          );
+        },
+      );
     });
 
     it('should sign typed message V1', async () => {
-      await withController(async ({ controller, initialState }) => {
-        const typedMsgParams = [
-          {
-            name: 'Message',
-            type: 'string',
-            value: 'Hi, Alice!',
-          },
-          {
-            name: 'A number',
-            type: 'uint32',
-            value: '1337',
-          },
-        ];
-        const account = initialState.keyrings[0].accounts[0];
-        const signature = await controller.signTypedMessage(
-          { data: typedMsgParams, from: account },
-          SignTypedDataVersion.V1,
-        );
-        const recovered = recoverTypedSignature({
-          data: typedMsgParams,
-          signature,
-          version: SignTypedDataVersion.V1,
-        });
-        expect(account).toBe(recovered);
-      });
+      await withController(
+        { keyringBuilders: [keyringBuilderFactory(QRKeyring)] },
+        async ({ controller, initialState }) => {
+          const typedMsgParams = [
+            {
+              name: 'Message',
+              type: 'string',
+              value: 'Hi, Alice!',
+            },
+            {
+              name: 'A number',
+              type: 'uint32',
+              value: '1337',
+            },
+          ];
+          const account = initialState.keyrings[0].accounts[0];
+          const signature = await controller.signTypedMessage(
+            { data: typedMsgParams, from: account },
+            SignTypedDataVersion.V1,
+          );
+          const recovered = recoverTypedSignature({
+            data: typedMsgParams,
+            signature,
+            version: SignTypedDataVersion.V1,
+          });
+          expect(account).toBe(recovered);
+        },
+      );
     });
 
     it('should sign typed message V3', async () => {
-      await withController(async ({ controller, initialState }) => {
-        const msgParams = {
-          domain: {
-            chainId: 1,
-            name: 'Ether Mail',
-            verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
-            version: '1',
-          },
-          message: {
-            contents: 'Hello, Bob!',
-            from: {
-              name: 'Cow',
-              wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+      await withController(
+        { keyringBuilders: [keyringBuilderFactory(QRKeyring)] },
+        async ({ controller, initialState }) => {
+          const msgParams = {
+            domain: {
+              chainId: 1,
+              name: 'Ether Mail',
+              verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+              version: '1',
             },
-            to: {
-              name: 'Bob',
-              wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+            message: {
+              contents: 'Hello, Bob!',
+              from: {
+                name: 'Cow',
+                wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+              },
+              to: {
+                name: 'Bob',
+                wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+              },
             },
-          },
-          primaryType: 'Mail' as const,
-          types: {
-            EIP712Domain: [
-              { name: 'name', type: 'string' },
-              { name: 'version', type: 'string' },
-              { name: 'chainId', type: 'uint256' },
-              { name: 'verifyingContract', type: 'address' },
-            ],
-            Mail: [
-              { name: 'from', type: 'Person' },
-              { name: 'to', type: 'Person' },
-              { name: 'contents', type: 'string' },
-            ],
-            Person: [
-              { name: 'name', type: 'string' },
-              { name: 'wallet', type: 'address' },
-            ],
-          },
-        };
-        const account = initialState.keyrings[0].accounts[0];
-        const signature = await controller.signTypedMessage(
-          { data: JSON.stringify(msgParams), from: account },
-          SignTypedDataVersion.V3,
-        );
-        const recovered = recoverTypedSignature({
-          data: msgParams,
-          signature,
-          version: SignTypedDataVersion.V3,
-        });
-        expect(account).toBe(recovered);
-      });
+            primaryType: 'Mail' as const,
+            types: {
+              EIP712Domain: [
+                { name: 'name', type: 'string' },
+                { name: 'version', type: 'string' },
+                { name: 'chainId', type: 'uint256' },
+                { name: 'verifyingContract', type: 'address' },
+              ],
+              Mail: [
+                { name: 'from', type: 'Person' },
+                { name: 'to', type: 'Person' },
+                { name: 'contents', type: 'string' },
+              ],
+              Person: [
+                { name: 'name', type: 'string' },
+                { name: 'wallet', type: 'address' },
+              ],
+            },
+          };
+          const account = initialState.keyrings[0].accounts[0];
+          const signature = await controller.signTypedMessage(
+            { data: JSON.stringify(msgParams), from: account },
+            SignTypedDataVersion.V3,
+          );
+          const recovered = recoverTypedSignature({
+            data: msgParams,
+            signature,
+            version: SignTypedDataVersion.V3,
+          });
+          expect(account).toBe(recovered);
+        },
+      );
     });
 
     it('should sign typed message V4', async () => {
-      await withController(async ({ controller, initialState }) => {
-        const msgParams = {
-          domain: {
-            chainId: 1,
-            name: 'Ether Mail',
-            verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
-            version: '1',
-          },
-          message: {
-            contents: 'Hello, Bob!',
-            from: {
-              name: 'Cow',
-              wallets: [
-                '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
-                '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
-              ],
+      await withController(
+        { keyringBuilders: [keyringBuilderFactory(QRKeyring)] },
+        async ({ controller, initialState }) => {
+          const msgParams = {
+            domain: {
+              chainId: 1,
+              name: 'Ether Mail',
+              verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+              version: '1',
             },
-            to: [
-              {
-                name: 'Bob',
+            message: {
+              contents: 'Hello, Bob!',
+              from: {
+                name: 'Cow',
                 wallets: [
-                  '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
-                  '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
-                  '0xB0B0b0b0b0b0B000000000000000000000000000',
+                  '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+                  '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
                 ],
               },
-            ],
-          },
-          primaryType: 'Mail' as const,
-          types: {
-            EIP712Domain: [
-              { name: 'name', type: 'string' },
-              { name: 'version', type: 'string' },
-              { name: 'chainId', type: 'uint256' },
-              { name: 'verifyingContract', type: 'address' },
-            ],
-            Group: [
-              { name: 'name', type: 'string' },
-              { name: 'members', type: 'Person[]' },
-            ],
-            Mail: [
-              { name: 'from', type: 'Person' },
-              { name: 'to', type: 'Person[]' },
-              { name: 'contents', type: 'string' },
-            ],
-            Person: [
-              { name: 'name', type: 'string' },
-              { name: 'wallets', type: 'address[]' },
-            ],
-          },
-        };
+              to: [
+                {
+                  name: 'Bob',
+                  wallets: [
+                    '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+                    '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
+                    '0xB0B0b0b0b0b0B000000000000000000000000000',
+                  ],
+                },
+              ],
+            },
+            primaryType: 'Mail' as const,
+            types: {
+              EIP712Domain: [
+                { name: 'name', type: 'string' },
+                { name: 'version', type: 'string' },
+                { name: 'chainId', type: 'uint256' },
+                { name: 'verifyingContract', type: 'address' },
+              ],
+              Group: [
+                { name: 'name', type: 'string' },
+                { name: 'members', type: 'Person[]' },
+              ],
+              Mail: [
+                { name: 'from', type: 'Person' },
+                { name: 'to', type: 'Person[]' },
+                { name: 'contents', type: 'string' },
+              ],
+              Person: [
+                { name: 'name', type: 'string' },
+                { name: 'wallets', type: 'address[]' },
+              ],
+            },
+          };
 
-        const account = initialState.keyrings[0].accounts[0];
-        const signature = await controller.signTypedMessage(
-          { data: JSON.stringify(msgParams), from: account },
-          SignTypedDataVersion.V4,
-        );
-        const recovered = recoverTypedSignature({
-          data: msgParams,
-          signature,
-          version: SignTypedDataVersion.V4,
-        });
-        expect(account).toBe(recovered);
-      });
+          const account = initialState.keyrings[0].accounts[0];
+          const signature = await controller.signTypedMessage(
+            { data: JSON.stringify(msgParams), from: account },
+            SignTypedDataVersion.V4,
+          );
+          const recovered = recoverTypedSignature({
+            data: msgParams,
+            signature,
+            version: SignTypedDataVersion.V4,
+          });
+          expect(account).toBe(recovered);
+        },
+      );
     });
 
     it('should fail when sign typed message format is wrong', async () => {
@@ -1148,7 +1160,7 @@ describe('KeyringController', () => {
 
     beforeEach(async () => {
       signProcessKeyringController = await withController(
-        {},
+        { keyringBuilders: [keyringBuilderFactory(QRKeyring)] },
         ({ controller }) => controller,
       );
       const qrkeyring = await signProcessKeyringController.getOrAddQRKeyring();
@@ -1568,6 +1580,7 @@ type WithControllerCallback<ReturnValue> = ({
   controller,
   preferences,
   initialState,
+  encryptor,
 }: {
   controller: KeyringController;
   preferences: {
@@ -1610,10 +1623,14 @@ async function withController<ReturnValue>(
   };
   const controller = new KeyringController(preferences, {
     encryptor,
-    keyringBuilders: [keyringBuilderFactory(QRKeyring)],
     cacheEncryptionKey: false,
     ...rest,
   });
   const initialState = await controller.createNewVaultAndKeychain(password);
-  return await fn({ controller, preferences, encryptor, initialState });
+  return await fn({
+    controller,
+    preferences,
+    encryptor,
+    initialState,
+  });
 }

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -53,21 +53,10 @@ describe('KeyringController', () => {
     sinon.restore();
   });
 
-  it('should set default state', async () => {
-    await withController({}, async ({ controller }) => {
-      expect(controller.state.keyrings).not.toStrictEqual([]);
-      const keyring = controller.state.keyrings[0];
-      expect(keyring.accounts).not.toStrictEqual([]);
-      expect(keyring.index).toStrictEqual(0);
-      expect(keyring.type).toStrictEqual('HD Key Tree');
-    });
-  });
-
   describe('addNewAccount', () => {
     describe('when accountCount is not provided', () => {
       it('should add new account', async () => {
         await withController(
-          {},
           async ({ controller, initialState, preferences }) => {
             const {
               keyringState: currentKeyringMemState,
@@ -98,7 +87,6 @@ describe('KeyringController', () => {
     describe('when accountCount is provided', () => {
       it('should add new account if accountCount is in sequence', async () => {
         await withController(
-          {},
           async ({ controller, initialState, preferences }) => {
             const {
               keyringState: currentKeyringMemState,
@@ -128,7 +116,7 @@ describe('KeyringController', () => {
       });
 
       it('should throw an error if passed accountCount param is out of sequence', async () => {
-        await withController({}, async ({ controller, initialState }) => {
+        await withController(async ({ controller, initialState }) => {
           const accountCount = initialState.keyrings[0].accounts.length;
           await expect(
             controller.addNewAccount(accountCount + 1),
@@ -137,7 +125,7 @@ describe('KeyringController', () => {
       });
 
       it('should not add a new account if called twice with the same accountCount param', async () => {
-        await withController({}, async ({ controller, initialState }) => {
+        await withController(async ({ controller, initialState }) => {
           const accountCount = initialState.keyrings[0].accounts.length;
           const { addedAccountAddress: firstAccountAdded } =
             await controller.addNewAccount(accountCount);
@@ -155,7 +143,6 @@ describe('KeyringController', () => {
   describe('addNewAccountWithoutUpdate', () => {
     it('should add new account without updating', async () => {
       await withController(
-        {},
         async ({ controller, initialState, preferences }) => {
           const initialUpdateIdentitiesCallCount =
             preferences.updateIdentities.callCount;
@@ -283,6 +270,16 @@ describe('KeyringController', () => {
               },
             );
           });
+
+          it('should set default state', async () => {
+            await withController(async ({ controller }) => {
+              expect(controller.state.keyrings).not.toStrictEqual([]);
+              const keyring = controller.state.keyrings[0];
+              expect(keyring.accounts).not.toStrictEqual([]);
+              expect(keyring.index).toStrictEqual(0);
+              expect(keyring.type).toStrictEqual('HD Key Tree');
+            });
+          });
         });
 
         describe('when there is an existing vault', () => {
@@ -321,7 +318,7 @@ describe('KeyringController', () => {
 
   describe('setLocked', () => {
     it('should set locked correctly', async () => {
-      await withController({}, async ({ controller }) => {
+      await withController(async ({ controller }) => {
         expect(controller.isUnlocked()).toBe(true);
         controller.setLocked();
         expect(controller.isUnlocked()).toBe(false);
@@ -332,7 +329,7 @@ describe('KeyringController', () => {
   describe('exportSeedPhrase', () => {
     describe('when correct password is provided', () => {
       it('should export seed phrase', async () => {
-        await withController({}, async ({ controller }) => {
+        await withController(async ({ controller }) => {
           const seed = await controller.exportSeedPhrase(password);
           expect(seed).not.toBe('');
         });
@@ -341,7 +338,7 @@ describe('KeyringController', () => {
 
     describe('when wrong password is provided', () => {
       it('should export seed phrase', async () => {
-        await withController({}, async ({ controller, encryptor }) => {
+        await withController(async ({ controller, encryptor }) => {
           sinon
             .stub(encryptor, 'decrypt')
             .throws(new Error('Invalid password'));
@@ -357,7 +354,7 @@ describe('KeyringController', () => {
     describe('when correct password is provided', () => {
       describe('when correct account is provided', () => {
         it('should export account', async () => {
-          await withController({}, async ({ controller, initialState }) => {
+          await withController(async ({ controller, initialState }) => {
             const account = initialState.keyrings[0].accounts[0];
             const newPrivateKey = await controller.exportAccount(
               password,
@@ -370,7 +367,7 @@ describe('KeyringController', () => {
 
       describe('when wrong account is provided', () => {
         it('should throw error', async () => {
-          await withController({}, async ({ controller }) => {
+          await withController(async ({ controller }) => {
             await expect(
               controller.exportAccount(password, ''),
             ).rejects.toThrow(/^No keyring found for the requested account./u);
@@ -382,7 +379,6 @@ describe('KeyringController', () => {
     describe('when wrong password is provided', () => {
       it('should throw error', async () => {
         await withController(
-          {},
           async ({ controller, initialState, encryptor }) => {
             const account = initialState.keyrings[0].accounts[0];
             sinon
@@ -404,7 +400,7 @@ describe('KeyringController', () => {
 
   describe('getAccounts', () => {
     it('should get accounts', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         const initialAccount = initialState.keyrings[0].accounts;
         const accounts = await controller.getAccounts();
         expect(accounts).toStrictEqual(initialAccount);
@@ -416,7 +412,7 @@ describe('KeyringController', () => {
     describe('using strategy privateKey', () => {
       describe('when correct key is provided', () => {
         it('should import account', async () => {
-          await withController({}, async ({ controller, initialState }) => {
+          await withController(async ({ controller, initialState }) => {
             const address = '0x51253087e6f8358b5f10c0a94315d69db3357859';
             const newKeyring = {
               accounts: [address],
@@ -437,7 +433,7 @@ describe('KeyringController', () => {
         });
 
         it('should not select imported account', async () => {
-          await withController({}, async ({ controller, preferences }) => {
+          await withController(async ({ controller, preferences }) => {
             await controller.importAccountWithStrategy(
               AccountImportStrategy.privateKey,
               [privateKey],
@@ -449,7 +445,7 @@ describe('KeyringController', () => {
 
       describe('when wrong key is provided', () => {
         it('should not import account', async () => {
-          await withController({}, async ({ controller }) => {
+          await withController(async ({ controller }) => {
             await expect(
               controller.importAccountWithStrategy(
                 AccountImportStrategy.privateKey,
@@ -487,7 +483,7 @@ describe('KeyringController', () => {
     describe('using strategy json', () => {
       describe('when correct data is provided', () => {
         it('should import account', async () => {
-          await withController({}, async ({ controller, initialState }) => {
+          await withController(async ({ controller, initialState }) => {
             const somePassword = 'holachao123';
             const address = '0xb97c80fab7a3793bbe746864db80d236f1345ea7';
 
@@ -511,7 +507,7 @@ describe('KeyringController', () => {
         });
 
         it('should not select imported account', async () => {
-          await withController({}, async ({ controller, preferences }) => {
+          await withController(async ({ controller, preferences }) => {
             const somePassword = 'holachao123';
             await controller.importAccountWithStrategy(
               AccountImportStrategy.json,
@@ -524,7 +520,7 @@ describe('KeyringController', () => {
 
       describe('when wrong data is provided', () => {
         it('should not import account with empty json', async () => {
-          await withController({}, async ({ controller }) => {
+          await withController(async ({ controller }) => {
             const somePassword = 'holachao123';
             await expect(
               controller.importAccountWithStrategy(AccountImportStrategy.json, [
@@ -536,7 +532,7 @@ describe('KeyringController', () => {
         });
 
         it('should not import account with wrong password', async () => {
-          await withController({}, async ({ controller }) => {
+          await withController(async ({ controller }) => {
             const somePassword = 'holachao12';
 
             await expect(
@@ -551,7 +547,7 @@ describe('KeyringController', () => {
         });
 
         it('should not import account with empty password', async () => {
-          await withController({}, async ({ controller }) => {
+          await withController(async ({ controller }) => {
             await expect(
               controller.importAccountWithStrategy(AccountImportStrategy.json, [
                 input,
@@ -567,7 +563,7 @@ describe('KeyringController', () => {
 
     describe('using unrecognized strategy', () => {
       it('should throw an unexpected import strategy error', async () => {
-        await withController({}, async ({ controller }) => {
+        await withController(async ({ controller }) => {
           const somePassword = 'holachao123';
           await expect(
             controller.importAccountWithStrategy(
@@ -587,7 +583,7 @@ describe('KeyringController', () => {
      * https://github.com/MetaMask/core/issues/801
      */
     it('should remove HD Key Tree keyring from state when single account associated with it is deleted', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         const account = initialState.keyrings[0].accounts[0];
         const finalState = await controller.removeAccount(account);
         expect(finalState.keyrings).toHaveLength(0);
@@ -595,7 +591,7 @@ describe('KeyringController', () => {
     });
 
     it('should remove account', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         await controller.importAccountWithStrategy(
           AccountImportStrategy.privateKey,
           [privateKey],
@@ -608,7 +604,7 @@ describe('KeyringController', () => {
     });
 
     it('should not remove account if wrong address is provided', async () => {
-      await withController({}, async ({ controller }) => {
+      await withController(async ({ controller }) => {
         await controller.importAccountWithStrategy(
           AccountImportStrategy.privateKey,
           [privateKey],
@@ -627,7 +623,7 @@ describe('KeyringController', () => {
 
   describe('signMessage', () => {
     it('should sign message', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         const data =
           '0x879a053d4800c6354e76c7985a865d2922c82fb5b3f4577b2fe08b998954f2e0';
         const account = initialState.keyrings[0].accounts[0];
@@ -640,7 +636,7 @@ describe('KeyringController', () => {
     });
 
     it('should not sign message if empty data is passed', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         await expect(() =>
           controller.signMessage({
             data: '',
@@ -651,7 +647,7 @@ describe('KeyringController', () => {
     });
 
     it('should not sign message if from account is not passed', async () => {
-      await withController({}, async ({ controller }) => {
+      await withController(async ({ controller }) => {
         await expect(
           controller.signMessage({
             data: '0x879a053d4800c6354e76c7985a865d2922c82fb5b3f4577b2fe08b998954f2e0',
@@ -666,7 +662,7 @@ describe('KeyringController', () => {
 
   describe('signPersonalMessage', () => {
     it('should sign personal message', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         const data = bufferToHex(Buffer.from('Hello from test', 'utf8'));
         const account = initialState.keyrings[0].accounts[0];
         const signature = await controller.signPersonalMessage({
@@ -683,7 +679,7 @@ describe('KeyringController', () => {
      * https://github.com/MetaMask/core/issues/799
      */
     it('should sign personal message even if empty data is passed', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         const account = initialState.keyrings[0].accounts[0];
         const signature = await controller.signPersonalMessage({
           data: '',
@@ -695,7 +691,7 @@ describe('KeyringController', () => {
     });
 
     it('should not sign personal message if from account is not passed', async () => {
-      await withController({}, async ({ controller }) => {
+      await withController(async ({ controller }) => {
         await expect(
           controller.signPersonalMessage({
             data: '0x879a053d4800c6354e76c7985a865d2922c82fb5b3f4577b2fe08b998954f2e0',
@@ -710,7 +706,7 @@ describe('KeyringController', () => {
 
   describe('signTypedMessage', () => {
     it('should throw when given invalid version', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         const typedMsgParams = [
           {
             name: 'Message',
@@ -736,7 +732,7 @@ describe('KeyringController', () => {
     });
 
     it('should sign typed message V1', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         const typedMsgParams = [
           {
             name: 'Message',
@@ -764,7 +760,7 @@ describe('KeyringController', () => {
     });
 
     it('should sign typed message V3', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         const msgParams = {
           domain: {
             chainId: 1,
@@ -817,7 +813,7 @@ describe('KeyringController', () => {
     });
 
     it('should sign typed message V4', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         const msgParams = {
           domain: {
             chainId: 1,
@@ -884,7 +880,7 @@ describe('KeyringController', () => {
     });
 
     it('should fail when sign typed message format is wrong', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         const msgParams = [{}];
         const account = initialState.keyrings[0].accounts[0];
 
@@ -905,7 +901,7 @@ describe('KeyringController', () => {
     });
 
     it('should fail in signing message when from address is not provided', async () => {
-      await withController({}, async ({ controller }) => {
+      await withController(async ({ controller }) => {
         const typedMsgParams = [
           {
             name: 'Message',
@@ -930,7 +926,7 @@ describe('KeyringController', () => {
 
   describe('signTransaction', () => {
     it('should sign transaction', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         const account = initialState.keyrings[0].accounts[0];
         const txParams = {
           chainId: 5,
@@ -956,7 +952,7 @@ describe('KeyringController', () => {
     });
 
     it('should not sign transaction if from account is not provided', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         await expect(async () => {
           const account = initialState.keyrings[0].accounts[0];
           const txParams = {
@@ -985,7 +981,7 @@ describe('KeyringController', () => {
      * https://github.com/MetaMask/core/issues/800
      */
     it('should not sign transaction if transaction is not valid', async () => {
-      await withController({}, async ({ controller, initialState }) => {
+      await withController(async ({ controller, initialState }) => {
         await expect(async () => {
           const account = initialState.keyrings[0].accounts[0];
           await controller.signTransaction({}, account);
@@ -1036,7 +1032,7 @@ describe('KeyringController', () => {
 
   describe('subscribe and unsubscribe', () => {
     it('should subscribe and unsubscribe', async () => {
-      await withController({}, async ({ controller }) => {
+      await withController(async ({ controller }) => {
         const listener = sinon.stub();
         controller.subscribe(listener);
         await controller.importAccountWithStrategy(
@@ -1055,7 +1051,7 @@ describe('KeyringController', () => {
 
   describe('onLock', () => {
     it('should receive lock event', async () => {
-      await withController({}, async ({ controller }) => {
+      await withController(async ({ controller }) => {
         const listenerLock = sinon.stub();
         controller.onLock(listenerLock);
         await controller.setLocked();
@@ -1066,7 +1062,7 @@ describe('KeyringController', () => {
 
   describe('onUnlock', () => {
     it('should receive unlock event', async () => {
-      await withController({}, async ({ controller }) => {
+      await withController(async ({ controller }) => {
         const listenerUnlock = sinon.stub();
         controller.onUnlock(listenerUnlock);
         await controller.submitPassword(password);
@@ -1077,14 +1073,14 @@ describe('KeyringController', () => {
 
   describe('verifySeedPhrase', () => {
     it('should return current seedphrase', async () => {
-      await withController({}, async ({ controller }) => {
+      await withController(async ({ controller }) => {
         const seedPhrase = await controller.verifySeedPhrase();
         expect(seedPhrase).toBeDefined();
       });
     });
 
     it('should return current seedphrase as Uint8Array', async () => {
-      await withController({}, async ({ controller }) => {
+      await withController(async ({ controller }) => {
         const seedPhrase = await controller.verifySeedPhrase();
         expect(seedPhrase).toBeInstanceOf(Uint8Array);
       });
@@ -1094,7 +1090,7 @@ describe('KeyringController', () => {
   describe('verifyPassword', () => {
     describe('when correct password is provided', () => {
       it('should not throw any error', async () => {
-        await withController({}, async ({ controller }) => {
+        await withController(async ({ controller }) => {
           expect(async () => {
             await controller.verifyPassword(password);
           }).not.toThrow();
@@ -1104,7 +1100,7 @@ describe('KeyringController', () => {
 
     describe('when wrong password is provided', () => {
       it('should throw an error', async () => {
-        await withController({}, async ({ controller, encryptor }) => {
+        await withController(async ({ controller, encryptor }) => {
           sinon
             .stub(encryptor, 'decrypt')
             .rejects(new Error('Incorrect password'));

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -91,6 +91,7 @@ export interface KeyringMemState extends BaseState {
 export interface KeyringConfig extends BaseConfig {
   encryptor?: any;
   keyringBuilders?: any[];
+  cacheEncryptionKey?: boolean;
 }
 
 /**
@@ -800,6 +801,13 @@ export class KeyringController extends BaseController<
     });
     await this.#keyring.persistAllKeyrings();
     await this.fullUpdate();
+  }
+
+  async submitEncryptionKey(
+    encryptionKey: string,
+    encryptionSalt: string,
+  ): Promise<KeyringMemState> {
+    return this.#keyring.submitEncryptionKey(encryptionKey, encryptionSalt);
   }
 }
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -80,6 +80,8 @@ export interface KeyringMemState extends BaseState {
   isUnlocked: boolean;
   keyringTypes: string[];
   keyrings: Keyring[];
+  encryptionKey?: string;
+  encryptionSalt?: string;
 }
 
 /**
@@ -313,7 +315,7 @@ export class KeyringController extends BaseController<
       } else {
         vault = await this.#keyring.createNewVaultAndKeychain(password);
         this.updateIdentities(await this.getAccounts());
-        this.fullUpdate();
+        await this.fullUpdate();
       }
 
       return vault;

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -564,7 +564,23 @@ export class KeyringController extends BaseController<
   }
 
   /**
-   * Attempts to decrypt the current vault and load its keyrings.
+   * Attempts to decrypt the current vault and load its keyrings,
+   * using the given encryption key and salt.
+   *
+   * @param encryptionKey - Key to unlock the keychain.
+   * @param encryptionSalt - Salt to unlock the keychain.
+   * @returns Promise resolving to the current state.
+   */
+  async submitEncryptionKey(
+    encryptionKey: string,
+    encryptionSalt: string,
+  ): Promise<KeyringMemState> {
+    return this.#keyring.submitEncryptionKey(encryptionKey, encryptionSalt);
+  }
+
+  /**
+   * Attempts to decrypt the current vault and load its keyrings,
+   * using the given password.
    *
    * @param password - Password to unlock the keychain.
    * @returns Promise resolving to the current state.
@@ -801,13 +817,6 @@ export class KeyringController extends BaseController<
     });
     await this.#keyring.persistAllKeyrings();
     await this.fullUpdate();
-  }
-
-  async submitEncryptionKey(
-    encryptionKey: string,
-    encryptionSalt: string,
-  ): Promise<KeyringMemState> {
-    return this.#keyring.submitEncryptionKey(encryptionKey, encryptionSalt);
   }
 }
 

--- a/packages/keyring-controller/tests/mocks/mockEncryptor.ts
+++ b/packages/keyring-controller/tests/mocks/mockEncryptor.ts
@@ -1,27 +1,52 @@
 const mockHex = '0xabcdef0123456789';
-const mockKey = Buffer.alloc(32);
+export const mockKey = Buffer.alloc(32);
 let cacheVal: any;
 
 export default class MockEncryptor {
-  encrypt(_password: string, dataObj: any) {
+  async encrypt(password: string, dataObj: any) {
+    return JSON.stringify({
+      ...this.encryptWithKey(password, dataObj),
+      salt: this.generateSalt(),
+    });
+  }
+
+  async decrypt(_password: string, _text: string) {
+    return cacheVal || {};
+  }
+
+  async encryptWithKey(_key: string, dataObj: any) {
     cacheVal = dataObj;
-    return Promise.resolve(mockHex);
+    return {
+      data: mockHex,
+      iv: 'anIv',
+    };
   }
 
-  decrypt(_password: string, _text: string) {
-    return Promise.resolve(cacheVal || {});
+  async encryptWithDetail(key: string, dataObj: any) {
+    return {
+      vault: await this.encrypt(key, dataObj),
+      exportedKeyString: mockKey.toString('hex'),
+    };
   }
 
-  encryptWithKey(key: string, dataObj: any) {
-    return this.encrypt(key, dataObj);
+  async decryptWithDetail(key: string, text: string) {
+    return {
+      vault: await this.decrypt(key, text),
+      salt: this.generateSalt(),
+      exportedKeyString: mockKey.toString('hex'),
+    };
   }
 
-  decryptWithKey(key: string, text: string) {
+  async decryptWithKey(key: string, text: string) {
     return this.decrypt(key, text);
   }
 
-  keyFromPassword(_password: string) {
-    return Promise.resolve(mockKey);
+  async keyFromPassword(_password: string) {
+    return mockKey;
+  }
+
+  async importKey(_key: string) {
+    return {};
   }
 
   generateSalt() {


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR extends the `KeyringConfig` type to support `cacheEncryptionKey?: boolean`, and adds the `submitEncryptionKey` method, to unlock keyrings with encryption key and salt.

Tests have been refactored:  
* Test cases now use a `withController` util function to create a fully initialized KeyringController with custom parameters passed by tests themselves 
* `MockEncryptor` has been edited to better match the supported API and work with encryption keys.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **ADDED**: `submitEncryptionKey` method
- **CHANGED**: `KeyringConfig` type to support optional `cacheEncryptionKey: boolean`

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes #1257
* Fixes #1252

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
