### PR TITLE
Add `requireApproval` option to `addTransaction` method option bag

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -809,7 +809,7 @@ describe('TransactionController', () => {
       );
     });
 
-    it('skip request for an approval using the approval controller', async () => {
+    it('skips request for an approval using the approval controller', async () => {
       const controller = newController();
 
       await controller.addTransaction(

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -809,7 +809,7 @@ describe('TransactionController', () => {
       );
     });
 
-    it('skips request for an approval using the approval controller', async () => {
+    it('skips approval if option explicitly false', async () => {
       const controller = newController();
 
       await controller.addTransaction(

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -809,6 +809,22 @@ describe('TransactionController', () => {
       );
     });
 
+    it('skip request for an approval using the approval controller', async () => {
+      const controller = newController();
+
+      await controller.addTransaction(
+        {
+          from: ACCOUNT_MOCK,
+          to: ACCOUNT_MOCK,
+        },
+        {
+          requireApproval: false,
+        },
+      );
+
+      expect(delayMessengerMock.call).toHaveBeenCalledTimes(0);
+    });
+
     it.each([
       ['mainnet', MOCK_MAINNET_NETWORK],
       ['custom network', MOCK_CUSTOM_NETWORK],

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -348,11 +348,11 @@ export class TransactionController extends BaseController<
     {
       deviceConfirmedOn,
       origin,
-      requireApproval = true,
+      requireApproval,
     }: {
       deviceConfirmedOn?: WalletDevice;
       origin?: string;
-      requireApproval?: boolean;
+      requireApproval?: boolean | undefined;
     } = {},
   ): Promise<Result> {
     const { chainId, networkId } = this.getChainAndNetworkId();
@@ -387,7 +387,7 @@ export class TransactionController extends BaseController<
 
     return {
       result: this.processApproval(transactionMeta, {
-        requireApproval: Boolean(requireApproval),
+        requireApproval,
       }),
       transactionMeta,
     };
@@ -891,13 +891,13 @@ export class TransactionController extends BaseController<
 
   private async processApproval(
     transactionMeta: TransactionMeta,
-    { requireApproval, shouldShowRequest = true }: { requireApproval: boolean },
+    { requireApproval, shouldShowRequest = true }: { requireApproval: boolean | undefined },
   ): Promise<string> {
     const transactionId = transactionMeta.id;
     let resultCallbacks: AcceptResultCallbacks | undefined;
 
     try {
-      if (requireApproval) {
+      if (requireApproval !== false) {
         const acceptResult = await this.requestApproval(transactionMeta, {
           shouldShowRequest,
         });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -340,7 +340,7 @@ export class TransactionController extends BaseController<
    * @param opts - Additional options to control how the transaction is added.
    * @param opts.deviceConfirmedOn - An enum to indicate what device confirmed the transaction.
    * @param opts.origin - The origin of the transaction request, such as a dApp hostname.
-   * @param opts.requireApproval - Whether to skip creating approval for transactions.
+   * @param opts.requireApproval - Whether the transaction requires approval by the user, defaults to true unless explicitly disabled.
    * @returns Object containing a promise resolving to the transaction hash if approved.
    */
   async addTransaction(

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -891,7 +891,13 @@ export class TransactionController extends BaseController<
 
   private async processApproval(
     transactionMeta: TransactionMeta,
-    { requireApproval, shouldShowRequest = true }: { requireApproval: boolean | undefined },
+    {
+      requireApproval,
+      shouldShowRequest = true,
+    }: {
+      requireApproval?: boolean | undefined;
+      shouldShowRequest?: boolean;
+    },
   ): Promise<string> {
     const transactionId = transactionMeta.id;
     let resultCallbacks: AcceptResultCallbacks | undefined;


### PR DESCRIPTION
## Explanation

This PR aims to add `requireApproval` option to `addTransaction` method options in order to either force or skip creating approval for transactions.

As seen in the PR `requireApproval` default value will be `true` to keep the same behavior as before, and set explicitly to `false` in order to skip approval. 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **ADDED**: Adds `requireApproval` option to `addTransaction` method options.

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've highlighted breaking changes using the "BREAKING" category above as appropriate
