### PR TITLE
Remove optional parameter from newUnsignedTypedMessage function

### DIFF
--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -461,7 +461,6 @@ describe('SignatureController', () => {
         messageParamsMock,
         requestMock,
         versionMock,
-        { parseJsonData: true },
       );
 
       expect(
@@ -501,7 +500,6 @@ describe('SignatureController', () => {
         messageParamsMock,
         requestMock,
         versionMock,
-        { parseJsonData: false },
       );
 
       expect(
@@ -523,7 +521,6 @@ describe('SignatureController', () => {
         messageParamsMock,
         requestMock,
         'V2',
-        { parseJsonData: true },
       );
 
       expect(keyringControllerMock.signTypedMessage).toHaveBeenCalledTimes(1);
@@ -541,7 +538,6 @@ describe('SignatureController', () => {
             messageParamsMock,
             requestMock,
             versionMock,
-            { parseJsonData: true },
           ),
       );
       expect(error instanceof EthereumProviderError).toBe(true);
@@ -561,7 +557,6 @@ describe('SignatureController', () => {
             messageParamsMock,
             requestMock,
             versionMock,
-            { parseJsonData: true },
           ),
       );
       expect(error.message).toBe(keyringErrorMessageMock);

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -333,15 +333,12 @@ export class SignatureController extends BaseControllerV2<
    * @param messageParams - The params passed to eth_signTypedData.
    * @param req - The original request, containing the origin.
    * @param version - The version indicating the format of the typed data.
-   * @param signingOpts - An options bag for signing.
-   * @param signingOpts.parseJsonData - Whether to parse the JSON before signing.
    * @returns Promise resolving to the raw data of the signature request.
    */
   async newUnsignedTypedMessage(
     messageParams: TypedMessageParams,
     req: OriginalRequest,
     version: string,
-    signingOpts: TypedMessageSigningOptions,
   ): Promise<string> {
     return this.#newUnsignedAbstractMessage(
       this.#typedMessageManager,
@@ -352,7 +349,9 @@ export class SignatureController extends BaseControllerV2<
       req,
       undefined,
       version,
-      signingOpts,
+      {
+        parseJsonData: true,
+      },
     );
   }
 


### PR DESCRIPTION
## Explanation

This PR aims to remove  `{ parseJsonData: boolean }` optional parameter from TypedMessage signer because it's never sent from extension. 

Here is the proof that this fix is working with that. https://github.com/MetaMask/metamask-extension/pull/19184