### PR TITLE
Remove unused `networkType` configuration

### DIFF
--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -19,7 +19,6 @@ import {
   ERC1155,
   OPENSEA_API_URL,
   OPENSEA_PROXY_URL,
-  NetworkType,
 } from '@metamask/controller-utils';
 import type {
   ApiNft,
@@ -131,11 +130,9 @@ interface AccountParams {
  * @type NftConfig
  *
  * NFT controller configuration
- * @property networkType - Network ID as per net_version
  * @property selectedAddress - Vault selected address
  */
 export interface NftConfig extends BaseConfig {
-  networkType: NetworkType;
   selectedAddress: string;
   chainId: string;
   ipfsGateway: string;
@@ -910,7 +907,6 @@ export class NftController extends BaseController<NftConfig, NftState> {
   ) {
     super(config, state);
     this.defaultConfig = {
-      networkType: NetworkType.mainnet,
       selectedAddress: '',
       chainId: '',
       ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -272,7 +272,6 @@ describe('NftDetectionController', () => {
     });
 
     nftController.configure({
-      networkType: NetworkType.mainnet,
       selectedAddress,
     });
     const { chainId } = nftDetection.config;
@@ -495,7 +494,6 @@ describe('NftDetectionController', () => {
 
     nftController.configure({
       selectedAddress,
-      networkType: NetworkType.mainnet,
     });
 
     const { chainId } = nftDetection.config;
@@ -663,7 +661,6 @@ describe('NftDetectionController', () => {
     });
 
     nftController.configure({
-      networkType: NetworkType.mainnet,
       selectedAddress,
     });
 
@@ -701,7 +698,6 @@ describe('NftDetectionController', () => {
     });
 
     nftController.configure({
-      networkType: NetworkType.mainnet,
       selectedAddress,
     });
 

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -20,7 +20,6 @@ import {
 import type { PreferencesState } from '@metamask/preferences-controller';
 import type { NetworkState } from '@metamask/network-controller';
 import {
-  NetworkType,
   toChecksumHexAddress,
   ERC721_INTERFACE_ID,
   ORIGIN_METAMASK,
@@ -42,11 +41,9 @@ import {
  * @type TokensConfig
  *
  * Tokens controller configuration
- * @property networkType - Network ID as per net_version
  * @property selectedAddress - Vault selected address
  */
 export interface TokensConfig extends BaseConfig {
-  networkType: NetworkType;
   selectedAddress: string;
   chainId: string;
   provider: any;
@@ -244,7 +241,6 @@ export class TokensController extends BaseController<
     super(config, state);
 
     this.defaultConfig = {
-      networkType: NetworkType.mainnet,
       selectedAddress: '',
       chainId: '',
       provider: undefined,


### PR DESCRIPTION
## Description

The `networkType` configuration option has been removed from the NFT controller and the tokens controller. In both cases it was unused.

## Changes

### `@metamask/assets-controllers`
- **BREAKING:** Remove the `networkType` configuration option from `NftController` and `TokensController`

## References

This relates to #1209

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
