### PR TITLE
Added an export for NetworkClientId in NetworkController

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -334,7 +334,7 @@ type CustomNetworkClientId = string;
 /**
  * The string that uniquely identifies a network client.
  */
-type NetworkClientId = BuiltInNetworkClientId | CustomNetworkClientId;
+export type NetworkClientId = BuiltInNetworkClientId | CustomNetworkClientId;
 
 /**
  * Information about networks not held by any other part of state.


### PR DESCRIPTION
## Explanation

We need this type in extension & mobile.

## References

* Related to https://github.com/MetaMask/MetaMask-planning/issues/1006

## Changelog

### `@metamask/network-controller`

- **ADDED**: Added an export for NetworkClientId in NetworkController

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
