### PR TITLE
Add `getKeyringForAccount` method

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -1,5 +1,6 @@
 import { bufferToHex } from 'ethereumjs-util';
 import {
+  normalize,
   recoverPersonalSignature,
   recoverTypedSignature,
   SignTypedDataVersion,
@@ -19,6 +20,7 @@ import {
   KeyringConfig,
   KeyringController,
   KeyringMemState,
+  KeyringObject,
   KeyringTypes,
 } from './KeyringController';
 
@@ -404,6 +406,34 @@ describe('KeyringController', () => {
         const initialAccount = initialState.keyrings[0].accounts;
         const accounts = await controller.getAccounts();
         expect(accounts).toStrictEqual(initialAccount);
+      });
+    });
+  });
+
+  describe('getKeyringForAccount', () => {
+    describe('when existing account is provided', () => {
+      it('should get correct keyring', async () => {
+        await withController(async ({ controller }) => {
+          const normalizedInitialAccounts =
+            controller.state.keyrings[0].accounts.map(normalize);
+          const keyring = (await controller.getKeyringForAccount(
+            normalizedInitialAccounts[0],
+          )) as KeyringObject;
+          expect(keyring.type).toBe('HD Key Tree');
+          expect(keyring.getAccounts()).toStrictEqual(
+            normalizedInitialAccounts,
+          );
+        });
+      });
+    });
+
+    describe('when non-existing account is provided', () => {
+      it('should throw error', async () => {
+        await withController(async ({ controller }) => {
+          await expect(controller.getKeyringForAccount('0x0')).rejects.toThrow(
+            'No keyring found for the requested account. Error info: There are keyrings, but none match the address',
+          );
+        });
       });
     });
   });

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -376,6 +376,17 @@ export class KeyringController extends BaseController<
   }
 
   /**
+   * Returns the currently initialized keyring that manages
+   * the specified `address` if one exists.
+   *
+   * @param account - An account address.
+   * @returns Promise resolving to keyring of the `account` if one exists.
+   */
+  async getKeyringForAccount(account: string): Promise<unknown> {
+    return this.#keyring.getKeyringForAccount(account);
+  }
+
+  /**
    * Imports an account with the specified import strategy.
    *
    * @param strategy - Import strategy name.


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR adds the `getKeyringForAccount` method on `KeyringController`.

This method calls the homonym `EthKeyringController` method, which returns the Keyring including the provided account. Throws an error when no matching keyring is found.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **ADDED**: `getKeyringForAccount` method

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes: #1256

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
