### PR TITLE
Update getEIP1559Compatibility to match extension

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -257,9 +257,7 @@ export const defaultState: NetworkState = {
     chainId: ChainId.mainnet,
   },
   networkDetails: {
-    EIPS: {
-      1559: false,
-    },
+    EIPS: {},
   },
   networkConfigurations: {},
 };
@@ -666,18 +664,20 @@ export class NetworkController extends BaseControllerV2<
    * and false otherwise.
    */
   async getEIP1559Compatibility() {
-    const { networkDetails = { EIPS: {} } } = this.state;
+    const { EIPS } = this.state.networkDetails;
 
-    if (networkDetails.EIPS[1559] || !this.#ethQuery) {
-      return true;
+    if (EIPS[1559] !== undefined) {
+      return EIPS[1559];
+    }
+
+    if (!this.#ethQuery) {
+      return false;
     }
 
     const isEIP1559Compatible = await this.#determineEIP1559Compatibility();
-    if (networkDetails.EIPS[1559] !== isEIP1559Compatible) {
-      this.update((state) => {
-        state.networkDetails.EIPS[1559] = isEIP1559Compatible;
-      });
-    }
+    this.update((state) => {
+      state.networkDetails.EIPS[1559] = isEIP1559Compatible;
+    });
     return isEIP1559Compatible;
   }
 


### PR DESCRIPTION

## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

There are two ways in which the `getEIP1559Compatibility` method in this
version of NetworkController differs from the same method in the
extension version:

- In this version, if `getEIP1559Compatibility` is called and
  `networkDetails.EIPS[1559]` in state is false, then the network is hit
  again in order to update the property. In the extension, however,
  that doesn't happen.
- In this version, if `getEIP1559Compatibility` is called but the
  provider has not been set yet, then the network is assumed to support
  EIP-1559 and the method returns true. In the extension, however,
  the network is assumed to _not_ support EIP-1559 and the method
  returns false.

With that in mind, this commit updates `getEIP1559Compatibility` to
better match the extension and updates the tests to match.

It also updates the initial state of `networkDetails` so that `EIPS` is
empty rather than `{ 1559: false }`.

For comparison with the extension, see: https://github.com/MetaMask/metamask-extension/blob/63b810f0dbf421258612e1cf5114258c13ed8710/app/scripts/controllers/network/network-controller.ts#L531

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

### `@metamask/network-controller`

- **BREAKING**: Update `getEIP1559Compatibility` to return false instead of true if provider has not been initialized yet
- **CHANGED**: Update `getEIP1559Compatibility` to not hit network if it is known that the current network does not support EIP-1559
- **CHANGED**: Update `networkDetails` initial state from `{ EIPS: { 1559: false } }` to `{ EIPS: {} }`

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Tangentially related to https://github.com/MetaMask/core/issues/1197.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
