### PR TITLE
Add loadBackup method to NetworkController

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -877,6 +877,25 @@ export class NetworkController extends BaseControllerV2<
   async destroy() {
     await this.#blockTrackerProxy?.destroy();
   }
+
+  /**
+   * Updates the controller using the given backup data.
+   *
+   * @param backup - The data that has been backed up.
+   * @param backup.networkConfigurations - Network configurations in the backup.
+   */
+  loadBackup({
+    networkConfigurations,
+  }: {
+    networkConfigurations: NetworkState['networkConfigurations'];
+  }): void {
+    this.update((state) => {
+      state.networkConfigurations = {
+        ...state.networkConfigurations,
+        ...networkConfigurations,
+      };
+    });
+  }
 }
 
 export default NetworkController;

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -5121,6 +5121,52 @@ describe('NetworkController', () => {
       });
     });
   });
+
+  describe('loadBackup', () => {
+    it('merges the network configurations from the given backup into state', async () => {
+      await withController(
+        {
+          state: {
+            networkConfigurations: {
+              networkConfigurationId1: {
+                id: 'networkConfigurationId1',
+                rpcUrl: 'https://rpc-url1.com',
+                chainId: toHex(1),
+                ticker: 'TEST1',
+              },
+            },
+          },
+        },
+        ({ controller }) => {
+          controller.loadBackup({
+            networkConfigurations: {
+              networkConfigurationId2: {
+                id: 'networkConfigurationId2',
+                rpcUrl: 'https://rpc-url2.com',
+                chainId: toHex(2),
+                ticker: 'TEST2',
+              },
+            },
+          });
+
+          expect(controller.state.networkConfigurations).toStrictEqual({
+            networkConfigurationId1: {
+              id: 'networkConfigurationId1',
+              rpcUrl: 'https://rpc-url1.com',
+              chainId: toHex(1),
+              ticker: 'TEST1',
+            },
+            networkConfigurationId2: {
+              id: 'networkConfigurationId2',
+              rpcUrl: 'https://rpc-url2.com',
+              chainId: toHex(2),
+              ticker: 'TEST2',
+            },
+          });
+        },
+      );
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

The extension offers a way to back up user customized settings in the
wallet and then restoring those settings later from a previous backup.
One of the settings that is preserved in this backup is the list of
custom networks. When restoring this list, the extension attempts to
update NetworkController's state directly. This worked in the extension
version of NetworkController, but it won't work with the version here in
core, as the `update` method in a controller that inherits from
BaseControllerV2 cannot be called from outside the controller itself.

To fix this, this commit adds a new method to NetworkController,
`loadBackup`, which ports the same functionality from the extension.

Related to https://github.com/MetaMask/metamask-extension/issues/17931.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **ADDED:** Add `loadBackup` method to NetworkController

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

See the BackupController in the extension for what this added behavior would replace: https://github.com/MetaMask/metamask-extension/blob/f77b1f65e249a901b8c3339e4fd21d6d043b4e65/app/scripts/controllers/backup.js#L34

This PR makes it possible to replace the extension network controller with the core network controller (https://github.com/MetaMask/metamask-extension/pull/19486).

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
