### PR TITLE
Fix changelog for `@metamask/assets-controllers@v6`

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -131,7 +131,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.0.0]
 ### Changed
 - **BREAKING:** Create approval requests using `@metamask/approval-controller` ([#1166](https://github.com/MetaMask/core/pull/1166))
-- **BREAKING:** Make `setProviderType` async ([#1191](https://github.com/MetaMask/core/pull/1191))
 
 ## [5.1.0]
 ### Added


### PR DESCRIPTION
## Explanation

The changelog for `@metamask/assets-controllers@v6` included an incorrect entry, a breaking change that didn't actually exist. The referenced change only affected a test file within the `assets-controllers` package, and the real change in the `network-controller` package wasn't released until the v49 release.

## References

Release created here: #1231
The changelog update was accidentally omitted, but added here: #1232
The change mistakenly referenced is #1191

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
