### PR TITLE
Fixed issue with type types from permissions rpc methods

### DIFF
--- a/packages/permission-controller/src/rpc-methods/index.ts
+++ b/packages/permission-controller/src/rpc-methods/index.ts
@@ -7,7 +7,4 @@ import { getPermissionsHandler, GetPermissionsHooks } from './getPermissions';
 export type PermittedRpcMethodHooks = RequestPermissionsHooks &
   GetPermissionsHooks;
 
-export const handlers: [
-  typeof requestPermissionsHandler,
-  typeof getPermissionsHandler,
-] = [requestPermissionsHandler, getPermissionsHandler];
+export const handlers = [requestPermissionsHandler, getPermissionsHandler] as const;

--- a/packages/permission-controller/src/rpc-methods/index.ts
+++ b/packages/permission-controller/src/rpc-methods/index.ts
@@ -7,4 +7,7 @@ import { getPermissionsHandler, GetPermissionsHooks } from './getPermissions';
 export type PermittedRpcMethodHooks = RequestPermissionsHooks &
   GetPermissionsHooks;
 
-export const handlers = [requestPermissionsHandler, getPermissionsHandler] as const;
+export const handlers = [
+  requestPermissionsHandler,
+  getPermissionsHandler,
+] as const;

--- a/packages/permission-controller/src/rpc-methods/index.ts
+++ b/packages/permission-controller/src/rpc-methods/index.ts
@@ -7,4 +7,7 @@ import { getPermissionsHandler, GetPermissionsHooks } from './getPermissions';
 export type PermittedRpcMethodHooks = RequestPermissionsHooks &
   GetPermissionsHooks;
 
-export const handlers = [requestPermissionsHandler, getPermissionsHandler];
+export const handlers: [
+  typeof requestPermissionsHandler,
+  typeof getPermissionsHandler,
+] = [requestPermissionsHandler, getPermissionsHandler];


### PR DESCRIPTION
Had this odd issue with these tuple types when importing into mobile. This fixes it by explicitly stating the tuple types.