### PR TITLE
Display result pages using the ApprovalController

### DIFF
--- a/packages/approval-controller/src/ApprovalController.test.ts
+++ b/packages/approval-controller/src/ApprovalController.test.ts
@@ -1,10 +1,15 @@
+/* eslint-disable jest/expect-expect */
+
 import { errorCodes, EthereumRpcError } from 'eth-rpc-errors';
 import { ControllerMessenger } from '@metamask/base-controller';
 import {
+  APPROVAL_TYPE_RESULT_ERROR,
+  APPROVAL_TYPE_RESULT_SUCCESS,
   ApprovalController,
   ApprovalControllerActions,
   ApprovalControllerEvents,
   ApprovalControllerMessenger,
+  ORIGIN_METAMASK,
   StartFlowOptions,
 } from './ApprovalController';
 import {
@@ -14,17 +19,190 @@ import {
   NoApprovalFlowsError,
 } from './errors';
 
+jest.mock('nanoid', () => ({
+  nanoid: jest.fn(() => 'TestId'),
+}));
+
 const PENDING_APPROVALS_STORE_KEY = 'pendingApprovals';
 const APPROVAL_FLOWS_STORE_KEY = 'approvalFlows';
-
 const TYPE = 'TYPE';
 const ID_MOCK = 'TestId';
 const ORIGIN_MOCK = 'TestOrigin';
 const VALUE_MOCK = 'TestValue';
 const RESULT_MOCK = 'TestResult';
 const ERROR_MOCK = new Error('TestError');
+const FLOW_ID_MOCK = 'TestFlowId';
+const MESSAGE_MOCK = 'TestMessage';
+const ERROR_MESSAGE_MOCK = 'TestErrorMessage';
+const RESULT_COMPONENT_MOCK = {
+  key: 'testKey',
+  name: 'TestComponentName',
+  properties: { testProp: 'testPropValue' },
+  children: ['testChild1', 'testChild2'],
+};
+const SUCCESS_OPTIONS_MOCK = {
+  message: MESSAGE_MOCK,
+  header: [RESULT_COMPONENT_MOCK],
+};
+const ERROR_OPTIONS_MOCK = {
+  error: ERROR_MESSAGE_MOCK,
+  header: [RESULT_COMPONENT_MOCK],
+};
 
 const controllerName = 'ApprovalController';
+
+/**
+ * Get an ID collision error.
+ *
+ * @param id - The ID with a collision.
+ * @returns The ID collision error.
+ */
+function getIdCollisionError(id: string) {
+  return getError(
+    `Approval request with id '${id}' already exists.`,
+    errorCodes.rpc.internal,
+  );
+}
+
+/**
+ * Get an origin type collision error.
+ *
+ * @param origin - The origin.
+ * @param type - The type.
+ * @returns An origin type collision error.
+ */
+function getOriginTypeCollisionError(origin: string, type = TYPE) {
+  const message = `Request of type '${type}' already pending for origin ${origin}. Please wait.`;
+  return getError(message, errorCodes.rpc.resourceUnavailable);
+}
+
+/**
+ * Get an invalid ID error.
+ *
+ * @returns An invalid ID error.
+ */
+function getInvalidIdError() {
+  return getError('Must specify non-empty string id.', errorCodes.rpc.internal);
+}
+
+/**
+ * Get an "ID not found" error.
+ *
+ * @param id - The ID that was not found.
+ * @returns An "ID not found" error.
+ */
+function getIdNotFoundError(id: string) {
+  return getError(`Approval request with id '${id}' not found.`);
+}
+
+/**
+ * Get an invalid ID type error.
+ *
+ * @returns An invalid ID type error.
+ */
+function getInvalidHasIdError() {
+  return getError('May not specify non-string id.');
+}
+
+/**
+ * Get an invalid origin type error.
+ *
+ * @returns The invalid origin type error.
+ */
+function getInvalidHasOriginError() {
+  return getError('May not specify non-string origin.');
+}
+
+/**
+ * Get an invalid type error.
+ *
+ * @returns The invalid type error.
+ */
+function getInvalidHasTypeError() {
+  return getError('May not specify non-string type.');
+}
+
+/**
+ * Get an invalid origin error.
+ *
+ * @returns The invalid origin error.
+ */
+function getInvalidOriginError() {
+  return getError(
+    'Must specify non-empty string origin.',
+    errorCodes.rpc.internal,
+  );
+}
+
+/**
+ * Get an invalid request data error.
+ *
+ * @returns The invalid request data error.
+ */
+function getInvalidRequestDataError() {
+  return getError(
+    'Request data must be a plain object if specified.',
+    errorCodes.rpc.internal,
+  );
+}
+
+/**
+ * Get an invalid request state error.
+ *
+ * @returns The invalid request data error.
+ */
+function getInvalidRequestStateError() {
+  return getError(
+    'Request state must be a plain object if specified.',
+    errorCodes.rpc.internal,
+  );
+}
+
+/**
+ * Get an invalid type error.
+ *
+ * @param code - The error code.
+ * @returns The invalid type error.
+ */
+function getInvalidTypeError(code: number) {
+  return getError('Must specify non-empty string type.', code);
+}
+
+/**
+ * Get an invalid params error.
+ *
+ * @returns The invalid params error.
+ */
+function getInvalidHasParamsError() {
+  return getError('Must specify a valid combination of id, origin, and type.');
+}
+
+/**
+ * Get an invalid approval count params error.
+ *
+ * @returns The invalid approval count params error.
+ */
+function getApprovalCountParamsError() {
+  return getError('Must specify origin, type, or both.');
+}
+
+/**
+ * Get an error.
+ *
+ * @param message - The error message.
+ * @param code - The error code.
+ * @returns An Error.
+ */
+function getError(message: string, code?: number) {
+  const err: any = {
+    name: 'Error',
+    message,
+  };
+  if (code !== undefined) {
+    err.code = code;
+  }
+  return err;
+}
 
 /**
  * Constructs a restricted controller messenger.
@@ -1106,159 +1284,222 @@ describe('approval controller', () => {
       ).toBeNull();
     });
   });
+
+  describe('result', () => {
+    /**
+     * Assert that an approval request has been added.
+     *
+     * @param expectedType - The expected approval type.
+     * @param expectedData - The expected request data.
+     */
+    function expectRequestAdded(
+      expectedType: string,
+      expectedData: Record<string, unknown>,
+    ) {
+      const requests = approvalController.state[PENDING_APPROVALS_STORE_KEY];
+      expect(Object.values(requests)).toHaveLength(1);
+
+      const request = Object.values(requests)[0];
+      expect(request.id).toStrictEqual(expect.any(String));
+      expect(request.requestData).toStrictEqual(expectedData);
+
+      expect(approvalController.has({ id: request.id })).toStrictEqual(true);
+      expect(approvalController.has({ origin: ORIGIN_METAMASK })).toStrictEqual(
+        true,
+      );
+      expect(approvalController.has({ type: expectedType })).toStrictEqual(
+        true,
+      );
+    }
+
+    /**
+     * Test template to verify that a result method ends the specified flow once approved.
+     *
+     * @param methodCallback - A callback to invoke the result method.
+     */
+    async function endsSpecifiedFlowTemplate(
+      methodCallback: (flowId: string) => Promise<any>,
+    ) {
+      approvalController.startFlow({ id: FLOW_ID_MOCK });
+
+      const promise = methodCallback(FLOW_ID_MOCK);
+
+      const resultRequestId = Object.values(
+        approvalController.state[PENDING_APPROVALS_STORE_KEY],
+      )[0].id;
+
+      approvalController.accept(resultRequestId);
+      await promise;
+
+      expect(approvalController.state[APPROVAL_FLOWS_STORE_KEY]).toHaveLength(
+        0,
+      );
+    }
+
+    /**
+     * Test template to verify that a result does not throw if adding the request fails.
+     *
+     * @param methodCallback - A callback to invoke the result method.
+     */
+    async function doesNotThrowIfAddingRequestFails(
+      methodCallback: () => Promise<any>,
+    ) {
+      jest.spyOn(global.console, 'info');
+
+      methodCallback();
+
+      // Second call will fail as mocked nanoid will generate the same ID.
+      methodCallback();
+
+      expect(console.info).toHaveBeenCalledTimes(1);
+      expect(console.info).toHaveBeenCalledWith(
+        'Failed to display result page',
+        expect.objectContaining({
+          message: `Approval request with id '${ID_MOCK}' already exists.`,
+        }),
+      );
+    }
+
+    /**
+     * Test template to verify that a result method does not throw if ending the flow fails.
+     *
+     * @param methodCallback - A callback to invoke the result method.
+     */
+    async function doesNotThrowIfEndFlowFails(
+      methodCallback: () => Promise<any>,
+    ) {
+      jest.spyOn(global.console, 'info');
+
+      const promise = methodCallback();
+
+      const resultRequestId = Object.values(
+        approvalController.state[PENDING_APPROVALS_STORE_KEY],
+      )[0].id;
+
+      approvalController.accept(resultRequestId);
+      await promise;
+
+      expect(console.info).toHaveBeenCalledTimes(1);
+      expect(console.info).toHaveBeenCalledWith('Failed to end flow', {
+        error: expect.objectContaining({ message: 'No approval flows found.' }),
+        id: FLOW_ID_MOCK,
+      });
+    }
+
+    describe('success', () => {
+      it('adds request with result success approval type', async () => {
+        approvalController.success(SUCCESS_OPTIONS_MOCK);
+        expectRequestAdded(APPROVAL_TYPE_RESULT_SUCCESS, SUCCESS_OPTIONS_MOCK);
+      });
+
+      it('adds request with no options', async () => {
+        approvalController.success();
+
+        expectRequestAdded(APPROVAL_TYPE_RESULT_SUCCESS, {
+          message: undefined,
+          header: undefined,
+        });
+      });
+
+      it('only includes relevant options in request data', async () => {
+        (approvalController as any).success({
+          ...SUCCESS_OPTIONS_MOCK,
+          extra: 'testValue',
+        });
+
+        const { requestData } = Object.values(
+          approvalController.state[PENDING_APPROVALS_STORE_KEY],
+        )[0];
+
+        expect(requestData).toStrictEqual(SUCCESS_OPTIONS_MOCK);
+      });
+
+      it('shows approval request', async () => {
+        approvalController.success(SUCCESS_OPTIONS_MOCK);
+        expect(showApprovalRequest).toHaveBeenCalledTimes(1);
+      });
+
+      it('ends specified flow', async () => {
+        await endsSpecifiedFlowTemplate((flowId) =>
+          approvalController.success({
+            ...SUCCESS_OPTIONS_MOCK,
+            flowToEnd: flowId,
+          }),
+        );
+      });
+
+      it('does not throw if adding request fails', async () => {
+        doesNotThrowIfAddingRequestFails(() =>
+          approvalController.success(SUCCESS_OPTIONS_MOCK),
+        );
+      });
+
+      it('does not throw if ending the flow fails', async () => {
+        await doesNotThrowIfEndFlowFails(() =>
+          approvalController.success({
+            ...SUCCESS_OPTIONS_MOCK,
+            flowToEnd: FLOW_ID_MOCK,
+          }),
+        );
+      });
+    });
+
+    describe('error', () => {
+      it('adds request with result error approval type', async () => {
+        approvalController.error(ERROR_OPTIONS_MOCK);
+        expectRequestAdded(APPROVAL_TYPE_RESULT_ERROR, ERROR_OPTIONS_MOCK);
+      });
+
+      it('adds request with no options', async () => {
+        approvalController.error();
+
+        expectRequestAdded(APPROVAL_TYPE_RESULT_ERROR, {
+          error: undefined,
+          header: undefined,
+        });
+      });
+
+      it('only includes relevant options in request data', async () => {
+        (approvalController as any).error({
+          ...ERROR_OPTIONS_MOCK,
+          extra: 'testValue',
+        });
+
+        const { requestData } = Object.values(
+          approvalController.state[PENDING_APPROVALS_STORE_KEY],
+        )[0];
+
+        expect(requestData).toStrictEqual(ERROR_OPTIONS_MOCK);
+      });
+
+      it('shows approval request', async () => {
+        approvalController.error(ERROR_OPTIONS_MOCK);
+        expect(showApprovalRequest).toHaveBeenCalledTimes(1);
+      });
+
+      it('ends specified flow', async () => {
+        await endsSpecifiedFlowTemplate((flowId) =>
+          approvalController.error({
+            ...ERROR_OPTIONS_MOCK,
+            flowToEnd: flowId,
+          }),
+        );
+      });
+
+      it('does not throw if adding request fails', async () => {
+        doesNotThrowIfAddingRequestFails(() =>
+          approvalController.error(ERROR_OPTIONS_MOCK),
+        );
+      });
+
+      it('does not throw if ending the flow fails', async () => {
+        await doesNotThrowIfEndFlowFails(() =>
+          approvalController.error({
+            ...ERROR_OPTIONS_MOCK,
+            flowToEnd: FLOW_ID_MOCK,
+          }),
+        );
+      });
+    });
+  });
 });
