### PR TITLE
Use Jest snapshots for testing initial NetworkController state

### DIFF
--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -182,17 +182,22 @@ describe('NetworkController', () => {
 
     it('initializes the state with some defaults', async () => {
       await withController(({ controller }) => {
-        expect(controller.state).toStrictEqual({
-          networkConfigurations: {},
-          networkId: null,
-          networkStatus: NetworkStatus.Unknown,
-          providerConfig: { type: NetworkType.mainnet, chainId: toHex(1) },
-          networkDetails: {
-            EIPS: {
-              1559: false,
+        expect(controller.state).toMatchInlineSnapshot(`
+          Object {
+            "networkConfigurations": Object {},
+            "networkDetails": Object {
+              "EIPS": Object {
+                "1559": false,
+              },
             },
-          },
-        });
+            "networkId": null,
+            "networkStatus": "unknown",
+            "providerConfig": Object {
+              "chainId": "0x1",
+              "type": "mainnet",
+            },
+          }
+        `);
       });
     });
 
@@ -200,6 +205,12 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
+            providerConfig: {
+              type: 'rpc',
+              rpcUrl: 'http://example-custom-rpc.metamask.io',
+              chainId: '0x9999' as const,
+              nickname: 'Test initial state',
+            },
             networkDetails: {
               EIPS: {
                 1559: true,
@@ -208,17 +219,24 @@ describe('NetworkController', () => {
           },
         },
         ({ controller }) => {
-          expect(controller.state).toStrictEqual({
-            networkConfigurations: {},
-            networkId: null,
-            networkStatus: NetworkStatus.Unknown,
-            providerConfig: { type: NetworkType.mainnet, chainId: toHex(1) },
-            networkDetails: {
-              EIPS: {
-                1559: true,
+          expect(controller.state).toMatchInlineSnapshot(`
+            Object {
+              "networkConfigurations": Object {},
+              "networkDetails": Object {
+                "EIPS": Object {
+                  "1559": true,
+                },
               },
-            },
-          });
+              "networkId": null,
+              "networkStatus": "unknown",
+              "providerConfig": Object {
+                "chainId": "0x9999",
+                "nickname": "Test initial state",
+                "rpcUrl": "http://example-custom-rpc.metamask.io",
+                "type": "rpc",
+              },
+            }
+          `);
         },
       );
     });


### PR DESCRIPTION


## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

The extension version of the tests for NetworkController use Jest snapshots to verify that the controller has the correct initial state after being constructed. This updates the tests to match.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

(None)

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Progresses https://github.com/MetaMask/core/issues/1197.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
