### PR TITLE
Update chain ID format

### DIFF
--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "@metamask/base-controller": "workspace:^",
-    "@metamask/controller-utils": "workspace:^"
+    "@metamask/controller-utils": "workspace:^",
+    "@metamask/utils": "^5.0.2"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.1.0",

--- a/packages/address-book-controller/src/AddressBookController.test.ts
+++ b/packages/address-book-controller/src/AddressBookController.test.ts
@@ -1,3 +1,4 @@
+import { toHex } from '@metamask/controller-utils';
 import { AddressBookController, AddressType } from './AddressBookController';
 
 describe('AddressBookController', () => {
@@ -12,10 +13,10 @@ describe('AddressBookController', () => {
 
     expect(controller.state).toStrictEqual({
       addressBook: {
-        1: {
+        [toHex(1)]: {
           '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
             address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '1',
+            chainId: toHex(1),
             isEns: false,
             memo: '',
             name: 'foo',
@@ -31,17 +32,17 @@ describe('AddressBookController', () => {
     controller.set(
       '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
       'foo',
-      '1',
+      toHex(1),
       'account 1',
       AddressType.externallyOwnedAccounts,
     );
 
     expect(controller.state).toStrictEqual({
       addressBook: {
-        1: {
+        [toHex(1)]: {
           '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
             address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '1',
+            chainId: toHex(1),
             isEns: false,
             memo: 'account 1',
             name: 'foo',
@@ -57,17 +58,17 @@ describe('AddressBookController', () => {
     controller.set(
       '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
       'foo',
-      '1',
+      toHex(1),
       'account 1',
       AddressType.contractAccounts,
     );
 
     expect(controller.state).toStrictEqual({
       addressBook: {
-        1: {
+        [toHex(1)]: {
           '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
             address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '1',
+            chainId: toHex(1),
             isEns: false,
             memo: 'account 1',
             name: 'foo',
@@ -83,17 +84,17 @@ describe('AddressBookController', () => {
     controller.set(
       '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
       'foo',
-      '1',
+      toHex(1),
       'account 1',
       AddressType.nonAccounts,
     );
 
     expect(controller.state).toStrictEqual({
       addressBook: {
-        1: {
+        [toHex(1)]: {
           '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
             address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '1',
+            chainId: toHex(1),
             isEns: false,
             memo: 'account 1',
             name: 'foo',
@@ -109,33 +110,33 @@ describe('AddressBookController', () => {
     controller.set(
       '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
       'foo',
-      '1',
+      toHex(1),
       'account 2',
     );
 
     controller.set(
       '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
       'foo',
-      '2',
+      toHex(2),
       'account 2',
     );
 
     expect(controller.state).toStrictEqual({
       addressBook: {
-        1: {
+        [toHex(1)]: {
           '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
             address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '1',
+            chainId: toHex(1),
             isEns: false,
             memo: 'account 2',
             name: 'foo',
             addressType: undefined,
           },
         },
-        2: {
+        [toHex(2)]: {
           '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
             address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '2',
+            chainId: toHex(2),
             isEns: false,
             memo: 'account 2',
             name: 'foo',
@@ -154,10 +155,10 @@ describe('AddressBookController', () => {
 
     expect(controller.state).toStrictEqual({
       addressBook: {
-        1: {
+        [toHex(1)]: {
           '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
             address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '1',
+            chainId: toHex(1),
             isEns: false,
             memo: '',
             name: 'bar',
@@ -170,6 +171,7 @@ describe('AddressBookController', () => {
 
   it('should not add invalid contact entry', () => {
     const controller = new AddressBookController();
+    // @ts-expect-error Intentionally invalid entry
     controller.set('0x01', 'foo', AddressType.externallyOwnedAccounts);
     expect(controller.state).toStrictEqual({ addressBook: {} });
   });
@@ -177,7 +179,7 @@ describe('AddressBookController', () => {
   it('should remove one contact entry', () => {
     const controller = new AddressBookController();
     controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
-    controller.delete('1', '0x32Be343B94f860124dC4fEe278FDCBD38C102D88');
+    controller.delete(toHex(1), '0x32Be343B94f860124dC4fEe278FDCBD38C102D88');
 
     expect(controller.state).toStrictEqual({ addressBook: {} });
   });
@@ -187,14 +189,14 @@ describe('AddressBookController', () => {
     controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
 
     controller.set('0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d', 'bar');
-    controller.delete('1', '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d');
+    controller.delete(toHex(1), '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d');
 
     expect(controller.state).toStrictEqual({
       addressBook: {
-        1: {
+        [toHex(1)]: {
           '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
             address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '1',
+            chainId: toHex(1),
             isEns: false,
             memo: '',
             name: 'foo',
@@ -213,10 +215,10 @@ describe('AddressBookController', () => {
 
     expect(controller.state).toStrictEqual({
       addressBook: {
-        1: {
+        [toHex(1)]: {
           '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
             address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '1',
+            chainId: toHex(1),
             isEns: false,
             memo: '',
             name: 'foo',
@@ -224,7 +226,7 @@ describe('AddressBookController', () => {
           },
           '0xC38bF1aD06ef69F0c04E29DBeB4152B4175f0A8D': {
             address: '0xC38bF1aD06ef69F0c04E29DBeB4152B4175f0A8D',
-            chainId: '1',
+            chainId: toHex(1),
             isEns: false,
             memo: '',
             name: 'bar',
@@ -244,10 +246,10 @@ describe('AddressBookController', () => {
 
     expect(controller.state).toStrictEqual({
       addressBook: {
-        1: {
+        [toHex(1)]: {
           '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
             address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '1',
+            chainId: toHex(1),
             isEns: true,
             memo: '',
             name: 'metamask.eth',
@@ -277,6 +279,7 @@ describe('AddressBookController', () => {
   it('should return false to indicate an address book entry has NOT been added', () => {
     const controller = new AddressBookController();
     expect(
+      // @ts-expect-error Intentionally invalid entry
       controller.set('0x00', 'foo', AddressType.externallyOwnedAccounts),
     ).toStrictEqual(false);
   });
@@ -286,14 +289,14 @@ describe('AddressBookController', () => {
     controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
 
     expect(
-      controller.delete('1', '0x32Be343B94f860124dC4fEe278FDCBD38C102D88'),
+      controller.delete(toHex(1), '0x32Be343B94f860124dC4fEe278FDCBD38C102D88'),
     ).toStrictEqual(true);
   });
 
   it('should return false to indicate an address book entry has NOT been deleted', () => {
     const controller = new AddressBookController();
     controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', '0x00');
-    expect(controller.delete('1', '0x01')).toStrictEqual(false);
+    expect(controller.delete(toHex(1), '0x01')).toStrictEqual(false);
   });
 
   it('should normalize addresses so adding and removing entries work across casings', () => {
@@ -302,13 +305,13 @@ describe('AddressBookController', () => {
 
     controller.set('0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d', 'bar');
 
-    controller.delete('1', '0xC38BF1AD06EF69F0C04E29DBEB4152B4175F0A8D');
+    controller.delete(toHex(1), '0xC38BF1AD06EF69F0C04E29DBEB4152B4175F0A8D');
     expect(controller.state).toStrictEqual({
       addressBook: {
-        1: {
+        [toHex(1)]: {
           '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
             address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '1',
+            chainId: toHex(1),
             isEns: false,
             memo: '',
             name: 'foo',

--- a/packages/address-book-controller/src/AddressBookController.ts
+++ b/packages/address-book-controller/src/AddressBookController.ts
@@ -1,7 +1,9 @@
+import type { Hex } from '@metamask/utils';
 import {
   normalizeEnsName,
   isValidHexAddress,
   toChecksumHexAddress,
+  toHex,
 } from '@metamask/controller-utils';
 import {
   BaseController,
@@ -43,7 +45,7 @@ export enum AddressType {
 export interface AddressBookEntry {
   address: string;
   name: string;
-  chainId: string;
+  chainId: Hex;
   memo: string;
   isEns: boolean;
   addressType?: AddressType;
@@ -56,7 +58,7 @@ export interface AddressBookEntry {
  * @property addressBook - Array of contact entry objects
  */
 export interface AddressBookState extends BaseState {
-  addressBook: { [chainId: string]: { [address: string]: AddressBookEntry } };
+  addressBook: { [chainId: Hex]: { [address: string]: AddressBookEntry } };
 }
 
 /**
@@ -99,7 +101,7 @@ export class AddressBookController extends BaseController<
    * @param address - Recipient address to delete.
    * @returns Whether the entry was deleted.
    */
-  delete(chainId: string, address: string) {
+  delete(chainId: Hex, address: string) {
     address = toChecksumHexAddress(address);
     if (
       !isValidHexAddress(address) ||
@@ -133,7 +135,7 @@ export class AddressBookController extends BaseController<
   set(
     address: string,
     name: string,
-    chainId = '1',
+    chainId = toHex(1),
     memo = '',
     addressType?: AddressType,
   ) {

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -2,6 +2,7 @@ import { BN } from 'ethereumjs-util';
 import abiSingleCallBalancesContract from 'single-call-balance-checker-abi';
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
+import type { Hex } from '@metamask/utils';
 import {
   BaseController,
   BaseConfig,
@@ -21,7 +22,7 @@ import { ERC20Standard } from './Standards/ERC20Standard';
  * @param chainId - ChainID of network
  * @returns Whether the current network supports token detection
  */
-export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID: Record<string, string> = {
+export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID: Record<Hex, string> = {
   [SupportedTokenDetectionNetworks.mainnet]:
     '0xb1f8e55c7f64d203c1400b9d8555d050f94adf39',
   [SupportedTokenDetectionNetworks.bsc]:
@@ -46,7 +47,7 @@ export const MISSING_PROVIDER_ERROR =
 export interface AssetsContractConfig extends BaseConfig {
   provider: any;
   ipfsGateway: string;
-  chainId: string;
+  chainId: Hex;
 }
 
 /**
@@ -95,7 +96,7 @@ export class AssetsContractController extends BaseController<
       onPreferencesStateChange,
       onNetworkStateChange,
     }: {
-      chainId: string;
+      chainId: Hex;
       onPreferencesStateChange: (
         listener: (preferencesState: PreferencesState) => void,
       ) => void;

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -15,6 +15,7 @@ import {
   ERC721,
   ChainId,
   NetworkType,
+  toHex,
 } from '@metamask/controller-utils';
 import { Network } from '@ethersproject/providers';
 import { AssetsContractController } from './AssetsContractController';
@@ -47,8 +48,8 @@ const DEPRESSIONIST_CLOUDFLARE_IPFS_SUBDOMAIN_PATH = getFormattedIpfsUrl(
   true,
 );
 
-const SEPOLIA = { chainId: '11155111', type: NetworkType.sepolia };
-const GOERLI = { chainId: '5', type: NetworkType.goerli };
+const SEPOLIA = { chainId: toHex(11155111), type: NetworkType.sepolia };
+const GOERLI = { chainId: toHex(5), type: NetworkType.goerli };
 
 // Mock out detectNetwork function for cleaner tests, Ethers calls this a bunch of times because the Web3Provider is paranoid.
 jest.mock('@ethersproject/providers', () => {
@@ -284,7 +285,7 @@ describe('NftController', () => {
           favorite: false,
         },
         // this object in the third argument slot is only defined when the NFT is added via detection
-        { userAddress: detectedUserAddress, chainId: '0x2' },
+        { userAddress: detectedUserAddress, chainId: toHex(2) },
       );
 
       expect(onNftAddedSpy).toHaveBeenCalledWith({

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -151,9 +151,9 @@ export interface NftConfig extends BaseConfig {
  */
 export interface NftState extends BaseState {
   allNftContracts: {
-    [key: string]: { [key: string]: NftContract[] };
+    [key: string]: { [chainId: Hex]: NftContract[] };
   };
-  allNfts: { [key: string]: { [key: string]: Nft[] } };
+  allNfts: { [key: string]: { [chainId: Hex]: Nft[] } };
   ignoredNfts: Nft[];
 }
 

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import { BN, stripHexPrefix } from 'ethereumjs-util';
 import { Mutex } from 'async-mutex';
+import type { Hex } from '@metamask/utils';
 import {
   BaseController,
   BaseConfig,
@@ -123,7 +124,7 @@ export interface NftMetadata {
 
 interface AccountParams {
   userAddress: string;
-  chainId: string;
+  chainId: Hex;
 }
 
 /**
@@ -134,7 +135,7 @@ interface AccountParams {
  */
 export interface NftConfig extends BaseConfig {
   selectedAddress: string;
-  chainId: string;
+  chainId: Hex;
   ipfsGateway: string;
   openSeaEnabled: boolean;
   useIPFSSubdomains: boolean;
@@ -203,7 +204,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
   private updateNestedNftState(
     newCollection: Nft[] | NftContract[],
     baseStateKey: 'allNfts' | 'allNftContracts',
-    { userAddress, chainId }: AccountParams | undefined = {
+    { userAddress, chainId } = {
       userAddress: this.config.selectedAddress,
       chainId: this.config.chainId,
     },
@@ -884,7 +885,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
       getERC1155TokenURI,
       onNftAdded,
     }: {
-      chainId: string;
+      chainId: Hex;
       onPreferencesStateChange: (
         listener: (preferencesState: PreferencesState) => void,
       ) => void;
@@ -1105,7 +1106,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
   async checkAndUpdateSingleNftOwnershipStatus(
     nft: Nft,
     batch: boolean,
-    { userAddress, chainId }: AccountParams | undefined = {
+    { userAddress, chainId } = {
       userAddress: this.config.selectedAddress,
       chainId: this.config.chainId,
     },
@@ -1211,7 +1212,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     address: string,
     tokenId: string,
     selectedAddress: string,
-    chainId: string,
+    chainId: Hex,
   ): { nft: Nft; index: number } | null {
     const { allNfts } = this.state;
     const nfts = allNfts[selectedAddress]?.[chainId] || [];
@@ -1241,7 +1242,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     nft: Nft,
     updates: Partial<Nft>,
     selectedAddress: string,
-    chainId: string,
+    chainId: Hex,
   ) {
     const { allNfts } = this.state;
     const nfts = allNfts[selectedAddress]?.[chainId] || [];
@@ -1281,7 +1282,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
   resetNftTransactionStatusByTransactionId(
     transactionId: string,
     selectedAddress: string,
-    chainId: string,
+    chainId: Hex,
   ): boolean {
     const { allNfts } = this.state;
     const nfts = allNfts[selectedAddress]?.[chainId] || [];

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -1,7 +1,7 @@
 import * as sinon from 'sinon';
 import nock from 'nock';
 import { PreferencesController } from '@metamask/preferences-controller';
-import { OPENSEA_PROXY_URL, ChainId } from '@metamask/controller-utils';
+import { OPENSEA_PROXY_URL, ChainId, toHex } from '@metamask/controller-utils';
 import { NftController } from './NftController';
 import { AssetsContractController } from './AssetsContractController';
 import { NftDetectionController } from './NftDetectionController';
@@ -201,7 +201,7 @@ describe('NftDetectionController', () => {
     preferences.setUseNftDetection(false);
     expect(nftDetection.config).toStrictEqual({
       interval: DEFAULT_INTERVAL,
-      chainId: '1',
+      chainId: toHex(1),
       selectedAddress: '',
       disabled: true,
     });

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -1,3 +1,4 @@
+import type { Hex } from '@metamask/utils';
 import {
   BaseController,
   BaseConfig,
@@ -122,7 +123,7 @@ export interface ApiNftCreator {
  */
 export interface NftDetectionConfig extends BaseConfig {
   interval: number;
-  chainId: string;
+  chainId: Hex;
   selectedAddress: string;
 }
 
@@ -223,7 +224,7 @@ export class NftDetectionController extends BaseController<
       addNft,
       getNftState,
     }: {
-      chainId: string;
+      chainId: Hex;
       onNftsStateChange: (listener: (nftsState: NftState) => void) => void;
       onPreferencesStateChange: (
         listener: (preferencesState: PreferencesState) => void,
@@ -395,7 +396,7 @@ export class NftDetectionController extends BaseController<
 
         await this.addNft(address, token_id, nftMetadata, {
           userAddress: selectedAddress,
-          chainId: chainId as string,
+          chainId,
         });
       }
     });

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -1,5 +1,6 @@
 import * as sinon from 'sinon';
 import { BN } from 'ethereumjs-util';
+import { toHex } from '@metamask/controller-utils';
 import {
   NetworkController,
   NetworkControllerMessenger,
@@ -142,7 +143,7 @@ describe('TokenBalancesController', () => {
   it('should update all balances', async () => {
     const { messenger, preferences } = setupControllers();
     const assets = new TokensController({
-      chainId: '1',
+      chainId: toHex(1),
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
@@ -179,7 +180,7 @@ describe('TokenBalancesController', () => {
   it('should handle `getERC20BalanceOf` error case', async () => {
     const { messenger, preferences } = setupControllers();
     const assets = new TokensController({
-      chainId: '1',
+      chainId: toHex(1),
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
@@ -228,13 +229,13 @@ describe('TokenBalancesController', () => {
   it('should subscribe to new sibling assets controllers', async () => {
     const { messenger, preferences } = setupControllers();
     const assetsContract = new AssetsContractController({
-      chainId: '1',
+      chainId: toHex(1),
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
     });
     const tokensController = new TokensController({
-      chainId: '1',
+      chainId: toHex(1),
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -7,7 +7,12 @@ import {
   NetworkState,
   ProviderConfig,
 } from '@metamask/network-controller';
-import { ChainId, NetworkType } from '@metamask/controller-utils';
+import {
+  ChainId,
+  NetworkType,
+  convertHexToDecimal,
+  toHex,
+} from '@metamask/controller-utils';
 import { PreferencesController } from '@metamask/preferences-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
 import {
@@ -143,11 +148,19 @@ describe('TokenDetectionController', () => {
 
   beforeEach(async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${ChainId.mainnet}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.mainnet)}`)
       .reply(200, sampleTokenList)
-      .get(`/token/${ChainId.mainnet}?address=${tokenAFromList.address}`)
+      .get(
+        `/token/${convertHexToDecimal(ChainId.mainnet)}?address=${
+          tokenAFromList.address
+        }`,
+      )
       .reply(200, tokenAFromList)
-      .get(`/token/${ChainId.mainnet}?address=${tokenBFromList.address}`)
+      .get(
+        `/token/${convertHexToDecimal(ChainId.mainnet)}?address=${
+          tokenBFromList.address
+        }`,
+      )
       .reply(200, tokenBFromList)
       .persist();
 
@@ -158,7 +171,7 @@ describe('TokenDetectionController', () => {
       .callsFake(() => null);
 
     tokensController = new TokensController({
-      chainId: '1',
+      chainId: ChainId.mainnet,
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         onNetworkStateChangeListeners.push(listener),
@@ -449,7 +462,7 @@ describe('TokenDetectionController', () => {
     tokenDetection.stop();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await networkStateChangeListener!({
-      providerConfig: { chainId: polygonDecimalChainId },
+      providerConfig: { chainId: toHex(polygonDecimalChainId) },
     });
 
     expect(getBalancesInSingleCallMock.called).toBe(false);

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -1,3 +1,4 @@
+import type { Hex } from '@metamask/utils';
 import {
   BaseController,
   BaseConfig,
@@ -30,7 +31,7 @@ const DEFAULT_INTERVAL = 180000;
 export interface TokenDetectionConfig extends BaseConfig {
   interval: number;
   selectedAddress: string;
-  chainId: string;
+  chainId: Hex;
   isDetectionEnabledFromPreferences: boolean;
   isDetectionEnabledForNetwork: boolean;
 }

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -7,7 +7,12 @@ import {
   NetworkStatus,
   ProviderConfig,
 } from '@metamask/network-controller';
-import { ChainId, NetworkType } from '@metamask/controller-utils';
+import {
+  ChainId,
+  NetworkType,
+  convertHexToDecimal,
+  toHex,
+} from '@metamask/controller-utils';
 import {
   TokenListController,
   TokenListStateChange,
@@ -285,7 +290,7 @@ const sampleSingleChainState = {
     },
   },
   tokensChainsCache: {
-    '1': {
+    [toHex(1)]: {
       timestamp,
       data: sampleMainnetTokensChainsCache,
     },
@@ -337,11 +342,11 @@ const sampleTwoChainState = {
     },
   },
   tokensChainsCache: {
-    '1': {
+    [toHex(1)]: {
       timestamp,
       data: sampleMainnetTokensChainsCache,
     },
-    '56': {
+    [toHex(56)]: {
       timestamp: timestamp + 150,
       data: sampleBinanceTokensChainsCache,
     },
@@ -374,7 +379,7 @@ const existingState = {
     },
   },
   tokensChainsCache: {
-    '1': {
+    [toHex(1)]: {
       timestamp,
       data: sampleMainnetTokensChainsCache,
     },
@@ -408,7 +413,7 @@ const outdatedExistingState = {
     },
   },
   tokensChainsCache: {
-    '1': {
+    [toHex(1)]: {
       timestamp,
       data: sampleMainnetTokensChainsCache,
     },
@@ -442,7 +447,7 @@ const expiredCacheExistingState: TokenListState = {
     },
   },
   tokensChainsCache: {
-    '1': {
+    [toHex(1)]: {
       timestamp: timestamp - 86400000,
       data: {
         '0x514910771af9ca656af840dff83e8264ecf986ca': {
@@ -581,7 +586,7 @@ describe('TokenListController', () => {
         },
       },
       tokensChainsCache: {
-        '1': {
+        [toHex(1)]: {
           timestamp,
           data: sampleMainnetTokensChainsCache,
         },
@@ -630,7 +635,7 @@ describe('TokenListController', () => {
 
   it('should update tokenList state when network updates are passed via onNetworkStateChange callback', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${ChainId.mainnet}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.mainnet)}`)
       .reply(200, sampleMainnetTokenList)
       .persist();
 
@@ -792,7 +797,7 @@ describe('TokenListController', () => {
 
   it('should update token list from api', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${ChainId.mainnet}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.mainnet)}`)
       .reply(200, sampleMainnetTokenList)
       .persist();
 
@@ -830,12 +835,12 @@ describe('TokenListController', () => {
 
   it('should update the cache before threshold time if the current data is undefined', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${ChainId.mainnet}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.mainnet)}`)
       .once()
       .reply(200, undefined);
 
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${ChainId.mainnet}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.mainnet)}`)
       .reply(200, sampleMainnetTokenList)
       .persist();
 
@@ -849,14 +854,13 @@ describe('TokenListController', () => {
     });
     await controller.start();
     expect(controller.state.tokenList).toStrictEqual({});
-    expect(controller.state.tokensChainsCache.data).toBeUndefined();
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 150));
     expect(controller.state.tokenList).toStrictEqual(
       sampleSingleChainState.tokenList,
     );
 
-    expect(controller.state.tokensChainsCache['1'].data).toStrictEqual(
-      sampleSingleChainState.tokensChainsCache['1'].data,
+    expect(controller.state.tokensChainsCache[toHex(1)].data).toStrictEqual(
+      sampleSingleChainState.tokensChainsCache[toHex(1)].data,
     );
     controller.destroy();
   });
@@ -886,7 +890,7 @@ describe('TokenListController', () => {
 
   it('should update token list after removing data with duplicate symbols', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${ChainId.mainnet}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.mainnet)}`)
       .reply(200, sampleWithDuplicateSymbols)
       .persist();
 
@@ -929,7 +933,7 @@ describe('TokenListController', () => {
 
   it('should update token list after removing data less than 3 occurrences', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${ChainId.mainnet}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.mainnet)}`)
       .reply(200, sampleWithLessThan3OccurencesResponse)
       .persist();
 
@@ -953,7 +957,7 @@ describe('TokenListController', () => {
 
   it('should update token list when the token property changes', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${ChainId.mainnet}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.mainnet)}`)
       .reply(200, sampleMainnetTokenList)
       .persist();
 
@@ -981,7 +985,7 @@ describe('TokenListController', () => {
 
   it('should update the cache when the timestamp expires', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${ChainId.mainnet}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.mainnet)}`)
       .reply(200, sampleMainnetTokenList)
       .persist();
 
@@ -1011,9 +1015,9 @@ describe('TokenListController', () => {
 
   it('should update token list when the chainId change', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${ChainId.mainnet}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.mainnet)}`)
       .reply(200, sampleMainnetTokenList)
-      .get(`/tokens/${ChainId.goerli}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.goerli)}`)
       .reply(200, { error: 'ChainId 5 is not supported' })
       .get(`/tokens/56`)
       .reply(200, sampleBinanceTokenList)
@@ -1062,7 +1066,7 @@ describe('TokenListController', () => {
       'NetworkController:stateChange',
       buildNetworkControllerStateWithProviderConfig({
         type: NetworkType.rpc,
-        chainId: '56',
+        chainId: toHex(56),
         rpcUrl: 'http://localhost:8545',
       }),
       [],
@@ -1079,8 +1083,8 @@ describe('TokenListController', () => {
       sampleTwoChainState.tokensChainsCache[ChainId.mainnet].data,
     );
 
-    expect(controller.state.tokensChainsCache['56'].data).toStrictEqual(
-      sampleTwoChainState.tokensChainsCache['56'].data,
+    expect(controller.state.tokensChainsCache[toHex(56)].data).toStrictEqual(
+      sampleTwoChainState.tokensChainsCache[toHex(56)].data,
     );
 
     controller.destroy();
@@ -1106,9 +1110,9 @@ describe('TokenListController', () => {
 
   it('should update preventPollingOnNetworkRestart and restart the polling on network restart', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${ChainId.mainnet}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.mainnet)}`)
       .reply(200, sampleMainnetTokenList)
-      .get(`/tokens/${ChainId.goerli}`)
+      .get(`/tokens/${convertHexToDecimal(ChainId.goerli)}`)
       .reply(200, { error: 'ChainId 5 is not supported' })
       .get(`/tokens/56`)
       .reply(200, sampleBinanceTokenList)
@@ -1157,9 +1161,9 @@ describe('TokenListController', () => {
           sampleTwoChainState.tokenList,
         );
 
-        expect(controller.state.tokensChainsCache['56'].data).toStrictEqual(
-          sampleTwoChainState.tokensChainsCache['56'].data,
-        );
+        expect(
+          controller.state.tokensChainsCache[toHex(56)].data,
+        ).toStrictEqual(sampleTwoChainState.tokensChainsCache[toHex(56)].data);
         messenger.clearEventSubscriptions('TokenListController:stateChange');
         controller.destroy();
         controllerMessenger.clearEventSubscriptions(
@@ -1172,7 +1176,7 @@ describe('TokenListController', () => {
         'NetworkController:stateChange',
         buildNetworkControllerStateWithProviderConfig({
           type: NetworkType.rpc,
-          chainId: '56',
+          chainId: toHex(56),
           rpcUrl: 'http://localhost:8545',
         }),
         [],

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -1,6 +1,7 @@
 import type { Patch } from 'immer';
 import { Mutex } from 'async-mutex';
 import { AbortController as WhatwgAbortController } from 'abort-controller';
+import type { Hex } from '@metamask/utils';
 import {
   BaseControllerV2,
   RestrictedControllerMessenger,
@@ -39,7 +40,7 @@ type DataCache = {
   data: TokenListMap;
 };
 type TokensChainsCache = {
-  [chainSlug: string]: DataCache;
+  [chainId: Hex]: DataCache;
 };
 
 export type TokenListState = {
@@ -94,7 +95,7 @@ export class TokenListController extends BaseControllerV2<
 
   private cacheRefreshThreshold: number;
 
-  private chainId: string;
+  private chainId: Hex;
 
   private abortController: WhatwgAbortController;
 
@@ -119,7 +120,7 @@ export class TokenListController extends BaseControllerV2<
     messenger,
     state,
   }: {
-    chainId: string;
+    chainId: Hex;
     preventPollingOnNetworkRestart?: boolean;
     onNetworkStateChange?: (
       listener: (networkState: NetworkState) => void,

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -6,6 +6,7 @@ import {
   NetworkControllerMessenger,
 } from '@metamask/network-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
+import { toHex } from '@metamask/controller-utils';
 import { TokenRatesController } from './TokenRatesController';
 import {
   TokensController,
@@ -118,7 +119,7 @@ describe('TokenRatesController', () => {
 
   it('should set default state', () => {
     const controller = new TokenRatesController({
-      chainId: '1',
+      chainId: toHex(1),
       onTokensStateChange: sinon.stub(),
       onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
@@ -130,7 +131,7 @@ describe('TokenRatesController', () => {
 
   it('should initialize with the default config', () => {
     const controller = new TokenRatesController({
-      chainId: '1',
+      chainId: toHex(1),
       onTokensStateChange: sinon.stub(),
       onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
@@ -139,7 +140,7 @@ describe('TokenRatesController', () => {
       disabled: false,
       interval: 180000,
       nativeCurrency: 'eth',
-      chainId: '1',
+      chainId: toHex(1),
       tokens: [],
       threshold: 21600000,
     });
@@ -147,7 +148,7 @@ describe('TokenRatesController', () => {
 
   it('should throw when tokens property is accessed', () => {
     const controller = new TokenRatesController({
-      chainId: '1',
+      chainId: toHex(1),
       onTokensStateChange: sinon.stub(),
       onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
@@ -163,7 +164,7 @@ describe('TokenRatesController', () => {
     const times = 5;
     new TokenRatesController(
       {
-        chainId: '1',
+        chainId: toHex(1),
         onTokensStateChange: jest.fn(),
         onCurrencyRateStateChange: jest.fn(),
         onNetworkStateChange: jest.fn(),
@@ -186,7 +187,7 @@ describe('TokenRatesController', () => {
   it('should not update rates if disabled', async () => {
     const controller = new TokenRatesController(
       {
-        chainId: '1',
+        chainId: toHex(1),
         onTokensStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
@@ -205,7 +206,7 @@ describe('TokenRatesController', () => {
     const mock = sinon.stub(global, 'clearTimeout');
     const controller = new TokenRatesController(
       {
-        chainId: '1',
+        chainId: toHex(1),
         onTokensStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
@@ -229,7 +230,7 @@ describe('TokenRatesController', () => {
     });
     const preferences = new PreferencesController();
     const tokensController = new TokensController({
-      chainId: '1',
+      chainId: toHex(1),
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
@@ -237,7 +238,7 @@ describe('TokenRatesController', () => {
     });
     const controller = new TokenRatesController(
       {
-        chainId: '1',
+        chainId: toHex(1),
         onTokensStateChange: (listener) => tokensController.subscribe(listener),
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: (listener) =>
@@ -265,7 +266,7 @@ describe('TokenRatesController', () => {
   it('should handle balance not found in API', async () => {
     const controller = new TokenRatesController(
       {
-        chainId: '1',
+        chainId: toHex(1),
         onTokensStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
@@ -294,7 +295,7 @@ describe('TokenRatesController', () => {
     const onNetworkStateChange = sinon.stub();
     const controller = new TokenRatesController(
       {
-        chainId: '1',
+        chainId: toHex(1),
         onTokensStateChange,
         onCurrencyRateStateChange,
         onNetworkStateChange,
@@ -321,7 +322,7 @@ describe('TokenRatesController', () => {
     const onNetworkStateChange = sinon.stub();
     const controller = new TokenRatesController(
       {
-        chainId: '1',
+        chainId: toHex(1),
         onTokensStateChange,
         onCurrencyRateStateChange,
         onNetworkStateChange,
@@ -371,7 +372,7 @@ describe('TokenRatesController', () => {
     const onNetworkStateChange = sinon.stub();
     const controller = new TokenRatesController(
       {
-        chainId: '137',
+        chainId: toHex(137),
         onTokensStateChange,
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange,
@@ -434,7 +435,7 @@ describe('TokenRatesController', () => {
 
     const controller = new TokenRatesController(
       {
-        chainId: '1',
+        chainId: toHex(1),
         onTokensStateChange,
         onNetworkStateChange,
         onCurrencyRateStateChange: sinon.stub(),
@@ -474,7 +475,7 @@ describe('TokenRatesController', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await networkChangeListener!({
-      providerConfig: { chainId: '4' },
+      providerConfig: { chainId: toHex(4) },
     });
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -507,7 +508,7 @@ describe('TokenRatesController', () => {
 
     const controller = new TokenRatesController(
       {
-        chainId: '1',
+        chainId: toHex(1),
         onTokensStateChange,
         onNetworkStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -1,3 +1,4 @@
+import type { Hex } from '@metamask/utils';
 import {
   BaseController,
   BaseConfig,
@@ -8,6 +9,7 @@ import {
   handleFetch,
   toChecksumHexAddress,
   FALL_BACK_VS_CURRENCY,
+  toHex,
 } from '@metamask/controller-utils';
 import type { NetworkState } from '@metamask/network-controller';
 import { fetchExchangeRate as fetchNativeExchangeRate } from './crypto-compare';
@@ -68,7 +70,7 @@ export interface Token {
 export interface TokenRatesConfig extends BaseConfig {
   interval: number;
   nativeCurrency: string;
-  chainId: string;
+  chainId: Hex;
   tokens: Token[];
   threshold: number;
 }
@@ -119,7 +121,7 @@ const CoinGeckoApi = {
  * @returns The CoinGecko slug for the given chain ID, or `null` if the slug was not found.
  */
 function findChainSlug(
-  chainId: string,
+  chainId: Hex,
   data: CoinGeckoPlatform[] | null,
 ): string | null {
   if (!data) {
@@ -128,7 +130,7 @@ function findChainSlug(
   const chain =
     data.find(
       ({ chain_identifier }) =>
-        chain_identifier !== null && String(chain_identifier) === chainId,
+        chain_identifier !== null && toHex(chain_identifier) === chainId,
     ) ?? null;
   return chain?.id || null;
 }
@@ -178,7 +180,7 @@ export class TokenRatesController extends BaseController<
       onCurrencyRateStateChange,
       onNetworkStateChange,
     }: {
-      chainId: string;
+      chainId: Hex;
       onTokensStateChange: (
         listener: (tokensState: TokensState) => void,
       ) => void;
@@ -247,7 +249,7 @@ export class TokenRatesController extends BaseController<
    *
    * @param _chainId - The current chain ID.
    */
-  set chainId(_chainId: string) {
+  set chainId(_chainId: Hex) {
     !this.disabled && safelyExecute(() => this.updateExchangeRates());
   }
 

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -9,6 +9,8 @@ import {
   ChainId,
   NetworkType,
   ORIGIN_METAMASK,
+  convertHexToDecimal,
+  toHex,
 } from '@metamask/controller-utils';
 import {
   NetworkState,
@@ -37,8 +39,8 @@ const stubCreateEthers = (ctrl: TokensController, res: boolean) => {
   });
 };
 
-const SEPOLIA = { chainId: '11155111', type: NetworkType.sepolia };
-const GOERLI = { chainId: '5', type: NetworkType.goerli };
+const SEPOLIA = { chainId: toHex(11155111), type: NetworkType.sepolia };
+const GOERLI = { chainId: toHex(5), type: NetworkType.goerli };
 
 const controllerName = 'TokensController' as const;
 
@@ -661,7 +663,11 @@ describe('TokensController', () => {
       const error = 'An error occured';
       const fullErrorMessage = `TokenService Error: ${error}`;
       nock(TOKEN_END_POINT_API)
-        .get(`/token/${ChainId.mainnet}?address=${dummyTokenAddress}`)
+        .get(
+          `/token/${convertHexToDecimal(
+            ChainId.mainnet,
+          )}?address=${dummyTokenAddress}`,
+        )
         .reply(200, { error })
         .persist();
 

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -7,6 +7,7 @@ import { Mutex } from 'async-mutex';
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
 import { AbortController as WhatwgAbortController } from 'abort-controller';
+import type { Hex } from '@metamask/utils';
 import {
   BaseController,
   BaseConfig,
@@ -41,7 +42,7 @@ import {
  */
 export interface TokensConfig extends BaseConfig {
   selectedAddress: string;
-  chainId: string;
+  chainId: Hex;
   provider: any;
 }
 
@@ -223,7 +224,7 @@ export class TokensController extends BaseController<
     state,
     messenger,
   }: {
-    chainId: string;
+    chainId: Hex;
     onPreferencesStateChange: (
       listener: (preferencesState: PreferencesState) => void,
     ) => void;
@@ -500,7 +501,7 @@ export class TokensController extends BaseController<
    */
   async addDetectedTokens(
     incomingDetectedTokens: Token[],
-    detectionDetails?: { selectedAddress: string; chainId: string },
+    detectionDetails?: { selectedAddress: string; chainId: Hex },
   ) {
     const releaseLock = await this.mutex.acquire();
     const { tokens, detectedTokens, ignoredTokens } = this.state;
@@ -808,7 +809,7 @@ export class TokensController extends BaseController<
     newIgnoredTokens?: string[];
     newDetectedTokens?: Token[];
     interactingAddress?: string;
-    interactingChainId?: string;
+    interactingChainId?: Hex;
   }) {
     const {
       newTokens,

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -111,9 +111,9 @@ export interface TokensState extends BaseState {
   tokens: Token[];
   ignoredTokens: string[];
   detectedTokens: Token[];
-  allTokens: { [key: string]: { [key: string]: Token[] } };
-  allIgnoredTokens: { [key: string]: { [key: string]: string[] } };
-  allDetectedTokens: { [key: string]: { [key: string]: Token[] } };
+  allTokens: { [chainId: Hex]: { [key: string]: Token[] } };
+  allIgnoredTokens: { [chainId: Hex]: { [key: string]: string[] } };
+  allDetectedTokens: { [chainId: Hex]: { [key: string]: Token[] } };
   suggestedAssets: SuggestedAssetMeta[];
 }
 

--- a/packages/assets-controllers/src/assetsUtil.test.ts
+++ b/packages/assets-controllers/src/assetsUtil.test.ts
@@ -1,4 +1,9 @@
-import { GANACHE_CHAIN_ID, ChainId } from '@metamask/controller-utils';
+import {
+  GANACHE_CHAIN_ID,
+  ChainId,
+  convertHexToDecimal,
+  toHex,
+} from '@metamask/controller-utils';
 import * as assetsUtil from './assetsUtil';
 import { Nft, NftMetadata } from './NftController';
 
@@ -112,23 +117,15 @@ describe('assetsUtil', () => {
       expect(formattedAggregatorNames).toStrictEqual(expectedValue);
     });
 
-    it('should format icon url with Codefi proxy correctly when passed chainId as a decimal string', () => {
+    it('should format icon url with Codefi proxy correctly', () => {
       const linkTokenAddress = '0x514910771af9ca656af840dff83e8264ecf986ca';
       const formattedIconUrl = assetsUtil.formatIconUrlWithProxy({
         chainId: ChainId.mainnet,
         tokenAddress: linkTokenAddress,
       });
-      const expectedValue = `https://static.metafi.codefi.network/api/v1/tokenIcons/${ChainId.mainnet}/${linkTokenAddress}.png`;
-      expect(formattedIconUrl).toStrictEqual(expectedValue);
-    });
-
-    it('should format icon url with Codefi proxy correctly when passed chainId as a hexadecimal string', () => {
-      const linkTokenAddress = '0x514910771af9ca656af840dff83e8264ecf986ca';
-      const formattedIconUrl = assetsUtil.formatIconUrlWithProxy({
-        chainId: `0x${Number(ChainId.mainnet).toString(16)}`,
-        tokenAddress: linkTokenAddress,
-      });
-      const expectedValue = `https://static.metafi.codefi.network/api/v1/tokenIcons/${ChainId.mainnet}/${linkTokenAddress}.png`;
+      const expectedValue = `https://static.metafi.codefi.network/api/v1/tokenIcons/${convertHexToDecimal(
+        ChainId.mainnet,
+      )}/${linkTokenAddress}.png`;
       expect(formattedIconUrl).toStrictEqual(expectedValue);
     });
   });
@@ -273,21 +270,19 @@ describe('assetsUtil', () => {
     });
 
     it('returns false for testnets such as Goerli', () => {
-      expect(assetsUtil.isTokenDetectionSupportedForNetwork('5')).toBe(false);
+      expect(assetsUtil.isTokenDetectionSupportedForNetwork(toHex(5))).toBe(
+        false,
+      );
     });
   });
 
   describe('isTokenListSupportedForNetwork', () => {
-    it('returns true for Mainnet when chainId is passed as a decimal string', () => {
+    it('returns true for Mainnet', () => {
       expect(
         assetsUtil.isTokenListSupportedForNetwork(
           assetsUtil.SupportedTokenDetectionNetworks.mainnet,
         ),
       ).toBe(true);
-    });
-
-    it('returns true for Mainnet when chainId is passed as a hexadecimal string', () => {
-      expect(assetsUtil.isTokenListSupportedForNetwork('0x1')).toBe(true);
     });
 
     it('returns true for ganache local network', () => {

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -1,5 +1,6 @@
 import { ethErrors } from 'eth-rpc-errors';
 import { CID } from 'multiformats/cid';
+import type { Hex } from '@metamask/utils';
 import {
   convertHexToDecimal,
   isValidHexAddress,
@@ -86,7 +87,7 @@ export const formatAggregatorNames = (aggregators: string[]) => {
  * Format token list assets to use image proxy from Codefi.
  *
  * @param params - Object that contains chainID and tokenAddress.
- * @param params.chainId - ChainID of network in decimal or hexadecimal format.
+ * @param params.chainId - ChainID of network in 0x-prefixed hexadecimal format.
  * @param params.tokenAddress - Address of token in mixed or lowercase.
  * @returns Formatted image url
  */
@@ -94,7 +95,7 @@ export const formatIconUrlWithProxy = ({
   chainId,
   tokenAddress,
 }: {
-  chainId: string;
+  chainId: Hex;
   tokenAddress: string;
 }) => {
   const chainIdDecimal = convertHexToDecimal(chainId).toString();
@@ -139,11 +140,11 @@ export function validateTokenToWatch(token: Token) {
  * Networks where token detection is supported - Values are in decimal format
  */
 export enum SupportedTokenDetectionNetworks {
-  mainnet = '1',
-  bsc = '56',
-  polygon = '137',
-  avax = '43114',
-  aurora = '1313161554',
+  mainnet = '0x1', // decimal: 1
+  bsc = '0x38', // decimal: 56
+  polygon = '0x89', // decimal: 137
+  avax = '0xa86a', // decimal: 43114
+  aurora = '0x4e454152', // decimal: 1313161554
 }
 
 /**
@@ -152,10 +153,8 @@ export enum SupportedTokenDetectionNetworks {
  * @param chainId - ChainID of network
  * @returns Whether the current network supports token detection
  */
-export function isTokenDetectionSupportedForNetwork(chainId: string): boolean {
-  return Object.values<string>(SupportedTokenDetectionNetworks).includes(
-    chainId,
-  );
+export function isTokenDetectionSupportedForNetwork(chainId: Hex): boolean {
+  return Object.values<Hex>(SupportedTokenDetectionNetworks).includes(chainId);
 }
 
 /**
@@ -165,11 +164,9 @@ export function isTokenDetectionSupportedForNetwork(chainId: string): boolean {
  * @param chainId - ChainID of network
  * @returns Whether the current network supports tokenlists
  */
-export function isTokenListSupportedForNetwork(chainId: string): boolean {
-  const chainIdDecimal = convertHexToDecimal(chainId).toString();
+export function isTokenListSupportedForNetwork(chainId: Hex): boolean {
   return (
-    isTokenDetectionSupportedForNetwork(chainIdDecimal) ||
-    chainIdDecimal === GANACHE_CHAIN_ID
+    isTokenDetectionSupportedForNetwork(chainId) || chainId === GANACHE_CHAIN_ID
   );
 }
 

--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import { AbortController as WhatwgAbortController } from 'abort-controller';
+import { toHex } from '@metamask/controller-utils';
 import {
   fetchTokenList,
   fetchTokenMetadata,
@@ -132,7 +133,8 @@ const sampleToken = {
   name: 'Chainlink',
 };
 
-const sampleChainId = '1';
+const sampleDecimalChainId = 1;
+const sampleChainId = toHex(sampleDecimalChainId);
 
 describe('Token service', () => {
   beforeAll(() => {
@@ -151,7 +153,7 @@ describe('Token service', () => {
     it('should call the tokens api and return the list of tokens', async () => {
       const { signal } = new WhatwgAbortController();
       nock(TOKEN_END_POINT_API)
-        .get(`/tokens/${sampleChainId}`)
+        .get(`/tokens/${sampleDecimalChainId}`)
         .reply(200, sampleTokenList)
         .persist();
 
@@ -163,7 +165,7 @@ describe('Token service', () => {
     it('should return undefined if the fetch is aborted', async () => {
       const abortController = new WhatwgAbortController();
       nock(TOKEN_END_POINT_API)
-        .get(`/tokens/${sampleChainId}`)
+        .get(`/tokens/${sampleDecimalChainId}`)
         // well beyond time it will take to abort
         .delay(ONE_SECOND_IN_MILLISECONDS)
         .reply(200, sampleTokenList)
@@ -181,7 +183,7 @@ describe('Token service', () => {
     it('should return undefined if the fetch fails with a network error', async () => {
       const { signal } = new WhatwgAbortController();
       nock(TOKEN_END_POINT_API)
-        .get(`/tokens/${sampleChainId}`)
+        .get(`/tokens/${sampleDecimalChainId}`)
         .replyWithError('Example network error')
         .persist();
 
@@ -193,7 +195,7 @@ describe('Token service', () => {
     it('should return undefined if the fetch fails with an unsuccessful status code', async () => {
       const { signal } = new WhatwgAbortController();
       nock(TOKEN_END_POINT_API)
-        .get(`/tokens/${sampleChainId}`)
+        .get(`/tokens/${sampleDecimalChainId}`)
         .reply(500)
         .persist();
 
@@ -205,7 +207,7 @@ describe('Token service', () => {
     it('should return undefined if the fetch fails with a timeout', async () => {
       const { signal } = new WhatwgAbortController();
       nock(TOKEN_END_POINT_API)
-        .get(`/tokens/${sampleChainId}`)
+        .get(`/tokens/${sampleDecimalChainId}`)
         // well beyond timeout
         .delay(ONE_SECOND_IN_MILLISECONDS)
         .reply(200, sampleTokenList)
@@ -224,7 +226,7 @@ describe('Token service', () => {
       const { signal } = new WhatwgAbortController();
       nock(TOKEN_END_POINT_API)
         .get(
-          `/token/${sampleChainId}?address=0x514910771af9ca656af840dff83e8264ecf986ca`,
+          `/token/${sampleDecimalChainId}?address=0x514910771af9ca656af840dff83e8264ecf986ca`,
         )
         .reply(200, sampleToken)
         .persist();
@@ -241,7 +243,7 @@ describe('Token service', () => {
     it('should return undefined if the fetch is aborted', async () => {
       const abortController = new WhatwgAbortController();
       nock(TOKEN_END_POINT_API)
-        .get(`/tokens/${sampleChainId}`)
+        .get(`/tokens/${sampleDecimalChainId}`)
         // well beyond time it will take to abort
         .delay(ONE_SECOND_IN_MILLISECONDS)
         .reply(200, sampleTokenList)
@@ -260,7 +262,7 @@ describe('Token service', () => {
     it('should return undefined if the fetch fails with a network error', async () => {
       const { signal } = new WhatwgAbortController();
       nock(TOKEN_END_POINT_API)
-        .get(`/tokens/${sampleChainId}`)
+        .get(`/tokens/${sampleDecimalChainId}`)
         .replyWithError('Example network error')
         .persist();
 
@@ -276,7 +278,7 @@ describe('Token service', () => {
     it('should return undefined if the fetch fails with an unsuccessful status code', async () => {
       const { signal } = new WhatwgAbortController();
       nock(TOKEN_END_POINT_API)
-        .get(`/tokens/${sampleChainId}`)
+        .get(`/tokens/${sampleDecimalChainId}`)
         .reply(500)
         .persist();
 
@@ -292,7 +294,7 @@ describe('Token service', () => {
     it('should return undefined if the fetch fails with a timeout', async () => {
       const { signal } = new WhatwgAbortController();
       nock(TOKEN_END_POINT_API)
-        .get(`/tokens/${sampleChainId}`)
+        .get(`/tokens/${sampleDecimalChainId}`)
         // well beyond timeout
         .delay(ONE_SECOND_IN_MILLISECONDS)
         .reply(200, sampleTokenList)
@@ -312,7 +314,7 @@ describe('Token service', () => {
       const { signal } = new WhatwgAbortController();
       await expect(
         fetchTokenMetadata(
-          '5',
+          toHex(5),
           '0x514910771af9ca656af840dff83e8264ecf986ca',
           signal,
         ),
@@ -323,7 +325,7 @@ describe('Token service', () => {
   it('should call the tokens api and return undefined', async () => {
     const { signal } = new WhatwgAbortController();
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${sampleChainId}`)
+      .get(`/tokens/${sampleDecimalChainId}`)
       .reply(404, undefined)
       .persist();
 

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -1,4 +1,5 @@
-import { timeoutFetch } from '@metamask/controller-utils';
+import type { Hex } from '@metamask/utils';
+import { convertHexToDecimal, timeoutFetch } from '@metamask/controller-utils';
 import { isTokenListSupportedForNetwork } from './assetsUtil';
 
 export const TOKEN_END_POINT_API = 'https://token-api.metaswap.codefi.network';
@@ -11,8 +12,8 @@ export const TOKEN_METADATA_NO_SUPPORT_ERROR =
  * @param chainId - The chain ID of the network the tokens requested are on.
  * @returns The tokens URL.
  */
-function getTokensURL(chainId: string) {
-  return `${TOKEN_END_POINT_API}/tokens/${chainId}`;
+function getTokensURL(chainId: Hex) {
+  return `${TOKEN_END_POINT_API}/tokens/${convertHexToDecimal(chainId)}`;
 }
 
 /**
@@ -22,8 +23,10 @@ function getTokensURL(chainId: string) {
  * @param tokenAddress - The token address.
  * @returns The token metadata URL.
  */
-function getTokenMetadataURL(chainId: string, tokenAddress: string) {
-  return `${TOKEN_END_POINT_API}/token/${chainId}?address=${tokenAddress}`;
+function getTokenMetadataURL(chainId: Hex, tokenAddress: string) {
+  return `${TOKEN_END_POINT_API}/token/${convertHexToDecimal(
+    chainId,
+  )}?address=${tokenAddress}`;
 }
 
 const tenSecondsInMilliseconds = 10_000;
@@ -43,7 +46,7 @@ const defaultTimeout = tenSecondsInMilliseconds;
  * @returns The token list, or `undefined` if the request was cancelled.
  */
 export async function fetchTokenList(
-  chainId: string,
+  chainId: Hex,
   abortSignal: AbortSignal,
   { timeout = defaultTimeout } = {},
 ): Promise<unknown> {
@@ -67,7 +70,7 @@ export async function fetchTokenList(
  * @returns The token metadata, or `undefined` if the request was either aborted or failed.
  */
 export async function fetchTokenMetadata<T>(
-  chainId: string,
+  chainId: Hex,
   tokenAddress: string,
   abortSignal: AbortSignal,
   { timeout = defaultTimeout } = {},

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -5,7 +5,8 @@ export const FALL_BACK_VS_CURRENCY = 'ETH';
 export const IPFS_DEFAULT_GATEWAY_URL = 'https://cloudflare-ipfs.com/ipfs/';
 
 // NETWORKS ID
-export const GANACHE_CHAIN_ID = '1337';
+// `toHex` not invoked to avoid cyclic dependency
+export const GANACHE_CHAIN_ID = '0x539'; // toHex(1337)
 /**
  * The largest possible chain ID we can handle.
  * Explanation: https://gist.github.com/rekmarks/a47bd5f2525936c4b8eee31a16345553

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -44,12 +44,14 @@ export enum BuiltInNetworkName {
 
 /**
  * Decimal string chain IDs of built-in networks, by name.
+ *
+ * `toHex` not invoked to avoid cyclic dependency
  */
 export const ChainId = {
-  [BuiltInNetworkName.Mainnet]: '1',
-  [BuiltInNetworkName.Goerli]: '5',
-  [BuiltInNetworkName.Sepolia]: '11155111',
-  [BuiltInNetworkName.Aurora]: '1313161554',
+  [BuiltInNetworkName.Mainnet]: '0x1', // toHex(1)
+  [BuiltInNetworkName.Goerli]: '0x5', // toHex(5)
+  [BuiltInNetworkName.Sepolia]: '0xaa36a7', // toHex(11155111)
+  [BuiltInNetworkName.Aurora]: '0x4e454152', // toHex(1313161554)
 } as const;
 export type ChainId = typeof ChainId[keyof typeof ChainId];
 

--- a/packages/controller-utils/src/util.test.ts
+++ b/packages/controller-utils/src/util.test.ts
@@ -13,9 +13,10 @@ describe('util', () => {
   });
 
   it('isSafeChainId', () => {
-    expect(util.isSafeChainId(MAX_SAFE_CHAIN_ID + 1)).toBe(false);
-    expect(util.isSafeChainId(MAX_SAFE_CHAIN_ID)).toBe(true);
-    expect(util.isSafeChainId(0)).toBe(false);
+    expect(util.isSafeChainId(util.toHex(MAX_SAFE_CHAIN_ID + 1))).toBe(false);
+    expect(util.isSafeChainId(util.toHex(MAX_SAFE_CHAIN_ID))).toBe(true);
+    expect(util.isSafeChainId(util.toHex(0))).toBe(false);
+    expect(util.isSafeChainId('0xinvalid')).toBe(false);
     // @ts-expect-error - ensure that string args return false.
     expect(util.isSafeChainId('test')).toBe(false);
   });

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -23,9 +23,15 @@ const TIMEOUT_ERROR = new Error('timeout');
  * @param chainId - The chain ID to check for safety.
  * @returns Whether the given chain ID is safe.
  */
-export function isSafeChainId(chainId: number): boolean {
+export function isSafeChainId(chainId: Hex): boolean {
+  if (!isHexString(chainId)) {
+    return false;
+  }
+  const decimalChainId = Number.parseInt(chainId);
   return (
-    Number.isSafeInteger(chainId) && chainId > 0 && chainId <= MAX_SAFE_CHAIN_ID
+    Number.isSafeInteger(decimalChainId) &&
+    decimalChainId > 0 &&
+    decimalChainId <= MAX_SAFE_CHAIN_ID
   );
 }
 /**

--- a/packages/ens-controller/src/EnsController.test.ts
+++ b/packages/ens-controller/src/EnsController.test.ts
@@ -1,5 +1,9 @@
 import { ControllerMessenger } from '@metamask/base-controller';
-import { NetworkType, toChecksumHexAddress } from '@metamask/controller-utils';
+import {
+  NetworkType,
+  toChecksumHexAddress,
+  toHex,
+} from '@metamask/controller-utils';
 import * as providersModule from '@ethersproject/providers';
 import { EnsController } from './EnsController';
 
@@ -63,13 +67,13 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, address1)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
-        1: {
+        [toHex(1)]: {
           [name1]: {
             address: address1Checksum,
-            chainId: '1',
+            chainId: toHex(1),
             ensName: name1,
           },
         },
@@ -115,7 +119,7 @@ describe('EnsController', () => {
         listener({
           networkId: '1',
           providerConfig: {
-            chainId: '1',
+            chainId: toHex(1),
             type: NetworkType.mainnet,
           },
         });
@@ -130,13 +134,13 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, null)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, null)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
-        1: {
+        [toHex(1)]: {
           [name1]: {
             address: null,
-            chainId: '1',
+            chainId: toHex(1),
             ensName: name1,
           },
         },
@@ -150,14 +154,14 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, address1)).toStrictEqual(true);
-    expect(controller.set('1', name1, address2)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, address2)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
-        1: {
+        [toHex(1)]: {
           [name1]: {
             address: address2Checksum,
-            chainId: '1',
+            chainId: toHex(1),
             ensName: name1,
           },
         },
@@ -171,14 +175,14 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, address1)).toStrictEqual(true);
-    expect(controller.set('1', name1, null)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, null)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
-        1: {
+        [toHex(1)]: {
           [name1]: {
             address: null,
-            chainId: '1',
+            chainId: toHex(1),
             ensName: name1,
           },
         },
@@ -192,14 +196,14 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, address1)).toStrictEqual(true);
-    expect(controller.set('1', name1, address1)).toStrictEqual(false);
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(false);
     expect(controller.state).toStrictEqual({
       ensEntries: {
-        1: {
+        [toHex(1)]: {
           [name1]: {
             address: address1Checksum,
-            chainId: '1',
+            chainId: toHex(1),
             ensName: name1,
           },
         },
@@ -213,14 +217,14 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, null)).toStrictEqual(true);
-    expect(controller.set('1', name1, null)).toStrictEqual(false);
+    expect(controller.set(toHex(1), name1, null)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, null)).toStrictEqual(false);
     expect(controller.state).toStrictEqual({
       ensEntries: {
-        1: {
+        [toHex(1)]: {
           [name1]: {
             address: null,
-            chainId: '1',
+            chainId: toHex(1),
             ensName: name1,
           },
         },
@@ -234,28 +238,28 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, address1)).toStrictEqual(true);
-    expect(controller.set('1', name2, address2)).toStrictEqual(true);
-    expect(controller.set('2', name1, address1)).toStrictEqual(true);
-    expect(controller.set('1', name1, address3)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name2, address2)).toStrictEqual(true);
+    expect(controller.set(toHex(2), name1, address1)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, address3)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
-        1: {
+        [toHex(1)]: {
           [name1]: {
             address: address3Checksum,
-            chainId: '1',
+            chainId: toHex(1),
             ensName: name1,
           },
           [name2]: {
             address: address2Checksum,
-            chainId: '1',
+            chainId: toHex(1),
             ensName: name2,
           },
         },
-        2: {
+        [toHex(2)]: {
           [name1]: {
             address: address1Checksum,
-            chainId: '2',
+            chainId: toHex(2),
             ensName: name1,
           },
         },
@@ -269,10 +273,10 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, address1)).toStrictEqual(true);
-    expect(controller.get('1', name1)).toStrictEqual({
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(true);
+    expect(controller.get(toHex(1), name1)).toStrictEqual({
       address: address1Checksum,
-      chainId: '1',
+      chainId: toHex(1),
       ensName: name1,
     });
   });
@@ -282,8 +286,8 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, address1)).toStrictEqual(true);
-    expect(controller.get('1', name2)).toBeNull();
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(true);
+    expect(controller.get(toHex(1), name2)).toBeNull();
   });
 
   it('should return null when getting nonexistent chainId', () => {
@@ -291,8 +295,8 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, address1)).toStrictEqual(true);
-    expect(controller.get('2', name1)).toBeNull();
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(true);
+    expect(controller.get(toHex(2), name1)).toBeNull();
   });
 
   it('should throw on attempt to set invalid ENS entry: chainId', () => {
@@ -301,6 +305,7 @@ describe('EnsController', () => {
       messenger,
     });
     expect(() => {
+      // @ts-expect-error Intentionally invalid chain ID
       controller.set('a', name1, address1);
     }).toThrow(
       'Invalid ENS entry: { chainId:a, ensName:foobarb.eth, address:0x32Be343B94f860124dC4fEe278FDCBD38C102D88}',
@@ -317,7 +322,7 @@ describe('EnsController', () => {
       messenger,
     });
     expect(() => {
-      controller.set('1', 'foo.eth', address1);
+      controller.set(toHex(1), 'foo.eth', address1);
     }).toThrow('Invalid ENS name: foo.eth');
     expect(controller.state).toStrictEqual({
       ensEntries: {},
@@ -331,9 +336,9 @@ describe('EnsController', () => {
       messenger,
     });
     expect(() => {
-      controller.set('1', name1, 'foo');
+      controller.set(toHex(1), name1, 'foo');
     }).toThrow(
-      'Invalid ENS entry: { chainId:1, ensName:foobarb.eth, address:foo}',
+      'Invalid ENS entry: { chainId:0x1, ensName:foobarb.eth, address:foo}',
     );
     expect(controller.state).toStrictEqual({
       ensEntries: {},
@@ -346,8 +351,8 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, address1)).toStrictEqual(true);
-    expect(controller.delete('1', name1)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(true);
+    expect(controller.delete(toHex(1), name1)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {},
       ensResolutionsByAddress: {},
@@ -359,15 +364,15 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    controller.set('1', name1, address1);
-    expect(controller.delete('1', 'bar')).toStrictEqual(false);
-    expect(controller.delete('2', 'bar')).toStrictEqual(false);
+    controller.set(toHex(1), name1, address1);
+    expect(controller.delete(toHex(1), 'bar')).toStrictEqual(false);
+    expect(controller.delete(toHex(2), 'bar')).toStrictEqual(false);
     expect(controller.state).toStrictEqual({
       ensEntries: {
-        1: {
+        [toHex(1)]: {
           [name1]: {
             address: address1Checksum,
-            chainId: '1',
+            chainId: toHex(1),
             ensName: name1,
           },
         },
@@ -381,23 +386,23 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, address1)).toStrictEqual(true);
-    expect(controller.set('1', name2, address2)).toStrictEqual(true);
-    expect(controller.set('2', name1, address1)).toStrictEqual(true);
-    expect(controller.delete('1', name1)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name2, address2)).toStrictEqual(true);
+    expect(controller.set(toHex(2), name1, address1)).toStrictEqual(true);
+    expect(controller.delete(toHex(1), name1)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
-        1: {
+        [toHex(1)]: {
           [name2]: {
             address: address2Checksum,
-            chainId: '1',
+            chainId: toHex(1),
             ensName: name2,
           },
         },
-        2: {
+        [toHex(2)]: {
           [name1]: {
             address: address1Checksum,
-            chainId: '2',
+            chainId: toHex(2),
             ensName: name1,
           },
         },
@@ -411,9 +416,9 @@ describe('EnsController', () => {
     const controller = new EnsController({
       messenger,
     });
-    expect(controller.set('1', name1, address1)).toStrictEqual(true);
-    expect(controller.set('1', name2, address2)).toStrictEqual(true);
-    expect(controller.set('2', name1, address1)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name1, address1)).toStrictEqual(true);
+    expect(controller.set(toHex(1), name2, address2)).toStrictEqual(true);
+    expect(controller.set(toHex(2), name1, address1)).toStrictEqual(true);
     controller.clear();
     expect(controller.state).toStrictEqual({
       ensEntries: {},
@@ -439,7 +444,7 @@ describe('EnsController', () => {
           listener({
             networkId: null,
             providerConfig: {
-              chainId: '1',
+              chainId: toHex(1),
               type: NetworkType.mainnet,
             },
           });
@@ -457,7 +462,7 @@ describe('EnsController', () => {
           listener({
             networkId: '1544',
             providerConfig: {
-              chainId: '1',
+              chainId: toHex(1),
               type: NetworkType.mainnet,
             },
           });
@@ -482,7 +487,7 @@ describe('EnsController', () => {
           listener({
             networkId: '1',
             providerConfig: {
-              chainId: '1',
+              chainId: toHex(1),
               type: NetworkType.mainnet,
             },
           });
@@ -509,7 +514,7 @@ describe('EnsController', () => {
           listener({
             networkId: '1',
             providerConfig: {
-              chainId: '1',
+              chainId: toHex(1),
               type: NetworkType.mainnet,
             },
           });
@@ -531,7 +536,7 @@ describe('EnsController', () => {
           listener({
             networkId: '1',
             providerConfig: {
-              chainId: '1',
+              chainId: toHex(1),
               type: NetworkType.mainnet,
             },
           });
@@ -556,7 +561,7 @@ describe('EnsController', () => {
           listener({
             networkId: '1',
             providerConfig: {
-              chainId: '1',
+              chainId: toHex(1),
               type: NetworkType.mainnet,
             },
           });
@@ -581,7 +586,7 @@ describe('EnsController', () => {
           listener({
             networkId: '1',
             providerConfig: {
-              chainId: '1',
+              chainId: toHex(1),
               type: NetworkType.mainnet,
             },
           });
@@ -608,7 +613,7 @@ describe('EnsController', () => {
           listener({
             networkId: '1',
             providerConfig: {
-              chainId: '1',
+              chainId: toHex(1),
               type: NetworkType.mainnet,
             },
           });
@@ -634,7 +639,7 @@ describe('EnsController', () => {
           listener({
             networkId: '1',
             providerConfig: {
-              chainId: '1',
+              chainId: toHex(1),
               type: NetworkType.mainnet,
             },
           });

--- a/packages/ens-controller/src/EnsController.ts
+++ b/packages/ens-controller/src/EnsController.ts
@@ -7,7 +7,7 @@ import {
   ExternalProvider,
   JsonRpcFetchFunc,
 } from '@ethersproject/providers';
-import { createProjectLogger, hasProperty } from '@metamask/utils';
+import { Hex, createProjectLogger, hasProperty } from '@metamask/utils';
 import {
   normalizeEnsName,
   isValidHexAddress,
@@ -47,7 +47,7 @@ const name = 'EnsController';
  * @property address - Hex address with the ENS name, or null
  */
 export type EnsEntry = {
-  chainId: string;
+  chainId: Hex;
   ensName: string;
   address: string | null;
 };
@@ -60,7 +60,7 @@ export type EnsEntry = {
  */
 export type EnsControllerState = {
   ensEntries: {
-    [chainId: string]: {
+    [chainId: Hex]: {
       [ensName: string]: EnsEntry;
     };
   };
@@ -179,7 +179,7 @@ export class EnsController extends BaseControllerV2<
    * @param ensName - Name of the ENS entry to delete.
    * @returns Boolean indicating if the entry was deleted.
    */
-  delete(chainId: string, ensName: string): boolean {
+  delete(chainId: Hex, ensName: string): boolean {
     const normalizedEnsName = normalizeEnsName(ensName);
     if (
       !normalizedEnsName ||
@@ -206,7 +206,7 @@ export class EnsController extends BaseControllerV2<
    * @param ensName - Name of the ENS entry to retrieve.
    * @returns The EnsEntry or null if it does not exist.
    */
-  get(chainId: string, ensName: string): EnsEntry | null {
+  get(chainId: Hex, ensName: string): EnsEntry | null {
     const normalizedEnsName = normalizeEnsName(ensName);
 
     // TODO Explicitly handle the case where `normalizedEnsName` is `null`
@@ -226,7 +226,7 @@ export class EnsController extends BaseControllerV2<
    * @param address - Associated address (or null) to add or update.
    * @returns Boolean indicating if the entry was set.
    */
-  set(chainId: string, ensName: string, address: string | null): boolean {
+  set(chainId: Hex, ensName: string, address: string | null): boolean {
     if (
       !Number.isInteger(Number.parseInt(chainId, 10)) ||
       !ensName ||

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -32,6 +32,7 @@
     "@metamask/base-controller": "workspace:^",
     "@metamask/controller-utils": "workspace:^",
     "@metamask/network-controller": "workspace:^",
+    "@metamask/utils": "^5.0.2",
     "@types/uuid": "^8.3.0",
     "babel-runtime": "^6.26.0",
     "eth-query": "^2.1.2",

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -833,7 +833,7 @@ describe('GasFeeController', () => {
         expect(estimateData).toMatchObject(mockDetermineGasFeeCalculations);
       });
 
-      it('should call determineGasFeeCalculations correctly for mainnet', async () => {
+      it('should call determineGasFeeCalculations with a URL that contains the chain ID', async () => {
         await setupGasFeeController({
           ...defaultConstructorOptions,
           EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import * as sinon from 'sinon';
+import type { Hex } from '@metamask/utils';
 import { ControllerMessenger } from '@metamask/base-controller';
 import {
   NetworkController,
@@ -9,7 +10,7 @@ import {
   NetworkState,
 } from '@metamask/network-controller';
 import EthQuery from 'eth-query';
-import { NetworkType } from '@metamask/controller-utils';
+import { NetworkType, toHex } from '@metamask/controller-utils';
 import {
   GAS_ESTIMATE_TYPES,
   GasFeeController,
@@ -229,7 +230,7 @@ describe('GasFeeController', () => {
     networkControllerState = {},
     interval,
   }: {
-    getChainId?: jest.Mock<`0x${string}` | `${number}` | number>;
+    getChainId?: jest.Mock<Hex>;
     getIsEIP1559Compatible?: jest.Mock<Promise<boolean>>;
     getCurrentNetworkLegacyGasAPICompatibility?: jest.Mock<boolean>;
     legacyAPIEndpoint?: string;
@@ -314,7 +315,7 @@ describe('GasFeeController', () => {
             networkControllerState: {
               providerConfig: {
                 type: NetworkType.rpc,
-                chainId: '1337',
+                chainId: toHex(1337),
                 rpcUrl: 'http://some/url',
               },
             },
@@ -369,7 +370,7 @@ describe('GasFeeController', () => {
             networkControllerState: {
               providerConfig: {
                 type: NetworkType.rpc,
-                chainId: '1337',
+                chainId: toHex(1337),
                 rpcUrl: 'http://some/url',
               },
             },
@@ -679,7 +680,7 @@ describe('GasFeeController', () => {
           networkControllerState: {
             providerConfig: {
               type: NetworkType.rpc,
-              chainId: '1337',
+              chainId: toHex(1337),
               rpcUrl: 'http://some/url',
             },
           },
@@ -790,7 +791,7 @@ describe('GasFeeController', () => {
           networkControllerState: {
             providerConfig: {
               type: NetworkType.rpc,
-              chainId: '1337',
+              chainId: toHex(1337),
               rpcUrl: 'http://some/url',
             },
           },
@@ -832,43 +833,11 @@ describe('GasFeeController', () => {
         expect(estimateData).toMatchObject(mockDetermineGasFeeCalculations);
       });
 
-      it('should call determineGasFeeCalculations correctly when getChainId returns a number input', async () => {
-        await setupGasFeeController({
-          ...defaultConstructorOptions,
-          EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',
-          getChainId: jest.fn().mockReturnValue(1),
-        });
-
-        await gasFeeController._fetchGasFeeEstimateData();
-
-        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
-          expect.objectContaining({
-            fetchGasEstimatesUrl: 'http://eip-1559.endpoint/1',
-          }),
-        );
-      });
-
-      it('should call determineGasFeeCalculations correctly when getChainId returns a hexstring input', async () => {
+      it('should call determineGasFeeCalculations correctly for mainnet', async () => {
         await setupGasFeeController({
           ...defaultConstructorOptions,
           EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',
           getChainId: jest.fn().mockReturnValue('0x1'),
-        });
-
-        await gasFeeController._fetchGasFeeEstimateData();
-
-        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
-          expect.objectContaining({
-            fetchGasEstimatesUrl: 'http://eip-1559.endpoint/1',
-          }),
-        );
-      });
-
-      it('should call determineGasFeeCalculations correctly when getChainId returns a numeric string input', async () => {
-        await setupGasFeeController({
-          ...defaultConstructorOptions,
-          EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',
-          getChainId: jest.fn().mockReturnValue('1'),
         });
 
         await gasFeeController._fetchGasFeeEstimateData();

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import type { Hex } from '@metamask/utils';
 import {
   BaseController,
   BaseConfig,
@@ -85,7 +86,7 @@ export type SecurityProviderRequest = (
   messageType: string,
 ) => Promise<Json>;
 
-type getCurrentChainId = () => string;
+type getCurrentChainId = () => Hex;
 
 /**
  * Controller in charge of managing - storing, adding, removing, updating - Messages.

--- a/packages/message-manager/src/utils.test.ts
+++ b/packages/message-manager/src/utils.test.ts
@@ -1,3 +1,4 @@
+import { convertHexToDecimal, toHex } from '@metamask/controller-utils';
 import * as util from './utils';
 
 describe('utils', () => {
@@ -119,7 +120,7 @@ describe('utils', () => {
   describe('validateTypedSignMessageDataV3V4', () => {
     const dataTyped =
       '{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Person":[{"name":"name","type":"string"},{"name":"wallet","type":"address"}],"Mail":[{"name":"from","type":"Person"},{"name":"to","type":"Person"},{"name":"contents","type":"string"}]},"primaryType":"Mail","domain":{"name":"Ether Mail","version":"1","chainId":1,"verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"},"message":{"from":{"name":"Cow","wallet":"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"},"to":{"name":"Bob","wallet":"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"},"contents":"Hello, Bob!"}}';
-    const mockedCurrentChainId = '1';
+    const mockedCurrentChainId = toHex(1);
     it('should throw if no from address', () => {
       expect(() =>
         util.validateTypedSignMessageDataV3V4(
@@ -212,15 +213,18 @@ describe('utils', () => {
             data: dataTyped.replace(`"chainId":1`, `"chainId":"0x1"`),
             from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           } as any,
+          // @ts-expect-error Intentionally invalid
           unexpectedChainId,
         ),
       ).toThrow(
-        `Cannot sign messages for chainId "${mockedCurrentChainId}", because MetaMask is switching networks.`,
+        `Cannot sign messages for chainId "${convertHexToDecimal(
+          mockedCurrentChainId,
+        )}", because MetaMask is switching networks.`,
       );
     });
 
     it('should throw if current chain id is not matched with provided in message data', () => {
-      const chainId = '2';
+      const chainId = toHex(2);
       expect(() =>
         util.validateTypedSignMessageDataV3V4(
           {
@@ -230,7 +234,9 @@ describe('utils', () => {
           chainId,
         ),
       ).toThrow(
-        `Provided chainId "${mockedCurrentChainId}" must match the active chainId "${chainId}"`,
+        `Provided chainId "${convertHexToDecimal(
+          mockedCurrentChainId,
+        )}" must match the active chainId "${convertHexToDecimal(chainId)}"`,
       );
     });
 

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -1,6 +1,7 @@
 import { addHexPrefix, bufferToHex, stripHexPrefix } from 'ethereumjs-util';
 import { TYPED_MESSAGE_SCHEMA, typedSignatureHash } from 'eth-sig-util';
 import { validate } from 'jsonschema';
+import type { Hex } from '@metamask/utils';
 import { isValidHexAddress } from '@metamask/controller-utils';
 import { MessageParams } from './MessageManager';
 import { PersonalMessageParams } from './PersonalMessageManager';
@@ -93,7 +94,7 @@ export function validateTypedSignMessageDataV1(
  */
 export function validateTypedSignMessageDataV3V4(
   messageData: TypedMessageParams,
-  currentChainId: string | undefined,
+  currentChainId?: Hex,
 ) {
   validateAddress(messageData.from, 'from');
 

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -94,7 +94,7 @@ export function validateTypedSignMessageDataV1(
  */
 export function validateTypedSignMessageDataV3V4(
   messageData: TypedMessageParams,
-  currentChainId?: Hex,
+  currentChainId: Hex | undefined,
 ) {
   validateAddress(messageData.from, 'from');
 

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -15,7 +15,6 @@ import {
   InfuraNetworkType,
   NetworkType,
   isSafeChainId,
-  toHex,
 } from '@metamask/controller-utils';
 import {
   Hex,
@@ -47,7 +46,7 @@ const log = createModuleLogger(projectLogger, 'NetworkController');
 export type ProviderConfig = {
   rpcUrl?: string;
   type: NetworkType;
-  chainId: string;
+  chainId: Hex;
   ticker?: string;
   nickname?: string;
   rpcPrefs?: { blockExplorerUrl?: string };
@@ -82,7 +81,7 @@ export type NetworkDetails = {
  */
 export type NetworkConfiguration = {
   rpcUrl: string;
-  chainId: string;
+  chainId: Hex;
   ticker: string;
   nickname?: string;
   rpcPrefs?: {
@@ -349,7 +348,7 @@ export class NetworkController extends BaseControllerV2<
   #configureProvider(
     type: NetworkType,
     rpcUrl: string | undefined,
-    chainId: string | undefined,
+    chainId: Hex | undefined,
   ) {
     switch (type) {
       case NetworkType.mainnet:
@@ -365,7 +364,7 @@ export class NetworkController extends BaseControllerV2<
         if (rpcUrl === undefined) {
           throw new Error('rpcUrl must be provided for custom RPC endpoints');
         }
-        this.#setupStandardProvider(rpcUrl, toHex(chainId));
+        this.#setupStandardProvider(rpcUrl, chainId);
         break;
       default:
         throw new Error(`Unrecognized network type: '${type}'`);
@@ -741,7 +740,7 @@ export class NetworkController extends BaseControllerV2<
   ): Promise<string> {
     assertIsStrictHexString(chainId);
 
-    if (!isSafeChainId(parseInt(chainId, 16))) {
+    if (!isSafeChainId(chainId)) {
       throw new Error(
         `Invalid chain ID "${chainId}": numerical value greater than max safe value.`,
       );

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -22,7 +22,11 @@ import {
 import { createInfuraMiddleware } from '@metamask/eth-json-rpc-infura';
 import type { Hex } from '@metamask/utils';
 import { PollingBlockTracker } from 'eth-block-tracker';
-import { InfuraNetworkType, ChainId } from '@metamask/controller-utils';
+import {
+  InfuraNetworkType,
+  ChainId,
+  NetworkId,
+} from '@metamask/controller-utils';
 import type { BlockTracker, Provider } from './types';
 
 const SECOND = 1000;
@@ -157,16 +161,14 @@ function createNetworkAndChainIdMiddleware({
 }: {
   network: InfuraNetworkType;
 }) {
-  const chainId = ChainId[network];
-
   return createScaffoldMiddleware({
-    eth_chainId: `0x${parseInt(chainId, 10).toString(16)}`,
-    net_version: chainId,
+    eth_chainId: ChainId[network],
+    net_version: NetworkId[network],
   });
 }
 
 const createChainIdMiddleware = (
-  chainId: string,
+  chainId: Hex,
 ): JsonRpcMiddleware<unknown, unknown> => {
   return (req, res, next, end) => {
     if (req.method === 'eth_chainId') {
@@ -192,7 +194,7 @@ function createCustomNetworkMiddleware({
   rpcApiMiddleware,
 }: {
   blockTracker: PollingBlockTracker;
-  chainId: string;
+  chainId: Hex;
   rpcApiMiddleware: any;
 }) {
   // eslint-disable-next-line node/no-process-env

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -289,7 +289,7 @@ describe('NetworkController', () => {
                       method: 'eth_chainId',
                     },
                     response: {
-                      result: '0x1337',
+                      result: toHex(1337),
                     },
                   },
                 ]);
@@ -314,7 +314,7 @@ describe('NetworkController', () => {
                   method: 'eth_chainId',
                   params: [],
                 });
-                expect(chainIdResult.result).toBe('0x1337');
+                expect(chainIdResult.result).toBe(toHex(1337));
               },
             );
           });
@@ -354,7 +354,7 @@ describe('NetworkController', () => {
                     method: 'eth_chainId',
                   },
                   response: {
-                    result: '0x1337',
+                    result: toHex(1337),
                   },
                 },
               ]);
@@ -379,7 +379,7 @@ describe('NetworkController', () => {
                 method: 'eth_chainId',
                 params: [],
               });
-              expect(chainIdResult.result).toBe('0x1337');
+              expect(chainIdResult.result).toBe(toHex(1337));
             },
           );
         });
@@ -494,7 +494,7 @@ describe('NetworkController', () => {
                       testNetworkConfigurationId: {
                         id: 'testNetworkConfigurationId',
                         rpcUrl: 'https://mock-rpc-url',
-                        chainId: '0x1337',
+                        chainId: toHex(1337),
                         ticker: 'ABC',
                       },
                     },
@@ -560,7 +560,7 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
-                      chainId: '0x1337',
+                      chainId: toHex(1337),
                       rpcUrl: 'https://mock-rpc-url',
                       type: NetworkClientType.Custom,
                     })
@@ -590,7 +590,7 @@ describe('NetworkController', () => {
                       testNetworkConfigurationId: {
                         id: 'testNetworkConfigurationId',
                         rpcUrl: 'https://mock-rpc-url',
-                        chainId: '0x1337',
+                        chainId: toHex(1337),
                         ticker: 'ABC',
                       },
                     },
@@ -662,7 +662,7 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
-                      chainId: '0x1337',
+                      chainId: toHex(1337),
                       rpcUrl: 'https://mock-rpc-url',
                       type: NetworkClientType.Custom,
                     })
@@ -698,7 +698,7 @@ describe('NetworkController', () => {
                       testNetworkConfigurationId: {
                         id: 'testNetworkConfigurationId',
                         rpcUrl: 'https://mock-rpc-url',
-                        chainId: '0x1337',
+                        chainId: toHex(1337),
                         ticker: 'ABC',
                       },
                     },
@@ -782,7 +782,7 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
-                      chainId: '0x1337',
+                      chainId: toHex(1337),
                       rpcUrl: 'https://mock-rpc-url',
                       type: NetworkClientType.Custom,
                     })
@@ -820,7 +820,7 @@ describe('NetworkController', () => {
                       testNetworkConfigurationId: {
                         id: 'testNetworkConfigurationId',
                         rpcUrl: 'https://mock-rpc-url',
-                        chainId: '0x1337',
+                        chainId: toHex(1337),
                         ticker: 'ABC',
                       },
                     },
@@ -892,7 +892,7 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
-                      chainId: '0x1337',
+                      chainId: toHex(1337),
                       rpcUrl: 'https://mock-rpc-url',
                       type: NetworkClientType.Custom,
                     })
@@ -939,7 +939,7 @@ describe('NetworkController', () => {
                       testNetworkConfigurationId: {
                         id: 'testNetworkConfigurationId',
                         rpcUrl: 'https://mock-rpc-url',
-                        chainId: '0x1337',
+                        chainId: toHex(1337),
                         ticker: 'ABC',
                       },
                     },
@@ -1005,7 +1005,7 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
-                      chainId: '0x1337',
+                      chainId: toHex(1337),
                       rpcUrl: 'https://mock-rpc-url',
                       type: NetworkClientType.Custom,
                     })
@@ -1035,7 +1035,7 @@ describe('NetworkController', () => {
                       testNetworkConfigurationId: {
                         id: 'testNetworkConfigurationId',
                         rpcUrl: 'https://mock-rpc-url',
-                        chainId: '0x1337',
+                        chainId: toHex(1337),
                         ticker: 'ABC',
                       },
                     },
@@ -1107,7 +1107,7 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
-                      chainId: '0x1337',
+                      chainId: toHex(1337),
                       rpcUrl: 'https://mock-rpc-url',
                       type: NetworkClientType.Custom,
                     })
@@ -1143,7 +1143,7 @@ describe('NetworkController', () => {
                       testNetworkConfigurationId: {
                         id: 'testNetworkConfigurationId',
                         rpcUrl: 'https://mock-rpc-url',
-                        chainId: '0x1337',
+                        chainId: toHex(1337),
                         ticker: 'ABC',
                       },
                     },
@@ -1227,7 +1227,7 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
-                      chainId: '0x1337',
+                      chainId: toHex(1337),
                       rpcUrl: 'https://mock-rpc-url',
                       type: NetworkClientType.Custom,
                     })
@@ -1265,7 +1265,7 @@ describe('NetworkController', () => {
                       testNetworkConfigurationId: {
                         id: 'testNetworkConfigurationId',
                         rpcUrl: 'https://mock-rpc-url',
-                        chainId: '0x1337',
+                        chainId: toHex(1337),
                         ticker: 'ABC',
                       },
                     },
@@ -1337,7 +1337,7 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
-                      chainId: '0x1337',
+                      chainId: toHex(1337),
                       rpcUrl: 'https://mock-rpc-url',
                       type: NetworkClientType.Custom,
                     })
@@ -1395,7 +1395,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: NetworkType.rpc,
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                 }),
               },
@@ -1452,7 +1452,7 @@ describe('NetworkController', () => {
               ];
               mockCreateNetworkClient()
                 .calledWith({
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                   type: NetworkClientType.Custom,
                 })
@@ -1485,7 +1485,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: NetworkType.rpc,
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                 }),
               },
@@ -1548,7 +1548,7 @@ describe('NetworkController', () => {
               ];
               mockCreateNetworkClient()
                 .calledWith({
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                   type: NetworkClientType.Custom,
                 })
@@ -1587,7 +1587,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: NetworkType.rpc,
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                 }),
               },
@@ -1662,7 +1662,7 @@ describe('NetworkController', () => {
               ];
               mockCreateNetworkClient()
                 .calledWith({
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                   type: NetworkClientType.Custom,
                 })
@@ -1703,7 +1703,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: NetworkType.rpc,
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                 }),
               },
@@ -1766,7 +1766,7 @@ describe('NetworkController', () => {
               ];
               mockCreateNetworkClient()
                 .calledWith({
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                   type: NetworkClientType.Custom,
                 })
@@ -1811,7 +1811,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: NetworkType.rpc,
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                 }),
               },
@@ -1868,7 +1868,7 @@ describe('NetworkController', () => {
               ];
               mockCreateNetworkClient()
                 .calledWith({
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                   type: NetworkClientType.Custom,
                 })
@@ -1901,7 +1901,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: NetworkType.rpc,
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                 }),
               },
@@ -1964,7 +1964,7 @@ describe('NetworkController', () => {
               ];
               mockCreateNetworkClient()
                 .calledWith({
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                   type: NetworkClientType.Custom,
                 })
@@ -2003,7 +2003,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: NetworkType.rpc,
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                 }),
               },
@@ -2078,7 +2078,7 @@ describe('NetworkController', () => {
               ];
               mockCreateNetworkClient()
                 .calledWith({
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                   type: NetworkClientType.Custom,
                 })
@@ -2119,7 +2119,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: buildProviderConfig({
                   type: NetworkType.rpc,
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                 }),
               },
@@ -2182,7 +2182,7 @@ describe('NetworkController', () => {
               ];
               mockCreateNetworkClient()
                 .calledWith({
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   rpcUrl: 'https://mock-rpc-url',
                   type: NetworkClientType.Custom,
                 })
@@ -3451,7 +3451,7 @@ describe('NetworkController', () => {
         await expect(async () =>
           controller.upsertNetworkConfiguration(
             {
-              chainId: '0x9999',
+              chainId: toHex(9999),
               nickname: 'RPC',
               rpcPrefs: { blockExplorerUrl: 'test-block-explorer.com' },
               ticker: 'RPC',
@@ -3513,14 +3513,14 @@ describe('NetworkController', () => {
             providerConfig: {
               type: NetworkType.rpc,
               rpcUrl: 'https://mock-rpc-url',
-              chainId: '0x111',
+              chainId: toHex(111),
               ticker: 'TEST',
               id: 'testNetworkConfigurationId',
             },
             networkConfigurations: {
               testNetworkConfigurationId: {
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '0x111',
+                chainId: toHex(111),
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
                 nickname: undefined,
@@ -3533,7 +3533,7 @@ describe('NetworkController', () => {
         async ({ controller }) => {
           const newNetworkConfiguration = {
             rpcUrl: 'https://new-chain-rpc-url',
-            chainId: '0x222',
+            chainId: toHex(222),
             ticker: 'NEW',
             nickname: 'new-chain',
             rpcPrefs: { blockExplorerUrl: 'https://block-explorer' },
@@ -3738,7 +3738,7 @@ describe('NetworkController', () => {
                 ticker: 'ticker-2',
                 nickname: 'nickname-2',
                 rpcPrefs: { blockExplorerUrl: 'testchainscan.io' },
-                chainId: '0x9999',
+                chainId: toHex(9999),
                 id: 'networkConfigurationId2',
               },
             },
@@ -3775,7 +3775,7 @@ describe('NetworkController', () => {
               ticker: 'ticker-2',
               nickname: 'nickname-2',
               rpcPrefs: { blockExplorerUrl: 'testchainscan.io' },
-              chainId: '0x9999',
+              chainId: toHex(9999),
               id: 'networkConfigurationId2',
             },
           ]);
@@ -3835,7 +3835,7 @@ describe('NetworkController', () => {
             providerConfig: {
               type: NetworkType.rpc,
               rpcUrl: 'https://mock-rpc-url',
-              chainId: '0x111',
+              chainId: toHex(111),
               ticker: 'TEST',
               id: 'testNetworkConfigurationId',
               nickname: undefined,
@@ -3844,7 +3844,7 @@ describe('NetworkController', () => {
             networkConfigurations: {
               testNetworkConfigurationId: {
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '0x111',
+                chainId: toHex(111),
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
                 nickname: undefined,
@@ -3891,7 +3891,7 @@ describe('NetworkController', () => {
             providerConfig: {
               type: NetworkType.rpc,
               rpcUrl: 'https://mock-rpc-url',
-              chainId: '0x111',
+              chainId: toHex(111),
               ticker: 'TEST',
               id: 'testNetworkConfigurationId',
               nickname: undefined,
@@ -3900,7 +3900,7 @@ describe('NetworkController', () => {
             networkConfigurations: {
               testNetworkConfigurationId: {
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '0x111',
+                chainId: toHex(111),
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
                 nickname: undefined,
@@ -3929,7 +3929,7 @@ describe('NetworkController', () => {
           ).toStrictEqual([
             {
               rpcUrl: 'https://mock-rpc-url',
-              chainId: '0x111',
+              chainId: toHex(111),
               ticker: 'TEST',
               id: 'testNetworkConfigurationId',
               nickname: undefined,
@@ -3969,7 +3969,7 @@ describe('NetworkController', () => {
                 ticker: 'old_rpc_ticker',
                 nickname: 'old_rpc_nickname',
                 rpcPrefs: { blockExplorerUrl: 'testchainscan.io' },
-                chainId: '0x1337',
+                chainId: toHex(1337),
                 id: testNetworkConfigurationId,
               },
             },
@@ -3994,7 +3994,7 @@ describe('NetworkController', () => {
                 ticker: 'old_rpc_ticker',
                 nickname: 'old_rpc_nickname',
                 rpcPrefs: { blockExplorerUrl: 'testchainscan.io' },
-                chainId: '0x1337',
+                chainId: toHex(1337),
                 id: testNetworkConfigurationId,
               },
             },
@@ -4027,7 +4027,7 @@ describe('NetworkController', () => {
                   testNetworkConfiguration: {
                     id: 'testNetworkConfiguration',
                     rpcUrl: 'https://mock-rpc-url',
-                    chainId: '0x1337',
+                    chainId: toHex(1337),
                     ticker: 'TEST',
                     nickname: 'test network',
                     rpcPrefs: {
@@ -4069,7 +4069,7 @@ describe('NetworkController', () => {
                   testNetworkConfiguration: {
                     id: 'testNetworkConfiguration',
                     rpcUrl: 'https://mock-rpc-url',
-                    chainId: '0x1337',
+                    chainId: toHex(1337),
                     ticker: 'TEST',
                     nickname: 'test network',
                     rpcPrefs: {
@@ -4111,7 +4111,7 @@ describe('NetworkController', () => {
                   testNetworkConfiguration: {
                     id: 'testNetworkConfiguration',
                     rpcUrl: 'https://mock-rpc-url',
-                    chainId: '0x1337',
+                    chainId: toHex(1337),
                     ticker: 'TEST',
                     nickname: 'test network',
                     rpcPrefs: {
@@ -4131,7 +4131,7 @@ describe('NetworkController', () => {
               mockCreateNetworkClient()
                 .calledWith({
                   rpcUrl: 'https://mock-rpc-url',
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   type: NetworkClientType.Custom,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
@@ -4146,7 +4146,7 @@ describe('NetworkController', () => {
                 type: 'rpc',
                 id: 'testNetworkConfiguration',
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '0x1337',
+                chainId: toHex(1337),
                 ticker: 'TEST',
                 nickname: 'test network',
                 rpcPrefs: {
@@ -4176,7 +4176,7 @@ describe('NetworkController', () => {
                   testNetworkConfiguration: {
                     id: 'testNetworkConfiguration',
                     rpcUrl: 'https://mock-rpc-url',
-                    chainId: '0x1337',
+                    chainId: toHex(1337),
                     ticker: 'TEST',
                   },
                 },
@@ -4208,7 +4208,7 @@ describe('NetworkController', () => {
               mockCreateNetworkClient()
                 .calledWith({
                   rpcUrl: 'https://mock-rpc-url',
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   type: NetworkClientType.Custom,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
@@ -4251,7 +4251,7 @@ describe('NetworkController', () => {
                   testNetworkConfiguration: {
                     id: 'testNetworkConfiguration',
                     rpcUrl: 'https://mock-rpc-url',
-                    chainId: '0x1337',
+                    chainId: toHex(1337),
                     ticker: 'TEST',
                   },
                 },
@@ -4279,7 +4279,7 @@ describe('NetworkController', () => {
               mockCreateNetworkClient()
                 .calledWith({
                   rpcUrl: 'https://mock-rpc-url',
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   type: NetworkClientType.Custom,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
@@ -4328,7 +4328,7 @@ describe('NetworkController', () => {
                   testNetworkConfiguration: {
                     id: 'testNetworkConfiguration',
                     rpcUrl: 'https://mock-rpc-url',
-                    chainId: '0x1337',
+                    chainId: toHex(1337),
                     ticker: 'TEST',
                   },
                 },
@@ -4356,7 +4356,7 @@ describe('NetworkController', () => {
               mockCreateNetworkClient()
                 .calledWith({
                   rpcUrl: 'https://mock-rpc-url',
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   type: NetworkClientType.Custom,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
@@ -4396,7 +4396,7 @@ describe('NetworkController', () => {
                   testNetworkConfiguration: {
                     id: 'testNetworkConfiguration',
                     rpcUrl: 'https://mock-rpc-url',
-                    chainId: '0x1337',
+                    chainId: toHex(1337),
                     ticker: 'TEST',
                   },
                 },
@@ -4412,7 +4412,7 @@ describe('NetworkController', () => {
               mockCreateNetworkClient()
                 .calledWith({
                   rpcUrl: 'https://mock-rpc-url',
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   type: NetworkClientType.Custom,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
@@ -4446,7 +4446,7 @@ describe('NetworkController', () => {
                   testNetworkConfiguration: {
                     id: 'testNetworkConfiguration',
                     rpcUrl: 'https://mock-rpc-url',
-                    chainId: '0x1337',
+                    chainId: toHex(1337),
                     ticker: 'TEST',
                   },
                 },
@@ -4472,7 +4472,7 @@ describe('NetworkController', () => {
               mockCreateNetworkClient()
                 .calledWith({
                   rpcUrl: 'https://mock-rpc-url',
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   type: NetworkClientType.Custom,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
@@ -4513,7 +4513,7 @@ describe('NetworkController', () => {
                   testNetworkConfiguration: {
                     id: 'testNetworkConfiguration',
                     rpcUrl: 'https://mock-rpc-url',
-                    chainId: '0x1337',
+                    chainId: toHex(1337),
                     ticker: 'TEST',
                   },
                 },
@@ -4546,7 +4546,7 @@ describe('NetworkController', () => {
               mockCreateNetworkClient()
                 .calledWith({
                   rpcUrl: 'https://mock-rpc-url',
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   type: NetworkClientType.Custom,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
@@ -4582,7 +4582,7 @@ describe('NetworkController', () => {
                   testNetworkConfiguration: {
                     id: 'testNetworkConfiguration',
                     rpcUrl: 'https://mock-rpc-url',
-                    chainId: '0x1337',
+                    chainId: toHex(1337),
                     ticker: 'TEST',
                   },
                 },
@@ -4619,7 +4619,7 @@ describe('NetworkController', () => {
               mockCreateNetworkClient()
                 .calledWith({
                   rpcUrl: 'https://mock-rpc-url',
-                  chainId: '0x1337',
+                  chainId: toHex(1337),
                   type: NetworkClientType.Custom,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
@@ -5567,7 +5567,7 @@ function refreshNetworkTests({
                 method: 'eth_chainId',
               },
               response: {
-                result: '0x1337',
+                result: toHex(1337),
               },
             },
           ]);
@@ -5592,7 +5592,7 @@ function refreshNetworkTests({
             method: 'eth_chainId',
             params: [],
           });
-          expect(chainIdResult.result).toBe('0x1337');
+          expect(chainIdResult.result).toBe(toHex(1337));
         },
       );
     });

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -131,7 +131,7 @@ const INFURA_NETWORKS = [
   {
     nickname: 'Mainnet',
     networkType: NetworkType.mainnet,
-    chainId: '1',
+    chainId: toHex(1),
     ticker: 'ETH',
     blockExplorerUrl: 'https://etherscan.io',
     networkVersion: '1',
@@ -139,7 +139,7 @@ const INFURA_NETWORKS = [
   {
     nickname: 'Goerli',
     networkType: NetworkType.goerli,
-    chainId: '5',
+    chainId: toHex(5),
     ticker: 'GoerliETH',
     blockExplorerUrl: 'https://goerli.etherscan.io',
     networkVersion: '5',
@@ -147,7 +147,7 @@ const INFURA_NETWORKS = [
   {
     nickname: 'Sepolia',
     networkType: NetworkType.sepolia,
-    chainId: '11155111',
+    chainId: toHex(11155111),
     ticker: 'SepoliaETH',
     blockExplorerUrl: 'https://sepolia.etherscan.io',
     networkVersion: '11155111',
@@ -207,7 +207,7 @@ describe('NetworkController', () => {
           networkConfigurations: {},
           networkId: null,
           networkStatus: NetworkStatus.Unknown,
-          providerConfig: { type: NetworkType.mainnet, chainId: '1' },
+          providerConfig: { type: NetworkType.mainnet, chainId: toHex(1) },
           networkDetails: {
             EIPS: {
               1559: false,
@@ -233,7 +233,7 @@ describe('NetworkController', () => {
             networkConfigurations: {},
             networkId: null,
             networkStatus: NetworkStatus.Unknown,
-            providerConfig: { type: NetworkType.mainnet, chainId: '1' },
+            providerConfig: { type: NetworkType.mainnet, chainId: toHex(1) },
             networkDetails: {
               EIPS: {
                 1559: true,
@@ -340,7 +340,7 @@ describe('NetworkController', () => {
               state: {
                 providerConfig: {
                   type: NetworkType.rpc,
-                  chainId: '1337',
+                  chainId: toHex(1337),
                   nickname: 'some cool network',
                   rpcUrl: 'http://example.com',
                   ticker: 'ABC',
@@ -2254,7 +2254,7 @@ describe('NetworkController', () => {
               providerConfig: {
                 type: NetworkType.rpc,
                 rpcUrl: 'http://somethingexisting.com',
-                chainId: '99999',
+                chainId: toHex(99999),
                 ticker: 'something existing',
                 nickname: 'something existing',
               },
@@ -2326,7 +2326,7 @@ describe('NetworkController', () => {
     refreshNetworkTests({
       expectedProviderConfig: {
         rpcUrl: 'https://mock-rpc-url',
-        chainId: '111',
+        chainId: toHex(111),
         ticker: 'TEST',
         nickname: 'something existing',
         id: 'testNetworkConfigurationId',
@@ -2337,7 +2337,7 @@ describe('NetworkController', () => {
         networkConfigurations: {
           testNetworkConfigurationId: {
             rpcUrl: 'https://mock-rpc-url',
-            chainId: '111',
+            chainId: toHex(111),
             ticker: 'TEST',
             nickname: 'something existing',
             id: 'testNetworkConfigurationId',
@@ -2359,7 +2359,7 @@ describe('NetworkController', () => {
               providerConfig: {
                 type: NetworkType.rpc,
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '111',
+                chainId: toHex(111),
                 ticker: 'TEST',
                 nickname: 'something existing',
                 rpcPrefs: undefined,
@@ -2367,7 +2367,7 @@ describe('NetworkController', () => {
               networkConfigurations: {
                 testNetworkConfigurationId1: {
                   rpcUrl: 'https://mock-rpc-url',
-                  chainId: '111',
+                  chainId: toHex(111),
                   ticker: 'TEST',
                   nickname: 'something existing',
                   id: 'testNetworkConfigurationId1',
@@ -2375,7 +2375,7 @@ describe('NetworkController', () => {
                 },
                 testNetworkConfigurationId2: {
                   rpcUrl: undefined,
-                  chainId: '222',
+                  chainId: toHex(222),
                   ticker: 'something existing',
                   nickname: 'something existing',
                   id: 'testNetworkConfigurationId2',
@@ -2414,7 +2414,7 @@ describe('NetworkController', () => {
               providerConfig: {
                 type: NetworkType.rpc,
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '111',
+                chainId: toHex(111),
                 ticker: 'TEST',
                 nickname: 'something existing',
                 rpcPrefs: undefined,
@@ -2422,7 +2422,7 @@ describe('NetworkController', () => {
               networkConfigurations: {
                 testNetworkConfigurationId1: {
                   rpcUrl: 'https://mock-rpc-url',
-                  chainId: '111',
+                  chainId: toHex(111),
                   ticker: 'TEST',
                   nickname: 'something existing',
                   id: 'testNetworkConfigurationId1',
@@ -3326,7 +3326,7 @@ describe('NetworkController', () => {
 
       await withController(async ({ controller }) => {
         const rpcUrlNetwork = {
-          chainId: '0x9999',
+          chainId: toHex(9999),
           rpcUrl: 'https://test-rpc.com',
           ticker: 'RPC',
         };
@@ -3363,7 +3363,7 @@ describe('NetworkController', () => {
                 ticker: 'old_rpc_ticker',
                 nickname: 'old_rpc_nickname',
                 rpcPrefs: { blockExplorerUrl: 'testchainscan.io' },
-                chainId: '0x1',
+                chainId: toHex(1),
                 id: 'testNetworkConfigurationId',
               },
             },
@@ -3376,7 +3376,7 @@ describe('NetworkController', () => {
               ticker: 'new_rpc_ticker',
               nickname: 'new_rpc_nickname',
               rpcPrefs: { blockExplorerUrl: 'alternativetestchainscan.io' },
-              chainId: '0x1',
+              chainId: toHex(1),
             },
             { referrer: 'https://test-dapp.com', source: 'dapp' },
           );
@@ -3389,7 +3389,7 @@ describe('NetworkController', () => {
                 nickname: 'new_rpc_nickname',
                 ticker: 'new_rpc_ticker',
                 rpcPrefs: { blockExplorerUrl: 'alternativetestchainscan.io' },
-                chainId: '0x1',
+                chainId: toHex(1),
                 id: 'testNetworkConfigurationId',
               },
             ]),
@@ -3404,6 +3404,7 @@ describe('NetworkController', () => {
         await expect(async () =>
           controller.upsertNetworkConfiguration(
             {
+              // @ts-expect-error Intentionally invalid
               chainId: invalidChainId,
               nickname: 'RPC',
               rpcPrefs: { blockExplorerUrl: 'test-block-explorer.com' },
@@ -3471,7 +3472,7 @@ describe('NetworkController', () => {
           controller.upsertNetworkConfiguration(
             // @ts-expect-error - we want to test the case where no ticker is present.
             {
-              chainId: '0x5',
+              chainId: toHex(5),
               nickname: 'RPC',
               rpcPrefs: { blockExplorerUrl: 'test-block-explorer.com' },
               rpcUrl: 'https://mock-rpc-url',
@@ -3494,7 +3495,7 @@ describe('NetworkController', () => {
         await expect(async () =>
           // @ts-expect-error - we want to test the case where no second arg is passed.
           controller.upsertNetworkConfiguration({
-            chainId: '0x5',
+            chainId: toHex(5),
             nickname: 'RPC',
             rpcPrefs: { blockExplorerUrl: 'test-block-explorer.com' },
             rpcUrl: 'https://mock-rpc-url',
@@ -3558,7 +3559,7 @@ describe('NetworkController', () => {
         },
         async ({ controller }) => {
           const rpcUrlNetwork = {
-            chainId: '0x1',
+            chainId: toHex(1),
             rpcUrl: 'https://test-rpc-url',
             ticker: 'test_ticker',
           };
@@ -3594,7 +3595,7 @@ describe('NetworkController', () => {
         },
         async ({ controller }) => {
           const rpcUrlNetwork = {
-            chainId: '0x1',
+            chainId: toHex(1),
             rpcUrl: 'https://test-rpc-url',
             ticker: 'test_ticker',
             invalidKey: 'new-chain',
@@ -3611,7 +3612,7 @@ describe('NetworkController', () => {
           ).toStrictEqual(
             expect.arrayContaining([
               {
-                chainId: '0x1',
+                chainId: toHex(1),
                 rpcUrl: 'https://test-rpc-url',
                 ticker: 'test_ticker',
                 nickname: undefined,
@@ -3635,7 +3636,7 @@ describe('NetworkController', () => {
                 ticker: 'ticker',
                 nickname: 'nickname',
                 rpcPrefs: { blockExplorerUrl: 'testchainscan.io' },
-                chainId: '0x1',
+                chainId: toHex(1),
                 id: 'networkConfigurationId',
               },
             },
@@ -3643,7 +3644,7 @@ describe('NetworkController', () => {
         },
         async ({ controller }) => {
           const rpcUrlNetwork = {
-            chainId: '0x1',
+            chainId: toHex(1),
             nickname: 'RPC',
             rpcPrefs: undefined,
             rpcUrl: 'https://test-rpc-url-2',
@@ -3664,7 +3665,7 @@ describe('NetworkController', () => {
                 ticker: 'ticker',
                 nickname: 'nickname',
                 rpcPrefs: { blockExplorerUrl: 'testchainscan.io' },
-                chainId: '0x1',
+                chainId: toHex(1),
                 id: 'networkConfigurationId',
               },
               { ...rpcUrlNetwork, id: 'networkConfigurationId2' },
@@ -3684,7 +3685,7 @@ describe('NetworkController', () => {
                 ticker: 'old_rpc_ticker',
                 nickname: 'old_rpc_chainName',
                 rpcPrefs: { blockExplorerUrl: 'testchainscan.io' },
-                chainId: '0x1',
+                chainId: toHex(1),
                 id: 'networkConfigurationId',
               },
             },
@@ -3697,7 +3698,7 @@ describe('NetworkController', () => {
             ticker: 'new_rpc_ticker',
             nickname: 'new_rpc_chainName',
             rpcPrefs: { blockExplorerUrl: 'alternativetestchainscan.io' },
-            chainId: '0x1',
+            chainId: toHex(1),
           };
           await controller.upsertNetworkConfiguration(updatedConfiguration, {
             referrer: 'https://test-dapp.com',
@@ -3711,7 +3712,7 @@ describe('NetworkController', () => {
               nickname: 'new_rpc_chainName',
               ticker: 'new_rpc_ticker',
               rpcPrefs: { blockExplorerUrl: 'alternativetestchainscan.io' },
-              chainId: '0x1',
+              chainId: toHex(1),
               id: 'networkConfigurationId',
             },
           ]);
@@ -3729,7 +3730,7 @@ describe('NetworkController', () => {
                 ticker: 'ticker',
                 nickname: 'nickname',
                 rpcPrefs: { blockExplorerUrl: 'testchainscan.io' },
-                chainId: '0x1',
+                chainId: toHex(1),
                 id: 'networkConfigurationId',
               },
               networkConfigurationId2: {
@@ -3750,7 +3751,7 @@ describe('NetworkController', () => {
               ticker: 'new-ticker',
               nickname: 'new-nickname',
               rpcPrefs: { blockExplorerUrl: 'alternativetestchainscan.io' },
-              chainId: '0x1',
+              chainId: toHex(1),
             },
             {
               referrer: 'https://test-dapp.com',
@@ -3766,7 +3767,7 @@ describe('NetworkController', () => {
               ticker: 'new-ticker',
               nickname: 'new-nickname',
               rpcPrefs: { blockExplorerUrl: 'alternativetestchainscan.io' },
-              chainId: '0x1',
+              chainId: toHex(1),
               id: 'networkConfigurationId',
             },
             {
@@ -3787,7 +3788,7 @@ describe('NetworkController', () => {
       const originalProvider = {
         type: 'rpc' as NetworkType,
         rpcUrl: 'https://mock-rpc-url',
-        chainId: '111',
+        chainId: toHex(111),
         ticker: 'TEST',
         id: 'testNetworkConfigurationId',
       };
@@ -3798,7 +3799,7 @@ describe('NetworkController', () => {
             networkConfigurations: {
               testNetworkConfigurationId: {
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '0x111',
+                chainId: toHex(111),
                 ticker: 'TEST',
                 id: 'testNetworkConfigurationId',
                 nickname: undefined,
@@ -3809,7 +3810,7 @@ describe('NetworkController', () => {
         },
         async ({ controller }) => {
           const rpcUrlNetwork = {
-            chainId: '0x222',
+            chainId: toHex(222),
             rpcUrl: 'https://test-rpc-url',
             ticker: 'test_ticker',
           };
@@ -3858,7 +3859,7 @@ describe('NetworkController', () => {
           createNetworkClientMock.mockReturnValue(fakeNetworkClient);
           const rpcUrlNetwork = {
             rpcUrl: 'https://test-rpc-url',
-            chainId: '0x222',
+            chainId: toHex(222),
             ticker: 'test_ticker',
           };
 
@@ -3871,7 +3872,7 @@ describe('NetworkController', () => {
           expect(controller.state.providerConfig).toStrictEqual({
             type: 'rpc',
             rpcUrl: 'https://test-rpc-url',
-            chainId: '0x222',
+            chainId: toHex(222),
             ticker: 'test_ticker',
             id: 'networkConfigurationId',
             nickname: undefined,
@@ -3912,7 +3913,7 @@ describe('NetworkController', () => {
         async ({ controller }) => {
           const newNetworkConfiguration = {
             rpcUrl: 'https://new-chain-rpc-url',
-            chainId: '0x222',
+            chainId: toHex(222),
             ticker: 'NEW',
             nickname: 'new-chain',
             rpcPrefs: { blockExplorerUrl: 'https://block-explorer' },
@@ -3946,7 +3947,7 @@ describe('NetworkController', () => {
               url: 'https://test-dapp.com',
             },
             properties: {
-              chain_id: '0x222',
+              chain_id: toHex(222),
               symbol: 'NEW',
               source: 'dapp',
             },
@@ -4724,7 +4725,7 @@ describe('NetworkController', () => {
               providerConfig: buildProviderConfig({
                 type: NetworkType.rpc,
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '1337',
+                chainId: toHex(1337),
                 nickname: 'network',
                 ticker: 'TEST',
                 rpcPrefs: {
@@ -4757,7 +4758,7 @@ describe('NetworkController', () => {
             expect(controller.state.providerConfig).toStrictEqual({
               type: 'goerli',
               rpcUrl: undefined,
-              chainId: '5',
+              chainId: toHex(5),
               ticker: 'GoerliETH',
               nickname: undefined,
               rpcPrefs: {
@@ -4771,7 +4772,7 @@ describe('NetworkController', () => {
               buildProviderConfig({
                 type: 'rpc',
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '1337',
+                chainId: toHex(1337),
                 nickname: 'network',
                 ticker: 'TEST',
                 rpcPrefs: {
@@ -4790,7 +4791,7 @@ describe('NetworkController', () => {
               providerConfig: buildProviderConfig({
                 type: NetworkType.rpc,
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '1337',
+                chainId: toHex(1337),
               }),
             },
             infuraProjectId: 'some-infura-project-id',
@@ -4859,7 +4860,7 @@ describe('NetworkController', () => {
               providerConfig: buildProviderConfig({
                 type: NetworkType.rpc,
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '1337',
+                chainId: toHex(1337),
               }),
             },
             infuraProjectId: 'some-infura-project-id',
@@ -4930,7 +4931,7 @@ describe('NetworkController', () => {
               providerConfig: buildProviderConfig({
                 type: NetworkType.rpc,
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '1337',
+                chainId: toHex(1337),
               }),
             },
             infuraProjectId: 'some-infura-project-id',
@@ -4992,7 +4993,7 @@ describe('NetworkController', () => {
               providerConfig: buildProviderConfig({
                 type: NetworkType.rpc,
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '1337',
+                chainId: toHex(1337),
               }),
             },
             infuraProjectId: 'some-infura-project-id',
@@ -5036,7 +5037,7 @@ describe('NetworkController', () => {
               providerConfig: buildProviderConfig({
                 type: NetworkType.rpc,
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '1337',
+                chainId: toHex(1337),
               }),
             },
             infuraProjectId: 'some-infura-project-id',
@@ -5082,7 +5083,7 @@ describe('NetworkController', () => {
               providerConfig: buildProviderConfig({
                 type: NetworkType.rpc,
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '1337',
+                chainId: toHex(1337),
               }),
             },
             infuraProjectId: 'some-infura-project-id',
@@ -5145,7 +5146,7 @@ describe('NetworkController', () => {
               providerConfig: buildProviderConfig({
                 type: NetworkType.rpc,
                 rpcUrl: 'https://mock-rpc-url',
-                chainId: '1337',
+                chainId: toHex(1337),
               }),
             },
             infuraProjectId: 'some-infura-project-id',
@@ -5533,7 +5534,7 @@ function refreshNetworkTests({
           await operation(controller);
 
           expect(createNetworkClientMock).toHaveBeenCalledWith({
-            chainId: toHex(expectedProviderConfig.chainId),
+            chainId: expectedProviderConfig.chainId,
             rpcUrl: expectedProviderConfig.rpcUrl,
             type: NetworkClientType.Custom,
           });
@@ -6932,7 +6933,7 @@ function buildProviderConfig(
   }
   return {
     type: NetworkType.rpc,
-    chainId: '1337',
+    chainId: toHex(1337),
     rpcUrl: 'http://doesntmatter.com',
     ...config,
   };

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -33,6 +33,7 @@
     "@metamask/base-controller": "workspace:^",
     "@metamask/controller-utils": "workspace:^",
     "@metamask/message-manager": "workspace:^",
+    "@metamask/utils": "^5.0.2",
     "eth-rpc-errors": "^4.0.2",
     "ethereumjs-util": "^7.0.10",
     "immer": "^9.0.6"

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -1,4 +1,5 @@
 import EventEmitter from 'events';
+import type { Hex } from '@metamask/utils';
 import {
   MessageManager,
   MessageParams,
@@ -112,7 +113,7 @@ export type SignatureControllerOptions = {
     requestData: any,
     methodName: string,
   ) => Promise<any>;
-  getCurrentChainId: () => string;
+  getCurrentChainId: () => Hex;
 };
 
 /**

--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -16,7 +16,7 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 80.78,
+      branches: 80.61,
       functions: 98.86,
       lines: 95.79,
       statements: 95.97,

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -34,6 +34,7 @@
     "@metamask/base-controller": "workspace:^",
     "@metamask/controller-utils": "workspace:^",
     "@metamask/network-controller": "workspace:^",
+    "@metamask/utils": "^5.0.2",
     "async-mutex": "^0.2.6",
     "babel-runtime": "^6.26.0",
     "eth-method-registry": "1.1.0",

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2,7 +2,7 @@ import * as sinon from 'sinon';
 import { PollingBlockTracker } from 'eth-block-tracker';
 import HttpProvider from 'ethjs-provider-http';
 import NonceTracker from 'nonce-tracker';
-import { ChainId, NetworkType } from '@metamask/controller-utils';
+import { ChainId, NetworkType, toHex } from '@metamask/controller-utils';
 import type {
   BlockTrackerProxy,
   NetworkState,
@@ -219,7 +219,7 @@ const MOCK_CUSTOM_NETWORK: MockNetwork = {
     networkDetails: { EIPS: { 1559: false } },
     providerConfig: {
       type: NetworkType.rpc,
-      chainId: '11297108109',
+      chainId: toHex(11297108109),
     },
     networkConfigurations: {},
   },
@@ -888,7 +888,7 @@ describe('TransactionController', () => {
         from: MOCK_PRFERENCES.state.selectedAddress,
         id: 'foo',
         networkID: '5',
-        chainId: '5',
+        chainId: toHex(5),
         status: TransactionStatus.submitted,
         transactionHash: '1337',
       } as any);
@@ -984,7 +984,7 @@ describe('TransactionController', () => {
       from: MOCK_PRFERENCES.state.selectedAddress,
       id: 'foo',
       networkID: '5',
-      chainId: '5',
+      chainId: toHex(5),
       status: TransactionStatus.confirmed,
       transactionHash: '1337',
       verifiedOnBlockchain: false,

--- a/packages/transaction-controller/src/mocks/txsMock.ts
+++ b/packages/transaction-controller/src/mocks/txsMock.ts
@@ -1,3 +1,4 @@
+import { toHex } from '@metamask/controller-utils';
 import { TransactionMeta, TransactionStatus } from '../TransactionController';
 
 export const ethTxsMock = (ethTxHash: string) => [
@@ -373,7 +374,7 @@ export const txsInStateMock = (
 ): TransactionMeta[] => [
   {
     id: 'token-transaction-id',
-    chainId: '1',
+    chainId: toHex(1),
     status: TransactionStatus.confirmed,
     time: 1615497996125,
     transaction: {
@@ -391,7 +392,7 @@ export const txsInStateMock = (
   },
   {
     id: 'eth-transaction-id',
-    chainId: '1',
+    chainId: toHex(1),
     status: TransactionStatus.confirmed,
     time: 1615497996125,
     transaction: {
@@ -415,7 +416,7 @@ export const txsInStateWithOutdatedStatusMock = (
 ): TransactionMeta[] => [
   {
     id: 'token-transaction-id',
-    chainId: '1',
+    chainId: toHex(1),
     status: TransactionStatus.rejected,
     time: 1615497996125,
     transaction: {
@@ -433,7 +434,7 @@ export const txsInStateWithOutdatedStatusMock = (
   },
   {
     id: 'eth-transaction-id',
-    chainId: '1',
+    chainId: toHex(1),
     status: TransactionStatus.rejected,
     time: 1615497996125,
     transaction: {
@@ -457,7 +458,7 @@ export const txsInStateWithOutdatedGasDataMock = (
 ): TransactionMeta[] => [
   {
     id: 'token-transaction-id',
-    chainId: '1',
+    chainId: toHex(1),
     status: TransactionStatus.confirmed,
     time: 1615497996125,
     transaction: {
@@ -475,7 +476,7 @@ export const txsInStateWithOutdatedGasDataMock = (
   },
   {
     id: 'eth-transaction-id',
-    chainId: '1',
+    chainId: toHex(1),
     status: TransactionStatus.confirmed,
     time: 1615497996125,
     transaction: {
@@ -499,7 +500,7 @@ export const txsInStateWithOutdatedStatusAndGasDataMock = (
 ): TransactionMeta[] => [
   {
     id: 'token-transaction-id',
-    chainId: '1',
+    chainId: toHex(1),
     status: TransactionStatus.rejected,
     time: 1615497996125,
     transaction: {
@@ -517,7 +518,7 @@ export const txsInStateWithOutdatedStatusAndGasDataMock = (
   },
   {
     id: 'eth-transaction-id',
-    chainId: '1',
+    chainId: toHex(1),
     status: TransactionStatus.rejected,
     time: 1615497996125,
     transaction: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,6 +1251,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
+    "@metamask/utils": ^5.0.2
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -1677,6 +1678,7 @@ __metadata:
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
     "@metamask/network-controller": "workspace:^"
+    "@metamask/utils": ^5.0.2
     "@types/jest": ^27.4.1
     "@types/jest-when": ^2.7.3
     "@types/uuid": ^8.3.0
@@ -1944,6 +1946,7 @@ __metadata:
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
     "@metamask/message-manager": "workspace:^"
+    "@metamask/utils": ^5.0.2
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     eth-rpc-errors: ^4.0.2
@@ -1975,6 +1978,7 @@ __metadata:
     "@metamask/controller-utils": "workspace:^"
     "@metamask/network-controller": "workspace:^"
     "@metamask/swappable-obj-proxy": ^2.1.0
+    "@metamask/utils": ^5.0.2
     "@types/jest": ^27.4.1
     "@types/node": ^16.18.24
     async-mutex: ^0.2.6


### PR DESCRIPTION
## Description

The chain ID is now formatted internally as a `0x`-prefixed hex string. This was chosen as the internal format for these reasons:
* It allows arbitrarily large chain IDs, unlike `number`
* It can be validated at runtime, unlike decimal strings
* It can be disambiguated from decimal strings and numbers at compile-time using the `Hex` type, unlike decimal strings
* It is serializable as JSON, unlike BigInt

However, to improve readability we will use the `toHex` helper function rather than string literals, letting us read chain IDs in the source code as decimal numbers or strings.

## Changes

### `@metamask/address-book-controller`
- **BREAKING:** The `addressBook` state property is now keyed by `Hex` chain ID rather than `string`, and the `chainId` property of each address book entry is also `Hex` rather than `string`.
  - This requires a state migration
- **BREAKING:** The methods `delete` and `set` now except the chain ID as `Hex` rather than as a decimal string
- CHANGED: Add `@metamask/utils` dependency

### `@metamask/assets-controllers`
- **BREAKING:** Update `@metamask/network-controller` peerDependency
- **BREAKING:** Change format of chain ID in state to 0x-prefixed hex string
  - The functions `isTokenDetectionSupportedForNetwork` and `formatIconUrlWithProxy` now expect a chain ID as type `Hex` rather than as a decimal `string`
  - The assets contract controller now expects the `chainId` configuration entry and constructor parameter as type `Hex` rather than decimal `string`
  - The NFT controller now expects the `chainId` configuration entry and constructor parameter as type `Hex` rather than decimal `string`
  - The NFT controller methods `addNft`, `checkAndUpdateSingleNftOwnershipStatus`, `findNftByAddressAndTokenId`, `updateNft`, and `resetNftTransactionStatusByTransactionId` now expect the chain ID to be type `Hex` rather than a decimal `string`
  - The NFT controller state properties `allNftContracts` and `allNfts` are now keyed by address and `Hex` chain ID, rather than by address and decimal `string` chain ID
    - This requires a state migration
  - The NFT detection controller now expects the `chainId` configuration entry and constructor parameter as type `Hex` rather than decimal `string`
  - The token detection controller now expects the `chainId` configuration entry as type `Hex` rather than decimal `string`
  - The token list controller now expects the `chainId` constructor parameter as type `Hex` rather than decimal `string`
  - The token list controller state property `tokensChainsCache` is now keyed by `Hex` chain ID rather than by decimal `string` chain ID.
    - This requires a state migration
  - The token rates controller now expects the `chainId` configuration entry and constructor parameter as type `Hex` rather than decimal `string`
  - The token rates controller `chainId` setter now expects the chain ID as `Hex` rather than as a decimal string
  - The tokens controller now expects the `chainId` configuration entry and constructor parameter as type `Hex` rather than decimal `string`
  - The tokens controller `addDetectedTokens` method now accepts the `chainId` property of the `detectionDetails` parameter to be of type `Hex` rather than decimal `string`.
  - The tokens controller state properties `allTokens`, `allIgnoredTokens`, and `allDetectedTokens` are now keyed by chain ID in `Hex` format rather than decimal `string`.
    - This requires a state migration

### `@metamask/controller-utils`
- **BREAKING:** The `isSafeChainId` parameter `chainId` is now type `Hex` rather than `number`
- **BREAKING:** The `ChainId` enum and the `GANACHE_CHAIN_ID` constant are now formatted as 0x-prefixed hex strings rather than as decimal strings.

### `@metamask/ens-controller`
- **BREAKING:** Update `@metamask/network-controller` peerDependency
- **BREAKING:** The `ensEntries` state property is now keyed by `Hex` chain ID rather than `string`, and the `chainId` property of each ENS entry is also `Hex` rather than `string`.
  - This requires a state migration
- **BREAKING:** The methods `get`, `set`, and `delete` have been updated to accept and return chain IDs as 0x-prefixed hex strings, rather than decimal strings.

### `@metamask/gas-fee-controller`
- **BREAKING:** Update `@metamask/network-controller` peerDependency
- **BREAKING:** The `getChainId` constructor parameter now expects a `Hex` return type rather than a decimal string
- CHANGED: Add `@metamask/utils` dependency

### `@metamask/message-manager`
- **BREAKING:** The `getCurrentChainId` constructor parameter for each message manager now expects a `Hex` return type rather than a decimal string
  - Note that while every message manager class accepts this as a constructor parameter, it's only used by the `TypedMessageManager` at the moment.

### `@metamask/network-controller`
- **BREAKING:** The `providerConfig` type and state property have changed. The `chainId` property is now a 0x-prefixed hex string rather than a decimal string.
  - This requires a state migration
  - This affects the return value of the `NetworkController:getProviderConfig` and `NetworkController:getState` actions.
- **BREAKING:** The `NetworkConfiguration` type and the `networkConfigurations` state property have changed. The `chainId` property on each configuration is now a 0x-prefixed hex string rather than a decimal string.
  - This requires a state migration
  - This change affects the `upsertNetworkConfiguration` method, which takes a network configuration as the first parameter
  - This affects the return value of the `NetworkController:getState` action

### `@metamask/signature-controller`
- **BREAKING:** The constructor option `getCurrentChainId` now expects a `Hex` return value rather than `string`
- CHANGED: Add `@metamask/utils` dependency

### `@metamask/transaction-controller`
- **BREAKING:** Update `@metamask/network-controller` dependency
  - This affects the `getNetworkState` and `onNetworkStateChange` constructor parameters
- **BREAKING:** Change format of chain ID in state to 0x-prefixed hex string
  - The `chainId` property of the `Transaction` type has been changed from a number to a 0x-prefixed hex string
  - The `chainId` property of the `TransactionMeta` type has been changed from a decimal string to a 0x-prefixed hex string, and the `transaction` property has been updated along with the `Transaction` type (as described above).
  - The state property `transactions` is an array of `TransactionMeta` objects, so it has changed according to the description above.
    - This requires a state migration: each entry should have the `chainId` property converted from a decimal string to a 0x-prefixed hex string, and the `transaction.chainId` property changed from a number to a 0x-prefixed hex string.
  - The `addTransaction` and `estimateGas` methods now expect the first parameter (`transaction`) to use the 0x-prefixed hex string format for the `chainId` property.
  - The `updateTransaction` method now expects the `transactionMeta` parameter to use the 0x-prefixed hex string format for the `chainId` property (and for the nested `transaction.chainId` property)
- CHANGED: Add `@metamask/utils` dependency

## References

Closes #1209

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
