### PR TITLE
Chainid network configs

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -1,5 +1,6 @@
 import { ControllerMessenger } from '@metamask/base-controller';
 import {
+  BUILT_IN_NETWORKS,
   ChainId,
   IPFS_DEFAULT_GATEWAY_URL,
   NetworkType,
@@ -41,6 +42,7 @@ async function setupControllers() {
     type: NetworkClientType.Infura,
     network: 'mainnet',
     infuraProjectId: '341eacb578dd44a1a049cbc5f6fd4035',
+    chainId: BUILT_IN_NETWORKS.mainnet.chainId,
   } as const;
 
   const messenger: NetworkControllerMessenger =
@@ -817,6 +819,7 @@ describe('AssetsContractController', () => {
     });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration: {
+        chainId: BUILT_IN_NETWORKS.sepolia.chainId,
         type: NetworkClientType.Infura,
         network: 'sepolia',
         infuraProjectId: networkClientConfiguration.infuraProjectId,

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1231,14 +1231,21 @@ export class NetworkController extends BaseControllerV2<
     });
   }
 
-  findNetworkClientIdByChainId(chainId: ChainId) {
+  /**
+   * Searches for a network configuration ID with the given ChainID and returns it.
+   * @param chainId ChainId to search for
+   * @returns networkClientId of the network configuration with the given chainId
+   */
+  findNetworkClientIdByChainId(chainId: Hex): NetworkClientId {
     const networkClients = this.getNetworkClientRegistry();
     const networkConfigurationIndex = Object.values(networkClients).findIndex(
       (networkClient) => {
         return networkClient.configuration.chainId === chainId;
       },
     );
-    if (networkConfigurationIndex === -1) { return null; }
+    if (networkConfigurationIndex === -1) {
+      throw new Error("Couldn't find networkClientId for chainId");
+    }
     return Object.keys(networkClients)[networkConfigurationIndex];
   }
 
@@ -1313,7 +1320,7 @@ export class NetworkController extends BaseControllerV2<
         type: NetworkClientType.Infura,
         network,
         infuraProjectId: this.#infuraProjectId,
-        chainId: BUILT_IN_NETWORKS[network].chainId
+        chainId: BUILT_IN_NETWORKS[network].chainId,
       };
       return [
         NetworkClientType.Infura,

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1239,15 +1239,13 @@ export class NetworkController extends BaseControllerV2<
    */
   findNetworkClientIdByChainId(chainId: Hex): NetworkClientId {
     const networkClients = this.getNetworkClientRegistry();
-    const networkConfigurationIndex = Object.values(networkClients).findIndex(
-      (networkClient) => {
-        return networkClient.configuration.chainId === chainId;
-      },
+    const networkClientId = Object.entries(networkClients).find(
+      ([_, networkClient]) => networkClient.configuration.chainId === chainId,
     );
-    if (networkConfigurationIndex === -1) {
+    if (networkClientId === undefined) {
       throw new Error("Couldn't find networkClientId for chainId");
     }
-    return Object.keys(networkClients)[networkConfigurationIndex];
+    return networkClientId[0];
   }
 
   /**

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1233,7 +1233,8 @@ export class NetworkController extends BaseControllerV2<
 
   /**
    * Searches for a network configuration ID with the given ChainID and returns it.
-   * @param chainId ChainId to search for
+   *
+   * @param chainId - ChainId to search for
    * @returns networkClientId of the network configuration with the given chainId
    */
   findNetworkClientIdByChainId(chainId: Hex): NetworkClientId {

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1231,6 +1231,17 @@ export class NetworkController extends BaseControllerV2<
     });
   }
 
+  findNetworkClientIdByChainId(chainId: ChainId) {
+    const networkClients = this.getNetworkClientRegistry();
+    const networkConfigurationIndex = Object.values(networkClients).findIndex(
+      (networkClient) => {
+        return networkClient.configuration.chainId === chainId;
+      },
+    );
+    if (networkConfigurationIndex === -1) { return null; }
+    return Object.keys(networkClients)[networkConfigurationIndex];
+  }
+
   /**
    * Before accessing or switching the network, the registry of network clients
    * needs to be populated. Otherwise, `#applyNetworkSelection` and
@@ -1302,6 +1313,7 @@ export class NetworkController extends BaseControllerV2<
         type: NetworkClientType.Infura,
         network,
         infuraProjectId: this.#infuraProjectId,
+        chainId: BUILT_IN_NETWORKS[network].chainId
       };
       return [
         NetworkClientType.Infura,

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1239,13 +1239,13 @@ export class NetworkController extends BaseControllerV2<
    */
   findNetworkClientIdByChainId(chainId: Hex): NetworkClientId {
     const networkClients = this.getNetworkClientRegistry();
-    const networkClientId = Object.entries(networkClients).find(
+    const networkClientEntry = Object.entries(networkClients).find(
       ([_, networkClient]) => networkClient.configuration.chainId === chainId,
     );
-    if (networkClientId === undefined) {
+    if (networkClientEntry === undefined) {
       throw new Error("Couldn't find networkClientId for chainId");
     }
-    return networkClientId[0];
+    return networkClientEntry[0];
   }
 
   /**

--- a/packages/network-controller/src/create-auto-managed-network-client.test.ts
+++ b/packages/network-controller/src/create-auto-managed-network-client.test.ts
@@ -1,4 +1,4 @@
-import { NetworkType } from '@metamask/controller-utils';
+import { BUILT_IN_NETWORKS, NetworkType } from '@metamask/controller-utils';
 import { promisify } from 'util';
 
 import { createAutoManagedNetworkClient } from './create-auto-managed-network-client';
@@ -23,6 +23,7 @@ describe('createAutoManagedNetworkClient', () => {
     {
       type: NetworkClientType.Infura,
       network: NetworkType.mainnet,
+      chainId: BUILT_IN_NETWORKS[NetworkType.mainnet].chainId,
       infuraProjectId: 'some-infura-project-id',
     } as const,
   ];

--- a/packages/network-controller/src/types.ts
+++ b/packages/network-controller/src/types.ts
@@ -30,6 +30,7 @@ export type CustomNetworkClientConfiguration = {
  * network.
  */
 export type InfuraNetworkClientConfiguration = {
+  chainId?: Hex;
   network: InfuraNetworkType;
   infuraProjectId: string;
   type: NetworkClientType.Infura;

--- a/packages/network-controller/src/types.ts
+++ b/packages/network-controller/src/types.ts
@@ -30,7 +30,7 @@ export type CustomNetworkClientConfiguration = {
  * network.
  */
 export type InfuraNetworkClientConfiguration = {
-  chainId?: Hex;
+  chainId: Hex;
   network: InfuraNetworkType;
   infuraProjectId: string;
   type: NetworkClientType.Infura;

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -311,7 +311,7 @@ describe('NetworkController', () => {
                 network: networkType,
                 infuraProjectId: 'some-infura-project-id',
                 type: NetworkClientType.Infura,
-                chainId: BUILT_IN_NETWORKS[networkType].chainId
+                chainId: BUILT_IN_NETWORKS[networkType].chainId,
               });
               expect(createNetworkClientMock).toHaveBeenCalledTimes(1);
             },
@@ -977,7 +977,7 @@ describe('NetworkController', () => {
                   network: networkType,
                   infuraProjectId: 'some-infura-project-id',
                   type: NetworkClientType.Infura,
-                  chainId: BUILT_IN_NETWORKS[networkType].chainId
+                  chainId: BUILT_IN_NETWORKS[networkType].chainId,
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
@@ -1065,7 +1065,7 @@ describe('NetworkController', () => {
                 network: NetworkType.goerli,
                 infuraProjectId: 'some-infura-project-id',
                 type: NetworkClientType.Infura,
-                chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId
+                chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId,
               })
               .mockReturnValue(fakeNetworkClients[0])
               .calledWith({
@@ -1120,6 +1120,25 @@ describe('NetworkController', () => {
 
             expect(networkClient).toBe(
               networkClientRegistry[NetworkType.mainnet],
+            );
+          },
+        );
+      });
+
+      it('returns a valid built-in Infura NetworkClient with a chainId in configuration', async () => {
+        await withController(
+          { infuraProjectId: 'some-infura-project-id' },
+          async ({ controller }) => {
+            const fakeNetworkClient = buildFakeClient();
+            mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
+
+            const networkClientRegistry = controller.getNetworkClientRegistry();
+            const networkClient = controller.getNetworkClientById(
+              NetworkType.mainnet,
+            );
+
+            expect(networkClient.configuration.chainId).toBe(
+              '0x1',
             );
           },
         );
@@ -1223,6 +1242,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId,
                   network: InfuraNetworkType.goerli,
                 },
               ],
@@ -1231,6 +1251,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType['linea-goerli']].chainId,
                   network: InfuraNetworkType['linea-goerli'],
                 },
               ],
@@ -1239,6 +1260,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType['linea-mainnet']].chainId,
                   network: InfuraNetworkType['linea-mainnet'],
                 },
               ],
@@ -1247,6 +1269,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.mainnet].chainId,
                   network: InfuraNetworkType.mainnet,
                 },
               ],
