### PR TITLE
Migrate KeyringController to BaseControllerV2

### DIFF
--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -48,7 +48,7 @@
     "@metamask/scure-bip39": "^2.1.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
-    "immer": "^10.0.2",
+    "immer": "^9.0.6",
     "jest": "^27.5.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -48,6 +48,7 @@
     "@metamask/scure-bip39": "^2.1.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
+    "immer": "^10.0.2",
     "jest": "^27.5.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -38,7 +38,8 @@
     "@metamask/preferences-controller": "workspace:^",
     "async-mutex": "^0.2.6",
     "ethereumjs-util": "^7.0.10",
-    "ethereumjs-wallet": "^1.0.1"
+    "ethereumjs-wallet": "^1.0.1",
+    "immer": "^9.0.6"
   },
   "devDependencies": {
     "@ethereumjs/common": "^2.6.1",
@@ -48,7 +49,6 @@
     "@metamask/scure-bip39": "^2.1.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
-    "immer": "^9.0.6",
     "jest": "^27.5.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -1079,8 +1079,8 @@ describe('KeyringController', () => {
           await withController(
             { cacheEncryptionKey },
             async ({ controller, initialState }) => {
-              const recoveredState = await controller.submitPassword(password);
-              expect(recoveredState).toStrictEqual(initialState);
+              await controller.submitPassword(password);
+              expect(controller.state).toStrictEqual(initialState);
             },
           );
         });
@@ -1114,11 +1114,11 @@ describe('KeyringController', () => {
       await withController(
         { cacheEncryptionKey: true },
         async ({ controller, initialState }) => {
-          const recoveredState = await controller.submitEncryptionKey(
+          await controller.submitEncryptionKey(
             mockKey.toString('hex'),
             initialState.encryptionSalt as string,
           );
-          expect(recoveredState).toStrictEqual(initialState);
+          expect(controller.state).toStrictEqual(initialState);
         },
       );
     });
@@ -1714,12 +1714,12 @@ async function withController<ReturnValue>(
     ...preferences,
     ...rest,
   });
-  const initialState = await controller.createNewVaultAndKeychain(password);
+  await controller.createNewVaultAndKeychain(password);
   return await fn({
     controller,
     preferences,
     encryptor,
-    initialState,
+    initialState: controller.state,
     messenger,
   });
 }

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -23,7 +23,7 @@ import {
   KeyringControllerEvents,
   KeyringControllerMessenger,
   KeyringControllerConfig,
-  KeyringState,
+  KeyringControllerState,
   KeyringTypes,
 } from './KeyringController';
 
@@ -1666,7 +1666,7 @@ type WithControllerCallback<ReturnValue> = ({
     setSelectedAddress: sinon.SinonStub;
   };
   encryptor: MockEncryptor;
-  initialState: KeyringState;
+  initialState: KeyringControllerState;
   messenger: KeyringControllerMessenger;
 }) => Promise<ReturnValue> | ReturnValue;
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -22,7 +22,7 @@ import {
   KeyringObject,
   KeyringControllerEvents,
   KeyringControllerMessenger,
-  KeyringControllerOptions,
+  KeyringControllerConfig,
   KeyringState,
   KeyringTypes,
 } from './KeyringController';
