### PR TITLE
Adds support re-create approval requests based on unapprovedTx when client restarts

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -18,7 +18,7 @@ module.exports = merge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 81.29,
-      functions: 95.14,
+      functions: 94.49,
       lines: 95.24,
       statements: 95.34,
     },

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1450,4 +1450,29 @@ describe('TransactionController', () => {
       },
     );
   });
+
+  describe('initApprovals', () => {
+    it('creates approvals for all unapproved transaction', async () => {
+      const controller = newController();
+      await controller.addTransaction({
+        from: ACCOUNT_MOCK,
+        to: ACCOUNT_MOCK,
+      });
+
+      expect(controller.state.transactions[0].status).toBe(
+        TransactionStatus.unapproved,
+      );
+
+      controller.initApprovals();
+
+      expect(delayMessengerMock.call).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not create any approval when there is no unapproved transaction', async () => {
+      const controller = newController();
+      controller.initApprovals();
+
+      expect(delayMessengerMock.call).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1454,10 +1454,13 @@ describe('TransactionController', () => {
   describe('initApprovals', () => {
     it('creates approvals for all unapproved transaction', async () => {
       const controller = newController();
-      await controller.addTransaction({
+      controller.state.transactions.push({
         from: ACCOUNT_MOCK,
-        to: ACCOUNT_MOCK,
-      });
+        id: 'foo',
+        networkID: '5',
+        status: TransactionStatus.unapproved,
+        transactionHash: '1337',
+      } as any);
 
       expect(controller.state.transactions[0].status).toBe(
         TransactionStatus.unapproved,
@@ -1465,7 +1468,18 @@ describe('TransactionController', () => {
 
       controller.initApprovals();
 
-      expect(delayMessengerMock.call).toHaveBeenCalledTimes(2);
+      expect(delayMessengerMock.call).toHaveBeenCalledTimes(1);
+      expect(delayMessengerMock.call).toHaveBeenCalledWith(
+        'ApprovalController:addRequest',
+        {
+          expectsResult: true,
+          id: 'foo',
+          origin: 'metamask',
+          requestData: { txId: 'foo' },
+          type: 'transaction',
+        },
+        false,
+      );
     });
 
     it('does not create any approval when there is no unapproved transaction', async () => {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1456,29 +1456,42 @@ describe('TransactionController', () => {
 
   describe('initApprovals', () => {
     it('creates approvals for all unapproved transaction', async () => {
-      const controller = newController();
-      controller.state.transactions.push({
+      const transaction = {
         from: ACCOUNT_MOCK,
-        id: 'foo',
+        id: 'mocked',
         networkID: '5',
         status: TransactionStatus.unapproved,
         transactionHash: '1337',
+      };
+      const controller = newController();
+      controller.state.transactions.push(transaction as any);
+      controller.state.transactions.push({
+        ...transaction,
+        id: 'mocked1',
+        transactionHash: '1338',
       } as any);
-
-      expect(controller.state.transactions[0].status).toBe(
-        TransactionStatus.unapproved,
-      );
 
       controller.initApprovals();
 
-      expect(delayMessengerMock.call).toHaveBeenCalledTimes(1);
+      expect(delayMessengerMock.call).toHaveBeenCalledTimes(2);
       expect(delayMessengerMock.call).toHaveBeenCalledWith(
         'ApprovalController:addRequest',
         {
           expectsResult: true,
-          id: 'foo',
+          id: 'mocked',
           origin: 'metamask',
-          requestData: { txId: 'foo' },
+          requestData: { txId: 'mocked' },
+          type: 'transaction',
+        },
+        false,
+      );
+      expect(delayMessengerMock.call).toHaveBeenCalledWith(
+        'ApprovalController:addRequest',
+        {
+          expectsResult: true,
+          id: 'mocked1',
+          origin: 'metamask',
+          requestData: { txId: 'mocked1' },
           type: 'transaction',
         },
         false,

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -406,6 +406,7 @@ export class TransactionController extends BaseController<
       this.processApproval(txMeta, {
         shouldShowRequest: false,
       }).catch((error) => {
+        /* istanbul ignore next */
         console.error('Error during persisted transaction approval', error);
       });
     });

--- a/packages/transaction-controller/src/utils.test.ts
+++ b/packages/transaction-controller/src/utils.test.ts
@@ -7,7 +7,10 @@ import type {
 import type { Transaction, TransactionMeta } from './types';
 import { TransactionStatus } from './types';
 import * as util from './utils';
-import { getAndFormatTransactionsForNonceTracker } from './utils';
+import {
+  getAndFormatTransactionsForNonceTracker,
+  transactionMatchesNetwork,
+} from './utils';
 
 const MAX_FEE_PER_GAS = 'maxFeePerGas';
 const MAX_PRIORITY_FEE_PER_GAS = 'maxPriorityFeePerGas';
@@ -304,6 +307,77 @@ describe('utils', () => {
         inputTransactions,
       );
       expect(result).toStrictEqual(expectedResult);
+    });
+  });
+
+  describe('transactionMatchesNetwork', () => {
+    const transaction: TransactionMeta = {
+      chainId: '0x1',
+      networkID: '1',
+      id: '1',
+      time: 123456,
+      transaction: {
+        from: '0x123',
+        gas: '0x100',
+        value: '0x200',
+        nonce: '0x1',
+      },
+      status: TransactionStatus.unapproved,
+    };
+    it('returns true if chainId matches', () => {
+      const chainId = '0x1';
+      const networkId = '1';
+      expect(transactionMatchesNetwork(transaction, chainId, networkId)).toBe(
+        true,
+      );
+    });
+
+    it('returns false if chainId does not match', () => {
+      const chainId = '0x1';
+      const networkId = '1';
+      expect(
+        transactionMatchesNetwork(
+          { ...transaction, chainId: '0x2' },
+          chainId,
+          networkId,
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true if networkID matches', () => {
+      const chainId = '0x1';
+      const networkId = '1';
+      expect(
+        transactionMatchesNetwork(
+          { ...transaction, chainId: undefined },
+          chainId,
+          networkId,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false if networkID does not match', () => {
+      const chainId = '0x1';
+      const networkId = '1';
+      expect(
+        transactionMatchesNetwork(
+          { ...transaction, networkID: '2', chainId: undefined },
+          chainId,
+          networkId,
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true if chainId and networkID are undefined', () => {
+      const chainId = '0x2';
+      const networkId = '1';
+      expect(
+        transactionMatchesNetwork(
+          { ...transaction, chainId: undefined, networkID: undefined },
+          chainId,
+          networkId,
+        ),
+      ).toBe(false);
     });
   });
 });

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -2,6 +2,7 @@ import {
   convertHexToDecimal,
   isValidHexAddress,
 } from '@metamask/controller-utils';
+import type { Hex } from '@metamask/utils';
 import { addHexPrefix, isHexString } from 'ethereumjs-util';
 import type { Transaction as NonceTrackerTransaction } from 'nonce-tracker/dist/NonceTracker';
 
@@ -206,4 +207,24 @@ export function getAndFormatTransactionsForNonceTracker(
         },
       };
     });
+}
+
+/**
+ * Checks whether a given transaction matches the specified network or chain ID.
+ * This function is used to determine if a transaction is relevant to the current network or chain.
+ *
+ * @param transaction - The transaction metadata to check.
+ * @param chainId - The chain ID of the current network.
+ * @param networkId - The network ID of the current network.
+ * @returns A boolean value indicating whether the transaction matches the current network or chain ID.
+ */
+export function transactionMatchesNetwork(
+  transaction: TransactionMeta,
+  chainId: Hex,
+  networkId: string | null,
+) {
+  if (typeof transaction.chainId !== 'undefined') {
+    return transaction.chainId === chainId;
+  }
+  return transaction.networkID === networkId;
 }

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -223,8 +223,11 @@ export function transactionMatchesNetwork(
   chainId: Hex,
   networkId: string | null,
 ) {
-  if (typeof transaction.chainId !== 'undefined') {
+  if (transaction.chainId) {
     return transaction.chainId === chainId;
   }
-  return transaction.networkID === networkId;
+  if (transaction.networkID) {
+    return transaction.networkID === networkId;
+  }
+  return false;
 }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR aims to add  `initApprovals` function to support re-create approval requests based on unapprovedTx when the client restarts. This is an existent function in the extension and it's coming to the core as part of the effort to unify the `TransactionController` in the core and in the extension.

Changes:
- Addtional parameter in `processApproval` and `requestApproval` to determine if when creates an approval request it should be shown (`shouldShowRequest`).
- Created an utility function `transactionMatchesNetwork` to facilitate the validation of whether a given transaction matches the specified network or chain ID.

resolves: https://github.com/MetaMask/MetaMask-planning/issues/959

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->


### `@metamask/transaction-controller`

- **ADDED**: Adds `initApprovals` function to support re-create approval requests based on unapprovedTx when the client restarts

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