-
-// helpers
-
-/**
- * Get an ID collision error.
- *
- * @param id - The ID with a collision.
- * @returns The ID collision error.
- */
-function getIdCollisionError(id: string) {
-  return getError(
-    `Approval request with id '${id}' already exists.`,
-    errorCodes.rpc.internal,
-  );
-}
-
-/**
- * Get an origin type collision error.
- *
- * @param origin - The origin.
- * @param type - The type.
- * @returns An origin type collision error.
- */
-function getOriginTypeCollisionError(origin: string, type = TYPE) {
-  const message = `Request of type '${type}' already pending for origin ${origin}. Please wait.`;
-  return getError(message, errorCodes.rpc.resourceUnavailable);
-}
-
-/**
- * Get an invalid ID error.
- *
- * @returns An invalid ID error.
- */
-function getInvalidIdError() {
-  return getError('Must specify non-empty string id.', errorCodes.rpc.internal);
-}
-
-/**
- * Get an "ID not found" error.
- *
- * @param id - The ID that was not found.
- * @returns An "ID not found" error.
- */
-function getIdNotFoundError(id: string) {
-  return getError(`Approval request with id '${id}' not found.`);
-}
-
-/**
- * Get an invalid ID type error.
- *
- * @returns An invalid ID type error.
- */
-function getInvalidHasIdError() {
-  return getError('May not specify non-string id.');
-}
-
-/**
- * Get an invalid origin type error.
- *
- * @returns The invalid origin type error.
- */
-function getInvalidHasOriginError() {
-  return getError('May not specify non-string origin.');
-}
-
-/**
- * Get an invalid type error.
- *
- * @returns The invalid type error.
- */
-function getInvalidHasTypeError() {
-  return getError('May not specify non-string type.');
-}
-
-/**
- * Get an invalid origin error.
- *
- * @returns The invalid origin error.
- */
-function getInvalidOriginError() {
-  return getError(
-    'Must specify non-empty string origin.',
-    errorCodes.rpc.internal,
-  );
-}
-
-/**
- * Get an invalid request data error.
- *
- * @returns The invalid request data error.
- */
-function getInvalidRequestDataError() {
-  return getError(
-    'Request data must be a plain object if specified.',
-    errorCodes.rpc.internal,
-  );
-}
-
-/**
- * Get an invalid request state error.
- *
- * @returns The invalid request data error.
- */
-function getInvalidRequestStateError() {
-  return getError(
-    'Request state must be a plain object if specified.',
-    errorCodes.rpc.internal,
-  );
-}
-
-/**
- * Get an invalid type error.
- *
- * @param code - The error code.
- * @returns The invalid type error.
- */
-function getInvalidTypeError(code: number) {
-  return getError('Must specify non-empty string type.', code);
-}
-
-/**
- * Get an invalid params error.
- *
- * @returns The invalid params error.
- */
-function getInvalidHasParamsError() {
-  return getError('Must specify a valid combination of id, origin, and type.');
-}
-
-/**
- * Get an invalid approval count params error.
- *
- * @returns The invalid approval count params error.
- */
-function getApprovalCountParamsError() {
-  return getError('Must specify origin, type, or both.');
-}
-
-/**
- * Get an error.
- *
- * @param message - The error message.
- * @param code - The error code.
- * @returns An Error.
- */
-function getError(message: string, code?: number) {
-  const err: any = {
-    name: 'Error',
-    message,
-  };
-  if (code !== undefined) {
-    err.code = code;
-  }
-  return err;
-}

