### PR TITLE
Await approval promise in TransactionController

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2,26 +2,15 @@ import * as sinon from 'sinon';
 import { PollingBlockTracker } from 'eth-block-tracker';
 import HttpProvider from 'ethjs-provider-http';
 import NonceTracker from 'nonce-tracker';
-import {
-  ChainId,
-  NetworkType,
-  toHex,
-  ApprovalType,
-  ORIGIN_METAMASK,
-} from '@metamask/controller-utils';
+import { ChainId, NetworkType, toHex } from '@metamask/controller-utils';
 import type {
   BlockTrackerProxy,
   NetworkState,
   ProviderProxy,
 } from '@metamask/network-controller';
 import { NetworkStatus } from '@metamask/network-controller';
-import {
-  AcceptRequest as AcceptApprovalRequest,
-  AddApprovalRequest,
-  RejectRequest as RejectApprovalRequest,
-} from '@metamask/approval-controller';
-import { ControllerMessenger } from '@metamask/base-controller';
 import { createEventEmitterProxy } from '@metamask/swappable-obj-proxy';
+import { errorCodes } from 'eth-rpc-errors';
 import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
 import { ESTIMATE_GAS_ERROR } from './utils';
 import {
@@ -29,7 +18,6 @@ import {
   TransactionStatus,
   TransactionMeta,
   TransactionControllerMessenger,
-  GasPriceValue,
 } from './TransactionController';
 import {
   ethTxsMock,
@@ -162,7 +150,56 @@ function buildMockBlockTracker(latestBlockNumber: string): BlockTrackerProxy {
   return createEventEmitterProxy<PollingBlockTracker>(fakeBlockTracker);
 }
 
-const MOCK_PREFERENCES = { state: { selectedAddress: 'foo' } };
+/**
+ * Create a mock controller messenger.
+ *
+ * @param opts - Options to customize the mock messenger.
+ * @param opts.approved - Whether transactions should immediately be approved or rejected.
+ * @param opts.delay - Whether to delay approval or rejection until the returned functions are called.
+ * @returns The mock controller messenger.
+ */
+function buildMockMessenger({
+  approved,
+  delay,
+}: {
+  approved?: boolean;
+  delay?: boolean;
+}): {
+  messenger: TransactionControllerMessenger;
+  approve: () => void;
+  reject: (reason: any) => void;
+} {
+  let approve, reject;
+  let promise: Promise<void>;
+
+  if (delay) {
+    promise = new Promise((res, rej) => {
+      approve = res;
+      reject = rej;
+    });
+  }
+
+  const messenger = {
+    call: jest.fn().mockImplementation(() => {
+      if (approved) {
+        return Promise.resolve(true);
+      }
+
+      if (delay) {
+        return promise;
+      }
+
+      // eslint-disable-next-line prefer-promise-reject-errors
+      return Promise.reject({
+        code: errorCodes.provider.userRejectedRequest,
+      });
+    }),
+  } as unknown as TransactionControllerMessenger;
+
+  return { messenger, approve: approve as any, reject: reject as any };
+}
+
+const MOCK_PRFERENCES = { state: { selectedAddress: 'foo' } };
 const GOERLI_PROVIDER = new HttpProvider(
   'https://goerli.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035',
 );
@@ -325,49 +362,19 @@ const MOCK_FETCH_TX_HISTORY_DATA_ERROR = {
   status: '0',
 };
 
-const controllerName = 'TransactionController' as const;
-
-type ApprovalActions =
-  | AddApprovalRequest
-  | AcceptApprovalRequest
-  | RejectApprovalRequest;
-
 describe('TransactionController', () => {
-  let callActionSpy: jest.SpyInstance;
-  const messengerMock = new ControllerMessenger<
-    ApprovalActions,
-    never
-  >().getRestricted<typeof controllerName, ApprovalActions['type'], never>({
-    name: controllerName,
-    allowedActions: [
-      'ApprovalController:addRequest',
-      'ApprovalController:acceptRequest',
-      'ApprovalController:rejectRequest',
-    ],
-  }) as TransactionControllerMessenger;
-
-  const setupMessengerCallSpy = (
-    approvalControllerCallResolves: boolean,
-    calledOnce: boolean,
-  ) => {
-    return approvalControllerCallResolves
-      ? jest.spyOn(messengerMock, 'call').mockResolvedValue({})
-      : jest.spyOn(messengerMock, 'call').mockImplementation(() => {
-          if (!calledOnce) {
-            calledOnce = true;
-            return Promise.resolve({});
-          }
-
-          throw new Error();
-        });
-  };
+  let messengerMock: TransactionControllerMessenger;
+  let rejectMessengerMock: TransactionControllerMessenger;
+  let delayMessengerMock: TransactionControllerMessenger;
 
   beforeEach(() => {
     for (const key in mockFlags) {
       mockFlags[key] = null;
     }
 
-    callActionSpy = jest.spyOn(messengerMock, 'call').mockResolvedValue({});
+    messengerMock = buildMockMessenger({ approved: true }).messenger;
+    rejectMessengerMock = buildMockMessenger({ approved: false }).messenger;
+    delayMessengerMock = buildMockMessenger({ delay: true }).messenger;
   });
 
   afterEach(() => {
@@ -494,7 +501,6 @@ describe('TransactionController', () => {
       messenger: messengerMock,
     });
     mockFlags.estimateGasValue = '0x12a05f200';
-    mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
 
     const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
     const result = await controller.estimateGas({ from, to: from });
@@ -611,56 +617,37 @@ describe('TransactionController', () => {
     ).rejects.toThrow('Invalid "from" address');
   });
 
-  it.each([
-    ['resolves', true],
-    ['rejects', false],
-  ])(
-    'should add a valid transaction if user confirms a message to ApprovalController %s',
-    async (_, approvalControllerCallResolves: boolean) => {
-      const calledOnce = false;
-      callActionSpy = setupMessengerCallSpy(
-        approvalControllerCallResolves,
-        calledOnce,
-      );
-      const controller = new TransactionController({
+  it('should add a valid transaction', async () => {
+    const controller = new TransactionController(
+      {
         getNetworkState: () => MOCK_NETWORK.state,
         onNetworkStateChange: MOCK_NETWORK.subscribe,
         provider: MOCK_NETWORK.provider,
         blockTracker: MOCK_NETWORK.blockTracker,
         messenger: messengerMock,
-      });
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      await controller.addTransaction({
-        from,
-        to: from,
-      });
-      expect(controller.state.transactions[0].transaction.from).toBe(from);
-      expect(controller.state.transactions[0].networkID).toBe(
-        MOCK_NETWORK.state.networkId,
-      );
+      },
+      {
+        sign: async (transaction: any) => transaction,
+      },
+    );
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    await controller.addTransaction({
+      from,
+      to: from,
+    });
+    expect(controller.state.transactions[0].transaction.from).toBe(from);
+    expect(controller.state.transactions[0].networkID).toBe(
+      MOCK_NETWORK.state.networkId,
+    );
 
-      expect(controller.state.transactions[0].chainId).toBe(
-        MOCK_NETWORK.state.providerConfig.chainId,
-      );
+    expect(controller.state.transactions[0].chainId).toBe(
+      MOCK_NETWORK.state.providerConfig.chainId,
+    );
 
-      expect(controller.state.transactions[0].status).toBe(
-        TransactionStatus.unapproved,
-      );
-      expect(callActionSpy).toHaveBeenCalledTimes(1);
-      expect(callActionSpy).toHaveBeenCalledWith(
-        'ApprovalController:addRequest',
-        {
-          id: expect.any(String),
-          origin: ORIGIN_METAMASK,
-          requestData: {
-            txId: expect.any(String),
-          },
-          type: ApprovalType.Transaction,
-        },
-        true,
-      );
-    },
-  );
+    expect(controller.state.transactions[0].status).toBe(
+      TransactionStatus.unapproved,
+    );
+  });
 
   it('should add a valid transaction after a network switch', async () => {
     const getNetworkState = sinon.stub().returns(MOCK_NETWORK.state);
@@ -675,7 +662,7 @@ describe('TransactionController', () => {
       onNetworkStateChange,
       provider: GOERLI_PROVIDER,
       blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
+      messenger: delayMessengerMock,
     });
 
     // switch from Goerli to Mainnet
@@ -716,7 +703,7 @@ describe('TransactionController', () => {
       onNetworkStateChange,
       provider: MOCK_CUSTOM_NETWORK.provider,
       blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
-      messenger: messengerMock,
+      messenger: delayMessengerMock,
     });
 
     // switch from Goerli to Mainnet
@@ -750,14 +737,13 @@ describe('TransactionController', () => {
       onNetworkStateChange: MOCK_NETWORK.subscribe,
       provider: MOCK_NETWORK.provider,
       blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
+      messenger: rejectMessengerMock,
     });
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const { result } = await controller.addTransaction({
       from,
       to: from,
     });
-    controller.cancelTransaction('foo');
     const transactionListener = new Promise(async (resolve) => {
       controller.hub.once(
         `${controller.state.transactions[0].id}:finished`,
@@ -770,27 +756,8 @@ describe('TransactionController', () => {
         },
       );
     });
-    controller.cancelTransaction(controller.state.transactions[0].id);
     await expect(result).rejects.toThrow('User rejected the transaction');
     await transactionListener;
-    expect(callActionSpy).toHaveBeenCalledTimes(2);
-    expect(callActionSpy).toHaveBeenCalledWith(
-      'ApprovalController:addRequest',
-      {
-        id: expect.any(String),
-        origin: ORIGIN_METAMASK,
-        requestData: {
-          txId: expect.any(String),
-        },
-        type: ApprovalType.Transaction,
-      },
-      true,
-    );
-    expect(callActionSpy).toHaveBeenCalledWith(
-      'ApprovalController:rejectRequest',
-      expect.any(String),
-      new Error('Rejected'),
-    );
   });
 
   it('should wipe transactions', async () => {
@@ -799,7 +766,7 @@ describe('TransactionController', () => {
       onNetworkStateChange: MOCK_NETWORK.subscribe,
       provider: MOCK_NETWORK.provider,
       blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
+      messenger: delayMessengerMock,
     });
     controller.wipeTransactions();
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
@@ -822,7 +789,7 @@ describe('TransactionController', () => {
     });
     controller.wipeTransactions();
     controller.state.transactions.push({
-      from: MOCK_PREFERENCES.state.selectedAddress,
+      from: MOCK_PRFERENCES.state.selectedAddress,
       id: 'foo',
       networkID: '5',
       status: TransactionStatus.submitted,
@@ -833,7 +800,6 @@ describe('TransactionController', () => {
   });
 
   it('should fail to approve an invalid transaction', async () => {
-    callActionSpy = jest.spyOn(messengerMock, 'call').mockResolvedValue({});
     const controller = new TransactionController(
       {
         getNetworkState: () => MOCK_NETWORK.state,
@@ -851,55 +817,40 @@ describe('TransactionController', () => {
     const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
     const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const { result } = await controller.addTransaction({ from, to });
-    await controller.approveTransaction(controller.state.transactions[0].id);
+    await expect(result).rejects.toThrow('foo');
     const { transaction, status } = controller.state.transactions[0];
     expect(transaction.from).toBe(from);
     expect(transaction.to).toBe(to);
     expect(status).toBe(TransactionStatus.failed);
-    await expect(result).rejects.toThrow('foo');
-    expect(callActionSpy).toHaveBeenCalledTimes(2);
-    expect(callActionSpy).toHaveBeenCalledWith(
-      'ApprovalController:addRequest',
-      {
-        id: expect.any(String),
-        origin: ORIGIN_METAMASK,
-        requestData: {
-          txId: expect.any(String),
-        },
-        type: ApprovalType.Transaction,
-      },
-      true,
-    );
-    expect(callActionSpy).toHaveBeenCalledWith(
-      'ApprovalController:rejectRequest',
-      expect.any(String),
-      new Error('Rejected'),
-    );
   });
 
   it('should have gasEstimatedError variable on transaction object if gas calculation fails', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_MAINNET_NETWORK.state,
-      onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
-      provider: MOCK_MAINNET_NETWORK.provider,
-      blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
+    const controller = new TransactionController(
+      {
+        getNetworkState: () => MOCK_MAINNET_NETWORK.state,
+        onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
+        provider: MOCK_MAINNET_NETWORK.provider,
+        blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
+        messenger: delayMessengerMock,
+      },
+      {
+        sign: async (transaction: any) => transaction,
+      },
+    );
+
     mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+
     await controller.addTransaction({
       from,
       to: from,
     });
 
-    controller.hub.once(
-      `${controller.state.transactions[0].id}:finished`,
-      () => {
-        const { transaction, status } = controller.state.transactions[0];
-        expect(transaction.estimateGasError).toBe(ESTIMATE_GAS_ERROR);
-        expect(status).toBe(TransactionStatus.submitted);
-      },
-    );
+    const {
+      transaction: { estimateGasError },
+    } = controller.state.transactions[0];
+
+    expect(estimateGasError).toBe(ESTIMATE_GAS_ERROR);
   });
 
   it('should have gasEstimatedError variable on transaction object on custom network if gas calculation fails', async () => {
@@ -908,23 +859,22 @@ describe('TransactionController', () => {
       onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
       provider: MOCK_CUSTOM_NETWORK.provider,
       blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
-      messenger: messengerMock,
+      messenger: delayMessengerMock,
     });
+
     mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+
     await controller.addTransaction({
       from,
       to: from,
     });
 
-    controller.hub.once(
-      `${controller.state.transactions[0].id}:finished`,
-      () => {
-        const { transaction, status } = controller.state.transactions[0];
-        expect(transaction.estimateGasError).toBe(ESTIMATE_GAS_ERROR);
-        expect(status).toBe(TransactionStatus.submitted);
-      },
-    );
+    const {
+      transaction: { estimateGasError },
+    } = controller.state.transactions[0];
+
+    expect(estimateGasError).toBe(ESTIMATE_GAS_ERROR);
   });
 
   it('should fail if no sign method defined', async () => {
@@ -941,30 +891,11 @@ describe('TransactionController', () => {
     const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
     const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const { result } = await controller.addTransaction({ from, to });
-    await controller.approveTransaction(controller.state.transactions[0].id);
+    await expect(result).rejects.toThrow('No sign method defined');
     const { transaction, status } = controller.state.transactions[0];
     expect(transaction.from).toBe(from);
     expect(transaction.to).toBe(to);
     expect(status).toBe(TransactionStatus.failed);
-    await expect(result).rejects.toThrow('No sign method defined');
-    expect(callActionSpy).toHaveBeenCalledTimes(2);
-    expect(callActionSpy).toHaveBeenCalledWith(
-      'ApprovalController:addRequest',
-      {
-        id: expect.any(String),
-        origin: ORIGIN_METAMASK,
-        requestData: {
-          txId: expect.any(String),
-        },
-        type: ApprovalType.Transaction,
-      },
-      true,
-    );
-    expect(callActionSpy).toHaveBeenCalledWith(
-      'ApprovalController:rejectRequest',
-      expect.any(String),
-      new Error('Rejected'),
-    );
   });
 
   it('should fail if no chainId is defined', async () => {
@@ -984,122 +915,38 @@ describe('TransactionController', () => {
     const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
     const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const { result } = await controller.addTransaction({ from, to });
-    await controller.approveTransaction(controller.state.transactions[0].id);
+    await expect(result).rejects.toThrow('No chainId defined');
     const { transaction, status } = controller.state.transactions[0];
     expect(transaction.from).toBe(from);
     expect(transaction.to).toBe(to);
     expect(status).toBe(TransactionStatus.failed);
-    await expect(result).rejects.toThrow('No chainId defined');
-    expect(callActionSpy).toHaveBeenCalledTimes(2);
-    expect(callActionSpy).toHaveBeenCalledWith(
-      'ApprovalController:addRequest',
-      {
-        id: expect.any(String),
-        origin: ORIGIN_METAMASK,
-        requestData: {
-          txId: expect.any(String),
-        },
-        type: ApprovalType.Transaction,
-      },
-      true,
-    );
-    expect(callActionSpy).toHaveBeenCalledWith(
-      'ApprovalController:rejectRequest',
-      expect.any(String),
-      new Error('Rejected'),
-    );
   });
 
-  it.each([
-    ['resolves', true],
-    ['rejects', false],
-  ])(
-    'should approve a transaction if user accepts and message to ApprovalController %s',
-    async (_, approvalControllerCallResolves: boolean) => {
-      const calledOnce = false;
-      callActionSpy = setupMessengerCallSpy(
-        approvalControllerCallResolves,
-        calledOnce,
-      );
-      await new Promise(async (resolve) => {
-        const controller = new TransactionController(
-          {
-            getNetworkState: () => MOCK_NETWORK.state,
-            onNetworkStateChange: MOCK_NETWORK.subscribe,
-            provider: MOCK_NETWORK.provider,
-            blockTracker: MOCK_NETWORK.blockTracker,
-            messenger: messengerMock,
-          },
-          {
-            sign: async (transaction: any) => transaction,
-          },
-        );
-        const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-        await controller.addTransaction({
-          from,
-          gas: '0x0',
-          gasPrice: '0x0',
-          to: from,
-          value: '0x0',
-        });
+  it('should approve a transaction', async () => {
+    const { messenger, approve } = buildMockMessenger({ delay: true });
 
-        controller.hub.once(
-          `${controller.state.transactions[0].id}:finished`,
-          () => {
-            const { transaction, status } = controller.state.transactions[0];
-            expect(transaction.from).toBe(from);
-            expect(status).toBe(TransactionStatus.submitted);
-            resolve('');
-          },
-        );
-        await controller.approveTransaction(
-          controller.state.transactions[0].id,
-        );
-        expect(callActionSpy).toHaveBeenCalledTimes(2);
-        expect(callActionSpy).toHaveBeenCalledWith(
-          'ApprovalController:addRequest',
-          {
-            id: expect.any(String),
-            origin: ORIGIN_METAMASK,
-            requestData: {
-              txId: expect.any(String),
-            },
-            type: ApprovalType.Transaction,
-          },
-          true,
-        );
-        expect(callActionSpy).toHaveBeenCalledWith(
-          'ApprovalController:acceptRequest',
-          expect.any(String),
-        );
-      });
-    },
-  );
-
-  it('fails to request transaction approval when messaging system throws', async () => {
-    jest.spyOn(messengerMock, 'call').mockImplementation(() => {
-      throw new Error('Messenger mocked call fails');
-    });
     const controller = new TransactionController(
       {
         getNetworkState: () => MOCK_NETWORK.state,
         onNetworkStateChange: MOCK_NETWORK.subscribe,
         provider: MOCK_NETWORK.provider,
         blockTracker: MOCK_NETWORK.blockTracker,
-        messenger: messengerMock,
+        messenger,
       },
       {
         sign: async (transaction: any) => transaction,
       },
     );
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    await controller.addTransaction({
+
+    const { result } = await controller.addTransaction({
       from,
       gas: '0x0',
       gasPrice: '0x0',
       to: from,
       value: '0x0',
     });
+
     controller.hub.once(
       `${controller.state.transactions[0].id}:finished`,
       () => {
@@ -1108,6 +955,9 @@ describe('TransactionController', () => {
         expect(status).toBe(TransactionStatus.submitted);
       },
     );
+
+    approve();
+    await result;
   });
 
   it('should query transaction statuses', async () => {
@@ -1125,7 +975,7 @@ describe('TransactionController', () => {
         },
       );
       controller.state.transactions.push({
-        from: MOCK_PREFERENCES.state.selectedAddress,
+        from: MOCK_PRFERENCES.state.selectedAddress,
         id: 'foo',
         networkID: '5',
         chainId: toHex(5),
@@ -1163,7 +1013,7 @@ describe('TransactionController', () => {
         },
       );
       controller.state.transactions.push({
-        from: MOCK_PREFERENCES.state.selectedAddress,
+        from: MOCK_PRFERENCES.state.selectedAddress,
         id: 'foo',
         networkID: '5',
         status: TransactionStatus.submitted,
@@ -1198,11 +1048,11 @@ describe('TransactionController', () => {
       },
     );
     controller.state.transactions.push({
-      from: MOCK_PREFERENCES.state.selectedAddress,
+      from: MOCK_PRFERENCES.state.selectedAddress,
       id: 'foo',
       networkID: '5',
       status: TransactionStatus.submitted,
-      transactionHash: '1111',
+      transactionHash: '1338',
     } as any);
     await controller.queryTransactionStatuses();
     expect(controller.state.transactions[0].status).toBe(
@@ -1224,7 +1074,7 @@ describe('TransactionController', () => {
       },
     );
     controller.state.transactions.push({
-      from: MOCK_PREFERENCES.state.selectedAddress,
+      from: MOCK_PRFERENCES.state.selectedAddress,
       id: 'foo',
       networkID: '5',
       chainId: toHex(5),
@@ -1469,68 +1319,18 @@ describe('TransactionController', () => {
     expect(registryLookup.called).toBe(false);
   });
 
-  it.each([
-    ['resolves', true],
-    ['rejects', false],
-  ])(
-    'stops a transaction if user rejects and message to ApprovalController %s',
-    async (_, approvalControllerCallResolves: boolean) => {
-      const calledOnce = false;
-      callActionSpy = setupMessengerCallSpy(
-        approvalControllerCallResolves,
-        calledOnce,
-      );
-      const controller = new TransactionController(
-        {
-          getNetworkState: () => MOCK_NETWORK.state,
-          onNetworkStateChange: MOCK_NETWORK.subscribe,
-          provider: MOCK_NETWORK.provider,
-          blockTracker: MOCK_NETWORK.blockTracker,
-          messenger: messengerMock,
-        },
-        {
-          sign: async (transaction: any) => transaction,
-        },
-      );
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      const { result } = await controller.addTransaction({
-        from,
-        gas: '0x0',
-        gasPrice: '0x1',
-        to: from,
-        value: '0x0',
-      });
-      controller.stopTransaction(controller.state.transactions[0].id);
-      await expect(result).rejects.toThrow('User cancelled the transaction');
-      expect(callActionSpy).toHaveBeenCalledTimes(2);
-      expect(callActionSpy).toHaveBeenCalledWith(
-        'ApprovalController:addRequest',
-        {
-          id: expect.any(String),
-          origin: ORIGIN_METAMASK,
-          requestData: {
-            txId: expect.any(String),
-          },
-          type: ApprovalType.Transaction,
-        },
-        true,
-      );
-      expect(callActionSpy).toHaveBeenCalledWith(
-        'ApprovalController:rejectRequest',
-        expect.any(String),
-        new Error('Rejected'),
-      );
-    },
-  );
+  it('should stop a transaction', async () => {
+    const { messenger, approve } = buildMockMessenger({
+      delay: true,
+    });
 
-  it('stops a transaction specifying gas price', async () => {
     const controller = new TransactionController(
       {
         getNetworkState: () => MOCK_NETWORK.state,
         onNetworkStateChange: MOCK_NETWORK.subscribe,
         provider: MOCK_NETWORK.provider,
         blockTracker: MOCK_NETWORK.blockTracker,
-        messenger: messengerMock,
+        messenger,
       },
       {
         sign: async (transaction: any) => transaction,
@@ -1544,27 +1344,11 @@ describe('TransactionController', () => {
       to: from,
       value: '0x0',
     });
-    const gasPrice: GasPriceValue = { gasPrice: '0x1' };
-    controller.stopTransaction(controller.state.transactions[0].id, gasPrice);
+
+    await controller.stopTransaction(controller.state.transactions[0].id);
+    approve();
+
     await expect(result).rejects.toThrow('User cancelled the transaction');
-    expect(callActionSpy).toHaveBeenCalledTimes(2);
-    expect(callActionSpy).toHaveBeenCalledWith(
-      'ApprovalController:addRequest',
-      {
-        id: expect.any(String),
-        origin: ORIGIN_METAMASK,
-        requestData: {
-          txId: expect.any(String),
-        },
-        type: ApprovalType.Transaction,
-      },
-      true,
-    );
-    expect(callActionSpy).toHaveBeenCalledWith(
-      'ApprovalController:rejectRequest',
-      expect.any(String),
-      new Error('Rejected'),
-    );
   });
 
   it('should fail to stop a transaction if no sign method', async () => {
@@ -1573,7 +1357,7 @@ describe('TransactionController', () => {
       onNetworkStateChange: MOCK_NETWORK.subscribe,
       provider: MOCK_NETWORK.provider,
       blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
+      messenger: delayMessengerMock,
     });
     const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
     const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
@@ -1606,12 +1390,7 @@ describe('TransactionController', () => {
         to: from,
         value: '0x0',
       });
-      const gasPrice: GasPriceValue = { gasPrice: '0x5916a6d6' };
-      await controller.approveTransaction(controller.state.transactions[0].id);
-      await controller.speedUpTransaction(
-        controller.state.transactions[0].id,
-        gasPrice,
-      );
+      await controller.speedUpTransaction(controller.state.transactions[0].id);
       expect(controller.state.transactions).toHaveLength(2);
       expect(controller.state.transactions[1].transaction.gasPrice).toBe(
         '0x5916a6d6', // 1.1 * 0x50fd51da
@@ -1621,38 +1400,35 @@ describe('TransactionController', () => {
   });
 
   it('should limit tx state to a length of 2', async () => {
-    await new Promise(async (resolve) => {
-      mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
-      const controller = new TransactionController(
-        {
-          getNetworkState: () => MOCK_NETWORK.state,
-          onNetworkStateChange: MOCK_NETWORK.subscribe,
-          provider: MOCK_NETWORK.provider,
-          blockTracker: MOCK_NETWORK.blockTracker,
-          messenger: messengerMock,
-        },
-        {
-          interval: 5000,
-          sign: async (transaction: any) => transaction,
-          txHistoryLimit: 2,
-        },
-      );
-      const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
-      await controller.fetchAll(from);
-      await controller.addTransaction({
-        from,
-        nonce: '55555',
-        gas: '0x0',
-        gasPrice: '0x50fd51da',
-        to: from,
-        value: '0x0',
-      });
-      expect(controller.state.transactions).toHaveLength(2);
-      expect(controller.state.transactions[0].transaction.gasPrice).toBe(
-        '0x4a817c800',
-      );
-      resolve('');
+    mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
+    const controller = new TransactionController(
+      {
+        getNetworkState: () => MOCK_NETWORK.state,
+        onNetworkStateChange: MOCK_NETWORK.subscribe,
+        provider: MOCK_NETWORK.provider,
+        blockTracker: MOCK_NETWORK.blockTracker,
+        messenger: delayMessengerMock,
+      },
+      {
+        interval: 5000,
+        sign: async (transaction: any) => transaction,
+        txHistoryLimit: 2,
+      },
+    );
+    const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+    await controller.fetchAll(from);
+    await controller.addTransaction({
+      from,
+      nonce: '55555',
+      gas: '0x0',
+      gasPrice: '0x50fd51da',
+      to: from,
+      value: '0x0',
     });
+    expect(controller.state.transactions).toHaveLength(2);
+    expect(controller.state.transactions[0].transaction.gasPrice).toBe(
+      '0x4a817c800',
+    );
   });
 
   it('should allow tx state to be greater than txHistorylimit due to speed up same nonce', async () => {
@@ -1691,45 +1467,47 @@ describe('TransactionController', () => {
       .mockImplementationOnce(() => 'aaaab1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d')
       .mockImplementationOnce(() => 'bbbb1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d');
 
-    await new Promise(async (resolve) => {
-      const controller = new TransactionController(
-        {
-          getNetworkState: () => MOCK_NETWORK.state,
-          onNetworkStateChange: MOCK_NETWORK.subscribe,
-          provider: MOCK_NETWORK.provider,
-          blockTracker: MOCK_NETWORK.blockTracker,
-          messenger: messengerMock,
-        },
-        {
-          sign: async (transaction: any) => transaction,
-        },
-      );
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      await controller.addTransaction({
-        from,
-        gas: '0x0',
-        gasPrice: '0x50fd51da',
-        to: from,
-        value: '0x0',
-      });
+    const controller = new TransactionController(
+      {
+        getNetworkState: () => MOCK_NETWORK.state,
+        onNetworkStateChange: MOCK_NETWORK.subscribe,
+        provider: MOCK_NETWORK.provider,
+        blockTracker: MOCK_NETWORK.blockTracker,
+        messenger: messengerMock,
+      },
+      {
+        sign: async (transaction: any) => transaction,
+      },
+    );
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
 
-      const firstTransaction = controller.state.transactions[0];
-      await controller.approveTransaction(firstTransaction.id);
-      await controller.addTransaction({
-        from,
-        gas: '0x2',
-        gasPrice: '0x50fd51da',
-        to: from,
-        value: '0x1290',
-      });
-      expect(controller.state.transactions).toHaveLength(2);
-      const secondTransaction = controller.state.transactions[1];
-      await controller.approveTransaction(secondTransaction.id);
-
-      expect(firstTransaction.transaction.nonce).toStrictEqual('0x0');
-      expect(secondTransaction.transaction.nonce).toStrictEqual('0x1');
-      resolve('');
+    const { result: firstResult } = await controller.addTransaction({
+      from,
+      gas: '0x0',
+      gasPrice: '0x50fd51da',
+      to: from,
+      value: '0x0',
     });
+
+    await firstResult.catch(() => undefined);
+
+    const firstTransaction = controller.state.transactions[0];
+
+    const { result: secondResult } = await controller.addTransaction({
+      from,
+      gas: '0x2',
+      gasPrice: '0x50fd51da',
+      to: from,
+      value: '0x1290',
+    });
+
+    await secondResult.catch(() => undefined);
+
+    expect(controller.state.transactions).toHaveLength(2);
+    const secondTransaction = controller.state.transactions[1];
+
+    expect(firstTransaction.transaction.nonce).toStrictEqual('0x0');
+    expect(secondTransaction.transaction.nonce).toStrictEqual('0x1');
   });
 
   describe('NonceTracker integration', () => {
@@ -1786,7 +1564,6 @@ describe('TransactionController', () => {
             resolve('');
           },
         );
-        controller.approveTransaction(controller.state.transactions[0].id);
       });
     });
 
@@ -1814,7 +1591,6 @@ describe('TransactionController', () => {
         });
 
         const originalTransaction = controller.state.transactions[0];
-        await controller.approveTransaction(originalTransaction.id);
         await controller.speedUpTransaction(originalTransaction.id);
         expect(getNonceLockSpy).toHaveBeenCalledTimes(1);
         expect(controller.state.transactions).toHaveLength(2);

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1556,8 +1556,42 @@ describe('TransactionController', () => {
     expect(secondTransaction.transaction.nonce).toStrictEqual('0x1');
   });
 
+  it('fails transaction if approval fails with unrecognised error', async () => {
+    const { messenger } = buildMockMessenger({
+      delay: true,
+    });
+
+    const controller = new TransactionController(
+      {
+        getNetworkState: () => MOCK_NETWORK.state,
+        onNetworkStateChange: MOCK_NETWORK.subscribe,
+        provider: MOCK_NETWORK.provider,
+        blockTracker: MOCK_NETWORK.blockTracker,
+        messenger,
+      },
+      {
+        sign: async (transaction: any) => transaction,
+      },
+    );
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+
+    (messenger.call as jest.MockedFunction<any>).mockImplementationOnce(() => {
+      throw new Error('TestError');
+    });
+
+    const { result } = await controller.addTransaction({
+      from,
+      gas: '0x0',
+      gasPrice: '0x0',
+      to: from,
+      value: '0x0',
+    });
+
+    await expect(result).rejects.toThrow('TestError');
+  });
+
   it('throws unknown error if status not expected', async () => {
-    const { messenger, approve } = buildMockMessenger({
+    const { messenger } = buildMockMessenger({
       delay: true,
     });
 
@@ -1588,7 +1622,41 @@ describe('TransactionController', () => {
       value: '0x0',
     });
 
-    approve();
+    await expect(result).rejects.toThrow('Unknown problem');
+  });
+
+  it('throws unknown error if transaction removed', async () => {
+    const { messenger } = buildMockMessenger({
+      delay: true,
+    });
+
+    const controller = new TransactionController(
+      {
+        getNetworkState: () => MOCK_NETWORK.state,
+        onNetworkStateChange: MOCK_NETWORK.subscribe,
+        provider: MOCK_NETWORK.provider,
+        blockTracker: MOCK_NETWORK.blockTracker,
+        messenger,
+      },
+      {
+        sign: async (transaction: any) => transaction,
+      },
+    );
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+
+    (messenger.call as jest.MockedFunction<any>).mockImplementationOnce(() => {
+      controller.state.transactions = [];
+      throw new Error('TestError');
+    });
+
+    const { result } = await controller.addTransaction({
+      from,
+      gas: '0x0',
+      gasPrice: '0x0',
+      to: from,
+      value: '0x0',
+    });
+
     await expect(result).rejects.toThrow('Unknown problem');
   });
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -366,6 +366,8 @@ describe('TransactionController', () => {
   let messengerMock: TransactionControllerMessenger;
   let rejectMessengerMock: TransactionControllerMessenger;
   let delayMessengerMock: TransactionControllerMessenger;
+  let getNonceLockSpy: jest.Mock<any, any>;
+  const nonceMock = 12;
 
   beforeEach(() => {
     for (const key in mockFlags) {
@@ -375,6 +377,13 @@ describe('TransactionController', () => {
     messengerMock = buildMockMessenger({ approved: true }).messenger;
     rejectMessengerMock = buildMockMessenger({ approved: false }).messenger;
     delayMessengerMock = buildMockMessenger({ delay: true }).messenger;
+
+    getNonceLockSpy = jest.fn().mockResolvedValue({
+      nextNonce: nonceMock,
+      releaseLock: () => Promise.resolve(),
+    });
+
+    NonceTracker.prototype.getNonceLock = getNonceLockSpy;
   });
 
   afterEach(() => {
@@ -382,83 +391,65 @@ describe('TransactionController', () => {
     sinon.restore();
   });
 
-  it('should set default state', () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-
-    expect(controller.state).toStrictEqual({
-      methodData: {},
-      transactions: [],
-    });
-  });
-
-  it('should set default config', () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    expect(controller.config).toStrictEqual({
-      interval: 15000,
-      txHistoryLimit: 40,
-    });
-  });
-
-  it('should poll and update transaction statuses in the right interval', async () => {
-    await new Promise((resolve) => {
-      const mock = sinon.stub(
-        TransactionController.prototype,
-        'queryTransactionStatuses',
-      );
-      new TransactionController(
-        {
-          getNetworkState: () => MOCK_NETWORK.state,
-          onNetworkStateChange: MOCK_NETWORK.subscribe,
-          provider: MOCK_NETWORK.provider,
-          blockTracker: MOCK_NETWORK.blockTracker,
-          messenger: messengerMock,
-        },
-        { interval: 10 },
-      );
-      expect(mock.called).toBe(true);
-      expect(mock.calledTwice).toBe(false);
-      setTimeout(() => {
-        expect(mock.calledTwice).toBe(true);
-        resolve('');
-      }, 15);
-    });
-  });
-
-  it('should clear previous interval', async () => {
-    const mock = sinon.stub(global, 'clearTimeout');
-    const controller = new TransactionController(
-      {
+  describe('constructor', () => {
+    it('sets default state', () => {
+      const controller = new TransactionController({
         getNetworkState: () => MOCK_NETWORK.state,
         onNetworkStateChange: MOCK_NETWORK.subscribe,
         provider: MOCK_NETWORK.provider,
         blockTracker: MOCK_NETWORK.blockTracker,
         messenger: messengerMock,
-      },
-      { interval: 1337 },
-    );
-    await new Promise((resolve) => {
-      setTimeout(() => {
-        controller.poll(1338);
-        expect(mock.called).toBe(true);
-        resolve('');
-      }, 100);
+      });
+
+      expect(controller.state).toStrictEqual({
+        methodData: {},
+        transactions: [],
+      });
+    });
+
+    it('sets default config', () => {
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_NETWORK.state,
+        onNetworkStateChange: MOCK_NETWORK.subscribe,
+        provider: MOCK_NETWORK.provider,
+        blockTracker: MOCK_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      expect(controller.config).toStrictEqual({
+        interval: 15000,
+        txHistoryLimit: 40,
+      });
     });
   });
 
-  it('should not update the state if there are no updates on transaction statuses', async () => {
-    await new Promise((resolve) => {
+  describe('poll', () => {
+    it('updates transaction statuses in the right interval', async () => {
+      await new Promise((resolve) => {
+        const mock = sinon.stub(
+          TransactionController.prototype,
+          'queryTransactionStatuses',
+        );
+        new TransactionController(
+          {
+            getNetworkState: () => MOCK_NETWORK.state,
+            onNetworkStateChange: MOCK_NETWORK.subscribe,
+            provider: MOCK_NETWORK.provider,
+            blockTracker: MOCK_NETWORK.blockTracker,
+            messenger: messengerMock,
+          },
+          { interval: 10 },
+        );
+        expect(mock.called).toBe(true);
+        expect(mock.calledTwice).toBe(false);
+        setTimeout(() => {
+          expect(mock.calledTwice).toBe(true);
+          resolve('');
+        }, 15);
+      });
+    });
+
+    it('clears previous interval', async () => {
+      const mock = sinon.stub(global, 'clearTimeout');
       const controller = new TransactionController(
         {
           getNetworkState: () => MOCK_NETWORK.state,
@@ -467,501 +458,767 @@ describe('TransactionController', () => {
           blockTracker: MOCK_NETWORK.blockTracker,
           messenger: messengerMock,
         },
-        { interval: 10 },
+        { interval: 1337 },
       );
-      const func = sinon.stub(controller, 'update');
-      setTimeout(() => {
-        expect(func.called).toBe(false);
-        resolve('');
-      }, 20);
-    });
-  });
-
-  it('should on eth_estimateGas succeed when gasBn it is greater than maxGasBN', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    mockFlags.estimateGasValue = '0x12a05f200';
-    const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
-    const result = await controller.estimateGas({ from, to: from });
-
-    expect(result.estimateGasError).toBeUndefined();
-  });
-
-  it('should on Mainnet eth_estimateGas succeed when gasBn it is higher than maxGasBN', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    mockFlags.estimateGasValue = '0x12a05f200';
-
-    const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
-    const result = await controller.estimateGas({ from, to: from });
-
-    expect(result.estimateGasError).toBeUndefined();
-  });
-
-  it('should on Custom Network eth_estimateGas succeed when gasBN  is equal to maxGasBN', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
-      onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
-      provider: MOCK_CUSTOM_NETWORK.provider,
-      blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
-    const result = await controller.estimateGas({ from, to: from });
-    expect(result.estimateGasError).toBeUndefined();
-  });
-
-  it('should on Custom Network eth_estimateGas fail when gasBN  is equal to maxGasBN', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
-      onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
-      provider: MOCK_CUSTOM_NETWORK.provider,
-      blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
-    const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
-    const result = await controller.estimateGas({ from, to: from });
-    expect(result.estimateGasError).toBe(ESTIMATE_GAS_ERROR);
-  });
-
-  it('should on Custom Network eth_estimateGas succeed when gasBN  is less than maxGasBN', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
-      onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
-      provider: MOCK_CUSTOM_NETWORK.provider,
-      blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-
-    mockFlags.getBlockByNumberValue = '0x12a05f200';
-
-    const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
-    const result = await controller.estimateGas({ from, to: from });
-    expect(result.estimateGasError).toBeUndefined();
-  });
-
-  it('should on Custom Network eth_estimateGas fail when gasBN  is less than maxGasBN', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
-      onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
-      provider: MOCK_CUSTOM_NETWORK.provider,
-      blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-
-    mockFlags.getBlockByNumberValue = '0x12a05f200';
-
-    mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
-    const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
-    const result = await controller.estimateGas({ from, to: from });
-
-    expect(result.estimateGasError).toBe(ESTIMATE_GAS_ERROR);
-  });
-
-  it('should eth_estimateGas succeed when gasBN  is less than maxGasBN and paddedGasBN is less than MaxGasBN', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-
-    mockFlags.getBlockByNumberValue = '0x12a05f200';
-
-    const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
-    const result = await controller.estimateGas({ from, to: from });
-
-    expect(result.estimateGasError).toBeUndefined();
-  });
-
-  it('should eth_estimateGas fail when gasBN  is less than maxGasBN and paddedGasBN is less than MaxGasBN', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-
-    mockFlags.getBlockByNumberValue = '0x12a05f200';
-    mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
-
-    const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
-    const result = await controller.estimateGas({ from, to: from });
-
-    expect(result.estimateGasError).toBe(ESTIMATE_GAS_ERROR);
-  });
-
-  it('should throw when adding invalid transaction', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    await expect(
-      controller.addTransaction({ from: 'foo' } as any),
-    ).rejects.toThrow('Invalid "from" address');
-  });
-
-  it('should add a valid transaction', async () => {
-    const controller = new TransactionController(
-      {
-        getNetworkState: () => MOCK_NETWORK.state,
-        onNetworkStateChange: MOCK_NETWORK.subscribe,
-        provider: MOCK_NETWORK.provider,
-        blockTracker: MOCK_NETWORK.blockTracker,
-        messenger: messengerMock,
-      },
-      {
-        sign: async (transaction: any) => transaction,
-      },
-    );
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    await controller.addTransaction({
-      from,
-      to: from,
-    });
-    expect(controller.state.transactions[0].transaction.from).toBe(from);
-    expect(controller.state.transactions[0].networkID).toBe(
-      MOCK_NETWORK.state.networkId,
-    );
-
-    expect(controller.state.transactions[0].chainId).toBe(
-      MOCK_NETWORK.state.providerConfig.chainId,
-    );
-
-    expect(controller.state.transactions[0].status).toBe(
-      TransactionStatus.unapproved,
-    );
-  });
-
-  it('should add a valid transaction after a network switch', async () => {
-    const getNetworkState = sinon.stub().returns(MOCK_NETWORK.state);
-    let networkStateChangeListener: ((state: NetworkState) => void) | null =
-      null;
-    const onNetworkStateChange = (listener: (state: NetworkState) => void) => {
-      networkStateChangeListener = listener;
-    };
-
-    const controller = new TransactionController({
-      getNetworkState,
-      onNetworkStateChange,
-      provider: GOERLI_PROVIDER,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: delayMessengerMock,
-    });
-
-    // switch from Goerli to Mainnet
-    getNetworkState.returns(MOCK_MAINNET_NETWORK.state);
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    networkStateChangeListener!(MOCK_MAINNET_NETWORK.state);
-
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    await controller.addTransaction({
-      from,
-      to: from,
-    });
-    expect(controller.state.transactions[0].transaction.from).toBe(from);
-    expect(controller.state.transactions[0].networkID).toBe(
-      MOCK_MAINNET_NETWORK.state.networkId,
-    );
-
-    expect(controller.state.transactions[0].chainId).toBe(
-      MOCK_MAINNET_NETWORK.state.providerConfig.chainId,
-    );
-
-    expect(controller.state.transactions[0].status).toBe(
-      TransactionStatus.unapproved,
-    );
-  });
-
-  it('should add a valid transaction after a switch to custom network', async () => {
-    const getNetworkState = sinon.stub().returns(MOCK_NETWORK.state);
-    let networkStateChangeListener: ((state: NetworkState) => void) | null =
-      null;
-    const onNetworkStateChange = (listener: (state: NetworkState) => void) => {
-      networkStateChangeListener = listener;
-    };
-
-    const controller = new TransactionController({
-      getNetworkState,
-      onNetworkStateChange,
-      provider: MOCK_CUSTOM_NETWORK.provider,
-      blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
-      messenger: delayMessengerMock,
-    });
-
-    // switch from Goerli to Mainnet
-    getNetworkState.returns(MOCK_CUSTOM_NETWORK.state);
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    networkStateChangeListener!(MOCK_CUSTOM_NETWORK.state);
-
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    await controller.addTransaction({
-      from,
-      to: from,
-    });
-    expect(controller.state.transactions[0].transaction.from).toBe(from);
-    expect(controller.state.transactions[0].networkID).toBe(
-      MOCK_CUSTOM_NETWORK.state.networkId,
-    );
-
-    expect(controller.state.transactions[0].chainId).toBe(
-      MOCK_CUSTOM_NETWORK.state.providerConfig.chainId,
-    );
-
-    expect(controller.state.transactions[0].status).toBe(
-      TransactionStatus.unapproved,
-    );
-  });
-
-  it('should cancel a transaction', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: rejectMessengerMock,
-    });
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const { result } = await controller.addTransaction({
-      from,
-      to: from,
-    });
-    const transactionListener = new Promise(async (resolve) => {
-      controller.hub.once(
-        `${controller.state.transactions[0].id}:finished`,
-        () => {
-          expect(controller.state.transactions[0].transaction.from).toBe(from);
-          expect(controller.state.transactions[0].status).toBe(
-            TransactionStatus.rejected,
-          );
+      await new Promise((resolve) => {
+        setTimeout(() => {
+          controller.poll(1338);
+          expect(mock.called).toBe(true);
           resolve('');
-        },
-      );
+        }, 100);
+      });
     });
-    await expect(result).rejects.toThrow('User rejected the transaction');
-    await transactionListener;
+
+    it('does not update the state if there are no updates on transaction statuses', async () => {
+      await new Promise((resolve) => {
+        const controller = new TransactionController(
+          {
+            getNetworkState: () => MOCK_NETWORK.state,
+            onNetworkStateChange: MOCK_NETWORK.subscribe,
+            provider: MOCK_NETWORK.provider,
+            blockTracker: MOCK_NETWORK.blockTracker,
+            messenger: messengerMock,
+          },
+          { interval: 10 },
+        );
+        const func = sinon.stub(controller, 'update');
+        setTimeout(() => {
+          expect(func.called).toBe(false);
+          resolve('');
+        }, 20);
+      });
+    });
   });
 
-  it('should wipe transactions', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: delayMessengerMock,
-    });
-    controller.wipeTransactions();
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    await controller.addTransaction({
-      from,
-      to: from,
-    });
-    controller.wipeTransactions();
-    expect(controller.state.transactions).toHaveLength(0);
-  });
-
-  // This tests the fallback to networkID only when there is no chainId present. Should be removed when networkID is completely removed.
-  it('should wipe transactions using networkID when there is no chainId', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    controller.wipeTransactions();
-    controller.state.transactions.push({
-      from: MOCK_PRFERENCES.state.selectedAddress,
-      id: 'foo',
-      networkID: '5',
-      status: TransactionStatus.submitted,
-      transactionHash: '1337',
-    } as any);
-    controller.wipeTransactions();
-    expect(controller.state.transactions).toHaveLength(0);
-  });
-
-  it('should fail to approve an invalid transaction', async () => {
-    const controller = new TransactionController(
-      {
+  describe('estimateGas', () => {
+    it('succeeds when gasBn is greater than maxGasBN', async () => {
+      const controller = new TransactionController({
         getNetworkState: () => MOCK_NETWORK.state,
         onNetworkStateChange: MOCK_NETWORK.subscribe,
         provider: MOCK_NETWORK.provider,
         blockTracker: MOCK_NETWORK.blockTracker,
         messenger: messengerMock,
-      },
-      {
-        sign: () => {
-          throw new Error('foo');
-        },
-      },
-    );
-    const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
-    const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const { result } = await controller.addTransaction({ from, to });
-    await expect(result).rejects.toThrow('foo');
-    const { transaction, status } = controller.state.transactions[0];
-    expect(transaction.from).toBe(from);
-    expect(transaction.to).toBe(to);
-    expect(status).toBe(TransactionStatus.failed);
-  });
+      });
+      mockFlags.estimateGasValue = '0x12a05f200';
+      const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
+      const result = await controller.estimateGas({ from, to: from });
 
-  it('should have gasEstimatedError variable on transaction object if gas calculation fails', async () => {
-    const controller = new TransactionController(
-      {
+      expect(result.estimateGasError).toBeUndefined();
+    });
+
+    it('succeeds on mainnet when gasBn is higher than maxGasBN', async () => {
+      const controller = new TransactionController({
         getNetworkState: () => MOCK_MAINNET_NETWORK.state,
         onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
         provider: MOCK_MAINNET_NETWORK.provider,
         blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      mockFlags.estimateGasValue = '0x12a05f200';
+
+      const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
+      const result = await controller.estimateGas({ from, to: from });
+
+      expect(result.estimateGasError).toBeUndefined();
+    });
+
+    it('succeeds on custom network when gasBN is equal to maxGasBN', async () => {
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
+        onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
+        provider: MOCK_CUSTOM_NETWORK.provider,
+        blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
+      const result = await controller.estimateGas({ from, to: from });
+      expect(result.estimateGasError).toBeUndefined();
+    });
+
+    it('fails on custom network when gasBN is equal to maxGasBN', async () => {
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
+        onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
+        provider: MOCK_CUSTOM_NETWORK.provider,
+        blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
+      const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
+      const result = await controller.estimateGas({ from, to: from });
+      expect(result.estimateGasError).toBe(ESTIMATE_GAS_ERROR);
+    });
+
+    it('succeed on custom network when gasBN is less than maxGasBN', async () => {
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
+        onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
+        provider: MOCK_CUSTOM_NETWORK.provider,
+        blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+
+      mockFlags.getBlockByNumberValue = '0x12a05f200';
+
+      const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
+      const result = await controller.estimateGas({ from, to: from });
+      expect(result.estimateGasError).toBeUndefined();
+    });
+
+    it('fails on custom network when gasBN is less than maxGasBN', async () => {
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
+        onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
+        provider: MOCK_CUSTOM_NETWORK.provider,
+        blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+
+      mockFlags.getBlockByNumberValue = '0x12a05f200';
+
+      mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
+      const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
+      const result = await controller.estimateGas({ from, to: from });
+
+      expect(result.estimateGasError).toBe(ESTIMATE_GAS_ERROR);
+    });
+
+    it('succeeds when gasBN is less than maxGasBN and paddedGasBN is less than MaxGasBN', async () => {
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_NETWORK.state,
+        onNetworkStateChange: MOCK_NETWORK.subscribe,
+        provider: MOCK_NETWORK.provider,
+        blockTracker: MOCK_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+
+      mockFlags.getBlockByNumberValue = '0x12a05f200';
+
+      const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
+      const result = await controller.estimateGas({ from, to: from });
+
+      expect(result.estimateGasError).toBeUndefined();
+    });
+
+    it('fails when gasBN is less than maxGasBN and paddedGasBN is less than MaxGasBN', async () => {
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_NETWORK.state,
+        onNetworkStateChange: MOCK_NETWORK.subscribe,
+        provider: MOCK_NETWORK.provider,
+        blockTracker: MOCK_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+
+      mockFlags.getBlockByNumberValue = '0x12a05f200';
+      mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
+
+      const from = '0x4579d0ad79bfbdf4539a1ddf5f10b378d724a34c';
+      const result = await controller.estimateGas({ from, to: from });
+
+      expect(result.estimateGasError).toBe(ESTIMATE_GAS_ERROR);
+    });
+  });
+
+  describe('addTransaction', () => {
+    it('adds unapproved transaction to state', async () => {
+      const controller = new TransactionController(
+        {
+          getNetworkState: () => MOCK_NETWORK.state,
+          onNetworkStateChange: MOCK_NETWORK.subscribe,
+          provider: MOCK_NETWORK.provider,
+          blockTracker: MOCK_NETWORK.blockTracker,
+          messenger: delayMessengerMock,
+        },
+        {
+          sign: async (transaction: any) => transaction,
+        },
+      );
+      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+      await controller.addTransaction({
+        from,
+        to: from,
+      });
+      expect(controller.state.transactions[0].transaction.from).toBe(from);
+      expect(controller.state.transactions[0].networkID).toBe(
+        MOCK_NETWORK.state.networkId,
+      );
+
+      expect(controller.state.transactions[0].chainId).toBe(
+        MOCK_NETWORK.state.providerConfig.chainId,
+      );
+
+      expect(controller.state.transactions[0].status).toBe(
+        TransactionStatus.unapproved,
+      );
+    });
+
+    it('adds unapproved transaction to state after a network switch', async () => {
+      const getNetworkState = sinon.stub().returns(MOCK_NETWORK.state);
+      let networkStateChangeListener: ((state: NetworkState) => void) | null =
+        null;
+      const onNetworkStateChange = (
+        listener: (state: NetworkState) => void,
+      ) => {
+        networkStateChangeListener = listener;
+      };
+
+      const controller = new TransactionController({
+        getNetworkState,
+        onNetworkStateChange,
+        provider: GOERLI_PROVIDER,
+        blockTracker: MOCK_NETWORK.blockTracker,
         messenger: delayMessengerMock,
-      },
-      {
-        sign: async (transaction: any) => transaction,
-      },
-    );
+      });
 
-    mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+      // switch from Goerli to Mainnet
+      getNetworkState.returns(MOCK_MAINNET_NETWORK.state);
 
-    await controller.addTransaction({
-      from,
-      to: from,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      networkStateChangeListener!(MOCK_MAINNET_NETWORK.state);
+
+      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+      await controller.addTransaction({
+        from,
+        to: from,
+      });
+      expect(controller.state.transactions[0].transaction.from).toBe(from);
+      expect(controller.state.transactions[0].networkID).toBe(
+        MOCK_MAINNET_NETWORK.state.networkId,
+      );
+
+      expect(controller.state.transactions[0].chainId).toBe(
+        MOCK_MAINNET_NETWORK.state.providerConfig.chainId,
+      );
+
+      expect(controller.state.transactions[0].status).toBe(
+        TransactionStatus.unapproved,
+      );
     });
 
-    const {
-      transaction: { estimateGasError },
-    } = controller.state.transactions[0];
+    it('adds unapproved transaction to state after switching to a custom network', async () => {
+      const getNetworkState = sinon.stub().returns(MOCK_NETWORK.state);
+      let networkStateChangeListener: ((state: NetworkState) => void) | null =
+        null;
+      const onNetworkStateChange = (
+        listener: (state: NetworkState) => void,
+      ) => {
+        networkStateChangeListener = listener;
+      };
 
-    expect(estimateGasError).toBe(ESTIMATE_GAS_ERROR);
-  });
+      const controller = new TransactionController({
+        getNetworkState,
+        onNetworkStateChange,
+        provider: MOCK_CUSTOM_NETWORK.provider,
+        blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
+        messenger: delayMessengerMock,
+      });
 
-  it('should have gasEstimatedError variable on transaction object on custom network if gas calculation fails', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
-      onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
-      provider: MOCK_CUSTOM_NETWORK.provider,
-      blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
-      messenger: delayMessengerMock,
+      // switch from Goerli to Mainnet
+      getNetworkState.returns(MOCK_CUSTOM_NETWORK.state);
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      networkStateChangeListener!(MOCK_CUSTOM_NETWORK.state);
+
+      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+      await controller.addTransaction({
+        from,
+        to: from,
+      });
+      expect(controller.state.transactions[0].transaction.from).toBe(from);
+      expect(controller.state.transactions[0].networkID).toBe(
+        MOCK_CUSTOM_NETWORK.state.networkId,
+      );
+
+      expect(controller.state.transactions[0].chainId).toBe(
+        MOCK_CUSTOM_NETWORK.state.providerConfig.chainId,
+      );
+
+      expect(controller.state.transactions[0].status).toBe(
+        TransactionStatus.unapproved,
+      );
     });
 
-    mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-
-    await controller.addTransaction({
-      from,
-      to: from,
-    });
-
-    const {
-      transaction: { estimateGasError },
-    } = controller.state.transactions[0];
-
-    expect(estimateGasError).toBe(ESTIMATE_GAS_ERROR);
-  });
-
-  it('should fail if no sign method defined', async () => {
-    const controller = new TransactionController(
-      {
+    it('throws if address invalid', async () => {
+      const controller = new TransactionController({
         getNetworkState: () => MOCK_NETWORK.state,
         onNetworkStateChange: MOCK_NETWORK.subscribe,
         provider: MOCK_NETWORK.provider,
         blockTracker: MOCK_NETWORK.blockTracker,
         messenger: messengerMock,
-      },
-      {},
-    );
-    const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
-    const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const { result } = await controller.addTransaction({ from, to });
-    await expect(result).rejects.toThrow('No sign method defined');
-    const { transaction, status } = controller.state.transactions[0];
-    expect(transaction.from).toBe(from);
-    expect(transaction.to).toBe(to);
-    expect(status).toBe(TransactionStatus.failed);
+      });
+      await expect(
+        controller.addTransaction({ from: 'foo' } as any),
+      ).rejects.toThrow('Invalid "from" address');
+    });
+
+    it('limits transaction state to a length of 2', async () => {
+      mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
+      const controller = new TransactionController(
+        {
+          getNetworkState: () => MOCK_NETWORK.state,
+          onNetworkStateChange: MOCK_NETWORK.subscribe,
+          provider: MOCK_NETWORK.provider,
+          blockTracker: MOCK_NETWORK.blockTracker,
+          messenger: delayMessengerMock,
+        },
+        {
+          interval: 5000,
+          sign: async (transaction: any) => transaction,
+          txHistoryLimit: 2,
+        },
+      );
+      const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      await controller.fetchAll(from);
+      await controller.addTransaction({
+        from,
+        nonce: '55555',
+        gas: '0x0',
+        gasPrice: '0x50fd51da',
+        to: from,
+        value: '0x0',
+      });
+      expect(controller.state.transactions).toHaveLength(2);
+      expect(controller.state.transactions[0].transaction.gasPrice).toBe(
+        '0x4a817c800',
+      );
+    });
+
+    it('increments nonce when adding a new non-cancel non-speedup transaction', async () => {
+      v1Stub
+        .mockImplementationOnce(() => 'aaaab1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d')
+        .mockImplementationOnce(() => 'bbbb1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d');
+
+      const controller = new TransactionController(
+        {
+          getNetworkState: () => MOCK_NETWORK.state,
+          onNetworkStateChange: MOCK_NETWORK.subscribe,
+          provider: MOCK_NETWORK.provider,
+          blockTracker: MOCK_NETWORK.blockTracker,
+          messenger: messengerMock,
+        },
+        {
+          sign: async (transaction: any) => transaction,
+        },
+      );
+      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+
+      const { result: firstResult } = await controller.addTransaction({
+        from,
+        gas: '0x0',
+        gasPrice: '0x50fd51da',
+        to: from,
+        value: '0x0',
+      });
+
+      await firstResult.catch(() => undefined);
+
+      const firstTransaction = controller.state.transactions[0];
+
+      // eslint-disable-next-line jest/prefer-spy-on
+      NonceTracker.prototype.getNonceLock = jest.fn().mockResolvedValue({
+        nextNonce: nonceMock + 1,
+        releaseLock: () => Promise.resolve(),
+      });
+
+      const { result: secondResult } = await controller.addTransaction({
+        from,
+        gas: '0x2',
+        gasPrice: '0x50fd51da',
+        to: from,
+        value: '0x1290',
+      });
+
+      await secondResult.catch(() => undefined);
+
+      expect(controller.state.transactions).toHaveLength(2);
+      const secondTransaction = controller.state.transactions[1];
+
+      expect(firstTransaction.transaction.nonce).toStrictEqual(
+        `0x${nonceMock.toString(16)}`,
+      );
+
+      expect(secondTransaction.transaction.nonce).toStrictEqual(
+        `0x${(nonceMock + 1).toString(16)}`,
+      );
+    });
+
+    describe('populates gasEstimatedError variable', () => {
+      it('if gas calculation fails', async () => {
+        const controller = new TransactionController({
+          getNetworkState: () => MOCK_MAINNET_NETWORK.state,
+          onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
+          provider: MOCK_MAINNET_NETWORK.provider,
+          blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
+          messenger: delayMessengerMock,
+        });
+
+        mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
+        const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+
+        await controller.addTransaction({
+          from,
+          to: from,
+        });
+
+        const {
+          transaction: { estimateGasError },
+        } = controller.state.transactions[0];
+
+        expect(estimateGasError).toBe(ESTIMATE_GAS_ERROR);
+      });
+
+      it('if gas calculation fails on custom network', async () => {
+        const controller = new TransactionController({
+          getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
+          onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
+          provider: MOCK_CUSTOM_NETWORK.provider,
+          blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
+          messenger: delayMessengerMock,
+        });
+
+        mockFlags.estimateGasError = ESTIMATE_GAS_ERROR;
+        const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+
+        await controller.addTransaction({
+          from,
+          to: from,
+        });
+
+        const {
+          transaction: { estimateGasError },
+        } = controller.state.transactions[0];
+
+        expect(estimateGasError).toBe(ESTIMATE_GAS_ERROR);
+      });
+    });
+
+    describe('on approve', () => {
+      it('submits transaction', async () => {
+        const { messenger, approve } = buildMockMessenger({ delay: true });
+
+        const controller = new TransactionController(
+          {
+            getNetworkState: () => MOCK_NETWORK.state,
+            onNetworkStateChange: MOCK_NETWORK.subscribe,
+            provider: MOCK_NETWORK.provider,
+            blockTracker: MOCK_NETWORK.blockTracker,
+            messenger,
+          },
+          {
+            sign: async (transaction: any) => transaction,
+          },
+        );
+
+        const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+
+        const { result } = await controller.addTransaction({
+          from,
+          gas: '0x0',
+          gasPrice: '0x0',
+          to: from,
+          value: '0x0',
+        });
+
+        controller.hub.once(
+          `${controller.state.transactions[0].id}:finished`,
+          () => {
+            const { transaction, status } = controller.state.transactions[0];
+            expect(transaction.from).toBe(from);
+            expect(status).toBe(TransactionStatus.submitted);
+          },
+        );
+
+        approve();
+        await result;
+      });
+
+      it('submits transaction with nonce from NonceTracker', async () => {
+        await new Promise(async (resolve) => {
+          const controller = new TransactionController(
+            {
+              getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
+              onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
+              provider: MOCK_CUSTOM_NETWORK.provider,
+              blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
+              messenger: messengerMock,
+            },
+            {
+              sign: async (transaction: any) => transaction,
+            },
+          );
+          const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+          await controller.addTransaction({
+            from,
+            gas: '0x0',
+            gasPrice: '0x0',
+            to: from,
+            value: '0x0',
+          });
+
+          controller.hub.once(
+            `${controller.state.transactions[0].id}:finished`,
+            () => {
+              const { transaction, status } = controller.state.transactions[0];
+              expect(transaction.from).toBe(from);
+              expect(transaction.nonce).toBe(`0x${nonceMock.toString(16)}`);
+              expect(getNonceLockSpy).toHaveBeenCalledTimes(1);
+              expect(status).toBe(TransactionStatus.submitted);
+              resolve('');
+            },
+          );
+        });
+      });
+
+      describe('fails', () => {
+        it('if signing error', async () => {
+          const controller = new TransactionController(
+            {
+              getNetworkState: () => MOCK_NETWORK.state,
+              onNetworkStateChange: MOCK_NETWORK.subscribe,
+              provider: MOCK_NETWORK.provider,
+              blockTracker: MOCK_NETWORK.blockTracker,
+              messenger: messengerMock,
+            },
+            {
+              sign: () => {
+                throw new Error('foo');
+              },
+            },
+          );
+          const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
+          const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+          const { result } = await controller.addTransaction({ from, to });
+          await expect(result).rejects.toThrow('foo');
+          const { transaction, status } = controller.state.transactions[0];
+          expect(transaction.from).toBe(from);
+          expect(transaction.to).toBe(to);
+          expect(status).toBe(TransactionStatus.failed);
+        });
+
+        it('if no sign method defined', async () => {
+          const controller = new TransactionController(
+            {
+              getNetworkState: () => MOCK_NETWORK.state,
+              onNetworkStateChange: MOCK_NETWORK.subscribe,
+              provider: MOCK_NETWORK.provider,
+              blockTracker: MOCK_NETWORK.blockTracker,
+              messenger: messengerMock,
+            },
+            {},
+          );
+          const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
+          const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+          const { result } = await controller.addTransaction({ from, to });
+          await expect(result).rejects.toThrow('No sign method defined');
+          const { transaction, status } = controller.state.transactions[0];
+          expect(transaction.from).toBe(from);
+          expect(transaction.to).toBe(to);
+          expect(status).toBe(TransactionStatus.failed);
+        });
+
+        it('if no chainId defined', async () => {
+          const controller = new TransactionController(
+            {
+              getNetworkState: () =>
+                MOCK_NETWORK_WITHOUT_CHAIN_ID.state as NetworkState,
+              onNetworkStateChange: MOCK_NETWORK_WITHOUT_CHAIN_ID.subscribe,
+              provider: MOCK_NETWORK_WITHOUT_CHAIN_ID.provider,
+              blockTracker: MOCK_NETWORK_WITHOUT_CHAIN_ID.blockTracker,
+              messenger: messengerMock,
+            },
+            {
+              sign: async (transaction: any) => transaction,
+            },
+          );
+          const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
+          const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+          const { result } = await controller.addTransaction({ from, to });
+          await expect(result).rejects.toThrow('No chainId defined');
+          const { transaction, status } = controller.state.transactions[0];
+          expect(transaction.from).toBe(from);
+          expect(transaction.to).toBe(to);
+          expect(status).toBe(TransactionStatus.failed);
+        });
+      });
+    });
+
+    describe('on reject', () => {
+      it('cancels transaction', async () => {
+        const controller = new TransactionController({
+          getNetworkState: () => MOCK_NETWORK.state,
+          onNetworkStateChange: MOCK_NETWORK.subscribe,
+          provider: MOCK_NETWORK.provider,
+          blockTracker: MOCK_NETWORK.blockTracker,
+          messenger: rejectMessengerMock,
+        });
+        const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+        const { result } = await controller.addTransaction({
+          from,
+          to: from,
+        });
+        const transactionListener = new Promise(async (resolve) => {
+          controller.hub.once(
+            `${controller.state.transactions[0].id}:finished`,
+            () => {
+              expect(controller.state.transactions[0].transaction.from).toBe(
+                from,
+              );
+              expect(controller.state.transactions[0].status).toBe(
+                TransactionStatus.rejected,
+              );
+              resolve('');
+            },
+          );
+        });
+        await expect(result).rejects.toThrow('User rejected the transaction');
+        await transactionListener;
+      });
+    });
   });
 
-  it('should fail if no chainId is defined', async () => {
-    const controller = new TransactionController(
-      {
-        getNetworkState: () =>
-          MOCK_NETWORK_WITHOUT_CHAIN_ID.state as NetworkState,
-        onNetworkStateChange: MOCK_NETWORK_WITHOUT_CHAIN_ID.subscribe,
-        provider: MOCK_NETWORK_WITHOUT_CHAIN_ID.provider,
-        blockTracker: MOCK_NETWORK_WITHOUT_CHAIN_ID.blockTracker,
-        messenger: messengerMock,
-      },
-      {
-        sign: async (transaction: any) => transaction,
-      },
-    );
-    const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
-    const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const { result } = await controller.addTransaction({ from, to });
-    await expect(result).rejects.toThrow('No chainId defined');
-    const { transaction, status } = controller.state.transactions[0];
-    expect(transaction.from).toBe(from);
-    expect(transaction.to).toBe(to);
-    expect(status).toBe(TransactionStatus.failed);
-  });
-
-  it('should approve a transaction', async () => {
-    const { messenger, approve } = buildMockMessenger({ delay: true });
-
-    const controller = new TransactionController(
-      {
+  describe('wipeTransactions', () => {
+    it('removes all transactions on current network', async () => {
+      const controller = new TransactionController({
         getNetworkState: () => MOCK_NETWORK.state,
         onNetworkStateChange: MOCK_NETWORK.subscribe,
         provider: MOCK_NETWORK.provider,
         blockTracker: MOCK_NETWORK.blockTracker,
-        messenger,
-      },
-      {
-        sign: async (transaction: any) => transaction,
-      },
-    );
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-
-    const { result } = await controller.addTransaction({
-      from,
-      gas: '0x0',
-      gasPrice: '0x0',
-      to: from,
-      value: '0x0',
+        messenger: delayMessengerMock,
+      });
+      controller.wipeTransactions();
+      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+      await controller.addTransaction({
+        from,
+        to: from,
+      });
+      controller.wipeTransactions();
+      expect(controller.state.transactions).toHaveLength(0);
     });
 
-    controller.hub.once(
-      `${controller.state.transactions[0].id}:finished`,
-      () => {
-        const { transaction, status } = controller.state.transactions[0];
-        expect(transaction.from).toBe(from);
-        expect(status).toBe(TransactionStatus.submitted);
-      },
-    );
-
-    approve();
-    await result;
+    // This tests the fallback to networkID only when there is no chainId present. Should be removed when networkID is completely removed.
+    it('removes all transactions using networkID when there is no chainId', async () => {
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_NETWORK.state,
+        onNetworkStateChange: MOCK_NETWORK.subscribe,
+        provider: MOCK_NETWORK.provider,
+        blockTracker: MOCK_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      controller.wipeTransactions();
+      controller.state.transactions.push({
+        from: MOCK_PRFERENCES.state.selectedAddress,
+        id: 'foo',
+        networkID: '5',
+        status: TransactionStatus.submitted,
+        transactionHash: '1337',
+      } as any);
+      controller.wipeTransactions();
+      expect(controller.state.transactions).toHaveLength(0);
+    });
   });
 
-  it('should query transaction statuses', async () => {
-    await new Promise((resolve) => {
+  describe('queryTransactionStatus', () => {
+    it('updates transaction status to confirmed', async () => {
+      await new Promise((resolve) => {
+        const controller = new TransactionController(
+          {
+            getNetworkState: () => MOCK_NETWORK.state,
+            onNetworkStateChange: MOCK_NETWORK.subscribe,
+            provider: MOCK_NETWORK.provider,
+            blockTracker: MOCK_NETWORK.blockTracker,
+            messenger: messengerMock,
+          },
+          {
+            sign: async (transaction: any) => transaction,
+          },
+        );
+        controller.state.transactions.push({
+          from: MOCK_PRFERENCES.state.selectedAddress,
+          id: 'foo',
+          networkID: '5',
+          chainId: toHex(5),
+          status: TransactionStatus.submitted,
+          transactionHash: '1337',
+        } as any);
+        controller.state.transactions.push({} as any);
+
+        controller.hub.once(
+          `${controller.state.transactions[0].id}:confirmed`,
+          () => {
+            expect(controller.state.transactions[0].status).toBe(
+              TransactionStatus.confirmed,
+            );
+            resolve('');
+          },
+        );
+        controller.queryTransactionStatuses();
+      });
+    });
+
+    // This tests the fallback to networkID only when there is no chainId present. Should be removed when networkID is completely removed.
+    it('uses networkID only when there is no chainId', async () => {
+      await new Promise((resolve) => {
+        const controller = new TransactionController(
+          {
+            getNetworkState: () => MOCK_NETWORK.state,
+            onNetworkStateChange: MOCK_NETWORK.subscribe,
+            provider: MOCK_NETWORK.provider,
+            blockTracker: MOCK_NETWORK.blockTracker,
+            messenger: messengerMock,
+          },
+          {
+            sign: async (transaction: any) => transaction,
+          },
+        );
+        controller.state.transactions.push({
+          from: MOCK_PRFERENCES.state.selectedAddress,
+          id: 'foo',
+          networkID: '5',
+          status: TransactionStatus.submitted,
+          transactionHash: '1337',
+        } as any);
+        controller.state.transactions.push({} as any);
+
+        controller.hub.once(
+          `${controller.state.transactions[0].id}:confirmed`,
+          () => {
+            expect(controller.state.transactions[0].status).toBe(
+              TransactionStatus.confirmed,
+            );
+            resolve('');
+          },
+        );
+        controller.queryTransactionStatuses();
+      });
+    });
+
+    it('leaves transaction status as submitted if transaction was not added to a block', async () => {
+      const controller = new TransactionController(
+        {
+          getNetworkState: () => MOCK_NETWORK.state,
+          onNetworkStateChange: MOCK_NETWORK.subscribe,
+          provider: MOCK_NETWORK.provider,
+          blockTracker: MOCK_NETWORK.blockTracker,
+          messenger: messengerMock,
+        },
+        {
+          sign: async (transaction: any) => transaction,
+        },
+      );
+      controller.state.transactions.push({
+        from: MOCK_PRFERENCES.state.selectedAddress,
+        id: 'foo',
+        networkID: '5',
+        status: TransactionStatus.submitted,
+        transactionHash: '1338',
+      } as any);
+      await controller.queryTransactionStatuses();
+      expect(controller.state.transactions[0].status).toBe(
+        TransactionStatus.submitted,
+      );
+    });
+
+    it('verifies transactions using the correct blockchain', async () => {
       const controller = new TransactionController(
         {
           getNetworkState: () => MOCK_NETWORK.state,
@@ -979,565 +1236,322 @@ describe('TransactionController', () => {
         id: 'foo',
         networkID: '5',
         chainId: toHex(5),
-        status: TransactionStatus.submitted,
+        status: TransactionStatus.confirmed,
         transactionHash: '1337',
-      } as any);
-      controller.state.transactions.push({} as any);
-
-      controller.hub.once(
-        `${controller.state.transactions[0].id}:confirmed`,
-        () => {
-          expect(controller.state.transactions[0].status).toBe(
-            TransactionStatus.confirmed,
-          );
-          resolve('');
+        verifiedOnBlockchain: false,
+        transaction: {
+          gasUsed: undefined,
         },
+      } as any);
+      await controller.queryTransactionStatuses();
+      expect(controller.state.transactions[0].verifiedOnBlockchain).toBe(true);
+      expect(controller.state.transactions[0].transaction.gasUsed).toBe(
+        '0x5208',
       );
-      controller.queryTransactionStatuses();
     });
   });
 
-  // This tests the fallback to networkID only when there is no chainId present. Should be removed when networkID is completely removed.
-  it('should query transaction statuses with networkID only when there is no chainId', async () => {
-    await new Promise((resolve) => {
+  describe('fetchAll', () => {
+    it('retrives all transactions matching an address, including incoming transactions, in goerli', async () => {
+      mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_NETWORK.state,
+        onNetworkStateChange: MOCK_NETWORK.subscribe,
+        provider: MOCK_NETWORK.provider,
+        blockTracker: MOCK_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      controller.wipeTransactions();
+      expect(controller.state.transactions).toHaveLength(0);
+
+      const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      const latestBlock = await controller.fetchAll(from);
+      expect(controller.state.transactions).toHaveLength(4);
+      expect(latestBlock).toBe('4535101');
+      expect(controller.state.transactions[0].transaction.to).toBe(from);
+    });
+
+    it('retrieves all transactions matching an address, including incoming token transactions, in mainnet', async () => {
+      mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_MAINNET_NETWORK.state,
+        onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
+        provider: MOCK_MAINNET_NETWORK.provider,
+        blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      controller.wipeTransactions();
+      expect(controller.state.transactions).toHaveLength(0);
+
+      const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      const latestBlock = await controller.fetchAll(from);
+      expect(controller.state.transactions).toHaveLength(17);
+      expect(latestBlock).toBe('4535101');
+      expect(controller.state.transactions[0].transaction.to).toBe(from);
+    });
+
+    it('retrieves all transactions matching an address, including incoming token transactions, without modifying transactions that have the same data in local and remote', async () => {
+      mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_MAINNET_NETWORK.state,
+        onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
+        provider: MOCK_MAINNET_NETWORK.provider,
+        blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      controller.wipeTransactions();
+      controller.state.transactions = TRANSACTIONS_IN_STATE;
+      await controller.fetchAll(from);
+      expect(controller.state.transactions).toHaveLength(17);
+      const tokenTransaction = controller.state.transactions.find(
+        ({ transactionHash }) => transactionHash === TOKEN_TRANSACTION_HASH,
+      ) || { id: '' };
+      const ethTransaction = controller.state.transactions.find(
+        ({ transactionHash }) => transactionHash === ETHER_TRANSACTION_HASH,
+      ) || { id: '' };
+      expect(tokenTransaction?.id).toStrictEqual('token-transaction-id');
+      expect(ethTransaction?.id).toStrictEqual('eth-transaction-id');
+    });
+
+    it('retrieves all transactions matching an address, including incoming transactions, in mainnet from block', async () => {
+      mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_MAINNET_NETWORK.state,
+        onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
+        provider: MOCK_MAINNET_NETWORK.provider,
+        blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      controller.wipeTransactions();
+      expect(controller.state.transactions).toHaveLength(0);
+
+      const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      const latestBlock = await controller.fetchAll(from, { fromBlock: '999' });
+      expect(controller.state.transactions).toHaveLength(3);
+      expect(latestBlock).toBe('4535101');
+      expect(controller.state.transactions[0].transaction.to).toBe(from);
+    });
+
+    it('retrieves and updates all transactions with outdated status using the data provided by the remote source in mainnet', async () => {
+      mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_MAINNET_NETWORK.state,
+        onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
+        provider: MOCK_MAINNET_NETWORK.provider,
+        blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      controller.wipeTransactions();
+      expect(controller.state.transactions).toHaveLength(0);
+
+      controller.state.transactions =
+        TRANSACTIONS_IN_STATE_WITH_OUTDATED_STATUS;
+
+      await controller.fetchAll(from);
+      expect(controller.state.transactions).toHaveLength(17);
+
+      const tokenTransaction = controller.state.transactions.find(
+        ({ transactionHash }) => transactionHash === TOKEN_TRANSACTION_HASH,
+      ) || { status: TransactionStatus.failed };
+      const ethTransaction = controller.state.transactions.find(
+        ({ transactionHash }) => transactionHash === ETHER_TRANSACTION_HASH,
+      ) || { status: TransactionStatus.failed };
+      expect(tokenTransaction?.status).toStrictEqual(
+        TransactionStatus.confirmed,
+      );
+      expect(ethTransaction?.status).toStrictEqual(TransactionStatus.confirmed);
+    });
+
+    it('retrieves and updates all transactions with outdated gas data using the data provided by the remote source in mainnet', async () => {
+      mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_MAINNET_NETWORK.state,
+        onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
+        provider: MOCK_MAINNET_NETWORK.provider,
+        blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      controller.wipeTransactions();
+      expect(controller.state.transactions).toHaveLength(0);
+
+      controller.state.transactions =
+        TRANSACTIONS_IN_STATE_WITH_OUTDATED_GAS_DATA;
+
+      await controller.fetchAll(from);
+      expect(controller.state.transactions).toHaveLength(17);
+
+      const tokenTransaction = controller.state.transactions.find(
+        ({ transactionHash }) => transactionHash === TOKEN_TRANSACTION_HASH,
+      ) || { transaction: { gasUsed: '0' } };
+      const ethTransaction = controller.state.transactions.find(
+        ({ transactionHash }) => transactionHash === ETHER_TRANSACTION_HASH,
+      ) || { transaction: { gasUsed: '0x0' } };
+      expect(tokenTransaction?.transaction.gasUsed).toStrictEqual('21000');
+      expect(ethTransaction?.transaction.gasUsed).toStrictEqual('0x5208');
+    });
+
+    it('retrieves and updates all transactions with outdated status and gas data using the data provided by the remote source in mainnet', async () => {
+      mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_MAINNET_NETWORK.state,
+        onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
+        provider: MOCK_MAINNET_NETWORK.provider,
+        blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      controller.wipeTransactions();
+      expect(controller.state.transactions).toHaveLength(0);
+
+      controller.state.transactions =
+        TRANSACTIONS_IN_STATE_WITH_OUTDATED_STATUS_AND_GAS_DATA;
+
+      await controller.fetchAll(from);
+      expect(controller.state.transactions).toHaveLength(17);
+
+      const tokenTransaction = controller.state.transactions.find(
+        ({ transactionHash }) => transactionHash === TOKEN_TRANSACTION_HASH,
+      ) || { status: TransactionStatus.failed, transaction: { gasUsed: '0' } };
+      const ethTransaction = controller.state.transactions.find(
+        ({ transactionHash }) => transactionHash === ETHER_TRANSACTION_HASH,
+      ) || {
+        status: TransactionStatus.failed,
+        transaction: { gasUsed: '0x0' },
+      };
+      expect(tokenTransaction?.status).toStrictEqual(
+        TransactionStatus.confirmed,
+      );
+      expect(ethTransaction?.status).toStrictEqual(TransactionStatus.confirmed);
+      expect(tokenTransaction?.transaction.gasUsed).toStrictEqual('21000');
+      expect(ethTransaction?.transaction.gasUsed).toStrictEqual('0x5208');
+    });
+
+    it('returns undefined if no matching transactions', async () => {
+      mockFetchWithStaticResponse(MOCK_FETCH_TX_HISTORY_DATA_ERROR);
+      const controller = new TransactionController({
+        getNetworkState: () => MOCK_NETWORK.state,
+        onNetworkStateChange: MOCK_NETWORK.subscribe,
+        provider: MOCK_NETWORK.provider,
+        blockTracker: MOCK_NETWORK.blockTracker,
+        messenger: messengerMock,
+      });
+      controller.wipeTransactions();
+      expect(controller.state.transactions).toHaveLength(0);
+      const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      const result = await controller.fetchAll(from);
+      expect(controller.state.transactions).toHaveLength(0);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('handleMethodData', () => {
+    it('loads method data from registry', async () => {
+      const controller = new TransactionController(
+        {
+          getNetworkState: () => MOCK_MAINNET_NETWORK.state,
+          onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
+          provider: MOCK_MAINNET_NETWORK.provider,
+          blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
+          messenger: messengerMock,
+        },
+        {},
+      );
+      const registry = await controller.handleMethodData('0xf39b5b9b');
+      expect(registry.parsedRegistryMethod).toStrictEqual({
+        args: [{ type: 'uint256' }, { type: 'uint256' }],
+        name: 'Eth To Token Swap Input',
+      });
+
+      expect(registry.registryMethod).toStrictEqual(
+        'ethToTokenSwapInput(uint256,uint256)',
+      );
+    });
+
+    it('skips reading registry if already cached in state', async () => {
+      const controller = new TransactionController(
+        {
+          getNetworkState: () => MOCK_MAINNET_NETWORK.state,
+          onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
+          provider: MOCK_MAINNET_NETWORK.provider,
+          blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
+          messenger: messengerMock,
+        },
+        {},
+      );
+      const registry = await controller.handleMethodData('0xf39b5b9b');
+      expect(registry.parsedRegistryMethod).toStrictEqual({
+        args: [{ type: 'uint256' }, { type: 'uint256' }],
+        name: 'Eth To Token Swap Input',
+      });
+      const registryLookup = sinon.stub(controller, 'registryLookup' as any);
+      await controller.handleMethodData('0xf39b5b9b');
+      expect(registryLookup.called).toBe(false);
+    });
+  });
+
+  describe('stopTransaction', () => {
+    it('rejects result promise', async () => {
+      const { messenger, approve } = buildMockMessenger({
+        delay: true,
+      });
+
       const controller = new TransactionController(
         {
           getNetworkState: () => MOCK_NETWORK.state,
           onNetworkStateChange: MOCK_NETWORK.subscribe,
           provider: MOCK_NETWORK.provider,
           blockTracker: MOCK_NETWORK.blockTracker,
-          messenger: messengerMock,
-        },
-        {
-          sign: async (transaction: any) => transaction,
-        },
-      );
-      controller.state.transactions.push({
-        from: MOCK_PRFERENCES.state.selectedAddress,
-        id: 'foo',
-        networkID: '5',
-        status: TransactionStatus.submitted,
-        transactionHash: '1337',
-      } as any);
-      controller.state.transactions.push({} as any);
-
-      controller.hub.once(
-        `${controller.state.transactions[0].id}:confirmed`,
-        () => {
-          expect(controller.state.transactions[0].status).toBe(
-            TransactionStatus.confirmed,
-          );
-          resolve('');
-        },
-      );
-      controller.queryTransactionStatuses();
-    });
-  });
-
-  it('should keep the transaction status as submitted if the transaction was not added to a block', async () => {
-    const controller = new TransactionController(
-      {
-        getNetworkState: () => MOCK_NETWORK.state,
-        onNetworkStateChange: MOCK_NETWORK.subscribe,
-        provider: MOCK_NETWORK.provider,
-        blockTracker: MOCK_NETWORK.blockTracker,
-        messenger: messengerMock,
-      },
-      {
-        sign: async (transaction: any) => transaction,
-      },
-    );
-    controller.state.transactions.push({
-      from: MOCK_PRFERENCES.state.selectedAddress,
-      id: 'foo',
-      networkID: '5',
-      status: TransactionStatus.submitted,
-      transactionHash: '1338',
-    } as any);
-    await controller.queryTransactionStatuses();
-    expect(controller.state.transactions[0].status).toBe(
-      TransactionStatus.submitted,
-    );
-  });
-
-  it('should verify the transaction using the correct blockchain', async () => {
-    const controller = new TransactionController(
-      {
-        getNetworkState: () => MOCK_NETWORK.state,
-        onNetworkStateChange: MOCK_NETWORK.subscribe,
-        provider: MOCK_NETWORK.provider,
-        blockTracker: MOCK_NETWORK.blockTracker,
-        messenger: messengerMock,
-      },
-      {
-        sign: async (transaction: any) => transaction,
-      },
-    );
-    controller.state.transactions.push({
-      from: MOCK_PRFERENCES.state.selectedAddress,
-      id: 'foo',
-      networkID: '5',
-      chainId: toHex(5),
-      status: TransactionStatus.confirmed,
-      transactionHash: '1337',
-      verifiedOnBlockchain: false,
-      transaction: {
-        gasUsed: undefined,
-      },
-    } as any);
-    await controller.queryTransactionStatuses();
-    expect(controller.state.transactions[0].verifiedOnBlockchain).toBe(true);
-    expect(controller.state.transactions[0].transaction.gasUsed).toBe('0x5208');
-  });
-
-  it('should fetch all the transactions from an address, including incoming transactions, in goerli', async () => {
-    mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    controller.wipeTransactions();
-    expect(controller.state.transactions).toHaveLength(0);
-
-    const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
-    const latestBlock = await controller.fetchAll(from);
-    expect(controller.state.transactions).toHaveLength(4);
-    expect(latestBlock).toBe('4535101');
-    expect(controller.state.transactions[0].transaction.to).toBe(from);
-  });
-
-  it('should fetch all the transactions from an address, including incoming token transactions, in mainnet', async () => {
-    mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_MAINNET_NETWORK.state,
-      onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
-      provider: MOCK_MAINNET_NETWORK.provider,
-      blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    controller.wipeTransactions();
-    expect(controller.state.transactions).toHaveLength(0);
-
-    const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
-    const latestBlock = await controller.fetchAll(from);
-    expect(controller.state.transactions).toHaveLength(17);
-    expect(latestBlock).toBe('4535101');
-    expect(controller.state.transactions[0].transaction.to).toBe(from);
-  });
-
-  it('should fetch all the transactions from an address, including incoming token transactions without modifying transactions that have the same data in local and remote', async () => {
-    mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_MAINNET_NETWORK.state,
-      onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
-      provider: MOCK_MAINNET_NETWORK.provider,
-      blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
-    controller.wipeTransactions();
-    controller.state.transactions = TRANSACTIONS_IN_STATE;
-    await controller.fetchAll(from);
-    expect(controller.state.transactions).toHaveLength(17);
-    const tokenTransaction = controller.state.transactions.find(
-      ({ transactionHash }) => transactionHash === TOKEN_TRANSACTION_HASH,
-    ) || { id: '' };
-    const ethTransaction = controller.state.transactions.find(
-      ({ transactionHash }) => transactionHash === ETHER_TRANSACTION_HASH,
-    ) || { id: '' };
-    expect(tokenTransaction?.id).toStrictEqual('token-transaction-id');
-    expect(ethTransaction?.id).toStrictEqual('eth-transaction-id');
-  });
-
-  it('should fetch all the transactions from an address, including incoming transactions, in mainnet from block', async () => {
-    mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_MAINNET_NETWORK.state,
-      onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
-      provider: MOCK_MAINNET_NETWORK.provider,
-      blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    controller.wipeTransactions();
-    expect(controller.state.transactions).toHaveLength(0);
-
-    const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
-    const latestBlock = await controller.fetchAll(from, { fromBlock: '999' });
-    expect(controller.state.transactions).toHaveLength(3);
-    expect(latestBlock).toBe('4535101');
-    expect(controller.state.transactions[0].transaction.to).toBe(from);
-  });
-
-  it('should fetch and updated all transactions with outdated status regarding the data provided by the remote source in mainnet', async () => {
-    mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_MAINNET_NETWORK.state,
-      onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
-      provider: MOCK_MAINNET_NETWORK.provider,
-      blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
-    controller.wipeTransactions();
-    expect(controller.state.transactions).toHaveLength(0);
-
-    controller.state.transactions = TRANSACTIONS_IN_STATE_WITH_OUTDATED_STATUS;
-
-    await controller.fetchAll(from);
-    expect(controller.state.transactions).toHaveLength(17);
-
-    const tokenTransaction = controller.state.transactions.find(
-      ({ transactionHash }) => transactionHash === TOKEN_TRANSACTION_HASH,
-    ) || { status: TransactionStatus.failed };
-    const ethTransaction = controller.state.transactions.find(
-      ({ transactionHash }) => transactionHash === ETHER_TRANSACTION_HASH,
-    ) || { status: TransactionStatus.failed };
-    expect(tokenTransaction?.status).toStrictEqual(TransactionStatus.confirmed);
-    expect(ethTransaction?.status).toStrictEqual(TransactionStatus.confirmed);
-  });
-
-  it('should fetch and updated all transactions with outdated gas data regarding the data provided by the remote source in mainnet', async () => {
-    mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_MAINNET_NETWORK.state,
-      onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
-      provider: MOCK_MAINNET_NETWORK.provider,
-      blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
-    controller.wipeTransactions();
-    expect(controller.state.transactions).toHaveLength(0);
-
-    controller.state.transactions =
-      TRANSACTIONS_IN_STATE_WITH_OUTDATED_GAS_DATA;
-
-    await controller.fetchAll(from);
-    expect(controller.state.transactions).toHaveLength(17);
-
-    const tokenTransaction = controller.state.transactions.find(
-      ({ transactionHash }) => transactionHash === TOKEN_TRANSACTION_HASH,
-    ) || { transaction: { gasUsed: '0' } };
-    const ethTransaction = controller.state.transactions.find(
-      ({ transactionHash }) => transactionHash === ETHER_TRANSACTION_HASH,
-    ) || { transaction: { gasUsed: '0x0' } };
-    expect(tokenTransaction?.transaction.gasUsed).toStrictEqual('21000');
-    expect(ethTransaction?.transaction.gasUsed).toStrictEqual('0x5208');
-  });
-
-  it('should fetch and updated all transactions with outdated status and gas data regarding the data provided by the remote source in mainnet', async () => {
-    mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_MAINNET_NETWORK.state,
-      onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
-      provider: MOCK_MAINNET_NETWORK.provider,
-      blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
-    controller.wipeTransactions();
-    expect(controller.state.transactions).toHaveLength(0);
-
-    controller.state.transactions =
-      TRANSACTIONS_IN_STATE_WITH_OUTDATED_STATUS_AND_GAS_DATA;
-
-    await controller.fetchAll(from);
-    expect(controller.state.transactions).toHaveLength(17);
-
-    const tokenTransaction = controller.state.transactions.find(
-      ({ transactionHash }) => transactionHash === TOKEN_TRANSACTION_HASH,
-    ) || { status: TransactionStatus.failed, transaction: { gasUsed: '0' } };
-    const ethTransaction = controller.state.transactions.find(
-      ({ transactionHash }) => transactionHash === ETHER_TRANSACTION_HASH,
-    ) || { status: TransactionStatus.failed, transaction: { gasUsed: '0x0' } };
-    expect(tokenTransaction?.status).toStrictEqual(TransactionStatus.confirmed);
-    expect(ethTransaction?.status).toStrictEqual(TransactionStatus.confirmed);
-    expect(tokenTransaction?.transaction.gasUsed).toStrictEqual('21000');
-    expect(ethTransaction?.transaction.gasUsed).toStrictEqual('0x5208');
-  });
-
-  it('should return', async () => {
-    mockFetchWithStaticResponse(MOCK_FETCH_TX_HISTORY_DATA_ERROR);
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: messengerMock,
-    });
-    controller.wipeTransactions();
-    expect(controller.state.transactions).toHaveLength(0);
-    const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
-    const result = await controller.fetchAll(from);
-    expect(controller.state.transactions).toHaveLength(0);
-    expect(result).toBeUndefined();
-  });
-
-  it('should handle new method data', async () => {
-    const controller = new TransactionController(
-      {
-        getNetworkState: () => MOCK_MAINNET_NETWORK.state,
-        onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
-        provider: MOCK_MAINNET_NETWORK.provider,
-        blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
-        messenger: messengerMock,
-      },
-      {},
-    );
-    const registry = await controller.handleMethodData('0xf39b5b9b');
-    expect(registry.parsedRegistryMethod).toStrictEqual({
-      args: [{ type: 'uint256' }, { type: 'uint256' }],
-      name: 'Eth To Token Swap Input',
-    });
-
-    expect(registry.registryMethod).toStrictEqual(
-      'ethToTokenSwapInput(uint256,uint256)',
-    );
-  });
-
-  it('should handle known method data', async () => {
-    const controller = new TransactionController(
-      {
-        getNetworkState: () => MOCK_MAINNET_NETWORK.state,
-        onNetworkStateChange: MOCK_MAINNET_NETWORK.subscribe,
-        provider: MOCK_MAINNET_NETWORK.provider,
-        blockTracker: MOCK_MAINNET_NETWORK.blockTracker,
-        messenger: messengerMock,
-      },
-      {},
-    );
-    const registry = await controller.handleMethodData('0xf39b5b9b');
-    expect(registry.parsedRegistryMethod).toStrictEqual({
-      args: [{ type: 'uint256' }, { type: 'uint256' }],
-      name: 'Eth To Token Swap Input',
-    });
-    const registryLookup = sinon.stub(controller, 'registryLookup' as any);
-    await controller.handleMethodData('0xf39b5b9b');
-    expect(registryLookup.called).toBe(false);
-  });
-
-  it('should stop a transaction', async () => {
-    const { messenger, approve } = buildMockMessenger({
-      delay: true,
-    });
-
-    const controller = new TransactionController(
-      {
-        getNetworkState: () => MOCK_NETWORK.state,
-        onNetworkStateChange: MOCK_NETWORK.subscribe,
-        provider: MOCK_NETWORK.provider,
-        blockTracker: MOCK_NETWORK.blockTracker,
-        messenger,
-      },
-      {
-        sign: async (transaction: any) => transaction,
-      },
-    );
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const { result } = await controller.addTransaction({
-      from,
-      gas: '0x0',
-      gasPrice: '0x1',
-      to: from,
-      value: '0x0',
-    });
-
-    await controller.stopTransaction(controller.state.transactions[0].id);
-    approve();
-
-    await expect(result).rejects.toThrow('User cancelled the transaction');
-  });
-
-  it('should fail to stop a transaction if no sign method', async () => {
-    const controller = new TransactionController({
-      getNetworkState: () => MOCK_NETWORK.state,
-      onNetworkStateChange: MOCK_NETWORK.subscribe,
-      provider: MOCK_NETWORK.provider,
-      blockTracker: MOCK_NETWORK.blockTracker,
-      messenger: delayMessengerMock,
-    });
-    const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
-    const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    await controller.addTransaction({ from, to });
-    controller.stopTransaction('nonexistent');
-    await expect(
-      controller.stopTransaction(controller.state.transactions[0].id),
-    ).rejects.toThrow('No sign method defined');
-  });
-
-  it('should speed up a transaction', async () => {
-    await new Promise(async (resolve) => {
-      const controller = new TransactionController(
-        {
-          getNetworkState: () => MOCK_NETWORK.state,
-          onNetworkStateChange: MOCK_NETWORK.subscribe,
-          provider: MOCK_NETWORK.provider,
-          blockTracker: MOCK_NETWORK.blockTracker,
-          messenger: messengerMock,
+          messenger,
         },
         {
           sign: async (transaction: any) => transaction,
         },
       );
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      await controller.addTransaction({
+      const { result } = await controller.addTransaction({
         from,
         gas: '0x0',
-        gasPrice: '0x50fd51da',
+        gasPrice: '0x1',
         to: from,
         value: '0x0',
       });
-      await controller.speedUpTransaction(controller.state.transactions[0].id);
-      expect(controller.state.transactions).toHaveLength(2);
-      expect(controller.state.transactions[1].transaction.gasPrice).toBe(
-        '0x5916a6d6', // 1.1 * 0x50fd51da
-      );
-      resolve('');
-    });
-  });
 
-  it('should limit tx state to a length of 2', async () => {
-    mockFetchWithDynamicResponse(MOCK_FETCH_TX_HISTORY_DATA_OK);
-    const controller = new TransactionController(
-      {
+      await controller.stopTransaction(controller.state.transactions[0].id);
+      approve();
+
+      await expect(result).rejects.toThrow('User cancelled the transaction');
+    });
+
+    it('throws if no sign method', async () => {
+      const controller = new TransactionController({
         getNetworkState: () => MOCK_NETWORK.state,
         onNetworkStateChange: MOCK_NETWORK.subscribe,
         provider: MOCK_NETWORK.provider,
         blockTracker: MOCK_NETWORK.blockTracker,
         messenger: delayMessengerMock,
-      },
-      {
-        interval: 5000,
-        sign: async (transaction: any) => transaction,
-        txHistoryLimit: 2,
-      },
-    );
-    const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
-    await controller.fetchAll(from);
-    await controller.addTransaction({
-      from,
-      nonce: '55555',
-      gas: '0x0',
-      gasPrice: '0x50fd51da',
-      to: from,
-      value: '0x0',
-    });
-    expect(controller.state.transactions).toHaveLength(2);
-    expect(controller.state.transactions[0].transaction.gasPrice).toBe(
-      '0x4a817c800',
-    );
-  });
-
-  it('should allow tx state to be greater than txHistorylimit due to speed up same nonce', async () => {
-    await new Promise(async (resolve) => {
-      const controller = new TransactionController(
-        {
-          getNetworkState: () => MOCK_NETWORK.state,
-          onNetworkStateChange: MOCK_NETWORK.subscribe,
-          provider: MOCK_NETWORK.provider,
-          blockTracker: MOCK_NETWORK.blockTracker,
-          messenger: messengerMock,
-        },
-        {
-          interval: 5000,
-          sign: async (transaction: any) => transaction,
-          txHistoryLimit: 1,
-        },
-      );
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      await controller.addTransaction({
-        from,
-        nonce: '1111111',
-        gas: '0x0',
-        gasPrice: '0x50fd51da',
-        to: from,
-        value: '0x0',
       });
-      await controller.speedUpTransaction(controller.state.transactions[0].id);
-      expect(controller.state.transactions).toHaveLength(2);
-      resolve('');
+      const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
+      const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+      await controller.addTransaction({ from, to });
+      controller.stopTransaction('nonexistent');
+      await expect(
+        controller.stopTransaction(controller.state.transactions[0].id),
+      ).rejects.toThrow('No sign method defined');
     });
   });
 
-  it('should increment nonce when adding a new non-cancel non-speedup transaction', async () => {
-    v1Stub
-      .mockImplementationOnce(() => 'aaaab1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d')
-      .mockImplementationOnce(() => 'bbbb1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d');
-
-    const controller = new TransactionController(
-      {
-        getNetworkState: () => MOCK_NETWORK.state,
-        onNetworkStateChange: MOCK_NETWORK.subscribe,
-        provider: MOCK_NETWORK.provider,
-        blockTracker: MOCK_NETWORK.blockTracker,
-        messenger: messengerMock,
-      },
-      {
-        sign: async (transaction: any) => transaction,
-      },
-    );
-    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-
-    const { result: firstResult } = await controller.addTransaction({
-      from,
-      gas: '0x0',
-      gasPrice: '0x50fd51da',
-      to: from,
-      value: '0x0',
-    });
-
-    await firstResult.catch(() => undefined);
-
-    const firstTransaction = controller.state.transactions[0];
-
-    const { result: secondResult } = await controller.addTransaction({
-      from,
-      gas: '0x2',
-      gasPrice: '0x50fd51da',
-      to: from,
-      value: '0x1290',
-    });
-
-    await secondResult.catch(() => undefined);
-
-    expect(controller.state.transactions).toHaveLength(2);
-    const secondTransaction = controller.state.transactions[1];
-
-    expect(firstTransaction.transaction.nonce).toStrictEqual('0x0');
-    expect(secondTransaction.transaction.nonce).toStrictEqual('0x1');
-  });
-
-  describe('NonceTracker integration', () => {
-    let getNonceLockSpy: jest.Mock<any, any>;
-    let originalGetNonceLock: any;
-    const testNonce = 12;
-
-    beforeEach(async () => {
-      originalGetNonceLock = NonceTracker.prototype.getNonceLock;
-
-      getNonceLockSpy = jest.fn().mockResolvedValue({
-        nextNonce: testNonce,
-        releaseLock: () => Promise.resolve(),
-      });
-
-      NonceTracker.prototype.getNonceLock = getNonceLockSpy;
-    });
-
-    afterEach(() => {
-      NonceTracker.prototype.getNonceLock = originalGetNonceLock;
-    });
-
-    it('should submit transaction with nonce from NonceTracker', async () => {
+  describe('speedUpTransaction', () => {
+    it('creates additional transaction with increased gas', async () => {
       await new Promise(async (resolve) => {
         const controller = new TransactionController(
           {
-            getNetworkState: () => MOCK_CUSTOM_NETWORK.state,
-            onNetworkStateChange: MOCK_CUSTOM_NETWORK.subscribe,
-            provider: MOCK_CUSTOM_NETWORK.provider,
-            blockTracker: MOCK_CUSTOM_NETWORK.blockTracker,
+            getNetworkState: () => MOCK_NETWORK.state,
+            onNetworkStateChange: MOCK_NETWORK.subscribe,
+            provider: MOCK_NETWORK.provider,
+            blockTracker: MOCK_NETWORK.blockTracker,
             messenger: messengerMock,
           },
           {
@@ -1548,26 +1562,22 @@ describe('TransactionController', () => {
         await controller.addTransaction({
           from,
           gas: '0x0',
-          gasPrice: '0x0',
+          gasPrice: '0x50fd51da',
           to: from,
           value: '0x0',
         });
-
-        controller.hub.once(
-          `${controller.state.transactions[0].id}:finished`,
-          () => {
-            const { transaction, status } = controller.state.transactions[0];
-            expect(transaction.from).toBe(from);
-            expect(transaction.nonce).toBe(`0x${testNonce.toString(16)}`);
-            expect(getNonceLockSpy).toHaveBeenCalledTimes(1);
-            expect(status).toBe(TransactionStatus.submitted);
-            resolve('');
-          },
+        await controller.speedUpTransaction(
+          controller.state.transactions[0].id,
         );
+        expect(controller.state.transactions).toHaveLength(2);
+        expect(controller.state.transactions[1].transaction.gasPrice).toBe(
+          '0x5916a6d6', // 1.1 * 0x50fd51da
+        );
+        resolve('');
       });
     });
 
-    it('should use the same nonce when speeding up a transaction', async () => {
+    it('uses the same nonce', async () => {
       await new Promise(async (resolve) => {
         const controller = new TransactionController(
           {
@@ -1597,6 +1607,39 @@ describe('TransactionController', () => {
         expect(originalTransaction.transaction.nonce).toStrictEqual(
           controller.state.transactions[1].transaction.nonce,
         );
+        resolve('');
+      });
+    });
+
+    it('allows tx state to be greater than txHistorylimit', async () => {
+      await new Promise(async (resolve) => {
+        const controller = new TransactionController(
+          {
+            getNetworkState: () => MOCK_NETWORK.state,
+            onNetworkStateChange: MOCK_NETWORK.subscribe,
+            provider: MOCK_NETWORK.provider,
+            blockTracker: MOCK_NETWORK.blockTracker,
+            messenger: messengerMock,
+          },
+          {
+            interval: 5000,
+            sign: async (transaction: any) => transaction,
+            txHistoryLimit: 1,
+          },
+        );
+        const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+        await controller.addTransaction({
+          from,
+          nonce: '1111111',
+          gas: '0x0',
+          gasPrice: '0x50fd51da',
+          to: from,
+          value: '0x0',
+        });
+        await controller.speedUpTransaction(
+          controller.state.transactions[0].id,
+        );
+        expect(controller.state.transactions).toHaveLength(2);
         resolve('');
       });
     });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1179,31 +1179,31 @@ export class TransactionController extends BaseController<
 
     const finalMeta = this.getTransaction(transactionId);
 
-    if (finalMeta?.status === TransactionStatus.submitted) {
-      resultCallbacks?.success();
-    } else if (finalMeta?.status === TransactionStatus.failed) {
-      resultCallbacks?.error(finalMeta?.error);
-    } else {
-      resultCallbacks?.error(new Error('Unknown problem'));
-    }
-
     if (finalMeta && finalMeta.status === TransactionStatus.failed) {
+      resultCallbacks?.error(finalMeta?.error);
       throw ethErrors.rpc.internal(finalMeta.error.message);
     }
 
     if (finalMeta?.status === TransactionStatus.cancelled) {
-      throw ethErrors.rpc.internal('User cancelled the transaction');
+      const error = ethErrors.rpc.internal('User cancelled the transaction');
+      resultCallbacks?.error(error);
+      throw error;
     }
 
     if (finalMeta && finalMeta.status === TransactionStatus.submitted) {
+      resultCallbacks?.success();
       return finalMeta.transactionHash as string;
     }
 
-    throw ethErrors.rpc.internal(
+    const error = ethErrors.rpc.internal(
       `MetaMask Tx Signature: Unknown problem: ${JSON.stringify(
         finalMeta || transactionId,
       )}`,
     );
+
+    resultCallbacks?.error(error);
+
+    throw error;
   }
 
   /**

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1140,70 +1140,62 @@ export class TransactionController extends BaseController<
     transactionMeta: TransactionMeta,
   ): Promise<string> {
     const transactionId = transactionMeta.id;
-    let rejected = false;
     let resultCallbacks: AcceptResultCallbacks | undefined;
 
     try {
       const acceptResult = await this.requestApproval(transactionMeta);
       resultCallbacks = acceptResult.resultCallbacks;
 
-      const updatedMeta = this.getTransaction(transactionId);
+      const { meta, isCompleted } = this.isTransactionCompleted(transactionId);
 
-      const isCompleted =
-        updatedMeta && this.isLocalFinalState(updatedMeta.status);
-
-      if (updatedMeta && !isCompleted) {
+      if (meta && !isCompleted) {
         await this.approveTransaction(transactionId);
       }
     } catch (error: any) {
-      const updatedMeta = this.getTransaction(transactionId);
+      const { meta, isCompleted } = this.isTransactionCompleted(transactionId);
 
-      const isCompleted =
-        updatedMeta && this.isLocalFinalState(updatedMeta.status);
-
-      if (updatedMeta && !isCompleted) {
+      if (meta && !isCompleted) {
         if (error.code === errorCodes.provider.userRejectedRequest) {
           this.cancelTransaction(transactionId);
-          rejected = true;
+
+          throw ethErrors.provider.userRejectedRequest(
+            'User rejected the transaction',
+          );
         } else {
-          this.failTransaction(updatedMeta, error);
+          this.failTransaction(meta, error);
         }
       }
     }
 
-    if (rejected) {
-      throw ethErrors.provider.userRejectedRequest(
-        'User rejected the transaction',
-      );
-    }
-
     const finalMeta = this.getTransaction(transactionId);
 
-    if (finalMeta && finalMeta.status === TransactionStatus.failed) {
-      resultCallbacks?.error(finalMeta?.error);
-      throw ethErrors.rpc.internal(finalMeta.error.message);
+    switch (finalMeta?.status) {
+      case TransactionStatus.failed:
+        resultCallbacks?.error(finalMeta.error);
+        throw ethErrors.rpc.internal(finalMeta.error.message);
+
+      case TransactionStatus.cancelled:
+        const cancelError = ethErrors.rpc.internal(
+          'User cancelled the transaction',
+        );
+
+        resultCallbacks?.error(cancelError);
+        throw cancelError;
+
+      case TransactionStatus.submitted:
+        resultCallbacks?.success();
+        return finalMeta.transactionHash as string;
+
+      default:
+        const internalError = ethErrors.rpc.internal(
+          `MetaMask Tx Signature: Unknown problem: ${JSON.stringify(
+            finalMeta || transactionId,
+          )}`,
+        );
+
+        resultCallbacks?.error(internalError);
+        throw internalError;
     }
-
-    if (finalMeta?.status === TransactionStatus.cancelled) {
-      const error = ethErrors.rpc.internal('User cancelled the transaction');
-      resultCallbacks?.error(error);
-      throw error;
-    }
-
-    if (finalMeta && finalMeta.status === TransactionStatus.submitted) {
-      resultCallbacks?.success();
-      return finalMeta.transactionHash as string;
-    }
-
-    const error = ethErrors.rpc.internal(
-      `MetaMask Tx Signature: Unknown problem: ${JSON.stringify(
-        finalMeta || transactionId,
-      )}`,
-    );
-
-    resultCallbacks?.error(error);
-
-    throw error;
   }
 
   /**
@@ -1289,7 +1281,6 @@ export class TransactionController extends BaseController<
       ]);
       transactionMeta.transactionHash = transactionHash;
       transactionMeta.status = TransactionStatus.submitted;
-      console.log('New Status', TransactionStatus.submitted);
       this.updateTransaction(transactionMeta);
       this.hub.emit(`${transactionMeta.id}:finished`, transactionMeta);
     } catch (error: any) {
@@ -1642,6 +1633,21 @@ export class TransactionController extends BaseController<
 
   private getApprovalId(txMeta: TransactionMeta) {
     return String(txMeta.id);
+  }
+
+  private isTransactionCompleted(transactionid: string): {
+    meta?: TransactionMeta;
+    isCompleted: boolean;
+  } {
+    const transaction = this.getTransaction(transactionid);
+
+    if (!transaction) {
+      return { meta: undefined, isCompleted: false };
+    }
+
+    const isCompleted = this.isLocalFinalState(transaction.status);
+
+    return { meta: transaction, isCompleted };
   }
 }
 


### PR DESCRIPTION
## Explanation

Update the `TransactionController` to await the approval request promise before automatically performing the relevant logic, either signing and submitting the transaction, or cancelling it.

This is part of the new confirmations architecture which aims to simplify the use of approvals in controllers, and decouple the public API from the concept of approval.

## Changelog

### `@metamask/transaction-controller`

- **BREAKING**: Change the `approveTransaction` and `cancelTransaction` methods to private.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
