### PR TITLE
Add runtime checks to NC setProviderType

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1,3 +1,4 @@
+import { strict as assert } from 'assert';
 import { createEventEmitterProxy } from '@metamask/swappable-obj-proxy';
 import type { SwappableProxy } from '@metamask/swappable-obj-proxy';
 import EthQuery from 'eth-query';
@@ -586,6 +587,15 @@ export class NetworkController extends BaseControllerV2<
    * @param type - Human readable network name.
    */
   async setProviderType(type: InfuraNetworkType) {
+    assert.notStrictEqual(
+      type,
+      NetworkType.rpc,
+      `NetworkController - cannot call "setProviderType" with type "${NetworkType.rpc}". Use "setActiveNetwork"`,
+    );
+    assert.ok(
+      isInfuraProviderType(type),
+      `Unknown Infura provider type "${type}".`,
+    );
     this.#previousProviderConfig = this.state.providerConfig;
 
     // If testnet the ticker symbol should use a testnet prefix

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -2365,7 +2365,7 @@ describe('NetworkController', () => {
               // @ts-expect-error Intentionally passing invalid type
               controller.setProviderType(NetworkType.rpc),
             ).rejects.toThrow(
-              'chainId must be provided for custom RPC endpoints',
+              'NetworkController - cannot call "setProviderType" with type "rpc". Use "setActiveNetwork"',
             );
           },
         );
@@ -2417,6 +2417,19 @@ describe('NetworkController', () => {
           }
 
           expect(controller.state.networkDetails.EIPS[1559]).toBeUndefined();
+        });
+      });
+    });
+
+    describe('given an invalid Infura network name', () => {
+      it('throws', async () => {
+        await withController(async ({ controller }) => {
+          await expect(() =>
+            // @ts-expect-error Intentionally passing invalid type
+            controller.setProviderType('invalid-infura-network'),
+          ).rejects.toThrow(
+            new Error('Unknown Infura provider type "invalid-infura-network".'),
+          );
         });
       });
     });


### PR DESCRIPTION


## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

The extension version of NetworkController checks the `type` that's passed to `setProviderType` at runtime to ensure that it's not "rpc" and it matches the name of a known built-in Infura network. This commit copies those checks along with their tests.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

(None)

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Progresses https://github.com/MetaMask/core/issues/1197.

For reference, see the extension: https://github.com/MetaMask/metamask-extension/blob/a5c370cdfa6bb42ab0a2e8d78a6387aa1dd17758/app/scripts/controllers/network/network-controller.ts#L710.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