--- a/packages/approval-controller/src/ApprovalController.ts
+++ b/packages/approval-controller/src/ApprovalController.ts
@@ -61,14 +61,7 @@ type ApprovalFlow = {
 };
 
 type ResultOptions = {
-  /**
-   * The ID of an approval flow to end after showing the result.
-   */
   flowToEnd?: string;
-
-  /**
-   * Text or components to display in the header of the result.
-   */
   header?: (string | ResultComponent)[];
 };
 
@@ -194,16 +187,10 @@ export type EndFlowOptions = Pick<ApprovalFlow, 'id'>;
 export type SetFlowLoadingTextOptions = ApprovalFlow;
 
 export type SuccessOptions = ResultOptions & {
-  /**
-   * The message text or components to display in the result.
-   */
   message?: string | ResultComponent | (string | ResultComponent)[];
 };
 
 export type ErrorOptions = ResultOptions & {
-  /**
-   * The error message or components to display in the result.
-   */
   error?: string | ResultComponent | (string | ResultComponent)[];
 };
 
@@ -832,6 +819,15 @@ export class ApprovalController extends BaseControllerV2<
     });
   }
 
+  /**
+   * Show a success page.
+   *
+   * @param opts - Options bag.
+   * @param opts.message - The message text or components to display in the page.
+   * @param opts.header - The text or components to display in the header of the page.
+   * @param opts.flowToEnd - The ID of the approval flow to end once the success page is approved.
+   * @returns Empty object to support future additions.
+   */
   async success(opts: SuccessOptions = {}): Promise<SuccessResult> {
     await this.#result(APPROVAL_TYPE_RESULT_SUCCESS, opts, {
       message: opts.message,
@@ -840,6 +836,15 @@ export class ApprovalController extends BaseControllerV2<
     return {};
   }
 