@@ -1255,6 +1278,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.sepolia].chainId,
                   network: InfuraNetworkType.sepolia,
                 },
               ],
@@ -1327,6 +1351,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId,
                   network: InfuraNetworkType.goerli,
                 },
               ],
@@ -1335,6 +1360,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType['linea-goerli']].chainId,
                   network: InfuraNetworkType['linea-goerli'],
                 },
               ],
@@ -1343,6 +1369,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType['linea-mainnet']].chainId,
                   network: InfuraNetworkType['linea-mainnet'],
                 },
               ],
@@ -1351,6 +1378,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.mainnet].chainId,
                   network: InfuraNetworkType.mainnet,
                 },
               ],
@@ -1359,6 +1387,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.sepolia].chainId,
                   network: InfuraNetworkType.sepolia,
                 },
               ],
@@ -1412,6 +1441,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                   network: InfuraNetworkType.goerli,
                 },
               ],
@@ -1420,6 +1450,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType['linea-goerli']].chainId,
                   network: InfuraNetworkType['linea-goerli'],
                 },
               ],
@@ -1428,6 +1459,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType['linea-mainnet']].chainId,
                   network: InfuraNetworkType['linea-mainnet'],
                 },
               ],
@@ -1436,6 +1468,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType.mainnet].chainId,
                   network: InfuraNetworkType.mainnet,
                 },
               ],
