### PR TITLE
Fix initial native currency `TokenRatesController` configuration

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -6,7 +6,7 @@ import {
   NetworkControllerMessenger,
 } from '@metamask/network-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
-import { toHex } from '@metamask/controller-utils';
+import { NetworksTicker, toHex } from '@metamask/controller-utils';
 import { TokenRatesController } from './TokenRatesController';
 import {
   TokensController,
@@ -120,6 +120,7 @@ describe('TokenRatesController', () => {
   it('should set default state', () => {
     const controller = new TokenRatesController({
       chainId: toHex(1),
+      ticker: NetworksTicker.mainnet,
       onTokensStateChange: sinon.stub(),
       onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
@@ -132,6 +133,7 @@ describe('TokenRatesController', () => {
   it('should initialize with the default config', () => {
     const controller = new TokenRatesController({
       chainId: toHex(1),
+      ticker: NetworksTicker.mainnet,
       onTokensStateChange: sinon.stub(),
       onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
@@ -139,7 +141,7 @@ describe('TokenRatesController', () => {
     expect(controller.config).toStrictEqual({
       disabled: false,
       interval: 180000,
-      nativeCurrency: 'eth',
+      nativeCurrency: NetworksTicker.mainnet,
       chainId: toHex(1),
       tokens: [],
       threshold: 21600000,
@@ -149,6 +151,7 @@ describe('TokenRatesController', () => {
   it('should throw when tokens property is accessed', () => {
     const controller = new TokenRatesController({
       chainId: toHex(1),
+      ticker: NetworksTicker.mainnet,
       onTokensStateChange: sinon.stub(),
       onCurrencyRateStateChange: sinon.stub(),
       onNetworkStateChange: sinon.stub(),
@@ -165,6 +168,7 @@ describe('TokenRatesController', () => {
     new TokenRatesController(
       {
         chainId: toHex(1),
+        ticker: NetworksTicker.mainnet,
         onTokensStateChange: jest.fn(),
         onCurrencyRateStateChange: jest.fn(),
         onNetworkStateChange: jest.fn(),
@@ -188,6 +192,7 @@ describe('TokenRatesController', () => {
     const controller = new TokenRatesController(
       {
         chainId: toHex(1),
+        ticker: NetworksTicker.mainnet,
         onTokensStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
@@ -207,6 +212,7 @@ describe('TokenRatesController', () => {
     const controller = new TokenRatesController(
       {
         chainId: toHex(1),
+        ticker: NetworksTicker.mainnet,
         onTokensStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
@@ -241,6 +247,7 @@ describe('TokenRatesController', () => {
     const controller = new TokenRatesController(
       {
         chainId: toHex(1),
+        ticker: NetworksTicker.mainnet,
         onTokensStateChange: (listener) => tokensController.subscribe(listener),
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: (listener) =>
@@ -269,6 +276,7 @@ describe('TokenRatesController', () => {
     const controller = new TokenRatesController(
       {
         chainId: toHex(1),
+        ticker: NetworksTicker.mainnet,
         onTokensStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: sinon.stub(),
@@ -298,6 +306,7 @@ describe('TokenRatesController', () => {
     const controller = new TokenRatesController(
       {
         chainId: toHex(1),
+        ticker: NetworksTicker.mainnet,
         onTokensStateChange,
         onCurrencyRateStateChange,
         onNetworkStateChange,
@@ -325,6 +334,7 @@ describe('TokenRatesController', () => {
     const controller = new TokenRatesController(
       {
         chainId: toHex(1),
+        ticker: NetworksTicker.mainnet,
         onTokensStateChange,
         onCurrencyRateStateChange,
         onNetworkStateChange,
@@ -375,13 +385,13 @@ describe('TokenRatesController', () => {
     const controller = new TokenRatesController(
       {
         chainId: toHex(137),
+        ticker: 'MATIC',
         onTokensStateChange,
         onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange,
       },
       { interval: 10 },
     );
-    await controller.configure({ nativeCurrency: 'MATIC' });
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await tokenStateChangeListener!({
@@ -438,6 +448,7 @@ describe('TokenRatesController', () => {
     const controller = new TokenRatesController(
       {
         chainId: toHex(1),
+        ticker: NetworksTicker.mainnet,
         onTokensStateChange,
         onNetworkStateChange,
         onCurrencyRateStateChange: sinon.stub(),
@@ -511,11 +522,12 @@ describe('TokenRatesController', () => {
     const controller = new TokenRatesController(
       {
         chainId: toHex(1),
+        ticker: NetworksTicker.mainnet,
         onTokensStateChange,
         onNetworkStateChange: sinon.stub(),
         onCurrencyRateStateChange: sinon.stub(),
       },
-      { interval: 10, nativeCurrency: 'ETH' },
+      { interval: 10 },
     );
 
     expect(controller.state.contractExchangeRates).toStrictEqual({});

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -168,6 +168,7 @@ export class TokenRatesController extends BaseController<
    *
    * @param options - The controller options.
    * @param options.chainId - The chain ID of the current network.
+   * @param options.ticker - The ticker for the current network.
    * @param options.onTokensStateChange - Allows subscribing to token controller state changes.
    * @param options.onCurrencyRateStateChange - Allows subscribing to currency rate controller state changes.
    * @param options.onNetworkStateChange - Allows subscribing to network state changes.
@@ -177,11 +178,13 @@ export class TokenRatesController extends BaseController<
   constructor(
     {
       chainId: initialChainId,
+      ticker: initialTicker,
       onTokensStateChange,
       onCurrencyRateStateChange,
       onNetworkStateChange,
     }: {
       chainId: Hex;
+      ticker: string;
       onTokensStateChange: (
         listener: (tokensState: TokensState) => void,
       ) => void;
@@ -199,7 +202,7 @@ export class TokenRatesController extends BaseController<
     this.defaultConfig = {
       disabled: false,
       interval: 3 * 60 * 1000,
-      nativeCurrency: 'eth',
+      nativeCurrency: initialTicker,
       chainId: initialChainId,
       tokens: [],
       threshold: 6 * 60 * 60 * 1000,


### PR DESCRIPTION
## Explanation

The `TokenRatesController` was always initialized with `eth` as the default `nativeCurrency` configuration. This could result in the wrong rates being retrieved if the current network has a different currency symbol.

The constructor has been updated to require a `ticker` parameter, used to initialize the `nativeCurrency` configuation for the current network at time of construction.

## References

This is tangentially related to https://github.com/MetaMask/core/issues/1466

## Changelog

### `@metamask/assets-controllers`

- **BREAKING**: New required `ticker` constructor parameter for the `TokenRatesController`
- Fixed: Fix bug where token rates were incorrect if initialized with a non-Ethereum selected network.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
  - The condition that would fail is no longer possible, so there is no way to add a test case for it. The tests for this controller are very difficult to work with at the moment anyway, which is partly what motivated this change.
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
