### PR TITLE
Replace hard-coded `chainId` on incoming token transactions

### DIFF
--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -378,7 +378,7 @@ export class TransactionController extends BaseController<
       status: TransactionStatus.confirmed,
       time,
       transaction: {
-        chainId: 1,
+        chainId: parseInt(currentChainId, undefined),
         from,
         gas,
         gasPrice,

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -378,6 +378,7 @@ export class TransactionController extends BaseController<
       status: TransactionStatus.confirmed,
       time,
       transaction: {
+        // TODO: Change base to 16 once chainIds are consistently hex-formatted (#1367)
         chainId: parseInt(currentChainId, undefined),
         from,
         gas,


### PR DESCRIPTION
## Description

Incoming token transactions were given the correct chain ID on the `txMeta` object, but the `transaction` object inside of that was given a hard-coded chain ID of `1`. Likely we don't use this property for anything, since we only keep track of these transactions to display them as transaction history, and we'd use the `txMeta` property for filtering those. But the type requires this property to be set, so it should be correct.

## Changes

- FIXED: Fix transaction parameters given to incoming token transactions

## References

Relates to #1209

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