@@ -1444,6 +1477,7 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType.sepolia].chainId,
                   network: InfuraNetworkType.sepolia,
                 },
               ],
@@ -1510,6 +1544,7 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId: BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                       network: InfuraNetworkType.goerli,
                     },
                   ],
@@ -1526,6 +1561,7 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId: BUILT_IN_NETWORKS[InfuraNetworkType['linea-goerli']].chainId,
                       network: InfuraNetworkType['linea-goerli'],
                     },
                   ],
@@ -1534,6 +1570,7 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId: BUILT_IN_NETWORKS[InfuraNetworkType['linea-mainnet']].chainId,
                       network: InfuraNetworkType['linea-mainnet'],
                     },
                   ],
@@ -1542,6 +1579,7 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId: BUILT_IN_NETWORKS[InfuraNetworkType.mainnet].chainId,
                       network: InfuraNetworkType.mainnet,
                     },
                   ],
@@ -1550,6 +1588,7 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId: BUILT_IN_NETWORKS[InfuraNetworkType.sepolia].chainId,
                       network: InfuraNetworkType.sepolia,
                     },
                   ],
@@ -1614,6 +1653,8 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                       network: InfuraNetworkType.goerli,
                     },
                   ],
@@ -1622,6 +1663,9 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType['linea-goerli']]
+                          .chainId,
                       network: InfuraNetworkType['linea-goerli'],
                     },
                   ],
@@ -1630,6 +1674,9 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType['linea-mainnet']]
+                          .chainId,
                       network: InfuraNetworkType['linea-mainnet'],
                     },
                   ],
@@ -1637,6 +1684,8 @@ describe('NetworkController', () => {
                     'mainnet',
                     {
                       type: NetworkClientType.Infura,
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType.mainnet].chainId,
                       infuraProjectId: 'some-infura-project-id',
                       network: InfuraNetworkType.mainnet,
                     },
@@ -1646,6 +1695,8 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType.sepolia].chainId,
                       network: InfuraNetworkType.sepolia,
                     },
                   ],
@@ -1701,7 +1752,7 @@ describe('NetworkController', () => {
                     'AAAA-AAAA-AAAA-AAAA',
                     {
                       type: NetworkClientType.Custom,
-                      chainId: toHex(1),
+                      chainId: '0x1',
                       rpcUrl: 'https://test.network',
                     },
                   ],
@@ -1710,6 +1761,8 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                       network: InfuraNetworkType.goerli,
                     },
                   ],
@@ -1718,6 +1771,9 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType['linea-goerli']]
+                          .chainId,
                       network: InfuraNetworkType['linea-goerli'],
                     },
                   ],
@@ -1726,6 +1782,9 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType['linea-mainnet']]
+                          .chainId,
                       network: InfuraNetworkType['linea-mainnet'],
                     },
                   ],
