### PR TITLE
Prevent redundant token rate updates

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -230,28 +230,41 @@ export class TokenRatesController extends BaseController<
     this.#updateTokenList();
 
     onPreferencesStateChange(async ({ selectedAddress }) => {
-      this.configure({ selectedAddress });
-      this.#updateTokenList();
-      if (this.#pollState === PollState.Active) {
-        await this.updateExchangeRates();
+      if (this.config.selectedAddress !== selectedAddress) {
+        this.configure({ selectedAddress });
+        this.#updateTokenList();
+        if (this.#pollState === PollState.Active) {
+          await this.updateExchangeRates();
+        }
       }
     });
 
     onTokensStateChange(async ({ allTokens, allDetectedTokens }) => {
-      this.configure({ allTokens, allDetectedTokens });
-      this.#updateTokenList();
-      if (this.#pollState === PollState.Active) {
-        await this.updateExchangeRates();
+      // These two state properties are assumed to be immutable
+      if (
+        this.config.allTokens !== allTokens ||
+        this.config.allDetectedTokens !== allDetectedTokens
+      ) {
+        this.configure({ allTokens, allDetectedTokens });
+        this.#updateTokenList();
+        if (this.#pollState === PollState.Active) {
+          await this.updateExchangeRates();
+        }
       }
     });
 
     onNetworkStateChange(async ({ providerConfig }) => {
       const { chainId, ticker } = providerConfig;
-      this.update({ contractExchangeRates: {} });
-      this.configure({ chainId, nativeCurrency: ticker });
-      this.#updateTokenList();
-      if (this.#pollState === PollState.Active) {
-        await this.updateExchangeRates();
+      if (
+        this.config.chainId !== chainId ||
+        this.config.nativeCurrency !== ticker
+      ) {
+        this.update({ contractExchangeRates: {} });
+        this.configure({ chainId, nativeCurrency: ticker });
+        this.#updateTokenList();
+        if (this.#pollState === PollState.Active) {
+          await this.updateExchangeRates();
+        }
       }
     });
   }


### PR DESCRIPTION
## Explanation

The `TokenRatesController` was updating token rates each time any state change event was recieved, even when the change was totally unrelated.

The controller now ignores irrelevant state changes. Only relevant state changes will trigger token rate updates.

## References

Fixes #1466

## Changelog

### `@metamask/assets-controllers`

- Fixed: Prevent the `TokenRateController` from making redundant token rate updates

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