@@ -255,12 +255,11 @@ describe('KeyringController', () => {
             await withController(
               { cacheEncryptionKey },
               async ({ controller, initialState, preferences, encryptor }) => {
-                const cleanKeyringController = new KeyringController({
+                const cleanKeyringController = new KeyringController(
                   preferences,
-                  cacheEncryptionKey,
-                  encryptor,
-                  messenger: buildKeyringControllerMessenger(),
-                });
+                  buildKeyringControllerMessenger(),
+                  { cacheEncryptionKey, encryptor },
+                );
                 const initialSeedWord = await controller.exportSeedPhrase(
                   password,
                 );
@@ -1671,7 +1670,7 @@ type WithControllerCallback<ReturnValue> = ({
   messenger: KeyringControllerMessenger;
 }) => Promise<ReturnValue> | ReturnValue;
 
-type WithControllerOptions = Partial<KeyringControllerOptions>;
+type WithControllerOptions = Partial<KeyringControllerConfig>;
 
 type WithControllerArgs<ReturnValue> =
   | [WithControllerCallback<ReturnValue>]
@@ -1724,11 +1723,9 @@ async function withController<ReturnValue>(
     setSelectedAddress: sinon.stub(),
   };
   const messenger = buildKeyringControllerMessenger();
-  const controller = new KeyringController({
-    preferences,
+  const controller = new KeyringController(preferences, messenger, {
     encryptor,
     cacheEncryptionKey: false,
-    messenger,
     ...rest,
   });
   const initialState = await controller.createNewVaultAndKeychain(password);

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -22,9 +22,9 @@ import {
   KeyringObject,
   KeyringControllerEvents,
   KeyringControllerMessenger,
-  KeyringControllerConfig,
   KeyringControllerState,
   KeyringTypes,
+  KeyringControllerOptions,
 } from './KeyringController';
 
 jest.mock('uuid', () => {
@@ -248,11 +248,12 @@ describe('KeyringController', () => {
             await withController(
               { cacheEncryptionKey },
               async ({ controller, initialState, preferences, encryptor }) => {
-                const cleanKeyringController = new KeyringController(
-                  preferences,
-                  buildKeyringControllerMessenger(),
-                  { cacheEncryptionKey, encryptor },
-                );
+                const cleanKeyringController = new KeyringController({
+                  ...preferences,
+                  messenger: buildKeyringControllerMessenger(),
+                  cacheEncryptionKey,
+                  encryptor,
+                });
                 const initialSeedWord = await controller.exportSeedPhrase(
                   password,
                 );
@@ -1649,7 +1650,7 @@ type WithControllerCallback<ReturnValue> = ({
   messenger: KeyringControllerMessenger;
 }) => Promise<ReturnValue> | ReturnValue;
 
-type WithControllerOptions = Partial<KeyringControllerConfig>;
+type WithControllerOptions = Partial<KeyringControllerOptions>;
 
 type WithControllerArgs<ReturnValue> =
   | [WithControllerCallback<ReturnValue>]
@@ -1706,9 +1707,11 @@ async function withController<ReturnValue>(
     setSelectedAddress: sinon.stub(),
   };
   const messenger = buildKeyringControllerMessenger();
-  const controller = new KeyringController(preferences, messenger, {
+  const controller = new KeyringController({
     encryptor,
     cacheEncryptionKey: false,
+    messenger,
+    ...preferences,
     ...rest,
   });
   const initialState = await controller.createNewVaultAndKeychain(password);

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -286,7 +286,6 @@ describe('KeyringController', () => {
               expect(controller.state.keyrings).not.toStrictEqual([]);
               const keyring = controller.state.keyrings[0];
               expect(keyring.accounts).not.toStrictEqual([]);
-              expect(keyring.index).toStrictEqual(0);
               expect(keyring.type).toStrictEqual('HD Key Tree');
               expect(controller.state.vault).toBeDefined();
             });
@@ -1106,19 +1105,6 @@ describe('KeyringController', () => {
           expect(recoveredState).toStrictEqual(initialState);
         },
       );
-    });
-  });
-
-  describe('subscribe and unsubscribe', () => {
-    it('should fire stateChange event', async () => {
-      await withController(async ({ controller, messenger }) => {
-        const listener = sinon.stub();
-        messenger.subscribe('KeyringController:stateChange', listener);
-
-        await controller.fullUpdate();
-
-        expect(listener.called).toBe(true);
-      });
     });
   });
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -222,7 +222,6 @@ export class KeyringController extends BaseControllerV2<
     this.#keyring = new EthKeyringController(
       Object.assign({ initState: state }, config),
     );
-    this.#keyring.store.subscribe(this.#fullUpdate.bind(this));
     this.#keyring.memStore.subscribe(this.#fullUpdate.bind(this));
 
     this.removeIdentity = removeIdentity;
@@ -704,13 +703,11 @@ export class KeyringController extends BaseControllerV2<
   }
 
   /**
-   * Sync controller state with current keyring
-   * store and memStore state.
+   * Sync controller state with current keyring memStore state.
    *
    */
   #fullUpdate() {
     this.update(() => ({
-      ...this.#keyring.store.getState(),
       ...this.#keyring.memStore.getState(),
     }));
   }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -109,16 +109,17 @@ export type KeyringControllerMessenger = RestrictedControllerMessenger<
   string
 >;
 
-/**
- * @type KeyringControllerConfig
- *
- * Keyring controller configuration
- * @property encryptor - Keyring encryptor
- */
-export type KeyringControllerConfig = {
+export type KeyringControllerOptions = {
+  removeIdentity: PreferencesController['removeIdentity'];
+  syncIdentities: PreferencesController['syncIdentities'];
+  updateIdentities: PreferencesController['updateIdentities'];
+  setSelectedAddress: PreferencesController['setSelectedAddress'];
+  setAccountLabel?: PreferencesController['setAccountLabel'];
   encryptor?: any;
   keyringBuilders?: any[];
   cacheEncryptionKey?: boolean;
+  messenger: KeyringControllerMessenger;
+  state?: Partial<KeyringControllerState>;
 };
 
 /**
@@ -189,34 +190,30 @@ export class KeyringController extends BaseControllerV2<
   /**
    * Creates a KeyringController instance.
    *
-   * @param options - The controller options.
-   * @param options.removeIdentity - Remove the identity with the given address.
-   * @param options.syncIdentities - Sync identities with the given list of addresses.
-   * @param options.updateIdentities - Generate an identity for each address given that doesn't already have an identity.
-   * @param options.setSelectedAddress - Set the selected address.
-   * @param options.setAccountLabel - Set a new name for account.
-   * @param messenger - A restricted controller messenger.
-   * @param config - Initial options used to configure this controller.
-   * @param state - Initial state to set on this controller.
+   * @param opts - Initial options used to configure this controller
+   * @param opts.removeIdentity - Remove the identity with the given address.
+   * @param opts.syncIdentities - Sync identities with the given list of addresses.
+   * @param opts.updateIdentities - Generate an identity for each address given that doesn't already have an identity.
+   * @param opts.setSelectedAddress - Set the selected address.
+   * @param opts.setAccountLabel - Set a new name for account.
+   * @param opts.encryptor - An optional object for defining encryption schemes.
+   * @param opts.keyringBuilders - Set a new name for account.
+   * @param opts.cacheEncryptionKey - Whether to cache or not encryption key.
+   * @param opts.messenger - A restricted controller messenger.
+   * @param opts.state - Initial state to set on this controller.
    */
-  constructor(
-    {
-      removeIdentity,
-      syncIdentities,
-      updateIdentities,
-      setSelectedAddress,
-      setAccountLabel,
-    }: {
-      removeIdentity: PreferencesController['removeIdentity'];
-      syncIdentities: PreferencesController['syncIdentities'];
-      updateIdentities: PreferencesController['updateIdentities'];
-      setSelectedAddress: PreferencesController['setSelectedAddress'];
-      setAccountLabel?: PreferencesController['setAccountLabel'];
-    },
-    messenger: KeyringControllerMessenger,
-    config?: KeyringControllerConfig,
-    state?: Partial<KeyringControllerState>,
-  ) {
+  constructor({
+    removeIdentity,
+    syncIdentities,
+    updateIdentities,
+    setSelectedAddress,
+    setAccountLabel,
+    encryptor,
+    keyringBuilders,
+    cacheEncryptionKey,
+    messenger,
+    state,
+  }: KeyringControllerOptions) {
     super({
       name,
       metadata: {
@@ -233,7 +230,10 @@ export class KeyringController extends BaseControllerV2<
     });
 
     this.#keyring = new EthKeyringController(
-      Object.assign({ initState: state }, config),
+      Object.assign(
+        { initState: state },
+        { encryptor, keyringBuilders, cacheEncryptionKey },
+      ),
     );
     this.#keyring.memStore.subscribe(this.#fullUpdate.bind(this));
     this.#keyring.store.subscribe(this.#fullUpdate.bind(this));

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -236,6 +236,7 @@ export class KeyringController extends BaseControllerV2<
       Object.assign({ initState: state }, config),
     );
     this.#keyring.memStore.subscribe(this.#fullUpdate.bind(this));
+    this.#keyring.store.subscribe(this.#fullUpdate.bind(this));
     this.#keyring.on('lock', this.#handleLock.bind(this));
     this.#keyring.on('unlock', this.#handleUnlock.bind(this));
 
@@ -822,12 +823,14 @@ export class KeyringController extends BaseControllerV2<
   }
 
   /**
-   * Sync controller state with current keyring memStore state.
+   * Sync controller state with current keyring store
+   * and memStore states.
    *
    * @fires KeyringController:stateChange
    */
   #fullUpdate() {
     this.update(() => ({
+      ...this.#keyring.store.getState(),
       ...this.#keyring.memStore.getState(),
     }));
   }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -357,7 +357,7 @@ export class KeyringController extends BaseControllerV2<
    * @returns Boolean returning true if the vault is unlocked.
    */
   isUnlocked(): boolean {
-    return this.#keyring.memStore.getState().isUnlocked;
+    return this.state.isUnlocked;
   }
 
   /**

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -220,8 +220,8 @@ export class KeyringController extends BaseControllerV2<
     super({
       name,
       metadata: {
-        vault: { persist: false, anonymous: false },
-        isUnlocked: { persist: false, anonymous: false },
+        vault: { persist: true, anonymous: false },
+        isUnlocked: { persist: false, anonymous: true },
         keyringTypes: { persist: false, anonymous: false },
         keyrings: { persist: false, anonymous: false },
       },

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -858,6 +858,13 @@ export class KeyringController extends BaseController<
     await this.#keyring.persistAllKeyrings();
     await this.fullUpdate();
   }
+
+  async submitEncryptionKey(
+    encryptionKey: string,
+    encryptionSalt: string,
+  ): Promise<KeyringMemState> {
+    return this.#keyring.submitEncryptionKey(encryptionKey, encryptionSalt);
+  }
 }
 
 export default KeyringController;

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -280,7 +280,7 @@ export class KeyringController extends BaseControllerV2<
       // we return the account already existing at index `accountCount`
       const primaryKeyringAccounts = await primaryKeyring.getAccounts();
       return {
-        keyringState: this.state,
+        keyringState: this.#getMemState(),
         addedAccountAddress: primaryKeyringAccounts[accountCount],
       };
     }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -221,6 +221,8 @@ export class KeyringController extends BaseControllerV2<
         isUnlocked: { persist: false, anonymous: true },
         keyringTypes: { persist: false, anonymous: false },
         keyrings: { persist: false, anonymous: false },
+        encryptionKey: { persist: false, anonymous: false },
+        encryptionSalt: { persist: false, anonymous: false },
       },
       messenger,
       state: {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -858,13 +858,6 @@ export class KeyringController extends BaseController<
     await this.#keyring.persistAllKeyrings();
     await this.fullUpdate();
   }
-
-  async submitEncryptionKey(
-    encryptionKey: string,
-    encryptionSalt: string,
-  ): Promise<KeyringMemState> {
-    return this.#keyring.submitEncryptionKey(encryptionKey, encryptionSalt);
-  }
 }
 
 export default KeyringController;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,6 +1725,7 @@ __metadata:
     deepmerge: ^4.2.2
     ethereumjs-util: ^7.0.10
     ethereumjs-wallet: ^1.0.1
+    immer: ^10.0.2
     jest: ^27.5.1
     sinon: ^9.2.4
     ts-jest: ^27.1.4
@@ -5816,6 +5817,13 @@ __metadata:
   version: 3.2.3
   resolution: "immediate@npm:3.2.3"
   checksum: 9867dc70794f3aa246a90afe8a0166607590b687e8c572839ff2342292ac2da4b1cdfd396d38f7b9e72625d817d601e73c33c2874e9c0b8e0f1d6658b3c03496
+  languageName: node
+  linkType: hard
+
+"immer@npm:^10.0.2":
+  version: 10.0.2
+  resolution: "immer@npm:10.0.2"
+  checksum: 525a3b14210d02ae420c3b9f6ca14f7e9bcf625611d1356e773e7739f14c7c8de50dac442e6c7de3a6e24a782f7b792b6b8666bc0b3f00269d21a95f8f68ca84
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,7 +1725,7 @@ __metadata:
     deepmerge: ^4.2.2
     ethereumjs-util: ^7.0.10
     ethereumjs-wallet: ^1.0.1
-    immer: ^10.0.2
+    immer: ^9.0.6
     jest: ^27.5.1
     sinon: ^9.2.4
     ts-jest: ^27.1.4
@@ -5817,13 +5817,6 @@ __metadata:
   version: 3.2.3
   resolution: "immediate@npm:3.2.3"
   checksum: 9867dc70794f3aa246a90afe8a0166607590b687e8c572839ff2342292ac2da4b1cdfd396d38f7b9e72625d817d601e73c33c2874e9c0b8e0f1d6658b3c03496
-  languageName: node
-  linkType: hard
-
-"immer@npm:^10.0.2":
-  version: 10.0.2
-  resolution: "immer@npm:10.0.2"
-  checksum: 525a3b14210d02ae420c3b9f6ca14f7e9bcf625611d1356e773e7739f14c7c8de50dac442e6c7de3a6e24a782f7b792b6b8666bc0b3f00269d21a95f8f68ca84
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR refactors `KeyringController` to extend `BaseControllerV2`. 

This controller's state is completely non-persistent and is kept in sync with the inner `EthKeyringController`'s memStore through event subscription. For this reason, the `fullUpdate` method is now unnecessary and has been removed - Tests have been refactored to use controller state for assertions so that this mechanism is implicitly well covered. 

All the methods that returned `fullUpdate`, now return the `KeyringController`'s state with `vault`, `encryptionKey` and `encryptionSalt` removed as sensitive data; these parameters can always be found with `KeyringController.state`  

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **BREAKING:** KeyringController now inherits from BaseControllerV2
  - The constructor takes a single argument, an options bag, instead of three arguments
  - The state of the controller is accessible via `controller.state` instead of `controller.store.getState()`
  - KeyringController now expects a `messenger` option (and corresponding type KeyringControllerMessenger is now available)
  - The messenger will now publish `KeyringController:getState` and `KeyringController:stateChange` events (and corresponding types KeyringControllerGetStateAction and KeyringControllerStateChangeEvent are now available)
  - Removed KeyringState, KeyringMemState, and KeyringConfig in favor of new types KeyringControllerState, KeyringControllerActions, KeyringControllerEvents, and KeyringControllerOptions
    - KeyringControllerState is like the previous KeyringMemState but with an extra `vault` property
    - KeyringControllerOptions incorporates the previous set of options and the KeyringConfig
  - Added `immer` as a dependency
- **BREAKING:** Removed `index` from the Keyring type
- **BREAKING:** The `keyringState` property in the return value of `addNewAccount`, `addNewAccountWithoutUpdate`, `createNewVaultAndRestore`, `createNewVaultAndKeychain`, `importAccountWithStrategy`, `removeAccount`, `setLocked`, `submitEncryptionKey`, and `submitPassword` is now a type of KeyringControllerMemState instead of KeyringMemState (and may omit `vault`, `encryptionKey`, and `encryptionSalt`)
- **BREAKING:** Removed `subscribe` and `unsubscribe` methods
  - State changes can be directly subscribed to (or unsubscribed from) via the messenger if necessary.
- **BREAKING:** Removed `lock` and `unlock` methods
  - `KeyringController:lock` and `KeyringController:unlock` may now be subscribed to via the messenger if necessary.
- **BREAKING:** Removed `fullUpdate` method
  - There is no need to call this method anymore because the controller should always be up to date with the EthKeyringController instance.
- **ADDED:** Added KeyringControllerMemState type
  - This is like the previous KeyringMemState but without `encryptionKey` or `encryptionSalt`
- **ADDED:** Added messenger events `NetworkController:lock` and `NetworkController:unlock` (and corresponding types KeyringControllerLockEvent and KeyringControllerUnlockEvent)
  - The messenger will publish `NetworkController:lock` when the inner EthKeyringController instance publishes its `lock` event and `NetworkController:unlock` when it publishes its `unlock` event
## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes #1258 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
