### PR TITLE
Support NFT detection on custom Mainnet RPC endpoints

### DIFF
--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -1,7 +1,7 @@
 import * as sinon from 'sinon';
 import nock from 'nock';
 import { PreferencesController } from '@metamask/preferences-controller';
-import { OPENSEA_PROXY_URL, NetworkType } from '@metamask/controller-utils';
+import { OPENSEA_PROXY_URL, ChainId } from '@metamask/controller-utils';
 import { NftController } from './NftController';
 import { AssetsContractController } from './AssetsContractController';
 import { NftDetectionController } from './NftDetectionController';
@@ -198,7 +198,6 @@ describe('NftDetectionController', () => {
     preferences.setUseNftDetection(false);
     expect(nftDetection.config).toStrictEqual({
       interval: DEFAULT_INTERVAL,
-      networkType: 'mainnet',
       chainId: '1',
       selectedAddress: '',
       disabled: true,
@@ -234,9 +233,9 @@ describe('NftDetectionController', () => {
   });
 
   it('should detect mainnet correctly', () => {
-    nftDetection.configure({ networkType: NetworkType.mainnet });
+    nftDetection.configure({ chainId: ChainId.mainnet });
     expect(nftDetection.isMainnet()).toStrictEqual(true);
-    nftDetection.configure({ networkType: NetworkType.goerli });
+    nftDetection.configure({ chainId: ChainId.goerli });
     expect(nftDetection.isMainnet()).toStrictEqual(false);
   });
 
@@ -256,7 +255,7 @@ describe('NftDetectionController', () => {
           addNft: nftController.addNft.bind(nftController),
           getNftState: () => nftController.state,
         },
-        { interval: 10, networkType: NetworkType.goerli },
+        { interval: 10, chainId: ChainId.goerli },
       );
       expect(mockNfts.called).toBe(false);
       resolve('');
@@ -267,7 +266,7 @@ describe('NftDetectionController', () => {
     const selectedAddress = '0x1';
 
     nftDetection.configure({
-      networkType: NetworkType.mainnet,
+      chainId: ChainId.mainnet,
       selectedAddress,
     });
 
@@ -296,7 +295,7 @@ describe('NftDetectionController', () => {
   it('should detect, add NFTs and do nor remove not detected NFTs correctly', async () => {
     const selectedAddress = '0x1';
     nftDetection.configure({
-      networkType: NetworkType.mainnet,
+      chainId: ChainId.mainnet,
       selectedAddress,
     });
     nftController.configure({ selectedAddress });
@@ -345,7 +344,7 @@ describe('NftDetectionController', () => {
   it('should not autodetect NFTs that exist in the ignoreList', async () => {
     const selectedAddress = '0x2';
     nftDetection.configure({
-      networkType: NetworkType.mainnet,
+      chainId: ChainId.mainnet,
       selectedAddress: '0x2',
     });
     nftController.configure({ selectedAddress });
@@ -372,7 +371,7 @@ describe('NftDetectionController', () => {
   it('should not detect and add NFTs if there is no selectedAddress', async () => {
     const selectedAddress = '';
     nftDetection.configure({
-      networkType: NetworkType.mainnet,
+      chainId: ChainId.mainnet,
       selectedAddress,
     });
     const { chainId } = nftDetection.config;
@@ -383,7 +382,7 @@ describe('NftDetectionController', () => {
 
   it('should not detect and add NFTs to the wrong selectedAddress', async () => {
     nftDetection.configure({
-      networkType: NetworkType.mainnet,
+      chainId: ChainId.mainnet,
       selectedAddress: '0x9',
     });
     const { chainId } = nftDetection.config;
@@ -406,7 +405,7 @@ describe('NftDetectionController', () => {
     preferences.setUseNftDetection(false);
     const selectedAddress = '0x9';
     nftDetection.configure({
-      networkType: NetworkType.mainnet,
+      chainId: ChainId.mainnet,
       selectedAddress,
     });
     const { chainId } = nftController.config;
@@ -420,7 +419,7 @@ describe('NftDetectionController', () => {
     preferences.setOpenSeaEnabled(false);
     const selectedAddress = '0x9';
     nftDetection.configure({
-      networkType: NetworkType.mainnet,
+      chainId: ChainId.mainnet,
       selectedAddress,
     });
     const { chainId } = nftController.config;
@@ -489,7 +488,7 @@ describe('NftDetectionController', () => {
     const selectedAddress = '0x1';
     nftDetection.configure({
       selectedAddress,
-      networkType: NetworkType.mainnet,
+      chainId: ChainId.mainnet,
     });
 
     nftController.configure({
@@ -656,7 +655,7 @@ describe('NftDetectionController', () => {
       });
 
     nftDetection.configure({
-      networkType: NetworkType.mainnet,
+      chainId: ChainId.mainnet,
       selectedAddress,
     });
 
@@ -693,7 +692,7 @@ describe('NftDetectionController', () => {
       .replyWithError(new Error('UNEXPECTED ERROR'));
 
     nftDetection.configure({
-      networkType: NetworkType.mainnet,
+      chainId: ChainId.mainnet,
       selectedAddress,
     });
 

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -8,9 +8,9 @@ import type { PreferencesState } from '@metamask/preferences-controller';
 import {
   OPENSEA_PROXY_URL,
   OPENSEA_API_URL,
-  NetworkType,
   fetchWithErrorHandling,
   toChecksumHexAddress,
+  ChainId,
 } from '@metamask/controller-utils';
 import type { NftController, NftState, NftMetadata } from './NftController';
 
@@ -122,7 +122,6 @@ export interface ApiNftCreator {
  */
 export interface NftDetectionConfig extends BaseConfig {
   interval: number;
-  networkType: NetworkType;
   chainId: `0x${string}` | `${number}` | number;
   selectedAddress: string;
 }
@@ -239,7 +238,6 @@ export class NftDetectionController extends BaseController<
     super(config, state);
     this.defaultConfig = {
       interval: DEFAULT_INTERVAL,
-      networkType: NetworkType.mainnet,
       chainId: '1',
       selectedAddress: '',
       disabled: true,
@@ -268,7 +266,6 @@ export class NftDetectionController extends BaseController<
 
     onNetworkStateChange(({ providerConfig }) => {
       this.configure({
-        networkType: providerConfig.type,
         chainId: providerConfig.chainId as NftDetectionConfig['chainId'],
       });
     });
@@ -319,7 +316,7 @@ export class NftDetectionController extends BaseController<
    *
    * @returns Whether current network is mainnet.
    */
-  isMainnet = (): boolean => this.config.networkType === NetworkType.mainnet;
+  isMainnet = (): boolean => this.config.chainId === ChainId.mainnet;
 
   /**
    * Triggers asset ERC721 token auto detection on mainnet. Any newly detected NFTs are


### PR DESCRIPTION
## Description

The NFT detection controller now supports NFT detection on any Ethereum Mainnet networks, including custom RPC endpoints. Previously this was only supported on the built-in Ethereum Mainnet. This restriction was likely not intentional in the first place (at least I can't think of a reason for it).

## Changes

- **BREAKING:** Remove the `networkType` configuration option from the NFT detection controller
- CHANGED: Support NFT detection on Ethereum Mainnet custom RPC endpoints

## References

This relates to #1209

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
