### PR TITLE
fix(controller-utils): Fix query function

### DIFF
--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@metamask/utils": "^5.0.2",
     "@spruceid/siwe-parser": "1.1.3",
+    "babel-runtime": "^6.26.0",
     "eth-ens-namehash": "^2.0.8",
     "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.2",

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -32,6 +32,7 @@
     "@metamask/utils": "^5.0.2",
     "@spruceid/siwe-parser": "1.1.3",
     "eth-ens-namehash": "^2.0.8",
+    "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.2",
     "ethereumjs-util": "^7.0.10",
     "ethjs-unit": "^0.1.6",

--- a/packages/controller-utils/src/util.test.ts
+++ b/packages/controller-utils/src/util.test.ts
@@ -439,50 +439,57 @@ describe('util', () => {
   describe('query', () => {
     describe('when the given method exists directly on the EthQuery', () => {
       it('should call the method on the EthQuery and, if it is successful, return a promise that resolves to the result', async () => {
-        const ethQuery = {
-          getBlockByHash: (blockId: any, cb: any) => cb(null, { id: blockId }),
-        };
+        class EthQuery {
+          getBlockByHash(blockId: any, cb: any) {
+            cb(null, { id: blockId });
+          }
+        }
         // @ts-expect-error Mock eth query does not fulfill type requirements
-        const result = await util.query(ethQuery, 'getBlockByHash', ['0x1234']);
+        const result = await util.query(new EthQuery(), 'getBlockByHash', [
+          '0x1234',
+        ]);
         expect(result).toStrictEqual({ id: '0x1234' });
       });
 
       it('should call the method on the EthQuery and, if it errors, return a promise that is rejected with the error', async () => {
-        const ethQuery = {
-          getBlockByHash: (_blockId: any, cb: any) =>
-            cb(new Error('uh oh'), null),
-        };
+        class EthQuery {
+          getBlockByHash(_blockId: any, cb: any) {
+            cb(new Error('uh oh'), null);
+          }
+        }
         await expect(
           // @ts-expect-error Mock eth query does not fulfill type requirements
-          util.query(ethQuery, 'getBlockByHash', ['0x1234']),
+          util.query(new EthQuery(), 'getBlockByHash', ['0x1234']),
         ).rejects.toThrow('uh oh');
       });
     });
 
     describe('when the given method does not exist directly on the EthQuery', () => {
       it('should use sendAsync to call the RPC endpoint and, if it is successful, return a promise that resolves to the result', async () => {
-        const ethQuery = {
-          sendAsync: ({ method, params }: any, cb: any) => {
+        class EthQuery {
+          sendAsync({ method, params }: any, cb: any) {
             if (method === 'eth_getBlockByHash') {
               return cb(null, { id: params[0] });
             }
             throw new Error(`Unsupported method ${method}`);
-          },
-        };
-        const result = await util.query(ethQuery, 'eth_getBlockByHash', [
+          }
+        }
+        // @ts-expect-error Mock eth query does not fulfill type requirements
+        const result = await util.query(new EthQuery(), 'eth_getBlockByHash', [
           '0x1234',
         ]);
         expect(result).toStrictEqual({ id: '0x1234' });
       });
 
       it('should use sendAsync to call the RPC endpoint and, if it errors, return a promise that is rejected with the error', async () => {
-        const ethQuery = {
-          sendAsync: (_args: any, cb: any) => {
+        class EthQuery {
+          sendAsync(_args: any, cb: any) {
             cb(new Error('uh oh'), null);
-          },
-        };
+          }
+        }
         await expect(
-          util.query(ethQuery, 'eth_getBlockByHash', ['0x1234']),
+          // @ts-expect-error Mock eth query does not fulfill type requirements
+          util.query(new EthQuery(), 'eth_getBlockByHash', ['0x1234']),
         ).rejects.toThrow('uh oh');
       });
     });

--- a/packages/gas-fee-controller/src/gas-util.ts
+++ b/packages/gas-fee-controller/src/gas-util.ts
@@ -1,4 +1,5 @@
 import { BN } from 'ethereumjs-util';
+import type EthQuery from 'eth-query';
 import {
   query,
   handleFetch,
@@ -116,7 +117,7 @@ export async function fetchLegacyGasPriceEstimates(
  * @returns A gas price estimate.
  */
 export async function fetchEthGasPriceEstimate(
-  ethQuery: any,
+  ethQuery: EthQuery,
 ): Promise<EthGasPriceEstimate> {
   const gasPrice = await query(ethQuery, 'gasPrice');
   return {

--- a/types/eth-query.d.ts
+++ b/types/eth-query.d.ts
@@ -47,5 +47,7 @@ declare module 'eth-query' {
       opts: Partial<SendAsyncPayload<Params>>,
       callback: SendAsyncCallback<Result>,
     ): void;
+
+    [method: string]: (...args: any[]) => void;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1422,6 +1422,7 @@ __metadata:
     "@spruceid/siwe-parser": 1.1.3
     "@types/jest": ^27.4.1
     abort-controller: ^3.0.0
+    babel-runtime: ^6.26.0
     deepmerge: ^4.2.2
     eth-ens-namehash: ^2.0.8
     eth-query: ^2.1.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,6 +1424,7 @@ __metadata:
     abort-controller: ^3.0.0
     deepmerge: ^4.2.2
     eth-ens-namehash: ^2.0.8
+    eth-query: ^2.1.2
     eth-rpc-errors: ^4.0.2
     ethereumjs-util: ^7.0.10
     ethjs-unit: ^0.1.6


### PR DESCRIPTION
## Explanation

The `query` function was updated in #1266 to use `hasProperty` has part of an effect to improve the types being used. Unfortunately this had the unexpected affected of breaking this condition because `hasProperty` doesn't look up the prototype chain, but the method we were checking for was on the prototype. `hasProperty` is only meant to be used with plain objects.

The condition has been updated to use `in`, and the tests have been updated to use a more realistic EthQuery mock that has methods as prototypes.

To fix various type errors, an old inlined EthQueryLike type has been replaced by the real EthQuery type. This required adding `eth-query` as a dependency to the controller utils package.

## References

Related to https://github.com/MetaMask/metamask-extension/issues/19735

## Changelog

### `@metamask/controller-utils`

- FIXED: Fix bug where `query` function failed to call built-in EthQuery methods
- CHANGED: Add dependencies `eth-query` and `babel-runtime`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
