### PR TITLE
Add `addNewKeyring` method

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -169,6 +169,29 @@ describe('KeyringController', () => {
     });
   });
 
+  describe('addNewKeyring', () => {
+    describe('when there is a builder for the given type', () => {
+      it('should add new keyring', async () => {
+        await withController(async ({ controller, initialState }) => {
+          const initialKeyrings = initialState.keyrings;
+          await controller.addNewKeyring(KeyringTypes.simple);
+          expect(controller.state.keyrings).not.toStrictEqual(initialKeyrings);
+          expect(controller.state.keyrings).toHaveLength(2);
+        });
+      });
+    });
+
+    describe('when there is no builder for the given type', () => {
+      it('should throw error', async () => {
+        await withController(async ({ controller }) => {
+          await expect(controller.addNewKeyring('fake')).rejects.toThrow(
+            'KeyringController - No keyringBuilder found for keyring. Keyring type: fake',
+          );
+        });
+      });
+    });
+  });
+
   describe('createNewVaultAndRestore', () => {
     [false, true].map((cacheEncryptionKey) =>
       describe(`when cacheEncryptionKey is ${cacheEncryptionKey}`, () => {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -376,6 +376,21 @@ export class KeyringController extends BaseControllerV2<
   }
 
   /**
+   * Adds a new keyring of the given `type`.
+   *
+   * @param type - Keyring type name.
+   * @param opts - Keyring options.
+   * @throws If a builder for the given `type` does not exist.
+   * @returns Promise resolving to the added keyring.
+   */
+  async addNewKeyring(
+    type: KeyringTypes | string,
+    opts?: unknown,
+  ): Promise<Keyring<Json>> {
+    return this.#keyring.addNewKeyring(type, opts);
+  }
+
+  /**
    * Method to verify a given password validity. Throws an
    * error if the password is invalid.
    *


### PR DESCRIPTION
## Explanation

This PR adds a `addNewKeyring` method to `KeyringController`, which can be used to add a keyring for a given type. 

This method internally calls `EthKeyringController.addNewKeyring`.

This is needed to migrate the last interactions between the extension and EthKeyringController.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

* Related to https://github.com/MetaMask/core/issues/1595

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/keyring-controller`

- **ADDED**: `addNewKeyring` method to add a new keyring for a given type

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
