### PR TITLE
Support hex and number `net_version` responses

### DIFF
--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -5682,55 +5682,60 @@ function lookupNetworkTests({
   operation: (controller: NetworkController) => Promise<void>;
 }) {
   describe('if the network ID and network details requests resolve successfully', () => {
-    describe('if the current network is different from the network in state', () => {
-      it('updates the network in state to match', async () => {
-        await withController(
-          {
-            state: initialState,
-          },
-          async ({ controller }) => {
-            await setFakeProvider(controller, {
-              stubs: [
-                {
-                  request: { method: 'net_version' },
-                  response: { result: '12345' },
-                },
-              ],
-              stubLookupNetworkWhileSetting: true,
-            });
+    const validNetworkIds = [12345, '12345', toHex(12345)];
+    for (const networkId of validNetworkIds) {
+      describe(`with a network id of '${networkId}'`, () => {
+        describe('if the current network is different from the network in state', () => {
+          it('updates the network in state to match', async () => {
+            await withController(
+              {
+                state: initialState,
+              },
+              async ({ controller }) => {
+                await setFakeProvider(controller, {
+                  stubs: [
+                    {
+                      request: { method: 'net_version' },
+                      response: { result: networkId },
+                    },
+                  ],
+                  stubLookupNetworkWhileSetting: true,
+                });
 
-            await operation(controller);
+                await operation(controller);
 
-            expect(controller.state.networkId).toBe('12345');
-          },
-        );
+                expect(controller.state.networkId).toBe('12345');
+              },
+            );
+          });
+        });
+
+        describe('if the version of the current network is the same as that in state', () => {
+          it('does not change network ID in state', async () => {
+            await withController(
+              {
+                state: initialState,
+              },
+              async ({ controller }) => {
+                await setFakeProvider(controller, {
+                  stubs: [
+                    {
+                      request: { method: 'net_version' },
+                      response: { result: networkId },
+                    },
+                  ],
+                  stubLookupNetworkWhileSetting: true,
+                });
+
+                await operation(controller);
+
+                await expect(controller.state.networkId).toBe('12345');
+              },
+            );
+          });
+        });
       });
-    });
-
-    describe('if the version of the current network is the same as that in state', () => {
-      it('does not change network ID in state', async () => {
-        await withController(
-          {
-            state: initialState,
-          },
-          async ({ controller }) => {
-            await setFakeProvider(controller, {
-              stubs: [
-                {
-                  request: { method: 'net_version' },
-                  response: { result: '12345' },
-                },
-              ],
-              stubLookupNetworkWhileSetting: true,
-            });
-
-            await operation(controller);
-
-            await expect(controller.state.networkId).toBe('12345');
-          },
-        );
-      });
-    });
+    }
 
     describe('if the network details of the current network are different from the network details in state', () => {
       it('updates the network in state to match', async () => {


### PR DESCRIPTION
## Description

Hex and number responses from the `net_version` request are now accepted. While most chains return decimal strings for this request, some chains were returning hex responses instead and failing our validation for this request.

Support for number responses was added because it likely worked in older versions of the extension  as well, so support is maintained to avoid similar problems.

## Changes

- CHANGED: Support hex and number responses to `net_version` requests

## References

This is a port of the extension PR: https://github.com/MetaMask/metamask-extension/pull/19156

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
