### PR TITLE
Use messenger actions instead of `KeyringController` as constructor param

### DIFF
--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.1.0",
+    "@metamask/keyring-controller": "workspace:^",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.1.0",
-    "@metamask/keyring-controller": "workspace:^",
+    "@metamask/keyring-controller": "^7.4.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -176,11 +176,11 @@ describe('SignatureController', () => {
 
     signatureController = new SignatureController({
       messenger: messengerMock,
-      keyringController: keyringControllerMock,
       getAllState: getAllStateMock,
       securityProviderRequest: securityProviderRequestMock,
       isEthSignEnabled: isEthSignEnabledMock,
       getCurrentChainId: getCurrentChainIdMock,
+      ...keyringControllerMock,
     } as SignatureControllerOptions);
   });
 

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -117,12 +117,6 @@ const createMessageManagerMock = <T>(prototype?: any): jest.Mocked<T> => {
   }) as jest.Mocked<T>;
 };
 
-const createKeyringControllerMock = () => ({
-  signMessage: jest.fn(),
-  signPersonalMessage: jest.fn(),
-  signTypedMessage: jest.fn(),
-});
-
 describe('SignatureController', () => {
   let signatureController: SignatureController;
 
@@ -148,13 +142,27 @@ describe('SignatureController', () => {
     error: jest.fn(),
   };
   const messengerMock = createMessengerMock();
-  const keyringControllerMock = createKeyringControllerMock();
   const getAllStateMock = jest.fn();
   const securityProviderRequestMock = jest.fn();
   const isEthSignEnabledMock = jest.fn();
   const getCurrentChainIdMock = jest.fn();
   const keyringErrorMessageMock = 'Keyring Error';
   const keyringErrorMock = new Error(keyringErrorMessageMock);
+
+  const mockMessengerAction = (
+    action: string,
+    callback: (actionName: string, ...args: any[]) => any,
+  ) => {
+    messengerMock.call.mockImplementation((actionName, ...rest) => {
+      if (actionName === action) {
+        return callback(actionName, ...rest);
+      }
+
+      return Promise.resolve({
+        resultCallbacks: resultCallbacksMock,
+      });
+    });
+  };
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -180,7 +188,6 @@ describe('SignatureController', () => {
       securityProviderRequest: securityProviderRequestMock,
       isEthSignEnabled: isEthSignEnabledMock,
       getCurrentChainId: getCurrentChainIdMock,
-      ...keyringControllerMock,
     } as SignatureControllerOptions);
   });
 
@@ -371,8 +378,9 @@ describe('SignatureController', () => {
         undefined,
       );
 
-      expect(messengerMock.call).toHaveBeenCalledTimes(1);
-      expect(messengerMock.call).toHaveBeenCalledWith(
+      expect(messengerMock.call).toHaveBeenCalledTimes(2);
+      expect(messengerMock.call).toHaveBeenNthCalledWith(
+        1,
         'ApprovalController:addRequest',
         {
           id: messageIdMock,
@@ -386,9 +394,9 @@ describe('SignatureController', () => {
     });
 
     it('throws if cannot get signature', async () => {
-      (keyringControllerMock as any).signMessage.mockRejectedValueOnce(
-        keyringErrorMock,
-      );
+      mockMessengerAction('KeyringController:signMessage', async () => {
+        throw keyringErrorMock;
+      });
       const listenerMock = jest.fn();
       signatureController.hub.on(`${messageIdMock}:signError`, listenerMock);
 
@@ -404,6 +412,7 @@ describe('SignatureController', () => {
       expect(listenerMock).toHaveBeenCalledWith({
         error,
       });
+      expect(messengerMock.call).toHaveBeenCalledTimes(2);
       expect(error.message).toBe(keyringErrorMessageMock);
       expect(messageManagerMock.rejectMessage).toHaveBeenCalledTimes(1);
       expect(messageManagerMock.rejectMessage).toHaveBeenCalledWith(
@@ -443,7 +452,7 @@ describe('SignatureController', () => {
         undefined,
       );
 
-      expect(messengerMock.call).toHaveBeenCalledTimes(1);
+      expect(messengerMock.call).toHaveBeenCalledTimes(2);
       expect(messengerMock.call).toHaveBeenCalledWith(
         'ApprovalController:addRequest',
         {
@@ -454,6 +463,11 @@ describe('SignatureController', () => {
           expectsResult: true,
         },
         true,
+      );
+      expect(messengerMock.call).toHaveBeenNthCalledWith(
+        2,
+        'KeyringController:signPersonalMessage',
+        messageParamsWithoutIdMock,
       );
     });
 
@@ -471,9 +485,10 @@ describe('SignatureController', () => {
     });
 
     it('throws if cannot get signature', async () => {
-      (keyringControllerMock as any).signPersonalMessage.mockRejectedValueOnce(
-        keyringErrorMock,
-      );
+      mockMessengerAction('KeyringController:signPersonalMessage', async () => {
+        throw keyringErrorMock;
+      });
+
       const error: any = await getError(
         async () =>
           await signatureController.newUnsignedPersonalMessage(
@@ -481,7 +496,14 @@ describe('SignatureController', () => {
             requestMock,
           ),
       );
+
+      expect(messengerMock.call).toHaveBeenCalledTimes(2);
       expect(error.message).toBe(keyringErrorMessageMock);
+      expect(messengerMock.call).toHaveBeenNthCalledWith(
+        2,
+        'KeyringController:signPersonalMessage',
+        messageParamsWithoutIdMock,
+      );
       expect(personalMessageManagerMock.rejectMessage).toHaveBeenCalledTimes(1);
       expect(personalMessageManagerMock.rejectMessage).toHaveBeenCalledWith(
         messageIdMock,
@@ -522,8 +544,9 @@ describe('SignatureController', () => {
         versionMock,
       );
 
-      expect(messengerMock.call).toHaveBeenCalledTimes(1);
-      expect(messengerMock.call).toHaveBeenCalledWith(
+      expect(messengerMock.call).toHaveBeenCalledTimes(2);
+      expect(messengerMock.call).toHaveBeenNthCalledWith(
+        1,
         'ApprovalController:addRequest',
         {
           id: messageIdMock,
@@ -533,6 +556,12 @@ describe('SignatureController', () => {
           expectsResult: true,
         },
         true,
+      );
+      expect(messengerMock.call).toHaveBeenNthCalledWith(
+        2,
+        'KeyringController:signTypedMessage',
+        messageParamsWithoutIdMock,
+        versionMock,
       );
     });
 
@@ -575,10 +604,11 @@ describe('SignatureController', () => {
         { parseJsonData: true },
       );
 
-      expect(keyringControllerMock.signTypedMessage).toHaveBeenCalledTimes(1);
-      expect(keyringControllerMock.signTypedMessage).toHaveBeenCalledWith(
+      expect(messengerMock.call).toHaveBeenNthCalledWith(
+        2,
+        'KeyringController:signTypedMessage',
         { ...messageParamsMock2, data: jsonData, deferSetAsSigned: false },
-        { version: 'V2' },
+        'V2',
       );
     });
 
@@ -598,9 +628,9 @@ describe('SignatureController', () => {
     });
 
     it('throws if cannot get signature', async () => {
-      keyringControllerMock.signTypedMessage.mockRejectedValueOnce(
-        keyringErrorMock,
-      );
+      mockMessengerAction('KeyringController:signTypedMessage', async () => {
+        throw keyringErrorMock;
+      });
       typedMessageManagerMock.addUnapprovedMessage.mockResolvedValue(
         messageIdMock,
       );

--- a/packages/signature-controller/tsconfig.build.json
+++ b/packages/signature-controller/tsconfig.build.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "../message-manager/tsconfig.build.json"
+    },
+    {
+      "path": "../keyring-controller/tsconfig.build.json"
     }
   ],
   "include": ["../../types", "./src"]

--- a/packages/signature-controller/tsconfig.json
+++ b/packages/signature-controller/tsconfig.json
@@ -15,6 +15,9 @@
     },
     {
       "path": "../message-manager"
+    },
+    {
+      "path": "../keyring-controller"
     }
   ],
   "include": ["../../types", "./src"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,7 +1790,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/keyring-controller@workspace:^, @metamask/keyring-controller@workspace:packages/keyring-controller":
+"@metamask/keyring-controller@^7.4.0, @metamask/keyring-controller@workspace:packages/keyring-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-controller@workspace:packages/keyring-controller"
   dependencies:
@@ -2114,7 +2114,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.2
-    "@metamask/keyring-controller": "workspace:^"
+    "@metamask/keyring-controller": ^7.4.0
     "@metamask/message-manager": ^7.3.1
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,7 +1790,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/keyring-controller@workspace:packages/keyring-controller":
+"@metamask/keyring-controller@workspace:^, @metamask/keyring-controller@workspace:packages/keyring-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-controller@workspace:packages/keyring-controller"
   dependencies:
@@ -2114,6 +2114,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.2
+    "@metamask/keyring-controller": "workspace:^"
     "@metamask/message-manager": ^7.3.1
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1


### PR DESCRIPTION
## Explanation

The `SignatureController` accepts an entire `KeyringController` instance as a constructor option, but would be better to use messenger actions instead, since this controller is a BaseControllerV2.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
-->

* Related to https://github.com/MetaMask/metamask-extension/issues/20510

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/signature-controller`

- **BREAKING**: Remove `keyringController` constructor option: messenger actions are now being used

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
