### PR TITLE
eth_signTypedData_v4 and v3 should take an object as well as string for data parameter.

### DIFF
--- a/packages/message-manager/src/TypedMessageManager.test.ts
+++ b/packages/message-manager/src/TypedMessageManager.test.ts
@@ -16,6 +16,9 @@ const typedMessage = [
     value: '1337',
   },
 ];
+
+const typedMessageV3V4 = { "types": { "EIP712Domain": [{ "name": "name", "type": "string" }, { "name": "version", "type": "string" }, { "name": "chainId", "type": "uint256" }, { "name": "verifyingContract", "type": "address" }], "Person": [{ "name": "name", "type": "string" }, { "name": "wallet", "type": "address" }], "Mail": [{ "name": "from", "type": "Person" }, { "name": "to", "type": "Person" }, { "name": "contents", "type": "string" }] }, "primaryType": "Mail", "domain": { "name": "Ether Mail", "version": "1", "chainId": 1, "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC" }, "message": { "from": { "name": "Cow", "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826" }, "to": { "name": "Bob", "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" }, "contents": "Hello, Bob!" } };
+
 describe('TypedMessageManager', () => {
   beforeEach(() => {
     controller = new TypedMessageManager();
@@ -66,6 +69,60 @@ describe('TypedMessageManager', () => {
     const messageType = 'eth_signTypedData';
     const version = 'version';
     const messageData = typedMessage;
+    const messageParams = {
+      data: messageData,
+      from: fromMock,
+    };
+    const originalRequest = { origin: 'origin' };
+    const messageId = await controller.addUnapprovedMessage(
+      messageParams,
+      originalRequest,
+      version,
+    );
+    expect(messageId).not.toBeUndefined();
+    const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.messageParams.from).toBe(messageParams.from);
+    expect(message.messageParams.data).toBe(messageParams.data);
+    expect(message.time).not.toBeUndefined();
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
+  });
+
+  it('should add a valid V3 unapproved message as a string', async () => {
+    const messageStatus = 'unapproved';
+    const messageType = 'eth_signTypedData';
+    const version = 'version';
+    const messageData = JSON.stringify(typedMessageV3V4);
+    const messageParams = {
+      data: messageData,
+      from: fromMock,
+    };
+    const originalRequest = { origin: 'origin' };
+    const messageId = await controller.addUnapprovedMessage(
+      messageParams,
+      originalRequest,
+      version,
+    );
+    expect(messageId).not.toBeUndefined();
+    const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is falsy');
+    }
+    expect(message.messageParams.from).toBe(messageParams.from);
+    expect(message.messageParams.data).toBe(messageParams.data);
+    expect(message.time).not.toBeUndefined();
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
+  });
+
+  it('should add a valid V3 unapproved message as an object', async () => {
+    const messageStatus = 'unapproved';
+    const messageType = 'eth_signTypedData';
+    const version = 'version';
+    const messageData = typedMessageV3V4;
     const messageParams = {
       data: messageData,
       from: fromMock,

--- a/packages/message-manager/src/TypedMessageManager.test.ts
+++ b/packages/message-manager/src/TypedMessageManager.test.ts
@@ -1,6 +1,7 @@
 import { TypedMessageManager } from './TypedMessageManager';
 
 let controller: TypedMessageManager;
+let getCurrentChainIdStub = jest.fn();
 
 const fromMock = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
 
@@ -51,7 +52,7 @@ const typedMessageV3V4 = {
 
 describe('TypedMessageManager', () => {
   beforeEach(() => {
-    controller = new TypedMessageManager();
+    controller = new TypedMessageManager(undefined, undefined, undefined, undefined, getCurrentChainIdStub);
   });
 
   it('should set default state', () => {
@@ -94,6 +95,25 @@ describe('TypedMessageManager', () => {
     expect(message.type).toBe(messageType);
   });
 
+  it('should throw when adding a valid unapproved message when getCurrentChainId is undefined', async () => {
+    controller = new TypedMessageManager();
+    const version = 'V3';
+    const messageData = JSON.stringify(typedMessageV3V4);
+    const messageParams = {
+      data: messageData,
+      from: fromMock,
+    };
+    const originalRequest = { origin: 'origin' };
+
+    await expect(
+      controller.addUnapprovedMessage(
+        messageParams,
+        originalRequest,
+        version,
+      )
+    ).rejects.toThrow("Current chainId cannot be null or undefined.");
+  });
+
   it('should add a valid unapproved message', async () => {
     const messageStatus = 'unapproved';
     const messageType = 'eth_signTypedData';
@@ -122,9 +142,10 @@ describe('TypedMessageManager', () => {
   });
 
   it('should add a valid V3 unapproved message as a string', async () => {
+    getCurrentChainIdStub.mockImplementation(() => 1);
     const messageStatus = 'unapproved';
     const messageType = 'eth_signTypedData';
-    const version = 'version';
+    const version = 'V3';
     const messageData = JSON.stringify(typedMessageV3V4);
     const messageParams = {
       data: messageData,
@@ -149,9 +170,10 @@ describe('TypedMessageManager', () => {
   });
 
   it('should add a valid V3 unapproved message as an object', async () => {
+    getCurrentChainIdStub.mockImplementation(() => 1);
     const messageStatus = 'unapproved';
     const messageType = 'eth_signTypedData';
-    const version = 'version';
+    const version = 'V3';
     const messageData = typedMessageV3V4;
     const messageParams = {
       data: messageData,
@@ -349,4 +371,5 @@ describe('TypedMessageManager', () => {
     }
     expect(message.status).toStrictEqual('errored');
   });
+
 });

--- a/packages/message-manager/src/TypedMessageManager.test.ts
+++ b/packages/message-manager/src/TypedMessageManager.test.ts
@@ -17,7 +17,37 @@ const typedMessage = [
   },
 ];
 
-const typedMessageV3V4 = { "types": { "EIP712Domain": [{ "name": "name", "type": "string" }, { "name": "version", "type": "string" }, { "name": "chainId", "type": "uint256" }, { "name": "verifyingContract", "type": "address" }], "Person": [{ "name": "name", "type": "string" }, { "name": "wallet", "type": "address" }], "Mail": [{ "name": "from", "type": "Person" }, { "name": "to", "type": "Person" }, { "name": "contents", "type": "string" }] }, "primaryType": "Mail", "domain": { "name": "Ether Mail", "version": "1", "chainId": 1, "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC" }, "message": { "from": { "name": "Cow", "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826" }, "to": { "name": "Bob", "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" }, "contents": "Hello, Bob!" } };
+const typedMessageV3V4 = {
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+    ],
+    Person: [
+      { name: 'name', type: 'string' },
+      { name: 'wallet', type: 'address' },
+    ],
+    Mail: [
+      { name: 'from', type: 'Person' },
+      { name: 'to', type: 'Person' },
+      { name: 'contents', type: 'string' },
+    ],
+  },
+  primaryType: 'Mail',
+  domain: {
+    name: 'Ether Mail',
+    version: '1',
+    chainId: 1,
+    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+  },
+  message: {
+    from: { name: 'Cow', wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826' },
+    to: { name: 'Bob', wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' },
+    contents: 'Hello, Bob!',
+  },
+};
 
 describe('TypedMessageManager', () => {
   beforeEach(() => {

--- a/packages/message-manager/src/TypedMessageManager.test.ts
+++ b/packages/message-manager/src/TypedMessageManager.test.ts
@@ -1,7 +1,7 @@
 import { TypedMessageManager } from './TypedMessageManager';
 
 let controller: TypedMessageManager;
-let getCurrentChainIdStub = jest.fn();
+const getCurrentChainIdStub = jest.fn();
 
 const fromMock = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
 
@@ -52,7 +52,13 @@ const typedMessageV3V4 = {
 
 describe('TypedMessageManager', () => {
   beforeEach(() => {
-    controller = new TypedMessageManager(undefined, undefined, undefined, undefined, getCurrentChainIdStub);
+    controller = new TypedMessageManager(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      getCurrentChainIdStub,
+    );
   });
 
   it('should set default state', () => {
@@ -106,12 +112,8 @@ describe('TypedMessageManager', () => {
     const originalRequest = { origin: 'origin' };
 
     await expect(
-      controller.addUnapprovedMessage(
-        messageParams,
-        originalRequest,
-        version,
-      )
-    ).rejects.toThrow("Current chainId cannot be null or undefined.");
+      controller.addUnapprovedMessage(messageParams, originalRequest, version),
+    ).rejects.toThrow('Current chainId cannot be null or undefined.');
   });
 
   it('should add a valid unapproved message', async () => {
@@ -371,5 +373,4 @@ describe('TypedMessageManager', () => {
     }
     expect(message.status).toStrictEqual('errored');
   });
-
 });

--- a/packages/message-manager/src/TypedMessageManager.test.ts
+++ b/packages/message-manager/src/TypedMessageManager.test.ts
@@ -143,7 +143,7 @@ describe('TypedMessageManager', () => {
     expect(message.type).toBe(messageType);
   });
 
-  it('should add a valid V3 unapproved message as a string', async () => {
+  it('should add a valid V3 unapproved message as a JSON-parseable string', async () => {
     getCurrentChainIdStub.mockImplementation(() => 1);
     const messageStatus = 'unapproved';
     const messageType = 'eth_signTypedData';

--- a/packages/message-manager/src/TypedMessageManager.ts
+++ b/packages/message-manager/src/TypedMessageManager.ts
@@ -68,7 +68,7 @@ export interface TypedMessageParams extends AbstractMessageParams {
  */
 export interface TypedMessageParamsMetamask
   extends AbstractMessageParamsMetamask {
-  data: Record<string, unknown>[] | string;
+  data: TypedMessageParams['data'];
   metamaskId?: string;
   error?: string;
   version?: string;

--- a/packages/message-manager/src/TypedMessageManager.ts
+++ b/packages/message-manager/src/TypedMessageManager.ts
@@ -10,6 +10,7 @@ import {
   AbstractMessageParamsMetamask,
   OriginalRequest,
 } from './AbstractMessageManager';
+import { type } from 'os';
 
 /**
  * @type TypedMessage
@@ -103,6 +104,13 @@ export class TypedMessageManager extends AbstractMessageManager<
     if (version === 'V3' || version === 'V4') {
       const currentChainId = this.getCurrentChainId?.();
       validateTypedSignMessageDataV3V4(messageParams, currentChainId);
+    }
+
+    if (
+      typeof messageParams.data !== 'string' &&
+      (version === 'V3' || version === 'V4')
+    ) {
+      messageParams.data = JSON.stringify(messageParams.data);
     }
 
     const messageId = random();

--- a/packages/message-manager/src/TypedMessageManager.ts
+++ b/packages/message-manager/src/TypedMessageManager.ts
@@ -34,6 +34,13 @@ export interface TypedMessage extends AbstractMessage {
   rawSig?: string;
 }
 
+export type SignTypedDataMessageV3V4 = {
+  types: Record<string, unknown>;
+  domain: Record<string, unknown>;
+  primaryType: string;
+  message: unknown;
+};
+
 /**
  * @type TypedMessageParams
  *
@@ -44,7 +51,7 @@ export interface TypedMessage extends AbstractMessage {
  * @property origin? - Added for request origin identification
  */
 export interface TypedMessageParams extends AbstractMessageParams {
-  data: Record<string, unknown>[] | string;
+  data: Record<string, unknown>[] | string | SignTypedDataMessageV3V4;
 }
 
 /**

--- a/packages/message-manager/src/TypedMessageManager.ts
+++ b/packages/message-manager/src/TypedMessageManager.ts
@@ -10,7 +10,6 @@ import {
   AbstractMessageParamsMetamask,
   OriginalRequest,
 } from './AbstractMessageManager';
-import { type } from 'os';
 
 /**
  * @type TypedMessage

--- a/packages/message-manager/src/utils.test.ts
+++ b/packages/message-manager/src/utils.test.ts
@@ -263,6 +263,18 @@ describe('utils', () => {
         ),
       ).not.toThrow();
     });
+
+    it('should not throw if data is correct (object format)', () => {
+      expect(() =>
+        util.validateTypedSignMessageDataV3V4(
+          {
+            data: JSON.parse(dataTyped),
+            from: '0x3244e191f1b4903970224322180f1fbbc415696b',
+          } as any,
+          mockedCurrentChainId,
+        ),
+      ).not.toThrow();
+    });
   });
 
   describe('validateEncryptionPublicKeyMessageData', () => {

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -99,9 +99,8 @@ export function validateTypedSignMessageDataV3V4(
   validateAddress(messageData.from, 'from');
 
   if (
-    !messageData.data ||
-    (typeof messageData.data !== 'object' &&
-      typeof messageData.data !== 'string')
+    !messageData.data || Array.isArray(messageData.data) ||
+    (typeof messageData.data !== 'object' && typeof messageData.data !== 'string')
   ) {
     throw new Error(
       `Invalid message "data": ${messageData.data} must be a valid string or object.`,

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -98,17 +98,27 @@ export function validateTypedSignMessageDataV3V4(
 ) {
   validateAddress(messageData.from, 'from');
 
-  if (!messageData.data || typeof messageData.data !== 'string') {
+  if (
+    !messageData.data ||
+    (typeof messageData.data !== 'object' &&
+      typeof messageData.data !== 'string')
+  ) {
     throw new Error(
-      `Invalid message "data": ${messageData.data} must be a valid array.`,
+      `Invalid message "data": ${messageData.data} must be a valid string or object.`,
     );
   }
+
   let data;
-  try {
-    data = JSON.parse(messageData.data);
-  } catch (e) {
-    throw new Error('Data must be passed as a valid JSON string.');
+  if (typeof messageData.data === 'object') {
+    data = messageData.data;
+  } else {
+    try {
+      data = JSON.parse(messageData.data);
+    } catch (e) {
+      throw new Error('Data must be passed as a valid JSON string.');
+    }
   }
+
   const validation = validate(data, TYPED_MESSAGE_SCHEMA);
   if (validation.errors.length > 0) {
     throw new Error(

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -99,8 +99,10 @@ export function validateTypedSignMessageDataV3V4(
   validateAddress(messageData.from, 'from');
 
   if (
-    !messageData.data || Array.isArray(messageData.data) ||
-    (typeof messageData.data !== 'object' && typeof messageData.data !== 'string')
+    !messageData.data ||
+    Array.isArray(messageData.data) ||
+    (typeof messageData.data !== 'object' &&
+      typeof messageData.data !== 'string')
   ) {
     throw new Error(
       `Invalid message "data": ${messageData.data} must be a valid string or object.`,

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -105,7 +105,7 @@ export function validateTypedSignMessageDataV3V4(
       typeof messageData.data !== 'string')
   ) {
     throw new Error(
-      `Invalid message "data": ${messageData.data} must be a valid string or object.`,
+      `Invalid message "data": Must be a valid string or object.`,
     );
   }
 


### PR DESCRIPTION
`eth_signTypedData_v4` and `v3` should take an object as well as string for `data` parameter.

These changes are NON breaking.

Check out the issue below for a deeper explanation of the issue.

fixes https://github.com/MetaMask/metamask-extension/issues/18462