### PR TITLE
Support MMI use cases in signing typed messages

### DIFF
--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -108,6 +108,7 @@ describe('AbstractTestManager', () => {
       type: messageType,
     };
 
+    await controller.addMessage(message);
     await controller.addMessage(message2);
     const messages = controller.getAllMessages();
     expect(messages).toStrictEqual([message, message2]);

--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -331,4 +331,32 @@ describe('AbstractTestManager', () => {
       expect(messageAfter?.status).toStrictEqual('newstatus');
     });
   });
+
+  describe('setMetadata', () => {
+    it('should set the given message metadata', async () => {
+      const controller = new AbstractTestManager();
+      await controller.addMessage({
+        id: messageId,
+        messageParams: { from: '0x1234', data: 'test' },
+        status: 'status',
+        time: 10,
+        type: 'type',
+      });
+
+      const messageBefore = controller.getMessage(messageId);
+      expect(messageBefore?.metadata).toBeUndefined();
+
+      controller.setMetadata(messageId, { foo: 'bar' });
+      const messageAfter = controller.getMessage(messageId);
+      expect(messageAfter?.metadata).toStrictEqual({ foo: 'bar' });
+    });
+
+    it('should throw an error if message is not found', () => {
+      const controller = new AbstractTestManager();
+
+      expect(() => controller.setMetadata(messageId, { foo: 'bar' })).toThrow(
+        'AbstractMessageManager: Message not found for id: 1.',
+      );
+    });
+  });
 });

--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -84,6 +84,24 @@ describe('AbstractTestManager', () => {
     expect(message.type).toBe(messageType);
   });
 
