### PR TITLE
Use exact versions for preview releases

### DIFF
--- a/scripts/prepare-preview-manifest.sh
+++ b/scripts/prepare-preview-manifest.sh
@@ -18,13 +18,19 @@ shorthash="$1"
 # of the version. Technically we'd want to bump the non-prerelease portion as
 # well if we wanted this to be SemVer-compliant, but it was simpler not to.
 # This is just for testing, it doesn't need to strictly follow SemVer.
-jq --raw-output ".version |= split(\"-\")[0] + \"-preview.${shorthash}\"" ./package.json > temp.json
+jq --raw-output --arg hash "$shorthash" '.version |= split("-")[0] + "-preview.\($hash)"' ./package.json |
+
+# The workspace dependencies are updated to point to the exact preview build
+# version, so that it does not try to resolve a different version from the
+# registry.
+jq --raw-output 'if has("devDependencies") then .devDependencies |= map_values(if . == "workspace:^" then "workspace:*" else . end) else . end' |
+jq --raw-output 'if has("dependencies") then .dependencies |= map_values(if . == "workspace:^" then "workspace:*" else . end) else . end' |
 
 # The registry is updated here because the manifest publish config always takes
 # precedence, and cannot be overwritten from the command-line.
-jq --raw-output ".publishConfig.registry = \"https://npm.pkg.github.com\"" ./temp.json > package.json
+jq --raw-output ".publishConfig.registry = \"https://npm.pkg.github.com\"" > temp.json
 
 # jq does not support in-place modification of files, so a temporary file is
-# used to store the result of the first operation.
-rm temp.json
-
+# used to store the result of the first operation. The original file is then
+# overwritten with the temporary file.
+mv temp.json package.json

--- a/scripts/prepare-preview-manifest.sh
+++ b/scripts/prepare-preview-manifest.sh
@@ -19,16 +19,14 @@ shorthash="$1"
 # well if we wanted this to be SemVer-compliant, but it was simpler not to.
 # This is just for testing, it doesn't need to strictly follow SemVer.
 jq --raw-output --arg hash "$shorthash" '.version |= split("-")[0] + "-preview.\($hash)"' ./package.json |
-
-# The workspace dependencies are updated to point to the exact preview build
-# version, so that it does not try to resolve a different version from the
-# registry.
-jq --raw-output 'if has("devDependencies") then .devDependencies |= map_values(if . == "workspace:^" then "workspace:*" else . end) else . end' |
-jq --raw-output 'if has("dependencies") then .dependencies |= map_values(if . == "workspace:^" then "workspace:*" else . end) else . end' |
-
-# The registry is updated here because the manifest publish config always takes
-# precedence, and cannot be overwritten from the command-line.
-jq --raw-output ".publishConfig.registry = \"https://npm.pkg.github.com\"" > temp.json
+  # The workspace dependencies are updated to point to the exact preview build
+  # version, so that it does not try to resolve a different version from the
+  # registry.
+  jq --raw-output 'if has("devDependencies") then .devDependencies |= map_values(if . == "workspace:^" then "workspace:*" else . end) else . end' |
+  jq --raw-output 'if has("dependencies") then .dependencies |= map_values(if . == "workspace:^" then "workspace:*" else . end) else . end' |
+  # The registry is updated here because the manifest publish config always takes
+  # precedence, and cannot be overwritten from the command-line.
+  jq --raw-output ".publishConfig.registry = \"https://npm.pkg.github.com\"" > temp.json
 
 # jq does not support in-place modification of files, so a temporary file is
 # used to store the result of the first operation. The original file is then


### PR DESCRIPTION
## Explanation

This ensures that preview builds don't accidentally reference the wrong preview versions of other packages that are dependencies.

## References

Ported from https://github.com/MetaMask/snaps/pull/1529

## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
