### PR TITLE
show test network

### DIFF
--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -16,6 +16,7 @@ describe('PreferencesController', () => {
         eth_sign: false,
       },
       isMultiAccountBalancesEnabled: true,
+      showTestNetworks: false,
     });
   });
 
@@ -191,5 +192,10 @@ describe('PreferencesController', () => {
     const controller = new PreferencesController();
     controller.setIsMultiAccountBalancesEnabled(true);
     expect(controller.state.isMultiAccountBalancesEnabled).toStrictEqual(true);
+  });
+  it('shoudl set showTestNetworks', () => {
+    const controller = new PreferencesController();
+    controller.setShowTestNetworks(true);
+    expect(controller.state.showTestNetworks).toStrictEqual(true);
   });
 });

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -193,7 +193,8 @@ describe('PreferencesController', () => {
     controller.setIsMultiAccountBalancesEnabled(true);
     expect(controller.state.isMultiAccountBalancesEnabled).toStrictEqual(true);
   });
-  it('shoudl set showTestNetworks', () => {
+
+  it('should set showTestNetworks', () => {
     const controller = new PreferencesController();
     controller.setShowTestNetworks(true);
     expect(controller.state.showTestNetworks).toStrictEqual(true);

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -40,6 +40,7 @@ export interface PreferencesState extends BaseState {
   disabledRpcMethodPreferences: {
     [methodName: string]: boolean;
   };
+  showTestNetworks: boolean;
 }
 
 /**
@@ -75,6 +76,7 @@ export class PreferencesController extends BaseController<
       disabledRpcMethodPreferences: {
         eth_sign: false,
       },
+      showTestNetworks: false,
     };
     this.initialize();
   }
@@ -290,6 +292,15 @@ export class PreferencesController extends BaseController<
    */
   setIsMultiAccountBalancesEnabled(isMultiAccountBalancesEnabled: boolean) {
     this.update({ isMultiAccountBalancesEnabled });
+  }
+
+/**
+ * A setter for the user have the test networks visible/hidden.
+ * 
+ * @param showTestNetworks - true to show test networks, false to hidden.
+ */
+  setShowTestNetworks(showTestNetworks: boolean) {
+      this.update({showTestNetworks});
   }
 }
 

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -294,13 +294,13 @@ export class PreferencesController extends BaseController<
     this.update({ isMultiAccountBalancesEnabled });
   }
 
-/**
- * A setter for the user have the test networks visible/hidden.
- * 
- * @param showTestNetworks - true to show test networks, false to hidden.
- */
-  setShowTestNetworks(showTestNetworks: boolean) {
-      this.update({showTestNetworks});
+  /**
+   * A setter for the user have the test networks visible/hidden.
+   *
+   * @param showTestNetworks - true to show test networks, false to hidden.
+   */
+  setShowTestNetworks(showTestNetworks: boolean) {
+    this.update({ showTestNetworks });
   }
 }
 


### PR DESCRIPTION
## Description
Added a toggle for showing the test networks to mobile, added to the preferences controller a variable `showTestNetworks` to save the user preference.

## Changes
- ADDED
Boolean for show test networks on the preferences controller. 


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
