### PR TITLE
Replace `NetworksChainId` constant with `ChainId`

### DIFF
--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -13,7 +13,7 @@ import {
   ERC1155,
   OPENSEA_API_URL,
   ERC721,
-  NetworksChainId,
+  ChainId,
   NetworkType,
 } from '@metamask/controller-utils';
 import { Network } from '@ethersproject/providers';
@@ -799,15 +799,11 @@ describe('NftController', () => {
       changeNetwork(SEPOLIA);
 
       expect(
-        nftController.state.allNfts[selectedAddress]?.[
-          NetworksChainId[GOERLI.type]
-        ],
+        nftController.state.allNfts[selectedAddress]?.[ChainId[GOERLI.type]],
       ).toBeUndefined();
 
       expect(
-        nftController.state.allNfts[selectedAddress][
-          NetworksChainId[SEPOLIA.type]
-        ][0],
+        nftController.state.allNfts[selectedAddress][ChainId[SEPOLIA.type]][0],
       ).toStrictEqual({
         address: '0x01',
         description: 'description',

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -7,7 +7,7 @@ import {
   NetworkState,
   ProviderConfig,
 } from '@metamask/network-controller';
-import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
+import { ChainId, NetworkType } from '@metamask/controller-utils';
 import { PreferencesController } from '@metamask/preferences-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
 import {
@@ -108,7 +108,7 @@ const setupTokenListController = (
   });
 
   const tokenList = new TokenListController({
-    chainId: NetworksChainId.mainnet,
+    chainId: ChainId.mainnet,
     preventPollingOnNetworkRestart: false,
     messenger: tokenListMessenger,
   });
@@ -137,21 +137,17 @@ describe('TokenDetectionController', () => {
     });
   };
   const mainnet = {
-    chainId: NetworksChainId.mainnet,
+    chainId: ChainId.mainnet,
     type: NetworkType.mainnet,
   };
 
   beforeEach(async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/tokens/${ChainId.mainnet}`)
       .reply(200, sampleTokenList)
-      .get(
-        `/token/${NetworksChainId.mainnet}?address=${tokenAFromList.address}`,
-      )
+      .get(`/token/${ChainId.mainnet}?address=${tokenAFromList.address}`)
       .reply(200, tokenAFromList)
-      .get(
-        `/token/${NetworksChainId.mainnet}?address=${tokenBFromList.address}`,
-      )
+      .get(`/token/${ChainId.mainnet}?address=${tokenBFromList.address}`)
       .reply(200, tokenBFromList)
       .persist();
 
@@ -211,7 +207,7 @@ describe('TokenDetectionController', () => {
       interval: DEFAULT_INTERVAL,
       selectedAddress: '',
       disabled: true,
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       isDetectionEnabledForNetwork: true,
       isDetectionEnabledFromPreferences: true,
     });
@@ -245,7 +241,7 @@ describe('TokenDetectionController', () => {
     expect(
       isTokenDetectionSupportedForNetwork(tokenDetection.config.chainId),
     ).toStrictEqual(true);
-    tokenDetection.configure({ chainId: NetworksChainId.goerli });
+    tokenDetection.configure({ chainId: ChainId.goerli });
     expect(
       isTokenDetectionSupportedForNetwork(tokenDetection.config.chainId),
     ).toStrictEqual(false);
@@ -254,7 +250,7 @@ describe('TokenDetectionController', () => {
   it('should not autodetect while not on supported networks', async () => {
     tokenDetection.configure({
       selectedAddress: '0x1',
-      chainId: NetworksChainId.goerli,
+      chainId: ChainId.goerli,
       isDetectionEnabledForNetwork: false,
     });
 
@@ -278,7 +274,7 @@ describe('TokenDetectionController', () => {
 
   it('should detect tokens correctly on the Aurora network', async () => {
     const auroraMainnet = {
-      chainId: NetworksChainId.aurora,
+      chainId: ChainId.aurora,
       type: NetworkType.mainnet,
     };
     preferences.update({ selectedAddress: '0x1' });
@@ -440,7 +436,7 @@ describe('TokenDetectionController', () => {
         isDetectionEnabledForNetwork: true,
         isDetectionEnabledFromPreferences: true,
         selectedAddress: '0x1',
-        chainId: NetworksChainId.mainnet,
+        chainId: ChainId.mainnet,
       },
     );
 
@@ -556,7 +552,7 @@ describe('TokenDetectionController', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await networkStateChangeListener!({
-      providerConfig: { chainId: NetworksChainId.mainnet },
+      providerConfig: { chainId: ChainId.mainnet },
     });
 
     expect(getBalancesInSingleCallMock.called).toBe(true);

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -7,7 +7,7 @@ import {
   NetworkStatus,
   ProviderConfig,
 } from '@metamask/network-controller';
-import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
+import { ChainId, NetworkType } from '@metamask/controller-utils';
 import {
   TokenListController,
   TokenListStateChange,
@@ -529,7 +529,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
     });
@@ -550,7 +550,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: existingState,
@@ -599,7 +599,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       messenger,
     });
 
@@ -616,7 +616,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -630,7 +630,7 @@ describe('TokenListController', () => {
 
   it('should update tokenList state when network updates are passed via onNetworkStateChange callback', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/tokens/${ChainId.mainnet}`)
       .reply(200, sampleMainnetTokenList)
       .persist();
 
@@ -638,7 +638,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger(controllerMessenger);
     let onNetworkStateChangeCallback!: (state: NetworkState) => void;
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       onNetworkStateChange: (cb) => (onNetworkStateChangeCallback = cb),
       preventPollingOnNetworkRestart: false,
       interval: 100,
@@ -651,7 +651,7 @@ describe('TokenListController', () => {
     );
     onNetworkStateChangeCallback(
       buildNetworkControllerStateWithProviderConfig({
-        chainId: NetworksChainId.goerli,
+        chainId: ChainId.goerli,
         type: NetworkType.goerli,
       }),
     );
@@ -670,7 +670,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -695,7 +695,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -723,7 +723,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger(controllerMessenger);
 
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -753,7 +753,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -775,7 +775,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.sepolia,
+      chainId: ChainId.sepolia,
       preventPollingOnNetworkRestart: false,
       interval: 100,
       messenger,
@@ -792,14 +792,14 @@ describe('TokenListController', () => {
 
   it('should update token list from api', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/tokens/${ChainId.mainnet}`)
       .reply(200, sampleMainnetTokenList)
       .persist();
 
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       interval: 750,
@@ -812,16 +812,15 @@ describe('TokenListController', () => {
       );
 
       expect(
-        controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+        controller.state.tokensChainsCache[ChainId.mainnet].data,
       ).toStrictEqual(
-        sampleSingleChainState.tokensChainsCache[NetworksChainId.mainnet].data,
+        sampleSingleChainState.tokensChainsCache[ChainId.mainnet].data,
       );
 
       expect(
-        controller.state.tokensChainsCache[NetworksChainId.mainnet].timestamp,
+        controller.state.tokensChainsCache[ChainId.mainnet].timestamp,
       ).toBeGreaterThanOrEqual(
-        sampleSingleChainState.tokensChainsCache[NetworksChainId.mainnet]
-          .timestamp,
+        sampleSingleChainState.tokensChainsCache[ChainId.mainnet].timestamp,
       );
       controller.destroy();
     } finally {
@@ -831,19 +830,19 @@ describe('TokenListController', () => {
 
   it('should update the cache before threshold time if the current data is undefined', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/tokens/${ChainId.mainnet}`)
       .once()
       .reply(200, undefined);
 
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/tokens/${ChainId.mainnet}`)
       .reply(200, sampleMainnetTokenList)
       .persist();
 
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       interval: 100,
@@ -866,7 +865,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: existingState,
@@ -878,23 +877,23 @@ describe('TokenListController', () => {
     );
 
     expect(
-      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+      controller.state.tokensChainsCache[ChainId.mainnet].data,
     ).toStrictEqual(
-      sampleSingleChainState.tokensChainsCache[NetworksChainId.mainnet].data,
+      sampleSingleChainState.tokensChainsCache[ChainId.mainnet].data,
     );
     controller.destroy();
   });
 
   it('should update token list after removing data with duplicate symbols', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/tokens/${ChainId.mainnet}`)
       .reply(200, sampleWithDuplicateSymbols)
       .persist();
 
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
     });
@@ -923,21 +922,21 @@ describe('TokenListController', () => {
     });
 
     expect(
-      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+      controller.state.tokensChainsCache[ChainId.mainnet].data,
     ).toStrictEqual(sampleWithDuplicateSymbolsTokensChainsCache);
     controller.destroy();
   });
 
   it('should update token list after removing data less than 3 occurrences', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/tokens/${ChainId.mainnet}`)
       .reply(200, sampleWithLessThan3OccurencesResponse)
       .persist();
 
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
     });
@@ -947,21 +946,21 @@ describe('TokenListController', () => {
     );
 
     expect(
-      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+      controller.state.tokensChainsCache[ChainId.mainnet].data,
     ).toStrictEqual(sampleWith3OrMoreOccurrences);
     controller.destroy();
   });
 
   it('should update token list when the token property changes', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/tokens/${ChainId.mainnet}`)
       .reply(200, sampleMainnetTokenList)
       .persist();
 
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: outdatedExistingState,
@@ -973,23 +972,23 @@ describe('TokenListController', () => {
     );
 
     expect(
-      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+      controller.state.tokensChainsCache[ChainId.mainnet].data,
     ).toStrictEqual(
-      sampleSingleChainState.tokensChainsCache[NetworksChainId.mainnet].data,
+      sampleSingleChainState.tokensChainsCache[ChainId.mainnet].data,
     );
     controller.destroy();
   });
 
   it('should update the cache when the timestamp expires', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/tokens/${ChainId.mainnet}`)
       .reply(200, sampleMainnetTokenList)
       .persist();
 
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: expiredCacheExistingState,
@@ -997,25 +996,24 @@ describe('TokenListController', () => {
     expect(controller.state).toStrictEqual(expiredCacheExistingState);
     await controller.start();
     expect(
-      controller.state.tokensChainsCache[NetworksChainId.mainnet].timestamp,
+      controller.state.tokensChainsCache[ChainId.mainnet].timestamp,
     ).toBeGreaterThan(
-      sampleSingleChainState.tokensChainsCache[NetworksChainId.mainnet]
-        .timestamp,
+      sampleSingleChainState.tokensChainsCache[ChainId.mainnet].timestamp,
     );
 
     expect(
-      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+      controller.state.tokensChainsCache[ChainId.mainnet].data,
     ).toStrictEqual(
-      sampleSingleChainState.tokensChainsCache[NetworksChainId.mainnet].data,
+      sampleSingleChainState.tokensChainsCache[ChainId.mainnet].data,
     );
     controller.destroy();
   });
 
   it('should update token list when the chainId change', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/tokens/${ChainId.mainnet}`)
       .reply(200, sampleMainnetTokenList)
