### PR TITLE
Fix another `TokenRatesController` event ordering bug

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -8,6 +8,7 @@ import {
   toHex,
 } from '@metamask/controller-utils';
 import type { NetworkState } from '@metamask/network-controller';
+import type { PreferencesState } from '@metamask/preferences-controller';
 import type { Hex } from '@metamask/utils';
 
 import { fetchExchangeRate as fetchNativeExchangeRate } from './crypto-compare';
@@ -69,7 +70,9 @@ export interface TokenRatesConfig extends BaseConfig {
   interval: number;
   nativeCurrency: string;
   chainId: Hex;
-  tokens: Token[];
+  selectedAddress: string;
+  allTokens: { [chainId: Hex]: { [key: string]: Token[] } };
+  allDetectedTokens: { [chainId: Hex]: { [key: string]: Token[] } };
   threshold: number;
 }
 
@@ -173,6 +176,8 @@ export class TokenRatesController extends BaseController<
    * @param options - The controller options.
    * @param options.chainId - The chain ID of the current network.
    * @param options.ticker - The ticker for the current network.
+   * @param options.selectedAddress - The current selected address.
+   * @param options.onPreferencesStateChange - Allows subscribing to preference controller state changes.
    * @param options.onTokensStateChange - Allows subscribing to token controller state changes.
    * @param options.onNetworkStateChange - Allows subscribing to network state changes.
    * @param config - Initial options used to configure this controller.
@@ -182,11 +187,17 @@ export class TokenRatesController extends BaseController<
     {
       chainId: initialChainId,
       ticker: initialTicker,
+      selectedAddress: initialSelectedAddress,
+      onPreferencesStateChange,
       onTokensStateChange,
       onNetworkStateChange,
     }: {
       chainId: Hex;
       ticker: string;
+      selectedAddress: string;
+      onPreferencesStateChange: (
+        listener: (preferencesState: PreferencesState) => void,
+      ) => void;
       onTokensStateChange: (
         listener: (tokensState: TokensState) => void,
       ) => void;
@@ -203,7 +214,9 @@ export class TokenRatesController extends BaseController<
       interval: 3 * 60 * 1000,
       nativeCurrency: initialTicker,
       chainId: initialChainId,
-      tokens: [],
+      selectedAddress: initialSelectedAddress,
+      allTokens: {}, // TODO: initialize these correctly, maybe as part of BaseControllerV2 migration
+      allDetectedTokens: {},
       threshold: 6 * 60 * 60 * 1000,
     };
 
@@ -214,12 +227,17 @@ export class TokenRatesController extends BaseController<
     if (config?.disabled) {
       this.configure({ disabled: true }, false, false);
     }
+    this.#updateTokenList();
 
-    this.tokenList = this.config.tokens;
+    onPreferencesStateChange(async ({ selectedAddress }) => {
+      this.configure({ selectedAddress });
+      this.#updateTokenList();
+      await this.updateExchangeRates();
+    });
 
-    onTokensStateChange(async ({ tokens, detectedTokens }) => {
-      this.configure({ tokens: [...tokens, ...detectedTokens] });
-      this.tokenList = this.config.tokens;
+    onTokensStateChange(async ({ allTokens, allDetectedTokens }) => {
+      this.configure({ allTokens, allDetectedTokens });
+      this.#updateTokenList();
       if (this.#pollState === PollState.Active) {
         await this.updateExchangeRates();
       }
@@ -229,10 +247,21 @@ export class TokenRatesController extends BaseController<
       const { chainId, ticker } = providerConfig;
       this.update({ contractExchangeRates: {} });
       this.configure({ chainId, nativeCurrency: ticker });
+      this.#updateTokenList();
       if (this.#pollState === PollState.Active) {
         await this.updateExchangeRates();
       }
     });
+  }
+
+  #updateTokenList() {
+    const { allTokens, allDetectedTokens } = this.config;
+    const tokens =
+      allTokens[this.config.chainId]?.[this.config.selectedAddress] || [];
+    const detectedTokens =
+      allDetectedTokens[this.config.chainId]?.[this.config.selectedAddress] ||
+      [];
+    this.tokenList = [...tokens, ...detectedTokens];
   }
 
   /**

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -232,7 +232,9 @@ export class TokenRatesController extends BaseController<
     onPreferencesStateChange(async ({ selectedAddress }) => {
       this.configure({ selectedAddress });
       this.#updateTokenList();
-      await this.updateExchangeRates();
+      if (this.#pollState === PollState.Active) {
+        await this.updateExchangeRates();
+      }
     });
 
     onTokensStateChange(async ({ allTokens, allDetectedTokens }) => {


### PR DESCRIPTION
## Explanation

When the network switches, the `TokenRatesController` was relying upon the combination of two state updates (from the network controller and the tokens controller), both of which were needed in order to ensure the controller configuration was valid. These events don't arrive at the same time, meaning that the controller was potentially making one invalid call each network switch.

Additionally, there is a risk that the second event could result in no update (e.g. because the destination network isn't supported, or because there were no tokens), resulting in the data from the invalid call remaining in state.

This has been prevented by updating the controller to use the `allTokens` and `allDetectedTokens` state rather than the `tokens` state. A network switch now triggers a single event, and the controller configuration never enters an invalid state.

## References

This tangentially relates to https://github.com/MetaMask/core/issues/1466

## Changelog

### `@metamask/assets-controllers`

- **BREAKING**: The `TokenRatesController` now requires two new constructor parameters: `selectedAddress` and `onPreferencesStateChange`
- Fixed: Prevent invalid `TokenRatesController` configuration/state upon network switching

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
