### PR TITLE
Reset network details when lookupNetwork request fails

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -507,7 +507,7 @@ export class NetworkController extends BaseControllerV2<
 
     let updatedNetworkStatus: NetworkStatus;
     let updatedNetworkId: NetworkId | null = null;
-    let updatedIsEIP1559Compatible = false;
+    let updatedIsEIP1559Compatible: boolean | undefined;
 
     try {
       const [networkId, isEIP1559Compatible] = await Promise.all([
@@ -561,7 +561,11 @@ export class NetworkController extends BaseControllerV2<
     this.update((state) => {
       state.networkId = updatedNetworkId;
       state.networkStatus = updatedNetworkStatus;
-      state.networkDetails.EIPS[1559] = updatedIsEIP1559Compatible;
+      if (updatedIsEIP1559Compatible === undefined) {
+        delete state.networkDetails.EIPS[1559];
+      } else {
+        state.networkDetails.EIPS[1559] = updatedIsEIP1559Compatible;
+      }
     });
 
     if (isInfura) {

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -6064,6 +6064,58 @@ function lookupNetworkTests({
       );
     });
 
+    it('resets the network details in state', async () => {
+      await withController(
+        {
+          state: initialState,
+        },
+        async ({ controller }) => {
+          await setFakeProvider(controller, {
+            stubs: [
+              // Called during provider initialization
+              {
+                request: { method: 'net_version' },
+                response: SUCCESSFUL_NET_VERSION_RESPONSE,
+              },
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                response: {
+                  result: PRE_1559_BLOCK,
+                },
+              },
+              // Called when calling the operation directly
+              {
+                request: { method: 'net_version' },
+                error: ethErrors.rpc.limitExceeded('some error'),
+              },
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                response: {
+                  result: POST_1559_BLOCK,
+                },
+              },
+            ],
+          });
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {
+              1559: false,
+            },
+          });
+
+          await operation(controller);
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {},
+          });
+        },
+      );
+    });
+
     if (expectedProviderConfig.type === NetworkType.rpc) {
       it('emits infuraIsUnblocked', async () => {
         await withController(
@@ -6322,6 +6374,58 @@ function lookupNetworkTests({
         );
       });
     }
+
+    it('resets the network details in state', async () => {
+      await withController(
+        {
+          state: initialState,
+        },
+        async ({ controller }) => {
+          await setFakeProvider(controller, {
+            stubs: [
+              // Called during provider initialization
+              {
+                request: { method: 'net_version' },
+                response: SUCCESSFUL_NET_VERSION_RESPONSE,
+              },
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                response: {
+                  result: PRE_1559_BLOCK,
+                },
+              },
+              // Called when calling the operation directly
+              {
+                request: { method: 'net_version' },
+                error: BLOCKED_INFURA_JSON_RPC_ERROR,
+              },
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                response: {
+                  result: POST_1559_BLOCK,
+                },
+              },
+            ],
+          });
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {
+              1559: false,
+            },
+          });
+
+          await operation(controller);
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {},
+          });
+        },
+      );
+    });
   });
 
   describe('if an internal error is encountered while retrieving the version of the current network', () => {
@@ -6344,6 +6448,58 @@ function lookupNetworkTests({
           await operation(controller);
 
           expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
+        },
+      );
+    });
+
+    it('resets the network details in state', async () => {
+      await withController(
+        {
+          state: initialState,
+        },
+        async ({ controller }) => {
+          await setFakeProvider(controller, {
+            stubs: [
+              // Called during provider initialization
+              {
+                request: { method: 'net_version' },
+                response: SUCCESSFUL_NET_VERSION_RESPONSE,
+              },
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                response: {
+                  result: PRE_1559_BLOCK,
+                },
+              },
+              // Called when calling the operation directly
+              {
+                request: { method: 'net_version' },
+                error: GENERIC_JSON_RPC_ERROR,
+              },
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                response: {
+                  result: POST_1559_BLOCK,
+                },
+              },
+            ],
+          });
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {
+              1559: false,
+            },
+          });
+
+          await operation(controller);
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {},
+          });
         },
       );
     });