-      .get(`/tokens/${NetworksChainId.goerli}`)
+      .get(`/tokens/${ChainId.goerli}`)
       .reply(200, { error: 'ChainId 5 is not supported' })
       .get(`/tokens/56`)
       .reply(200, sampleBinanceTokenList)
@@ -1024,7 +1022,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: existingState,
@@ -1037,16 +1035,16 @@ describe('TokenListController', () => {
     );
 
     expect(
-      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+      controller.state.tokensChainsCache[ChainId.mainnet].data,
     ).toStrictEqual(
-      sampleTwoChainState.tokensChainsCache[NetworksChainId.mainnet].data,
+      sampleTwoChainState.tokensChainsCache[ChainId.mainnet].data,
     );
 
     controllerMessenger.publish(
       'NetworkController:stateChange',
       buildNetworkControllerStateWithProviderConfig({
         type: NetworkType.goerli,
-        chainId: NetworksChainId.goerli,
+        chainId: ChainId.goerli,
       }),
       [],
     );
@@ -1055,9 +1053,9 @@ describe('TokenListController', () => {
 
     expect(controller.state.tokenList).toStrictEqual({});
     expect(
-      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+      controller.state.tokensChainsCache[ChainId.mainnet].data,
     ).toStrictEqual(
-      sampleTwoChainState.tokensChainsCache[NetworksChainId.mainnet].data,
+      sampleTwoChainState.tokensChainsCache[ChainId.mainnet].data,
     );
 
     controllerMessenger.publish(
@@ -1076,9 +1074,9 @@ describe('TokenListController', () => {
     );
 
     expect(
-      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+      controller.state.tokensChainsCache[ChainId.mainnet].data,
     ).toStrictEqual(
-      sampleTwoChainState.tokensChainsCache[NetworksChainId.mainnet].data,
+      sampleTwoChainState.tokensChainsCache[ChainId.mainnet].data,
     );
 
     expect(controller.state.tokensChainsCache['56'].data).toStrictEqual(
@@ -1092,7 +1090,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
       preventPollingOnNetworkRestart: false,
       messenger,
       state: existingState,
@@ -1108,9 +1106,9 @@ describe('TokenListController', () => {
 
   it('should update preventPollingOnNetworkRestart and restart the polling on network restart', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/tokens/${ChainId.mainnet}`)
       .reply(200, sampleMainnetTokenList)
-      .get(`/tokens/${NetworksChainId.goerli}`)
+      .get(`/tokens/${ChainId.goerli}`)
       .reply(200, { error: 'ChainId 5 is not supported' })
       .get(`/tokens/56`)
       .reply(200, sampleBinanceTokenList)
@@ -1119,7 +1117,7 @@ describe('TokenListController', () => {
     const controllerMessenger = getControllerMessenger();
     const messenger = getRestrictedMessenger(controllerMessenger);
     const controller = new TokenListController({
-      chainId: NetworksChainId.goerli,
+      chainId: ChainId.goerli,
       preventPollingOnNetworkRestart: true,
       messenger,
       interval: 100,
@@ -1129,7 +1127,7 @@ describe('TokenListController', () => {
       'NetworkController:stateChange',
       buildNetworkControllerStateWithProviderConfig({
         type: NetworkType.mainnet,
-        chainId: NetworksChainId.mainnet,
+        chainId: ChainId.mainnet,
       }),
       [],
     );

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -10,7 +10,7 @@ import contractMaps from '@metamask/contract-metadata';
 import { PreferencesController } from '@metamask/preferences-controller';
 import {
   ApprovalType,
-  NetworksChainId,
+  ChainId,
   NetworkType,
   ORIGIN_METAMASK,
 } from '@metamask/controller-utils';
@@ -83,7 +83,7 @@ describe('TokensController', () => {
       onNetworkStateChange: (listener) =>
         (onNetworkStateChangeListener = listener),
       config: {
-        chainId: NetworksChainId.mainnet,
+        chainId: ChainId.mainnet,
         selectedAddress: defaultSelectedAddress,
       },
       messenger,
@@ -672,7 +672,7 @@ describe('TokensController', () => {
       const error = 'An error occured';
       const fullErrorMessage = `TokenService Error: ${error}`;
       nock(TOKEN_END_POINT_API)
-        .get(`/token/${NetworksChainId.mainnet}?address=${dummyTokenAddress}`)
+        .get(`/token/${ChainId.mainnet}?address=${dummyTokenAddress}`)
         .reply(200, { error })
         .persist();
 
@@ -831,28 +831,26 @@ describe('TokensController', () => {
     it('should nest newTokens under chain ID and selected address when provided with newTokens as input', () => {
       tokensController.configure({
         selectedAddress: dummySelectedAddress,
-        chainId: NetworksChainId.mainnet,
+        chainId: ChainId.mainnet,
       });
       const processedTokens = tokensController._getNewAllTokensState({
         newTokens: dummyTokens,
       });
       expect(
-        processedTokens.newAllTokens[NetworksChainId.mainnet][
-          dummySelectedAddress
-        ],
+        processedTokens.newAllTokens[ChainId.mainnet][dummySelectedAddress],
       ).toStrictEqual(dummyTokens);
     });
 
     it('should nest detectedTokens under chain ID and selected address when provided with detectedTokens as input', () => {
       tokensController.configure({
         selectedAddress: dummySelectedAddress,
-        chainId: NetworksChainId.mainnet,
+        chainId: ChainId.mainnet,
       });
       const processedTokens = tokensController._getNewAllTokensState({
         newDetectedTokens: dummyTokens,
       });
       expect(
-        processedTokens.newAllDetectedTokens[NetworksChainId.mainnet][
+        processedTokens.newAllDetectedTokens[ChainId.mainnet][
           dummySelectedAddress
         ],
       ).toStrictEqual(dummyTokens);
@@ -861,14 +859,14 @@ describe('TokensController', () => {
     it('should nest ignoredTokens under chain ID and selected address when provided with ignoredTokens as input', () => {
       tokensController.configure({
         selectedAddress: dummySelectedAddress,
-        chainId: NetworksChainId.mainnet,
+        chainId: ChainId.mainnet,
       });
       const dummyIgnoredTokens = [dummyTokens[0].address];
       const processedTokens = tokensController._getNewAllTokensState({
         newIgnoredTokens: dummyIgnoredTokens,
       });
       expect(
-        processedTokens.newAllIgnoredTokens[NetworksChainId.mainnet][
+        processedTokens.newAllIgnoredTokens[ChainId.mainnet][
           dummySelectedAddress
         ],
       ).toStrictEqual(dummyIgnoredTokens);
@@ -1142,14 +1140,10 @@ describe('TokensController', () => {
       expect(tokensController.state.tokens).toHaveLength(0);
       expect(tokensController.state.tokens).toStrictEqual([]);
       expect(
-        tokensController.state.allTokens[NetworksChainId.mainnet][
-          interactingAddress
-        ],
+        tokensController.state.allTokens[ChainId.mainnet][interactingAddress],
       ).toHaveLength(1);
       expect(
-        tokensController.state.allTokens[NetworksChainId.mainnet][
-          interactingAddress
-        ],
+        tokensController.state.allTokens[ChainId.mainnet][interactingAddress],
       ).toStrictEqual([
         {
           isERC721: false,
@@ -1504,28 +1498,26 @@ describe('TokensController', () => {
     it('should clear nest allTokens under chain ID and selected address when an added token is ignored', async () => {
       tokensController.configure({
         selectedAddress,
-        chainId: NetworksChainId.mainnet,
+        chainId: ChainId.mainnet,
       });
       await tokensController.addTokens(dummyTokens);
       tokensController.ignoreTokens(['0x01']);
       expect(
-        tokensController.state.allTokens[NetworksChainId.mainnet][
-          selectedAddress
-        ],
+        tokensController.state.allTokens[ChainId.mainnet][selectedAddress],
       ).toStrictEqual([]);
     });
 
     it('should clear nest allIgnoredTokens under chain ID and selected address when an ignored token is re-added', async () => {
       tokensController.configure({
         selectedAddress,
-        chainId: NetworksChainId.mainnet,
+        chainId: ChainId.mainnet,
       });
       await tokensController.addTokens(dummyTokens);
       tokensController.ignoreTokens([tokenAddress]);
       await tokensController.addTokens(dummyTokens);
 
       expect(
-        tokensController.state.allIgnoredTokens[NetworksChainId.mainnet][
+        tokensController.state.allIgnoredTokens[ChainId.mainnet][
           selectedAddress
         ],
       ).toStrictEqual([]);
@@ -1534,13 +1526,13 @@ describe('TokensController', () => {
     it('should clear nest allDetectedTokens under chain ID and selected address when an detected token is added to tokens list', async () => {
       tokensController.configure({
         selectedAddress,
-        chainId: NetworksChainId.mainnet,
+        chainId: ChainId.mainnet,
       });
       await tokensController.addDetectedTokens(dummyTokens);
       await tokensController.addTokens(dummyTokens);
 
       expect(
-        tokensController.state.allDetectedTokens[NetworksChainId.mainnet][
+        tokensController.state.allDetectedTokens[ChainId.mainnet][
           selectedAddress
         ],
       ).toStrictEqual([]);

--- a/packages/assets-controllers/src/assetsUtil.test.ts
+++ b/packages/assets-controllers/src/assetsUtil.test.ts
@@ -1,4 +1,4 @@
-import { GANACHE_CHAIN_ID, NetworksChainId } from '@metamask/controller-utils';
+import { GANACHE_CHAIN_ID, ChainId } from '@metamask/controller-utils';
 import * as assetsUtil from './assetsUtil';
 import { Nft, NftMetadata } from './NftController';
 
@@ -115,20 +115,20 @@ describe('assetsUtil', () => {
     it('should format icon url with Codefi proxy correctly when passed chainId as a decimal string', () => {
       const linkTokenAddress = '0x514910771af9ca656af840dff83e8264ecf986ca';
       const formattedIconUrl = assetsUtil.formatIconUrlWithProxy({
-        chainId: NetworksChainId.mainnet,
+        chainId: ChainId.mainnet,
         tokenAddress: linkTokenAddress,
       });
-      const expectedValue = `https://static.metafi.codefi.network/api/v1/tokenIcons/${NetworksChainId.mainnet}/${linkTokenAddress}.png`;
+      const expectedValue = `https://static.metafi.codefi.network/api/v1/tokenIcons/${ChainId.mainnet}/${linkTokenAddress}.png`;
       expect(formattedIconUrl).toStrictEqual(expectedValue);
     });
 
     it('should format icon url with Codefi proxy correctly when passed chainId as a hexadecimal string', () => {
       const linkTokenAddress = '0x514910771af9ca656af840dff83e8264ecf986ca';
       const formattedIconUrl = assetsUtil.formatIconUrlWithProxy({
-        chainId: `0x${Number(NetworksChainId.mainnet).toString(16)}`,
+        chainId: `0x${Number(ChainId.mainnet).toString(16)}`,
         tokenAddress: linkTokenAddress,
       });
-      const expectedValue = `https://static.metafi.codefi.network/api/v1/tokenIcons/${NetworksChainId.mainnet}/${linkTokenAddress}.png`;
+      const expectedValue = `https://static.metafi.codefi.network/api/v1/tokenIcons/${ChainId.mainnet}/${linkTokenAddress}.png`;
       expect(formattedIconUrl).toStrictEqual(expectedValue);
     });
   });
@@ -305,9 +305,9 @@ describe('assetsUtil', () => {
     });
 
     it('returns false for testnets such as Goerli', () => {
-      expect(
-        assetsUtil.isTokenListSupportedForNetwork(NetworksChainId.goerli),
-      ).toBe(false);
+      expect(assetsUtil.isTokenListSupportedForNetwork(ChainId.goerli)).toBe(
+        false,
+      );
     });
   });
 

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -1,9 +1,4 @@
-import {
-  NetworkType,
-  NetworksTicker,
-  NetworksChainId,
-  NetworkId,
-} from './types';
+import { NetworkType, NetworksTicker, ChainId, NetworkId } from './types';
 
 export const RPC = 'rpc';
 export const FALL_BACK_VS_CURRENCY = 'ETH';
@@ -52,21 +47,21 @@ export const TESTNET_TICKER_SYMBOLS = {
  */
 export const BUILT_IN_NETWORKS = {
   [NetworkType.goerli]: {
-    chainId: NetworksChainId.goerli,
+    chainId: ChainId.goerli,
     ticker: NetworksTicker.goerli,
     rpcPrefs: {
       blockExplorerUrl: `https://${NetworkType.goerli}.etherscan.io`,
     },
   },
   [NetworkType.sepolia]: {
-    chainId: NetworksChainId.sepolia,
+    chainId: ChainId.sepolia,
     ticker: NetworksTicker.sepolia,
     rpcPrefs: {
       blockExplorerUrl: `https://${NetworkType.sepolia}.etherscan.io`,
     },
   },
   [NetworkType.mainnet]: {
-    chainId: NetworksChainId.mainnet,
+    chainId: ChainId.mainnet,
     ticker: NetworksTicker.mainnet,
     rpcPrefs: {
       blockExplorerUrl: 'https://etherscan.io',

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -35,7 +35,7 @@ export function isNetworkType(val: any): val is NetworkType {
  *
  * This includes both Infura and non-Infura networks.
  */
-export enum BuiltInNetwork {
+export enum BuiltInNetworkName {
   Mainnet = 'mainnet',
   Goerli = 'goerli',
   Sepolia = 'sepolia',
@@ -46,10 +46,10 @@ export enum BuiltInNetwork {
  * Decimal string chain IDs of built-in networks, by name.
  */
 export const ChainId = {
-  [BuiltInNetwork.Mainnet]: '1',
-  [BuiltInNetwork.Goerli]: '5',
-  [BuiltInNetwork.Sepolia]: '11155111',
-  [BuiltInNetwork.Aurora]: '1313161554',
+  [BuiltInNetworkName.Mainnet]: '1',
+  [BuiltInNetworkName.Goerli]: '5',
+  [BuiltInNetworkName.Sepolia]: '11155111',
+  [BuiltInNetworkName.Aurora]: '1313161554',
 } as const;
 export type ChainId = typeof ChainId[keyof typeof ChainId];
 

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -30,19 +30,38 @@ export function isNetworkType(val: any): val is NetworkType {
   return Object.values(NetworkType).includes(val);
 }
 
-export enum NetworksChainId {
-  mainnet = '1',
-  goerli = '5',
-  sepolia = '11155111',
-  aurora = '1313161554',
-  rpc = '',
+/**
+ * Names of networks built into the wallet.
+ *
+ * This includes both Infura and non-Infura networks.
+ */
+export enum BuiltInNetwork {
+  Mainnet = 'mainnet',
+  Goerli = 'goerli',
+  Sepolia = 'sepolia',
+  Aurora = 'aurora',
 }
 
-export enum NetworkId {
-  mainnet = '1',
-  goerli = '5',
-  sepolia = '11155111',
-}
+/**
+ * Decimal string chain IDs of built-in networks, by name.
+ */
+export const ChainId = {
+  [BuiltInNetwork.Mainnet]: '1',
+  [BuiltInNetwork.Goerli]: '5',
+  [BuiltInNetwork.Sepolia]: '11155111',
+  [BuiltInNetwork.Aurora]: '1313161554',
+} as const;
+export type ChainId = typeof ChainId[keyof typeof ChainId];
+
+/**
+ * Decimal string network IDs of built-in Infura networks, by name.
+ */
+export const NetworkId = {
+  [InfuraNetworkType.mainnet]: '1',
+  [InfuraNetworkType.goerli]: '5',
+  [InfuraNetworkType.sepolia]: '11155111',
+} as const;
+export type NetworkId = typeof NetworkId[keyof typeof NetworkId];
 
 export enum NetworksTicker {
   mainnet = 'ETH',

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -12,7 +12,7 @@ import { errorCodes } from 'eth-rpc-errors';
 import {
   BUILT_IN_NETWORKS,
   NetworksTicker,
-  NetworksChainId,
+  ChainId,
   InfuraNetworkType,
   NetworkType,
   isSafeChainId,
@@ -247,7 +247,7 @@ export const defaultState: NetworkState = {
   networkStatus: NetworkStatus.Unknown,
   providerConfig: {
     type: NetworkType.mainnet,
-    chainId: NetworksChainId.mainnet,
+    chainId: ChainId.mainnet,
   },
   networkDetails: {
     EIPS: {
@@ -560,7 +560,7 @@ export class NetworkController extends BaseControllerV2<
    *
    * @param type - Human readable network name.
    */
-  async setProviderType(type: NetworkType) {
+  async setProviderType(type: InfuraNetworkType) {
     this.#previousProviderConfig = this.state.providerConfig;
 
     // If testnet the ticker symbol should use a testnet prefix
@@ -572,7 +572,7 @@ export class NetworkController extends BaseControllerV2<
     this.update((state) => {
       state.providerConfig.type = type;
       state.providerConfig.ticker = ticker;
-      state.providerConfig.chainId = NetworksChainId[type];
+      state.providerConfig.chainId = ChainId[type];
       state.providerConfig.rpcPrefs = BUILT_IN_NETWORKS[type].rpcPrefs;
       state.providerConfig.rpcUrl = undefined;
       state.providerConfig.nickname = undefined;

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -22,7 +22,7 @@ import {
 import { createInfuraMiddleware } from '@metamask/eth-json-rpc-infura';
 import type { Hex } from '@metamask/utils';
 import { PollingBlockTracker } from 'eth-block-tracker';
-import { InfuraNetworkType, NetworksChainId } from '@metamask/controller-utils';
+import { InfuraNetworkType, ChainId } from '@metamask/controller-utils';
 import type { BlockTracker, Provider } from './types';
 
 const SECOND = 1000;
@@ -157,7 +157,7 @@ function createNetworkAndChainIdMiddleware({
 }: {
   network: InfuraNetworkType;
 }) {
-  const chainId = NetworksChainId[network];
+  const chainId = ChainId[network];
 
   return createScaffoldMiddleware({
     eth_chainId: `0x${parseInt(chainId, 10).toString(16)}`,

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -567,7 +567,7 @@ describe('NetworkController', () => {
     }
 
     describe('given a network type of "rpc"', () => {
-      it('throws because there is no way to set the rpcUrl using this method', async () => {
+      it('throws because there is no way to switch to a custom RPC endpoint using this method', async () => {
         await withController(
           {
             state: {
@@ -582,9 +582,10 @@ describe('NetworkController', () => {
           },
           async ({ controller }) => {
             await expect(() =>
+              // @ts-expect-error Intentionally passing invalid type
               controller.setProviderType(NetworkType.rpc),
             ).rejects.toThrow(
-              'rpcUrl must be provided for custom RPC endpoints',
+              'chainId must be provided for custom RPC endpoints',
             );
           },
         );
@@ -597,6 +598,7 @@ describe('NetworkController', () => {
           createNetworkClientMock.mockReturnValue(fakeNetworkClient);
 
           try {
+            // @ts-expect-error Intentionally passing invalid type
             await controller.setProviderType(NetworkType.rpc);
           } catch {
             // catch the rejection (it is tested above)
@@ -628,6 +630,7 @@ describe('NetworkController', () => {
           createNetworkClientMock.mockReturnValue(fakeNetworkClient);
 
           try {
+            // @ts-expect-error Intentionally passing invalid type
             await controller.setProviderType(NetworkType.rpc);
           } catch {
             // catch the rejection (it is tested above)

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2,7 +2,7 @@ import * as sinon from 'sinon';
 import { PollingBlockTracker } from 'eth-block-tracker';
 import HttpProvider from 'ethjs-provider-http';
 import NonceTracker from 'nonce-tracker';
-import { NetworksChainId, NetworkType } from '@metamask/controller-utils';
+import { ChainId, NetworkType } from '@metamask/controller-utils';
 import type {
   BlockTrackerProxy,
   NetworkState,
@@ -175,7 +175,7 @@ const MOCK_NETWORK: MockNetwork = {
     networkDetails: { EIPS: { 1559: false } },
     providerConfig: {
       type: NetworkType.goerli,
-      chainId: NetworksChainId.goerli,
+      chainId: ChainId.goerli,
     },
     networkConfigurations: {},
   },
@@ -204,7 +204,7 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
     networkDetails: { EIPS: { 1559: false } },
     providerConfig: {
       type: NetworkType.mainnet,
-      chainId: NetworksChainId.mainnet,
+      chainId: ChainId.mainnet,
     },
     networkConfigurations: {},
   },


### PR DESCRIPTION
## Description

The constant `NetworksChainId` was ambiguous in whether it referred to network or chain Ids, and it didn't match our enum naming conventions. It was also undocumented, and unclear in which networks it was intended to contain.

It has been replaced with a `ChainId` constant with documentation and a clear scope (built-in networks). A `BuiltInNetworks` enum has been added as well to make that more clear.

## Changes

### `@metamask/controller-utils`
- **BREAKING**: Replace the `NetworksChainId` constant with `ChainId`
- Added: Add constants `BuiltInNetwork` and `ChainId`

## References

Relates to #1209

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