+  it('should get all messages', async () => {
+    const controller = new AbstractTestManager();
+    const message = {
+      id: messageId,
+      messageParams: {
+        data: typedMessage,
+        from,
+      },
+      status: messageStatus,
+      time: messageTime,
+      type: messageType,
+    };
+
+    await controller.addMessage(message);
+    const messages = controller.getAllMessages();
+    expect(messages).toStrictEqual([message]);
+  });
+
   it('adds a valid message with provider security response', async () => {
     const securityProviderResponseMock = { flagAsDangerous: 2 };
     const securityProviderRequestMock: SecurityProviderRequest = jest

--- a/packages/message-manager/src/AbstractMessageManager.test.ts
+++ b/packages/message-manager/src/AbstractMessageManager.test.ts
@@ -40,6 +40,7 @@ const typedMessage = [
   },
 ];
 const messageId = '1';
+const messageId2 = '2';
 const from = '0x0123';
 const messageTime = Date.now();
 const messageStatus = 'unapproved';
@@ -96,10 +97,20 @@ describe('AbstractTestManager', () => {
       time: messageTime,
       type: messageType,
     };
+    const message2 = {
+      id: messageId2,
+      messageParams: {
+        data: typedMessage,
+        from,
+      },
+      status: messageStatus,
+      time: messageTime,
+      type: messageType,
+    };
 
-    await controller.addMessage(message);
+    await controller.addMessage(message2);
     const messages = controller.getAllMessages();
-    expect(messages).toStrictEqual([message]);
+    expect(messages).toStrictEqual([message, message2]);
   });
 
   it('adds a valid message with provider security response', async () => {

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -43,10 +43,12 @@ export interface AbstractMessage {
  * Represents the parameters to pass to the signing method once the signature request is approved.
  * @property from - Address from which the message is processed
  * @property origin? - Added for request origin identification
+ * @property deferSetAsSigned? - Whether to defer setting the message as signed immediately after the keyring is told to sign it
  */
 export interface AbstractMessageParams {
   from: string;
   origin?: string;
+  deferSetAsSigned?: boolean;
 }
 
 /**

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -262,6 +262,14 @@ export abstract class AbstractMessageManager<
   }
 
   /**
+   * Returns all the messages
+   *
+   */
+  getAllMessages() {
+    return this.messages;
+  }
+
+  /**
    * Approves a Message. Sets the message status via a call to this.setMessageStatusApproved,
    * and returns a promise with any the message params modified for proper signing.
    *

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -25,6 +25,7 @@ export interface OriginalRequest {
  * A 'Message' which always has a signing type
  * @property rawSig - Raw data of the signature request
  * @property securityProviderResponse - Response from a security provider, whether it is malicious or not
+ * @property metadata - Additional data for the message, for example external identifiers
  */
 export interface AbstractMessage {
   id: string;
@@ -33,6 +34,7 @@ export interface AbstractMessage {
   type: string;
   rawSig?: string;
   securityProviderResponse?: Record<string, Json>;
+  metadata?: Record<string, string>;
 }
 
 /**
@@ -328,6 +330,22 @@ export abstract class AbstractMessageManager<
       return;
     }
     message.rawSig = result;
+    this.updateMessage(message, false);
+  }
+
+  /**
+   * Sets the messsage metadata
+   *
+   * @param messageId - The id of the Message to update
+   * @param metadata - The data with which to replace the metadata property in the message
+   */
+
+  setMetadata(messageId: string, metadata: Record<string, string>) {
+    const message = this.getMessage(messageId);
+    if (!message) {
+      throw new Error(`${this.name}: Message not found for id: ${messageId}.`);
+    }
+    message.metadata = metadata;
     this.updateMessage(message, false);
   }
 

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -34,7 +34,7 @@ export interface AbstractMessage {
   type: string;
   rawSig?: string;
   securityProviderResponse?: Record<string, Json>;
-  metadata?: Record<string, string>;
+  metadata?: Json;
 }
 
 /**
@@ -351,7 +351,7 @@ export abstract class AbstractMessageManager<
    * @param metadata - The data with which to replace the metadata property in the message
    */
 
-  setMetadata(messageId: string, metadata: Record<string, string>) {
+  setMetadata(messageId: string, metadata: Json) {
     const message = this.getMessage(messageId);
     if (!message) {
       throw new Error(`${this.name}: Message not found for id: ${messageId}.`);

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -262,8 +262,9 @@ export abstract class AbstractMessageManager<
   }
 
   /**
-   * Returns all the messages
+   * Returns all the messages.
    *
+   * @returns An array of messages.
    */
   getAllMessages() {
     return this.messages;

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -432,7 +432,7 @@ describe('SignatureController', () => {
       it('approves message and signs', async () => {
         await new Promise(async (resolve) => {
           signatureController.hub.once(`${rpcMethodName}:signed`, (data) => {
-            expect(data).toStrictEqual(signatureMock);
+            expect(data.signature).toStrictEqual(signatureMock);
             resolve('');
           });
 

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -430,7 +430,7 @@ describe('SignatureController', () => {
       });
 
       it('approves message and signs', async () => {
-        return new Promise(async (resolve) => {
+        await new Promise(async (resolve) => {
           signatureController.hub.once(`${rpcMethodName}:signed`, (data) => {
             expect(data).toStrictEqual(signatureMock);
             resolve('');

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -25,6 +25,7 @@ jest.mock('@metamask/controller-utils', () => {
 
 const messageIdMock = '123';
 const messageIdMock2 = '456';
+const messageIdMock3 = '789';
 const versionMock = '1';
 const signatureMock = '0xAABBCC';
 const stateMock = { test: 123 };
@@ -42,6 +43,15 @@ const messageParamsMock2 = {
   origin: 'http://test4.com',
   data: '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA',
   metamaskId: messageIdMock,
+};
+
+const messageParamsMock3 = {
+  from: '0x125',
+  origin: 'http://test5.com',
+  data: '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF',
+  metamaskId: messageIdMock3,
+  deferSetAsSigned: true,
+  version: 'V1',
 };
 
 const messageMock = {
@@ -435,6 +445,28 @@ describe('SignatureController', () => {
           messageParamsMock2.metamaskId,
           signatureMock,
         );
+      });
+
+      it('does not set as signed, messages with deferSetAsSigned', async () => {
+        messageManager.approveMessage.mockReset();
+        messageManager.approveMessage.mockResolvedValueOnce(messageParamsMock3);
+
+        console.log('messageParamsMock3', messageParamsMock3);
+        await (signatureController as any)[signMethodName](messageParamsMock3);
+
+        const keyringControllerExtraArgs =
+          // eslint-disable-next-line jest/no-if
+          signMethodName === 'signTypedMessage'
+            ? [{ version: messageParamsMock.version }]
+            : [];
+
+        expect(keyringControllerMethod).toHaveBeenCalledTimes(1);
+        expect(keyringControllerMethod).toHaveBeenCalledWith(
+          messageParamsMock3,
+          ...keyringControllerExtraArgs,
+        );
+
+        expect(messageManager.setMessageStatusSigned).not.toHaveBeenCalled();
       });
 
       it('returns current state', async () => {

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -492,7 +492,7 @@ export class SignatureController extends BaseControllerV2<
       const cleanMessageParams = await messageManager.approveMessage(msgParams);
       const signature = await getSignature(cleanMessageParams);
 
-      this.hub.emit(`${methodName}:signed`, signature);
+      this.hub.emit(`${methodName}:signed`, { signature, messageId });
 
       if (!cleanMessageParams.deferSetAsSigned) {
         messageManager.setMessageStatusSigned(messageId, signature);

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -492,7 +492,10 @@ export class SignatureController extends BaseControllerV2<
       const cleanMessageParams = await messageManager.approveMessage(msgParams);
       const signature = await getSignature(cleanMessageParams);
 
-      messageManager.setMessageStatusSigned(messageId, signature);
+      console.log(cleanMessageParams);
+      if (!cleanMessageParams.deferSetAsSigned) {
+        messageManager.setMessageStatusSigned(messageId, signature);
+      }
 
       this.#acceptApproval(messageId);
 

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -492,7 +492,8 @@ export class SignatureController extends BaseControllerV2<
       const cleanMessageParams = await messageManager.approveMessage(msgParams);
       const signature = await getSignature(cleanMessageParams);
 
-      console.log(cleanMessageParams);
+      this.hub.emit(`${methodName}:signed`, signature);
+
       if (!cleanMessageParams.deferSetAsSigned) {
         messageManager.setMessageStatusSigned(messageId, signature);
       }


### PR DESCRIPTION
## Description



## Changes

- **ADDED**: Metadata property of messages, plus a method to mutate it
- **ADDED**: A means of deferring the message setting as signed, via the params
- **ADDED**: Method to get all messages
- **ADDED**: Event to surface message signing to the client


## References


* Fixes #1341 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
