### PR TITLE
Improve error handling when state metadata is missing

### DIFF
--- a/packages/base-controller/src/BaseControllerV2.test.ts
+++ b/packages/base-controller/src/BaseControllerV2.test.ts
@@ -556,6 +556,34 @@ describe('getAnonymizedState', () => {
 
     expect(anonymizedState).toStrictEqual({ count: 1 });
   });
+
+  it('should suppress errors thrown when deriving state', () => {
+    const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
+    const persistentState = getAnonymizedState(
+      {
+        extraState: 'extraState',
+        privateKey: '123',
+        network: 'mainnet',
+      },
+      // @ts-expect-error Intentionally testing invalid state
+      {
+        privateKey: {
+          anonymous: true,
+          persist: true,
+        },
+        network: {
+          anonymous: false,
+          persist: false,
+        },
+      },
+    );
+    expect(persistentState).toStrictEqual({
+      privateKey: '123',
+    });
+    expect(setTimeoutStub.callCount).toBe(1);
+    const onTimeout = setTimeoutStub.firstCall.args[0];
+    expect(() => onTimeout()).toThrow(`No metadata found for 'extraState'`);
+  });
 });
 
 describe('getPersistentState', () => {
@@ -701,6 +729,34 @@ describe('getPersistentState', () => {
     );
 
     expect(persistentState).toStrictEqual({ count: 1 });
+  });
+
+  it('should suppress errors thrown when deriving state', () => {
+    const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
+    const persistentState = getPersistentState(
+      {
+        extraState: 'extraState',
+        privateKey: '123',
+        network: 'mainnet',
+      },
+      // @ts-expect-error Intentionally testing invalid state
+      {
+        privateKey: {
+          anonymous: false,
+          persist: true,
+        },
+        network: {
+          anonymous: false,
+          persist: false,
+        },
+      },
+    );
+    expect(persistentState).toStrictEqual({
+      privateKey: '123',
+    });
+    expect(setTimeoutStub.callCount).toBe(1);
+    const onTimeout = setTimeoutStub.firstCall.args[0];
+    expect(() => onTimeout()).toThrow(`No metadata found for 'extraState'`);
   });
 
   describe('inter-controller communication', () => {

--- a/packages/base-controller/src/BaseControllerV2.test.ts
+++ b/packages/base-controller/src/BaseControllerV2.test.ts
@@ -413,6 +413,10 @@ describe('BaseController', () => {
 });
 
 describe('getAnonymizedState', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should return empty state', () => {
     expect(getAnonymizedState({}, {})).toStrictEqual({});
   });
@@ -587,6 +591,10 @@ describe('getAnonymizedState', () => {
 });
 
 describe('getPersistentState', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should return empty state', () => {
     expect(getPersistentState({}, {})).toStrictEqual({});
   });


### PR DESCRIPTION
## Explanation

The state derivation functions will throw an error today if any state properties are missing metadata. This interrupts the state operation completely. There are a few state operations that we want to ensure are never interrupted, even if some data is invalid, so this behavior has been changed.

Instead we will skip any state properties with missing metadata, and throw an error in a timeout handler so that the problem is still captured.

## References

None

## Changelog

### `@metamask/base-controller`

- Changed: When deriving state, skip properties with invalid metadata
  - The previous behavior was to throw an error
  - An error is thrown in a timeout handler so that it can still be captured in the console, and by global unhandled error handlers.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
