### PR TITLE
Adds a support of wiping transactions with specific address on current chain

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -220,7 +220,7 @@ function waitForTransactionFinished(
   });
 }
 
-const MOCK_PRFERENCES = { state: { selectedAddress: 'foo' } };
+const MOCK_PREFERENCES = { state: { selectedAddress: 'foo' } };
 const INFURA_PROJECT_ID = '341eacb578dd44a1a049cbc5f6fd4035';
 const GOERLI_PROVIDER = new HttpProvider(
   `https://goerli.infura.io/v3/${INFURA_PROJECT_ID}`,
@@ -1038,7 +1038,7 @@ describe('TransactionController', () => {
       controller.wipeTransactions();
 
       controller.state.transactions.push({
-        from: MOCK_PRFERENCES.state.selectedAddress,
+        from: MOCK_PREFERENCES.state.selectedAddress,
         id: 'foo',
         networkID: '5',
         status: TransactionStatus.submitted,
@@ -1050,7 +1050,7 @@ describe('TransactionController', () => {
       expect(controller.state.transactions).toHaveLength(0);
     });
 
-    it('removes only txs from given address on current network', async () => {
+    it('removes only txs with given address on current network', async () => {
       const controller = newController();
 
       controller.wipeTransactions();
@@ -1111,7 +1111,7 @@ describe('TransactionController', () => {
       const controller = newController();
 
       controller.state.transactions.push({
-        from: MOCK_PRFERENCES.state.selectedAddress,
+        from: MOCK_PREFERENCES.state.selectedAddress,
         id: 'foo',
         networkID: '5',
         chainId: toHex(5),
@@ -1137,7 +1137,7 @@ describe('TransactionController', () => {
       const controller = newController();
 
       controller.state.transactions.push({
-        from: MOCK_PRFERENCES.state.selectedAddress,
+        from: MOCK_PREFERENCES.state.selectedAddress,
         id: 'foo',
         networkID: '5',
         status: TransactionStatus.submitted,
@@ -1160,7 +1160,7 @@ describe('TransactionController', () => {
       const controller = newController();
 
       controller.state.transactions.push({
-        from: MOCK_PRFERENCES.state.selectedAddress,
+        from: MOCK_PREFERENCES.state.selectedAddress,
         id: 'foo',
         networkID: '5',
         status: TransactionStatus.submitted,
@@ -1177,7 +1177,7 @@ describe('TransactionController', () => {
       const controller = newController();
 
       controller.state.transactions.push({
-        from: MOCK_PRFERENCES.state.selectedAddress,
+        from: MOCK_PREFERENCES.state.selectedAddress,
         id: 'foo',
         networkID: '5',
         chainId: toHex(5),

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1075,7 +1075,7 @@ describe('TransactionController', () => {
         },
       } as any);
 
-      controller.wipeTransactions(false, mockFromAccount2);
+      controller.wipeTransactions(true, mockFromAccount2);
 
       expect(controller.state.transactions).toHaveLength(1);
       expect(controller.state.transactions[0].id).toBe('1');

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1049,6 +1049,61 @@ describe('TransactionController', () => {
 
       expect(controller.state.transactions).toHaveLength(0);
     });
+
+    it('removes only txs from given address on current network', async () => {
+      const controller = newController();
+
+      controller.wipeTransactions();
+
+      const mockFromAccount1 = '0x1bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      const mockFromAccount2 = '0x2bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      const mockDifferentChainId = toHex(1);
+      const mockCurrentChainId = toHex(5);
+
+      controller.state.transactions.push({
+        id: '1',
+        chainId: mockCurrentChainId,
+        transaction: {
+          from: mockFromAccount1,
+        },
+      } as any);
+
+      controller.state.transactions.push({
+        id: '2',
+        chainId: mockCurrentChainId,
+        transaction: {
+          from: mockFromAccount2,
+        },
+      } as any);
+
+      controller.state.transactions.push({
+        id: '3',
+        chainId: mockCurrentChainId,
+        transaction: {
+          from: mockFromAccount2,
+        },
+      } as any);
+
+      controller.state.transactions.push({
+        id: '4',
+        chainId: mockDifferentChainId,
+        transaction: {
+          from: mockFromAccount2,
+        },
+      } as any);
+
+      controller.wipeTransactions(false, mockFromAccount2);
+
+      const remainingTxsOnCurrentChain = controller.state.transactions.filter(
+        (tx) => tx.chainId === mockCurrentChainId,
+      );
+      const remainingTxsOnDifferentChain = controller.state.transactions.filter(
+        (tx) => tx.chainId === mockDifferentChainId,
+      );
+
+      expect(remainingTxsOnCurrentChain).toHaveLength(1);
+      expect(remainingTxsOnDifferentChain).toHaveLength(1);
+    });
   });
 
   describe('queryTransactionStatus', () => {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1050,14 +1050,13 @@ describe('TransactionController', () => {
       expect(controller.state.transactions).toHaveLength(0);
     });
 
-    it('removes only txs with given address on current network', async () => {
+    it('removes only txs with given address', async () => {
       const controller = newController();
 
       controller.wipeTransactions();
 
       const mockFromAccount1 = '0x1bf137f335ea1b8f193b8f6ea92561a60d23a207';
       const mockFromAccount2 = '0x2bf137f335ea1b8f193b8f6ea92561a60d23a207';
-      const mockDifferentChainId = toHex(1);
       const mockCurrentChainId = toHex(5);
 
       controller.state.transactions.push({
@@ -1076,11 +1075,26 @@ describe('TransactionController', () => {
         },
       } as any);
 
+      controller.wipeTransactions(false, mockFromAccount2);
+
+      expect(controller.state.transactions).toHaveLength(1);
+      expect(controller.state.transactions[0].id).toBe('1');
+    });
+
+    it('removes only txs with given address only on current network', async () => {
+      const controller = newController();
+
+      controller.wipeTransactions();
+
+      const mockFromAccount1 = '0x1bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      const mockDifferentChainId = toHex(1);
+      const mockCurrentChainId = toHex(5);
+
       controller.state.transactions.push({
-        id: '3',
+        id: '1',
         chainId: mockCurrentChainId,
         transaction: {
-          from: mockFromAccount2,
+          from: mockFromAccount1,
         },
       } as any);
 
@@ -1088,21 +1102,14 @@ describe('TransactionController', () => {
         id: '4',
         chainId: mockDifferentChainId,
         transaction: {
-          from: mockFromAccount2,
+          from: mockFromAccount1,
         },
       } as any);
 
-      controller.wipeTransactions(false, mockFromAccount2);
+      controller.wipeTransactions(false, mockFromAccount1);
 
-      const remainingTxsOnCurrentChain = controller.state.transactions.filter(
-        (tx) => tx.chainId === mockCurrentChainId,
-      );
-      const remainingTxsOnDifferentChain = controller.state.transactions.filter(
-        (tx) => tx.chainId === mockDifferentChainId,
-      );
-
-      expect(remainingTxsOnCurrentChain).toHaveLength(1);
-      expect(remainingTxsOnDifferentChain).toHaveLength(1);
+      expect(controller.state.transactions).toHaveLength(1);
+      expect(controller.state.transactions[0].id).toBe('4');
     });
   });
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -794,7 +794,7 @@ export class TransactionController extends BaseController<
    */
   wipeTransactions(ignoreNetwork?: boolean, address?: string) {
     /* istanbul ignore next */
-    if (ignoreNetwork) {
+    if (ignoreNetwork && !address) {
       this.update({ transactions: [] });
       return;
     }
@@ -808,7 +808,7 @@ export class TransactionController extends BaseController<
           chainId === currentChainId ||
           (!chainId && networkID === currentNetworkID);
         if (address) {
-          const isFromAddress = transaction.from === address;
+          const isFromAddress = transaction.from?.toLowerCase() === address.toLowerCase();
           return !(isCurrentNetwork && isFromAddress);
         }
         return !isCurrentNetwork;

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -804,14 +804,19 @@ export class TransactionController extends BaseController<
     const newTransactions = this.state.transactions.filter(
       ({ networkID, chainId, transaction }) => {
         // Using fallback to networkID only when there is no chainId present. Should be removed when networkID is completely removed.
-        const isCurrentNetwork =
+        const isMatchingNetwork =
+          ignoreNetwork ||
           chainId === currentChainId ||
           (!chainId && networkID === currentNetworkID);
-        if (address) {
-          const isFromAddress = transaction.from?.toLowerCase() === address.toLowerCase();
-          return !(isCurrentNetwork && isFromAddress);
+
+        if (!isMatchingNetwork) {
+          return true;
         }
-        return !isCurrentNetwork;
+
+        const isMatchingAddress =
+          !address || transaction.from?.toLowerCase() === address.toLowerCase();
+
+        return !isMatchingAddress;
       },
     );
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -789,8 +789,10 @@ export class TransactionController extends BaseController<
    *
    * @param ignoreNetwork - Determines whether to wipe all transactions, or just those on the
    * current network. If `true`, all transactions are wiped.
+   * @param address - If specified, only transactions originating from this address will be
+   * wiped on current network.
    */
-  wipeTransactions(ignoreNetwork?: boolean) {
+  wipeTransactions(ignoreNetwork?: boolean, address?: string) {
     /* istanbul ignore next */
     if (ignoreNetwork) {
       this.update({ transactions: [] });
@@ -800,11 +802,15 @@ export class TransactionController extends BaseController<
       this.getNetworkState();
     const { chainId: currentChainId } = providerConfig;
     const newTransactions = this.state.transactions.filter(
-      ({ networkID, chainId }) => {
+      ({ networkID, chainId, transaction }) => {
         // Using fallback to networkID only when there is no chainId present. Should be removed when networkID is completely removed.
         const isCurrentNetwork =
           chainId === currentChainId ||
           (!chainId && networkID === currentNetworkID);
+        if (address) {
+          const isFromAddress = transaction.from === address;
+          return !(isCurrentNetwork && isFromAddress);
+        }
         return !isCurrentNetwork;
       },
     );


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR aims to add an additional parameter on `TxController.wipeTransaction` function to support wiping only the transactions with supplied address. 

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->


### `@metamask/transaction-controller`

- **ADDED**: Adds optional `address` parameter to `TransactionController.wipeTransaction` function to support wiping the transactions only given address.

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've highlighted breaking changes using the "BREAKING" category above as appropriate
