### PR TITLE
Remove `TokenRateController` setters

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -447,22 +447,26 @@ describe('TokenRatesController', () => {
         onTokensStateChange,
         onNetworkStateChange,
       },
-      { interval: 10, nativeCurrency: 'ETH', tokens: [
-        {
-          address: '0x02',
-          decimals: 18,
-          image: undefined,
-          symbol: 'bar',
-          isERC721: false,
-        },
-        {
-          address: '0x03',
-          decimals: 18,
-          image: undefined,
-          symbol: 'bazz',
-          isERC721: false,
-        },
-      ] },
+      {
+        interval: 10,
+        nativeCurrency: 'ETH',
+        tokens: [
+          {
+            address: '0x02',
+            decimals: 18,
+            image: undefined,
+            symbol: 'bar',
+            isERC721: false,
+          },
+          {
+            address: '0x03',
+            decimals: 18,
+            image: undefined,
+            symbol: 'bazz',
+            isERC721: false,
+          },
+        ],
+      },
     );
 
     await controller.updateExchangeRates();

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -215,6 +215,8 @@ export class TokenRatesController extends BaseController<
       this.configure({ disabled: true }, false, false);
     }
 
+    this.tokenList = this.config.tokens;
+
     onTokensStateChange(async ({ tokens, detectedTokens }) => {
       this.configure({ tokens: [...tokens, ...detectedTokens] });
       this.tokenList = this.config.tokens;

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -215,14 +215,21 @@ export class TokenRatesController extends BaseController<
       this.configure({ disabled: true }, false, false);
     }
 
-    onTokensStateChange(({ tokens, detectedTokens }) => {
+    onTokensStateChange(async ({ tokens, detectedTokens }) => {
       this.configure({ tokens: [...tokens, ...detectedTokens] });
+      this.tokenList = this.config.tokens;
+      if (this.#pollState === PollState.Active) {
+        await this.updateExchangeRates();
+      }
     });
 
-    onNetworkStateChange(({ providerConfig }) => {
+    onNetworkStateChange(async ({ providerConfig }) => {
       const { chainId, ticker } = providerConfig;
       this.update({ contractExchangeRates: {} });
       this.configure({ chainId, nativeCurrency: ticker });
+      if (this.#pollState === PollState.Active) {
+        await this.updateExchangeRates();
+      }
     });
   }
 
@@ -263,41 +270,6 @@ export class TokenRatesController extends BaseController<
     this.handle = setTimeout(() => {
       this.#poll();
     }, this.config.interval);
-  }
-
-  /**
-   * Sets a new chainId.
-   *
-   * TODO: Replace this with a method.
-   *
-   * @param _chainId - The current chain ID.
-   */
-  set chainId(_chainId: Hex) {
-    if (this.#pollState === PollState.Active) {
-      this.updateExchangeRates();
-    }
-  }
-
-  get chainId() {
-    throw new Error('Property only used for setting');
-  }
-
-  /**
-   * Sets a new token list to track prices.
-   *
-   * TODO: Replace this with a method.
-   *
-   * @param tokens - List of tokens to track exchange rates for.
-   */
-  set tokens(tokens: Token[]) {
-    this.tokenList = tokens;
-    if (this.#pollState === PollState.Active) {
-      this.updateExchangeRates();
-    }
-  }
-
-  get tokens() {
-    throw new Error('Property only used for setting');
   }
 
   /**


### PR DESCRIPTION
## Explanation

The `TokenRateController` setters for `chainId` and `tokens` have been removed. These were confusing, unnecessary, and presented obstacles to testing asynchronous events triggered by these setters.

## References

This is tangentially related to https://github.com/MetaMask/core/issues/1466

## Changelog

### `@metamask/assets-controllers`

- **BREAKING**: Remove `TokenRatecontroller` setter for `chainId` and `tokens` properties

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
