### PR TITLE
Prevent bug where incorrect symbol used for token rates

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -122,7 +122,6 @@ describe('TokenRatesController', () => {
       chainId: toHex(1),
       ticker: NetworksTicker.mainnet,
       onTokensStateChange: sinon.stub(),
-      onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
     });
     expect(controller.state).toStrictEqual({
@@ -135,7 +134,6 @@ describe('TokenRatesController', () => {
       chainId: toHex(1),
       ticker: NetworksTicker.mainnet,
       onTokensStateChange: sinon.stub(),
-      onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
     });
     expect(controller.config).toStrictEqual({
@@ -153,7 +151,6 @@ describe('TokenRatesController', () => {
       chainId: toHex(1),
       ticker: NetworksTicker.mainnet,
       onTokensStateChange: sinon.stub(),
-      onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
     });
     expect(() => console.log(controller.tokens)).toThrow(
@@ -170,7 +167,6 @@ describe('TokenRatesController', () => {
         chainId: toHex(1),
         ticker: NetworksTicker.mainnet,
         onTokensStateChange: jest.fn(),
-        onCurrencyRateStateChange: jest.fn(),
         onNetworkStateChange: jest.fn(),
       },
       {
@@ -194,7 +190,6 @@ describe('TokenRatesController', () => {
         chainId: toHex(1),
         ticker: NetworksTicker.mainnet,
         onTokensStateChange: sinon.stub(),
-        onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
       },
       {
@@ -214,7 +209,6 @@ describe('TokenRatesController', () => {
         chainId: toHex(1),
         ticker: NetworksTicker.mainnet,
         onTokensStateChange: sinon.stub(),
-        onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
       },
       { interval: 1337 },
@@ -249,7 +243,6 @@ describe('TokenRatesController', () => {
         chainId: toHex(1),
         ticker: NetworksTicker.mainnet,
         onTokensStateChange: (listener) => tokensController.subscribe(listener),
-        onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: (listener) =>
           messenger.subscribe('NetworkController:stateChange', listener),
       },
@@ -278,7 +271,6 @@ describe('TokenRatesController', () => {
         chainId: toHex(1),
         ticker: NetworksTicker.mainnet,
         onTokensStateChange: sinon.stub(),
-        onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
       },
       { interval: 10 },
@@ -301,14 +293,12 @@ describe('TokenRatesController', () => {
     const onTokensStateChange = sinon.stub().callsFake((listener) => {
       tokenStateChangeListener = listener;
     });
-    const onCurrencyRateStateChange = sinon.stub();
     const onNetworkStateChange = sinon.stub();
     const controller = new TokenRatesController(
       {
         chainId: toHex(1),
         ticker: NetworksTicker.mainnet,
         onTokensStateChange,
-        onCurrencyRateStateChange,
         onNetworkStateChange,
       },
       { interval: 10 },
@@ -324,19 +314,17 @@ describe('TokenRatesController', () => {
     expect(updateExchangeRatesStub.callCount).toStrictEqual(2);
   });
 
-  it('should update exchange rates when native currency changes', async () => {
-    let currencyRateStateChangeListener: (state: any) => void;
+  it('should update exchange rates when ticker changes', async () => {
+    let networkStateChangeListener: (state: any) => void;
     const onTokensStateChange = sinon.stub();
-    const onCurrencyRateStateChange = sinon.stub().callsFake((listener) => {
-      currencyRateStateChangeListener = listener;
+    const onNetworkStateChange = sinon.stub().callsFake((listener) => {
+      networkStateChangeListener = listener;
     });
-    const onNetworkStateChange = sinon.stub();
     const controller = new TokenRatesController(
       {
         chainId: toHex(1),
         ticker: NetworksTicker.mainnet,
         onTokensStateChange,
-        onCurrencyRateStateChange,
         onNetworkStateChange,
       },
       { interval: 10 },
@@ -347,7 +335,9 @@ describe('TokenRatesController', () => {
       'updateExchangeRates',
     );
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    currencyRateStateChangeListener!({ nativeCurrency: 'dai' });
+    networkStateChangeListener!({
+      providerConfig: { chainId: toHex(1), ticker: 'dai' },
+    });
     // FIXME: This is now being called twice
     expect(updateExchangeRatesStub.callCount).toStrictEqual(2);
   });
@@ -387,7 +377,6 @@ describe('TokenRatesController', () => {
         chainId: toHex(137),
         ticker: 'MATIC',
         onTokensStateChange,
-        onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange,
       },
       { interval: 10 },
@@ -451,7 +440,6 @@ describe('TokenRatesController', () => {
         ticker: NetworksTicker.mainnet,
         onTokensStateChange,
         onNetworkStateChange,
-        onCurrencyRateStateChange: sinon.stub(),
       },
       { interval: 10 },
     );
@@ -525,7 +513,6 @@ describe('TokenRatesController', () => {
         ticker: NetworksTicker.mainnet,
         onTokensStateChange,
         onNetworkStateChange: sinon.stub(),
-        onCurrencyRateStateChange: sinon.stub(),
       },
       { interval: 10 },
     );

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -14,7 +14,6 @@ import {
 import type { NetworkState } from '@metamask/network-controller';
 import { fetchExchangeRate as fetchNativeExchangeRate } from './crypto-compare';
 import type { TokensState } from './TokensController';
-import type { CurrencyRateState } from './CurrencyRateController';
 
 /**
  * @type CoinGeckoResponse
@@ -170,7 +169,6 @@ export class TokenRatesController extends BaseController<
    * @param options.chainId - The chain ID of the current network.
    * @param options.ticker - The ticker for the current network.
    * @param options.onTokensStateChange - Allows subscribing to token controller state changes.
-   * @param options.onCurrencyRateStateChange - Allows subscribing to currency rate controller state changes.
    * @param options.onNetworkStateChange - Allows subscribing to network state changes.
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
@@ -180,16 +178,12 @@ export class TokenRatesController extends BaseController<
       chainId: initialChainId,
       ticker: initialTicker,
       onTokensStateChange,
-      onCurrencyRateStateChange,
       onNetworkStateChange,
     }: {
       chainId: Hex;
       ticker: string;
       onTokensStateChange: (
         listener: (tokensState: TokensState) => void,
-      ) => void;
-      onCurrencyRateStateChange: (
-        listener: (currencyRateState: CurrencyRateState) => void,
       ) => void;
       onNetworkStateChange: (
         listener: (networkState: NetworkState) => void,
@@ -220,14 +214,10 @@ export class TokenRatesController extends BaseController<
       this.configure({ tokens: [...tokens, ...detectedTokens] });
     });
 
-    onCurrencyRateStateChange((currencyRateState) => {
-      this.configure({ nativeCurrency: currencyRateState.nativeCurrency });
-    });
-
     onNetworkStateChange(({ providerConfig }) => {
-      const { chainId } = providerConfig;
+      const { chainId, ticker } = providerConfig;
       this.update({ contractExchangeRates: {} });
-      this.configure({ chainId });
+      this.configure({ chainId, nativeCurrency: ticker });
     });
     this.poll();
   }


### PR DESCRIPTION
## Explanation

There is a bug present in the TokenRatesController where a network switch can result in token rates being requested for the wrong network.

This can happen when the network state update event comes before currency rate controller state update event. The controller only works correctly if the currency rate controller state update event happens first.

Instead of getting the ticker from the currency rate controller, we now get it directly from the network controller. This simplifies the controller and ensures that we always use the currency symbol corresponding with the current chain ID.

## References

This is tangentially related to https://github.com/MetaMask/core/issues/1466

## Changelog

### `@metamask/assets-controllers`

- **BREAKING**: Remove `onCurrencyRateStateChange` constructor parameter from TokenRatesController
- Fixed: Fix bug where token rates would be invalid if event handlers were triggered in the wrong order

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
  - The condition that would fail is no longer possible, so there is no way to add a test case for it. The tests for this controller are very difficult to work with at the moment anyway, which is partly what motivated this change
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
