### PR TITLE
feat: add linea networks support

### DIFF
--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -41,6 +41,7 @@ export const ASSET_TYPES = {
 export const TESTNET_TICKER_SYMBOLS = {
   GOERLI: 'GoerliETH',
   SEPOLIA: 'SepoliaETH',
+  LINEA_GOERLI: 'LineaETH',
 };
 
 /**
@@ -66,6 +67,20 @@ export const BUILT_IN_NETWORKS = {
     ticker: NetworksTicker.mainnet,
     rpcPrefs: {
       blockExplorerUrl: 'https://etherscan.io',
+    },
+  },
+  [NetworkType['linea-goerli']]: {
+    chainId: ChainId['linea-goerli'],
+    ticker: NetworksTicker['linea-goerli'],
+    rpcPrefs: {
+      blockExplorerUrl: 'https://explorer.goerli.linea.build',
+    },
+  },
+  [NetworkType['linea-mainnet']]: {
+    chainId: ChainId['linea-mainnet'],
+    ticker: NetworksTicker['linea-mainnet'],
+    rpcPrefs: {
+      blockExplorerUrl: 'https://lineascan.build',
     },
   },
   [NetworkType.rpc]: {
@@ -117,4 +132,6 @@ export const NETWORK_ID_TO_ETHERS_NETWORK_NAME_MAP: Record<
   [NetworkId.goerli]: NetworkType.goerli,
   [NetworkId.sepolia]: NetworkType.sepolia,
   [NetworkId.mainnet]: NetworkType.mainnet,
+  [NetworkId['linea-goerli']]: NetworkType['linea-goerli'],
+  [NetworkId['linea-mainnet']]: NetworkType['linea-mainnet'],
 };

--- a/packages/controller-utils/src/types.test.ts
+++ b/packages/controller-utils/src/types.test.ts
@@ -9,6 +9,8 @@ describe('types', () => {
     expect(isNetworkType(NetworkType.mainnet)).toBe(true);
     expect(isNetworkType(NetworkType.goerli)).toBe(true);
     expect(isNetworkType(NetworkType.sepolia)).toBe(true);
+    expect(isNetworkType(NetworkType['linea-goerli'])).toBe(true);
+    expect(isNetworkType(NetworkType['linea-mainnet'])).toBe(true);
     expect(isNetworkType(NetworkType.rpc)).toBe(true);
   });
 });

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -5,6 +5,8 @@ export const InfuraNetworkType = {
   mainnet: 'mainnet',
   goerli: 'goerli',
   sepolia: 'sepolia',
+  'linea-goerli': 'linea-goerli',
+  'linea-mainnet': 'linea-mainnet',
 } as const;
 
 export type InfuraNetworkType =
@@ -39,6 +41,8 @@ export enum BuiltInNetworkName {
   Mainnet = 'mainnet',
   Goerli = 'goerli',
   Sepolia = 'sepolia',
+  LineaGoerli = 'linea-goerli',
+  LineaMainnet = 'linea-mainnet',
   Aurora = 'aurora',
 }
 
@@ -52,6 +56,8 @@ export const ChainId = {
   [BuiltInNetworkName.Goerli]: '0x5', // toHex(5)
   [BuiltInNetworkName.Sepolia]: '0xaa36a7', // toHex(11155111)
   [BuiltInNetworkName.Aurora]: '0x4e454152', // toHex(1313161554)
+  [BuiltInNetworkName.LineaGoerli]: '0xe704', // toHex(59140)
+  [BuiltInNetworkName.LineaMainnet]: '0xe708', // toHex(59144)
 } as const;
 export type ChainId = typeof ChainId[keyof typeof ChainId];
 
@@ -62,6 +68,8 @@ export const NetworkId = {
   [InfuraNetworkType.mainnet]: '1',
   [InfuraNetworkType.goerli]: '5',
   [InfuraNetworkType.sepolia]: '11155111',
+  [InfuraNetworkType['linea-goerli']]: '59140',
+  [InfuraNetworkType['linea-mainnet']]: '59144',
 } as const;
 export type NetworkId = typeof NetworkId[keyof typeof NetworkId];
 
@@ -69,5 +77,7 @@ export enum NetworksTicker {
   mainnet = 'ETH',
   goerli = 'GoerliETH',
   sepolia = 'SepoliaETH',
+  'linea-goerli' = 'LineaETH',
+  'linea-mainnet' = 'ETH',
   rpc = '',
 }

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@metamask/base-controller": "workspace:^",
     "@metamask/controller-utils": "workspace:^",
-    "@metamask/eth-json-rpc-infura": "^8.0.0",
+    "@metamask/eth-json-rpc-infura": "^8.1.0",
     "@metamask/eth-json-rpc-middleware": "^11.0.0",
     "@metamask/eth-json-rpc-provider": "^1.0.0",
     "@metamask/swappable-obj-proxy": "^2.1.0",

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -87,6 +87,18 @@ const BLOCK: Block = POST_1559_BLOCK;
  */
 const INFURA_NETWORKS = [
   {
+    networkType: NetworkType['linea-goerli'],
+    chainId: toHex(59140),
+    ticker: 'LineaETH',
+    blockExplorerUrl: 'https://explorer.goerli.linea.build',
+  },
+  {
+    networkType: NetworkType['linea-mainnet'],
+    chainId: toHex(59144),
+    ticker: 'ETH',
+    blockExplorerUrl: 'https://lineascan.build',
+  },
+  {
     networkType: NetworkType.mainnet,
     chainId: toHex(1),
     ticker: 'ETH',
@@ -1089,28 +1101,51 @@ describe('NetworkController', () => {
             mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
 
             const networkClientsById = controller.getNetworkClientsById();
-            const simplifiedNetworkClients = Object.entries(
-              networkClientsById,
-            ).map(([networkClientId, networkClient]) => [
-              networkClientId,
-              networkClient.configuration,
-            ]);
+            const simplifiedNetworkClients = Object.entries(networkClientsById)
+              .map(
+                ([networkClientId, networkClient]) =>
+                  [networkClientId, networkClient.configuration] as const,
+              )
+              .sort(
+                (
+                  [networkClientId1, _networkClient1],
+                  [networkClientId2, _networkClient2],
+                ) => {
+                  return networkClientId1.localeCompare(networkClientId2);
+                },
+              );
 
             expect(simplifiedNetworkClients).toStrictEqual([
-              [
-                'mainnet',
-                {
-                  type: NetworkClientType.Infura,
-                  infuraProjectId: 'some-infura-project-id',
-                  network: InfuraNetworkType.mainnet,
-                },
-              ],
               [
                 'goerli',
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
                   network: InfuraNetworkType.goerli,
+                },
+              ],
+              [
+                'linea-goerli',
+                {
+                  type: NetworkClientType.Infura,
+                  infuraProjectId: 'some-infura-project-id',
+                  network: InfuraNetworkType['linea-goerli'],
+                },
+              ],
+              [
+                'linea-mainnet',
+                {
+                  type: NetworkClientType.Infura,
+                  infuraProjectId: 'some-infura-project-id',
+                  network: InfuraNetworkType['linea-mainnet'],
+                },
+              ],
+              [
+                'mainnet',
+                {
+                  type: NetworkClientType.Infura,
+                  infuraProjectId: 'some-infura-project-id',
+                  network: InfuraNetworkType.mainnet,
                 },
               ],
               [
@@ -1154,38 +1189,21 @@ describe('NetworkController', () => {
             mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
 
             const networkClientsById = controller.getNetworkClientsById();
-            const simplifiedNetworkClients = Object.entries(
-              networkClientsById,
-            ).map(([networkClientId, networkClient]) => [
-              networkClientId,
-              networkClient.configuration,
-            ]);
+            const simplifiedNetworkClients = Object.entries(networkClientsById)
+              .map(
+                ([networkClientId, networkClient]) =>
+                  [networkClientId, networkClient.configuration] as const,
+              )
+              .sort(
+                (
+                  [networkClientId1, _networkClient1],
+                  [networkClientId2, _networkClient2],
+                ) => {
+                  return networkClientId1.localeCompare(networkClientId2);
+                },
+              );
 
             expect(simplifiedNetworkClients).toStrictEqual([
-              [
-                'mainnet',
-                {
-                  type: NetworkClientType.Infura,
-                  infuraProjectId: 'some-infura-project-id',
-                  network: InfuraNetworkType.mainnet,
-                },
-              ],
-              [
-                'goerli',
-                {
-                  type: NetworkClientType.Infura,
-                  infuraProjectId: 'some-infura-project-id',
-                  network: InfuraNetworkType.goerli,
-                },
-              ],
-              [
-                'sepolia',
-                {
-                  type: NetworkClientType.Infura,
-                  infuraProjectId: 'some-infura-project-id',
-                  network: InfuraNetworkType.sepolia,
-                },
-              ],
               [
                 'AAAA-AAAA-AAAA-AAAA',
                 {
@@ -1200,6 +1218,46 @@ describe('NetworkController', () => {
                   type: NetworkClientType.Custom,
                   chainId: toHex(2),
                   rpcUrl: 'https://test.network.2',
+                },
+              ],
+              [
+                'goerli',
+                {
+                  type: NetworkClientType.Infura,
+                  infuraProjectId: 'some-infura-project-id',
+                  network: InfuraNetworkType.goerli,
+                },
+              ],
+              [
+                'linea-goerli',
+                {
+                  type: NetworkClientType.Infura,
+                  infuraProjectId: 'some-infura-project-id',
+                  network: InfuraNetworkType['linea-goerli'],
+                },
+              ],
+              [
+                'linea-mainnet',
+                {
+                  type: NetworkClientType.Infura,
+                  infuraProjectId: 'some-infura-project-id',
+                  network: InfuraNetworkType['linea-mainnet'],
+                },
+              ],
+              [
+                'mainnet',
+                {
+                  type: NetworkClientType.Infura,
+                  infuraProjectId: 'some-infura-project-id',
+                  network: InfuraNetworkType.mainnet,
+                },
+              ],
+              [
+                'sepolia',
+                {
+                  type: NetworkClientType.Infura,
+                  infuraProjectId: 'some-infura-project-id',
+                  network: InfuraNetworkType.sepolia,
                 },
               ],
             ]);
@@ -1231,28 +1289,51 @@ describe('NetworkController', () => {
             mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
 
             const networkClientsById = controller.getNetworkClientsById();
-            const simplifiedNetworkClients = Object.entries(
-              networkClientsById,
-            ).map(([networkClientId, networkClient]) => [
-              networkClientId,
-              networkClient.configuration,
-            ]);
+            const simplifiedNetworkClients = Object.entries(networkClientsById)
+              .map(
+                ([networkClientId, networkClient]) =>
+                  [networkClientId, networkClient.configuration] as const,
+              )
+              .sort(
+                (
+                  [networkClientId1, _networkClient1],
+                  [networkClientId2, _networkClient2],
+                ) => {
+                  return networkClientId1.localeCompare(networkClientId2);
+                },
+              );
 
             expect(simplifiedNetworkClients).toStrictEqual([
-              [
-                'mainnet',
-                {
-                  type: NetworkClientType.Infura,
-                  infuraProjectId: 'some-infura-project-id',
-                  network: InfuraNetworkType.mainnet,
-                },
-              ],
               [
                 'goerli',
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
                   network: InfuraNetworkType.goerli,
+                },
+              ],
+              [
+                'linea-goerli',
+                {
+                  type: NetworkClientType.Infura,
+                  infuraProjectId: 'some-infura-project-id',
+                  network: InfuraNetworkType['linea-goerli'],
+                },
+              ],
+              [
+                'linea-mainnet',
+                {
+                  type: NetworkClientType.Infura,
+                  infuraProjectId: 'some-infura-project-id',
+                  network: InfuraNetworkType['linea-mainnet'],
+                },
+              ],
+              [
+                'mainnet',
+                {
+                  type: NetworkClientType.Infura,
+                  infuraProjectId: 'some-infura-project-id',
+                  network: InfuraNetworkType.mainnet,
                 },
               ],
               [
@@ -1299,18 +1380,27 @@ describe('NetworkController', () => {
                 const networkClientsById = controller.getNetworkClientsById();
                 const simplifiedNetworkClients = Object.entries(
                   networkClientsById,
-                ).map(([networkClientId, networkClient]) => [
-                  networkClientId,
-                  networkClient.configuration,
-                ]);
+                )
+                  .map(
+                    ([networkClientId, networkClient]) =>
+                      [networkClientId, networkClient.configuration] as const,
+                  )
+                  .sort(
+                    (
+                      [networkClientId1, _networkClient1],
+                      [networkClientId2, _networkClient2],
+                    ) => {
+                      return networkClientId1.localeCompare(networkClientId2);
+                    },
+                  );
 
                 expect(simplifiedNetworkClients).toStrictEqual([
                   [
-                    'mainnet',
+                    'AAAA-AAAA-AAAA-AAAA',
                     {
-                      type: NetworkClientType.Infura,
-                      infuraProjectId: 'some-infura-project-id',
-                      network: InfuraNetworkType.mainnet,
+                      type: NetworkClientType.Custom,
+                      chainId: toHex(1),
+                      rpcUrl: 'https://test.network.1',
                     },
                   ],
                   [
@@ -1322,27 +1412,43 @@ describe('NetworkController', () => {
                     },
                   ],
                   [
-                    'sepolia',
-                    {
-                      type: NetworkClientType.Infura,
-                      infuraProjectId: 'some-infura-project-id',
-                      network: InfuraNetworkType.sepolia,
-                    },
-                  ],
-                  [
-                    'AAAA-AAAA-AAAA-AAAA',
-                    {
-                      type: NetworkClientType.Custom,
-                      chainId: toHex(1),
-                      rpcUrl: 'https://test.network.1',
-                    },
-                  ],
-                  [
                     'https://test.network.2',
                     {
                       type: NetworkClientType.Custom,
                       chainId: toHex(2),
                       rpcUrl: 'HTTPS://TEST.NETWORK.2',
+                    },
+                  ],
+                  [
+                    'linea-goerli',
+                    {
+                      type: NetworkClientType.Infura,
+                      infuraProjectId: 'some-infura-project-id',
+                      network: InfuraNetworkType['linea-goerli'],
+                    },
+                  ],
+                  [
+                    'linea-mainnet',
+                    {
+                      type: NetworkClientType.Infura,
+                      infuraProjectId: 'some-infura-project-id',
+                      network: InfuraNetworkType['linea-mainnet'],
+                    },
+                  ],
+                  [
+                    'mainnet',
+                    {
+                      type: NetworkClientType.Infura,
+                      infuraProjectId: 'some-infura-project-id',
+                      network: InfuraNetworkType.mainnet,
+                    },
+                  ],
+                  [
+                    'sepolia',
+                    {
+                      type: NetworkClientType.Infura,
+                      infuraProjectId: 'some-infura-project-id',
+                      network: InfuraNetworkType.sepolia,
                     },
                   ],
                 ]);
@@ -1379,18 +1485,27 @@ describe('NetworkController', () => {
                 const networkClientsById = controller.getNetworkClientsById();
                 const simplifiedNetworkClients = Object.entries(
                   networkClientsById,
-                ).map(([networkClientId, networkClient]) => [
-                  networkClientId,
-                  networkClient.configuration,
-                ]);
+                )
+                  .map(
+                    ([networkClientId, networkClient]) =>
+                      [networkClientId, networkClient.configuration] as const,
+                  )
+                  .sort(
+                    (
+                      [networkClientId1, _networkClient1],
+                      [networkClientId2, _networkClient2],
+                    ) => {
+                      return networkClientId1.localeCompare(networkClientId2);
+                    },
+                  );
 
                 expect(simplifiedNetworkClients).toStrictEqual([
                   [
-                    'mainnet',
+                    'AAAA-AAAA-AAAA-AAAA',
                     {
-                      type: NetworkClientType.Infura,
-                      infuraProjectId: 'some-infura-project-id',
-                      network: InfuraNetworkType.mainnet,
+                      type: NetworkClientType.Custom,
+                      chainId: '0x1',
+                      rpcUrl: 'https://test.network',
                     },
                   ],
                   [
@@ -1402,19 +1517,35 @@ describe('NetworkController', () => {
                     },
                   ],
                   [
+                    'linea-goerli',
+                    {
+                      type: NetworkClientType.Infura,
+                      infuraProjectId: 'some-infura-project-id',
+                      network: InfuraNetworkType['linea-goerli'],
+                    },
+                  ],
+                  [
+                    'linea-mainnet',
+                    {
+                      type: NetworkClientType.Infura,
+                      infuraProjectId: 'some-infura-project-id',
+                      network: InfuraNetworkType['linea-mainnet'],
+                    },
+                  ],
+                  [
+                    'mainnet',
+                    {
+                      type: NetworkClientType.Infura,
+                      infuraProjectId: 'some-infura-project-id',
+                      network: InfuraNetworkType.mainnet,
+                    },
+                  ],
+                  [
                     'sepolia',
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
                       network: InfuraNetworkType.sepolia,
-                    },
-                  ],
-                  [
-                    'AAAA-AAAA-AAAA-AAAA',
-                    {
-                      type: NetworkClientType.Custom,
-                      chainId: '0x1',
-                      rpcUrl: 'https://test.network',
                     },
                   ],
                 ]);
@@ -1451,18 +1582,27 @@ describe('NetworkController', () => {
                 const networkClientsById = controller.getNetworkClientsById();
                 const simplifiedNetworkClients = Object.entries(
                   networkClientsById,
-                ).map(([networkClientId, networkClient]) => [
-                  networkClientId,
-                  networkClient.configuration,
-                ]);
+                )
+                  .map(
+                    ([networkClientId, networkClient]) =>
+                      [networkClientId, networkClient.configuration] as const,
+                  )
+                  .sort(
+                    (
+                      [networkClientId1, _networkClient1],
+                      [networkClientId2, _networkClient2],
+                    ) => {
+                      return networkClientId1.localeCompare(networkClientId2);
+                    },
+                  );
 
                 expect(simplifiedNetworkClients).toStrictEqual([
                   [
-                    'mainnet',
+                    'AAAA-AAAA-AAAA-AAAA',
                     {
-                      type: NetworkClientType.Infura,
-                      infuraProjectId: 'some-infura-project-id',
-                      network: InfuraNetworkType.mainnet,
+                      type: NetworkClientType.Custom,
+                      chainId: toHex(1),
+                      rpcUrl: 'https://test.network',
                     },
                   ],
                   [
@@ -1474,19 +1614,35 @@ describe('NetworkController', () => {
                     },
                   ],
                   [
+                    'linea-goerli',
+                    {
+                      type: NetworkClientType.Infura,
+                      infuraProjectId: 'some-infura-project-id',
+                      network: InfuraNetworkType['linea-goerli'],
+                    },
+                  ],
+                  [
+                    'linea-mainnet',
+                    {
+                      type: NetworkClientType.Infura,
+                      infuraProjectId: 'some-infura-project-id',
+                      network: InfuraNetworkType['linea-mainnet'],
+                    },
+                  ],
+                  [
+                    'mainnet',
+                    {
+                      type: NetworkClientType.Infura,
+                      infuraProjectId: 'some-infura-project-id',
+                      network: InfuraNetworkType.mainnet,
+                    },
+                  ],
+                  [
                     'sepolia',
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
                       network: InfuraNetworkType.sepolia,
-                    },
-                  ],
-                  [
-                    'AAAA-AAAA-AAAA-AAAA',
-                    {
-                      type: NetworkClientType.Custom,
-                      chainId: toHex(1),
-                      rpcUrl: 'https://test.network',
                     },
                   ],
                 ]);
@@ -1525,18 +1681,27 @@ describe('NetworkController', () => {
               const networkClientsById = controller.getNetworkClientsById();
               const simplifiedNetworkClients = Object.entries(
                 networkClientsById,
-              ).map(([networkClientId, networkClient]) => [
-                networkClientId,
-                networkClient.configuration,
-              ]);
+              )
+                .map(
+                  ([networkClientId, networkClient]) =>
+                    [networkClientId, networkClient.configuration] as const,
+                )
+                .sort(
+                  (
+                    [networkClientId1, _networkClient1],
+                    [networkClientId2, _networkClient2],
+                  ) => {
+                    return networkClientId1.localeCompare(networkClientId2);
+                  },
+                );
 
               expect(simplifiedNetworkClients).toStrictEqual([
                 [
-                  'mainnet',
+                  'AAAA-AAAA-AAAA-AAAA',
                   {
-                    type: NetworkClientType.Infura,
-                    infuraProjectId: 'some-infura-project-id',
-                    network: InfuraNetworkType.mainnet,
+                    type: NetworkClientType.Custom,
+                    chainId: toHex(1),
+                    rpcUrl: 'https://test.network.1',
                   },
                 ],
                 [
@@ -1548,19 +1713,35 @@ describe('NetworkController', () => {
                   },
                 ],
                 [
+                  'linea-goerli',
+                  {
+                    type: NetworkClientType.Infura,
+                    infuraProjectId: 'some-infura-project-id',
+                    network: InfuraNetworkType['linea-goerli'],
+                  },
+                ],
+                [
+                  'linea-mainnet',
+                  {
+                    type: NetworkClientType.Infura,
+                    infuraProjectId: 'some-infura-project-id',
+                    network: InfuraNetworkType['linea-mainnet'],
+                  },
+                ],
+                [
+                  'mainnet',
+                  {
+                    type: NetworkClientType.Infura,
+                    infuraProjectId: 'some-infura-project-id',
+                    network: InfuraNetworkType.mainnet,
+                  },
+                ],
+                [
                   'sepolia',
                   {
                     type: NetworkClientType.Infura,
                     infuraProjectId: 'some-infura-project-id',
                     network: InfuraNetworkType.sepolia,
-                  },
-                ],
-                [
-                  'AAAA-AAAA-AAAA-AAAA',
-                  {
-                    type: NetworkClientType.Custom,
-                    chainId: toHex(1),
-                    rpcUrl: 'https://test.network.1',
                   },
                 ],
               ]);
@@ -4184,7 +4365,7 @@ describe('NetworkController', () => {
             );
 
             const networkClientsById = controller.getNetworkClientsById();
-            expect(Object.keys(networkClientsById)).toHaveLength(4);
+            expect(Object.keys(networkClientsById)).toHaveLength(6);
             expect(networkClientsById).toMatchObject({
               'AAAA-AAAA-AAAA-AAAA': expect.objectContaining({
                 configuration: {
@@ -4715,7 +4896,7 @@ describe('NetworkController', () => {
 
                 const networkClientsById = controller.getNetworkClientsById();
                 expect(networkClientToDestroy.destroy).toHaveBeenCalled();
-                expect(Object.keys(networkClientsById)).toHaveLength(4);
+                expect(Object.keys(networkClientsById)).toHaveLength(6);
                 expect(networkClientsById).not.toMatchObject({
                   [oldRpcUrl]: expect.objectContaining({
                     configuration: {
@@ -4769,7 +4950,7 @@ describe('NetworkController', () => {
                 );
 
                 const networkClientsById = controller.getNetworkClientsById();
-                expect(Object.keys(networkClientsById)).toHaveLength(4);
+                expect(Object.keys(networkClientsById)).toHaveLength(6);
                 expect(networkClientsById).toMatchObject({
                   'AAAA-AAAA-AAAA-AAAA': expect.objectContaining({
                     configuration: {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -4,6 +4,13 @@ import HttpProvider from 'ethjs-provider-http';
 import NonceTracker from 'nonce-tracker';
 import { errorCodes } from 'eth-rpc-errors';
 import Common from '@ethereumjs/common';
+import { ChainId, NetworkType, toHex } from '@metamask/controller-utils';
+import type {
+  BlockTracker,
+  NetworkState,
+  Provider,
+} from '@metamask/network-controller';
+import { NetworkStatus } from '@metamask/network-controller';
 import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
 import {
   AcceptResultCallbacks,
@@ -26,13 +33,6 @@ import {
   txsInStateWithOutdatedGasDataMock,
   txsInStateWithOutdatedStatusAndGasDataMock,
 } from './mocks/txsMock';
-import { NetworkStatus } from '@metamask/network-controller';
-import type {
-  BlockTracker,
-  NetworkState,
-  Provider,
-} from '@metamask/network-controller';
-import { ChainId, NetworkType, toHex } from '@metamask/controller-utils';
 
 const v1Stub = jest
   .fn()

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -630,7 +630,11 @@ export class TransactionController extends BaseController<
       providerConfig: { type: chain, chainId, nickname: name },
     } = this.getNetworkState();
 
-    if (chain !== RPC) {
+    if (
+      chain !== RPC &&
+      chain !== NetworkType['linea-goerli'] &&
+      chain !== NetworkType['linea-mainnet']
+    ) {
       return new Common({ chain, hardfork: HARDFORK });
     }
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -52,7 +52,7 @@ import {
   ESTIMATE_GAS_ERROR,
 } from './utils';
 
-const HARDFORK = 'london';
+export const HARDFORK = 'london';
 
 /**
  * @type Result

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,16 +1581,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-infura@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@metamask/eth-json-rpc-infura@npm:8.0.0"
+"@metamask/eth-json-rpc-infura@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@metamask/eth-json-rpc-infura@npm:8.1.0"
   dependencies:
     "@metamask/utils": ^3.0.1
     eth-json-rpc-middleware: ^9.0.0
     eth-rpc-errors: ^4.0.3
     json-rpc-engine: ^6.1.0
     node-fetch: ^2.6.7
-  checksum: e8c3a4b75d4f2bb09f68d7d2ac6b992f264df893921b50a05c35968ee684b7bba90180870eebecfc89b7fbf40d11de2a545ab68f1d511f569ce0a6519c64b0aa
+  checksum: fd09383e2b3c16187b8889b53bfc431fc7ea4f6483acc23ddf77f2fd771ad0fbff41d6a62d4b05833e7cda66adafe0cb3730d7c0e9575b89683b71a82ab1ee1f
   languageName: node
   linkType: hard
 
@@ -1796,7 +1796,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
-    "@metamask/eth-json-rpc-infura": ^8.0.0
+    "@metamask/eth-json-rpc-infura": ^8.1.0
     "@metamask/eth-json-rpc-middleware": ^11.0.0
     "@metamask/eth-json-rpc-provider": ^1.0.0
     "@metamask/swappable-obj-proxy": ^2.1.0


### PR DESCRIPTION
## Description

- Added linea networks support in controller utils
- Added linea networks support in network controller
- Added linea networks support in transaction controller
- Updated `@metamask/eth-json-rpc-infura` package version to 8.1.0 to support linea networks

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->
### `@metamask/controller-utils`

- **ADDED:** Add Linea networks to `TESTNET_TICKER_SYMBOLS`, `BUILT_IN_NETWORKS`, `NETWORK_ID_TO_ETHERS_NETWORK_NAME_MAP`, `InfuraNetworkType`, `NetworkType`, `BuiltInNetworkName`, `ChainId`, `NetworkId`, and `NetworksTicker`
  - `isNetworkType` will now return true when given `linea-mainnet` or `linea-goerli`

### `@metamask/network-controller`

- **ADDED:** Add support for Infura provider types `linea-mainnet` and `linea-goerli`
- **CHANGED:** Update `@metamask/eth-json-rpc-infura` package version to 8.1.0 to support Linea networks

### `@metamask/transaction-controller`

- **CHANGED:** Update `approveTransaction`, `stopTransaction`, and `speedUpTransaction` to use proper chain ID and network ID when creating transaction for Linea networks
## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
