### PR TITLE
Add Europa Liquidity Hub | SKALE to the token detection networks list

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -33,6 +33,8 @@ export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID: Record<Hex, string> = {
     '0xD023D153a0DFa485130ECFdE2FAA7e612EF94818',
   [SupportedTokenDetectionNetworks.aurora]:
     '0x1286415D333855237f89Df27D388127181448538',
+  [SupportedTokenDetectionNetworks.europa_skale]:
+    '0xb44d3D2865841F4051332AF90EbE028e01f92f7C',
 };
 
 export const MISSING_PROVIDER_ERROR =

--- a/packages/assets-controllers/src/assetsUtil.test.ts
+++ b/packages/assets-controllers/src/assetsUtil.test.ts
@@ -269,6 +269,14 @@ describe('assetsUtil', () => {
       ).toBe(true);
     });
 
+    it('returns true for the Europa Liquidity Hub | SKALE network', () => {
+      expect(
+        assetsUtil.isTokenDetectionSupportedForNetwork(
+          assetsUtil.SupportedTokenDetectionNetworks.europa_skale,
+        ),
+      ).toBe(true);
+    });
+
     it('returns false for testnets such as Goerli', () => {
       expect(assetsUtil.isTokenDetectionSupportedForNetwork(toHex(5))).toBe(
         false,

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -145,6 +145,7 @@ export enum SupportedTokenDetectionNetworks {
   polygon = '0x89', // decimal: 137
   avax = '0xa86a', // decimal: 43114
   aurora = '0x4e454152', // decimal: 1313161554
+  europa_skale = '0x79f99296', // decimal: 2046399126
 }
 
 /**


### PR DESCRIPTION
Add support of Europa Liquidity Hub | SKALE as a network with token detection availability