### PR TITLE
Make PermissionController `unrestrictedMethods` constructor arg readonly

### DIFF
--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -490,7 +490,7 @@ function getPermissionControllerMessenger(
  * @returns The unrestricted methods array
  */
 function getDefaultUnrestrictedMethods() {
-  return ['wallet_unrestrictedMethod'];
+  return Object.freeze(['wallet_unrestrictedMethod']);
 }
 
 /**

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -476,7 +476,7 @@ export type PermissionControllerOptions<
   messenger: PermissionControllerMessenger;
   caveatSpecifications: CaveatSpecificationMap<ControllerCaveatSpecification>;
   permissionSpecifications: PermissionSpecificationMap<ControllerPermissionSpecification>;
-  unrestrictedMethods: string[];
+  unrestrictedMethods: readonly string[];
   state?: Partial<
     PermissionControllerState<
       ExtractPermission<


### PR DESCRIPTION
## Description
In the extension we pass a frozen array to the PermissionController, but TypeScript complains that it is expecting a mutable array, since we haven't specified the array to be readonly. This PR fixes that.

This shouldn't change anything functionally, merely correcting a type error.

## Changes
- **Changed**: Make PermissionController `unrestrictedMethods` constructor arg `readonly`

