### PR TITLE
Remove unnecessary `babel-runtime` dependencies

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -314,7 +314,12 @@ gen_enforced_field(WorkspaceCwd, 'publishConfig.registry', 'https://registry.npm
 gen_enforced_field(WorkspaceCwd, 'publishConfig', null) :-
   workspace_field(WorkspaceCwd, 'private', true).
 
-% eth-query has an unlisted dependency on babel-runtime, so that package needs
-% to be present if eth-query is present.
+% nonce-tracker has an unlisted dependency on babel-runtime (via `ethjs-query`), so that package
+% needs to be present if nonce-tracker is present.
 gen_enforced_dependency(WorkspaceCwd, 'babel-runtime', '^6.26.0', DependencyType) :-
-  workspace_has_dependency(WorkspaceCwd, 'eth-query', _, DependencyType).
+  workspace_has_dependency(WorkspaceCwd, 'nonce-tracker', _, DependencyType).
+
+% eth-method-registry has an unlisted dependency on babel-runtime (via `ethjs->ethjs-query`), so
+% that package needs to be present if eth-method-registry is present.
+gen_enforced_dependency(WorkspaceCwd, 'babel-runtime', '^6.26.0', DependencyType) :-
+  workspace_has_dependency(WorkspaceCwd, 'eth-method-registry', _, DependencyType).

--- a/constraints.pro
+++ b/constraints.pro
@@ -316,10 +316,14 @@ gen_enforced_field(WorkspaceCwd, 'publishConfig', null) :-
 
 % nonce-tracker has an unlisted dependency on babel-runtime (via `ethjs-query`), so that package
 % needs to be present if nonce-tracker is present.
-gen_enforced_dependency(WorkspaceCwd, 'babel-runtime', '^6.26.0', DependencyType) :-
-  workspace_has_dependency(WorkspaceCwd, 'nonce-tracker', _, DependencyType).
+gen_enforced_dependency(WorkspaceCwd, 'babel-runtime', '^6.26.0', 'peerDependencies') :-
+  workspace_has_dependency(WorkspaceCwd, 'nonce-tracker', _, 'dependencies').
+gen_enforced_dependency(WorkspaceCwd, 'babel-runtime', '^6.26.0', 'devDependencies') :-
+  workspace_has_dependency(WorkspaceCwd, 'nonce-tracker', _, 'dependencies').
 
 % eth-method-registry has an unlisted dependency on babel-runtime (via `ethjs->ethjs-query`), so
 % that package needs to be present if eth-method-registry is present.
-gen_enforced_dependency(WorkspaceCwd, 'babel-runtime', '^6.26.0', DependencyType) :-
-  workspace_has_dependency(WorkspaceCwd, 'eth-method-registry', _, DependencyType).
+gen_enforced_dependency(WorkspaceCwd, 'babel-runtime', '^6.26.0', 'peerDependencies') :-
+  workspace_has_dependency(WorkspaceCwd, 'eth-method-registry', _, 'dependencies').
+gen_enforced_dependency(WorkspaceCwd, 'babel-runtime', '^6.26.0', 'devDependencies') :-
+  workspace_has_dependency(WorkspaceCwd, 'eth-method-registry', _, 'dependencies').

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -46,7 +46,6 @@
     "@types/uuid": "^8.3.0",
     "abort-controller": "^3.0.0",
     "async-mutex": "^0.2.6",
-    "babel-runtime": "^6.26.0",
     "eth-query": "^2.1.2",
     "ethereumjs-util": "^7.0.10",
     "immer": "^9.0.6",

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@metamask/utils": "^5.0.2",
     "@spruceid/siwe-parser": "1.1.3",
-    "babel-runtime": "^6.26.0",
     "eth-ens-namehash": "^2.0.8",
     "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.2",

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -34,7 +34,6 @@
     "@metamask/network-controller": "workspace:^",
     "@metamask/utils": "^5.0.2",
     "@types/uuid": "^8.3.0",
-    "babel-runtime": "^6.26.0",
     "eth-query": "^2.1.2",
     "ethereumjs-util": "^7.0.10",
     "ethjs-unit": "^0.1.6",

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -37,7 +37,6 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/utils": "^5.0.2",
     "async-mutex": "^0.2.6",
-    "babel-runtime": "^6.26.0",
     "eth-block-tracker": "^7.0.1",
     "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.2",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -37,7 +37,6 @@
     "@metamask/network-controller": "workspace:^",
     "@metamask/utils": "^5.0.2",
     "async-mutex": "^0.2.6",
-    "babel-runtime": "^6.26.0",
     "eth-method-registry": "1.1.0",
     "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.2",
@@ -49,6 +48,7 @@
     "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.18.24",
+    "babel-runtime": "^6.26.0",
     "deepmerge": "^4.2.2",
     "ethjs-provider-http": "^0.1.6",
     "jest": "^27.5.1",
@@ -60,7 +60,8 @@
   },
   "peerDependencies": {
     "@metamask/approval-controller": "workspace:^",
-    "@metamask/network-controller": "workspace:^"
+    "@metamask/network-controller": "workspace:^",
+    "babel-runtime": "^6.26.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2047,6 +2047,7 @@ __metadata:
   peerDependencies:
     "@metamask/approval-controller": "workspace:^"
     "@metamask/network-controller": "workspace:^"
+    babel-runtime: ^6.26.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,7 +1324,6 @@ __metadata:
     "@types/uuid": ^8.3.0
     abort-controller: ^3.0.0
     async-mutex: ^0.2.6
-    babel-runtime: ^6.26.0
     deepmerge: ^4.2.2
     eth-query: ^2.1.2
     ethereumjs-util: ^7.0.10
@@ -1422,7 +1421,6 @@ __metadata:
     "@spruceid/siwe-parser": 1.1.3
     "@types/jest": ^27.4.1
     abort-controller: ^3.0.0
-    babel-runtime: ^6.26.0
     deepmerge: ^4.2.2
     eth-ens-namehash: ^2.0.8
     eth-query: ^2.1.2
@@ -1699,7 +1697,6 @@ __metadata:
     "@types/jest": ^27.4.1
     "@types/jest-when": ^2.7.3
     "@types/uuid": ^8.3.0
-    babel-runtime: ^6.26.0
     deepmerge: ^4.2.2
     eth-query: ^2.1.2
     ethereumjs-util: ^7.0.10
@@ -1818,7 +1815,6 @@ __metadata:
     "@types/jest-when": ^2.7.3
     "@types/lodash": ^4.14.191
     async-mutex: ^0.2.6
-    babel-runtime: ^6.26.0
     deepmerge: ^4.2.2
     eth-block-tracker: ^7.0.1
     eth-query: ^2.1.2


### PR DESCRIPTION
## Explanation

We included `babel-runtime` as a dependency to a few packages because we thought it was an undocumented dependency of `eth-query`, but we had gotten it mixed up with `ethjs-query`. Really we only need this as a dependency in the transaction controller.

The constraints have been updated, and all unnecessary references to `babel-runtime` have been removed.

Additionally, in the one package where it's still required, `babel-runtime` has been made into a `peerDependency` instead of a direct dependency. This better reflects the requirement: we don't need to use it directly, we just need it to be available in the environment this package is run in.

## References

The missing `babel-runtime` dependency was discovered in https://github.com/MetaMask/core/pull/341

## Changelog

### `@metamask/assets-controllers`

- Changed: Remove `babel-runtime` dependency

### `@metamask/controller-utils`

- Changed: Remove `babel-runtime` dependency

### `@metamask/network-controller`

- Changed: Remove `babel-runtime` dependency

### `@metamask/transaction-controller`

- **BREAKING**: Change `babel-runtime` from a `dependency` to a `peerDependency`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
