### PR TITLE
Use block tracker to poll incoming transactions

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -18,7 +18,7 @@ module.exports = merge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 81.29,
-      functions: 95.14,
+      functions: 94.64,
       lines: 95.24,
       statements: 95.34,
     },

--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,9 +17,9 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 81.29,
-      functions: 94.64,
-      lines: 95.24,
+      branches: 83.33,
+      functions: 93.22,
+      lines: 95.22,
       statements: 95.34,
     },
   },

--- a/packages/transaction-controller/src/EtherscanRemoteTransactionSource.test.ts
+++ b/packages/transaction-controller/src/EtherscanRemoteTransactionSource.test.ts
@@ -1,5 +1,6 @@
 import { v1 as random } from 'uuid';
 
+import { CHAIN_IDS } from './constants';
 import type {
   EtherscanTokenTransactionMeta,
   EtherscanTransactionMeta,
@@ -63,7 +64,6 @@ const ETHERSCAN_TOKEN_TRANSACTION_MOCK: EtherscanTokenTransactionMeta = {
 
 const ETHERSCAN_TRANSACTION_RESPONSE_MOCK: EtherscanTransactionResponse<EtherscanTransactionMeta> =
   {
-    status: '1',
     result: [
       ETHERSCAN_TRANSACTION_SUCCESS_MOCK,
       ETHERSCAN_TRANSACTION_ERROR_MOCK,
@@ -72,7 +72,6 @@ const ETHERSCAN_TRANSACTION_RESPONSE_MOCK: EtherscanTransactionResponse<Ethersca
 
 const ETHERSCAN_TOKEN_TRANSACTION_RESPONSE_MOCK: EtherscanTransactionResponse<EtherscanTokenTransactionMeta> =
   {
-    status: '1',
     result: [
       ETHERSCAN_TOKEN_TRANSACTION_MOCK,
       ETHERSCAN_TOKEN_TRANSACTION_MOCK,
@@ -81,7 +80,6 @@ const ETHERSCAN_TOKEN_TRANSACTION_RESPONSE_MOCK: EtherscanTransactionResponse<Et
 
 const ETHERSCAN_TRANSACTION_RESPONSE_EMPTY_MOCK: EtherscanTransactionResponse<EtherscanTransactionMeta> =
   {
-    status: '0',
     result: [],
   };
 
@@ -159,6 +157,26 @@ describe('EtherscanRemoteTransactionSource', () => {
     randomMock.mockReturnValue(ID_MOCK);
   });
 
+  describe('isSupportedNetwork', () => {
+    it('returns true if chain ID in constant', () => {
+      expect(
+        new EtherscanRemoteTransactionSource().isSupportedNetwork(
+          CHAIN_IDS.MAINNET,
+          '1',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false if chain ID not in constant', () => {
+      expect(
+        new EtherscanRemoteTransactionSource().isSupportedNetwork(
+          '0x1324567891234',
+          '1',
+        ),
+      ).toBe(false);
+    });
+  });
+
   describe('fetchTransactions', () => {
     it('returns normalized transactions fetched from Etherscan', async () => {
       fetchEtherscanTransactionsMock.mockResolvedValueOnce(
@@ -190,6 +208,18 @@ describe('EtherscanRemoteTransactionSource', () => {
         EXPECTED_NORMALISED_TOKEN_TRANSACTION,
         EXPECTED_NORMALISED_TOKEN_TRANSACTION,
       ]);
+    });
+
+    it('returns no normalized token transactions if flag disabled', async () => {
+      fetchEtherscanTokenTransactionsMock.mockResolvedValueOnce(
+        ETHERSCAN_TOKEN_TRANSACTION_RESPONSE_MOCK,
+      );
+
+      const transactions = await new EtherscanRemoteTransactionSource({
+        includeTokenTransfers: false,
+      }).fetchTransactions({} as any);
+
+      expect(transactions).toStrictEqual([]);
     });
   });
 });

--- a/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
@@ -3,10 +3,12 @@ import type { Hex } from '@metamask/utils';
 import { BN } from 'ethereumjs-util';
 import { v1 as random } from 'uuid';
 
+import { ETHERSCAN_SUPPORTED_NETWORKS } from './constants';
 import type {
   EtherscanTokenTransactionMeta,
   EtherscanTransactionMeta,
   EtherscanTransactionMetaBase,
+  EtherscanTransactionResponse,
 } from './etherscan';
 import {
   fetchEtherscanTokenTransactions,
@@ -25,20 +27,36 @@ import { TransactionStatus } from './types';
 export class EtherscanRemoteTransactionSource
   implements RemoteTransactionSource
 {
-  /**
-   * Retrieve transaction data from Etherscan.
-   *
-   * @param request - The configuration required to fetch Etherscan transaction data.
-   * @returns An array of transaction metadata.
-   */
+  #includeTokenTransfers: boolean;
+
+  constructor({
+    includeTokenTransfers,
+  }: { includeTokenTransfers?: boolean } = {}) {
+    this.#includeTokenTransfers = includeTokenTransfers ?? true;
+  }
+
+  isSupportedNetwork(chainId: Hex, _networkId: string): boolean {
+    return Object.keys(ETHERSCAN_SUPPORTED_NETWORKS).includes(chainId);
+  }
+
   async fetchTransactions(
     request: RemoteTransactionSourceRequest,
   ): Promise<TransactionMeta[]> {
+    const etherscanRequest = {
+      ...request,
+      chainId: request.currentChainId,
+    };
+
+    const transactionPromise = fetchEtherscanTransactions(etherscanRequest);
+
+    const tokenTransactionPromise = this.#includeTokenTransfers
+      ? fetchEtherscanTokenTransactions(etherscanRequest)
+      : Promise.resolve({
+          result: [] as EtherscanTokenTransactionMeta[],
+        } as EtherscanTransactionResponse<EtherscanTokenTransactionMeta>);
+
     const [etherscanTransactions, etherscanTokenTransactions] =
-      await Promise.all([
-        fetchEtherscanTransactions(request),
-        fetchEtherscanTokenTransactions(request),
-      ]);
+      await Promise.all([transactionPromise, tokenTransactionPromise]);
 
     const transactions = etherscanTransactions.result.map((tx) =>
       this.#normalizeTransaction(

--- a/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
@@ -8,6 +8,7 @@ import type {
   EtherscanTokenTransactionMeta,
   EtherscanTransactionMeta,
   EtherscanTransactionMetaBase,
+  EtherscanTransactionRequest,
   EtherscanTransactionResponse,
 } from './etherscan';
 import {
@@ -27,11 +28,15 @@ import { TransactionStatus } from './types';
 export class EtherscanRemoteTransactionSource
   implements RemoteTransactionSource
 {
+  #apiKey?: string;
+
   #includeTokenTransfers: boolean;
 
   constructor({
+    apiKey,
     includeTokenTransfers,
-  }: { includeTokenTransfers?: boolean } = {}) {
+  }: { apiKey?: string; includeTokenTransfers?: boolean } = {}) {
+    this.#apiKey = apiKey;
     this.#includeTokenTransfers = includeTokenTransfers ?? true;
   }
 
@@ -42,8 +47,9 @@ export class EtherscanRemoteTransactionSource
   async fetchTransactions(
     request: RemoteTransactionSourceRequest,
   ): Promise<TransactionMeta[]> {
-    const etherscanRequest = {
+    const etherscanRequest: EtherscanTransactionRequest = {
       ...request,
+      apiKey: this.#apiKey,
       chainId: request.currentChainId,
     };
 

--- a/packages/transaction-controller/src/IncomingTransactionHelper.test.ts
+++ b/packages/transaction-controller/src/IncomingTransactionHelper.test.ts
@@ -1,10 +1,14 @@
-import { NetworkType, isSmartContractCode } from '@metamask/controller-utils';
-import type EthQuery from '@metamask/eth-query';
-import type { NetworkState } from '@metamask/network-controller';
+/* eslint-disable jsdoc/require-jsdoc */
+
+import { NetworkType } from '@metamask/controller-utils';
+import type { BlockTracker, NetworkState } from '@metamask/network-controller';
 
 import { IncomingTransactionHelper } from './IncomingTransactionHelper';
-import type { RemoteTransactionSource, TransactionMeta } from './types';
-import { TransactionStatus } from './types';
+import {
+  TransactionStatus,
+  type RemoteTransactionSource,
+  type TransactionMeta,
+} from './types';
 
 jest.mock('@metamask/controller-utils', () => ({
   ...jest.requireActual('@metamask/controller-utils'),
@@ -20,56 +24,104 @@ const NETWORK_STATE_MOCK: NetworkState = {
   networkId: '1',
 } as unknown as NetworkState;
 
+const ADDERSS_MOCK = '0x1';
+const FROM_BLOCK_HEX_MOCK = '0x20';
+const FROM_BLOCK_DECIMAL_MOCK = 32;
+
+const BLOCK_TRACKER_MOCK = {
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+} as unknown as jest.Mocked<BlockTracker>;
+
 const CONTROLLER_ARGS_MOCK = {
+  blockTracker: BLOCK_TRACKER_MOCK,
+  getCurrentAccount: () => ADDERSS_MOCK,
   getNetworkState: () => NETWORK_STATE_MOCK,
-  getEthQuery: () => ({} as unknown as EthQuery),
-  transactionLimit: 1,
   remoteTransactionSource: {} as RemoteTransactionSource,
+  transactionLimit: 1,
 };
 
 const TRANSACTION_MOCK: TransactionMeta = {
-  transactionHash: '0x1',
-  transaction: { to: '0x1', gasUsed: '0x1' },
-  time: 0,
-  status: TransactionStatus.submitted,
-  blockNumber: '1',
+  blockNumber: '123',
   chainId: '0x1',
+  status: TransactionStatus.submitted,
+  time: 0,
+  transaction: { to: '0x1', gasUsed: '0x1' },
+  transactionHash: '0x1',
 } as unknown as TransactionMeta;
 
 const TRANSACTION_MOCK_2: TransactionMeta = {
-  transactionHash: '0x2',
-  transaction: { to: '0x1' },
-  time: 1,
-  blockNumber: '2',
+  blockNumber: '234',
   chainId: '0x1',
+  time: 1,
+  transaction: { to: '0x1' },
+  transactionHash: '0x2',
 } as unknown as TransactionMeta;
-
-const RECONCILE_ARGS_MOCK = {
-  address: '0x1',
-  localTransactions: [],
-  fromBlock: '0x3',
-  apiKey: 'testApiKey',
-};
 
 const createRemoteTransactionSourceMock = (
   remoteTransactions: TransactionMeta[],
+  {
+    isSupportedNetwork,
+    error,
+  }: { isSupportedNetwork?: boolean; error?: boolean } = {},
 ): RemoteTransactionSource => ({
-  fetchTransactions: jest.fn(() => Promise.resolve(remoteTransactions)),
+  isSupportedNetwork: jest.fn(() => isSupportedNetwork ?? true),
+  fetchTransactions: jest.fn(() =>
+    error
+      ? Promise.reject(new Error('Test Error'))
+      : Promise.resolve(remoteTransactions),
+  ),
 });
 
-describe('IncomingTransactionHelper', () => {
-  const isSmartContractCodeMock = isSmartContractCode as jest.MockedFn<
-    typeof isSmartContractCode
-  >;
+async function emitBlockTrackerLatestEvent(
+  helper: IncomingTransactionHelper,
+  { start, error }: { start?: boolean; error?: boolean } = {},
+) {
+  const transactionsListener = jest.fn();
+  const blockNumberListener = jest.fn();
 
+  if (error) {
+    transactionsListener.mockImplementation(() => {
+      throw new Error('Test Error');
+    });
+  }
+
+  helper.hub.addListener('transactions', transactionsListener);
+  helper.hub.addListener('updatedLastFetchedBlockNumbers', blockNumberListener);
+
+  if (start !== false) {
+    helper.start();
+  }
+
+  await BLOCK_TRACKER_MOCK.addListener.mock.calls[0]?.[1]?.(
+    FROM_BLOCK_HEX_MOCK,
+  );
+
+  return {
+    transactions: transactionsListener.mock.calls[0]?.[0],
+    lastFetchBlockNumbers: blockNumberListener.mock.calls[0]?.[0],
+    transactionsListener,
+    blockNumberListener,
+  };
+}
+
+describe('IncomingTransactionHelper', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-
-    TRANSACTION_MOCK.toSmartContract = undefined;
-    TRANSACTION_MOCK_2.toSmartContract = undefined;
   });
 
-  describe('reconcile', () => {
+  describe('on block tracker latest event', () => {
+    it('handles errors', async () => {
+      const helper = new IncomingTransactionHelper({
+        ...CONTROLLER_ARGS_MOCK,
+        remoteTransactionSource: createRemoteTransactionSourceMock([
+          TRANSACTION_MOCK_2,
+        ]),
+      });
+
+      await emitBlockTrackerLatestEvent(helper, { error: true });
+    });
+
     describe('fetches remote transactions', () => {
       it('using remote transaction source', async () => {
         const remoteTransactionSource = createRemoteTransactionSourceMock([]);
@@ -79,62 +131,70 @@ describe('IncomingTransactionHelper', () => {
           remoteTransactionSource,
         });
 
-        await helper.reconcile(RECONCILE_ARGS_MOCK);
+        await emitBlockTrackerLatestEvent(helper);
 
         expect(remoteTransactionSource.fetchTransactions).toHaveBeenCalledTimes(
           1,
         );
 
         expect(remoteTransactionSource.fetchTransactions).toHaveBeenCalledWith({
-          address: RECONCILE_ARGS_MOCK.address,
-          apiKey: RECONCILE_ARGS_MOCK.apiKey,
+          address: ADDERSS_MOCK,
           currentChainId: NETWORK_STATE_MOCK.providerConfig.chainId,
           currentNetworkId: NETWORK_STATE_MOCK.networkId,
-          fromBlock: RECONCILE_ARGS_MOCK.fromBlock,
+          fromBlock: expect.any(Number),
           limit: CONTROLLER_ARGS_MOCK.transactionLimit,
-          networkType: NETWORK_STATE_MOCK.providerConfig.type,
         });
       });
 
-      it('sorts transactions by time in ascending order', async () => {
-        const firstTransaction = { ...TRANSACTION_MOCK_2, time: 5 };
-        const secondTransaction = { ...TRANSACTION_MOCK, time: 6 };
+      it('using from block as latest block minus ten if no last fetched data', async () => {
+        const remoteTransactionSource = createRemoteTransactionSourceMock([]);
 
         const helper = new IncomingTransactionHelper({
           ...CONTROLLER_ARGS_MOCK,
-          remoteTransactionSource: createRemoteTransactionSourceMock([
-            firstTransaction,
-          ]),
+          remoteTransactionSource,
         });
 
-        const { transactions } = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [secondTransaction],
+        await emitBlockTrackerLatestEvent(helper);
+
+        expect(remoteTransactionSource.fetchTransactions).toHaveBeenCalledTimes(
+          1,
+        );
+
+        expect(remoteTransactionSource.fetchTransactions).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fromBlock: FROM_BLOCK_DECIMAL_MOCK - 10,
+          }),
+        );
+      });
+
+      it('using from block as last fetched value plus one', async () => {
+        const remoteTransactionSource = createRemoteTransactionSourceMock([]);
+
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource,
+          lastFetchedBlockNumbers: {
+            [`${NETWORK_STATE_MOCK.providerConfig.chainId}#${ADDERSS_MOCK}`]:
+              FROM_BLOCK_DECIMAL_MOCK,
+          },
         });
 
-        expect(transactions).toStrictEqual([
-          firstTransaction,
-          secondTransaction,
-        ]);
+        await emitBlockTrackerLatestEvent(helper);
+
+        expect(remoteTransactionSource.fetchTransactions).toHaveBeenCalledTimes(
+          1,
+        );
+
+        expect(remoteTransactionSource.fetchTransactions).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fromBlock: FROM_BLOCK_DECIMAL_MOCK + 1,
+          }),
+        );
       });
     });
 
-    describe('returns update required', () => {
-      it('as false if current network is not supported', async () => {
-        const helper = new IncomingTransactionHelper({
-          ...CONTROLLER_ARGS_MOCK,
-          getNetworkState: () => ({ ...NETWORK_STATE_MOCK, networkId: '0x2' }),
-        });
-
-        const result = await helper.reconcile(RECONCILE_ARGS_MOCK);
-
-        expect(result).toStrictEqual({
-          updateRequired: false,
-          transactions: [],
-        });
-      });
-
-      it('as true if new transaction fetched', async () => {
+    describe('emits transactions event', () => {
+      it('if new transaction fetched', async () => {
         const helper = new IncomingTransactionHelper({
           ...CONTROLLER_ARGS_MOCK,
           remoteTransactionSource: createRemoteTransactionSourceMock([
@@ -142,19 +202,35 @@ describe('IncomingTransactionHelper', () => {
           ]),
         });
 
-        const result = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [TRANSACTION_MOCK],
-        });
+        const { transactions } = await emitBlockTrackerLatestEvent(helper);
 
-        expect(result.updateRequired).toBe(true);
-        expect(result.transactions).toStrictEqual([
-          TRANSACTION_MOCK,
-          TRANSACTION_MOCK_2,
-        ]);
+        expect(transactions).toStrictEqual([TRANSACTION_MOCK_2]);
       });
 
-      it('as true if existing transaction fetched with different status', async () => {
+      it('if new outgoing transaction fetched and update transactions enabled', async () => {
+        const outgoingTransaction = {
+          ...TRANSACTION_MOCK_2,
+          transaction: {
+            ...TRANSACTION_MOCK_2.transaction,
+            from: '0x1',
+            to: '0x2',
+          },
+        };
+
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock([
+            outgoingTransaction,
+          ]),
+          updateTransactions: true,
+        });
+
+        const { transactions } = await emitBlockTrackerLatestEvent(helper);
+
+        expect(transactions).toStrictEqual([outgoingTransaction]);
+      });
+
+      it('if existing transaction fetched with different status and update transactions enabled', async () => {
         const updatedTransaction = {
           ...TRANSACTION_MOCK,
           status: TransactionStatus.confirmed,
@@ -165,18 +241,16 @@ describe('IncomingTransactionHelper', () => {
           remoteTransactionSource: createRemoteTransactionSourceMock([
             updatedTransaction,
           ]),
+          getLocalTransactions: () => [TRANSACTION_MOCK],
+          updateTransactions: true,
         });
 
-        const result = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [TRANSACTION_MOCK],
-        });
+        const { transactions } = await emitBlockTrackerLatestEvent(helper);
 
-        expect(result.updateRequired).toBe(true);
-        expect(result.transactions).toStrictEqual([updatedTransaction]);
+        expect(transactions).toStrictEqual([updatedTransaction]);
       });
 
-      it('as true if existing transaction fetched with different gas used', async () => {
+      it('if existing transaction fetched with different gas used and update transactions enabled', async () => {
         const updatedTransaction = {
           ...TRANSACTION_MOCK,
           transaction: {
@@ -190,20 +264,160 @@ describe('IncomingTransactionHelper', () => {
           remoteTransactionSource: createRemoteTransactionSourceMock([
             updatedTransaction,
           ]),
+          getLocalTransactions: () => [TRANSACTION_MOCK],
+          updateTransactions: true,
         });
 
-        const result = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [TRANSACTION_MOCK],
+        const { transactions } = await emitBlockTrackerLatestEvent(helper);
+
+        expect(transactions).toStrictEqual([updatedTransaction]);
+      });
+
+      it('sorted by time in ascending order', async () => {
+        const firstTransaction = { ...TRANSACTION_MOCK, time: 5 };
+        const secondTransaction = { ...TRANSACTION_MOCK, time: 6 };
+        const thirdTransaction = { ...TRANSACTION_MOCK, time: 7 };
+
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock([
+            firstTransaction,
+            thirdTransaction,
+            secondTransaction,
+          ]),
         });
 
-        expect(result.updateRequired).toBe(true);
-        expect(result.transactions).toStrictEqual([updatedTransaction]);
+        const { transactions } = await emitBlockTrackerLatestEvent(helper);
+
+        expect(transactions).toStrictEqual([
+          firstTransaction,
+          secondTransaction,
+          thirdTransaction,
+        ]);
+      });
+
+      it('does not if identical transaction fetched and update transactions enabled', async () => {
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock([
+            TRANSACTION_MOCK,
+          ]),
+          getLocalTransactions: () => [TRANSACTION_MOCK],
+          updateTransactions: true,
+        });
+
+        const { transactionsListener } = await emitBlockTrackerLatestEvent(
+          helper,
+        );
+
+        expect(transactionsListener).not.toHaveBeenCalled();
+      });
+
+      it('does not if disabled', async () => {
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock([
+            TRANSACTION_MOCK,
+          ]),
+          isEnabled: jest
+            .fn()
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(false),
+        });
+
+        const { transactionsListener } = await emitBlockTrackerLatestEvent(
+          helper,
+        );
+
+        expect(transactionsListener).not.toHaveBeenCalled();
+      });
+
+      it('does not if current network is not supported by remote transaction source', async () => {
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock(
+            [TRANSACTION_MOCK],
+            { isSupportedNetwork: false },
+          ),
+        });
+
+        const { transactionsListener } = await emitBlockTrackerLatestEvent(
+          helper,
+        );
+
+        expect(transactionsListener).not.toHaveBeenCalled();
+      });
+
+      it('does not if no remote transactions', async () => {
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock([]),
+        });
+
+        const { transactionsListener } = await emitBlockTrackerLatestEvent(
+          helper,
+        );
+
+        expect(transactionsListener).not.toHaveBeenCalled();
+      });
+
+      it('does not if update transactions disabled and no incoming transactions', async () => {
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock([
+            {
+              ...TRANSACTION_MOCK,
+              transaction: { to: '0x2' },
+            } as TransactionMeta,
+            {
+              ...TRANSACTION_MOCK,
+              transaction: { to: undefined },
+            } as TransactionMeta,
+          ]),
+        });
+
+        const { transactionsListener } = await emitBlockTrackerLatestEvent(
+          helper,
+        );
+
+        expect(transactionsListener).not.toHaveBeenCalled();
+      });
+
+      it('does not if error fetching transactions', async () => {
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock(
+            [TRANSACTION_MOCK],
+            { error: true },
+          ),
+        });
+
+        const { transactionsListener } = await emitBlockTrackerLatestEvent(
+          helper,
+        );
+
+        expect(transactionsListener).not.toHaveBeenCalled();
+      });
+
+      it('does not if not started', async () => {
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock([
+            TRANSACTION_MOCK,
+          ]),
+        });
+
+        const { transactionsListener } = await emitBlockTrackerLatestEvent(
+          helper,
+          { start: false },
+        );
+
+        expect(transactionsListener).not.toHaveBeenCalled();
       });
     });
 
-    describe('returns latest block number', () => {
-      it('of transactions with matching chain ID and to address', async () => {
+    describe('emits updatedLastFetchedBlockNumbers event', () => {
+      it('if fetched transaction has higher block number', async () => {
         const helper = new IncomingTransactionHelper({
           ...CONTROLLER_ARGS_MOCK,
           remoteTransactionSource: createRemoteTransactionSourceMock([
@@ -211,39 +425,30 @@ describe('IncomingTransactionHelper', () => {
           ]),
         });
 
-        const result = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [TRANSACTION_MOCK],
-        });
-
-        expect(result.latestBlockNumber).toBeDefined();
-        expect(result.latestBlockNumber).toStrictEqual(
-          TRANSACTION_MOCK_2.blockNumber,
+        const { lastFetchBlockNumbers } = await emitBlockTrackerLatestEvent(
+          helper,
         );
+
+        expect(lastFetchBlockNumbers).toStrictEqual({
+          [`${NETWORK_STATE_MOCK.providerConfig.chainId}#${ADDERSS_MOCK}`]:
+            parseInt(TRANSACTION_MOCK_2.blockNumber as string, 10),
+        });
       });
 
-      it('of transactions with matching network ID if no chain ID', async () => {
+      it('does not if no fetched transactions', async () => {
         const helper = new IncomingTransactionHelper({
           ...CONTROLLER_ARGS_MOCK,
-          remoteTransactionSource: createRemoteTransactionSourceMock([
-            { ...TRANSACTION_MOCK_2, chainId: undefined, networkID: '1' },
-          ]),
+          remoteTransactionSource: createRemoteTransactionSourceMock([]),
         });
 
-        const result = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [
-            { ...TRANSACTION_MOCK, chainId: undefined, networkID: '1' },
-          ],
-        });
-
-        expect(result.latestBlockNumber).toBeDefined();
-        expect(result.latestBlockNumber).toStrictEqual(
-          TRANSACTION_MOCK_2.blockNumber,
+        const { blockNumberListener } = await emitBlockTrackerLatestEvent(
+          helper,
         );
+
+        expect(blockNumberListener).not.toHaveBeenCalled();
       });
 
-      it('of transactions with block number', async () => {
+      it('does not if no block number on fetched transaction', async () => {
         const helper = new IncomingTransactionHelper({
           ...CONTROLLER_ARGS_MOCK,
           remoteTransactionSource: createRemoteTransactionSourceMock([
@@ -251,123 +456,123 @@ describe('IncomingTransactionHelper', () => {
           ]),
         });
 
-        const result = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [TRANSACTION_MOCK],
+        const { blockNumberListener } = await emitBlockTrackerLatestEvent(
+          helper,
+        );
+
+        expect(blockNumberListener).not.toHaveBeenCalled();
+      });
+
+      it('does not if fetch transaction not to current account', async () => {
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock([
+            {
+              ...TRANSACTION_MOCK_2,
+              transaction: { to: '0x2' },
+            } as TransactionMeta,
+          ]),
         });
 
-        expect(result.latestBlockNumber).toBeDefined();
-        expect(result.latestBlockNumber).toStrictEqual(
-          TRANSACTION_MOCK.blockNumber,
+        const { blockNumberListener } = await emitBlockTrackerLatestEvent(
+          helper,
         );
+
+        expect(blockNumberListener).not.toHaveBeenCalled();
+      });
+
+      it('does not if fetched transaction has same block number', async () => {
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock([
+            TRANSACTION_MOCK_2,
+          ]),
+          lastFetchedBlockNumbers: {
+            [`${NETWORK_STATE_MOCK.providerConfig.chainId}#${ADDERSS_MOCK}`]:
+              parseInt(TRANSACTION_MOCK_2.blockNumber as string, 10),
+          },
+        });
+
+        const { blockNumberListener } = await emitBlockTrackerLatestEvent(
+          helper,
+        );
+
+        expect(blockNumberListener).not.toHaveBeenCalled();
       });
     });
+  });
 
-    describe('updates toSmartContract property on transactions', () => {
-      it('to false if no to address', async () => {
-        const helper = new IncomingTransactionHelper({
-          ...CONTROLLER_ARGS_MOCK,
-          remoteTransactionSource: createRemoteTransactionSourceMock([
-            {
-              ...TRANSACTION_MOCK_2,
-              transaction: { ...TRANSACTION_MOCK_2.transaction, to: undefined },
-            },
-          ]),
-        });
-
-        const result = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [
-            {
-              ...TRANSACTION_MOCK,
-              transaction: { ...TRANSACTION_MOCK.transaction, to: undefined },
-            },
-          ],
-        });
-
-        expect(result.transactions[0].toSmartContract).toBe(false);
-        expect(result.transactions[1].toSmartContract).toBe(false);
+  describe('start', () => {
+    it('adds listener to block tracker', async () => {
+      const helper = new IncomingTransactionHelper({
+        ...CONTROLLER_ARGS_MOCK,
+        remoteTransactionSource: createRemoteTransactionSourceMock([]),
       });
 
-      it('to false if data is explicitly empty', async () => {
-        const helper = new IncomingTransactionHelper({
-          ...CONTROLLER_ARGS_MOCK,
-          remoteTransactionSource: createRemoteTransactionSourceMock([
-            {
-              ...TRANSACTION_MOCK_2,
-              transaction: { ...TRANSACTION_MOCK_2.transaction, data: '0x' },
-            },
-          ]),
-        });
+      helper.start();
 
-        const result = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [
-            {
-              ...TRANSACTION_MOCK,
-              transaction: { ...TRANSACTION_MOCK.transaction, data: '0x' },
-            },
-          ],
-        });
+      expect(
+        CONTROLLER_ARGS_MOCK.blockTracker.addListener,
+      ).toHaveBeenCalledTimes(1);
+    });
 
-        expect(result.transactions[0].toSmartContract).toBe(false);
-        expect(result.transactions[1].toSmartContract).toBe(false);
+    it('does nothing if already started', async () => {
+      const helper = new IncomingTransactionHelper({
+        ...CONTROLLER_ARGS_MOCK,
+        remoteTransactionSource: createRemoteTransactionSourceMock([]),
       });
 
-      it('to false if isSmartContractCode returns false', async () => {
-        isSmartContractCodeMock.mockReturnValue(false);
+      helper.start();
+      helper.start();
 
-        const helper = new IncomingTransactionHelper({
-          ...CONTROLLER_ARGS_MOCK,
-          remoteTransactionSource: createRemoteTransactionSourceMock([
-            TRANSACTION_MOCK_2,
-          ]),
-        });
+      expect(
+        CONTROLLER_ARGS_MOCK.blockTracker.addListener,
+      ).toHaveBeenCalledTimes(1);
+    });
 
-        const result = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [TRANSACTION_MOCK],
-        });
-
-        expect(result.transactions[0].toSmartContract).toBe(false);
-        expect(result.transactions[1].toSmartContract).toBe(false);
+    it('does nothing if disabled', async () => {
+      const helper = new IncomingTransactionHelper({
+        ...CONTROLLER_ARGS_MOCK,
+        isEnabled: () => false,
+        remoteTransactionSource: createRemoteTransactionSourceMock([]),
       });
 
-      it('to true if isSmartContractCode returns true', async () => {
-        isSmartContractCodeMock.mockReturnValue(true);
+      helper.start();
 
-        const helper = new IncomingTransactionHelper({
-          ...CONTROLLER_ARGS_MOCK,
-          remoteTransactionSource: createRemoteTransactionSourceMock([
-            TRANSACTION_MOCK_2,
-          ]),
-        });
+      expect(
+        CONTROLLER_ARGS_MOCK.blockTracker.addListener,
+      ).not.toHaveBeenCalled();
+    });
 
-        const result = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [TRANSACTION_MOCK],
-        });
-
-        expect(result.transactions[0].toSmartContract).toBe(true);
-        expect(result.transactions[1].toSmartContract).toBe(true);
+    it('does nothing if network not supported by remote transaction source', async () => {
+      const helper = new IncomingTransactionHelper({
+        ...CONTROLLER_ARGS_MOCK,
+        remoteTransactionSource: createRemoteTransactionSourceMock([], {
+          isSupportedNetwork: false,
+        }),
       });
 
-      it('to existing value if already set', async () => {
-        const helper = new IncomingTransactionHelper({
-          ...CONTROLLER_ARGS_MOCK,
-          remoteTransactionSource: createRemoteTransactionSourceMock([
-            { ...TRANSACTION_MOCK_2, toSmartContract: false },
-          ]),
-        });
+      helper.start();
 
-        const result = await helper.reconcile({
-          ...RECONCILE_ARGS_MOCK,
-          localTransactions: [{ ...TRANSACTION_MOCK, toSmartContract: true }],
-        });
+      expect(
+        CONTROLLER_ARGS_MOCK.blockTracker.addListener,
+      ).not.toHaveBeenCalled();
+    });
+  });
 
-        expect(result.transactions[0].toSmartContract).toBe(true);
-        expect(result.transactions[1].toSmartContract).toBe(false);
+  describe('stop', () => {
+    it('removes listener from block tracker', async () => {
+      const helper = new IncomingTransactionHelper({
+        ...CONTROLLER_ARGS_MOCK,
+        remoteTransactionSource: createRemoteTransactionSourceMock([]),
       });
+
+      helper.start();
+      helper.stop();
+
+      expect(
+        CONTROLLER_ARGS_MOCK.blockTracker.removeListener,
+      ).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/transaction-controller/src/IncomingTransactionHelper.ts
+++ b/packages/transaction-controller/src/IncomingTransactionHelper.ts
@@ -1,162 +1,143 @@
-import { isSmartContractCode, query } from '@metamask/controller-utils';
-import type EthQuery from '@metamask/eth-query';
-import type { NetworkState } from '@metamask/network-controller';
+import type { BlockTracker, NetworkState } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
+import EventEmitter from 'events';
 
-import type {
-  RemoteTransactionSource,
-  Transaction,
-  TransactionMeta,
-  TransactionStatus,
-} from './types';
+import type { RemoteTransactionSource, TransactionMeta } from './types';
 
-const SUPPORTED_NETWORK_IDS = [
-  '1', // Mainnet
-  '5', // Goerli
-  '11155111', // Sepolia
+const UPDATE_CHECKS: ((txMeta: TransactionMeta) => any)[] = [
+  (txMeta) => txMeta.status,
+  (txMeta) => txMeta.transaction.gasUsed,
 ];
 
 export class IncomingTransactionHelper {
+  hub: EventEmitter;
+
+  #blockTracker: BlockTracker;
+
+  #getCurrentAccount: () => string;
+
+  #getLocalTransactions: () => TransactionMeta[];
+
   #getNetworkState: () => NetworkState;
 
-  #getEthQuery: () => EthQuery;
+  #isEnabled: () => boolean;
 
-  #transactionLimit: number;
+  #isRunning: boolean;
+
+  #lastFetchedBlockNumbers: Record<string, number>;
+
+  #onLatestBlock: (blockNumberHex: Hex) => Promise<void>;
 
   #remoteTransactionSource: RemoteTransactionSource;
 
+  #transactionLimit?: number;
+
+  #updateTransactions: boolean;
+
   constructor({
+    blockTracker,
+    getCurrentAccount,
+    getLocalTransactions,
     getNetworkState,
-    getEthQuery,
-    transactionLimit,
+    isEnabled,
+    lastFetchedBlockNumbers,
     remoteTransactionSource,
+    transactionLimit,
+    updateTransactions,
   }: {
+    blockTracker: BlockTracker;
+    getCurrentAccount: () => string;
     getNetworkState: () => NetworkState;
-    getEthQuery: () => EthQuery;
-    transactionLimit: number;
+    getLocalTransactions?: () => TransactionMeta[];
+    isEnabled?: () => boolean;
+    lastFetchedBlockNumbers?: Record<string, number>;
     remoteTransactionSource: RemoteTransactionSource;
+    transactionLimit?: number;
+    updateTransactions?: boolean;
   }) {
+    this.hub = new EventEmitter();
+
+    this.#blockTracker = blockTracker;
+    this.#getCurrentAccount = getCurrentAccount;
+    this.#getLocalTransactions = getLocalTransactions || (() => []);
     this.#getNetworkState = getNetworkState;
-    this.#getEthQuery = getEthQuery;
-    this.#transactionLimit = transactionLimit;
+    this.#isEnabled = isEnabled ?? (() => true);
+    this.#isRunning = false;
+    this.#lastFetchedBlockNumbers = lastFetchedBlockNumbers ?? {};
     this.#remoteTransactionSource = remoteTransactionSource;
-  }
+    this.#transactionLimit = transactionLimit;
+    this.#updateTransactions = updateTransactions ?? false;
 
-  async reconcile({
-    address,
-    localTransactions,
-    fromBlock,
-    apiKey,
-  }: {
-    address: string;
-    localTransactions: TransactionMeta[];
-    fromBlock?: string;
-    apiKey?: string;
-  }): Promise<{
-    updateRequired: boolean;
-    transactions: TransactionMeta[];
-    latestBlockNumber?: string;
-  }> {
-    const { providerConfig, networkId: currentNetworkId } =
-      this.#getNetworkState();
-    const { chainId: currentChainId, type: networkType } = providerConfig;
-
-    if (
-      currentNetworkId === null ||
-      !SUPPORTED_NETWORK_IDS.includes(currentNetworkId)
-    ) {
-      return { updateRequired: false, transactions: [] };
-    }
-
-    const remoteTransactions =
-      await this.#remoteTransactionSource.fetchTransactions({
-        address,
-        networkType,
-        limit: this.#transactionLimit,
-        currentChainId,
-        currentNetworkId,
-        fromBlock,
-        apiKey,
-      });
-
-    const [updateRequired, transactions] = this.#reconcileTransactions(
-      localTransactions,
-      remoteTransactions,
-    );
-
-    this.#sortTransactionsByTime(transactions);
-
-    const latestBlockNumber = this.#getLatestBlockNumber(
-      transactions,
-      address,
-      currentChainId,
-      currentNetworkId,
-    );
-
-    await this.#updateSmartContractProperty(transactions);
-
-    return { updateRequired, transactions, latestBlockNumber };
-  }
-
-  async #updateSmartContractProperty(transactions: TransactionMeta[]) {
-    await Promise.all(
-      transactions.map(async (tx) => {
-        tx.toSmartContract ??= await this.#isToSmartContract(tx.transaction);
-      }),
-    );
-  }
-
-  #getLatestBlockNumber(
-    transactions: TransactionMeta[],
-    address: string,
-    currentChainId: Hex,
-    currentNetworkId: string,
-  ): string | undefined {
-    let latestBlockNumber: string | undefined;
-
-    for (const tx of transactions) {
-      const onCurrentChain =
-        tx.chainId === currentChainId ||
-        (!tx.chainId && tx.networkID === currentNetworkId);
-
-      const toCurrentAccount =
-        tx.transaction.to?.toLowerCase() === address.toLowerCase();
-
-      const currentBlockNumberValue = tx.blockNumber
-        ? parseInt(tx.blockNumber, 10)
-        : -1;
-
-      const latestBlockNumberValue = latestBlockNumber
-        ? parseInt(latestBlockNumber, 10)
-        : -1;
-
-      if (
-        onCurrentChain &&
-        toCurrentAccount &&
-        latestBlockNumberValue < currentBlockNumberValue
-      ) {
-        latestBlockNumber = tx.blockNumber;
+    // Using a property instead of a method to provide a listener reference
+    // with the correct scope that we can remove later if stopped.
+    this.#onLatestBlock = async (blockNumberHex: Hex) => {
+      try {
+        await this.#update(blockNumberHex);
+      } catch (error) {
+        console.error('Error while checking incoming transactions', error);
       }
-    }
-
-    return latestBlockNumber;
+    };
   }
 
-  async #isToSmartContract(transaction: Transaction): Promise<boolean> {
-    // Contract Deploy
-    if (!transaction.to) {
-      return false;
+  start() {
+    if (this.#isRunning) {
+      return;
     }
 
-    // Send
-    if (transaction.data === '0x') {
-      return false;
+    if (!this.#canStart()) {
+      return;
     }
 
-    const ethQuery = this.#getEthQuery();
-    const code = await query(ethQuery, 'getCode', [transaction.to]);
+    this.#blockTracker.addListener('latest', this.#onLatestBlock);
+    this.#isRunning = true;
+  }
 
-    return isSmartContractCode(code);
+  stop() {
+    this.#blockTracker.removeListener('latest', this.#onLatestBlock);
+    this.#isRunning = false;
+  }
+
+  async #update(latestBlockNumberHex: Hex): Promise<void> {
+    if (!this.#canStart()) {
+      return;
+    }
+
+    const latestBlockNumber = parseInt(latestBlockNumberHex, 16);
+    const fromBlock = this.#getFromBlock(latestBlockNumber);
+    const address = this.#getCurrentAccount();
+    const currentChainId = this.#getCurrentChainId();
+    const currentNetworkId = this.#getCurrentNetworkId();
+
+    let remoteTransactions = [];
+
+    try {
+      remoteTransactions =
+        await this.#remoteTransactionSource.fetchTransactions({
+          address,
+          currentChainId,
+          currentNetworkId,
+          fromBlock,
+          limit: this.#transactionLimit,
+        });
+    } catch (error: any) {
+      return;
+    }
+
+    if (!this.#updateTransactions) {
+      remoteTransactions = remoteTransactions.filter(
+        (tx) => tx.transaction.to?.toLowerCase() === address.toLowerCase(),
+      );
+    }
+
+    this.#updateLastFetchedBlockNumber(remoteTransactions);
+
+    const [updateRequired, transactions] =
+      this.#reconcileTransactions(remoteTransactions);
+
+    if (updateRequired) {
+      this.#sortTransactionsByTime(transactions);
+      this.hub.emit('transactions', transactions);
+    }
   }
 
   #sortTransactionsByTime(transactions: TransactionMeta[]) {
@@ -164,9 +145,14 @@ export class IncomingTransactionHelper {
   }
 
   #reconcileTransactions(
-    localTxs: TransactionMeta[],
     remoteTxs: TransactionMeta[],
   ): [boolean, TransactionMeta[]] {
+    if (!this.#updateTransactions) {
+      return [remoteTxs.length > 0, remoteTxs];
+    }
+
+    const localTxs = this.#getLocalTransactions();
+
     const updatedTxs: TransactionMeta[] = this.#getUpdatedTransactions(
       remoteTxs,
       localTxs,
@@ -177,15 +163,8 @@ export class IncomingTransactionHelper {
       localTxs,
     );
 
-    const updatedLocalTxs = localTxs.map((tx: TransactionMeta) => {
-      const txIdx = updatedTxs.findIndex(
-        ({ transactionHash }) => transactionHash === tx.transactionHash,
-      );
-      return txIdx === -1 ? tx : updatedTxs[txIdx];
-    });
-
     const updateRequired = newTxs.length > 0 || updatedTxs.length > 0;
-    const transactions = [...newTxs, ...updatedLocalTxs];
+    const transactions = [...newTxs, ...updatedTxs];
 
     return [updateRequired, transactions];
   }
@@ -194,61 +173,106 @@ export class IncomingTransactionHelper {
     remoteTxs: TransactionMeta[],
     localTxs: TransactionMeta[],
   ): TransactionMeta[] {
-    return remoteTxs.filter((tx) => {
-      const alreadyInTransactions = localTxs.find(
-        ({ transactionHash }) => transactionHash === tx.transactionHash,
-      );
-      return !alreadyInTransactions;
-    });
+    return remoteTxs.filter(
+      (tx) =>
+        !localTxs.some(
+          ({ transactionHash }) => transactionHash === tx.transactionHash,
+        ),
+    );
   }
 
   #getUpdatedTransactions(
     remoteTxs: TransactionMeta[],
     localTxs: TransactionMeta[],
   ): TransactionMeta[] {
-    return remoteTxs.filter((remoteTx) => {
-      const isTxOutdated = localTxs.find((localTx) => {
-        return (
+    return remoteTxs.filter((remoteTx) =>
+      localTxs.some(
+        (localTx) =>
           remoteTx.transactionHash === localTx.transactionHash &&
-          this.#isTransactionOutdated(remoteTx, localTx)
-        );
-      });
-      return isTxOutdated;
-    });
+          this.#isTransactionOutdated(remoteTx, localTx),
+      ),
+    );
   }
 
   #isTransactionOutdated(
     remoteTx: TransactionMeta,
     localTx: TransactionMeta,
   ): boolean {
-    const statusOutdated = this.#isStatusOutdated(
-      remoteTx.transactionHash,
-      localTx.transactionHash,
-      remoteTx.status,
-      localTx.status,
+    return UPDATE_CHECKS.some(
+      (getValue) => getValue(remoteTx) !== getValue(localTx),
     );
-
-    const gasDataOutdated = this.#isGasDataOutdated(
-      remoteTx.transaction.gasUsed,
-      localTx.transaction.gasUsed,
-    );
-
-    return statusOutdated || gasDataOutdated;
   }
 
-  #isStatusOutdated(
-    remoteTxHash: string | undefined,
-    localTxHash: string | undefined,
-    remoteTxStatus: TransactionStatus,
-    localTxStatus: TransactionStatus,
-  ): boolean {
-    return remoteTxHash === localTxHash && remoteTxStatus !== localTxStatus;
+  #getFromBlock(latestBlockNumber: number): number {
+    const lastFetchedKey = this.#getBlockNumberKey();
+
+    const lastFetchedBlockNumber =
+      this.#lastFetchedBlockNumbers[lastFetchedKey];
+
+    if (lastFetchedBlockNumber) {
+      return lastFetchedBlockNumber + 1;
+    }
+
+    // Avoid using latest block as remote transaction source
+    // may not have indexed it yet
+    return Math.max(latestBlockNumber - 10, 0);
   }
 
-  #isGasDataOutdated(
-    remoteGasUsed: string | undefined,
-    localGasUsed: string | undefined,
-  ): boolean {
-    return remoteGasUsed !== localGasUsed;
+  #updateLastFetchedBlockNumber(remoteTxs: TransactionMeta[]) {
+    let lastFetchedBlockNumber = -1;
+
+    for (const tx of remoteTxs) {
+      const currentBlockNumberValue = tx.blockNumber
+        ? parseInt(tx.blockNumber, 10)
+        : -1;
+
+      lastFetchedBlockNumber = Math.max(
+        lastFetchedBlockNumber,
+        currentBlockNumberValue,
+      );
+    }
+
+    if (lastFetchedBlockNumber === -1) {
+      return;
+    }
+
+    const lastFetchedKey = this.#getBlockNumberKey();
+    const previousValue = this.#lastFetchedBlockNumbers[lastFetchedKey];
+
+    if (previousValue === lastFetchedBlockNumber) {
+      return;
+    }
+
+    this.#lastFetchedBlockNumbers[lastFetchedKey] = lastFetchedBlockNumber;
+
+    this.hub.emit(
+      'updatedLastFetchedBlockNumbers',
+      this.#lastFetchedBlockNumbers,
+    );
+  }
+
+  #getBlockNumberKey(): string {
+    return `${this.#getCurrentChainId()}#${this.#getCurrentAccount().toLowerCase()}`;
+  }
+
+  #canStart(): boolean {
+    const isEnabled = this.#isEnabled();
+    const currentChainId = this.#getCurrentChainId();
+    const currentNetworkId = this.#getCurrentNetworkId();
+
+    const isSupportedNetwork = this.#remoteTransactionSource.isSupportedNetwork(
+      currentChainId,
+      currentNetworkId,
+    );
+
+    return isEnabled && isSupportedNetwork;
+  }
+
+  #getCurrentChainId(): Hex {
+    return this.#getNetworkState().providerConfig.chainId;
+  }
+
+  #getCurrentNetworkId(): string {
+    return this.#getNetworkState().networkId as string;
   }
 }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -218,32 +218,46 @@ export class TransactionController extends BaseController<
    * Creates a TransactionController instance.
    *
    * @param options - The controller options.
+   * @param options.blockTracker - The block tracker used to poll for new blocks data.
    * @param options.getNetworkState - Gets the state of the network controller.
+   * @param options.getSelectedAddress - Gets the address of the currently selected account.
+   * @param options.incomingTransactions - Configuration options for incoming transaction support.
+   * @param options.incomingTransactions.includeTokenTransfers - Whether or not to include ERC20 token transfers.
+   * @param options.incomingTransactions.isEnabled - Whether or not incoming transaction retrieval is enabled.
+   * @param options.incomingTransactions.updateTransactions - Whether or not to update local transactions using remote transaction data.
+   * @param options.messenger - The controller messenger.
    * @param options.onNetworkStateChange - Allows subscribing to network controller state changes.
    * @param options.provider - The provider used to create the underlying EthQuery instance.
-   * @param options.blockTracker - The block tracker used to poll for new blocks data.
-   * @param options.messenger - The controller messenger.
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
    */
   constructor(
     {
+      blockTracker,
       getNetworkState,
+      getSelectedAddress,
+      incomingTransactions = {},
+      messenger,
       onNetworkStateChange,
       provider,
-      blockTracker,
-      messenger,
     }: {
+      blockTracker: BlockTracker;
       getNetworkState: () => NetworkState;
+      getSelectedAddress: () => string;
+      incomingTransactions: {
+        includeTokenTransfers?: boolean;
+        isEnabled?: () => boolean;
+        updateTransactions?: boolean;
+      };
+      messenger: TransactionControllerMessenger;
       onNetworkStateChange: (listener: (state: NetworkState) => void) => void;
       provider: Provider;
-      blockTracker: BlockTracker;
-      messenger: TransactionControllerMessenger;
     },
     config?: Partial<TransactionConfig>,
     state?: Partial<TransactionState>,
   ) {
     super(config, state);
+
     this.defaultConfig = {
       interval: 15000,
       txHistoryLimit: 40,
@@ -253,12 +267,15 @@ export class TransactionController extends BaseController<
       methodData: {},
       transactions: [],
     };
+
     this.initialize();
+
     this.provider = provider;
     this.messagingSystem = messenger;
     this.getNetworkState = getNetworkState;
     this.ethQuery = new EthQuery(provider);
     this.registry = new MethodRegistry({ provider });
+
     this.nonceTracker = new NonceTracker({
       provider,
       blockTracker,
@@ -275,17 +292,24 @@ export class TransactionController extends BaseController<
           this.state.transactions,
         ),
     });
+
     this.incomingTransactionHelper = new IncomingTransactionHelper({
+      blockTracker,
+      getCurrentAccount: getSelectedAddress,
       getNetworkState,
-      getEthQuery: () => this.ethQuery,
+      isEnabled: incomingTransactions.isEnabled,
+      remoteTransactionSource: new EtherscanRemoteTransactionSource({
+        includeTokenTransfers: incomingTransactions.includeTokenTransfers,
+      }),
       transactionLimit: this.config.txHistoryLimit,
-      remoteTransactionSource: new EtherscanRemoteTransactionSource(),
+      updateTransactions: incomingTransactions.updateTransactions,
     });
 
     onNetworkStateChange(() => {
       this.ethQuery = new EthQuery(this.provider);
       this.registry = new MethodRegistry({ provider: this.provider });
     });
+
     this.poll();
   }
 
@@ -814,36 +838,12 @@ export class TransactionController extends BaseController<
     });
   }
 
