### PR TITLE
Network meta

### DIFF
--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -520,7 +520,7 @@ function buildNetworkControllerStateWithProviderConfig(
     selectedNetworkClientId,
     providerConfig,
     networkId: '1',
-    networkMeta: {
+    networksMetadata: {
       [selectedNetworkClientId]: {
         details: { EIPS: {} },
         status: NetworkStatus.Available,

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -515,13 +515,16 @@ const getRestrictedMessenger = (
 function buildNetworkControllerStateWithProviderConfig(
   providerConfig: ProviderConfig,
 ): NetworkState {
+  const selectedNetworkClientId = providerConfig.type || 'uuid-1';
   return {
-    selectedNetworkClientId: providerConfig.type || 'uuid-1',
+    selectedNetworkClientId,
     providerConfig,
     networkId: '1',
-    networkStatus: NetworkStatus.Available,
-    networkDetails: {
-      EIPS: {},
+    networkMeta: {
+      [selectedNetworkClientId]: {
+        details: { EIPS: {} },
+        status: NetworkStatus.Available,
+      }
     },
     networkConfigurations: {},
   };

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -522,7 +522,7 @@ function buildNetworkControllerStateWithProviderConfig(
     networkId: '1',
     networksMetadata: {
       [selectedNetworkClientId]: {
-        details: { EIPS: {} },
+        EIPS: {},
         status: NetworkStatus.Available,
       },
     },

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -524,7 +524,7 @@ function buildNetworkControllerStateWithProviderConfig(
       [selectedNetworkClientId]: {
         details: { EIPS: {} },
         status: NetworkStatus.Available,
-      }
+      },
     },
     networkConfigurations: {},
   };

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -68,10 +68,9 @@ export type Block = {
 };
 
 /**
- * Information about the network not held by any other part of state. Currently
- * only used to capture whether a network supports EIP-1559.
+ * Information about a network not held by any other part of state.
  */
-export type NetworkDetails = {
+export type NetworkMetadata = {
   /**
    * EIPs supported by the network.
    */
@@ -337,11 +336,12 @@ type CustomNetworkClientId = string;
  */
 type NetworkClientId = BuiltInNetworkClientId | CustomNetworkClientId;
 
+
 /**
  * Information about networks not held by any other part of state.
  */
 export type NetworksMetadata = {
-  [networkClientId: NetworkClientId]: NetworkDetails;
+  [networkClientId: NetworkClientId]: NetworkMetadata;
 };
 
 /**

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -336,7 +336,6 @@ type CustomNetworkClientId = string;
  */
 type NetworkClientId = BuiltInNetworkClientId | CustomNetworkClientId;
 
-
 /**
  * Information about networks not held by any other part of state.
  */

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -338,7 +338,7 @@ type CustomNetworkClientId = string;
 type NetworkClientId = BuiltInNetworkClientId | CustomNetworkClientId;
 
 /**
- * Data related to a particular network.
+ * Information about networks not held by any other part of state.
  */
 export type NetworksMetadata = {
   [networkClientId: NetworkClientId]: NetworkDetails;

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -336,7 +336,7 @@ type NetworkClientId = BuiltInNetworkClientId | CustomNetworkClientId;
 /**
  * Data related to a particular network.
  */
-export type NetworkMeta = {
+export type NetworksMetadata = {
   [networkClientId: NetworkClientId]: {
     details: NetworkDetails,
     status: NetworkStatus,
@@ -363,7 +363,7 @@ export type NetworkState = {
   networkId: NetworkId | null;
   providerConfig: ProviderConfig;
   networkConfigurations: NetworkConfigurations;
-  networkMeta: NetworkMeta;
+  networksMetadata: NetworksMetadata;
 };
 
 const name = 'NetworkController';
@@ -482,7 +482,7 @@ export const defaultState: NetworkState = {
     chainId: ChainId.mainnet,
     ticker: NetworksTicker.mainnet,
   },
-  networkMeta: {},
+  networksMetadata: {},
   networkConfigurations: {},
 };
 
@@ -567,7 +567,7 @@ export class NetworkController extends BaseControllerV2<
           persist: true,
           anonymous: false,
         },
-        networkMeta: {
+        networksMetadata: {
           persist: true,
           anonymous: false
         },
@@ -788,7 +788,7 @@ export class NetworkController extends BaseControllerV2<
 
     this.update((state) => {
       state.networkId = updatedNetworkId;
-      const meta = state.networkMeta[state.selectedNetworkClientId];
+      const meta = state.networksMetadata[state.selectedNetworkClientId];
       meta.status = updatedNetworkStatus;
       if (updatedIsEIP1559Compatible === undefined) {
         delete meta.details.EIPS[1559];
@@ -920,7 +920,7 @@ export class NetworkController extends BaseControllerV2<
       return false;
     }
 
-    const { EIPS } = this.state.networkMeta[this.state.selectedNetworkClientId].details;
+    const { EIPS } = this.state.networksMetadata[this.state.selectedNetworkClientId].details;
 
     if (EIPS[1559] !== undefined) {
       return EIPS[1559];
@@ -929,7 +929,7 @@ export class NetworkController extends BaseControllerV2<
     const isEIP1559Compatible = await this.#determineEIP1559Compatibility();
     this.update((state) => {
       if (isEIP1559Compatible !== undefined) {
-        state.networkMeta[
+        state.networksMetadata[
           state.selectedNetworkClientId
         ].details.EIPS[1559] = isEIP1559Compatible;
       }
@@ -1388,8 +1388,8 @@ export class NetworkController extends BaseControllerV2<
 
     this.update((state) => {
       state.selectedNetworkClientId = networkClientId;
-      if (state.networkMeta[networkClientId] === undefined) {
-        state.networkMeta[networkClientId] = {
+      if (state.networksMetadata[networkClientId] === undefined) {
+        state.networksMetadata[networkClientId] = {
           status: NetworkStatus.Unknown,
           details: {
             EIPS: {}

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -78,6 +78,10 @@ export type NetworkDetails = {
   EIPS: {
     [eipNumber: number]: boolean;
   };
+  /**
+   * Indicates the availability of the network
+   */
+  status: NetworkStatus;
 };
 
 /**
@@ -337,10 +341,7 @@ type NetworkClientId = BuiltInNetworkClientId | CustomNetworkClientId;
  * Data related to a particular network.
  */
 export type NetworksMetadata = {
-  [networkClientId: NetworkClientId]: {
-    details: NetworkDetails;
-    status: NetworkStatus;
-  };
+  [networkClientId: NetworkClientId]: NetworkDetails;
 };
 
 /**
@@ -788,9 +789,9 @@ export class NetworkController extends BaseControllerV2<
       const meta = state.networksMetadata[state.selectedNetworkClientId];
       meta.status = updatedNetworkStatus;
       if (updatedIsEIP1559Compatible === undefined) {
-        delete meta.details.EIPS[1559];
+        delete meta.EIPS[1559];
       } else {
-        meta.details.EIPS[1559] = updatedIsEIP1559Compatible;
+        meta.EIPS[1559] = updatedIsEIP1559Compatible;
       }
     });
 
@@ -918,7 +919,7 @@ export class NetworkController extends BaseControllerV2<
     }
 
     const { EIPS } =
-      this.state.networksMetadata[this.state.selectedNetworkClientId].details;
+      this.state.networksMetadata[this.state.selectedNetworkClientId];
 
     if (EIPS[1559] !== undefined) {
       return EIPS[1559];
@@ -927,9 +928,8 @@ export class NetworkController extends BaseControllerV2<
     const isEIP1559Compatible = await this.#determineEIP1559Compatibility();
     this.update((state) => {
       if (isEIP1559Compatible !== undefined) {
-        state.networksMetadata[
-          state.selectedNetworkClientId
-        ].details.EIPS[1559] = isEIP1559Compatible;
+        state.networksMetadata[state.selectedNetworkClientId].EIPS[1559] =
+          isEIP1559Compatible;
       }
     });
     return isEIP1559Compatible;
@@ -1390,9 +1390,7 @@ export class NetworkController extends BaseControllerV2<
       if (state.networksMetadata[networkClientId] === undefined) {
         state.networksMetadata[networkClientId] = {
           status: NetworkStatus.Unknown,
-          details: {
-            EIPS: {},
-          },
+          EIPS: {},
         };
       }
     });

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -338,16 +338,15 @@ type NetworkClientId = BuiltInNetworkClientId | CustomNetworkClientId;
  */
 export type NetworksMetadata = {
   [networkClientId: NetworkClientId]: {
-    details: NetworkDetails,
-    status: NetworkStatus,
-  }
+    details: NetworkDetails;
+    status: NetworkStatus;
+  };
 };
 
 /**
  * The network ID of a network.
  */
 export type NetworkId = `${number}`;
-
 
 /**
  * @type NetworkState
@@ -569,7 +568,7 @@ export class NetworkController extends BaseControllerV2<
         },
         networksMetadata: {
           persist: true,
-          anonymous: false
+          anonymous: false,
         },
         providerConfig: {
           persist: true,
@@ -603,8 +602,6 @@ export class NetworkController extends BaseControllerV2<
     );
 
     this.#previousProviderConfig = this.state.providerConfig;
-    // this.#ensureAutoManagedNetworkClientRegistryPopulated();
-    // this.#applyNetworkSelection();
   }
 
   /**
@@ -920,7 +917,8 @@ export class NetworkController extends BaseControllerV2<
       return false;
     }
 
-    const { EIPS } = this.state.networksMetadata[this.state.selectedNetworkClientId].details;
+    const { EIPS } =
+      this.state.networksMetadata[this.state.selectedNetworkClientId].details;
 
     if (EIPS[1559] !== undefined) {
       return EIPS[1559];
@@ -1361,7 +1359,8 @@ export class NetworkController extends BaseControllerV2<
       networkClientId = buildInfuraNetworkClientId(providerConfig);
       const builtInNetworkClientRegistry =
         this.#autoManagedNetworkClientRegistry[networkClientType];
-      autoManagedNetworkClient = builtInNetworkClientRegistry[networkClientId as BuiltInNetworkClientId];
+      autoManagedNetworkClient =
+        builtInNetworkClientRegistry[networkClientId as BuiltInNetworkClientId];
       if (!autoManagedNetworkClient) {
         throw new Error(
           `Could not find custom network matching ${networkClientId}`,
@@ -1392,8 +1391,8 @@ export class NetworkController extends BaseControllerV2<
         state.networksMetadata[networkClientId] = {
           status: NetworkStatus.Unknown,
           details: {
-            EIPS: {}
-          }
+            EIPS: {},
+          },
         };
       }
     });

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -207,7 +207,7 @@ describe('NetworkController', () => {
             },
             networksMetadata: {
               mainnet: {
-                details: { EIPS: { 1559: true } },
+                EIPS: { 1559: true },
                 status: NetworkStatus.Unknown,
               },
             },
@@ -220,10 +220,8 @@ describe('NetworkController', () => {
               "networkId": null,
               "networksMetadata": Object {
                 "mainnet": Object {
-                  "details": Object {
-                    "EIPS": Object {
-                      "1559": true,
-                    },
+                  "EIPS": Object {
+                    "1559": true,
                   },
                   "status": "unknown",
                 },
@@ -2103,19 +2101,15 @@ describe('NetworkController', () => {
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
                   expect(
-                    controller.state.networksMetadata[networkType].details,
-                  ).toStrictEqual({
-                    EIPS: {
-                      1559: true,
-                    },
-                  });
+                    controller.state.networksMetadata[networkType].EIPS[1559],
+                  ).toBe(true);
 
                   await waitForStateChanges({
                     messenger,
                     propertyPath: [
                       'networksMetadata',
                       'testNetworkConfigurationId',
-                      'details',
+                      'EIPS',
                     ],
                     operation: async () => {
                       await controller.lookupNetwork();
@@ -2124,12 +2118,8 @@ describe('NetworkController', () => {
 
                   expect(
                     controller.state.networksMetadata.testNetworkConfigurationId
-                      .details,
-                  ).toStrictEqual({
-                    EIPS: {
-                      1559: false,
-                    },
-                  });
+                      .EIPS[1559],
+                  ).toBe(false);
                 },
               );
             });
@@ -2571,8 +2561,7 @@ describe('NetworkController', () => {
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
                   expect(
-                    controller.state.networksMetadata[networkType].details
-                      .EIPS[1559],
+                    controller.state.networksMetadata[networkType].EIPS[1559],
                   ).toBe(true);
 
                   await waitForStateChanges({
@@ -2580,7 +2569,7 @@ describe('NetworkController', () => {
                     propertyPath: [
                       'networksMetadata',
                       'testNetworkConfigurationId',
-                      'details',
+                      'EIPS',
                     ],
                     operation: async () => {
                       await controller.lookupNetwork();
@@ -2589,7 +2578,7 @@ describe('NetworkController', () => {
 
                   expect(
                     controller.state.networksMetadata.testNetworkConfigurationId
-                      .details.EIPS[1559],
+                      .EIPS[1559],
                   ).toBe(false);
                 },
               );
@@ -3028,27 +3017,19 @@ describe('NetworkController', () => {
               await controller.initializeProvider();
               expect(
                 controller.state.networksMetadata['https://mock-rpc-url']
-                  .details,
-              ).toStrictEqual({
-                EIPS: {
-                  1559: true,
-                },
-              });
+                  .EIPS[1559],
+              ).toBe(true);
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: [
-                  'networksMetadata',
-                  NetworkType.goerli,
-                  'details',
-                ],
+                propertyPath: ['networksMetadata', NetworkType.goerli, 'EIPS'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
               expect(
-                controller.state.networksMetadata[NetworkType.goerli].details
+                controller.state.networksMetadata[NetworkType.goerli]
                   .EIPS[1559],
               ).toBe(false);
             },
@@ -3459,32 +3440,24 @@ describe('NetworkController', () => {
               await controller.initializeProvider();
               expect(
                 controller.state.networksMetadata['https://mock-rpc-url']
-                  .details,
-              ).toStrictEqual({
-                EIPS: {
-                  1559: true,
-                },
-              });
+                  .EIPS[1559],
+              ).toBe(true);
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: [
-                  'networksMetadata',
-                  NetworkType.goerli,
-                  'details',
-                ],
+                propertyPath: ['networksMetadata', NetworkType.goerli, 'EIPS'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
               expect(
-                controller.state.networksMetadata[NetworkType.goerli].details
+                controller.state.networksMetadata[NetworkType.goerli]
                   .EIPS[1559],
               ).toBe(false);
               expect(
                 controller.state.networksMetadata['https://mock-rpc-url']
-                  .details.EIPS[1559],
+                  .EIPS[1559],
               ).toBe(true);
             },
           );
@@ -3727,7 +3700,7 @@ describe('NetworkController', () => {
         });
       });
 
-      it('does not update networksMetadata[...].details.EIPS in state', async () => {
+      it('does not update networksMetadata[...].EIPS in state', async () => {
         await withController(async ({ controller, messenger }) => {
           const fakeProvider = buildFakeProvider([
             {
@@ -3747,13 +3720,7 @@ describe('NetworkController', () => {
 
           const promiseForNoStateChanges = await waitForStateChanges({
             messenger,
-            propertyPath: [
-              'networksMetadata',
-              NetworkType.rpc,
-              'details',
-              'EIPS',
-              '1559',
-            ],
+            propertyPath: ['networksMetadata', NetworkType.rpc, 'EIPS', '1559'],
             count: 0,
             operation: async () => {
               try {
@@ -4073,10 +4040,8 @@ describe('NetworkController', () => {
             state: {
               networksMetadata: {
                 mainnet: {
-                  details: {
-                    EIPS: {
-                      1559: true,
-                    },
+                  EIPS: {
+                    1559: true,
                   },
                   status: NetworkStatus.Unknown,
                 },
@@ -4106,10 +4071,8 @@ describe('NetworkController', () => {
             state: {
               networksMetadata: {
                 mainnet: {
-                  details: {
-                    EIPS: {
-                      1559: true,
-                    },
+                  EIPS: {
+                    1559: true,
                   },
                   status: NetworkStatus.Unknown,
                 },
@@ -4155,7 +4118,7 @@ describe('NetworkController', () => {
               expect(
                 controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
-                ].details.EIPS[1559],
+                ].EIPS[1559],
               ).toBe(true);
             });
           });
@@ -4208,7 +4171,7 @@ describe('NetworkController', () => {
               expect(
                 controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
-                ].details.EIPS[1559],
+                ].EIPS[1559],
               ).toBe(false);
             });
           });
@@ -4260,7 +4223,7 @@ describe('NetworkController', () => {
               expect(
                 controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
-                ].details.EIPS[1559],
+                ].EIPS[1559],
               ).toBeUndefined();
             });
           });
@@ -6171,12 +6134,12 @@ describe('NetworkController', () => {
                 expect(
                   controller.state.networksMetadata[
                     controller.state.selectedNetworkClientId
-                  ].details.EIPS[1559],
+                  ].EIPS[1559],
                 ).toBe(false);
 
                 await waitForStateChanges({
                   messenger,
-                  propertyPath: ['networksMetadata', networkType, 'details'],
+                  propertyPath: ['networksMetadata', networkType, 'EIPS'],
                   count: 2,
                   operation: async () => {
                     await controller.rollbackToPreviousProvider();
@@ -6185,7 +6148,7 @@ describe('NetworkController', () => {
                 expect(
                   controller.state.networksMetadata[
                     controller.state.selectedNetworkClientId
-                  ].details.EIPS[1559],
+                  ].EIPS[1559],
                 ).toBe(true);
               },
             );
@@ -6680,14 +6643,14 @@ describe('NetworkController', () => {
               expect(
                 controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
-                ].details.EIPS[1559],
+                ].EIPS[1559],
               ).toBe(false);
 
               await controller.rollbackToPreviousProvider();
               expect(
                 controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
-                ].details.EIPS[1559],
+                ].EIPS[1559],
               ).toBe(true);
             },
           );
@@ -7197,7 +7160,7 @@ function lookupNetworkTests({
                 expect(
                   controller.state.networksMetadata[
                     controller.state.selectedNetworkClientId
-                  ].details.EIPS[1559],
+                  ].EIPS[1559],
                 ).toBe(true);
               },
             );
@@ -7214,7 +7177,7 @@ function lookupNetworkTests({
               ...initialState,
               networksMetadata: {
                 mainnet: {
-                  details: { EIPS: { 1559: false } },
+                  EIPS: { 1559: false },
                   status: NetworkStatus.Unknown,
                 },
               },
@@ -7243,7 +7206,7 @@ function lookupNetworkTests({
             expect(
               controller.state.networksMetadata[
                 controller.state.selectedNetworkClientId
-              ].details.EIPS[1559],
+              ].EIPS[1559],
             ).toBe(true);
           },
         );
@@ -7258,7 +7221,7 @@ function lookupNetworkTests({
               ...initialState,
               networksMetadata: {
                 mainnet: {
-                  details: { EIPS: { 1559: true } },
+                  EIPS: { 1559: true },
                   status: NetworkStatus.Unknown,
                 },
               },
@@ -7287,7 +7250,7 @@ function lookupNetworkTests({
             expect(
               controller.state.networksMetadata[
                 controller.state.selectedNetworkClientId
-              ].details.EIPS[1559],
+              ].EIPS[1559],
             ).toBe(true);
           },
         );
@@ -7412,7 +7375,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559],
+            ].EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -7420,7 +7383,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS,
+            ].EIPS,
           ).toStrictEqual({});
         },
       );
@@ -7735,7 +7698,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559],
+            ].EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -7743,7 +7706,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS,
+            ].EIPS,
           ).toStrictEqual({});
         },
       );
@@ -7820,7 +7783,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559],
+            ].EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -7828,7 +7791,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS,
+            ].EIPS,
           ).toStrictEqual({});
         },
       );
@@ -7995,7 +7958,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559],
+            ].EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -8003,7 +7966,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS,
+            ].EIPS,
           ).toStrictEqual({});
         },
       );
@@ -8163,7 +8126,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559],
+            ].EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -8171,7 +8134,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS,
+            ].EIPS,
           ).toStrictEqual({});
         },
       );
@@ -8502,7 +8465,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559],
+            ].EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -8510,7 +8473,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS,
+            ].EIPS,
           ).toStrictEqual({});
         },
       );
@@ -8579,7 +8542,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559],
+            ].EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -8587,7 +8550,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS,
+            ].EIPS,
           ).toStrictEqual({});
         },
       );

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -182,7 +182,7 @@ describe('NetworkController', () => {
           Object {
             "networkConfigurations": Object {},
             "networkId": null,
-            "networkMeta": Object {},
+            "networksMetadata": Object {},
             "providerConfig": Object {
               "chainId": "0x1",
               "ticker": "ETH",
@@ -205,7 +205,7 @@ describe('NetworkController', () => {
               nickname: 'Test initial state',
               ticker: 'TEST',
             },
-            networkMeta: {
+            networksMetadata: {
               mainnet: {
                 details: { EIPS: { 1559: true } },
                 status: NetworkStatus.Unknown,
@@ -218,7 +218,7 @@ describe('NetworkController', () => {
             Object {
               "networkConfigurations": Object {},
               "networkId": null,
-              "networkMeta": Object {
+              "networksMetadata": Object {
                 "mainnet": Object {
                   "details": Object {
                     "EIPS": Object {
@@ -1871,19 +1871,19 @@ describe('NetworkController', () => {
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
                   expect(
-                    controller.state.networkMeta[networkType].status
+                    controller.state.networksMetadata[networkType].status
                   ).toBe('available');
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'status'],
+                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'status'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
                   });
 
                   expect(
-                    controller.state.networkMeta[
+                    controller.state.networksMetadata[
                       controller.state.selectedNetworkClientId
                     ].status
                   ).toBe('unknown');
@@ -2098,7 +2098,7 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
-                  expect(controller.state.networkMeta[networkType].details).toStrictEqual({
+                  expect(controller.state.networksMetadata[networkType].details).toStrictEqual({
                     EIPS: {
                       1559: true,
                     },
@@ -2106,13 +2106,13 @@ describe('NetworkController', () => {
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'details'],
+                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'details'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
                   });
 
-                  expect(controller.state.networkMeta['testNetworkConfigurationId'].details).toStrictEqual({
+                  expect(controller.state.networksMetadata['testNetworkConfigurationId'].details).toStrictEqual({
                     EIPS: {
                       1559: false,
                     },
@@ -2222,7 +2222,7 @@ describe('NetworkController', () => {
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'status'],
+                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'status'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
@@ -2322,21 +2322,21 @@ describe('NetworkController', () => {
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
                   expect(
-                    controller.state.networkMeta[
+                    controller.state.networksMetadata[
                       networkType
                     ].status
                   ).toBe('available');
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'status'],
+                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'status'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
                   });
 
                   expect(
-                    controller.state.networkMeta[
+                    controller.state.networksMetadata[
                       controller.state.selectedNetworkClientId
                     ].status
                   ).toBe('unknown');
@@ -2551,17 +2551,17 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
-                  expect(controller.state.networkMeta[networkType].details.EIPS[1559]).toBe(true);
+                  expect(controller.state.networksMetadata[networkType].details.EIPS[1559]).toBe(true);
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'details'],
+                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'details'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
                   });
 
-                  expect(controller.state.networkMeta['testNetworkConfigurationId'].details.EIPS[1559]).toBe(false);
+                  expect(controller.state.networksMetadata['testNetworkConfigurationId'].details.EIPS[1559]).toBe(false);
                 },
               );
             });
@@ -2667,7 +2667,7 @@ describe('NetworkController', () => {
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'status'],
+                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'status'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
@@ -2775,18 +2775,18 @@ describe('NetworkController', () => {
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
               expect(
-                controller.state.networkMeta['https://mock-rpc-url'].status
+                controller.state.networksMetadata['https://mock-rpc-url'].status
               ).toBe('available');
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkMeta', NetworkType.goerli, 'status'],
+                propertyPath: ['networksMetadata', NetworkType.goerli, 'status'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networkMeta[NetworkType.goerli].status).toBe('unknown');
+              expect(controller.state.networksMetadata[NetworkType.goerli].status).toBe('unknown');
             },
           );
         });
@@ -2986,7 +2986,7 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
-              expect(controller.state.networkMeta['https://mock-rpc-url'].details).toStrictEqual({
+              expect(controller.state.networksMetadata['https://mock-rpc-url'].details).toStrictEqual({
                 EIPS: {
                   1559: true,
                 },
@@ -2994,13 +2994,13 @@ describe('NetworkController', () => {
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkMeta', NetworkType.goerli, 'details'],
+                propertyPath: ['networksMetadata', NetworkType.goerli, 'details'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networkMeta[NetworkType.goerli].details.EIPS[1559]).toBe(false);
+              expect(controller.state.networksMetadata[NetworkType.goerli].details.EIPS[1559]).toBe(false);
             },
           );
         });
@@ -3099,7 +3099,7 @@ describe('NetworkController', () => {
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkMeta', 'goerli', 'status'],
+                propertyPath: ['networksMetadata', 'goerli', 'status'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
@@ -3188,17 +3188,17 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
-              expect(controller.state.networkMeta['https://mock-rpc-url'].status).toBe('available');
+              expect(controller.state.networksMetadata['https://mock-rpc-url'].status).toBe('available');
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkMeta', NetworkType.goerli, 'status'],
+                propertyPath: ['networksMetadata', NetworkType.goerli, 'status'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networkMeta[NetworkType.goerli].status).toBe('unknown');
+              expect(controller.state.networksMetadata[NetworkType.goerli].status).toBe('unknown');
             },
           );
         });
@@ -3398,7 +3398,7 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
-              expect(controller.state.networkMeta['https://mock-rpc-url'].details).toStrictEqual({
+              expect(controller.state.networksMetadata['https://mock-rpc-url'].details).toStrictEqual({
                 EIPS: {
                   1559: true,
                 },
@@ -3406,14 +3406,14 @@ describe('NetworkController', () => {
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkMeta', NetworkType.goerli, 'details'],
+                propertyPath: ['networksMetadata', NetworkType.goerli, 'details'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networkMeta[NetworkType.goerli].details.EIPS[1559]).toBe(false);
-              expect(controller.state.networkMeta['https://mock-rpc-url'].details.EIPS[1559]).toBe(true);
+              expect(controller.state.networksMetadata[NetworkType.goerli].details.EIPS[1559]).toBe(false);
+              expect(controller.state.networksMetadata['https://mock-rpc-url'].details.EIPS[1559]).toBe(true);
             },
           );
         });
@@ -3512,7 +3512,7 @@ describe('NetworkController', () => {
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkMeta', NetworkType.goerli, 'status'],
+                propertyPath: ['networksMetadata', NetworkType.goerli, 'status'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
@@ -3651,7 +3651,7 @@ describe('NetworkController', () => {
         });
       });
 
-      it('does not update networkMeta[...].details.EIPS in state', async () => {
+      it('does not update networksMetadata[...].details.EIPS in state', async () => {
         await withController(async ({ controller, messenger }) => {
           const fakeProvider = buildFakeProvider([
             {
@@ -3671,7 +3671,7 @@ describe('NetworkController', () => {
 
           const promiseForNoStateChanges = await waitForStateChanges({
             messenger,
-            propertyPath:[ 'networkMeta', NetworkType.rpc, 'details', 'EIPS', '1559' ],
+            propertyPath:[ 'networksMetadata', NetworkType.rpc, 'details', 'EIPS', '1559' ],
             count: 0,
             operation: async () => {
               try {
@@ -3984,12 +3984,12 @@ describe('NetworkController', () => {
       });
     });
 
-    describe('if a provider has been set but networkMeta[selectedNetworkId].EIPS in state already has a "1559" property', () => {
+    describe('if a provider has been set but networksMetadata[selectedNetworkId].EIPS in state already has a "1559" property', () => {
       it('does not make any state changes', async () => {
         await withController(
           {
             state: {
-              networkMeta: {
+              networksMetadata: {
                 'mainnet': {
                   details: {
                     EIPS: {
@@ -4022,7 +4022,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              networkMeta: {
+              networksMetadata: {
                 'mainnet': {
                   details: {
                     EIPS: {
@@ -4048,7 +4048,7 @@ describe('NetworkController', () => {
       });
     });
 
-    describe('if a provider has been set and networkMeta[selectedNetworkId].EIPS in state does not already have a "1559" property', () => {
+    describe('if a provider has been set and networksMetadata[selectedNetworkId].EIPS in state does not already have a "1559" property', () => {
       describe('if the request for the latest block is successful', () => {
         describe('if the latest block has a "baseFeePerGas" property', () => {
           it('sets the "1559" property to true', async () => {
@@ -4071,7 +4071,7 @@ describe('NetworkController', () => {
               await controller.getEIP1559Compatibility();
 
               expect(
-                controller.state.networkMeta[
+                controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
                 ].details.EIPS[1559]
               ).toBe(true);
@@ -4124,7 +4124,7 @@ describe('NetworkController', () => {
               await controller.getEIP1559Compatibility();
 
               expect(
-                controller.state.networkMeta[
+                controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
                 ].details.EIPS[1559]
               ).toBe(false);
@@ -4176,7 +4176,7 @@ describe('NetworkController', () => {
               await controller.getEIP1559Compatibility();
 
               expect(
-                controller.state.networkMeta[
+                controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
                 ].details.EIPS[1559]
               ).toBeUndefined();
@@ -5731,11 +5731,11 @@ describe('NetworkController', () => {
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
                 await controller.setActiveNetwork('testNetworkConfiguration');
-                expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('available');
+                expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('available');
 
                 await waitForStateChanges({
                   messenger,
-                  propertyPath: ['networkMeta', networkType, 'status'],
+                  propertyPath: ['networksMetadata', networkType, 'status'],
                   // We only care about the first state change, because it
                   // happens before networkDidChange
                   count: 1,
@@ -5745,7 +5745,7 @@ describe('NetworkController', () => {
                     controller.rollbackToPreviousProvider();
                   },
                   beforeResolving: () => {
-                    expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('unknown');
+                    expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('unknown');
                   },
                 });
               },
@@ -5997,16 +5997,16 @@ describe('NetworkController', () => {
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
                 await controller.setActiveNetwork('testNetworkConfiguration');
-                expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('unavailable');
+                expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('unavailable');
 
                 await waitForStateChanges({
                   messenger,
-                  propertyPath: ['networkMeta', networkType, 'status'],
+                  propertyPath: ['networksMetadata', networkType, 'status'],
                   operation: async () => {
                     await controller.rollbackToPreviousProvider();
                   },
                 });
-                expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('available');
+                expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('available');
               },
             );
           });
@@ -6071,21 +6071,21 @@ describe('NetworkController', () => {
                   .mockReturnValue(fakeNetworkClients[1]);
                 await controller.setActiveNetwork('testNetworkConfiguration');
                 expect(
-                  controller.state.networkMeta[
+                  controller.state.networksMetadata[
                     controller.state.selectedNetworkClientId
                   ].details.EIPS[1559]
                 ).toBe(false);
 
                 await waitForStateChanges({
                   messenger,
-                  propertyPath: ['networkMeta', networkType, 'details'],
+                  propertyPath: ['networksMetadata', networkType, 'details'],
                   count: 2,
                   operation: async () => {
                     await controller.rollbackToPreviousProvider();
                   },
                 });
                 expect(
-                  controller.state.networkMeta[
+                  controller.state.networksMetadata[
                     controller.state.selectedNetworkClientId
                   ].details.EIPS[1559]
                 ).toBe(true);
@@ -6270,11 +6270,11 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.setProviderType('goerli');
-              expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('available');
+              expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('available');
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkMeta', 'https://mock-rpc-url', 'status'],
+                propertyPath: ['networksMetadata', 'https://mock-rpc-url', 'status'],
                 // We only care about the first state change, because it
                 // happens before networkDidChange
                 count: 1,
@@ -6284,7 +6284,7 @@ describe('NetworkController', () => {
                   controller.rollbackToPreviousProvider();
                 },
                 beforeResolving: () => {
-                  expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('unknown');
+                  expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('unknown');
                 },
               });
             },
@@ -6498,10 +6498,10 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.setProviderType('goerli');
-              expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('unavailable');
+              expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('unavailable');
 
               await controller.rollbackToPreviousProvider();
-              expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('available');
+              expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('available');
             },
           );
         });
@@ -6560,14 +6560,14 @@ describe('NetworkController', () => {
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.setProviderType('goerli');
               expect(
-                controller.state.networkMeta[
+                controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
                 ].details.EIPS[1559]
               ).toBe(false);
 
               await controller.rollbackToPreviousProvider();
               expect(
-                controller.state.networkMeta[
+                controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
                 ].details.EIPS[1559]
               ).toBe(true);
@@ -7077,7 +7077,7 @@ function lookupNetworkTests({
                 await operation(controller);
 
                 expect(
-                  controller.state.networkMeta[
+                  controller.state.networksMetadata[
                     controller.state.selectedNetworkClientId
                   ].details.EIPS[1559]
                 ).toBe(true);
@@ -7094,7 +7094,7 @@ function lookupNetworkTests({
           {
             state: {
               ...initialState,
-              networkMeta: {
+              networksMetadata: {
                 mainnet: {
                   details: { EIPS: { 1559: false } },
                   status: NetworkStatus.Unknown,
@@ -7123,7 +7123,7 @@ function lookupNetworkTests({
             await operation(controller);
 
             expect(
-              controller.state.networkMeta[
+              controller.state.networksMetadata[
                 controller.state.selectedNetworkClientId
               ].details.EIPS[1559]
             ).toBe(true);
@@ -7138,7 +7138,7 @@ function lookupNetworkTests({
           {
             state: {
               ...initialState,
-              networkMeta: {
+              networksMetadata: {
                 mainnet: {
                   details: { EIPS: { 1559: true } },
                   status: NetworkStatus.Unknown,
@@ -7167,7 +7167,7 @@ function lookupNetworkTests({
             await operation(controller);
 
             expect(
-              controller.state.networkMeta[
+              controller.state.networksMetadata[
                 controller.state.selectedNetworkClientId
               ].details.EIPS[1559]
             ).toBe(true);
@@ -7243,7 +7243,7 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(
+          expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(
             NetworkStatus.Unavailable,
           );
         },
@@ -7290,7 +7290,7 @@ function lookupNetworkTests({
           });
 
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS[1559]
           ).toBe(false);
@@ -7298,7 +7298,7 @@ function lookupNetworkTests({
           await operation(controller);
 
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS
           ).toStrictEqual({});
@@ -7418,7 +7418,7 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
+            expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
           },
         );
       });
@@ -7500,7 +7500,7 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Blocked);
+            expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Blocked);
           },
         );
       });
@@ -7605,7 +7605,7 @@ function lookupNetworkTests({
           });
 
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS[1559]
           ).toBe(false);
@@ -7613,7 +7613,7 @@ function lookupNetworkTests({
           await operation(controller);
 
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS
           ).toStrictEqual({});
@@ -7641,7 +7641,7 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
+          expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
         },
       );
     });
@@ -7686,7 +7686,7 @@ function lookupNetworkTests({
           });
 
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS[1559]
           ).toBe(false);
@@ -7694,7 +7694,7 @@ function lookupNetworkTests({
           await operation(controller);
 
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS
           ).toStrictEqual({});
@@ -7813,7 +7813,7 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
+          expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
         },
       );
     });
@@ -7857,7 +7857,7 @@ function lookupNetworkTests({
             ],
           });
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS[1559]
           ).toBe(false);
@@ -7865,7 +7865,7 @@ function lookupNetworkTests({
           await operation(controller);
 
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS
           ).toStrictEqual({});
@@ -7987,7 +7987,7 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(
+          expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(
             NetworkStatus.Unavailable,
           );
         },
@@ -8023,7 +8023,7 @@ function lookupNetworkTests({
             ],
           });
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS[1559]
           ).toBe(false);
@@ -8031,7 +8031,7 @@ function lookupNetworkTests({
           await operation(controller);
 
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS
           ).toStrictEqual({});
@@ -8163,7 +8163,7 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
+            expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
           },
         );
       });
@@ -8254,7 +8254,7 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Blocked);
+            expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Blocked);
           },
         );
       });
@@ -8354,7 +8354,7 @@ function lookupNetworkTests({
             ],
           });
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS[1559]
           ).toBe(false);
@@ -8362,7 +8362,7 @@ function lookupNetworkTests({
           await operation(controller);
 
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS
           ).toStrictEqual({});
@@ -8393,7 +8393,7 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
+          expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
         },
       );
     });
@@ -8427,7 +8427,7 @@ function lookupNetworkTests({
             ],
           });
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS[1559]
           ).toBe(false);
@@ -8435,7 +8435,7 @@ function lookupNetworkTests({
           await operation(controller);
 
           expect(
-            controller.state.networkMeta[
+            controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
             ].details.EIPS
           ).toStrictEqual({});

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -181,11 +181,8 @@ describe('NetworkController', () => {
         expect(controller.state).toMatchInlineSnapshot(`
           Object {
             "networkConfigurations": Object {},
-            "networkDetails": Object {
-              "EIPS": Object {},
-            },
             "networkId": null,
-            "networkStatus": "unknown",
+            "networkMeta": Object {},
             "providerConfig": Object {
               "chainId": "0x1",
               "ticker": "ETH",
@@ -208,9 +205,10 @@ describe('NetworkController', () => {
               nickname: 'Test initial state',
               ticker: 'TEST',
             },
-            networkDetails: {
-              EIPS: {
-                1559: true,
+            networkMeta: {
+              mainnet: {
+                details: { EIPS: { 1559: true } },
+                status: NetworkStatus.Unknown,
               },
             },
           },
@@ -219,13 +217,17 @@ describe('NetworkController', () => {
           expect(controller.state).toMatchInlineSnapshot(`
             Object {
               "networkConfigurations": Object {},
-              "networkDetails": Object {
-                "EIPS": Object {
-                  "1559": true,
+              "networkId": null,
+              "networkMeta": Object {
+                "mainnet": Object {
+                  "details": Object {
+                    "EIPS": Object {
+                      "1559": true,
+                    },
+                  },
+                  "status": "unknown",
                 },
               },
-              "networkId": null,
-              "networkStatus": "unknown",
               "providerConfig": Object {
                 "chainId": "0x9999",
                 "nickname": "Test initial state",
@@ -1868,17 +1870,23 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
-                  expect(controller.state.networkStatus).toBe('available');
+                  expect(
+                    controller.state.networkMeta[networkType].status
+                  ).toBe('available');
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkStatus'],
+                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'status'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
                   });
 
-                  expect(controller.state.networkStatus).toBe('unknown');
+                  expect(
+                    controller.state.networkMeta[
+                      controller.state.selectedNetworkClientId
+                    ].status
+                  ).toBe('unknown');
                 },
               );
             });
@@ -2090,7 +2098,7 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
-                  expect(controller.state.networkDetails).toStrictEqual({
+                  expect(controller.state.networkMeta[networkType].details).toStrictEqual({
                     EIPS: {
                       1559: true,
                     },
@@ -2098,13 +2106,13 @@ describe('NetworkController', () => {
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkDetails'],
+                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'details'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
                   });
 
-                  expect(controller.state.networkDetails).toStrictEqual({
+                  expect(controller.state.networkMeta['testNetworkConfigurationId'].details).toStrictEqual({
                     EIPS: {
                       1559: false,
                     },
@@ -2214,7 +2222,7 @@ describe('NetworkController', () => {
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkStatus'],
+                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'status'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
@@ -2313,17 +2321,25 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
-                  expect(controller.state.networkStatus).toBe('available');
+                  expect(
+                    controller.state.networkMeta[
+                      networkType
+                    ].status
+                  ).toBe('available');
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkStatus'],
+                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'status'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
                   });
 
-                  expect(controller.state.networkStatus).toBe('unknown');
+                  expect(
+                    controller.state.networkMeta[
+                      controller.state.selectedNetworkClientId
+                    ].status
+                  ).toBe('unknown');
                 },
               );
             });
@@ -2535,25 +2551,17 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
-                  expect(controller.state.networkDetails).toStrictEqual({
-                    EIPS: {
-                      1559: true,
-                    },
-                  });
+                  expect(controller.state.networkMeta[networkType].details.EIPS[1559]).toBe(true);
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkDetails'],
+                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'details'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
                   });
 
-                  expect(controller.state.networkDetails).toStrictEqual({
-                    EIPS: {
-                      1559: false,
-                    },
-                  });
+                  expect(controller.state.networkMeta['testNetworkConfigurationId'].details.EIPS[1559]).toBe(false);
                 },
               );
             });
@@ -2659,7 +2667,7 @@ describe('NetworkController', () => {
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networkStatus'],
+                    propertyPath: ['networkMeta', 'testNetworkConfigurationId', 'status'],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
@@ -2766,17 +2774,19 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
-              expect(controller.state.networkStatus).toBe('available');
+              expect(
+                controller.state.networkMeta['https://mock-rpc-url'].status
+              ).toBe('available');
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkStatus'],
+                propertyPath: ['networkMeta', NetworkType.goerli, 'status'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networkStatus).toBe('unknown');
+              expect(controller.state.networkMeta[NetworkType.goerli].status).toBe('unknown');
             },
           );
         });
@@ -2976,7 +2986,7 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
-              expect(controller.state.networkDetails).toStrictEqual({
+              expect(controller.state.networkMeta['https://mock-rpc-url'].details).toStrictEqual({
                 EIPS: {
                   1559: true,
                 },
@@ -2984,17 +2994,13 @@ describe('NetworkController', () => {
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkDetails'],
+                propertyPath: ['networkMeta', NetworkType.goerli, 'details'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networkDetails).toStrictEqual({
-                EIPS: {
-                  1559: false,
-                },
-              });
+              expect(controller.state.networkMeta[NetworkType.goerli].details.EIPS[1559]).toBe(false);
             },
           );
         });
@@ -3093,7 +3099,7 @@ describe('NetworkController', () => {
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkStatus'],
+                propertyPath: ['networkMeta', 'goerli', 'status'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
@@ -3182,17 +3188,17 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
-              expect(controller.state.networkStatus).toBe('available');
+              expect(controller.state.networkMeta['https://mock-rpc-url'].status).toBe('available');
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkStatus'],
+                propertyPath: ['networkMeta', NetworkType.goerli, 'status'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networkStatus).toBe('unknown');
+              expect(controller.state.networkMeta[NetworkType.goerli].status).toBe('unknown');
             },
           );
         });
@@ -3392,7 +3398,7 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
-              expect(controller.state.networkDetails).toStrictEqual({
+              expect(controller.state.networkMeta['https://mock-rpc-url'].details).toStrictEqual({
                 EIPS: {
                   1559: true,
                 },
@@ -3400,17 +3406,14 @@ describe('NetworkController', () => {
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkDetails'],
+                propertyPath: ['networkMeta', NetworkType.goerli, 'details'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networkDetails).toStrictEqual({
-                EIPS: {
-                  1559: false,
-                },
-              });
+              expect(controller.state.networkMeta[NetworkType.goerli].details.EIPS[1559]).toBe(false);
+              expect(controller.state.networkMeta['https://mock-rpc-url'].details.EIPS[1559]).toBe(true);
             },
           );
         });
@@ -3509,7 +3512,7 @@ describe('NetworkController', () => {
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkStatus'],
+                propertyPath: ['networkMeta', NetworkType.goerli, 'status'],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
@@ -3648,8 +3651,8 @@ describe('NetworkController', () => {
         });
       });
 
-      it('does not update networkDetails.EIPS in state', async () => {
-        await withController(async ({ controller }) => {
+      it('does not update networkMeta[...].details.EIPS in state', async () => {
+        await withController(async ({ controller, messenger }) => {
           const fakeProvider = buildFakeProvider([
             {
               request: {
@@ -3666,14 +3669,21 @@ describe('NetworkController', () => {
           const fakeNetworkClient = buildFakeClient(fakeProvider);
           createNetworkClientMock.mockReturnValue(fakeNetworkClient);
 
-          try {
-            // @ts-expect-error Intentionally passing invalid type
-            await controller.setProviderType(NetworkType.rpc);
-          } catch {
-            // catch the rejection (it is tested above)
-          }
+          const promiseForNoStateChanges = await waitForStateChanges({
+            messenger,
+            propertyPath:[ 'networkMeta', NetworkType.rpc, 'details', 'EIPS', '1559' ],
+            count: 0,
+            operation: async () => {
+              try {
+                // @ts-expect-error Intentionally passing invalid type
+                await controller.setProviderType(NetworkType.rpc);
+              } catch {
+                // catch the rejection (it is tested above)
+              }
+            },
+          });
 
-          expect(controller.state.networkDetails.EIPS[1559]).toBeUndefined();
+          expect(Boolean(promiseForNoStateChanges)).toBe(true);
         });
       });
     });
@@ -3974,16 +3984,21 @@ describe('NetworkController', () => {
       });
     });
 
-    describe('if a provider has been set but networkDetails.EIPS in state already has a "1559" property', () => {
+    describe('if a provider has been set but networkMeta[selectedNetworkId].EIPS in state already has a "1559" property', () => {
       it('does not make any state changes', async () => {
         await withController(
           {
             state: {
-              networkDetails: {
-                EIPS: {
-                  1559: true,
-                },
-              },
+              networkMeta: {
+                'mainnet': {
+                  details: {
+                    EIPS: {
+                      1559: true
+                    }
+                  },
+                  status: NetworkStatus.Unknown,
+                }
+              }
             },
           },
           async ({ controller, messenger }) => {
@@ -4007,11 +4022,16 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              networkDetails: {
-                EIPS: {
-                  1559: true,
-                },
-              },
+              networkMeta: {
+                'mainnet': {
+                  details: {
+                    EIPS: {
+                      1559: true
+                    }
+                  },
+                  status: NetworkStatus.Unknown,
+                }
+              }
             },
           },
           async ({ controller }) => {
@@ -4028,7 +4048,7 @@ describe('NetworkController', () => {
       });
     });
 
-    describe('if a provider has been set and networkDetails.EIPS in state does not already have a "1559" property', () => {
+    describe('if a provider has been set and networkMeta[selectedNetworkId].EIPS in state does not already have a "1559" property', () => {
       describe('if the request for the latest block is successful', () => {
         describe('if the latest block has a "baseFeePerGas" property', () => {
           it('sets the "1559" property to true', async () => {
@@ -4050,7 +4070,11 @@ describe('NetworkController', () => {
 
               await controller.getEIP1559Compatibility();
 
-              expect(controller.state.networkDetails.EIPS[1559]).toBe(true);
+              expect(
+                controller.state.networkMeta[
+                  controller.state.selectedNetworkClientId
+                ].details.EIPS[1559]
+              ).toBe(true);
             });
           });
 
@@ -4099,7 +4123,11 @@ describe('NetworkController', () => {
 
               await controller.getEIP1559Compatibility();
 
-              expect(controller.state.networkDetails.EIPS[1559]).toBe(false);
+              expect(
+                controller.state.networkMeta[
+                  controller.state.selectedNetworkClientId
+                ].details.EIPS[1559]
+              ).toBe(false);
             });
           });
 
@@ -4148,7 +4176,9 @@ describe('NetworkController', () => {
               await controller.getEIP1559Compatibility();
 
               expect(
-                controller.state.networkDetails.EIPS[1559],
+                controller.state.networkMeta[
+                  controller.state.selectedNetworkClientId
+                ].details.EIPS[1559]
               ).toBeUndefined();
             });
           });
@@ -5701,11 +5731,11 @@ describe('NetworkController', () => {
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
                 await controller.setActiveNetwork('testNetworkConfiguration');
-                expect(controller.state.networkStatus).toBe('available');
+                expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('available');
 
                 await waitForStateChanges({
                   messenger,
-                  propertyPath: ['networkStatus'],
+                  propertyPath: ['networkMeta', networkType, 'status'],
                   // We only care about the first state change, because it
                   // happens before networkDidChange
                   count: 1,
@@ -5715,84 +5745,7 @@ describe('NetworkController', () => {
                     controller.rollbackToPreviousProvider();
                   },
                   beforeResolving: () => {
-                    expect(controller.state.networkStatus).toBe('unknown');
-                  },
-                });
-              },
-            );
-          });
-
-          it('clears EIP-1559 support for the network from state before updating the provider', async () => {
-            await withController(
-              {
-                state: {
-                  providerConfig: buildProviderConfig({
-                    type: networkType,
-                  }),
-                  networkConfigurations: {
-                    testNetworkConfiguration: {
-                      id: 'testNetworkConfiguration',
-                      rpcUrl: 'https://mock-rpc-url',
-                      chainId: toHex(1337),
-                      ticker: 'TEST',
-                    },
-                  },
-                },
-                infuraProjectId: 'some-infura-project-id',
-              },
-              async ({ controller, messenger }) => {
-                const fakeProviders = [
-                  buildFakeProvider([
-                    {
-                      request: {
-                        method: 'eth_getBlockByNumber',
-                      },
-                      response: {
-                        result: POST_1559_BLOCK,
-                      },
-                    },
-                  ]),
-                  buildFakeProvider(),
-                ];
-                const fakeNetworkClients = [
-                  buildFakeClient(fakeProviders[0]),
-                  buildFakeClient(fakeProviders[1]),
-                ];
-                mockCreateNetworkClient()
-                  .calledWith({
-                    rpcUrl: 'https://mock-rpc-url',
-                    chainId: toHex(1337),
-                    type: NetworkClientType.Custom,
-                  })
-                  .mockReturnValue(fakeNetworkClients[0])
-                  .calledWith({
-                    network: networkType,
-                    infuraProjectId: 'some-infura-project-id',
-                    type: NetworkClientType.Infura,
-                  })
-                  .mockReturnValue(fakeNetworkClients[1]);
-                await controller.setActiveNetwork('testNetworkConfiguration');
-                expect(controller.state.networkDetails).toStrictEqual({
-                  EIPS: {
-                    1559: true,
-                  },
-                });
-
-                await waitForStateChanges({
-                  messenger,
-                  propertyPath: ['networkDetails'],
-                  // We only care about the first state change, because it
-                  // happens before networkDidChange
-                  count: 1,
-                  operation: () => {
-                    // Intentionally not awaited because we want to check state
-                    // while this operation is in-progress
-                    controller.rollbackToPreviousProvider();
-                  },
-                  beforeResolving: () => {
-                    expect(controller.state.networkDetails).toStrictEqual({
-                      EIPS: {},
-                    });
+                    expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('unknown');
                   },
                 });
               },
@@ -6044,16 +5997,16 @@ describe('NetworkController', () => {
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
                 await controller.setActiveNetwork('testNetworkConfiguration');
-                expect(controller.state.networkStatus).toBe('unavailable');
+                expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('unavailable');
 
                 await waitForStateChanges({
                   messenger,
-                  propertyPath: ['networkStatus'],
+                  propertyPath: ['networkMeta', networkType, 'status'],
                   operation: async () => {
                     await controller.rollbackToPreviousProvider();
                   },
                 });
-                expect(controller.state.networkStatus).toBe('available');
+                expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('available');
               },
             );
           });
@@ -6117,27 +6070,25 @@ describe('NetworkController', () => {
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
                 await controller.setActiveNetwork('testNetworkConfiguration');
-                expect(controller.state.networkDetails).toStrictEqual({
-                  EIPS: {
-                    1559: false,
-                  },
-                });
+                expect(
+                  controller.state.networkMeta[
+                    controller.state.selectedNetworkClientId
+                  ].details.EIPS[1559]
+                ).toBe(false);
 
                 await waitForStateChanges({
                   messenger,
-                  propertyPath: ['networkDetails'],
-                  // rollbackToPreviousProvider clears networkDetails first, and
-                  // then updates it to what we expect it to be
+                  propertyPath: ['networkMeta', networkType, 'details'],
                   count: 2,
                   operation: async () => {
                     await controller.rollbackToPreviousProvider();
                   },
                 });
-                expect(controller.state.networkDetails).toStrictEqual({
-                  EIPS: {
-                    1559: true,
-                  },
-                });
+                expect(
+                  controller.state.networkMeta[
+                    controller.state.selectedNetworkClientId
+                  ].details.EIPS[1559]
+                ).toBe(true);
               },
             );
           });
@@ -6319,11 +6270,11 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.setProviderType('goerli');
-              expect(controller.state.networkStatus).toBe('available');
+              expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('available');
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networkStatus'],
+                propertyPath: ['networkMeta', 'https://mock-rpc-url', 'status'],
                 // We only care about the first state change, because it
                 // happens before networkDidChange
                 count: 1,
@@ -6333,78 +6284,7 @@ describe('NetworkController', () => {
                   controller.rollbackToPreviousProvider();
                 },
                 beforeResolving: () => {
-                  expect(controller.state.networkStatus).toBe('unknown');
-                },
-              });
-            },
-          );
-        });
-
-        it('clears EIP-1559 support for the network from state before updating the provider', async () => {
-          await withController(
-            {
-              state: {
-                providerConfig: buildProviderConfig({
-                  type: NetworkType.rpc,
-                  rpcUrl: 'https://mock-rpc-url',
-                  chainId: toHex(1337),
-                }),
-              },
-              infuraProjectId: 'some-infura-project-id',
-            },
-            async ({ controller, messenger }) => {
-              const fakeProviders = [
-                buildFakeProvider([
-                  {
-                    request: {
-                      method: 'eth_getBlockByNumber',
-                    },
-                    response: {
-                      result: POST_1559_BLOCK,
-                    },
-                  },
-                ]),
-                buildFakeProvider(),
-              ];
-              const fakeNetworkClients = [
-                buildFakeClient(fakeProviders[0]),
-                buildFakeClient(fakeProviders[1]),
-              ];
-              mockCreateNetworkClient()
-                .calledWith({
-                  network: InfuraNetworkType.goerli,
-                  infuraProjectId: 'some-infura-project-id',
-                  type: NetworkClientType.Infura,
-                })
-                .mockReturnValue(fakeNetworkClients[0])
-                .calledWith({
-                  rpcUrl: 'https://mock-rpc-url',
-                  chainId: toHex(1337),
-                  type: NetworkClientType.Custom,
-                })
-                .mockReturnValue(fakeNetworkClients[1]);
-              await controller.setProviderType('goerli');
-              expect(controller.state.networkDetails).toStrictEqual({
-                EIPS: {
-                  1559: true,
-                },
-              });
-
-              await waitForStateChanges({
-                messenger,
-                propertyPath: ['networkDetails'],
-                // We only care about the first state change, because it
-                // happens before networkDidChange
-                count: 1,
-                operation: () => {
-                  // Intentionally not awaited because we want to check state
-                  // while this operation is in-progress
-                  controller.rollbackToPreviousProvider();
-                },
-                beforeResolving: () => {
-                  expect(controller.state.networkDetails).toStrictEqual({
-                    EIPS: {},
-                  });
+                  expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('unknown');
                 },
               });
             },
@@ -6618,10 +6498,10 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.setProviderType('goerli');
-              expect(controller.state.networkStatus).toBe('unavailable');
+              expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('unavailable');
 
               await controller.rollbackToPreviousProvider();
-              expect(controller.state.networkStatus).toBe('available');
+              expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe('available');
             },
           );
         });
@@ -6679,18 +6559,18 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.setProviderType('goerli');
-              expect(controller.state.networkDetails).toStrictEqual({
-                EIPS: {
-                  1559: false,
-                },
-              });
+              expect(
+                controller.state.networkMeta[
+                  controller.state.selectedNetworkClientId
+                ].details.EIPS[1559]
+              ).toBe(false);
 
               await controller.rollbackToPreviousProvider();
-              expect(controller.state.networkDetails).toStrictEqual({
-                EIPS: {
-                  1559: true,
-                },
-              });
+              expect(
+                controller.state.networkMeta[
+                  controller.state.selectedNetworkClientId
+                ].details.EIPS[1559]
+              ).toBe(true);
             },
           );
         });
@@ -6913,7 +6793,7 @@ function refreshNetworkTests({
 
         await waitForStateChanges({
           messenger,
-          propertyPath: ['networkDetails'],
+          propertyPath: ['networkId'],
           // We only care about the first state change, because it
           // happens before the network lookup
           count: 1,
@@ -6925,127 +6805,6 @@ function refreshNetworkTests({
         });
 
         expect(controller.state.networkId).toBeNull();
-      },
-    );
-  });
-
-  it('clears network status from state', async () => {
-    await withController(
-      {
-        infuraProjectId: 'infura-project-id',
-        state: initialState,
-      },
-      async ({ controller, messenger }) => {
-        const fakeProvider = buildFakeProvider([
-          // Called during provider initialization
-          {
-            request: {
-              method: 'net_version',
-            },
-            response: SUCCESSFUL_NET_VERSION_RESPONSE,
-          },
-          {
-            request: {
-              method: 'eth_getBlockByNumber',
-            },
-            response: SUCCESSFUL_ETH_GET_BLOCK_BY_NUMBER_RESPONSE,
-          },
-          // Called during network lookup after resetting connection.
-          // Delayed to ensure that we can check the network status
-          // before this resolves.
-          {
-            delay: 1,
-            request: {
-              method: 'net_version',
-            },
-            response: SUCCESSFUL_NET_VERSION_RESPONSE,
-          },
-          {
-            delay: 1,
-            request: {
-              method: 'eth_getBlockByNumber',
-            },
-            response: SUCCESSFUL_ETH_GET_BLOCK_BY_NUMBER_RESPONSE,
-          },
-        ]);
-        const fakeNetworkClient = buildFakeClient(fakeProvider);
-        createNetworkClientMock.mockReturnValue(fakeNetworkClient);
-        await controller.initializeProvider();
-        expect(controller.state.networkStatus).toBe(NetworkStatus.Available);
-
-        await waitForStateChanges({
-          messenger,
-          propertyPath: ['networkStatus'],
-          // We only care about the first state change, because it
-          // happens before the network lookup
-          count: 1,
-          operation: () => {
-            // Intentionally not awaited because we want to check state
-            // partway through the operation
-            operation(controller);
-          },
-        });
-
-        expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
-      },
-    );
-  });
-
-  it('clears network details from state', async () => {
-    await withController(
-      {
-        infuraProjectId: 'infura-project-id',
-        state: initialState,
-      },
-      async ({ controller, messenger }) => {
-        const fakeProvider = buildFakeProvider([
-          // Called during provider initialization
-          {
-            request: {
-              method: 'eth_getBlockByNumber',
-            },
-            response: {
-              result: '0x1',
-            },
-          },
-          // Called during network lookup after resetting connection.
-          // Delayed to ensure that we can check the network details
-          // before this resolves.
-          {
-            delay: 1,
-            request: {
-              method: 'eth_getBlockByNumber',
-            },
-            response: {
-              result: '0x1',
-            },
-          },
-        ]);
-        const fakeNetworkClient = buildFakeClient(fakeProvider);
-        createNetworkClientMock.mockReturnValue(fakeNetworkClient);
-        await controller.initializeProvider();
-        expect(controller.state.networkDetails).toStrictEqual({
-          EIPS: {
-            1559: false,
-          },
-        });
-
-        await waitForStateChanges({
-          messenger,
-          propertyPath: ['networkDetails'],
-          // We only care about the first state change, because it
-          // happens before the network lookup
-          count: 1,
-          operation: () => {
-            // Intentionally not awaited because we want to check state
-            // partway through the operation
-            operation(controller);
-          },
-        });
-
-        expect(controller.state.networkDetails).toStrictEqual({
-          EIPS: {},
-        });
       },
     );
   });
@@ -7317,11 +7076,11 @@ function lookupNetworkTests({
 
                 await operation(controller);
 
-                await expect(controller.state.networkDetails).toStrictEqual({
-                  EIPS: {
-                    1559: true,
-                  },
-                });
+                expect(
+                  controller.state.networkMeta[
+                    controller.state.selectedNetworkClientId
+                  ].details.EIPS[1559]
+                ).toBe(true);
               },
             );
           });
@@ -7335,9 +7094,10 @@ function lookupNetworkTests({
           {
             state: {
               ...initialState,
-              networkDetails: {
-                EIPS: {
-                  1559: false,
+              networkMeta: {
+                mainnet: {
+                  details: { EIPS: { 1559: false } },
+                  status: NetworkStatus.Unknown,
                 },
               },
             },
@@ -7362,11 +7122,11 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networkDetails).toStrictEqual({
-              EIPS: {
-                1559: true,
-              },
-            });
+            expect(
+              controller.state.networkMeta[
+                controller.state.selectedNetworkClientId
+              ].details.EIPS[1559]
+            ).toBe(true);
           },
         );
       });
@@ -7378,9 +7138,10 @@ function lookupNetworkTests({
           {
             state: {
               ...initialState,
-              networkDetails: {
-                EIPS: {
-                  1559: true,
+              networkMeta: {
+                mainnet: {
+                  details: { EIPS: { 1559: true } },
+                  status: NetworkStatus.Unknown,
                 },
               },
             },
@@ -7405,11 +7166,11 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networkDetails).toStrictEqual({
-              EIPS: {
-                1559: true,
-              },
-            });
+            expect(
+              controller.state.networkMeta[
+                controller.state.selectedNetworkClientId
+              ].details.EIPS[1559]
+            ).toBe(true);
           },
         );
       });
@@ -7482,7 +7243,7 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networkStatus).toBe(
+          expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(
             NetworkStatus.Unavailable,
           );
         },
@@ -7527,16 +7288,20 @@ function lookupNetworkTests({
               },
             ],
           });
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {
-              1559: false,
-            },
-          });
+
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS[1559]
+          ).toBe(false);
 
           await operation(controller);
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {},
-          });
+
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS
+          ).toStrictEqual({});
         },
       );
     });
@@ -7653,7 +7418,7 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
+            expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
           },
         );
       });
@@ -7735,7 +7500,7 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networkStatus).toBe(NetworkStatus.Blocked);
+            expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Blocked);
           },
         );
       });
@@ -7838,16 +7603,20 @@ function lookupNetworkTests({
               },
             ],
           });
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {
-              1559: false,
-            },
-          });
+
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS[1559]
+          ).toBe(false);
 
           await operation(controller);
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {},
-          });
+
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS
+          ).toStrictEqual({});
         },
       );
     });
@@ -7872,7 +7641,7 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
+          expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
         },
       );
     });
@@ -7915,16 +7684,20 @@ function lookupNetworkTests({
               },
             ],
           });
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {
-              1559: false,
-            },
-          });
+
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS[1559]
+          ).toBe(false);
 
           await operation(controller);
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {},
-          });
+
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS
+          ).toStrictEqual({});
         },
       );
     });
@@ -8040,7 +7813,7 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
+          expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
         },
       );
     });
@@ -8083,16 +7856,19 @@ function lookupNetworkTests({
               },
             ],
           });
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {
-              1559: false,
-            },
-          });
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS[1559]
+          ).toBe(false);
 
           await operation(controller);
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {},
-          });
+
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS
+          ).toStrictEqual({});
         },
       );
     });
@@ -8211,7 +7987,7 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networkStatus).toBe(
+          expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(
             NetworkStatus.Unavailable,
           );
         },
@@ -8246,16 +8022,19 @@ function lookupNetworkTests({
               },
             ],
           });
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {
-              1559: false,
-            },
-          });
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS[1559]
+          ).toBe(false);
 
           await operation(controller);
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {},
-          });
+
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS
+          ).toStrictEqual({});
         },
       );
     });
@@ -8384,7 +8163,7 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
+            expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
           },
         );
       });
@@ -8475,7 +8254,7 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networkStatus).toBe(NetworkStatus.Blocked);
+            expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Blocked);
           },
         );
       });
@@ -8574,16 +8353,19 @@ function lookupNetworkTests({
               },
             ],
           });
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {
-              1559: false,
-            },
-          });
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS[1559]
+          ).toBe(false);
 
           await operation(controller);
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {},
-          });
+
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS
+          ).toStrictEqual({});
         },
       );
     });
@@ -8611,7 +8393,7 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networkStatus).toBe(NetworkStatus.Unknown);
+          expect(controller.state.networkMeta[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
         },
       );
     });
@@ -8644,16 +8426,19 @@ function lookupNetworkTests({
               },
             ],
           });
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {
-              1559: false,
-            },
-          });
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS[1559]
+          ).toBe(false);
 
           await operation(controller);
-          expect(controller.state.networkDetails).toStrictEqual({
-            EIPS: {},
-          });
+
+          expect(
+            controller.state.networkMeta[
+              controller.state.selectedNetworkClientId
+            ].details.EIPS
+          ).toStrictEqual({});
         },
       );
     });

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -3701,7 +3701,7 @@ describe('NetworkController', () => {
       });
 
       it('does not update networksMetadata[...].EIPS in state', async () => {
-        await withController(async ({ controller, messenger }) => {
+        await withController(async ({ controller }) => {
           const fakeProvider = buildFakeProvider([
             {
               request: {
@@ -3718,21 +3718,24 @@ describe('NetworkController', () => {
           const fakeNetworkClient = buildFakeClient(fakeProvider);
           createNetworkClientMock.mockReturnValue(fakeNetworkClient);
 
-          const promiseForNoStateChanges = await waitForStateChanges({
-            messenger,
-            propertyPath: ['networksMetadata', NetworkType.rpc, 'EIPS', '1559'],
-            count: 0,
-            operation: async () => {
-              try {
-                // @ts-expect-error Intentionally passing invalid type
-                await controller.setProviderType(NetworkType.rpc);
-              } catch {
-                // catch the rejection (it is tested above)
-              }
-            },
-          });
+          const detailsPre =
+            controller.state.networksMetadata[
+              controller.state.selectedNetworkClientId
+            ];
 
-          expect(Boolean(promiseForNoStateChanges)).toBe(true);
+          try {
+            // @ts-expect-error Intentionally passing invalid type
+            await controller.setProviderType(NetworkType.rpc);
+          } catch {
+            // catch the rejection (it is tested above)
+          }
+
+          const detailsPost =
+            controller.state.networksMetadata[
+              controller.state.selectedNetworkClientId
+            ];
+
+          expect(detailsPost).toBe(detailsPre);
         });
       });
     });

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -1871,12 +1871,16 @@ describe('NetworkController', () => {
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
                   expect(
-                    controller.state.networksMetadata[networkType].status
+                    controller.state.networksMetadata[networkType].status,
                   ).toBe('available');
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'status'],
+                    propertyPath: [
+                      'networksMetadata',
+                      'testNetworkConfigurationId',
+                      'status',
+                    ],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
@@ -1885,7 +1889,7 @@ describe('NetworkController', () => {
                   expect(
                     controller.state.networksMetadata[
                       controller.state.selectedNetworkClientId
-                    ].status
+                    ].status,
                   ).toBe('unknown');
                 },
               );
@@ -2098,7 +2102,9 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
-                  expect(controller.state.networksMetadata[networkType].details).toStrictEqual({
+                  expect(
+                    controller.state.networksMetadata[networkType].details,
+                  ).toStrictEqual({
                     EIPS: {
                       1559: true,
                     },
@@ -2106,13 +2112,20 @@ describe('NetworkController', () => {
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'details'],
+                    propertyPath: [
+                      'networksMetadata',
+                      'testNetworkConfigurationId',
+                      'details',
+                    ],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
                   });
 
-                  expect(controller.state.networksMetadata['testNetworkConfigurationId'].details).toStrictEqual({
+                  expect(
+                    controller.state.networksMetadata.testNetworkConfigurationId
+                      .details,
+                  ).toStrictEqual({
                     EIPS: {
                       1559: false,
                     },
@@ -2222,7 +2235,11 @@ describe('NetworkController', () => {
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'status'],
+                    propertyPath: [
+                      'networksMetadata',
+                      'testNetworkConfigurationId',
+                      'status',
+                    ],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
@@ -2322,14 +2339,16 @@ describe('NetworkController', () => {
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
                   expect(
-                    controller.state.networksMetadata[
-                      networkType
-                    ].status
+                    controller.state.networksMetadata[networkType].status,
                   ).toBe('available');
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'status'],
+                    propertyPath: [
+                      'networksMetadata',
+                      'testNetworkConfigurationId',
+                      'status',
+                    ],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
@@ -2338,7 +2357,7 @@ describe('NetworkController', () => {
                   expect(
                     controller.state.networksMetadata[
                       controller.state.selectedNetworkClientId
-                    ].status
+                    ].status,
                   ).toBe('unknown');
                 },
               );
@@ -2551,17 +2570,27 @@ describe('NetworkController', () => {
                     })
                     .mockReturnValue(fakeNetworkClients[1]);
                   await controller.initializeProvider();
-                  expect(controller.state.networksMetadata[networkType].details.EIPS[1559]).toBe(true);
+                  expect(
+                    controller.state.networksMetadata[networkType].details
+                      .EIPS[1559],
+                  ).toBe(true);
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'details'],
+                    propertyPath: [
+                      'networksMetadata',
+                      'testNetworkConfigurationId',
+                      'details',
+                    ],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
                   });
 
-                  expect(controller.state.networksMetadata['testNetworkConfigurationId'].details.EIPS[1559]).toBe(false);
+                  expect(
+                    controller.state.networksMetadata.testNetworkConfigurationId
+                      .details.EIPS[1559],
+                  ).toBe(false);
                 },
               );
             });
@@ -2667,7 +2696,11 @@ describe('NetworkController', () => {
 
                   await waitForStateChanges({
                     messenger,
-                    propertyPath: ['networksMetadata', 'testNetworkConfigurationId', 'status'],
+                    propertyPath: [
+                      'networksMetadata',
+                      'testNetworkConfigurationId',
+                      'status',
+                    ],
                     operation: async () => {
                       await controller.lookupNetwork();
                     },
@@ -2775,18 +2808,25 @@ describe('NetworkController', () => {
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
               expect(
-                controller.state.networksMetadata['https://mock-rpc-url'].status
+                controller.state.networksMetadata['https://mock-rpc-url']
+                  .status,
               ).toBe('available');
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networksMetadata', NetworkType.goerli, 'status'],
+                propertyPath: [
+                  'networksMetadata',
+                  NetworkType.goerli,
+                  'status',
+                ],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networksMetadata[NetworkType.goerli].status).toBe('unknown');
+              expect(
+                controller.state.networksMetadata[NetworkType.goerli].status,
+              ).toBe('unknown');
             },
           );
         });
@@ -2986,7 +3026,10 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
-              expect(controller.state.networksMetadata['https://mock-rpc-url'].details).toStrictEqual({
+              expect(
+                controller.state.networksMetadata['https://mock-rpc-url']
+                  .details,
+              ).toStrictEqual({
                 EIPS: {
                   1559: true,
                 },
@@ -2994,13 +3037,20 @@ describe('NetworkController', () => {
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networksMetadata', NetworkType.goerli, 'details'],
+                propertyPath: [
+                  'networksMetadata',
+                  NetworkType.goerli,
+                  'details',
+                ],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networksMetadata[NetworkType.goerli].details.EIPS[1559]).toBe(false);
+              expect(
+                controller.state.networksMetadata[NetworkType.goerli].details
+                  .EIPS[1559],
+              ).toBe(false);
             },
           );
         });
@@ -3188,17 +3238,26 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
-              expect(controller.state.networksMetadata['https://mock-rpc-url'].status).toBe('available');
+              expect(
+                controller.state.networksMetadata['https://mock-rpc-url']
+                  .status,
+              ).toBe('available');
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networksMetadata', NetworkType.goerli, 'status'],
+                propertyPath: [
+                  'networksMetadata',
+                  NetworkType.goerli,
+                  'status',
+                ],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networksMetadata[NetworkType.goerli].status).toBe('unknown');
+              expect(
+                controller.state.networksMetadata[NetworkType.goerli].status,
+              ).toBe('unknown');
             },
           );
         });
@@ -3398,7 +3457,10 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
-              expect(controller.state.networksMetadata['https://mock-rpc-url'].details).toStrictEqual({
+              expect(
+                controller.state.networksMetadata['https://mock-rpc-url']
+                  .details,
+              ).toStrictEqual({
                 EIPS: {
                   1559: true,
                 },
@@ -3406,14 +3468,24 @@ describe('NetworkController', () => {
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networksMetadata', NetworkType.goerli, 'details'],
+                propertyPath: [
+                  'networksMetadata',
+                  NetworkType.goerli,
+                  'details',
+                ],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
               });
 
-              expect(controller.state.networksMetadata[NetworkType.goerli].details.EIPS[1559]).toBe(false);
-              expect(controller.state.networksMetadata['https://mock-rpc-url'].details.EIPS[1559]).toBe(true);
+              expect(
+                controller.state.networksMetadata[NetworkType.goerli].details
+                  .EIPS[1559],
+              ).toBe(false);
+              expect(
+                controller.state.networksMetadata['https://mock-rpc-url']
+                  .details.EIPS[1559],
+              ).toBe(true);
             },
           );
         });
@@ -3512,7 +3584,11 @@ describe('NetworkController', () => {
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networksMetadata', NetworkType.goerli, 'status'],
+                propertyPath: [
+                  'networksMetadata',
+                  NetworkType.goerli,
+                  'status',
+                ],
                 operation: async () => {
                   await controller.lookupNetwork();
                 },
@@ -3671,7 +3747,13 @@ describe('NetworkController', () => {
 
           const promiseForNoStateChanges = await waitForStateChanges({
             messenger,
-            propertyPath:[ 'networksMetadata', NetworkType.rpc, 'details', 'EIPS', '1559' ],
+            propertyPath: [
+              'networksMetadata',
+              NetworkType.rpc,
+              'details',
+              'EIPS',
+              '1559',
+            ],
             count: 0,
             operation: async () => {
               try {
@@ -3990,15 +4072,15 @@ describe('NetworkController', () => {
           {
             state: {
               networksMetadata: {
-                'mainnet': {
+                mainnet: {
                   details: {
                     EIPS: {
-                      1559: true
-                    }
+                      1559: true,
+                    },
                   },
                   status: NetworkStatus.Unknown,
-                }
-              }
+                },
+              },
             },
           },
           async ({ controller, messenger }) => {
@@ -4023,15 +4105,15 @@ describe('NetworkController', () => {
           {
             state: {
               networksMetadata: {
-                'mainnet': {
+                mainnet: {
                   details: {
                     EIPS: {
-                      1559: true
-                    }
+                      1559: true,
+                    },
                   },
                   status: NetworkStatus.Unknown,
-                }
-              }
+                },
+              },
             },
           },
           async ({ controller }) => {
@@ -4073,7 +4155,7 @@ describe('NetworkController', () => {
               expect(
                 controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
-                ].details.EIPS[1559]
+                ].details.EIPS[1559],
               ).toBe(true);
             });
           });
@@ -4126,7 +4208,7 @@ describe('NetworkController', () => {
               expect(
                 controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
-                ].details.EIPS[1559]
+                ].details.EIPS[1559],
               ).toBe(false);
             });
           });
@@ -4178,7 +4260,7 @@ describe('NetworkController', () => {
               expect(
                 controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
-                ].details.EIPS[1559]
+                ].details.EIPS[1559],
               ).toBeUndefined();
             });
           });
@@ -5731,7 +5813,11 @@ describe('NetworkController', () => {
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
                 await controller.setActiveNetwork('testNetworkConfiguration');
-                expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('available');
+                expect(
+                  controller.state.networksMetadata[
+                    controller.state.selectedNetworkClientId
+                  ].status,
+                ).toBe('available');
 
                 await waitForStateChanges({
                   messenger,
@@ -5745,7 +5831,11 @@ describe('NetworkController', () => {
                     controller.rollbackToPreviousProvider();
                   },
                   beforeResolving: () => {
-                    expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('unknown');
+                    expect(
+                      controller.state.networksMetadata[
+                        controller.state.selectedNetworkClientId
+                      ].status,
+                    ).toBe('unknown');
                   },
                 });
               },
@@ -5997,7 +6087,11 @@ describe('NetworkController', () => {
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
                 await controller.setActiveNetwork('testNetworkConfiguration');
-                expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('unavailable');
+                expect(
+                  controller.state.networksMetadata[
+                    controller.state.selectedNetworkClientId
+                  ].status,
+                ).toBe('unavailable');
 
                 await waitForStateChanges({
                   messenger,
@@ -6006,7 +6100,11 @@ describe('NetworkController', () => {
                     await controller.rollbackToPreviousProvider();
                   },
                 });
-                expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('available');
+                expect(
+                  controller.state.networksMetadata[
+                    controller.state.selectedNetworkClientId
+                  ].status,
+                ).toBe('available');
               },
             );
           });
@@ -6073,7 +6171,7 @@ describe('NetworkController', () => {
                 expect(
                   controller.state.networksMetadata[
                     controller.state.selectedNetworkClientId
-                  ].details.EIPS[1559]
+                  ].details.EIPS[1559],
                 ).toBe(false);
 
                 await waitForStateChanges({
@@ -6087,7 +6185,7 @@ describe('NetworkController', () => {
                 expect(
                   controller.state.networksMetadata[
                     controller.state.selectedNetworkClientId
-                  ].details.EIPS[1559]
+                  ].details.EIPS[1559],
                 ).toBe(true);
               },
             );
@@ -6270,11 +6368,19 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.setProviderType('goerli');
-              expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('available');
+              expect(
+                controller.state.networksMetadata[
+                  controller.state.selectedNetworkClientId
+                ].status,
+              ).toBe('available');
 
               await waitForStateChanges({
                 messenger,
-                propertyPath: ['networksMetadata', 'https://mock-rpc-url', 'status'],
+                propertyPath: [
+                  'networksMetadata',
+                  'https://mock-rpc-url',
+                  'status',
+                ],
                 // We only care about the first state change, because it
                 // happens before networkDidChange
                 count: 1,
@@ -6284,7 +6390,11 @@ describe('NetworkController', () => {
                   controller.rollbackToPreviousProvider();
                 },
                 beforeResolving: () => {
-                  expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('unknown');
+                  expect(
+                    controller.state.networksMetadata[
+                      controller.state.selectedNetworkClientId
+                    ].status,
+                  ).toBe('unknown');
                 },
               });
             },
@@ -6498,10 +6608,18 @@ describe('NetworkController', () => {
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.setProviderType('goerli');
-              expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('unavailable');
+              expect(
+                controller.state.networksMetadata[
+                  controller.state.selectedNetworkClientId
+                ].status,
+              ).toBe('unavailable');
 
               await controller.rollbackToPreviousProvider();
-              expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe('available');
+              expect(
+                controller.state.networksMetadata[
+                  controller.state.selectedNetworkClientId
+                ].status,
+              ).toBe('available');
             },
           );
         });
@@ -6562,14 +6680,14 @@ describe('NetworkController', () => {
               expect(
                 controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
-                ].details.EIPS[1559]
+                ].details.EIPS[1559],
               ).toBe(false);
 
               await controller.rollbackToPreviousProvider();
               expect(
                 controller.state.networksMetadata[
                   controller.state.selectedNetworkClientId
-                ].details.EIPS[1559]
+                ].details.EIPS[1559],
               ).toBe(true);
             },
           );
@@ -7079,7 +7197,7 @@ function lookupNetworkTests({
                 expect(
                   controller.state.networksMetadata[
                     controller.state.selectedNetworkClientId
-                  ].details.EIPS[1559]
+                  ].details.EIPS[1559],
                 ).toBe(true);
               },
             );
@@ -7125,7 +7243,7 @@ function lookupNetworkTests({
             expect(
               controller.state.networksMetadata[
                 controller.state.selectedNetworkClientId
-              ].details.EIPS[1559]
+              ].details.EIPS[1559],
             ).toBe(true);
           },
         );
@@ -7169,7 +7287,7 @@ function lookupNetworkTests({
             expect(
               controller.state.networksMetadata[
                 controller.state.selectedNetworkClientId
-              ].details.EIPS[1559]
+              ].details.EIPS[1559],
             ).toBe(true);
           },
         );
@@ -7243,9 +7361,11 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(
-            NetworkStatus.Unavailable,
-          );
+          expect(
+            controller.state.networksMetadata[
+              controller.state.selectedNetworkClientId
+            ].status,
+          ).toBe(NetworkStatus.Unavailable);
         },
       );
     });
@@ -7292,7 +7412,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559]
+            ].details.EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -7300,7 +7420,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS
+            ].details.EIPS,
           ).toStrictEqual({});
         },
       );
@@ -7418,7 +7538,11 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
+            expect(
+              controller.state.networksMetadata[
+                controller.state.selectedNetworkClientId
+              ].status,
+            ).toBe(NetworkStatus.Unknown);
           },
         );
       });
@@ -7500,7 +7624,11 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Blocked);
+            expect(
+              controller.state.networksMetadata[
+                controller.state.selectedNetworkClientId
+              ].status,
+            ).toBe(NetworkStatus.Blocked);
           },
         );
       });
@@ -7607,7 +7735,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559]
+            ].details.EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -7615,7 +7743,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS
+            ].details.EIPS,
           ).toStrictEqual({});
         },
       );
@@ -7641,7 +7769,11 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
+          expect(
+            controller.state.networksMetadata[
+              controller.state.selectedNetworkClientId
+            ].status,
+          ).toBe(NetworkStatus.Unknown);
         },
       );
     });
@@ -7688,7 +7820,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559]
+            ].details.EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -7696,7 +7828,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS
+            ].details.EIPS,
           ).toStrictEqual({});
         },
       );
@@ -7813,7 +7945,11 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
+          expect(
+            controller.state.networksMetadata[
+              controller.state.selectedNetworkClientId
+            ].status,
+          ).toBe(NetworkStatus.Unknown);
         },
       );
     });
@@ -7859,7 +7995,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559]
+            ].details.EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -7867,7 +8003,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS
+            ].details.EIPS,
           ).toStrictEqual({});
         },
       );
@@ -7987,9 +8123,11 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(
-            NetworkStatus.Unavailable,
-          );
+          expect(
+            controller.state.networksMetadata[
+              controller.state.selectedNetworkClientId
+            ].status,
+          ).toBe(NetworkStatus.Unavailable);
         },
       );
     });
@@ -8025,7 +8163,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559]
+            ].details.EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -8033,7 +8171,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS
+            ].details.EIPS,
           ).toStrictEqual({});
         },
       );
@@ -8163,7 +8301,11 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
+            expect(
+              controller.state.networksMetadata[
+                controller.state.selectedNetworkClientId
+              ].status,
+            ).toBe(NetworkStatus.Unknown);
           },
         );
       });
@@ -8254,7 +8396,11 @@ function lookupNetworkTests({
 
             await operation(controller);
 
-            expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Blocked);
+            expect(
+              controller.state.networksMetadata[
+                controller.state.selectedNetworkClientId
+              ].status,
+            ).toBe(NetworkStatus.Blocked);
           },
         );
       });
@@ -8356,7 +8502,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559]
+            ].details.EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -8364,7 +8510,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS
+            ].details.EIPS,
           ).toStrictEqual({});
         },
       );
@@ -8393,7 +8539,11 @@ function lookupNetworkTests({
 
           await operation(controller);
 
-          expect(controller.state.networksMetadata[controller.state.selectedNetworkClientId].status).toBe(NetworkStatus.Unknown);
+          expect(
+            controller.state.networksMetadata[
+              controller.state.selectedNetworkClientId
+            ].status,
+          ).toBe(NetworkStatus.Unknown);
         },
       );
     });
@@ -8429,7 +8579,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS[1559]
+            ].details.EIPS[1559],
           ).toBe(false);
 
           await operation(controller);
@@ -8437,7 +8587,7 @@ function lookupNetworkTests({
           expect(
             controller.state.networksMetadata[
               controller.state.selectedNetworkClientId
-            ].details.EIPS
+            ].details.EIPS,
           ).toStrictEqual({});
         },
       );

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -282,8 +282,12 @@ const MOCK_NETWORK: MockNetwork = {
   state: {
     selectedNetworkClientId: NetworkType.goerli,
     networkId: '5',
-    networkStatus: NetworkStatus.Available,
-    networkDetails: { EIPS: { 1559: false } },
+    networkMeta: {
+      [NetworkType.goerli]: {
+        details: { EIPS: { 1559: false } },
+        status: NetworkStatus.Available,
+      }
+    },
     providerConfig: {
       type: NetworkType.goerli,
       chainId: ChainId.goerli,
@@ -299,8 +303,12 @@ const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
   state: {
     selectedNetworkClientId: NetworkType.goerli,
     networkId: '5',
-    networkStatus: NetworkStatus.Available,
-    networkDetails: { EIPS: { 1559: false } },
+    networkMeta: {
+      [NetworkType.goerli]: {
+        details: { EIPS: { 1559: false } },
+        status: NetworkStatus.Available,
+      }
+    },
     providerConfig: {
       type: NetworkType.goerli,
     } as NetworkState['providerConfig'],
@@ -314,8 +322,12 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
   state: {
     selectedNetworkClientId: NetworkType.mainnet,
     networkId: '1',
-    networkStatus: NetworkStatus.Available,
-    networkDetails: { EIPS: { 1559: false } },
+    networkMeta: {
+      [NetworkType.mainnet]: {
+        details: { EIPS: { 1559: false } },
+        status: NetworkStatus.Available,
+      }
+    },
     providerConfig: {
       type: NetworkType.mainnet,
       chainId: ChainId.mainnet,
@@ -332,8 +344,12 @@ const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
   state: {
     selectedNetworkClientId: NetworkType['linea-mainnet'],
     networkId: '59144',
-    networkStatus: NetworkStatus.Available,
-    networkDetails: { EIPS: { 1559: false } },
+    networkMeta: {
+      [NetworkType['linea-mainnet']]: {
+        details: { EIPS: { 1559: false } },
+        status: NetworkStatus.Available,
+      }
+    },
     providerConfig: {
       type: NetworkType['linea-mainnet'],
       chainId: toHex(59144),
@@ -348,14 +364,18 @@ const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
   provider: PALM_PROVIDER,
   blockTracker: buildMockBlockTracker('0xA6EDFC'),
   state: {
-    selectedNetworkClientId: NetworkType['linea-mainnet'],
+    selectedNetworkClientId: NetworkType['linea-goerli'],
     networkId: '59140',
-    networkStatus: NetworkStatus.Available,
-    networkDetails: { EIPS: { 1559: false } },
+    networkMeta: {
+      [NetworkType['linea-goerli']]: {
+        details: { EIPS: { 1559: false } },
+        status: NetworkStatus.Available,
+      }
+    },
     providerConfig: {
       type: NetworkType['linea-goerli'],
       chainId: toHex(59140),
-      ticker: NetworksTicker['linea-mainnet'],
+      ticker: NetworksTicker['linea-goerli'],
     },
     networkConfigurations: {},
   },
@@ -368,8 +388,12 @@ const MOCK_CUSTOM_NETWORK: MockNetwork = {
   state: {
     selectedNetworkClientId: 'uuid-1',
     networkId: '11297108109',
-    networkStatus: NetworkStatus.Available,
-    networkDetails: { EIPS: { 1559: false } },
+    networkMeta: {
+      'uuid-1': {
+        details: { EIPS: { 1559: false } },
+        status: NetworkStatus.Available,
+      }
+    },
     providerConfig: {
       type: NetworkType.rpc,
       chainId: toHex(11297108109),

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -286,7 +286,7 @@ const MOCK_NETWORK: MockNetwork = {
       [NetworkType.goerli]: {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,
-      }
+      },
     },
     providerConfig: {
       type: NetworkType.goerli,
@@ -307,7 +307,7 @@ const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
       [NetworkType.goerli]: {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,
-      }
+      },
     },
     providerConfig: {
       type: NetworkType.goerli,
@@ -326,7 +326,7 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
       [NetworkType.mainnet]: {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,
-      }
+      },
     },
     providerConfig: {
       type: NetworkType.mainnet,
@@ -348,7 +348,7 @@ const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
       [NetworkType['linea-mainnet']]: {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,
-      }
+      },
     },
     providerConfig: {
       type: NetworkType['linea-mainnet'],
@@ -370,7 +370,7 @@ const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
       [NetworkType['linea-goerli']]: {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,
-      }
+      },
     },
     providerConfig: {
       type: NetworkType['linea-goerli'],
@@ -392,7 +392,7 @@ const MOCK_CUSTOM_NETWORK: MockNetwork = {
       'uuid-1': {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,
-      }
+      },
     },
     providerConfig: {
       type: NetworkType.rpc,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -282,7 +282,7 @@ const MOCK_NETWORK: MockNetwork = {
   state: {
     selectedNetworkClientId: NetworkType.goerli,
     networkId: '5',
-    networkMeta: {
+    networksMetadata: {
       [NetworkType.goerli]: {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,
@@ -303,7 +303,7 @@ const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
   state: {
     selectedNetworkClientId: NetworkType.goerli,
     networkId: '5',
-    networkMeta: {
+    networksMetadata: {
       [NetworkType.goerli]: {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,
@@ -322,7 +322,7 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
   state: {
     selectedNetworkClientId: NetworkType.mainnet,
     networkId: '1',
-    networkMeta: {
+    networksMetadata: {
       [NetworkType.mainnet]: {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,
@@ -344,7 +344,7 @@ const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
   state: {
     selectedNetworkClientId: NetworkType['linea-mainnet'],
     networkId: '59144',
-    networkMeta: {
+    networksMetadata: {
       [NetworkType['linea-mainnet']]: {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,
@@ -366,7 +366,7 @@ const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
   state: {
     selectedNetworkClientId: NetworkType['linea-goerli'],
     networkId: '59140',
-    networkMeta: {
+    networksMetadata: {
       [NetworkType['linea-goerli']]: {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,
@@ -388,7 +388,7 @@ const MOCK_CUSTOM_NETWORK: MockNetwork = {
   state: {
     selectedNetworkClientId: 'uuid-1',
     networkId: '11297108109',
-    networkMeta: {
+    networksMetadata: {
       'uuid-1': {
         details: { EIPS: { 1559: false } },
         status: NetworkStatus.Available,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -284,7 +284,7 @@ const MOCK_NETWORK: MockNetwork = {
     networkId: '5',
     networksMetadata: {
       [NetworkType.goerli]: {
-        details: { EIPS: { 1559: false } },
+        EIPS: { 1559: false },
         status: NetworkStatus.Available,
       },
     },
@@ -305,7 +305,7 @@ const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
     networkId: '5',
     networksMetadata: {
       [NetworkType.goerli]: {
-        details: { EIPS: { 1559: false } },
+        EIPS: { 1559: false },
         status: NetworkStatus.Available,
       },
     },
@@ -324,7 +324,7 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
     networkId: '1',
     networksMetadata: {
       [NetworkType.mainnet]: {
-        details: { EIPS: { 1559: false } },
+        EIPS: { 1559: false },
         status: NetworkStatus.Available,
       },
     },
@@ -346,7 +346,7 @@ const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
     networkId: '59144',
     networksMetadata: {
       [NetworkType['linea-mainnet']]: {
-        details: { EIPS: { 1559: false } },
+        EIPS: { 1559: false },
         status: NetworkStatus.Available,
       },
     },
@@ -368,7 +368,7 @@ const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
     networkId: '59140',
     networksMetadata: {
       [NetworkType['linea-goerli']]: {
-        details: { EIPS: { 1559: false } },
+        EIPS: { 1559: false },
         status: NetworkStatus.Available,
       },
     },
@@ -390,7 +390,7 @@ const MOCK_CUSTOM_NETWORK: MockNetwork = {
     networkId: '11297108109',
     networksMetadata: {
       'uuid-1': {
-        details: { EIPS: { 1559: false } },
+        EIPS: { 1559: false },
         status: NetworkStatus.Available,
       },
     },


### PR DESCRIPTION
## Explanation
Fixes: https://github.com/MetaMask/MetaMask-planning/issues/1005
Fixes: #1560 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/network-controller`
- **BREAKING**: NetworkStatus is moved into networkDetails.
- **BREAKING**: Network status and details are no longer on the networkcontroller state root. The same values are retrieved by networkClientId via `networkController.state.networksMetadata[<networkClientId>]`. Most cases can update to use 
`networkController.state.networksMetadata[networkController.state.selectedNetworkClientId]` to get at the status and details in the following shape:
```
{
  status: NetworkStatus,
  EIPS: {
      ...
  }
}
```


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
