### PR TITLE
Update network details even when ID matches

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -514,9 +514,6 @@ export class NetworkController extends BaseControllerV2<
         this.#getNetworkId(),
         this.#determineEIP1559Compatibility(),
       ]);
-      if (this.state.networkId === networkId) {
-        return;
-      }
       updatedNetworkStatus = NetworkStatus.Available;
       updatedNetworkId = networkId;
       updatedIsEIP1559Compatible = isEIP1559Compatible;

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -5733,6 +5733,58 @@ function lookupNetworkTests({
               },
             );
           });
+
+          it('updates the network details', async () => {
+            await withController(
+              {
+                state: initialState,
+              },
+              async ({ controller }) => {
+                await setFakeProvider(controller, {
+                  stubs: [
+                    // Called during provider initialization
+                    {
+                      request: {
+                        method: 'net_version',
+                      },
+                      response: { result: networkId },
+                    },
+                    {
+                      request: {
+                        method: 'eth_getBlockByNumber',
+                      },
+                      response: {
+                        result: PRE_1559_BLOCK,
+                      },
+                    },
+                    // Called via `lookupNetwork` directly
+                    {
+                      request: {
+                        method: 'net_version',
+                      },
+                      response: { result: networkId },
+                    },
+                    {
+                      request: {
+                        method: 'eth_getBlockByNumber',
+                      },
+                      response: {
+                        result: POST_1559_BLOCK,
+                      },
+                    },
+                  ],
+                });
+
+                await operation(controller);
+
+                await expect(controller.state.networkDetails).toStrictEqual({
+                  EIPS: {
+                    1559: true,
+                  },
+                });
+              },
+            );
+          });
         });
       });
     }


### PR DESCRIPTION
## Description

The `lookupNetwork` method has been updated to ensure the network details are updated correctly even when the network ID is the same as before.

A test has been added to confirm that this works. It was failing before this change.

When writing this test, I noticed that the previous test was broken as well. It was passing but it didn't setup the test scenario correctly (the network ID was changing, but it was expected not to). It has been fixed as well.

## Changes

- FIXED: Update network details even when the network ID remains unchanged

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