-  /**
-   * Get transactions from Etherscan for the given address. By default all transactions are
-   * returned, but the `fromBlock` option can be given to filter just for transactions from a
-   * specific block onward.
-   *
-   * @param address - The address to fetch the transactions for.
-   * @param opt - Object containing optional data, fromBlock and Etherscan API key.
-   * @returns The block number of the latest incoming transaction.
-   */
-  async fetchAll(
-    address: string,
-    opt?: FetchAllOptions,
-  ): Promise<string | void> {
-    const { transactions: localTransactions } = this.state;
+  startIncomingTransactionProcessing() {
+    this.incomingTransactionHelper.start();
+  }
 
-    const { updateRequired, transactions, latestBlockNumber } =
-      await this.incomingTransactionHelper.reconcile({
-        address,
-        localTransactions,
-        fromBlock: opt?.fromBlock,
-        apiKey: opt?.etherscanApiKey,
-      });
-
-    if (updateRequired) {
-      this.update({
-        transactions: this.trimTransactionsForState(transactions),
-      });
-    }
-
-    return latestBlockNumber;
+  stopIncomingTransactionProcessing() {
+    this.incomingTransactionHelper.stop();
   }
 
   private async processApproval(

--- a/packages/transaction-controller/src/constants.ts
+++ b/packages/transaction-controller/src/constants.ts
@@ -1,0 +1,122 @@
+export const CHAIN_IDS = {
+  MAINNET: '0x1',
+  GOERLI: '0x5',
+  BSC: '0x38',
+  BSC_TESTNET: '0x61',
+  OPTIMISM: '0xa',
+  OPTIMISM_TESTNET: '0x1a4',
+  POLYGON: '0x89',
+  POLYGON_TESTNET: '0x13881',
+  AVALANCHE: '0xa86a',
+  AVALANCHE_TESTNET: '0xa869',
+  FANTOM: '0xfa',
+  FANTOM_TESTNET: '0xfa2',
+  SEPOLIA: '0xaa36a7',
+  LINEA_GOERLI: '0xe704',
+  LINEA_MAINNET: '0xe708',
+  MOONBEAM: '0x504',
+  MOONBEAM_TESTNET: '0x507',
+  MOONRIVER: '0x505',
+  GNOSIS: '0x64',
+} as const;
+
+const DEFAULT_ETHERSCAN_DOMAIN = 'etherscan.io';
+const DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX = 'api';
+
+export const ETHERSCAN_SUPPORTED_NETWORKS = {
+  [CHAIN_IDS.GOERLI]: {
+    domain: DEFAULT_ETHERSCAN_DOMAIN,
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-goerli`,
+    networkId: parseInt(CHAIN_IDS.GOERLI, 16).toString(),
+  },
+  [CHAIN_IDS.MAINNET]: {
+    domain: DEFAULT_ETHERSCAN_DOMAIN,
+    subdomain: DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX,
+    networkId: parseInt(CHAIN_IDS.MAINNET, 16).toString(),
+  },
+  [CHAIN_IDS.SEPOLIA]: {
+    domain: DEFAULT_ETHERSCAN_DOMAIN,
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-sepolia`,
+    networkId: parseInt(CHAIN_IDS.SEPOLIA, 16).toString(),
+  },
+  [CHAIN_IDS.LINEA_GOERLI]: {
+    domain: 'lineascan.build',
+    subdomain: 'goerli',
+    networkId: parseInt(CHAIN_IDS.LINEA_GOERLI, 16).toString(),
+  },
+  [CHAIN_IDS.LINEA_MAINNET]: {
+    domain: 'lineascan.build',
+    subdomain: DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX,
+    networkId: parseInt(CHAIN_IDS.LINEA_MAINNET, 16).toString(),
+  },
+  [CHAIN_IDS.BSC]: {
+    domain: 'bscscan.com',
+    subdomain: DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX,
+    networkId: parseInt(CHAIN_IDS.BSC, 16).toString(),
+  },
+  [CHAIN_IDS.BSC_TESTNET]: {
+    domain: 'bscscan.com',
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-testnet`,
+    networkId: parseInt(CHAIN_IDS.BSC_TESTNET, 16).toString(),
+  },
+  [CHAIN_IDS.OPTIMISM]: {
+    domain: DEFAULT_ETHERSCAN_DOMAIN,
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-optimistic`,
+    networkId: parseInt(CHAIN_IDS.OPTIMISM, 16).toString(),
+  },
+  [CHAIN_IDS.OPTIMISM_TESTNET]: {
+    domain: DEFAULT_ETHERSCAN_DOMAIN,
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-goerli-optimistic`,
+    networkId: parseInt(CHAIN_IDS.OPTIMISM_TESTNET, 16).toString(),
+  },
+  [CHAIN_IDS.POLYGON]: {
+    domain: 'polygonscan.com',
+    subdomain: DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX,
+    networkId: parseInt(CHAIN_IDS.POLYGON, 16).toString(),
+  },
+  [CHAIN_IDS.POLYGON_TESTNET]: {
+    domain: 'polygonscan.com',
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-mumbai`,
+    networkId: parseInt(CHAIN_IDS.POLYGON_TESTNET, 16).toString(),
+  },
+  [CHAIN_IDS.AVALANCHE]: {
+    domain: 'snowtrace.io',
+    subdomain: DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX,
+    networkId: parseInt(CHAIN_IDS.AVALANCHE, 16).toString(),
+  },
+  [CHAIN_IDS.AVALANCHE_TESTNET]: {
+    domain: 'snowtrace.io',
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-testnet`,
+    networkId: parseInt(CHAIN_IDS.AVALANCHE_TESTNET, 16).toString(),
+  },
+  [CHAIN_IDS.FANTOM]: {
+    domain: 'ftmscan.com',
+    subdomain: DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX,
+    networkId: parseInt(CHAIN_IDS.FANTOM, 16).toString(),
+  },
+  [CHAIN_IDS.FANTOM_TESTNET]: {
+    domain: 'ftmscan.com',
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-testnet`,
+    networkId: parseInt(CHAIN_IDS.FANTOM_TESTNET, 16).toString(),
+  },
+  [CHAIN_IDS.MOONBEAM]: {
+    domain: 'moonscan.io',
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-moonbeam`,
+    networkId: parseInt(CHAIN_IDS.MOONBEAM, 16).toString(),
+  },
+  [CHAIN_IDS.MOONBEAM_TESTNET]: {
+    domain: 'moonscan.io',
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-moonbase`,
+    networkId: parseInt(CHAIN_IDS.MOONBEAM_TESTNET, 16).toString(),
+  },
+  [CHAIN_IDS.MOONRIVER]: {
+    domain: 'moonscan.io',
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-moonriver`,
+    networkId: parseInt(CHAIN_IDS.MOONRIVER, 16).toString(),
+  },
+  [CHAIN_IDS.GNOSIS]: {
+    domain: 'gnosisscan.io',
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-gnosis`,
+    networkId: parseInt(CHAIN_IDS.GNOSIS, 16).toString(),
+  },
+};

--- a/packages/transaction-controller/src/etherscan.ts
+++ b/packages/transaction-controller/src/etherscan.ts
@@ -1,4 +1,7 @@
-import { NetworkType, handleFetch } from '@metamask/controller-utils';
+import { handleFetch } from '@metamask/controller-utils';
+import type { Hex } from '@metamask/utils';
+
+import { ETHERSCAN_SUPPORTED_NETWORKS } from './constants';
 
 export interface EtherscanTransactionMetaBase {
   blockNumber: string;
@@ -36,16 +39,21 @@ export interface EtherscanTokenTransactionMeta
 export interface EtherscanTransactionResponse<
   T extends EtherscanTransactionMetaBase,
 > {
-  status: '0' | '1';
   result: T[];
 }
 
 export interface EtherscanTransactionRequest {
   address: string;
-  networkType: NetworkType;
-  limit: number;
-  fromBlock?: string;
   apiKey?: string;
+  chainId: Hex;
+  fromBlock?: number;
+  limit?: number;
+}
+
+interface RawEtherscanResponse<T extends EtherscanTransactionMetaBase> {
+  status: '0' | '1';
+  message: string;
+  result: string | T[];
 }
 
 /**
@@ -53,27 +61,27 @@ export interface EtherscanTransactionRequest {
  *
  * @param request - Configuration required to fetch transactions.
  * @param request.address - Address to retrieve transactions for.
- * @param request.networkType - Current network type used to determine the Etherscan subdomain.
- * @param request.limit - Maximum number of transactions to retrieve.
  * @param request.apiKey - Etherscan API key.
+ * @param request.chainId - Current chain ID used to determine subdomain and domain.
  * @param request.fromBlock - Block number to start fetching transactions from.
+ * @param request.limit - Number of transactions to retrieve.
  * @returns An Etherscan response object containing the request status and an array of token transaction data.
  */
 export async function fetchEtherscanTransactions({
   address,
-  networkType,
-  limit,
   apiKey,
+  chainId,
   fromBlock,
+  limit,
 }: EtherscanTransactionRequest): Promise<
   EtherscanTransactionResponse<EtherscanTransactionMeta>
 > {
   return await fetchTransactions('txlist', {
     address,
-    networkType,
-    limit,
-    fromBlock,
     apiKey,
+    chainId,
+    fromBlock,
+    limit,
   });
 }
 
@@ -82,27 +90,27 @@ export async function fetchEtherscanTransactions({
  *
  * @param request - Configuration required to fetch token transactions.
  * @param request.address - Address to retrieve token transactions for.
- * @param request.networkType - Current network type used to determine the Etherscan subdomain.
- * @param request.limit - Maximum number of token transactions to retrieve.
  * @param request.apiKey - Etherscan API key.
+ * @param request.chainId - Current chain ID used to determine subdomain and domain.
  * @param request.fromBlock - Block number to start fetching token transactions from.
+ * @param request.limit - Number of token transactions to retrieve.
  * @returns An Etherscan response object containing the request status and an array of token transaction data.
  */
 export async function fetchEtherscanTokenTransactions({
   address,
-  networkType,
-  limit,
   apiKey,
+  chainId,
   fromBlock,
+  limit,
 }: EtherscanTransactionRequest): Promise<
   EtherscanTransactionResponse<EtherscanTokenTransactionMeta>
 > {
   return await fetchTransactions('tokentx', {
     address,
-    networkType,
-    limit,
-    fromBlock,
     apiKey,
+    chainId,
+    fromBlock,
+    limit,
   });
 }
 
@@ -112,73 +120,76 @@ export async function fetchEtherscanTokenTransactions({
  * @param action - The Etherscan endpoint to use.
  * @param options - Options bag.
  * @param options.address - Address to retrieve transactions for.
- * @param options.networkType - Current network type used to determine the Etherscan subdomain.
- * @param options.limit - Maximum number of transactions to retrieve.
  * @param options.apiKey - Etherscan API key.
+ * @param options.chainId - Current chain ID used to determine subdomain and domain.
  * @param options.fromBlock - Block number to start fetching transactions from.
+ * @param options.limit - Number of transactions to retrieve.
  * @returns An object containing the request status and an array of transaction data.
  */
 async function fetchTransactions<T extends EtherscanTransactionMetaBase>(
   action: string,
   {
     address,
-    networkType,
-    limit,
     apiKey,
+    chainId,
     fromBlock,
+    limit,
   }: {
     address: string;
-    networkType: NetworkType;
-    limit: number;
-    fromBlock?: string;
     apiKey?: string;
+    chainId: Hex;
+    fromBlock?: number;
+    limit?: number;
   },
 ): Promise<EtherscanTransactionResponse<T>> {
   const urlParams = {
     module: 'account',
     address,
-    startBlock: fromBlock,
+    startBlock: fromBlock?.toString(),
     apikey: apiKey,
-    offset: limit.toString(),
+    offset: limit?.toString(),
     order: 'desc',
   };
 
-  const etherscanTxUrl = getEtherscanApiUrl(networkType, {
+  const etherscanTxUrl = getEtherscanApiUrl(chainId, {
     ...urlParams,
     action,
   });
 
   const response = (await handleFetch(
     etherscanTxUrl,
-  )) as EtherscanTransactionResponse<T>;
+  )) as RawEtherscanResponse<T>;
 
-  if (response.status === '0' || response.result.length <= 0) {
-    return { status: response.status, result: [] };
+  if (response.status === '0' && response.message === 'NOTOK') {
+    throw new Error(`Etherscan request failed - ${response.result}`);
   }
 
-  return response;
+  return { result: response.result as T[] };
 }
 
 /**
  * Return a URL that can be used to fetch data from Etherscan.
  *
- * @param networkType - Network type of desired network.
+ * @param chainId - Current chain ID used to determine subdomain and domain.
  * @param urlParams - The parameters used to construct the URL.
  * @returns URL to access Etherscan data.
  */
 function getEtherscanApiUrl(
-  networkType: string,
+  chainId: Hex,
   urlParams: Record<string, string | undefined>,
 ): string {
-  let etherscanSubdomain = 'api';
+  type SupportedChainId = keyof typeof ETHERSCAN_SUPPORTED_NETWORKS;
 
-  if (networkType !== NetworkType.mainnet) {
-    etherscanSubdomain = `api-${networkType}`;
+  const networkInfo = ETHERSCAN_SUPPORTED_NETWORKS[chainId as SupportedChainId];
+
+  if (!networkInfo) {
+    throw new Error(`Etherscan does not support chain with ID: ${chainId}`);
   }
 
-  const apiUrl = `https://${etherscanSubdomain}.etherscan.io`;
+  const apiUrl = `https://${networkInfo.subdomain}.${networkInfo.domain}`;
   let url = `${apiUrl}/api?`;
 
+  // eslint-disable-next-line guard-for-in
   for (const paramKey in urlParams) {
     const value = urlParams[paramKey];
 

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1,4 +1,3 @@
-import type { NetworkType } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 
 /**
@@ -127,17 +126,12 @@ export interface RemoteTransactionSourceRequest {
   /**
    * Block number to start fetching transactions from.
    */
-  fromBlock?: string;
+  fromBlock?: number;
 
   /**
    * Maximum number of transactions to retrieve.
    */
-  limit: number;
-
-  /**
-   * The type of the current network.
-   */
-  networkType: NetworkType;
+  limit?: number;
 }
 
 /**
@@ -145,6 +139,8 @@ export interface RemoteTransactionSourceRequest {
  * Used by the IncomingTransactionHelper to retrieve remote transaction data.
  */
 export interface RemoteTransactionSource {
+  isSupportedNetwork: (chainId: Hex, networkId: string) => boolean;
+
   fetchTransactions: (
     request: RemoteTransactionSourceRequest,
   ) => Promise<TransactionMeta[]>;


### PR DESCRIPTION
## Explanation

Currently the `TransactionController` retrieves incoming transactions when explicitly requested via the `fetchAll` method meaning the cadence of polling is dictated by the client.

This PR removes the `fetchAll` method and instead uses the `blockTracker` instance provided to the controller to automatically poll for incoming transactions whenever the current network has a new block.

This polling can be started and stopped using the `startIncomingTransactionPolling` and `stopIncomingTransactionPolling` methods respectively. Or an update can be required immediately via the `updateIncomingTransactions` method.

Additional optional arguments have also been added to the constructor to configure the incoming transaction support.

## References

Closes [#965](https://github.com/MetaMask/MetaMask-planning/issues/965)

## Changelog

### `@metamask/transaction-controller`

- **BREAKING**: Remove `fetchAll` method.
- **BREAKING**: Add required `getSelectedAddress` callback argument to constructor.
- **BREAKING**: Update `fromBlock` and `limit` types in `RemoteTransactionSourceRequest`.
- **BREAKING**: Add `isSupportedNetwork` method to `RemoteTransactionSource` interface.
- **ADDED**: Optional `incomingTransactions` constructor arguments including `apiKey`, `includeTokenTransfers`, `isEnabled`, and `updateTransactions`.
- **ADDED**: `startIncomingTransactionPolling`, `stopIncomingTransactionPolling`, and `updateIncomingTransactions` methods.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
