### PR TITLE
Add sign version to approval message in Signature Controller

### DIFF
--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -375,6 +375,9 @@ describe('SignatureController', () => {
       (keyringControllerMock as any).signMessage.mockRejectedValueOnce(
         keyringErrorMock,
       );
+      const listenerMock = jest.fn();
+      signatureController.hub.on(`${messageIdMock}:signError`, listenerMock);
+
       const error: any = await getError(
         async () =>
           await signatureController.newUnsignedMessage(
@@ -383,6 +386,10 @@ describe('SignatureController', () => {
           ),
       );
 
+      expect(listenerMock).toHaveBeenCalledTimes(1);
+      expect(listenerMock).toHaveBeenCalledWith({
+        error,
+      });
       expect(error.message).toBe(keyringErrorMessageMock);
       expect(messageManagerMock.rejectMessage).toHaveBeenCalledTimes(1);
       expect(messageManagerMock.rejectMessage).toHaveBeenCalledWith(

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -468,6 +468,7 @@ describe('SignatureController', () => {
         messageParamsMock,
         requestMock,
         versionMock,
+        { parseJsonData: false },
       );
 
       expect(
@@ -507,6 +508,7 @@ describe('SignatureController', () => {
         messageParamsMock,
         requestMock,
         versionMock,
+        { parseJsonData: false },
       );
 
       expect(
@@ -528,6 +530,7 @@ describe('SignatureController', () => {
         messageParamsMock,
         requestMock,
         'V2',
+        { parseJsonData: true },
       );
 
       expect(keyringControllerMock.signTypedMessage).toHaveBeenCalledTimes(1);
@@ -545,6 +548,7 @@ describe('SignatureController', () => {
             messageParamsMock,
             requestMock,
             versionMock,
+            { parseJsonData: true },
           ),
       );
       expect(error instanceof EthereumProviderError).toBe(true);
@@ -564,6 +568,7 @@ describe('SignatureController', () => {
             messageParamsMock,
             requestMock,
             versionMock,
+            { parseJsonData: true },
           ),
       );
       expect(error.message).toBe(keyringErrorMessageMock);

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -389,11 +389,7 @@ export class SignatureController extends BaseControllerV2<
     messageManager: AbstractMessageManager<M, P, PM>,
     approvalType: ApprovalType,
     messageName: string,
-    signMessage: (
-      messageParams: PM,
-      version?: string,
-      signingOpts?: SO,
-    ) => void,
+    signMessage: (messageParams: PM, signingOpts?: SO) => void,
     messageParams: PM,
     req: OriginalRequest,
     validateMessage?: (params: PM) => void,
@@ -413,6 +409,7 @@ export class SignatureController extends BaseControllerV2<
     const messageParamsWithId = {
       ...messageParams,
       metamaskId: messageId,
+      ...(version && { version }),
     };
 
     const signaturePromise = messageManager.waitForFinishStatus(
@@ -428,7 +425,7 @@ export class SignatureController extends BaseControllerV2<
         'User rejected the request.',
       );
     }
-    await signMessage(messageParamsWithId, version, signingOpts);
+    await signMessage(messageParamsWithId, signingOpts);
 
     return signaturePromise;
   }
@@ -471,14 +468,12 @@ export class SignatureController extends BaseControllerV2<
    * Triggers the callback in newUnsignedTypedMessage.
    *
    * @param msgParams - The params passed to eth_signTypedData.
-   * @param version - The version indicating the format of the typed data.
    * @param opts - The options for the method.
    * @param opts.parseJsonData - Whether to parse JSON data before calling the KeyringController.
    * @returns Signature result from signing.
    */
   async #signTypedMessage(
     msgParams: TypedMessageParamsMetamask,
-    version?: string,
     opts?: TypedMessageSigningOptions,
   ): Promise<any> {
     return await this.#signAbstractMessage(
@@ -486,6 +481,7 @@ export class SignatureController extends BaseControllerV2<
       ApprovalType.EthSignTypedData,
       msgParams,
       async (cleanMsgParams) => {
+        const { version } = msgParams;
         // Options will allways be defined, but we want to satisfy the TS
         // hence we ignore the branch here
         /* istanbul ignore next */

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -333,12 +333,15 @@ export class SignatureController extends BaseControllerV2<
    * @param messageParams - The params passed to eth_signTypedData.
    * @param req - The original request, containing the origin.
    * @param version - The version indicating the format of the typed data.
+   * @param signingOpts - An options bag for signing.
+   * @param signingOpts.parseJsonData - Whether to parse the JSON before signing.
    * @returns Promise resolving to the raw data of the signature request.
    */
   async newUnsignedTypedMessage(
     messageParams: TypedMessageParams,
     req: OriginalRequest,
     version: string,
+    signingOpts: TypedMessageSigningOptions,
   ): Promise<string> {
     return this.#newUnsignedAbstractMessage(
       this.#typedMessageManager,
@@ -349,9 +352,7 @@ export class SignatureController extends BaseControllerV2<
       req,
       undefined,
       version,
-      {
-        parseJsonData: true,
-      },
+      signingOpts,
     );
   }
 
@@ -474,18 +475,16 @@ export class SignatureController extends BaseControllerV2<
    */
   async #signTypedMessage(
     msgParams: TypedMessageParamsMetamask,
-    opts?: TypedMessageSigningOptions,
+    /* istanbul ignore next */
+    opts = { parseJsonData: true },
   ): Promise<any> {
+    const { version } = msgParams;
     return await this.#signAbstractMessage(
       this.#typedMessageManager,
       ApprovalType.EthSignTypedData,
       msgParams,
       async (cleanMsgParams) => {
-        const { version } = msgParams;
-        // Options will allways be defined, but we want to satisfy the TS
-        // hence we ignore the branch here
-        /* istanbul ignore next */
-        const finalMessageParams = opts?.parseJsonData
+        const finalMessageParams = opts.parseJsonData
           ? this.#removeJsonData(cleanMsgParams, version as string)
           : cleanMsgParams;
 


### PR DESCRIPTION
## Explanation

This PR is aiming to add version in Typed Messages in Signature Controller while passing message data to messengers. 