### PR TITLE
Fix ENS controller network change handler

### DIFF
--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -32,6 +32,7 @@
     "@ethersproject/providers": "^5.7.0",
     "@metamask/base-controller": "workspace:^",
     "@metamask/controller-utils": "workspace:^",
+    "@metamask/network-controller": "workspace:^",
     "@metamask/utils": "^5.0.2",
     "ethereum-ens-network-map": "^1.0.2",
     "punycode": "^2.1.1"
@@ -45,6 +46,9 @@
     "typedoc": "^0.22.15",
     "typedoc-plugin-missing-exports": "^0.22.6",
     "typescript": "~4.6.3"
+  },
+  "peerDependencies": {
+    "@metamask/network-controller": "workspace:^"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/ens-controller/src/EnsController.test.ts
+++ b/packages/ens-controller/src/EnsController.test.ts
@@ -1,5 +1,5 @@
 import { ControllerMessenger } from '@metamask/base-controller';
-import { toChecksumHexAddress } from '@metamask/controller-utils';
+import { NetworkType, toChecksumHexAddress } from '@metamask/controller-utils';
 import * as providersModule from '@ethersproject/providers';
 import { EnsController } from './EnsController';
 
@@ -113,9 +113,10 @@ describe('EnsController', () => {
       provider: getProvider(),
       onNetworkStateChange: (listener) => {
         listener({
-          network: '1',
+          networkId: '1',
           providerConfig: {
             chainId: '1',
+            type: NetworkType.mainnet,
           },
         });
       },
@@ -436,9 +437,10 @@ describe('EnsController', () => {
         provider: getProvider(),
         onNetworkStateChange: (listener) => {
           listener({
-            network: 'loading',
+            networkId: null,
             providerConfig: {
               chainId: '1',
+              type: NetworkType.mainnet,
             },
           });
         },
@@ -453,9 +455,10 @@ describe('EnsController', () => {
         provider: getProvider(),
         onNetworkStateChange: (listener) => {
           listener({
-            network: '1544',
+            networkId: '1544',
             providerConfig: {
               chainId: '1',
+              type: NetworkType.mainnet,
             },
           });
         },
@@ -477,9 +480,10 @@ describe('EnsController', () => {
         provider: getProvider(),
         onNetworkStateChange: (listener) => {
           listener({
-            network: '1',
+            networkId: '1',
             providerConfig: {
               chainId: '1',
+              type: NetworkType.mainnet,
             },
           });
         },
@@ -503,9 +507,10 @@ describe('EnsController', () => {
         provider: getProvider(),
         onNetworkStateChange: (listener) => {
           listener({
-            network: '1',
+            networkId: '1',
             providerConfig: {
               chainId: '1',
+              type: NetworkType.mainnet,
             },
           });
         },
@@ -524,9 +529,10 @@ describe('EnsController', () => {
         provider: getProvider(),
         onNetworkStateChange: (listener) => {
           listener({
-            network: '1',
+            networkId: '1',
             providerConfig: {
               chainId: '1',
+              type: NetworkType.mainnet,
             },
           });
         },
@@ -548,9 +554,10 @@ describe('EnsController', () => {
         provider: getProvider(),
         onNetworkStateChange: (listener) => {
           listener({
-            network: '1',
+            networkId: '1',
             providerConfig: {
               chainId: '1',
+              type: NetworkType.mainnet,
             },
           });
         },
@@ -572,9 +579,10 @@ describe('EnsController', () => {
         provider: getProvider(),
         onNetworkStateChange: (listener) => {
           listener({
-            network: '1',
+            networkId: '1',
             providerConfig: {
               chainId: '1',
+              type: NetworkType.mainnet,
             },
           });
         },
@@ -598,9 +606,10 @@ describe('EnsController', () => {
         provider: getProvider(),
         onNetworkStateChange: (listener) => {
           listener({
-            network: '1',
+            networkId: '1',
             providerConfig: {
               chainId: '1',
+              type: NetworkType.mainnet,
             },
           });
         },
@@ -623,9 +632,10 @@ describe('EnsController', () => {
         provider: getProvider(),
         onNetworkStateChange: (listener) => {
           listener({
-            network: '1',
+            networkId: '1',
             providerConfig: {
               chainId: '1',
+              type: NetworkType.mainnet,
             },
           });
         },

--- a/packages/ens-controller/src/EnsController.ts
+++ b/packages/ens-controller/src/EnsController.ts
@@ -15,6 +15,7 @@ import {
   NETWORK_ID_TO_ETHERS_NETWORK_NAME_MAP,
   convertHexToDecimal,
 } from '@metamask/controller-utils';
+import type { NetworkState } from '@metamask/network-controller';
 import { toASCII } from 'punycode/';
 import ensNetworkMap from 'ethereum-ens-network-map';
 
@@ -118,12 +119,9 @@ export class EnsController extends BaseControllerV2<
     state?: Partial<EnsControllerState>;
     provider?: ExternalProvider | JsonRpcFetchFunc;
     onNetworkStateChange?: (
-      listener: (networkState: {
-        network: string;
-        providerConfig: {
-          chainId: string;
-        };
-      }) => void,
+      listener: (
+        networkState: Pick<NetworkState, 'networkId' | 'providerConfig'>,
+      ) => void,
     ) => void;
   }) {
     super({
@@ -139,8 +137,7 @@ export class EnsController extends BaseControllerV2<
     if (provider && onNetworkStateChange) {
       onNetworkStateChange((networkState) => {
         this.resetState();
-        const currentNetwork =
-          networkState.network === 'loading' ? null : networkState.network;
+        const currentNetwork = networkState.networkId;
         if (
           isKnownNetworkId(currentNetwork) &&
           this.#getNetworkEnsSupport(currentNetwork)

--- a/packages/ens-controller/tsconfig.build.json
+++ b/packages/ens-controller/tsconfig.build.json
@@ -7,7 +7,8 @@
   },
   "references": [
     { "path": "../base-controller/tsconfig.build.json" },
-    { "path": "../controller-utils/tsconfig.build.json" }
+    { "path": "../controller-utils/tsconfig.build.json" },
+    { "path": "../network-controller/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/ens-controller/tsconfig.json
+++ b/packages/ens-controller/tsconfig.json
@@ -5,7 +5,8 @@
   },
   "references": [
     { "path": "../base-controller" },
-    { "path": "../controller-utils" }
+    { "path": "../controller-utils" },
+    { "path": "../network-controller" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,6 +1499,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
+    "@metamask/network-controller": "workspace:^"
     "@metamask/utils": ^5.0.2
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1509,6 +1510,8 @@ __metadata:
     typedoc: ^0.22.15
     typedoc-plugin-missing-exports: ^0.22.6
     typescript: ~4.6.3
+  peerDependencies:
+    "@metamask/network-controller": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

The network change handler for the ENS controller has been broken since the PR #1170 due to a conflict with #1196, which was merged around the same time. It referenced the `network` property of the network state that we have removed.

The change handler has been updated to use `networkId` instead. Additionally, the `NetworkState` type has been imported so that we're less likely to make this mistake again.

## Changes

- **Fixed**: Fix ENS controller failure to initialize after switching networks.

## References

Relates to #1209

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
