### PR TITLE
Modify error handling for wallet_WatchAsset in NftController

### DIFF
--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -995,13 +995,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     asset: NftAsset,
     type: NFTStandardType,
     accountAddress: string,
-  ): Promise<{
-    nftAlreadyWatchedError: boolean;
-    ownerFetchError: boolean;
-    wrongOwnerError: boolean;
-  }> {
-    const { chainId } = this.config;
-
+  ) {
     const { address: contractAddress, tokenId } = asset;
 
     // Validate parameters
@@ -1027,33 +1021,14 @@ export class NftController extends BaseController<NftConfig, NftState> {
       throw rpcErrors.invalidParams('Invalid tokenId');
     }
 
-    // Check if the suggested NFT is already pending
-    // if (
     // TODO: check if the suggested NFT is already pending in approval controller state
+    // if (
+    //   this.approvalController.state.pendingApproval.find(({requestData: {asset: {address, tokenId}}}) => contractAddress === contractAddress && tokenId === tokenId)
     // ) {
     //   throw rpcErrors.internal('Suggested NFT already pending');
     // }
 
-    const errors = {
-      nftAlreadyWatchedError: false,
-      ownerFetchError: false,
-      wrongOwnerError: false,
-    };
-    // Check if the suggested NFT is already being watched by the selected account
-    if (
-      this.state.allNfts?.[accountAddress]?.[chainId]?.find(
-        ({ address: watchedAssetAddress, tokenId: watchedAssetTokenId }) => {
-          return (
-            watchedAssetAddress === contractAddress &&
-            watchedAssetTokenId === tokenId
-          );
-        },
-      )
-    ) {
-      errors.nftAlreadyWatchedError = true;
-      return errors;
-    }
-
+    // Check if the user owns the suggested NFT
     try {
       const isOwner = await this.isNftOwner(
         accountAddress,
@@ -1061,13 +1036,14 @@ export class NftController extends BaseController<NftConfig, NftState> {
         tokenId,
       );
       if (!isOwner) {
-        errors.wrongOwnerError = true;
+        throw rpcErrors.invalidInput(
+          'Suggested NFT is not owned by the selected account',
+        );
       }
-    } catch {
-      errors.ownerFetchError = true;
+    } catch (error: any) {
+      // error thrown here: "Unable to verify ownership. Possibly because the standard is not supported or the user's currently selected network does not match the chain of the asset in question."
+      throw rpcErrors.resourceUnavailable(`${error.message}`);
     }
-
-    return errors;
   }
 
   /**
@@ -1084,7 +1060,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
   async watchNft(asset: NftAsset, type: NFTStandardType, origin: string) {
     const { selectedAddress } = this.config;
 
-    const errors = await this.validateWatchNft(asset, type, selectedAddress);
+    await this.validateWatchNft(asset, type, selectedAddress);
 
     const nftMetadata = await this.getNftInformation(
       asset.address,
@@ -1099,7 +1075,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
       interactingAddress: selectedAddress,
       origin,
     };
-    await this._requestApproval({ suggestedNftMeta, errors });
+    await this._requestApproval(suggestedNftMeta);
 
     const { address, tokenId } = asset;
     const { name, standard, description, image } = nftMetadata;
@@ -1157,7 +1133,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     }
 
     throw new Error(
-      'Unable to verify ownership. Probably because the standard is not supported or the chain is incorrect.',
+      `Unable to verify ownership. Possibly because the standard is not supported or the user's currently selected network does not match the chain of the asset in question.`,
     );
   }
 
@@ -1475,17 +1451,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     return true;
   }
 
-  async _requestApproval({
-    suggestedNftMeta,
-    errors,
-  }: {
-    suggestedNftMeta: SuggestedNftMeta;
-    errors: {
-      nftAlreadyWatchedError: boolean;
-      ownerFetchError: boolean;
-      wrongOwnerError: boolean;
-    };
-  }) {
+  async _requestApproval(suggestedNftMeta: SuggestedNftMeta) {
     return this.messagingSystem.call(
       'ApprovalController:addRequest',
       {
@@ -1495,7 +1461,6 @@ export class NftController extends BaseController<NftConfig, NftState> {
         requestData: {
           id: suggestedNftMeta.id,
           interactingAddress: suggestedNftMeta.interactingAddress,
-          errors,
           asset: {
             address: suggestedNftMeta.asset.address,
             tokenId: suggestedNftMeta.asset.tokenId,

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1021,13 +1021,6 @@ export class NftController extends BaseController<NftConfig, NftState> {
       throw rpcErrors.invalidParams('Invalid tokenId');
     }
 
-    // TODO: check if the suggested NFT is already pending in approval controller state
-    // if (
-    //   this.approvalController.state.pendingApproval.find(({requestData: {asset: {address, tokenId}}}) => contractAddress === contractAddress && tokenId === tokenId)
-    // ) {
-    //   throw rpcErrors.internal('Suggested NFT already pending');
-    // }
-
     // Check if the user owns the suggested NFT
     try {
       const isOwner = await this.isNftOwner(
@@ -1042,7 +1035,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
       }
     } catch (error: any) {
       // error thrown here: "Unable to verify ownership. Possibly because the standard is not supported or the user's currently selected network does not match the chain of the asset in question."
-      throw rpcErrors.resourceUnavailable(`${error.message}`);
+      throw rpcErrors.resourceUnavailable(error.message);
     }
   }
 


### PR DESCRIPTION
Modifies the error handling pattern for the wallet_watchAsset NFT support introduced in https://github.com/MetaMask/core/pull/1173. In that approach we were passing certain errors in the `requestData`  to the `ApprovalController` so that the errors could be displayed in the UI. We have elected to not pursue this approach because it diverges from the pattern of throwing these errors directly to the dApp we use everywhere else. 