@@ -6460,6 +6616,58 @@ function lookupNetworkTests({
           await operation(controller);
 
           expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
+        },
+      );
+    });
+
+    it('resets the network details in state', async () => {
+      await withController(
+        {
+          state: initialState,
+        },
+        async ({ controller }) => {
+          await setFakeProvider(controller, {
+            stubs: [
+              // Called during provider initialization
+              {
+                request: { method: 'net_version' },
+                response: SUCCESSFUL_NET_VERSION_RESPONSE,
+              },
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                response: {
+                  result: PRE_1559_BLOCK,
+                },
+              },
+              // Called when calling the operation directly
+              {
+                request: { method: 'net_version' },
+                response: { result: 'invalid' },
+              },
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                response: {
+                  result: POST_1559_BLOCK,
+                },
+              },
+            ],
+          });
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {
+              1559: false,
+            },
+          });
+
+          await operation(controller);
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {},
+          });
         },
       );
     });
@@ -6581,6 +6789,48 @@ function lookupNetworkTests({
           expect(controller.state.networkStatus).toBe(
             NetworkStatus.Unavailable,
           );
+        },
+      );
+    });
+
+    it('resets the network details in state', async () => {
+      await withController(
+        {
+          state: initialState,
+        },
+        async ({ controller }) => {
+          await setFakeProvider(controller, {
+            stubs: [
+              // Called during provider initialization
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                response: {
+                  result: PRE_1559_BLOCK,
+                },
+              },
+              // Called when calling the operation directly
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                error: ethErrors.rpc.limitExceeded('some error'),
+              },
+            ],
+          });
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {
+              1559: false,
+            },
+          });
+
+          await operation(controller);
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {},
+          });
         },
       );
     });
@@ -6870,6 +7120,48 @@ function lookupNetworkTests({
         );
       });
     }
+
+    it('resets the network details in state', async () => {
+      await withController(
+        {
+          state: initialState,
+        },
+        async ({ controller }) => {
+          await setFakeProvider(controller, {
+            stubs: [
+              // Called during provider initialization
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                response: {
+                  result: PRE_1559_BLOCK,
+                },
+              },
+              // Called when calling the operation directly
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                error: BLOCKED_INFURA_JSON_RPC_ERROR,
+              },
+            ],
+          });
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {
+              1559: false,
+            },
+          });
+
+          await operation(controller);
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {},
+          });
+        },
+      );
+    });
   });
 
   describe('if an internal error is encountered while retrieving the network details of the current network', () => {
@@ -6895,6 +7187,48 @@ function lookupNetworkTests({
           await operation(controller);
 
           expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
+        },
+      );
+    });
+
+    it('resets the network details in state', async () => {
+      await withController(
+        {
+          state: initialState,
+        },
+        async ({ controller }) => {
+          await setFakeProvider(controller, {
+            stubs: [
+              // Called during provider initialization
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                response: {
+                  result: PRE_1559_BLOCK,
+                },
+              },
+              // Called when calling the operation directly
+              {
+                request: {
+                  method: 'eth_getBlockByNumber',
+                  params: ['latest', false],
+                },
+                error: GENERIC_JSON_RPC_ERROR,
+              },
+            ],
+          });
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {
+              1559: false,
+            },
+          });
+
+          await operation(controller);
+          expect(controller.state.networkDetails).toStrictEqual({
+            EIPS: {},
+          });
         },
       );
     });


### PR DESCRIPTION


## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

`lookupNetwork`, a method in NetworkController, collects information about the network via two requests and stores that information in state. If either of these requests fails, it means that this step was unsuccessful, and we should reset all of the pieces of state that would ordinarily get updated after a call to `lookupNetwork` in order to match the initial state of the controller. The network ID and network status are correctly reset, but the network details aren't. To be specific, `networkDetails.EIPS[1559]` will be set to false to indicate that the network doesn't support EIP-1559. This isn't completely accurate, as we actually don't know that. This commit fixes this problem by removing the property instead of setting it to false.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

### `@metamask/network-controller`

- **CHANGED**: Update `lookupNetwork` to unset `networkDetails.EIPS[1559]` in state instead of setting it false if either of its requests for the network ID or network details fails.

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Tangentially related to https://github.com/MetaMask/core/issues/1197.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
