### PR TITLE
Disaggregate the `detection` param for `addNft()` 

### DIFF
--- a/packages/approval-controller/src/ApprovalController.ts
+++ b/packages/approval-controller/src/ApprovalController.ts
@@ -203,8 +203,8 @@ export type ApprovalControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
   ApprovalControllerActions,
   ApprovalControllerEvents,
-  never,
-  never
+  string,
+  string
 >;
 
 type ApprovalControllerOptions = {

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -21,6 +21,7 @@ import {
   toHex,
   ApprovalType,
   ERC20,
+  Source,
 } from '@metamask/controller-utils';
 import { AddApprovalRequest } from '@metamask/approval-controller';
 import { Network } from '@ethersproject/providers';
@@ -734,8 +735,8 @@ describe('NftController', () => {
           standard: 'ERC721',
           favorite: false,
         },
-        // this object in the third argument slot is only defined when the NFT is added via detection
         { userAddress: detectedUserAddress, chainId: toHex(2) },
+        Source.Detected,
       );
 
       expect(onNftAddedSpy).toHaveBeenCalledWith({
@@ -1300,6 +1301,7 @@ describe('NftController', () => {
           userAddress: selectedAddress,
           chainId,
         },
+        Source.Detected,
       );
 
       expect(
@@ -1318,6 +1320,7 @@ describe('NftController', () => {
           userAddress: selectedAddress,
           chainId,
         },
+        Source.Detected,
       );
 
       expect(

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -21,7 +21,6 @@ import {
   toHex,
   ApprovalType,
   ERC20,
-  Source,
 } from '@metamask/controller-utils';
 import {
   AddApprovalRequest,
@@ -32,6 +31,7 @@ import { Network } from '@ethersproject/providers';
 import { AssetsContractController } from './AssetsContractController';
 import { NftController } from './NftController';
 import { getFormattedIpfsUrl } from './assetsUtil';
+import { Source } from './constants';
 
 const CRYPTOPUNK_ADDRESS = '0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB';
 const ERC721_KUDOSADDRESS = '0x2aEa4Add166EBf38b63d09a75dE1a7b94Aa24163';

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -26,7 +26,6 @@ import {
   OPENSEA_API_URL,
   OPENSEA_PROXY_URL,
   ApprovalType,
-  Source,
 } from '@metamask/controller-utils';
 import type {
   ApiNft,
@@ -36,6 +35,7 @@ import type {
 } from './NftDetectionController';
 import type { AssetsContractController } from './AssetsContractController';
 import { compareNftMetadata, getFormattedIpfsUrl } from './assetsUtil';
+import { Source } from './constants';
 
 type NFTStandardType = 'ERC721' | 'ERC1155';
 

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -634,7 +634,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     nftMetadata: NftMetadata,
     nftContract: NftContract,
     accountParams?: AccountParams,
-    source?: Source,
+    source = Source.Custom,
   ): Promise<Nft[]> {
     // TODO: Remove unused return
     const releaseLock = await this.mutex.acquire();
@@ -699,7 +699,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
           symbol: nftContract.symbol,
           tokenId: tokenId.toString(),
           standard: nftMetadata.standard,
-          source: source || Source.Custom,
+          source,
         });
       }
 
@@ -1182,7 +1182,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     tokenId: string,
     nftMetadata?: NftMetadata,
     accountParams?: AccountParams,
-    source?: Source,
+    source = Source.Custom,
   ) {
     address = toChecksumHexAddress(address);
     const newNftContracts = await this.addNftContract(

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1082,7 +1082,6 @@ export class NftController extends BaseController<NftConfig, NftState> {
       origin,
     };
     await this._requestApproval(suggestedNftMeta);
-
     const { address, tokenId } = asset;
     const { name, standard, description, image } = nftMetadata;
 

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -26,6 +26,7 @@ import {
   OPENSEA_API_URL,
   OPENSEA_PROXY_URL,
   ApprovalType,
+  Source,
 } from '@metamask/controller-utils';
 import type {
   ApiNft,
@@ -243,8 +244,8 @@ export class NftController extends BaseController<NftConfig, NftState> {
    * @param newCollection - the modified piece of state to update in the controller's store
    * @param baseStateKey - The root key in the store to update.
    * @param passedConfig - An object containing the selectedAddress and chainId that are passed through the auto-detection flow.
-   * @param passedConfig.userAddress - the address passed through the NFT detection flow to ensure detected assets are stored to the correct account
-   * @param passedConfig.chainId - the chainId passed through the NFT detection flow to ensure detected assets are stored to the correct account
+   * @param passedConfig.userAddress - the address passed through the NFT detection flow to ensure assets are stored to the correct account
+   * @param passedConfig.chainId - the chainId passed through the NFT detection flow to ensure assets are stored to the correct account
    */
   private updateNestedNftState(
     newCollection: Nft[] | NftContract[],
@@ -623,7 +624,8 @@ export class NftController extends BaseController<NftConfig, NftState> {
    * @param tokenId - The NFT identifier.
    * @param nftMetadata - NFT optional information (name, image and description).
    * @param nftContract - An object containing contract data of the NFT being added.
-   * @param detection - The chain ID and address of the currently selected network and account at the moment the NFT was detected.
+   * @param accountParams - The chain ID and address of network and account to which the nftContract should be added.
+   * @param source - Whether the NFT was detected, added manually or suggested by a dapp.
    * @returns Promise resolving to the current NFT list.
    */
   private async addIndividualNft(
@@ -631,7 +633,8 @@ export class NftController extends BaseController<NftConfig, NftState> {
     tokenId: string,
     nftMetadata: NftMetadata,
     nftContract: NftContract,
-    detection?: AccountParams,
+    accountParams?: AccountParams,
+    source?: Source,
   ): Promise<Nft[]> {
     // TODO: Remove unused return
     const releaseLock = await this.mutex.acquire();
@@ -639,9 +642,9 @@ export class NftController extends BaseController<NftConfig, NftState> {
       address = toChecksumHexAddress(address);
       const { allNfts } = this.state;
       let chainId, selectedAddress;
-      if (detection) {
-        chainId = detection.chainId;
-        selectedAddress = detection.userAddress;
+      if (accountParams) {
+        chainId = accountParams.chainId;
+        selectedAddress = accountParams.userAddress;
       } else {
         chainId = this.config.chainId;
         selectedAddress = this.config.selectedAddress;
@@ -696,7 +699,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
           symbol: nftContract.symbol,
           tokenId: tokenId.toString(),
           standard: nftMetadata.standard,
-          source: detection ? 'detected' : 'custom',
+          source: source || Source.Custom,
         });
       }
 
@@ -710,21 +713,23 @@ export class NftController extends BaseController<NftConfig, NftState> {
    * Adds an NFT contract to the stored NFT contracts list.
    *
    * @param address - Hex address of the NFT contract.
-   * @param detection - The chain ID and address of the currently selected network and account at the moment the NFT was detected.
+   * @param accountParams - The chain ID and address of network and account to which the nftContract should be added.
+   * @param source - Whether the NFT was detected, added manually or suggested by a dapp.
    * @returns Promise resolving to the current NFT contracts list.
    */
   private async addNftContract(
     address: string,
-    detection?: AccountParams,
+    accountParams?: AccountParams,
+    source?: Source,
   ): Promise<NftContract[]> {
     const releaseLock = await this.mutex.acquire();
     try {
       address = toChecksumHexAddress(address);
       const { allNftContracts } = this.state;
       let chainId, selectedAddress;
-      if (detection) {
-        chainId = detection.chainId;
-        selectedAddress = detection.userAddress;
+      if (accountParams) {
+        chainId = accountParams.chainId;
+        selectedAddress = accountParams.userAddress;
       } else {
         chainId = this.config.chainId;
         selectedAddress = this.config.selectedAddress;
@@ -751,11 +756,19 @@ export class NftController extends BaseController<NftConfig, NftState> {
         collection: { name, image_url },
       } = contractInformation;
 
-      // If being auto-detected opensea information is expected
-      // Otherwise at least name from the contract is needed
+      // If the nft is auto-detected we want some valid metadata to be present
       if (
-        (detection && !name) ||
-        Object.keys(contractInformation).length === 0
+        source === Source.Detected &&
+        Object.entries(contractInformation).every(([k, v]: [string, any]) => {
+          if (k === 'address') {
+            return true; // address will always be present
+          }
+          // collection will always be an object, we need to check the internal values
+          if (k === 'collection') {
+            return v?.name === null && v?.image_url === null;
+          }
+          return Boolean(v) === false;
+        })
       ) {
         return nftContracts;
       }
@@ -894,7 +907,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     symbol: string | undefined;
     tokenId: string;
     standard: string | null;
-    source: string;
+    source: Source;
   }) => void;
 
   /**
@@ -1051,7 +1064,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
    * @returns Object containing a Promise resolving to the suggestedAsset address if accepted.
    */
   async watchNft(asset: NftAsset, type: NFTStandardType, origin: string) {
-    const { selectedAddress } = this.config;
+    const { selectedAddress, chainId } = this.config;
 
     await this.validateWatchNft(asset, type, selectedAddress);
 
@@ -1073,12 +1086,21 @@ export class NftController extends BaseController<NftConfig, NftState> {
     const { address, tokenId } = asset;
     const { name, standard, description, image } = nftMetadata;
 
-    await this.addNft(address, tokenId, {
-      name: name ?? null,
-      description: description ?? null,
-      image: image ?? null,
-      standard: standard ?? null,
-    });
+    await this.addNft(
+      address,
+      tokenId,
+      {
+        name: name ?? null,
+        description: description ?? null,
+        image: image ?? null,
+        standard: standard ?? null,
+      },
+      {
+        chainId,
+        userAddress: selectedAddress,
+      },
+      Source.Dapp,
+    );
   }
 
   /**
@@ -1151,17 +1173,23 @@ export class NftController extends BaseController<NftConfig, NftState> {
    * @param address - Hex address of the NFT contract.
    * @param tokenId - The NFT identifier.
    * @param nftMetadata - NFT optional metadata.
-   * @param detection - The chain ID and address of the currently selected network and account at the moment the NFT was detected.
+   * @param accountParams - The chain ID and address of network and account to which the nftContract should be added.
+   * @param source - Whether the NFT was detected, added manually or suggested by a dapp.
    * @returns Promise resolving to the current NFT list.
    */
   async addNft(
     address: string,
     tokenId: string,
     nftMetadata?: NftMetadata,
-    detection?: AccountParams,
+    accountParams?: AccountParams,
+    source?: Source,
   ) {
     address = toChecksumHexAddress(address);
-    const newNftContracts = await this.addNftContract(address, detection);
+    const newNftContracts = await this.addNftContract(
+      address,
+      accountParams,
+      source,
+    );
     nftMetadata =
       nftMetadata || (await this.getNftInformation(address, tokenId));
 
@@ -1177,7 +1205,8 @@ export class NftController extends BaseController<NftConfig, NftState> {
         tokenId,
         nftMetadata,
         nftContract,
-        detection,
+        accountParams,
+        source,
       );
     }
   }
@@ -1236,8 +1265,8 @@ export class NftController extends BaseController<NftConfig, NftState> {
    * @param nft - The NFT object to check and update.
    * @param batch - A boolean indicating whether this method is being called as part of a batch or single update.
    * @param accountParams - The userAddress and chainId to check ownership against
-   * @param accountParams.userAddress - the address passed through the confirmed transaction flow to ensure detected assets are stored to the correct account
-   * @param accountParams.chainId - the chainId passed through the confirmed transaction flow to ensure detected assets are stored to the correct account
+   * @param accountParams.userAddress - the address passed through the confirmed transaction flow to ensure assets are stored to the correct account
+   * @param accountParams.chainId - the chainId passed through the confirmed transaction flow to ensure assets are stored to the correct account
    * @returns the NFT with the updated isCurrentlyOwned value
    */
   async checkAndUpdateSingleNftOwnershipStatus(

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -313,6 +313,31 @@ describe('NftDetectionController', () => {
     ]);
   });
 
+  it('should not add nfts for which no contract information can be fetched', async () => {
+    const selectedAddress = '0x1';
+
+    nftDetection.configure({
+      chainId: ChainId.mainnet,
+      selectedAddress,
+    });
+
+    nftController.configure({
+      selectedAddress,
+    });
+
+    sinon
+      .stub(nftController, 'getNftContractInformationFromApi' as any)
+      .returns(undefined);
+
+    sinon
+      .stub(nftController, 'getNftInformationFromApi' as any)
+      .returns(undefined);
+
+    await nftDetection.detectNfts();
+
+    expect(nftController.state.allNfts).toStrictEqual({});
+  });
+
   it('should detect, add NFTs and do nor remove not detected NFTs correctly', async () => {
     const selectedAddress = '0x1';
     nftDetection.configure({

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -12,9 +12,9 @@ import {
   fetchWithErrorHandling,
   toChecksumHexAddress,
   ChainId,
-  Source,
 } from '@metamask/controller-utils';
 import type { NftController, NftState, NftMetadata } from './NftController';
+import { Source } from './constants';
 
 const DEFAULT_INTERVAL = 180000;
 

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -12,6 +12,7 @@ import {
   fetchWithErrorHandling,
   toChecksumHexAddress,
   ChainId,
+  Source,
 } from '@metamask/controller-utils';
 import type { NftController, NftState, NftMetadata } from './NftController';
 
@@ -394,10 +395,16 @@ export class NftDetectionController extends BaseController<
           last_sale && { lastSale: last_sale },
         );
 
-        await this.addNft(address, token_id, nftMetadata, {
-          userAddress: selectedAddress,
-          chainId,
-        });
+        await this.addNft(
+          address,
+          token_id,
+          nftMetadata,
+          {
+            userAddress: selectedAddress,
+            chainId,
+          },
+          Source.Detected,
+        );
       }
     });
     await Promise.all(addNftPromises);

--- a/packages/assets-controllers/src/constants.ts
+++ b/packages/assets-controllers/src/constants.ts
@@ -1,0 +1,5 @@
+export enum Source {
+  Custom = 'custom',
+  Dapp = 'dapp',
+  Detected = 'detected',
+}

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -116,9 +116,3 @@ export const NETWORK_ID_TO_ETHERS_NETWORK_NAME_MAP: Record<
   [NetworkId.sepolia]: NetworkType.sepolia,
   [NetworkId.mainnet]: NetworkType.mainnet,
 };
-
-export enum Source {
-  Custom = 'custom',
-  Dapp = 'dapp',
-  Detected = 'detected',
-}

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -116,3 +116,9 @@ export const NETWORK_ID_TO_ETHERS_NETWORK_NAME_MAP: Record<
   [NetworkId.sepolia]: NetworkType.sepolia,
   [NetworkId.mainnet]: NetworkType.mainnet,
 };
+
+export enum Source {
+  Custom = 'custom',
+  Dapp = 'dapp',
+  Detected = 'detected',
+}


### PR DESCRIPTION
This PR decouples the `detection` parameter passed to the `addNft` method on the NftController, introducing more granular control over the logic within the function. Now instead of receiving a single `detection` argument as `{ chainId, accountAddress }` the presence of which was meant to both indicate that the nft being added was detected and which account/chainId to add the NFT to in state, there are two separate arguments `accountParams` and `source. 

This allows us to be more clear and explicit about the source of the NFT being added (manually, via dapp, or auto-detection) which in turn allows us finer tuned logic control and event handling for those different sources.


**Changelog entries:**

## `@metamask/approval-controller`

- **FIXED:** Fix ApprovalController constructor so that it accepts a messenger created via a `getRestricted` without explicitly specifying type parameters

## `@metamask/assets-controller`

- **ADDED:** Add a fifth parameter to `addNft` in NftController which can be used to specify whether the NFT was detected, added manually, or suggested by a dapp
- **FIXED:** Fix `watchNft` in NftController to ensure that if the network changes before the user accepts the request, the NFT is added to the chain ID and address before the request was initiated



