### PR TITLE
Adding preference for security alerts

### DIFF
--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -12,6 +12,7 @@ describe('PreferencesController', () => {
       useTokenDetection: true,
       useNftDetection: false,
       openSeaEnabled: false,
+      securityAlertsEnabled: false,
       disabledRpcMethodPreferences: {
         eth_sign: false,
       },
@@ -174,6 +175,12 @@ describe('PreferencesController', () => {
     controller.setOpenSeaEnabled(true);
     controller.setUseNftDetection(true);
     expect(controller.state.useNftDetection).toBe(true);
+  });
+
+  it('should set securityAlertsEnabled', () => {
+    const controller = new PreferencesController();
+    controller.setSecurityAlertsEnabled(true);
+    expect(controller.state.securityAlertsEnabled).toBe(true);
   });
 
   it('should set disabledRpcMethodPreferences', () => {

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -33,6 +33,7 @@ export interface PreferencesState extends BaseState {
   useTokenDetection: boolean;
   useNftDetection: boolean;
   openSeaEnabled: boolean;
+  securityAlertsEnabled: boolean;
   isMultiAccountBalancesEnabled: boolean;
   disabledRpcMethodPreferences: {
     [methodName: string]: boolean;
@@ -69,6 +70,7 @@ export class PreferencesController extends BaseController<
       useTokenDetection: true,
       useNftDetection: false,
       openSeaEnabled: false,
+      securityAlertsEnabled: false,
       isMultiAccountBalancesEnabled: true,
       disabledRpcMethodPreferences: {
         eth_sign: false,
@@ -265,6 +267,15 @@ export class PreferencesController extends BaseController<
     if (!openSeaEnabled) {
       this.update({ useNftDetection: false });
     }
+  }
+
+  /**
+   * Toggle the security alert enabled setting.
+   *
+   * @param securityAlertsEnabled - Boolean indicating user preference on using security alerts.
+   */
+  setSecurityAlertsEnabled(securityAlertsEnabled: boolean) {
+    this.update({ securityAlertsEnabled });
   }
 
   /**


### PR DESCRIPTION
Adding `securityAlertsEnabled` to preference controller, this is required for enabling blockaid on mobile.