### PR TITLE
Sync NetworkController constructor tests w/ extension

### DIFF
--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -162,6 +162,24 @@ describe('NetworkController', () => {
   });
 
   describe('constructor', () => {
+    const invalidInfuraProjectIds = [undefined, null, {}, 1];
+    invalidInfuraProjectIds.forEach((invalidProjectId) => {
+      it(`throws given an invalid Infura ID of "${inspect(
+        invalidProjectId,
+      )}"`, () => {
+        const messenger = buildMessenger();
+        const restrictedMessenger = buildNetworkControllerMessenger(messenger);
+        expect(
+          () =>
+            new NetworkController({
+              messenger: restrictedMessenger,
+              // @ts-expect-error We are intentionally passing bad input.
+              infuraProjectId: invalidProjectId,
+            }),
+        ).toThrow('Invalid Infura project ID');
+      });
+    });
+
     it('initializes the state with some defaults', async () => {
       await withController(({ controller }) => {
         expect(controller.state).toStrictEqual({
@@ -203,29 +221,6 @@ describe('NetworkController', () => {
           });
         },
       );
-    });
-
-    it('throws if the infura project ID is missing', async () => {
-      expect(
-        () =>
-          // @ts-expect-error Required parameter intentionally omitted
-          new NetworkController({
-            messenger: buildNetworkControllerMessenger(),
-            trackMetaMetricsEvent: jest.fn(),
-          }),
-      ).toThrow('Invalid Infura project ID');
-    });
-
-    it('throws if the infura project ID is not a string', async () => {
-      expect(
-        () =>
-          new NetworkController({
-            messenger: buildNetworkControllerMessenger(),
-            trackMetaMetricsEvent: jest.fn(),
-            // @ts-expect-error Required parameter intentionally omitted
-            infuraProjectId: 10,
-          }),
-      ).toThrow('Invalid Infura project ID');
     });
   });
 


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This makes it easier to visually compare differences in the
NetworkController unit tests between extension and this repo.


## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

(None)

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Progresses https://github.com/MetaMask/core/issues/1197.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
