### PR TITLE
MMI-3035 create the getAllMessages and setMetadata

### DIFF
--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -607,8 +607,8 @@ describe('SignatureController', () => {
     });
   });
 
-  describe('setMessageMetadata', () => {
-    it('resets state in all message managers', () => {
+  describe('trySetMessageMetadata', () => {
+    it('sets the metadata in a message manager', () => {
       signatureController.setMessageMetadata(
         messageParamsMock.metamaskId,
         messageParamsMock.data,
@@ -620,21 +620,12 @@ describe('SignatureController', () => {
         messageParamsWithoutIdMock.data,
       );
 
-      expect(personalMessageManagerMock.setMetadata).toHaveBeenCalledTimes(1);
-      expect(personalMessageManagerMock.setMetadata).toHaveBeenCalledWith(
-        messageIdMock,
-        messageParamsWithoutIdMock.data,
-      );
-
-      expect(typedMessageManagerMock.setMetadata).toHaveBeenCalledTimes(1);
-      expect(typedMessageManagerMock.setMetadata).toHaveBeenCalledWith(
-        messageIdMock,
-        messageParamsWithoutIdMock.data,
-      );
+      expect(personalMessageManagerMock.setMetadata).not.toHaveBeenCalled();
+      expect(typedMessageManagerMock.setMetadata).not.toHaveBeenCalled();
     });
   });
 
-  describe('allMessages', () => {
+  describe('messages getter', () => {
     const message = [
       {
         name: 'some message',
@@ -654,17 +645,19 @@ describe('SignatureController', () => {
       typedMessageManagerMock.getAllMessages.mockReturnValueOnce(message);
       personalMessageManagerMock.getAllMessages.mockReturnValueOnce([]);
       messageManagerMock.getAllMessages.mockReturnValueOnce([]);
-      expect(signatureController.allMessages).toMatchObject({
-        id: '1',
-        messageParams: {
-          data: [],
-          from: '0x0123',
+      expect(signatureController.messages).toMatchObject({
+        '1': {
+          id: '1',
+          messageParams: {
+            data: [],
+            from: '0x0123',
+          },
+          name: 'some message',
+          status: '',
+          time: 1,
+          type: 'type',
+          value: 'value',
         },
-        name: 'some message',
-        status: '',
-        time: 1,
-        type: 'type',
-        value: 'value',
       });
     });
   });

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -105,6 +105,8 @@ const createMessageManagerMock = <T>(prototype?: any): jest.Mocked<T> => {
     rejectMessage: jest.fn(),
     subscribe: jest.fn(),
     update: jest.fn(),
+    setMetadata: jest.fn(),
+    getAllMessages: jest.fn(),
     hub: {
       on: jest.fn(),
     },
@@ -602,6 +604,43 @@ describe('SignatureController', () => {
       expect(
         typedMessageManagerMock.setMessageStatusInProgress,
       ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setMessageMetadata', () => {
+    it('calls the message manager', async () => {
+      signatureController.setMessageMetadata(
+        messageParamsMock.metamaskId,
+        messageParamsMock.data
+      );
+
+      expect(
+        messageManagerMock.setMetadata,
+      ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('allMessages', () => {
+    const message = [
+      {
+        name: 'some message',
+        type: 'type',
+        value: 'value',
+        messageParams: {
+          data: [],
+          from: '0x0123',
+        },
+        time: 1,
+        status: '',
+        id: '1',
+      }
+    ];
+
+    it('returns all the messages from typed, personal and messageManager', () => {
+      typedMessageManagerMock.getAllMessages.mockReturnValueOnce(message);
+      personalMessageManagerMock.getAllMessages.mockReturnValueOnce([]);
+      messageManagerMock.getAllMessages.mockReturnValueOnce([]);
+      expect(signatureController.allMessages).toMatchObject(message);
     });
   });
 

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -623,6 +623,24 @@ describe('SignatureController', () => {
       expect(personalMessageManagerMock.setMetadata).not.toHaveBeenCalled();
       expect(typedMessageManagerMock.setMetadata).not.toHaveBeenCalled();
     });
+
+    it('should return false when an error occurs', () => {
+      messageManagerMock.setMetadata = jest.fn().mockImplementation(() => {
+        throw new Error('mocked error');
+      });
+  
+      const result = signatureController.setMessageMetadata(
+        messageParamsMock.metamaskId,
+        messageParamsMock.data,
+      );
+  
+      expect(result).toBe(undefined);
+      expect(messageManagerMock.setMetadata).toHaveBeenCalledTimes(1);
+      expect(messageManagerMock.setMetadata).toHaveBeenCalledWith(
+        messageIdMock,
+        messageParamsWithoutIdMock.data,
+      );
+    });
   });
 
   describe('messages getter', () => {

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -608,13 +608,29 @@ describe('SignatureController', () => {
   });
 
   describe('setMessageMetadata', () => {
-    it('calls the message manager', async () => {
+    it('resets state in all message managers', () => {
       signatureController.setMessageMetadata(
         messageParamsMock.metamaskId,
         messageParamsMock.data,
       );
 
       expect(messageManagerMock.setMetadata).toHaveBeenCalledTimes(1);
+      expect(messageManagerMock.setMetadata).toHaveBeenCalledWith(
+        messageIdMock,
+        messageParamsWithoutIdMock.data,
+      );
+
+      expect(personalMessageManagerMock.setMetadata).toHaveBeenCalledTimes(1);
+      expect(personalMessageManagerMock.setMetadata).toHaveBeenCalledWith(
+        messageIdMock,
+        messageParamsWithoutIdMock.data,
+      );
+
+      expect(typedMessageManagerMock.setMetadata).toHaveBeenCalledTimes(1);
+      expect(typedMessageManagerMock.setMetadata).toHaveBeenCalledWith(
+        messageIdMock,
+        messageParamsWithoutIdMock.data,
+      );
     });
   });
 
@@ -638,7 +654,18 @@ describe('SignatureController', () => {
       typedMessageManagerMock.getAllMessages.mockReturnValueOnce(message);
       personalMessageManagerMock.getAllMessages.mockReturnValueOnce([]);
       messageManagerMock.getAllMessages.mockReturnValueOnce([]);
-      expect(signatureController.allMessages).toMatchObject(message);
+      expect(signatureController.allMessages).toMatchObject({
+        id: '1',
+        messageParams: {
+          data: [],
+          from: '0x0123',
+        },
+        name: 'some message',
+        status: '',
+        time: 1,
+        type: 'type',
+        value: 'value',
+      });
     });
   });
 

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -625,16 +625,16 @@ describe('SignatureController', () => {
     });
 
     it('should return false when an error occurs', () => {
-      messageManagerMock.setMetadata = jest.fn().mockImplementation(() => {
+      jest.spyOn(messageManagerMock, 'setMetadata').mockImplementation(() => {
         throw new Error('mocked error');
       });
-  
+
       const result = signatureController.setMessageMetadata(
         messageParamsMock.metamaskId,
         messageParamsMock.data,
       );
-  
-      expect(result).toBe(undefined);
+
+      expect(result).toBeUndefined();
       expect(messageManagerMock.setMetadata).toHaveBeenCalledTimes(1);
       expect(messageManagerMock.setMetadata).toHaveBeenCalledWith(
         messageIdMock,

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -611,12 +611,10 @@ describe('SignatureController', () => {
     it('calls the message manager', async () => {
       signatureController.setMessageMetadata(
         messageParamsMock.metamaskId,
-        messageParamsMock.data
+        messageParamsMock.data,
       );
 
-      expect(
-        messageManagerMock.setMetadata,
-      ).toHaveBeenCalledTimes(1);
+      expect(messageManagerMock.setMetadata).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -633,7 +631,7 @@ describe('SignatureController', () => {
         time: 1,
         status: '',
         id: '1',
-      }
+      },
     ];
 
     it('returns all the messages from typed, personal and messageManager', () => {

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -260,8 +260,8 @@ export class SignatureController extends BaseControllerV2<
     return [
       ...this.#typedMessageManager.getAllMessages(),
       ...this.#personalMessageManager.getAllMessages(),
-      ...this.#messageManager.getAllMessages()
-    ]
+      ...this.#messageManager.getAllMessages(),
+    ];
   }
 
   /**

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -257,7 +257,7 @@ export class SignatureController extends BaseControllerV2<
    * @returns The array of all messages from their proxies.
    */
   get allMessages(): unknown[] {
-    const messagesObject: any = {};
+    let messagesObject: any = {};
 
     const allMessages = [
       ...this.#typedMessageManager.getAllMessages(),
@@ -266,8 +266,7 @@ export class SignatureController extends BaseControllerV2<
     ];
 
     for (const message of allMessages) {
-      const id = message.id;
-      messagesObject[id] = message;
+      messagesObject = { ...messagesObject, ...message };
     }
 
     return messagesObject;

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -544,12 +544,8 @@ export class SignatureController extends BaseControllerV2<
     );
   }
 
-  #trySetMessageMetadata<
-    M extends AbstractMessage,
-    P extends AbstractMessageParams,
-    PM extends AbstractMessageParamsMetamask,
-  >(
-    messageManager: AbstractMessageManager<M, P, PM>,
+  #trySetMessageMetadata(
+    messageManager: AbstractMessageManager<any, any, any>,
     messageId: string,
     metadata: Json,
   ) {

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -257,11 +257,20 @@ export class SignatureController extends BaseControllerV2<
    * @returns The array of all messages from their proxies.
    */
   get allMessages(): unknown[] {
-    return [
+    const messagesObject: any = {};
+
+    const allMessages = [
       ...this.#typedMessageManager.getAllMessages(),
       ...this.#personalMessageManager.getAllMessages(),
       ...this.#messageManager.getAllMessages(),
     ];
+  
+    for (const message of allMessages) {
+      const id = message.id;
+      messagesObject.id = message;
+    }
+  
+    return messagesObject;
   }
 
   /**
@@ -371,7 +380,9 @@ export class SignatureController extends BaseControllerV2<
   }
 
   setMessageMetadata(messageId: string, metadata: Json) {
-    this.#messageManager.setMetadata(messageId, metadata);
+    this.#setMessageMetadata(this.#messageManager, messageId, metadata);
+    this.#setMessageMetadata(this.#personalMessageManager, messageId, metadata);
+    this.#setMessageMetadata(this.#typedMessageManager, messageId, metadata);
   }
 
   setTypedMessageInProgress(messageId: string) {
@@ -514,6 +525,18 @@ export class SignatureController extends BaseControllerV2<
         );
       },
     );
+  }
+
+  #setMessageMetadata<
+    M extends AbstractMessage,
+    P extends AbstractMessageParams,
+    PM extends AbstractMessageParamsMetamask,
+  >(
+    messageManager: AbstractMessageManager<M, P, PM>,
+    messageId: string,
+    metadata: Json,
+  ) {
+    messageManager.setMetadata(messageId, metadata);
   }
 
   #rejectUnapproved<

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -252,9 +252,9 @@ export class SignatureController extends BaseControllerV2<
   }
 
   /**
-   * A getter for returning all messages from TypedMessages & PersonalMessages
+   * Retrieves an array of all messages from TypedMessages and PersonalMessages.
    *
-   * @returns The array of all messages from their proxies
+   * @returns The array of all messages from their proxies.
    */
   get allMessages(): unknown[] {
     return [

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -255,9 +255,9 @@ export class SignatureController extends BaseControllerV2<
   }
 
   /**
-   * A getter for returning an array of all messages.
+   * A getter for returning all messages.
    *
-   * @returns The array of all messages.
+   * @returns The object containing all messages.
    */
   get messages(): { [id: string]: Message | PersonalMessage | TypedMessage } {
     const messages = [
@@ -396,9 +396,7 @@ export class SignatureController extends BaseControllerV2<
     ];
 
     for (const manager of messageManagers) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      if (this.#trySetMessageMetadata(manager, messageId, metadata)) {
+      if (this.#trySetMessageMetadata(manager as any, messageId, metadata)) {
         return;
       }
     }

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -396,7 +396,7 @@ export class SignatureController extends BaseControllerV2<
     ];
 
     for (const manager of messageManagers) {
-      if (this.#trySetMessageMetadata(manager as any, messageId, metadata)) {
+      if (this.#trySetMessageMetadata(manager, messageId, metadata)) {
         return;
       }
     }

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -264,12 +264,12 @@ export class SignatureController extends BaseControllerV2<
       ...this.#personalMessageManager.getAllMessages(),
       ...this.#messageManager.getAllMessages(),
     ];
-  
+
     for (const message of allMessages) {
       const id = message.id;
-      messagesObject.id = message;
+      messagesObject[id] = message;
     }
-  
+
     return messagesObject;
   }
 

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -20,6 +20,7 @@ import {
 } from '@metamask/message-manager';
 import { ethErrors } from 'eth-rpc-errors';
 import { bufferToHex } from 'ethereumjs-util';
+import { Json } from '@metamask/utils';
 
 import {
   BaseControllerV2,
@@ -251,6 +252,19 @@ export class SignatureController extends BaseControllerV2<
   }
 
   /**
+   * A getter for returning all messages from TypedMessages & PersonalMessages
+   *
+   * @returns The array of all messages from their proxies
+   */
+  get allMessages(): unknown[] {
+    return [
+      ...this.#typedMessageManager.getAllMessages(),
+      ...this.#personalMessageManager.getAllMessages(),
+      ...this.#messageManager.getAllMessages()
+    ]
+  }
+
+  /**
    * Reset the controller state to the initial state.
    */
   resetState() {
@@ -354,6 +368,10 @@ export class SignatureController extends BaseControllerV2<
       version,
       signingOpts,
     );
+  }
+
+  setMessageMetadata(messageId: string, metadata: Json) {
+    this.#messageManager.setMetadata(messageId, metadata);
   }
 
   setTypedMessageInProgress(messageId: string) {


### PR DESCRIPTION
## Description

This PR adds a few necessary methods for MMI, we need to access the 3 message manager methods to get all the messages. Also need a method to act as a proxy to the `setMetadata` in message manager.

## Changes

- **ADDED**: A method to set message metadata using the message manager -> `setMetadata`
- **ADDED**: A getter called `allMessages` to get all messages using the 3 managers


## References


* Fixes https://github.com/MetaMask/core/issues/1341#issuecomment-1562893931

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