@@ -1733,6 +1792,8 @@ describe('NetworkController', () => {
                     'mainnet',
                     {
                       type: NetworkClientType.Infura,
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType.mainnet].chainId,
                       infuraProjectId: 'some-infura-project-id',
                       network: InfuraNetworkType.mainnet,
                     },
@@ -1742,6 +1803,8 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType.sepolia].chainId,
                       network: InfuraNetworkType.sepolia,
                     },
                   ],
@@ -1793,7 +1856,6 @@ describe('NetworkController', () => {
                     return networkClientId1.localeCompare(networkClientId2);
                   },
                 );
-
               expect(simplifiedNetworkClients).toStrictEqual([
                 [
                   'AAAA-AAAA-AAAA-AAAA',
@@ -1808,6 +1870,8 @@ describe('NetworkController', () => {
                   {
                     type: NetworkClientType.Infura,
                     infuraProjectId: 'some-infura-project-id',
+                    chainId:
+                      BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                     network: InfuraNetworkType.goerli,
                   },
                 ],
@@ -1816,6 +1880,9 @@ describe('NetworkController', () => {
                   {
                     type: NetworkClientType.Infura,
                     infuraProjectId: 'some-infura-project-id',
+                    chainId:
+                      BUILT_IN_NETWORKS[InfuraNetworkType['linea-goerli']]
+                        .chainId,
                     network: InfuraNetworkType['linea-goerli'],
                   },
                 ],
@@ -1824,6 +1891,9 @@ describe('NetworkController', () => {
                   {
                     type: NetworkClientType.Infura,
                     infuraProjectId: 'some-infura-project-id',
+                    chainId:
+                      BUILT_IN_NETWORKS[InfuraNetworkType['linea-mainnet']]
+                        .chainId,
                     network: InfuraNetworkType['linea-mainnet'],
                   },
                 ],
@@ -1831,6 +1901,8 @@ describe('NetworkController', () => {
                   'mainnet',
                   {
                     type: NetworkClientType.Infura,
+                    chainId:
+                      BUILT_IN_NETWORKS[InfuraNetworkType.mainnet].chainId,
                     infuraProjectId: 'some-infura-project-id',
                     network: InfuraNetworkType.mainnet,
                   },
@@ -1840,6 +1912,8 @@ describe('NetworkController', () => {
                   {
                     type: NetworkClientType.Infura,
                     infuraProjectId: 'some-infura-project-id',
+                    chainId:
+                      BUILT_IN_NETWORKS[InfuraNetworkType.sepolia].chainId,
                     network: InfuraNetworkType.sepolia,
                   },
                 ],
@@ -1943,6 +2017,7 @@ describe('NetworkController', () => {
                       network: networkType,
                       infuraProjectId: 'some-infura-project-id',
                       type: NetworkClientType.Infura,
+                      chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
@@ -2055,6 +2130,7 @@ describe('NetworkController', () => {
                       network: networkType,
                       infuraProjectId: 'some-infura-project-id',
                       type: NetworkClientType.Infura,
+                      chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
@@ -2175,6 +2251,7 @@ describe('NetworkController', () => {
                       network: networkType,
                       infuraProjectId: 'some-infura-project-id',
                       type: NetworkClientType.Infura,
+                      chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
@@ -2286,6 +2363,7 @@ describe('NetworkController', () => {
                       network: networkType,
                       infuraProjectId: 'some-infura-project-id',
                       type: NetworkClientType.Infura,
+                      chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
@@ -2403,6 +2481,7 @@ describe('NetworkController', () => {
                       network: networkType,
                       infuraProjectId: 'some-infura-project-id',
                       type: NetworkClientType.Infura,
+                      chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
@@ -2515,6 +2594,7 @@ describe('NetworkController', () => {
                       network: networkType,
                       infuraProjectId: 'some-infura-project-id',
                       type: NetworkClientType.Infura,
+                      chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
@@ -2635,6 +2715,7 @@ describe('NetworkController', () => {
                       network: networkType,
                       infuraProjectId: 'some-infura-project-id',
                       type: NetworkClientType.Infura,
+                      chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     })
                     .mockReturnValue(fakeNetworkClients[0])
                     .calledWith({
@@ -2745,6 +2826,7 @@ describe('NetworkController', () => {
                     .calledWith({
                       network: networkType,
                       infuraProjectId: 'some-infura-project-id',
+                      chainId: BUILT_IN_NETWORKS[networkType].chainId,
                       type: NetworkClientType.Infura,
                     })
                     .mockReturnValue(fakeNetworkClients[0])
@@ -2877,6 +2959,7 @@ describe('NetworkController', () => {
                   network: NetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
                   type: NetworkClientType.Infura,
+                  chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId,
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
@@ -2981,6 +3064,7 @@ describe('NetworkController', () => {
                 .calledWith({
                   network: NetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId,
                   type: NetworkClientType.Infura,
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
@@ -3095,6 +3179,7 @@ describe('NetworkController', () => {
                 .calledWith({
                   network: NetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId,
                   type: NetworkClientType.Infura,
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
@@ -3197,6 +3282,7 @@ describe('NetworkController', () => {
                 .calledWith({
                   network: NetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId,
                   type: NetworkClientType.Infura,
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
@@ -3299,6 +3385,7 @@ describe('NetworkController', () => {
                 .calledWith({
                   network: NetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId,
                   type: NetworkClientType.Infura,
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
@@ -3404,6 +3491,7 @@ describe('NetworkController', () => {
                 .calledWith({
                   network: NetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId,
                   type: NetworkClientType.Infura,
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
@@ -3518,6 +3606,7 @@ describe('NetworkController', () => {
                 .calledWith({
                   network: NetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId,
                   type: NetworkClientType.Infura,
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
@@ -3624,6 +3713,7 @@ describe('NetworkController', () => {
                 .calledWith({
                   network: NetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId,
                   type: NetworkClientType.Infura,
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
@@ -5784,6 +5874,7 @@ describe('NetworkController', () => {
                   .calledWith({
                     network: networkType,
                     infuraProjectId: 'some-infura-project-id',
+                    chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     type: NetworkClientType.Infura,
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
@@ -5860,6 +5951,7 @@ describe('NetworkController', () => {
                   .mockReturnValue(fakeNetworkClients[0])
                   .calledWith({
                     network: networkType,
+                    chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     infuraProjectId: 'some-infura-project-id',
                     type: NetworkClientType.Infura,
                   })
@@ -5940,6 +6032,7 @@ describe('NetworkController', () => {
                   .calledWith({
                     network: networkType,
                     infuraProjectId: 'some-infura-project-id',
+                    chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     type: NetworkClientType.Infura,
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
@@ -5999,6 +6092,7 @@ describe('NetworkController', () => {
                   .calledWith({
                     network: networkType,
                     infuraProjectId: 'some-infura-project-id',
+                    chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     type: NetworkClientType.Infura,
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
@@ -6059,6 +6153,7 @@ describe('NetworkController', () => {
                   .calledWith({
                     network: networkType,
                     infuraProjectId: 'some-infura-project-id',
+                    chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     type: NetworkClientType.Infura,
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
@@ -6135,6 +6230,7 @@ describe('NetworkController', () => {
                   .calledWith({
                     network: networkType,
                     infuraProjectId: 'some-infura-project-id',
+                    chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     type: NetworkClientType.Infura,
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
@@ -6216,6 +6312,7 @@ describe('NetworkController', () => {
                   .calledWith({
                     network: networkType,
                     infuraProjectId: 'some-infura-project-id',
+                    chainId: BUILT_IN_NETWORKS[networkType].chainId,
                     type: NetworkClientType.Infura,
                   })
                   .mockReturnValue(fakeNetworkClients[1]);
@@ -6334,6 +6431,7 @@ describe('NetworkController', () => {
                   network: InfuraNetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
                   type: NetworkClientType.Infura,
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
                 .calledWith({
@@ -6411,6 +6509,7 @@ describe('NetworkController', () => {
                   network: InfuraNetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
                   type: NetworkClientType.Infura,
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
                 .calledWith({
@@ -6488,6 +6587,7 @@ describe('NetworkController', () => {
                   network: InfuraNetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
                   type: NetworkClientType.Infura,
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
                 .calledWith({
@@ -6538,6 +6638,7 @@ describe('NetworkController', () => {
                   network: InfuraNetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
                   type: NetworkClientType.Infura,
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
                 .calledWith({
@@ -6581,6 +6682,7 @@ describe('NetworkController', () => {
                 .calledWith({
                   network: InfuraNetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                   type: NetworkClientType.Infura,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
@@ -6650,6 +6752,7 @@ describe('NetworkController', () => {
                 .calledWith({
                   network: InfuraNetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                   type: NetworkClientType.Infura,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
@@ -6719,6 +6822,7 @@ describe('NetworkController', () => {
                 .calledWith({
                   network: InfuraNetworkType.goerli,
                   infuraProjectId: 'some-infura-project-id',
+                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                   type: NetworkClientType.Infura,
                 })
                 .mockReturnValue(fakeNetworkClients[0])
@@ -6840,17 +6944,20 @@ function mockCreateNetworkClientWithDefaultsForBuiltInNetworkClients({
       network: NetworkType.mainnet,
       infuraProjectId,
       type: NetworkClientType.Infura,
+      chainId: BUILT_IN_NETWORKS[InfuraNetworkType.mainnet].chainId,
     })
     .mockReturnValue(builtInNetworkClient)
     .calledWith({
       network: NetworkType.goerli,
       infuraProjectId,
+      chainId: BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
       type: NetworkClientType.Infura,
     })
     .mockReturnValue(builtInNetworkClient)
     .calledWith({
       network: NetworkType.sepolia,
       infuraProjectId,
+      chainId: BUILT_IN_NETWORKS[InfuraNetworkType.sepolia].chainId,
       type: NetworkClientType.Infura,
     })
     .mockReturnValue(builtInNetworkClient);
@@ -7048,6 +7155,7 @@ function refreshNetworkTests({
           expect(createNetworkClientMock).toHaveBeenCalledWith({
             network: expectedProviderConfig.type,
             infuraProjectId: 'infura-project-id',
+            chainId: BUILT_IN_NETWORKS[expectedProviderConfig.type].chainId,
             type: NetworkClientType.Infura,
           });
           const { provider } = controller.getProviderAndBlockTracker();
@@ -7092,6 +7200,9 @@ function refreshNetworkTests({
             : {
                 network: controller.state.providerConfig.type,
                 infuraProjectId: 'infura-project-id',
+                chainId:
+                  BUILT_IN_NETWORKS[controller.state.providerConfig.type]
+                    .chainId,
                 type: NetworkClientType.Infura,
               };
         const operationNetworkClientOptions: Parameters<
@@ -7107,6 +7218,7 @@ function refreshNetworkTests({
             : {
                 network: expectedProviderConfig.type,
                 infuraProjectId: 'infura-project-id',
+                chainId: BUILT_IN_NETWORKS[expectedProviderConfig.type].chainId,
                 type: NetworkClientType.Infura,
               };
         mockCreateNetworkClient()

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -1104,6 +1104,34 @@ describe('NetworkController', () => {
     });
   });
 
+  describe('findNetworkConfigurationByChainId', () => {
+    it('returns the network configuration for the given chainId', async () => {
+      await withController(
+        { infuraProjectId: 'some-infura-project-id' },
+        async ({ controller }) => {
+          const fakeNetworkClient = buildFakeClient();
+          mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
+
+          const networkClientId = controller.findNetworkClientIdByChainId("0x1");
+          expect(networkClientId).toBe('mainnet');
+        },
+      );
+    });
+
+    it('throws if the chainId doesnt exist in the configuration', async () => {
+      await withController(
+        { infuraProjectId: 'some-infura-project-id' },
+        async ({ controller }) => {
+          const fakeNetworkClient = buildFakeClient();
+          mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
+          expect(() => controller.findNetworkClientIdByChainId("0xdeadbeef")).toThrowError(
+            "Couldn't find networkClientId for chainId"
+          );
+        },
+      );
+    });
+  })
+
   describe('getNetworkClientById', () => {
     describe('If passed an existing networkClientId', () => {
       it('returns a valid built-in Infura NetworkClient', async () => {
@@ -1137,9 +1165,8 @@ describe('NetworkController', () => {
               NetworkType.mainnet,
             );
 
-            expect(networkClient.configuration.chainId).toBe(
-              '0x1',
-            );
+            expect(networkClient.configuration.chainId).toBe('0x1');
+            expect(networkClientRegistry.mainnet.configuration.chainId).toBe('0x1');
           },
         );
       });
@@ -1251,7 +1278,8 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
-                  chainId: BUILT_IN_NETWORKS[NetworkType['linea-goerli']].chainId,
+                  chainId:
+                    BUILT_IN_NETWORKS[NetworkType['linea-goerli']].chainId,
                   network: InfuraNetworkType['linea-goerli'],
                 },
               ],
@@ -1260,7 +1288,8 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
-                  chainId: BUILT_IN_NETWORKS[NetworkType['linea-mainnet']].chainId,
+                  chainId:
+                    BUILT_IN_NETWORKS[NetworkType['linea-mainnet']].chainId,
                   network: InfuraNetworkType['linea-mainnet'],
                 },
               ],
@@ -1360,7 +1389,8 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
-                  chainId: BUILT_IN_NETWORKS[NetworkType['linea-goerli']].chainId,
+                  chainId:
+                    BUILT_IN_NETWORKS[NetworkType['linea-goerli']].chainId,
                   network: InfuraNetworkType['linea-goerli'],
                 },
               ],
@@ -1369,7 +1399,8 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
-                  chainId: BUILT_IN_NETWORKS[NetworkType['linea-mainnet']].chainId,
+                  chainId:
+                    BUILT_IN_NETWORKS[NetworkType['linea-mainnet']].chainId,
                   network: InfuraNetworkType['linea-mainnet'],
                 },
               ],
@@ -1450,7 +1481,9 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
-                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType['linea-goerli']].chainId,
+                  chainId:
+                    BUILT_IN_NETWORKS[InfuraNetworkType['linea-goerli']]
+                      .chainId,
                   network: InfuraNetworkType['linea-goerli'],
                 },
               ],
@@ -1459,7 +1492,9 @@ describe('NetworkController', () => {
                 {
                   type: NetworkClientType.Infura,
                   infuraProjectId: 'some-infura-project-id',
-                  chainId: BUILT_IN_NETWORKS[InfuraNetworkType['linea-mainnet']].chainId,
+                  chainId:
+                    BUILT_IN_NETWORKS[InfuraNetworkType['linea-mainnet']]
+                      .chainId,
                   network: InfuraNetworkType['linea-mainnet'],
                 },
               ],
@@ -1544,7 +1579,8 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
-                      chainId: BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType.goerli].chainId,
                       network: InfuraNetworkType.goerli,
                     },
                   ],
@@ -1561,7 +1597,9 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
-                      chainId: BUILT_IN_NETWORKS[InfuraNetworkType['linea-goerli']].chainId,
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType['linea-goerli']]
+                          .chainId,
                       network: InfuraNetworkType['linea-goerli'],
                     },
                   ],
@@ -1570,7 +1608,9 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
-                      chainId: BUILT_IN_NETWORKS[InfuraNetworkType['linea-mainnet']].chainId,
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType['linea-mainnet']]
+                          .chainId,
                       network: InfuraNetworkType['linea-mainnet'],
                     },
                   ],
@@ -1579,7 +1619,8 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
-                      chainId: BUILT_IN_NETWORKS[InfuraNetworkType.mainnet].chainId,
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType.mainnet].chainId,
                       network: InfuraNetworkType.mainnet,
                     },
                   ],
@@ -1588,7 +1629,8 @@ describe('NetworkController', () => {
                     {
                       type: NetworkClientType.Infura,
                       infuraProjectId: 'some-infura-project-id',
-                      chainId: BUILT_IN_NETWORKS[InfuraNetworkType.sepolia].chainId,
+                      chainId:
+                        BUILT_IN_NETWORKS[InfuraNetworkType.sepolia].chainId,
                       network: InfuraNetworkType.sepolia,
                     },
                   ],

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -1797,7 +1797,7 @@ describe('NetworkController', () => {
                     'AAAA-AAAA-AAAA-AAAA',
                     {
                       type: NetworkClientType.Custom,
-                      chainId: '0x1',
+                      chainId: toHex(1),
                       rpcUrl: 'https://test.network',
                     },
                   ],

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -1901,6 +1901,7 @@ describe('NetworkController', () => {
                     return networkClientId1.localeCompare(networkClientId2);
                   },
                 );
+
               expect(simplifiedNetworkClients).toStrictEqual([
                 [
                   'AAAA-AAAA-AAAA-AAAA',

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -1112,7 +1112,8 @@ describe('NetworkController', () => {
           const fakeNetworkClient = buildFakeClient();
           mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
 
-          const networkClientId = controller.findNetworkClientIdByChainId("0x1");
+          const networkClientId =
+            controller.findNetworkClientIdByChainId('0x1');
           expect(networkClientId).toBe('mainnet');
         },
       );
@@ -1124,13 +1125,13 @@ describe('NetworkController', () => {
         async ({ controller }) => {
           const fakeNetworkClient = buildFakeClient();
           mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
-          expect(() => controller.findNetworkClientIdByChainId("0xdeadbeef")).toThrowError(
-            "Couldn't find networkClientId for chainId"
-          );
+          expect(() =>
+            controller.findNetworkClientIdByChainId('0xdeadbeef'),
+          ).toThrow("Couldn't find networkClientId for chainId");
         },
       );
     });
-  })
+  });
 
   describe('getNetworkClientById', () => {
     describe('If passed an existing networkClientId', () => {
@@ -1166,7 +1167,9 @@ describe('NetworkController', () => {
             );
 
             expect(networkClient.configuration.chainId).toBe('0x1');
-            expect(networkClientRegistry.mainnet.configuration.chainId).toBe('0x1');
+            expect(networkClientRegistry.mainnet.configuration.chainId).toBe(
+              '0x1',
+            );
           },
         );
       });

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -311,6 +311,7 @@ describe('NetworkController', () => {
                 network: networkType,
                 infuraProjectId: 'some-infura-project-id',
                 type: NetworkClientType.Infura,
+                chainId: BUILT_IN_NETWORKS[networkType].chainId
               });
               expect(createNetworkClientMock).toHaveBeenCalledTimes(1);
             },
@@ -976,6 +977,7 @@ describe('NetworkController', () => {
                   network: networkType,
                   infuraProjectId: 'some-infura-project-id',
                   type: NetworkClientType.Infura,
+                  chainId: BUILT_IN_NETWORKS[networkType].chainId
                 })
                 .mockReturnValue(fakeNetworkClients[1]);
               await controller.initializeProvider();
@@ -1063,6 +1065,7 @@ describe('NetworkController', () => {
                 network: NetworkType.goerli,
                 infuraProjectId: 'some-infura-project-id',
                 type: NetworkClientType.Infura,
+                chainId: BUILT_IN_NETWORKS[NetworkType.goerli].chainId
               })
               .mockReturnValue(fakeNetworkClients[0])
               .calledWith({

--- a/packages/network-controller/tests/provider-api-tests/helpers.ts
+++ b/packages/network-controller/tests/provider-api-tests/helpers.ts
@@ -1,5 +1,6 @@
 import type { JSONRPCResponse } from '@json-rpc-specification/meta-schema';
 import type { InfuraNetworkType } from '@metamask/controller-utils';
+import { BUILT_IN_NETWORKS } from '@metamask/controller-utils';
 import EthQuery from '@metamask/eth-query';
 import type { Hex } from '@metamask/utils';
 import nock from 'nock';
@@ -443,6 +444,7 @@ export async function withNetworkClient(
           network: infuraNetwork,
           infuraProjectId: MOCK_INFURA_PROJECT_ID,
           type: NetworkClientType.Infura,
+          chainId: BUILT_IN_NETWORKS[infuraNetwork].chainId,
         })
       : createNetworkClient({
           chainId: customChainId,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -6,6 +6,7 @@ import {
   NetworkType,
   NetworksTicker,
   toHex,
+  BUILT_IN_NETWORKS,
 } from '@metamask/controller-utils';
 import type {
   BlockTracker,
@@ -1234,6 +1235,7 @@ describe('TransactionController', () => {
       const controller = newController({ network: MOCK_MAINNET_NETWORK });
       mockNetwork({
         networkClientConfiguration: {
+          chainId: BUILT_IN_NETWORKS.mainnet.chainId,
           type: NetworkClientType.Infura,
           network: 'mainnet',
           infuraProjectId: INFURA_PROJECT_ID,
@@ -1272,6 +1274,7 @@ describe('TransactionController', () => {
       const controller = newController({ network: MOCK_MAINNET_NETWORK });
       mockNetwork({
         networkClientConfiguration: {
+          chainId: BUILT_IN_NETWORKS.mainnet.chainId,
           type: NetworkClientType.Infura,
           network: 'mainnet',
           infuraProjectId: INFURA_PROJECT_ID,


### PR DESCRIPTION
## Explanation
Adding chainId to the network configurations allows other code to treat the configurations as the same wether they are infura or a custom network.

As a result it simplifies the implementation for `findNetworkClientIdByChainId`.

We need `findNetworkClientIdByChainId` because the dapp API accepts chainId via `switchEthereumChain` and possibly caip-27 in the future. We need a way to map from chainId to networkClientId. If there are multiple networkClientIds for a given chainId we just naively return the first one. 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->
* Related to https://github.com/MetaMask/MetaMask-planning/issues/1006

## Changelog


<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/network-controller`

- **ADDED**: `findNetworkClientIdByChainId`
- **ADDED**: chainId to built-in network configurations

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
