### PR TITLE
Add verifyPassword and remove validatePassword

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -56,12 +56,13 @@ describe('KeyringController', () => {
     keyringTypes: string[];
     keyrings: Keyring[];
   };
+  const encryptor = new MockEncryptor();
   const additionalKeyrings = [QRKeyring];
   const additionalKeyringBuilders = additionalKeyrings.map((keyringType) =>
     keyringBuilderFactory(keyringType),
   );
   const baseConfig: Partial<KeyringConfig> = {
-    encryptor: new MockEncryptor(),
+    encryptor,
     keyringBuilders: additionalKeyringBuilders,
   };
 
@@ -269,34 +270,58 @@ describe('KeyringController', () => {
   });
 
   describe('exportSeedPhrase', () => {
-    it('should export seed phrase', () => {
-      const seed = keyringController.exportSeedPhrase(password);
-      expect(seed).not.toBe('');
-      expect(() => keyringController.exportSeedPhrase('')).toThrow(
-        'Invalid password',
-      );
+    describe('when correct password is provided', () => {
+      it('should export seed phrase', async () => {
+        const seed = await keyringController.exportSeedPhrase(password);
+        expect(seed).not.toBe('');
+      });
+    });
+
+    describe('when wrong password is provided', () => {
+      it('should export seed phrase', async () => {
+        sinon.stub(encryptor, 'decrypt').throws(new Error('Invalid password'));
+        await expect(keyringController.exportSeedPhrase('')).rejects.toThrow(
+          'Invalid password',
+        );
+      });
     });
   });
 
   describe('exportAccount', () => {
-    it('should export account', async () => {
-      const account = initialState.keyrings[0].accounts[0];
-      const newPrivateKey = await keyringController.exportAccount(
-        password,
-        account,
-      );
-      expect(newPrivateKey).not.toBe('');
-      expect(() => keyringController.exportAccount('', account)).toThrow(
-        'Invalid password',
-      );
+    describe('when correct password is provided', () => {
+      describe('when correct account is provided', () => {
+        it('should export account', async () => {
+          const account = initialState.keyrings[0].accounts[0];
+          const newPrivateKey = await keyringController.exportAccount(
+            password,
+            account,
+          );
+          expect(newPrivateKey).not.toBe('');
+        });
+      });
 
-      expect(() =>
-        keyringController.exportAccount('JUNK_VALUE', account),
-      ).toThrow('Invalid password');
+      describe('when wrong account is provided', () => {
+        it('should throw error', async () => {
+          await expect(
+            keyringController.exportAccount(password, ''),
+          ).rejects.toThrow(/^No keyring found for the requested account./u);
+        });
+      });
+    });
 
-      await expect(
-        keyringController.exportAccount(password, ''),
-      ).rejects.toThrow(/^No keyring found for the requested account./u);
+    describe('when wrong password is provided', () => {
+      it('should throw error', async () => {
+        const account = initialState.keyrings[0].accounts[0];
+        sinon.stub(encryptor, 'decrypt').rejects(new Error('Invalid password'));
+
+        await expect(
+          keyringController.exportAccount('', account),
+        ).rejects.toThrow('Invalid password');
+
+        await expect(
+          keyringController.exportAccount('JUNK_VALUE', account),
+        ).rejects.toThrow('Invalid password');
+      });
     });
   });
 
@@ -884,13 +909,25 @@ describe('KeyringController', () => {
     });
   });
 
-  describe('validatePassword', () => {
-    it('should validate password as true if it matches with input', () => {
-      expect(keyringController.validatePassword(password)).toBe(true);
+  describe('verifyPassword', () => {
+    describe('when correct password is provided', () => {
+      it('should not throw any error', async () => {
+        expect(async () => {
+          await keyringController.verifyPassword(password);
+        }).not.toThrow();
+      });
     });
 
-    it('should validate password as false if it does not match with input', () => {
-      expect(keyringController.validatePassword('12341234')).toBe(false);
+    describe('when wrong password is provided', () => {
+      it('should throw an error', async () => {
+        sinon
+          .stub(encryptor, 'decrypt')
+          .rejects(new Error('Incorrect password'));
+
+        await expect(
+          keyringController.verifyPassword('12341234'),
+        ).rejects.toThrow('Incorrect password');
+      });
     });
   });
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -322,13 +322,13 @@ export class KeyringController extends BaseController<
   }
 
   /**
-   * Method to validate a password against the password from the keyring.
+   * Method to verify a given password validity. Throws an
+   * error if the password is invalid.
    *
    * @param password - Password of the keyring.
-   * @returns Boolean indicating if input password is valid
    */
-  validatePassword(password: string): boolean {
-    return this.#keyring.password === password;
+  async verifyPassword(password: string) {
+    await this.#keyring.verifyPassword(password);
   }
 
   /**
@@ -346,11 +346,9 @@ export class KeyringController extends BaseController<
    * @param password - Password of the keyring.
    * @returns Promise resolving to the seed phrase.
    */
-  exportSeedPhrase(password: string) {
-    if (this.validatePassword(password)) {
-      return this.#keyring.keyrings[0].mnemonic;
-    }
-    throw new Error('Invalid password');
+  async exportSeedPhrase(password: string) {
+    await this.verifyPassword(password);
+    return this.#keyring.keyrings[0].mnemonic;
   }
 
   /**
@@ -360,11 +358,9 @@ export class KeyringController extends BaseController<
    * @param address - Address to export.
    * @returns Promise resolving to the private key for an address.
    */
-  exportAccount(password: string, address: string): Promise<string> {
-    if (this.validatePassword(password)) {
-      return this.#keyring.exportAccount(address);
-    }
-    throw new Error('Invalid password');
+  async exportAccount(password: string, address: string): Promise<string> {
+    await this.verifyPassword(password);
+    return this.#keyring.exportAccount(address);
   }
 
   /**


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR removes the `validatePassword` method in favor of `verifyPassword`, using internally `EthKeyringController.verifyPassword` instead of manually comparing the provided password with the `EthKeyringController`'s state.

Now that `verifyPassword` is async, other methods that verify a password must now await; therefore, `exportSeedPhrase` and `exportAccount` have been made async too. 

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **REMOVED**: `validatePassword` method in favor of `verifyPassword`
- **ADDED**: `verifyPassword(psw: string): Promise<void>` method to use `EthKeyringController.verifyPassword`
- **BREAKING**: `exportAccount` has been made async
- **BREAKING**: `exportSeedPhrase` has been made async

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes #1253

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