+  /**
+   * Show an error page.
+   *
+   * @param opts - Options bag.
+   * @param opts.message - The message text or components to display in the page.
+   * @param opts.header - The text or components to display in the header of the page.
+   * @param opts.flowToEnd - The ID of the approval flow to end once the error page is approved.
+   * @returns Empty object to support future additions.
+   */
   async error(opts: ErrorOptions = {}): Promise<ErrorResult> {
     await this.#result(APPROVAL_TYPE_RESULT_ERROR, opts, {
       error: opts.error,

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -91,21 +91,23 @@ export const ORIGIN_METAMASK = 'metamask';
  */
 export enum ApprovalType {
   AddEthereumChain = 'wallet_addEthereumChain',
+  ConnectAccounts = 'connect_accounts',
   EthDecrypt = 'eth_decrypt',
   EthGetEncryptionPublicKey = 'eth_getEncryptionPublicKey',
   EthSign = 'eth_sign',
   EthSignTypedData = 'eth_signTypedData',
   PersonalSign = 'personal_sign',
-  SwitchEthereumChain = 'wallet_switchEthereumChain',
-  Transaction = 'transaction',
-  WalletRequestPermissions = 'wallet_requestPermissions',
-  WatchAsset = 'wallet_watchAsset',
+  ResultError = 'result_error',
+  ResultSuccess = 'result_success',
   SnapDialogAlert = 'snap_dialog:alert',
   SnapDialogConfirmation = 'snap_dialog:confirmation',
   SnapDialogPrompt = 'snap_dialog:prompt',
+  SwitchEthereumChain = 'wallet_switchEthereumChain',
+  Transaction = 'transaction',
   Unlock = 'unlock',
-  ConnectAccounts = 'connect_accounts',
   WalletConnect = 'wallet_connect',
+  WalletRequestPermissions = 'wallet_requestPermissions',
+  WatchAsset = 'wallet_watchAsset',
 }
 
 export const NETWORK_ID_TO_ETHERS_NETWORK_NAME_MAP: Record<


### PR DESCRIPTION
## Explanation

Adds `success` and `error` methods to the `ApprovalController` to easily create standardised approvals to display success or error pages in the clients.

These methods both support optional arguments including `message`, `error`, and `header` to configure what text or components are displayed in the approval, plus `flowToEnd` which will end the specified flow when the result confirmation is approved.

This PR also includes some minor refactors for consistency, including:

- Replacing use of the `private` modifier with the `#` syntax to protect private properties and methods at runtime.
- Removing calls to any private methods from the unit tests.
- Grouping the many types into categories to simplify future additions.

## Changelog

### `@metamask/approval-controller`

- **ADDED**: `success` and `error` methods to display standardised result pages

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
