### PR TITLE
Consolidate state changes in lookupNetwork

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -492,16 +492,18 @@ export class NetworkController extends BaseControllerV2<
     try {
       let updatedNetworkStatus: NetworkStatus;
       let updatedNetworkId: NetworkId | null = null;
+      let updatedIsEIP1559Compatible = false;
       try {
-        const [networkId] = await Promise.all([
+        const [networkId, isEIP1559Compatible] = await Promise.all([
           this.#getNetworkId(),
-          this.getEIP1559Compatibility(),
+          this.#determineEIP1559Compatibility(),
         ]);
         if (this.state.networkId === networkId) {
           return;
         }
         updatedNetworkStatus = NetworkStatus.Available;
         updatedNetworkId = networkId;
+        updatedIsEIP1559Compatible = isEIP1559Compatible;
       } catch (error) {
         if (isErrorWithCode(error)) {
           let responseBody;
@@ -536,6 +538,7 @@ export class NetworkController extends BaseControllerV2<
       this.update((state) => {
         state.networkId = updatedNetworkId;
         state.networkStatus = updatedNetworkStatus;
+        state.networkDetails.EIPS[1559] = updatedIsEIP1559Compatible;
       });
 
       if (isInfura) {
@@ -630,6 +633,14 @@ export class NetworkController extends BaseControllerV2<
     });
   }
 
+  /**
+   * Determines whether the network supports EIP-1559 by checking whether the
+   * latest block has a `baseFeePerGas` property, then updates state
+   * appropriately.
+   *
+   * @returns A promise that resolves to true if the network supports EIP-1559
+   * and false otherwise.
+   */
   async getEIP1559Compatibility() {
     const { networkDetails = { EIPS: {} } } = this.state;
 
@@ -637,15 +648,26 @@ export class NetworkController extends BaseControllerV2<
       return true;
     }
 
-    const latestBlock = await this.#getLatestBlock();
-    const isEIP1559Compatible =
-      typeof latestBlock.baseFeePerGas !== 'undefined';
+    const isEIP1559Compatible = await this.#determineEIP1559Compatibility();
     if (networkDetails.EIPS[1559] !== isEIP1559Compatible) {
       this.update((state) => {
         state.networkDetails.EIPS[1559] = isEIP1559Compatible;
       });
     }
     return isEIP1559Compatible;
+  }
+
+  /**
+   * Retrieves the latest block from the currently selected network; if the
+   * block has a `baseFeePerGas` property, then we know that the network
+   * supports EIP-1559; otherwise it doesn't.
+   *
+   * @returns A promise that resolves to true if the network supports EIP-1559
+   * and false otherwise.
+   */
+  async #determineEIP1559Compatibility(): Promise<boolean> {
+    const latestBlock = await this.#getLatestBlock();
+    return latestBlock?.baseFeePerGas !== undefined;
   }
 
   /**

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -807,7 +807,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
 
                 await waitForStateChanges({
@@ -845,7 +845,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
 
                 const isEIP1559Compatible =
@@ -880,7 +880,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
                 const promiseForIsEIP1559CompatibleChanges =
                   waitForStateChanges({
@@ -919,7 +919,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
 
                 const isEIP1559Compatible =
@@ -953,7 +953,7 @@ describe('NetworkController', () => {
                     },
                   },
                 ],
-                stubGetEIP1559CompatibilityWhileSetting: true,
+                stubLookupNetworkWhileSetting: true,
               });
               const promiseForIsEIP1559CompatibleChanges = waitForStateChanges({
                 messenger,
@@ -993,7 +993,7 @@ describe('NetworkController', () => {
                     },
                   },
                 ],
-                stubGetEIP1559CompatibilityWhileSetting: true,
+                stubLookupNetworkWhileSetting: true,
               });
 
               const promiseForIsEIP1559Compatible =
@@ -1036,7 +1036,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
 
                 await waitForStateChanges({
@@ -1077,7 +1077,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
 
                 const isEIP1559Compatible =
@@ -1115,7 +1115,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
 
                 await waitForStateChanges({
@@ -1156,7 +1156,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
 
                 const isEIP1559Compatible =
@@ -1193,7 +1193,7 @@ describe('NetworkController', () => {
                     },
                   },
                 ],
-                stubGetEIP1559CompatibilityWhileSetting: true,
+                stubLookupNetworkWhileSetting: true,
               });
               const promiseForIsEIP1559CompatibleChanges = waitForStateChanges({
                 messenger,
@@ -1236,7 +1236,7 @@ describe('NetworkController', () => {
                     },
                   },
                 ],
-                stubGetEIP1559CompatibilityWhileSetting: true,
+                stubLookupNetworkWhileSetting: true,
               });
 
               const promiseForIsEIP1559Compatible =
@@ -1280,7 +1280,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
 
                 await waitForStateChanges({
@@ -1322,7 +1322,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
 
                 const isEIP1559Compatible =
@@ -1361,7 +1361,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
                 const promiseForIsEIP1559CompatibleChanges =
                   waitForStateChanges({
@@ -1404,7 +1404,7 @@ describe('NetworkController', () => {
                       },
                     },
                   ],
-                  stubGetEIP1559CompatibilityWhileSetting: true,
+                  stubLookupNetworkWhileSetting: true,
                 });
 
                 const isEIP1559Compatible =
@@ -1442,7 +1442,7 @@ describe('NetworkController', () => {
                     },
                   },
                 ],
-                stubGetEIP1559CompatibilityWhileSetting: true,
+                stubLookupNetworkWhileSetting: true,
               });
               const promiseForIsEIP1559CompatibleChanges = waitForStateChanges({
                 messenger,
@@ -1486,7 +1486,7 @@ describe('NetworkController', () => {
                     },
                   },
                 ],
-                stubGetEIP1559CompatibilityWhileSetting: true,
+                stubLookupNetworkWhileSetting: true,
               });
 
               const promiseForIsEIP1559Compatible =
@@ -1515,7 +1515,7 @@ describe('NetworkController', () => {
           },
           async ({ controller, messenger }) => {
             await setFakeProvider(controller, {
-              stubGetEIP1559CompatibilityWhileSetting: true,
+              stubLookupNetworkWhileSetting: true,
             });
             const promiseForIsEIP1559CompatibleChanges = waitForStateChanges({
               messenger,
@@ -1542,7 +1542,7 @@ describe('NetworkController', () => {
           },
           async ({ controller }) => {
             await setFakeProvider(controller, {
-              stubGetEIP1559CompatibilityWhileSetting: true,
+              stubLookupNetworkWhileSetting: true,
             });
 
             const result = await controller.getEIP1559Compatibility();
@@ -4122,6 +4122,7 @@ function lookupNetworkTests({
                   },
                 },
               ],
+              stubLookupNetworkWhileSetting: true,
             });
 
             await operation(controller);
@@ -4719,7 +4720,7 @@ function lookupNetworkTests({
                 error: ethErrors.rpc.limitExceeded('some error'),
               },
             ],
-            stubGetEIP1559CompatibilityWhileSetting: true,
+            stubLookupNetworkWhileSetting: true,
           });
 
           await operation(controller);
@@ -4748,7 +4749,7 @@ function lookupNetworkTests({
                   error: ethErrors.rpc.limitExceeded('some error'),
                 },
               ],
-              stubGetEIP1559CompatibilityWhileSetting: true,
+              stubLookupNetworkWhileSetting: true,
             });
 
             const infuraIsUnblocked = waitForPublishedEvents({
@@ -4780,7 +4781,7 @@ function lookupNetworkTests({
                   error: ethErrors.rpc.limitExceeded('some error'),
                 },
               ],
-              stubGetEIP1559CompatibilityWhileSetting: true,
+              stubLookupNetworkWhileSetting: true,
             });
 
             const infuraIsUnblocked = waitForPublishedEvents({
@@ -4814,7 +4815,7 @@ function lookupNetworkTests({
                 error: ethErrors.rpc.limitExceeded('some error'),
               },
             ],
-            stubGetEIP1559CompatibilityWhileSetting: true,
+            stubLookupNetworkWhileSetting: true,
           });
 
           const infuraIsBlocked = waitForPublishedEvents({
@@ -5035,6 +5036,7 @@ function lookupNetworkTests({
                 error: ethErrors.rpc.internal('some error'),
               },
             ],
+            stubLookupNetworkWhileSetting: true,
           });
 
           await operation(controller);
@@ -5061,7 +5063,7 @@ function lookupNetworkTests({
                   error: ethErrors.rpc.internal('some error'),
                 },
               ],
-              stubGetEIP1559CompatibilityWhileSetting: true,
+              stubLookupNetworkWhileSetting: true,
             });
 
             const infuraIsUnblocked = waitForPublishedEvents({
@@ -5093,7 +5095,7 @@ function lookupNetworkTests({
                   error: ethErrors.rpc.internal('some error'),
                 },
               ],
-              stubGetEIP1559CompatibilityWhileSetting: true,
+              stubLookupNetworkWhileSetting: true,
             });
 
             const infuraIsUnblocked = waitForPublishedEvents({
@@ -5127,7 +5129,7 @@ function lookupNetworkTests({
                 error: ethErrors.rpc.internal('some error'),
               },
             ],
-            stubGetEIP1559CompatibilityWhileSetting: true,
+            stubLookupNetworkWhileSetting: true,
           });
 
           const infuraIsBlocked = waitForPublishedEvents({
@@ -5321,14 +5323,6 @@ function buildFakeProvider(stubs: FakeProviderStub[] = []): Provider {
  * `lookupNetwork` once, and since `lookupNetwork` is called out of band, the
  * test may run with unexpected results. By stubbing `lookupNetwork` before
  * setting the provider, the test is free to explicitly call it.
- * @param options.stubGetEIP1559CompatibilityWhileSetting - Whether to stub the
- * call to `getEIP1559Compatibility` that happens when the provider is set. This
- * option is useful in tests that need a provider to get set but also call
- * `getEIP1559Compatibility` on their own. In this case, since the
- * `providerConfig` setter already calls `getEIP1559Compatibility` once, and
- * since `getEIP1559Compatibility` is called out of band, the test may run with
- * unexpected results. By stubbing `getEIP1559Compatibility` before setting the
- * provider, the test is free to explicitly call it.
  * @returns The set provider.
  */
 async function setFakeProvider(
@@ -5336,27 +5330,18 @@ async function setFakeProvider(
   {
     stubs = [],
     stubLookupNetworkWhileSetting = false,
-    stubGetEIP1559CompatibilityWhileSetting = false,
   }: {
     stubs?: FakeProviderStub[];
     stubLookupNetworkWhileSetting?: boolean;
-    stubGetEIP1559CompatibilityWhileSetting?: boolean;
   } = {},
 ): Promise<void> {
   const fakeProvider = buildFakeProvider(stubs);
   const fakeNetworkClient = buildFakeClient(fakeProvider);
   createNetworkClientMock.mockReturnValue(fakeNetworkClient);
   const lookupNetworkMock = jest.spyOn(controller, 'lookupNetwork');
-  const lookupGetEIP1559CompatibilityMock = jest.spyOn(
-    controller,
-    'getEIP1559Compatibility',
-  );
 
   if (stubLookupNetworkWhileSetting) {
     lookupNetworkMock.mockResolvedValue(undefined);
-  }
-  if (stubGetEIP1559CompatibilityWhileSetting) {
-    lookupGetEIP1559CompatibilityMock.mockResolvedValue(false);
   }
 
   await controller.initializeProvider();
@@ -5364,9 +5349,6 @@ async function setFakeProvider(
 
   if (stubLookupNetworkWhileSetting) {
     lookupNetworkMock.mockRestore();
-  }
-  if (stubGetEIP1559CompatibilityWhileSetting) {
-    lookupGetEIP1559CompatibilityMock.mockRestore();
   }
 }
 


### PR DESCRIPTION


## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

Currently, `lookupNetwork` spawns two asynchronous operations. One operation fetches the network ID and the other determines whether the network supports EIP-1559. Because the second operation makes use of `getEIP1559Compatibility`, it results in changing the controller state implicitly. This is a bit strange, because `lookupNetwork` also changes the controller state. In the extension version of `lookupNetwork`, the steps are divided such that all state changes occur _after_ all asynchronous operations complete. This commit brings the behavior of `lookupNetwork` in line with the extension.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

There should be no functional changes, so no changelog entry needed.

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
