### PR TITLE
Remove `@metamask/types`

### DIFF
--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -32,7 +32,6 @@
     "@metamask/approval-controller": "workspace:^",
     "@metamask/base-controller": "workspace:^",
     "@metamask/controller-utils": "workspace:^",
-    "@metamask/types": "^1.1.0",
     "@metamask/utils": "^5.0.2",
     "@types/deep-freeze-strict": "^1.1.0",
     "deep-freeze-strict": "^1.1.1",

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -1,10 +1,9 @@
 /* eslint-enable @typescript-eslint/no-unused-vars */
-import { Mutable } from '@metamask/types';
 import deepFreeze from 'deep-freeze-strict';
 import { castDraft, Draft, Patch } from 'immer';
 import { nanoid } from 'nanoid';
 import { EthereumRpcError } from 'eth-rpc-errors';
-import { hasProperty, Json } from '@metamask/utils';
+import { hasProperty, Json, Mutable } from '@metamask/utils';
 import {
   AcceptRequest as AcceptApprovalRequest,
   AddApprovalRequest,

--- a/packages/permission-controller/src/rpc-methods/getPermissions.ts
+++ b/packages/permission-controller/src/rpc-methods/getPermissions.ts
@@ -1,8 +1,6 @@
-import type {
-  JsonRpcEngineEndCallback,
-  PendingJsonRpcResponse,
-  PermittedHandlerExport,
-} from '@metamask/types';
+import type { PendingJsonRpcResponse } from '@metamask/utils';
+import type { JsonRpcEngineEndCallback } from 'json-rpc-engine';
+import type { PermittedHandlerExport } from '../utils';
 import { MethodNames } from '../utils';
 
 import type { PermissionConstraint } from '../Permission';
@@ -10,7 +8,7 @@ import type { SubjectPermissions } from '../PermissionController';
 
 export const getPermissionsHandler: PermittedHandlerExport<
   GetPermissionsHooks,
-  void,
+  undefined,
   PermissionConstraint[]
 > = {
   methodNames: [MethodNames.getPermissions],

--- a/packages/permission-controller/src/rpc-methods/requestPermissions.ts
+++ b/packages/permission-controller/src/rpc-methods/requestPermissions.ts
@@ -1,11 +1,8 @@
 import { ethErrors } from 'eth-rpc-errors';
-import type {
-  JsonRpcEngineEndCallback,
-  JsonRpcRequest,
-  PendingJsonRpcResponse,
-  PermittedHandlerExport,
-} from '@metamask/types';
+import type { JsonRpcEngineEndCallback } from 'json-rpc-engine';
+import type { JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
 import { isPlainObject } from '@metamask/controller-utils';
+import type { PermittedHandlerExport } from '../utils';
 import { MethodNames } from '../utils';
 import { invalidParams } from '../errors';
 import type { PermissionConstraint, RequestedPermissions } from '../Permission';

--- a/packages/permission-controller/src/utils.ts
+++ b/packages/permission-controller/src/utils.ts
@@ -1,3 +1,13 @@
+import type {
+  Json,
+  JsonRpcParams,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+import type {
+  JsonRpcEngineEndCallback,
+  JsonRpcEngineNextCallback,
+} from 'json-rpc-engine';
 import {
   CaveatSpecificationConstraint,
   CaveatSpecificationMap,
@@ -25,3 +35,41 @@ export type ExtractSpecifications<
     | CaveatSpecificationMap<CaveatSpecificationConstraint>
     | PermissionSpecificationMap<PermissionSpecificationConstraint>,
 > = SpecificationsMap[keyof SpecificationsMap];
+
+/**
+ * A middleware function for handling a permitted method.
+ */
+export type HandlerMiddlewareFunction<
+  T,
+  U extends JsonRpcParams,
+  V extends Json,
+> = (
+  req: JsonRpcRequest<U>,
+  res: PendingJsonRpcResponse<V>,
+  next: JsonRpcEngineNextCallback,
+  end: JsonRpcEngineEndCallback,
+  hooks: T,
+) => void | Promise<void>;
+
+/**
+ * We use a mapped object type in order to create a type that requires the
+ * presence of the names of all hooks for the given handler.
+ * This can then be used to select only the necessary hooks whenever a method
+ * is called for purposes of POLA.
+ */
+export type HookNames<T> = {
+  [Property in keyof T]: true;
+};
+
+/**
+ * A handler for a permitted method.
+ */
+export type PermittedHandlerExport<
+  T,
+  U extends JsonRpcParams,
+  V extends Json,
+> = {
+  implementation: HandlerMiddlewareFunction<T, U, V>;
+  hookNames: HookNames<T>;
+  methodNames: string[];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,7 +1835,6 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
-    "@metamask/types": ^1.1.0
     "@metamask/utils": ^5.0.2
     "@types/deep-freeze-strict": ^1.1.0
     "@types/jest": ^27.4.1
@@ -1997,13 +1996,6 @@ __metadata:
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
-
-"@metamask/types@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@metamask/types@npm:1.1.0"
-  checksum: 500e8c076a2b0a6d688c8c465101256f090547d99c9a5585efe3d1db7a494b6b2712b127043fb316912caffc4fff78976b9a7780780abb68305e8a3bf812689c
-  languageName: node
-  linkType: hard
 
 "@metamask/utils@npm:^3.0.1, @metamask/utils@npm:^3.0.3, @metamask/utils@npm:^3.4.1":
   version: 3.6.0


### PR DESCRIPTION
## Description

The `@metamask/types` package is no longer actively maintained, so it has been removed. Most types we used to get from there were migrated to `@metamask/utils` or can be gotten from `json-rpc-engine`.

Just one type had no replacement: `PermittedHandlerExport`. Since it is specific to the permission controller anyway, it was added to that package directly.

## Changes

- CHANGED: The export `permissionRpcMethods` has a slightly different type; the second generic type variable of the `getPermissions` handler is now `undefined` rather than `void`
- CHANGED: The `@metamask/types` dependency has been removed

## References

 None
 
## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
