### PR TITLE
controller-utils/deps: move eth-query to devDeps; remove babel-runtime

### DIFF
--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -31,9 +31,7 @@
   "dependencies": {
     "@metamask/utils": "^5.0.2",
     "@spruceid/siwe-parser": "1.1.3",
-    "babel-runtime": "^6.26.0",
     "eth-ens-namehash": "^2.0.8",
-    "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.2",
     "ethereumjs-util": "^7.0.10",
     "ethjs-unit": "^0.1.6",
@@ -44,6 +42,7 @@
     "@types/jest": "^27.4.1",
     "abort-controller": "^3.0.0",
     "deepmerge": "^4.2.2",
+    "eth-query": "^2.1.2",
     "jest": "^27.5.1",
     "nock": "^13.0.7",
     "ts-jest": "^27.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1422,7 +1422,6 @@ __metadata:
     "@spruceid/siwe-parser": 1.1.3
     "@types/jest": ^27.4.1
     abort-controller: ^3.0.0
-    babel-runtime: ^6.26.0
     deepmerge: ^4.2.2
     eth-ens-namehash: ^2.0.8
     eth-query: ^2.1.2


### PR DESCRIPTION
## Explanation

While some controllers import `eth-query` in order to be able to create new `EthQuery` instances, `@metamask/controller-utils` only use the package for types.

This moves the package to `devDependency` and removes `babel-runtime`, which was imported as an implicit peerDependency of `eth-query`.

## References

## Changelog


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
