### PR TITLE
lookupNetwork: Drop mutex; bail on network change

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -36,7 +36,10 @@ const setupControllers = () => {
   const messenger: NetworkControllerMessenger =
     new ControllerMessenger().getRestricted({
       name: 'NetworkController',
-      allowedEvents: ['NetworkController:stateChange'],
+      allowedEvents: [
+        'NetworkController:stateChange',
+        'NetworkController:networkDidChange',
+      ],
       allowedActions: [],
     });
   const network = new NetworkController({

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -4,6 +4,7 @@ import { ControllerMessenger } from '@metamask/base-controller';
 import {
   NetworkController,
   NetworkControllerGetStateAction,
+  NetworkControllerNetworkDidChangeEvent,
   NetworkControllerStateChangeEvent,
   NetworkState,
 } from '@metamask/network-controller';
@@ -40,7 +41,9 @@ const name = 'GasFeeController';
 
 type MainControllerMessenger = ControllerMessenger<
   GetGasFeeState | NetworkControllerGetStateAction,
-  GasFeeStateChange | NetworkControllerStateChangeEvent
+  | GasFeeStateChange
+  | NetworkControllerStateChangeEvent
+  | NetworkControllerNetworkDidChangeEvent
 >;
 
 const getControllerMessenger = (): MainControllerMessenger => {
@@ -59,7 +62,10 @@ const setupNetworkController = async ({
   const restrictedMessenger = unrestrictedMessenger.getRestricted({
     name: 'NetworkController',
     allowedActions: ['NetworkController:getState'],
-    allowedEvents: ['NetworkController:stateChange'],
+    allowedEvents: [
+      'NetworkController:stateChange',
+      'NetworkController:networkDidChange',
+    ],
   });
 
   const networkController = new NetworkController({

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -811,7 +811,6 @@ describe('NetworkController', () => {
               );
             });
 
-            // This will change when the mutex is removed
             it('emits infuraIsUnblocked, not infuraIsBlocked, assuming that the first network was blocked', async () => {
               await withController(
                 {


### PR DESCRIPTION

## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

If the network is changed multiple times in quick succession, multiple "instances" of `lookupNetwork` can get run simultaneously. This happens because each time the network is changed, `lookupNetwork` is called. Because we do not expect `lookupNetwork` to run synchronously — it makes HTTP requests and waits for them to complete — and because it makes changes to the state, this creates a race condition where the state may not reflect the last network that was selected.

Currently, to resolve this problem, `lookupNetwork` makes use of a mutex. This ensures that only one "instance" of `lookupNetwork` is running at a given time. However, this trades one problem for another, because as a result, on mobile, the UI will be slow to update, as the network controller has to "process" all of the network changes one at a time.

So instead of using a mutex, a better solution is to copy the extension, which makes it such if the network is changed while HTTP requests are being awaited, no state changes will occur. This still guarantees that later network changes override earlier ones while removing the bottleneck.

Notable changes that I found while adding tests for this new behavior:

- When on an Infura network and the network is switched to a non-Infura network during a request for `net_version` or `eth_getBlockByNumber`, and Infura is blocking requests, `infuraIsBlocked` will no longer be emitted.
- Similarly, when on a non-Infura network and the network is switched to a Infura network during a request for `net_version` or `eth_getBlockByNumber`, and Infura is blocking requests, `infuraIsUnblocked` will no longer be emitted.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

### `@metamask/network-controller`

- **FIXED:** Removed bottleneck on `lookupNetwork` so that it will no longer block on multiple simultaneous calls but will abort if a network change is detected midway through execution.
  - This means that clients are able to visually respond to rapid network switches more quickly.
  - This also has consequences for when `infuraIsBlocked` or `infuraIsUnblocked` is emitted. Notably, when on an Infura network and the network is switched to a non-Infura network during a request for `net_version` or `eth_getBlockByNumber`, and Infura is blocking requests, `infuraIsBlocked` will no longer be emitted. Similarly, when on a non-Infura network and the network is switched to a Infura network during a request for `net_version` or `eth_getBlockByNumber`, and Infura is blocking requests, `infuraIsUnblocked` will no longer be emitted.

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Fixes https://github.com/MetaMask/core/issues/1206.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
