### PR TITLE
Temporarily disable npm publish Slack notifications

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -50,8 +50,9 @@ jobs:
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
         uses: MetaMask/action-npm-publish@v3
-        with:
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        # Temporarily disabled
+        # with:
+        #   slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         env:
           SKIP_PREPACK: true
 


### PR DESCRIPTION
## Description

Slack notifications of release review requests have been temporarily disabled. They will be re-enabled after that action has been updated to ensure those notifications don't include a group mention for the whole team.

## Changes

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
