### PR TITLE
Simplify network types accepted by TransactionController

### DIFF
--- a/packages/network-controller/src/index.ts
+++ b/packages/network-controller/src/index.ts
@@ -1,3 +1,3 @@
 export * from './NetworkController';
 export * from './constants';
-export type { Provider } from './types';
+export type { BlockTracker, Provider } from './types';

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -47,11 +47,9 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.1.0",
-    "@metamask/swappable-obj-proxy": "^2.1.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.18.24",
     "deepmerge": "^4.2.2",
-    "eth-block-tracker": "^7.0.1",
     "ethjs-provider-http": "^0.1.6",
     "jest": "^27.5.1",
     "sinon": "^9.2.4",

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1,5 +1,4 @@
 import * as sinon from 'sinon';
-import { PollingBlockTracker } from 'eth-block-tracker';
 import HttpProvider from 'ethjs-provider-http';
 import NonceTracker from 'nonce-tracker';
 import {
@@ -9,19 +8,18 @@ import {
   ApprovalType,
   ORIGIN_METAMASK,
 } from '@metamask/controller-utils';
-import type {
-  BlockTrackerProxy,
-  NetworkState,
-  ProviderProxy,
-} from '@metamask/network-controller';
 import { NetworkStatus } from '@metamask/network-controller';
+import type {
+  BlockTracker,
+  NetworkState,
+  Provider,
+} from '@metamask/network-controller';
 import {
   AcceptRequest as AcceptApprovalRequest,
   AddApprovalRequest,
   RejectRequest as RejectApprovalRequest,
 } from '@metamask/approval-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
-import { createEventEmitterProxy } from '@metamask/swappable-obj-proxy';
 import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
 import { ESTIMATE_GAS_ERROR } from './utils';
 import {
@@ -156,10 +154,10 @@ function mockFetchWithDynamicResponse(dataForUrl: any) {
  * always return.
  * @returns The mocked block tracker.
  */
-function buildMockBlockTracker(latestBlockNumber: string): BlockTrackerProxy {
+function buildMockBlockTracker(latestBlockNumber: string): BlockTracker {
   const fakeBlockTracker = new FakeBlockTracker();
   fakeBlockTracker.mockLatestBlockNumber(latestBlockNumber);
-  return createEventEmitterProxy<PollingBlockTracker>(fakeBlockTracker);
+  return fakeBlockTracker;
 }
 
 const MOCK_PREFERENCES = { state: { selectedAddress: 'foo' } };
@@ -174,8 +172,8 @@ const PALM_PROVIDER = new HttpProvider(
 );
 
 type MockNetwork = {
-  provider: ProviderProxy;
-  blockTracker: BlockTrackerProxy;
+  provider: Provider;
+  blockTracker: BlockTracker;
   state: NetworkState;
   subscribe: (listener: (state: NetworkState) => void) => void;
 };

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -15,9 +15,9 @@ import {
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
 import type {
+  BlockTracker,
   NetworkState,
-  ProviderProxy,
-  BlockTrackerProxy,
+  Provider,
 } from '@metamask/network-controller';
 import {
   BNToHex,
@@ -311,7 +311,7 @@ export class TransactionController extends BaseController<
 
   private registry: any;
 
-  private provider: ProviderProxy;
+  private provider: Provider;
 
   private handle?: ReturnType<typeof setTimeout>;
 
@@ -472,8 +472,8 @@ export class TransactionController extends BaseController<
     }: {
       getNetworkState: () => NetworkState;
       onNetworkStateChange: (listener: (state: NetworkState) => void) => void;
-      provider: ProviderProxy;
-      blockTracker: BlockTrackerProxy;
+      provider: Provider;
+      blockTracker: BlockTracker;
       messenger: TransactionControllerMessenger;
     },
     config?: Partial<TransactionConfig>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2014,14 +2014,12 @@ __metadata:
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
     "@metamask/network-controller": "workspace:^"
-    "@metamask/swappable-obj-proxy": ^2.1.0
     "@metamask/utils": ^5.0.2
     "@types/jest": ^27.4.1
     "@types/node": ^16.18.24
     async-mutex: ^0.2.6
     babel-runtime: ^6.26.0
     deepmerge: ^4.2.2
-    eth-block-tracker: ^7.0.1
     eth-method-registry: 1.1.0
     eth-query: ^2.1.2
     eth-rpc-errors: ^4.0.2


### PR DESCRIPTION


## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

According to its types, TransactionController takes the proxy versions of the provider and block tracker that NetworkController exposes. However, this isn't really necessary, and in fact this introduces churn, because if anything around that proxy changes on the NetworkController side, then the tests for TransactionController need to change too. By relaxing the types so that TransactionController only need accept the _actual_ provider and block tracker interfaces rather than the proxies, it prevents the tests from having to be unnecessary updated and makes things simpler for consumers as well.

To make this change, `@metamask/network-controller` needed to be updated to not only expose its Provider type but also its BlockTracker type.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

Related to https://github.com/MetaMask/core/pull/1439.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/network-controller`

- **ADDED**: Expose `BlockTracker` type

### `@metamask/transaction-controller`

- **CHANGED**: Relax types of `provider` and `blockTracker` options from proxy versions of Provider and BlockTracker to non-proxy versions

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
