### PR TITLE
Add test for NFT added via `wallet_watchAsset`

### DIFF
--- a/packages/approval-controller/src/ApprovalController.ts
+++ b/packages/approval-controller/src/ApprovalController.ts
@@ -203,8 +203,8 @@ export type ApprovalControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
   ApprovalControllerActions,
   ApprovalControllerEvents,
-  never,
-  never
+  string,
+  string
 >;
 
 type ApprovalControllerOptions = {

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1082,7 +1082,6 @@ export class NftController extends BaseController<NftConfig, NftState> {
       origin,
     };
     await this._requestApproval(suggestedNftMeta);
-
     const { address, tokenId } = asset;
     const { name, standard, description, image } = nftMetadata;
 


### PR DESCRIPTION
## Added
 - a test to ensure that nfts are added to correct account/chainId when the user changes account/chain before accepting the pending request
 