### PR TITLE
Add getEncryptionPublicKey on KeyringController

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -452,6 +452,26 @@ describe('KeyringController', () => {
     });
   });
 
+  describe('getEncryptionPublicKey', () => {
+    it('should return the correct encryption public key', async () => {
+      await withController(async ({ controller }) => {
+        const { importedAccountAddress } =
+          await controller.importAccountWithStrategy(
+            AccountImportStrategy.privateKey,
+            [privateKey],
+          );
+
+        const encryptionPublicKey = await controller.getEncryptionPublicKey(
+          importedAccountAddress,
+        );
+
+        expect(encryptionPublicKey).toBe(
+          'ZfKqt4HSy4tt9/WvqP3QrnzbIS04cnV//BhksKbLgVA=',
+        );
+      });
+    });
+  });
+
   describe('getKeyringForAccount', () => {
     describe('when existing account is provided', () => {
       it('should get correct keyring', async () => {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -428,6 +428,21 @@ export class KeyringController extends BaseControllerV2<
   }
 
   /**
+   * Get encryption public key.
+   *
+   * @param account - An account address.
+   * @param opts - Additional encryption options.
+   * @throws If the `account` does not exist or does not support the `getEncryptionPublicKey` method
+   * @returns Promise resolving to encyption public key of the `account` if one exists.
+   */
+  async getEncryptionPublicKey(
+    account: string,
+    opts?: Record<string, unknown>,
+  ): Promise<string> {
+    return this.#keyring.getEncryptionPublicKey(account, opts);
+  }
+
+  /**
    * Returns the currently initialized keyring that manages
    * the specified `address` if one exists.
    *


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* What packages are you updating?
* Are you introducing a breaking change to a package (renaming or removing a part of a public interface)?
-->

This PR adds the `getEncryptionPublicKey` method on `KeyringController`.

This method calls the homonym `EthKeyringController` method, which returns the encryption public key of the specified address.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **ADDED**: `getEncryptionPublicKey` method

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes: #1556

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
