### PR TITLE
Add SKALE Calypso NFT Hub

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -31,6 +31,8 @@ export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID: Record<Hex, string> = {
     '0xD023D153a0DFa485130ECFdE2FAA7e612EF94818',
   [SupportedTokenDetectionNetworks.aurora]:
     '0x1286415D333855237f89Df27D388127181448538',
+  [SupportedTokenDetectionNetworks.calypso_skale]:
+    '0x546753F1B9cd13459DB496C42735a503953668f8',
 };
 
 export const MISSING_PROVIDER_ERROR =

--- a/packages/assets-controllers/src/assetsUtil.test.ts
+++ b/packages/assets-controllers/src/assetsUtil.test.ts
@@ -270,6 +270,14 @@ describe('assetsUtil', () => {
       ).toBe(true);
     });
 
+    it('returns true for the SKALE Calypso NFT Hub network', () => {
+      expect(
+        assetsUtil.isTokenDetectionSupportedForNetwork(
+          assetsUtil.SupportedTokenDetectionNetworks.calypso_skale,
+        ),
+      ).toBe(true);
+    });
+
     it('returns false for testnets such as Goerli', () => {
       expect(assetsUtil.isTokenDetectionSupportedForNetwork(toHex(5))).toBe(
         false,

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -146,6 +146,7 @@ export enum SupportedTokenDetectionNetworks {
   polygon = '0x89', // decimal: 137
   avax = '0xa86a', // decimal: 43114
   aurora = '0x4e454152', // decimal: 1313161554
+  calypso_skale = '0x5d456c62', // decimal: 1564830818
 }
 
 /**


### PR DESCRIPTION
Add support for SKALE Calypso NFT Hub as a network with token detection availability