### PR TITLE
Fire `KeyringController:accountRemoved` event when removing account

### DIFF
--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -89,6 +89,11 @@ export type KeyringControllerStateChangeEvent = {
   payload: [KeyringControllerState, Patch[]];
 };
 
+export type KeyringControllerAccountRemovedEvent = {
+  type: `${typeof name}:accountRemoved`;
+  payload: [string];
+};
+
 export type KeyringControllerLockEvent = {
   type: `${typeof name}:lock`;
   payload: [];
@@ -104,7 +109,8 @@ export type KeyringControllerActions = KeyringControllerGetStateAction;
 export type KeyringControllerEvents =
   | KeyringControllerStateChangeEvent
   | KeyringControllerLockEvent
-  | KeyringControllerUnlockEvent;
+  | KeyringControllerUnlockEvent
+  | KeyringControllerAccountRemovedEvent;
 
 export type KeyringControllerMessenger = RestrictedControllerMessenger<
   typeof name,
@@ -514,11 +520,13 @@ export class KeyringController extends BaseControllerV2<
    * Removes an account from keyring state.
    *
    * @param address - Address of the account to remove.
+   * @fires KeyringController:accountRemoved
    * @returns Promise resolving current state when this account removal completes.
    */
   async removeAccount(address: string): Promise<KeyringControllerMemState> {
     this.removeIdentity(address);
     await this.#keyring.removeAccount(address);
+    this.messagingSystem.publish(`${name}:accountRemoved`, address);
     return this.#getMemState();
   }
 


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

With this PR, the `KeyringController` emits an `accountRemoved` event with a `string` payload representing the account removed, whenever `removeAccount` method is called. 

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **ADDED**: `KeyringController:accountRemoved` event, fired whenever an account is removed through `removeAccount` method.

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes #1260 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
