### PR TITLE
Add baseFeePerGas to transaction state

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,7 +17,7 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 84.02,
+      branches: 83.91,
       functions: 92.68,
       lines: 95.35,
       statements: 95.46,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -104,6 +104,7 @@ jest.mock('@metamask/eth-query', () =>
             gasUsed: '0x5208',
             status: '0x1',
             transactionIndex: 1337,
+            blockHash: '1337',
           },
           {
             transactionHash: '1111',
@@ -116,6 +117,16 @@ jest.mock('@metamask/eth-query', () =>
           (element: any) => element.transactionHash === _hash,
         );
         callback(undefined, tx);
+      },
+      getBlockByHash: (_blockHash: any, callback: any) => {
+        const blocks: any = [
+          { hash: '1337', number: '0x1', baseFeePerGas: '0x14' },
+          { hash: '1338', number: '0x2' },
+        ];
+        const block: any = blocks.find(
+          (element: any) => element.hash === _blockHash,
+        );
+        callback(undefined, block);
       },
     };
   }),

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1279,6 +1279,7 @@ describe('TransactionController', () => {
       const transactionMeta = controller.state.transactions[0];
       expect(transactionMeta.verifiedOnBlockchain).toBe(true);
       expect(transactionMeta.transaction.gasUsed).toBe('0x5208');
+      expect(transactionMeta.baseFeePerGas).toBe('0x14');
       expect(transactionMeta.txReceipt?.transactionIndex).toBe(1337);
     });
   });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1162,9 +1162,7 @@ export class TransactionController extends BaseController<
         meta.verifiedOnBlockchain = true;
         meta.transaction.gasUsed = txReceipt.gasUsed;
         meta.txReceipt = txReceipt;
-        if (txBlock && txBlock.baseFeePerGas) {
-          meta.baseFeePerGas = txBlock.baseFeePerGas;
-        }
+        meta.baseFeePerGas = txBlock?.baseFeePerGas;
 
         // According to the Web3 docs:
         // TRUE if the transaction was successful, FALSE if the EVM reverted the transaction.

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1155,9 +1155,16 @@ export class TransactionController extends BaseController<
           return [meta, false];
         }
 
+        const txBlock = await query(this.ethQuery, 'getBlockByHash', [
+          txReceipt.blockHash,
+        ]);
+
         meta.verifiedOnBlockchain = true;
         meta.transaction.gasUsed = txReceipt.gasUsed;
         meta.txReceipt = txReceipt;
+        if (txBlock && txBlock.baseFeePerGas) {
+          meta.baseFeePerGas = txBlock.baseFeePerGas;
+        }
 
         // According to the Web3 docs:
         // TRUE if the transaction was successful, FALSE if the EVM reverted the transaction.

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -5,19 +5,19 @@ import type { Hex } from '@metamask/utils';
  *
  * TransactionMeta representation
  * @property baseFeePerGas - Base fee of the block as a hex value, introduced in EIP-1559.
- * @property error - Synthesized error information for failed transactions
- * @property id - Generated UUID associated with this transaction
- * @property networkID - Network code as per EIP-155 for this transaction
- * @property origin - Origin this transaction was sent from
- * @property deviceConfirmedOn - string to indicate what device the transaction was confirmed
- * @property rawTransaction - Hex representation of the underlying transaction
- * @property status - String status of this transaction
- * @property time - Timestamp associated with this transaction
- * @property toSmartContract - Whether transaction recipient is a smart contract
- * @property transaction - Underlying Transaction object
- * @property txReceipt - Transaction receipt
- * @property transactionHash - Hash of a successful transaction
- * @property blockNumber - Number of the block where the transaction has been included
+ * @property error - Synthesized error information for failed transactions.
+ * @property id - Generated UUID associated with this transaction.
+ * @property networkID - Network code as per EIP-155 for this transaction.
+ * @property origin - Origin this transaction was sent from.
+ * @property deviceConfirmedOn - string to indicate what device the transaction was confirmed.
+ * @property rawTransaction - Hex representation of the underlying transaction.
+ * @property status - String status of this transaction.
+ * @property time - Timestamp associated with this transaction.
+ * @property toSmartContract - Whether transaction recipient is a smart contract.
+ * @property transaction - Underlying Transaction object.
+ * @property txReceipt - Transaction receipt.
+ * @property transactionHash - Hash of a successful transaction.
+ * @property blockNumber - Number of the block where the transaction has been included.
  */
 export type TransactionMeta =
   | ({
@@ -27,23 +27,23 @@ export type TransactionMeta =
 
 type TransactionMetaBase = {
   baseFeePerGas?: Hex;
-  isTransfer?: boolean;
-  transferInformation?: {
-    symbol: string;
-    contractAddress: string;
-    decimals: number;
-  };
-  id: string;
-  networkID?: string;
+  blockNumber?: string;
   chainId?: Hex;
+  deviceConfirmedOn?: WalletDevice;
+  id: string;
+  isTransfer?: boolean;
+  networkID?: string;
   origin?: string;
   rawTransaction?: string;
   time: number;
   toSmartContract?: boolean;
   transaction: Transaction;
   transactionHash?: string;
-  blockNumber?: string;
-  deviceConfirmedOn?: WalletDevice;
+  transferInformation?: {
+    contractAddress: string;
+    decimals: number;
+    symbol: string;
+  };
   verifiedOnBlockchain?: boolean;
   txReceipt?: TransactionReceipt;
 };

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -4,7 +4,7 @@ import type { Hex } from '@metamask/utils';
  * @type TransactionMeta
  *
  * TransactionMeta representation
- * @property baseFeePerGas - The estimated block baseFeePerGas that will be burned. Introduced in EIP 1559. Value in hex wei
+ * @property baseFeePerGas - Base fee of the block as a hex value, introduced in EIP-1559.
  * @property error - Synthesized error information for failed transactions
  * @property id - Generated UUID associated with this transaction
  * @property networkID - Network code as per EIP-155 for this transaction

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -4,6 +4,7 @@ import type { Hex } from '@metamask/utils';
  * @type TransactionMeta
  *
  * TransactionMeta representation
+ * @property baseFeePerGas - The estimated block baseFeePerGas that will be burned. Introduced in EIP 1559. Value in hex wei
  * @property error - Synthesized error information for failed transactions
  * @property id - Generated UUID associated with this transaction
  * @property networkID - Network code as per EIP-155 for this transaction
@@ -25,6 +26,7 @@ export type TransactionMeta =
   | ({ status: TransactionStatus.failed; error: Error } & TransactionMetaBase);
 
 type TransactionMetaBase = {
+  baseFeePerGas?: Hex;
   isTransfer?: boolean;
   transferInformation?: {
     symbol: string;


### PR DESCRIPTION
## Explanation
The extension `TransactionController` persists in a `baseFeePerGas` value for each confirmed transaction. Including this property into the transaction state in the core to support the unification initiative between the core and extension.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->
Fixes https://github.com/MetaMask/MetaMask-planning/issues/1072

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **ADDED**:  add `baseFeePerGas` to the transaction state and persists the value for each confirmed transaction


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
