### PR TITLE
Re-enable the slack bot

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
         uses: MetaMask/action-npm-publish@v3
-        # Temporarily disabled
-        # with:
-        #   slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          target-name: metamask-npm-publishers
         env:
           SKIP_PREPACK: true
 


### PR DESCRIPTION
## Description

Now that we've landed the changes in https://github.com/MetaMask/action-npm-publish/pull/37 we can safely turn this back on _without_ pinging all of `@metamask` :upside_down_face: 