### PR TITLE
Fix race condition when creating typed messages

### DIFF
--- a/packages/message-manager/src/TypedMessageManager.ts
+++ b/packages/message-manager/src/TypedMessageManager.ts
@@ -135,7 +135,7 @@ export class TypedMessageManager extends AbstractMessageManager<
       time: Date.now(),
       type: 'eth_signTypedData',
     };
-    this.addMessage(messageData);
+    await this.addMessage(messageData);
     this.hub.emit(`unapprovedMessage`, messageParamsMetamask);
     return messageId;
   }


### PR DESCRIPTION
## Explanation

Currently, when adding typed messages using the `TypedMessageManager`, it does not wait for the security provider request to be completed and for the message to be added before firing the `unapprovedMessage` event. This is causing errors in the clients as logic triggered by the event assumes the message is available.

This `await` is already present in the `PersonalMessageManager` and `MessageManager`.

## References

Fixes [#19826](https://github.com/MetaMask/metamask-extension/issues/19826) in the extension pending release and adoption.

## Changelog

### `@metamask/message-manager`

- **FIXED**: Race condition when adding typed messages

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
