### PR TITLE
add validation that the nft standard matches the type argument

### DIFF
--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1073,6 +1073,12 @@ export class NftController extends BaseController<NftConfig, NftState> {
       asset.tokenId,
     );
 
+    if (nftMetadata.standard && nftMetadata.standard !== type) {
+      throw rpcErrors.invalidInput(
+        `Suggested NFT of type ${nftMetadata.standard} does not match received type ${type}`,
+      );
+    }
+
     const suggestedNftMeta: SuggestedNftMeta = {
       asset: { ...asset, ...nftMetadata },
       type,


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/MetaMask-planning/issues/854

Currently when `wallet_watchAsset` is called with type `ERC721` or `ERC1155`, we don't check whether the asset actually matches the type passed - we push it into a flow for suggested NFTs do a bunch of other validation, and if it passes we add it with the correct value for `standard` even if it doesn't match the `type` (standard) originally passed in the request. This adds validation of this type.

After:
https://github.com/MetaMask/core/assets/34557516/92a9bba5-c466-4ebc-b82c-b395649be52b



## Changelog

### `@metamask/package-b`

- **ADDED**: Adds validation that the standard of an NFT added via the `watchNFT` method matches the `type` argument passed with the request.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
