### PR TITLE
[Draft] Support adding transactions without approval in the core transaction controller

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -25,7 +25,7 @@ import type {
 } from './TransactionController';
 import { TransactionController, HARDFORK } from './TransactionController';
 import type { TransactionMeta } from './types';
-import { TransactionStatus } from './types';
+import { WalletDevice, TransactionStatus } from './types';
 import { ESTIMATE_GAS_ERROR } from './utils';
 import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
 import { mockNetwork } from '../../../tests/mock-network';
@@ -654,10 +654,19 @@ describe('TransactionController', () => {
     it('adds unapproved transaction to state', async () => {
       const controller = newController();
 
-      await controller.addTransaction({
-        from: ACCOUNT_MOCK,
-        to: ACCOUNT_MOCK,
-      });
+      const mockDeviceConfirmedOn = WalletDevice.OTHER;
+      const mockOrigin = 'origin';
+
+      await controller.addTransaction(
+        {
+          from: ACCOUNT_MOCK,
+          to: ACCOUNT_MOCK,
+        },
+        {
+          deviceConfirmedOn: mockDeviceConfirmedOn,
+          origin: mockOrigin,
+        },
+      );
 
       expect(controller.state.transactions[0].transaction.from).toBe(
         ACCOUNT_MOCK,
@@ -668,6 +677,10 @@ describe('TransactionController', () => {
       expect(controller.state.transactions[0].chainId).toBe(
         MOCK_NETWORK.state.providerConfig.chainId,
       );
+      expect(controller.state.transactions[0].deviceConfirmedOn).toBe(
+        mockDeviceConfirmedOn,
+      );
+      expect(controller.state.transactions[0].origin).toBe(mockOrigin);
       expect(controller.state.transactions[0].status).toBe(
         TransactionStatus.unapproved,
       );

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -809,6 +809,22 @@ describe('TransactionController', () => {
       );
     });
 
+    it('skip request for an approval using the approval controller', async () => {
+      const controller = newController();
+
+      await controller.addTransaction(
+        {
+          from: ACCOUNT_MOCK,
+          to: ACCOUNT_MOCK,
+        },
+        {
+          requireApproval: false,
+        },
+      );
+
+      expect(delayMessengerMock.call).toHaveBeenCalledTimes(0);
+    });
+
     it.each([
       ['mainnet', MOCK_MAINNET_NETWORK],
       ['custom network', MOCK_CUSTOM_NETWORK],

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -342,7 +342,13 @@ export class TransactionController extends BaseController<
    */
   async addTransaction(
     transaction: Transaction,
-    { deviceConfirmedOn, origin } = {},
+    {
+      deviceConfirmedOn,
+      origin,
+    }: {
+      deviceConfirmedOn?: WalletDevice;
+      origin?: string;
+    } = {},
   ): Promise<Result> {
     const { providerConfig, networkId } = this.getNetworkState();
     const { transactions } = this.state;

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -125,18 +125,6 @@ export interface TransactionState extends BaseState {
 }
 
 /**
- * @type AddTransactionOptions
- *
- * Transaction controller addTransaction method options
- * @param origin - The domain origin to append to the generated TransactionMeta.
- * @param deviceConfirmedOn - An enum to indicate what device the transaction was confirmed to append to the generated TransactionMeta.
- */
-type AddTransactionOptions = {
-  origin?: string;
-  deviceConfirmedOn?: WalletDevice;
-};
-
-/**
  * Multiplier used to determine a transaction's increased gas fee during cancellation
  */
 export const CANCEL_RATE = 1.5;
@@ -347,12 +335,14 @@ export class TransactionController extends BaseController<
    * if not provided. If A `<tx.id>:unapproved` hub event will be emitted once added.
    *
    * @param transaction - The transaction object to add.
-   * @param opts - The options bag for addTransaction.
+   * @param opts - The options bag for addTransaction
+   * @param opts.deviceConfirmedOn - An enum to indicate what device the transaction was confirmed.
+   * @param opts.origin - The domain origin
    * @returns Object containing a promise resolving to the transaction hash if approved.
    */
   async addTransaction(
     transaction: Transaction,
-    opts: AddTransactionOptions = {},
+    { deviceConfirmedOn, origin } = {},
   ): Promise<Result> {
     const { providerConfig, networkId } = this.getNetworkState();
     const { transactions } = this.state;
@@ -363,11 +353,11 @@ export class TransactionController extends BaseController<
       id: random(),
       networkID: networkId ?? undefined,
       chainId: providerConfig.chainId,
-      origin: opts.origin,
+      origin,
       status: TransactionStatus.unapproved as TransactionStatus.unapproved,
       time: Date.now(),
       transaction,
-      deviceConfirmedOn: opts.deviceConfirmedOn,
+      deviceConfirmedOn,
       verifiedOnBlockchain: false,
     };
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -125,6 +125,18 @@ export interface TransactionState extends BaseState {
 }
 
 /**
+ * @type AddTransactionOptions
+ *
+ * Transaction controller addTransaction method options
+ * @param origin - The domain origin to append to the generated TransactionMeta.
+ * @param deviceConfirmedOn - An enum to indicate what device the transaction was confirmed to append to the generated TransactionMeta.
+ */
+type AddTransactionOptions = {
+  origin?: string;
+  deviceConfirmedOn?: WalletDevice;
+};
+
+/**
  * Multiplier used to determine a transaction's increased gas fee during cancellation
  */
 export const CANCEL_RATE = 1.5;
@@ -335,14 +347,12 @@ export class TransactionController extends BaseController<
    * if not provided. If A `<tx.id>:unapproved` hub event will be emitted once added.
    *
    * @param transaction - The transaction object to add.
-   * @param origin - The domain origin to append to the generated TransactionMeta.
-   * @param deviceConfirmedOn - An enum to indicate what device the transaction was confirmed to append to the generated TransactionMeta.
+   * @param opts - The options bag for addTransaction.
    * @returns Object containing a promise resolving to the transaction hash if approved.
    */
   async addTransaction(
     transaction: Transaction,
-    origin?: string,
-    deviceConfirmedOn?: WalletDevice,
+    opts: AddTransactionOptions = {},
   ): Promise<Result> {
     const { providerConfig, networkId } = this.getNetworkState();
     const { transactions } = this.state;
@@ -353,11 +363,11 @@ export class TransactionController extends BaseController<
       id: random(),
       networkID: networkId ?? undefined,
       chainId: providerConfig.chainId,
-      origin,
+      origin: opts.origin,
       status: TransactionStatus.unapproved as TransactionStatus.unapproved,
       time: Date.now(),
       transaction,
-      deviceConfirmedOn,
+      deviceConfirmedOn: opts.deviceConfirmedOn,
       verifiedOnBlockchain: false,
     };
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
