### PR TITLE
Update root manifest: 'dependencies' -> 'devDependencies'

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "simple-git-hooks": {
     "pre-push": "yarn lint"
   },
-  "dependencies": {
+  "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",
     "@metamask/create-release-branch": "^1.0.1",
     "@metamask/eslint-config": "^12.0.0",


### PR DESCRIPTION


## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

None of the dependencies specified at the root are required to install any of the packages within the monorepo; they purely exist for development purposes. So moving them to `devDependencies` communicates their intended usage better.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

(N/A)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
