### PR TITLE
Release 74.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "73.0.0",
+  "version": "74.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/address-book-controller/CHANGELOG.md
+++ b/packages/address-book-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [3.1.0]
 ### Changed
 - Update `@metamask/utils` to `^6.2.0` ([#1514](https://github.com/MetaMask/core/pull/1514))
@@ -42,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@3.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@3.1.1...HEAD
+[3.1.1]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@3.1.0...@metamask/address-book-controller@3.1.1
 [3.1.0]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@3.0.0...@metamask/address-book-controller@3.1.0
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@2.0.0...@metamask/address-book-controller@3.0.0
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@1.1.0...@metamask/address-book-controller@2.0.0

--- a/packages/address-book-controller/CHANGELOG.md
+++ b/packages/address-book-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.1.1]
 ### Changed
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 
 ## [3.1.0]
 ### Changed

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/address-book-controller",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Manages a list of recipient addresses associated with nicknames",
   "keywords": [
     "MetaMask",
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.1",
     "@metamask/utils": "^6.2.0"
   },

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^4.3.1",
+    "@metamask/controller-utils": "^4.3.2",
     "@metamask/utils": "^6.2.0"
   },
   "devDependencies": {

--- a/packages/announcement-controller/CHANGELOG.md
+++ b/packages/announcement-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [4.0.0]
 ### Changed
 - **BREAKING:** Bump to Node 16 ([#1262](https://github.com/MetaMask/core/pull/1262))
@@ -53,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@4.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@4.0.1...HEAD
+[4.0.1]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@4.0.0...@metamask/announcement-controller@4.0.1
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@3.0.0...@metamask/announcement-controller@4.0.0
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@2.0.1...@metamask/announcement-controller@3.0.0
 [2.0.1]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@2.0.0...@metamask/announcement-controller@2.0.1

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/announcement-controller",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Manages in-app announcements",
   "keywords": [
     "MetaMask",
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0"
+    "@metamask/base-controller": "^3.2.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.1.0",

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [3.5.0]
 ### Changed
 - Update `@metamask/utils` to `^6.2.0` ([#1514](https://github.com/MetaMask/core/pull/1514))
@@ -67,7 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@3.5.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@3.5.1...HEAD
+[3.5.1]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@3.5.0...@metamask/approval-controller@3.5.1
 [3.5.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@3.4.0...@metamask/approval-controller@3.5.0
 [3.4.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@3.3.0...@metamask/approval-controller@3.4.0
 [3.3.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@3.2.0...@metamask/approval-controller@3.3.0

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/approval-controller",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Manages requests that require user approval",
   "keywords": [
     "MetaMask",
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/utils": "^6.2.0",
     "eth-rpc-errors": "^4.0.2",
     "immer": "^9.0.6",

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
 - Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
 - Bump dependency and peer dependency on `@metamask/preferences-controller` to ^4.3.1
+- Update NftController to add fallback for when IPFS gateway is disabled ([#1577](https://github.com/MetaMask/core/pull/1577))
 
 ## [11.0.1]
 ### Changed

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
 - Bump dependency on `@metamask/controller-utils` to ^4.3.2
 - Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
-- Bump dependency and peer dependency on `@metamask/preferences-controller` to ^4.3.1
+- Bump dependency and peer dependency on `@metamask/preferences-controller` to ^4.4.0
 - Update NftController to add fallback for when IPFS gateway is disabled ([#1577](https://github.com/MetaMask/core/pull/1577))
 
 ## [11.0.1]

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.1.0]
+### Added
+- Capture token URL from OpenSea API under `tokenURI` property ([#1577](https://github.com/MetaMask/core/pull/1577))
+
+### Changed
+- Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
+- Bump dependency and peer dependency on `@metamask/preferences-controller` to ^4.3.1
+
 ## [11.0.1]
 ### Changed
 - Replace `eth-query` ^2.1.2 with `@metamask/eth-query` ^3.0.1 ([#1546](https://github.com/MetaMask/core/pull/1546))
@@ -213,7 +223,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use Ethers for AssetsContractController ([#845](https://github.com/MetaMask/core/pull/845))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@11.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@11.1.0...HEAD
+[11.1.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@11.0.1...@metamask/assets-controllers@11.1.0
 [11.0.1]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@11.0.0...@metamask/assets-controllers@11.0.1
 [11.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@10.0.0...@metamask/assets-controllers@11.0.0
 [10.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@9.2.0...@metamask/assets-controllers@10.0.0

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [11.1.0]
 ### Added
-- Capture token URL from OpenSea API under `tokenURI` property ([#1577](https://github.com/MetaMask/core/pull/1577))
+- Populate token URL for NFTs in state under `tokenURI` in `NftMetadata` ([#1577](https://github.com/MetaMask/core/pull/1577))
 
 ### Changed
 - Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 - Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
 - Bump dependency and peer dependency on `@metamask/preferences-controller` to ^4.3.1
 - Update NftController to add fallback for when IPFS gateway is disabled ([#1577](https://github.com/MetaMask/core/pull/1577))

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [11.1.0]
 ### Added
-- Populate token URL for NFTs in state under `tokenURI` in `NftMetadata` ([#1577](https://github.com/MetaMask/core/pull/1577))
+- Add `tokenURI` to `NftMetadata` type ([#1577](https://github.com/MetaMask/core/pull/1577))
+- Populate token URL for NFT metadata under `tokenURI` ([#1577](https://github.com/MetaMask/core/pull/1577))
 
 ### Changed
 - Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/assets-controllers",
-  "version": "11.0.1",
+  "version": "11.1.0",
   "description": "Controllers which manage interactions involving ERC-20, ERC-721, and ERC-1155 tokens (including NFTs)",
   "keywords": [
     "MetaMask",
@@ -33,14 +33,14 @@
     "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@metamask/abi-utils": "^2.0.1",
-    "@metamask/approval-controller": "^3.5.0",
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/approval-controller": "^3.5.1",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/contract-metadata": "^2.3.1",
     "@metamask/controller-utils": "^4.3.1",
     "@metamask/eth-query": "^3.0.1",
     "@metamask/metamask-eth-abis": "3.0.0",
-    "@metamask/network-controller": "^12.1.1",
-    "@metamask/preferences-controller": "^4.3.0",
+    "@metamask/network-controller": "^12.1.2",
+    "@metamask/preferences-controller": "^4.3.1",
     "@metamask/rpc-errors": "^5.1.1",
     "@metamask/utils": "^6.2.0",
     "@types/uuid": "^8.3.0",
@@ -68,9 +68,9 @@
     "typescript": "~4.6.3"
   },
   "peerDependencies": {
-    "@metamask/approval-controller": "^3.5.0",
-    "@metamask/network-controller": "^12.1.1",
-    "@metamask/preferences-controller": "^4.3.0"
+    "@metamask/approval-controller": "^3.5.1",
+    "@metamask/network-controller": "^12.1.2",
+    "@metamask/preferences-controller": "^4.3.1"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -40,7 +40,7 @@
     "@metamask/eth-query": "^3.0.1",
     "@metamask/metamask-eth-abis": "3.0.0",
     "@metamask/network-controller": "^12.1.2",
-    "@metamask/preferences-controller": "^4.3.1",
+    "@metamask/preferences-controller": "^4.4.0",
     "@metamask/rpc-errors": "^5.1.1",
     "@metamask/utils": "^6.2.0",
     "@types/uuid": "^8.3.0",
@@ -70,7 +70,7 @@
   "peerDependencies": {
     "@metamask/approval-controller": "^3.5.1",
     "@metamask/network-controller": "^12.1.2",
-    "@metamask/preferences-controller": "^4.3.1"
+    "@metamask/preferences-controller": "^4.4.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -36,7 +36,7 @@
     "@metamask/approval-controller": "^3.5.1",
     "@metamask/base-controller": "^3.2.1",
     "@metamask/contract-metadata": "^2.3.1",
-    "@metamask/controller-utils": "^4.3.1",
+    "@metamask/controller-utils": "^4.3.2",
     "@metamask/eth-query": "^3.0.1",
     "@metamask/metamask-eth-abis": "3.0.0",
     "@metamask/network-controller": "^12.1.2",

--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.1]
+### Changed
+- There are no consumer-facing changes to this package. This version is a part of a synchronized release across all packages in our monorepo.
+
 ## [3.2.0]
 ### Changed
 - When deriving state, skip properties with invalid metadata  ([#1529](https://github.com/MetaMask/core/pull/1529))
@@ -61,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/base-controller@3.2.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/base-controller@3.2.1...HEAD
+[3.2.1]: https://github.com/MetaMask/core/compare/@metamask/base-controller@3.2.0...@metamask/base-controller@3.2.1
 [3.2.0]: https://github.com/MetaMask/core/compare/@metamask/base-controller@3.1.0...@metamask/base-controller@3.2.0
 [3.1.0]: https://github.com/MetaMask/core/compare/@metamask/base-controller@3.0.0...@metamask/base-controller@3.1.0
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/base-controller@2.0.0...@metamask/base-controller@3.0.0

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/base-controller",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Provides scaffolding for controllers as well a communication system for all controllers",
   "keywords": [
     "MetaMask",

--- a/packages/composable-controller/CHANGELOG.md
+++ b/packages/composable-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [3.0.0]
 ### Changed
 - **BREAKING:** Bump to Node 16 ([#1262](https://github.com/MetaMask/core/pull/1262))
@@ -33,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@3.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@3.0.1...HEAD
+[3.0.1]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@3.0.0...@metamask/composable-controller@3.0.1
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@2.0.0...@metamask/composable-controller@3.0.0
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@1.0.2...@metamask/composable-controller@2.0.0
 [1.0.2]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@1.0.1...@metamask/composable-controller@1.0.2

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/composable-controller",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Consolidates the state from multiple controllers into one",
   "keywords": [
     "MetaMask",
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0"
+    "@metamask/base-controller": "^3.2.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.1.0",

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.2]
+### Changed
+- There are no consumer-facing changes to this package. This version is a part of a synchronized release across all packages in our monorepo.
+
 ## [4.3.1]
 ### Changed
 - Replace `eth-query` ^2.1.2 with `@metamask/eth-query` ^3.0.1 ([#1546](https://github.com/MetaMask/core/pull/1546))
@@ -143,7 +147,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@4.3.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@4.3.2...HEAD
+[4.3.2]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@4.3.1...@metamask/controller-utils@4.3.2
 [4.3.1]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@4.3.0...@metamask/controller-utils@4.3.1
 [4.3.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@4.2.0...@metamask/controller-utils@4.3.0
 [4.2.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@4.1.0...@metamask/controller-utils@4.2.0

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/controller-utils",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Data and convenience functions shared by multiple packages",
   "keywords": [
     "MetaMask",

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.1.1]
 ### Changed
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 - Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
 
 ## [4.1.0]

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.1]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
+
 ## [4.1.0]
 ### Changed
 - Update `@metamask/utils` to `^6.2.0` ([#1514](https://github.com/MetaMask/core/pull/1514))
@@ -54,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@4.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@4.1.1...HEAD
+[4.1.1]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@4.1.0...@metamask/ens-controller@4.1.1
 [4.1.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@4.0.0...@metamask/ens-controller@4.1.0
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@3.1.0...@metamask/ens-controller@4.0.0
 [3.1.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@3.0.0...@metamask/ens-controller@3.1.0

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@ethersproject/providers": "^5.7.0",
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^4.3.1",
+    "@metamask/controller-utils": "^4.3.2",
     "@metamask/network-controller": "^12.1.2",
     "@metamask/utils": "^6.2.0",
     "ethereum-ens-network-map": "^1.0.2",

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ens-controller",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Maps ENS names to their resolved addresses by chain id",
   "keywords": [
     "MetaMask",
@@ -29,9 +29,9 @@
   },
   "dependencies": {
     "@ethersproject/providers": "^5.7.0",
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.1",
-    "@metamask/network-controller": "^12.1.1",
+    "@metamask/network-controller": "^12.1.2",
     "@metamask/utils": "^6.2.0",
     "ethereum-ens-network-map": "^1.0.2",
     "punycode": "^2.1.1"
@@ -47,7 +47,7 @@
     "typescript": "~4.6.3"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^12.1.1"
+    "@metamask/network-controller": "^12.1.2"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.2]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
+
 ## [6.1.1]
 ### Uncategorized
 - Replace `eth-query` ^2.1.2 with `@metamask/eth-query` ^3.0.1 ([#1546](https://github.com/MetaMask/core/pull/1546))
@@ -71,7 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@6.1.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@6.1.2...HEAD
+[6.1.2]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@6.1.1...@metamask/gas-fee-controller@6.1.2
 [6.1.1]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@6.1.0...@metamask/gas-fee-controller@6.1.1
 [6.1.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@6.0.1...@metamask/gas-fee-controller@6.1.0
 [6.0.1]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@6.0.0...@metamask/gas-fee-controller@6.0.1

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.1.2]
 ### Changed
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 - Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
 
 ## [6.1.1]

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/gas-fee-controller",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Periodically calculates gas fee estimates based on various gas limits as well as other data displayed on transaction confirm screens",
   "keywords": [
     "MetaMask",
@@ -28,10 +28,10 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.1",
     "@metamask/eth-query": "^3.0.1",
-    "@metamask/network-controller": "^12.1.1",
+    "@metamask/network-controller": "^12.1.2",
     "@metamask/utils": "^6.2.0",
     "@types/uuid": "^8.3.0",
     "ethereumjs-util": "^7.0.10",
@@ -54,7 +54,7 @@
     "typescript": "~4.6.3"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^12.1.1"
+    "@metamask/network-controller": "^12.1.2"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^4.3.1",
+    "@metamask/controller-utils": "^4.3.2",
     "@metamask/eth-query": "^3.0.1",
     "@metamask/network-controller": "^12.1.2",
     "@metamask/utils": "^6.2.0",

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.2.0]
+### Added
+- Add `addNewAccountForKeyring` method ([#1591](https://github.com/MetaMask/core/pull/1591))
+- Add `addNewKeyring` method ([#1594](https://github.com/MetaMask/core/pull/1594))
+- Add `persistAllKeyrings` method ([#1574](https://github.com/MetaMask/core/pull/1574))
+
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/message-manager` to ^7.3.1
+- Bump dependency and peer dependency on `@metamask/preferences-controller` to ^4.3.1
+
 ## [7.1.0]
 ### Added
 - Add `getEncryptionPublicKey` method on KeyringController ([#1569](https://github.com/MetaMask/core/pull/1569))
@@ -147,7 +158,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@7.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@7.2.0...HEAD
+[7.2.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@7.1.0...@metamask/keyring-controller@7.2.0
 [7.1.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@7.0.0...@metamask/keyring-controller@7.1.0
 [7.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@6.1.0...@metamask/keyring-controller@7.0.0
 [6.1.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@6.0.0...@metamask/keyring-controller@6.1.0

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
 - Bump dependency on `@metamask/message-manager` to ^7.3.1
-- Bump dependency and peer dependency on `@metamask/preferences-controller` to ^4.3.1
+- Bump dependency and peer dependency on `@metamask/preferences-controller` to ^4.4.0
 
 ## [7.1.0]
 ### Added

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-controller",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Stores identities seen in the wallet and manages interactions such as signing",
   "keywords": [
     "MetaMask",
@@ -29,10 +29,10 @@
   },
   "dependencies": {
     "@keystonehq/metamask-airgapped-keyring": "^0.13.1",
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/eth-keyring-controller": "^13.0.0",
-    "@metamask/message-manager": "^7.3.0",
-    "@metamask/preferences-controller": "^4.3.0",
+    "@metamask/message-manager": "^7.3.1",
+    "@metamask/preferences-controller": "^4.3.1",
     "@metamask/utils": "^6.2.0",
     "async-mutex": "^0.2.6",
     "ethereumjs-util": "^7.0.10",
@@ -57,7 +57,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@metamask/preferences-controller": "^4.3.0"
+    "@metamask/preferences-controller": "^4.3.1"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -32,7 +32,7 @@
     "@metamask/base-controller": "^3.2.1",
     "@metamask/eth-keyring-controller": "^13.0.0",
     "@metamask/message-manager": "^7.3.1",
-    "@metamask/preferences-controller": "^4.3.1",
+    "@metamask/preferences-controller": "^4.4.0",
     "@metamask/utils": "^6.2.0",
     "async-mutex": "^0.2.6",
     "ethereumjs-util": "^7.0.10",
@@ -57,7 +57,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@metamask/preferences-controller": "^4.3.1"
+    "@metamask/preferences-controller": "^4.4.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/logging-controller/CHANGELOG.md
+++ b/packages/logging-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.1]
 ### Changed
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 
 ## [1.0.0]
 ### Added

--- a/packages/logging-controller/CHANGELOG.md
+++ b/packages/logging-controller/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [1.0.0]
 ### Added
 - Initial Release
   - Add logging controller ([#1089](https://github.com/MetaMask/core.git/pull/1089))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@1.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@1.0.1...HEAD
+[1.0.1]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@1.0.0...@metamask/logging-controller@1.0.1
 [1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/logging-controller@1.0.0

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/logging-controller",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Manages logging data to assist users and support staff",
   "keywords": [
     "MetaMask",
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.1",
     "uuid": "^8.3.2"
   },

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^4.3.1",
+    "@metamask/controller-utils": "^4.3.2",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [7.3.1]
 ### Changed
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 
 ## [7.3.0]
 ### Changed

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.3.1]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [7.3.0]
 ### Changed
 - Add Blockaid validation response to messages ([#1541](https://github.com/MetaMask/core/pull/1541))
@@ -100,7 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.3.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.3.1...HEAD
+[7.3.1]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.3.0...@metamask/message-manager@7.3.1
 [7.3.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.2.0...@metamask/message-manager@7.3.0
 [7.2.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.1.0...@metamask/message-manager@7.2.0
 [7.1.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.0.2...@metamask/message-manager@7.1.0

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/message-manager",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Stores and manages interactions with signing requests",
   "keywords": [
     "MetaMask",
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.1",
     "@metamask/eth-sig-util": "^6.0.0",
     "@metamask/utils": "^6.2.0",

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^4.3.1",
+    "@metamask/controller-utils": "^4.3.2",
     "@metamask/eth-sig-util": "^6.0.0",
     "@metamask/utils": "^6.2.0",
     "@types/uuid": "^8.3.0",

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [12.1.2]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [12.1.1]
 ### Added
 - Added an export for NetworkClientId in NetworkController ([#1583](https://github.com/MetaMask/core/pull/1583))
@@ -240,7 +244,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@12.1.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@12.1.2...HEAD
+[12.1.2]: https://github.com/MetaMask/core/compare/@metamask/network-controller@12.1.1...@metamask/network-controller@12.1.2
 [12.1.1]: https://github.com/MetaMask/core/compare/@metamask/network-controller@12.1.0...@metamask/network-controller@12.1.1
 [12.1.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@12.0.0...@metamask/network-controller@12.1.0
 [12.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@11.0.0...@metamask/network-controller@12.0.0

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [12.1.2]
 ### Changed
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 
 ## [12.1.1]
 ### Added

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-controller",
-  "version": "12.1.1",
+  "version": "12.1.2",
   "description": "Provides an interface to the currently selected network via a MetaMask-compatible provider object",
   "keywords": [
     "MetaMask",
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.1",
     "@metamask/eth-json-rpc-infura": "^8.1.1",
     "@metamask/eth-json-rpc-middleware": "^11.0.0",

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^4.3.1",
+    "@metamask/controller-utils": "^4.3.2",
     "@metamask/eth-json-rpc-infura": "^8.1.1",
     "@metamask/eth-json-rpc-middleware": "^11.0.0",
     "@metamask/eth-json-rpc-provider": "^1.0.0",

--- a/packages/notification-controller/CHANGELOG.md
+++ b/packages/notification-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [3.1.0]
 ### Changed
 - Update `@metamask/utils` to `^6.2.0` ([#1514](https://github.com/MetaMask/core/pull/1514))
@@ -37,7 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@3.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@3.1.1...HEAD
+[3.1.1]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@3.1.0...@metamask/notification-controller@3.1.1
 [3.1.0]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@3.0.0...@metamask/notification-controller@3.1.0
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@2.0.0...@metamask/notification-controller@3.0.0
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@1.0.2...@metamask/notification-controller@2.0.0

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/notification-controller",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Manages display of notifications within MetaMask",
   "keywords": [
     "MetaMask",
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/utils": "^6.2.0",
     "immer": "^9.0.6",
     "nanoid": "^3.1.31"

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.1]
+### Changed
+- Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [4.1.0]
 ### Changed
 - Update `@metamask/utils` to `^6.2.0` ([#1514](https://github.com/MetaMask/core/pull/1514))
@@ -73,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@4.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@4.1.1...HEAD
+[4.1.1]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@4.1.0...@metamask/permission-controller@4.1.1
 [4.1.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@4.0.1...@metamask/permission-controller@4.1.0
 [4.0.1]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@4.0.0...@metamask/permission-controller@4.0.1
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@3.2.0...@metamask/permission-controller@4.0.0

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 
 ## [4.1.0]
 ### Changed

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@metamask/approval-controller": "^3.5.1",
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^4.3.1",
+    "@metamask/controller-utils": "^4.3.2",
     "@metamask/utils": "^6.2.0",
     "@types/deep-freeze-strict": "^1.1.0",
     "deep-freeze-strict": "^1.1.1",

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/permission-controller",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Mediates access to JSON-RPC methods, used to interact with pieces of the MetaMask stack, via middleware for json-rpc-engine",
   "keywords": [
     "MetaMask",
@@ -28,8 +28,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/approval-controller": "^3.5.0",
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/approval-controller": "^3.5.1",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.1",
     "@metamask/utils": "^6.2.0",
     "@types/deep-freeze-strict": "^1.1.0",
@@ -50,7 +50,7 @@
     "typescript": "~4.6.3"
   },
   "peerDependencies": {
-    "@metamask/approval-controller": "^3.5.0"
+    "@metamask/approval-controller": "^3.5.1"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.1]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [6.0.0]
 ### Changed
 - **BREAKING:** Remove fallback phishing configuration ([#1527](https://github.com/MetaMask/core/pull/1527))
@@ -75,7 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@6.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@6.0.1...HEAD
+[6.0.1]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@6.0.0...@metamask/phishing-controller@6.0.1
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@5.0.0...@metamask/phishing-controller@6.0.0
 [5.0.0]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@4.0.0...@metamask/phishing-controller@5.0.0
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@3.0.0...@metamask/phishing-controller@4.0.0

--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.0.1]
 ### Changed
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 
 ## [6.0.0]
 ### Changed

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^4.3.1",
+    "@metamask/controller-utils": "^4.3.2",
     "@types/punycode": "^2.1.0",
     "eth-phishing-detect": "^1.2.0",
     "punycode": "^2.1.1"

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/phishing-controller",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Maintains a periodically updated list of approved and unapproved website origins",
   "keywords": [
     "MetaMask",
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.1",
     "@types/punycode": "^2.1.0",
     "eth-phishing-detect": "^1.2.0",

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.3.1]
+## [4.4.0]
+### Added
+- Add `isIpfsGatewayEnabled` property to PreferencesController state ([#1577](https://github.com/MetaMask/core/pull/1577))
+- Add `setIsIpfsGatewayEnabled` to set `isIpfsGatewayEnabled` ([#1577](https://github.com/MetaMask/core/pull/1577))
+
 ### Changed
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
 
@@ -58,8 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.3.1...HEAD
-[4.3.1]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.3.0...@metamask/preferences-controller@4.3.1
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.4.0...HEAD
+[4.4.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.3.0...@metamask/preferences-controller@4.4.0
 [4.3.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.2.0...@metamask/preferences-controller@4.3.0
 [4.2.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.1.0...@metamask/preferences-controller@4.2.0
 [4.1.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.0.0...@metamask/preferences-controller@4.1.0

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 
 ## [4.3.0]
 ### Added

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.1]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [4.3.0]
 ### Added
 - Add preference for security alerts ([#1589](https://github.com/MetaMask/core/pull/1589))
@@ -54,7 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.3.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.3.1...HEAD
+[4.3.1]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.3.0...@metamask/preferences-controller@4.3.1
 [4.3.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.2.0...@metamask/preferences-controller@4.3.0
 [4.2.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.1.0...@metamask/preferences-controller@4.2.0
 [4.1.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@4.0.0...@metamask/preferences-controller@4.1.0

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^4.3.1"
+    "@metamask/controller-utils": "^4.3.2"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.1.0",

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/preferences-controller",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "Manages user-configurable settings for MetaMask",
   "keywords": [
     "MetaMask",

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/preferences-controller",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Manages user-configurable settings for MetaMask",
   "keywords": [
     "MetaMask",
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.1"
   },
   "devDependencies": {

--- a/packages/rate-limit-controller/CHANGELOG.md
+++ b/packages/rate-limit-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1]
+### Changed
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+
 ## [3.0.0]
 ### Changed
 - **BREAKING:** Allow `RateLimitController` to define a rate-limit per method ([#1355](https://github.com/MetaMask/core/pull/1355))
@@ -38,7 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@3.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@3.0.1...HEAD
+[3.0.1]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@3.0.0...@metamask/rate-limit-controller@3.0.1
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@2.0.1...@metamask/rate-limit-controller@3.0.0
 [2.0.1]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@2.0.0...@metamask/rate-limit-controller@2.0.1
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@1.0.2...@metamask/rate-limit-controller@2.0.0

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rate-limit-controller",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Contains logic for rate-limiting API endpoints by requesting origin",
   "keywords": [
     "MetaMask",
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/base-controller": "^3.2.1",
     "eth-rpc-errors": "^4.0.2",
     "immer": "^9.0.6"
   },

--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.1]
+### Changed
+- Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/message-manager` to ^7.3.1
+
 ## [5.3.0]
 ### Added
 - Add new methods `setDeferredSignSuccess` and `setDeferredSignError` ([#1506](https://github.com/MetaMask/core/pull/1506))
@@ -59,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release ([#1214](https://github.com/MetaMask/core/pull/1214))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@5.3.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@5.3.1...HEAD
+[5.3.1]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@5.3.0...@metamask/signature-controller@5.3.1
 [5.3.0]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@5.2.0...@metamask/signature-controller@5.3.0
 [5.2.0]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@5.1.0...@metamask/signature-controller@5.2.0
 [5.1.0]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@5.0.0...@metamask/signature-controller@5.1.0

--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 - Bump dependency on `@metamask/message-manager` to ^7.3.1
 
 ## [5.3.0]

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@metamask/approval-controller": "^3.5.1",
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^4.3.1",
+    "@metamask/controller-utils": "^4.3.2",
     "@metamask/message-manager": "^7.3.1",
     "@metamask/utils": "^6.2.0",
     "eth-rpc-errors": "^4.0.2",

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/signature-controller",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Processes signing requests in order to sign arbitrary and typed data",
   "keywords": [
     "MetaMask",
@@ -28,10 +28,10 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/approval-controller": "^3.5.0",
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/approval-controller": "^3.5.1",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.1",
-    "@metamask/message-manager": "^7.3.0",
+    "@metamask/message-manager": "^7.3.1",
     "@metamask/utils": "^6.2.0",
     "eth-rpc-errors": "^4.0.2",
     "ethereumjs-util": "^7.0.10",
@@ -49,7 +49,7 @@
     "typescript": "~4.6.3"
   },
   "peerDependencies": {
-    "@metamask/approval-controller": "^3.5.0"
+    "@metamask/approval-controller": "^3.5.1"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.1]
+## Changed
+- Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1
+- Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
+
 ## [9.0.0]
 ### Added
 - Add `baseFeePerGas` to transaction metadata ([#1590](https://github.com/MetaMask/core/pull/1590))
@@ -135,7 +141,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@9.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@9.0.1...HEAD
+[9.0.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@9.0.0...@metamask/transaction-controller@9.0.1
 [9.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@8.0.1...@metamask/transaction-controller@9.0.0
 [8.0.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@8.0.0...@metamask/transaction-controller@8.0.1
 [8.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@7.1.0...@metamask/transaction-controller@8.0.0

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [9.1.0]
 ### Added
-- Add `blockTimestamp` to TransactionMetaBase ([#1616](https://github.com/MetaMask/core/pull/1616))
+- Add `blockTimestamp` to `TransactionMetaBase` type ([#1616](https://github.com/MetaMask/core/pull/1616))
+- Update `queryTransactionStatuses` to populate `blockTimestamp` on each transaction when it is verified ([#1616](https://github.com/MetaMask/core/pull/1616))
 
 ### Changed
 - Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
 - Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
-- Update `queryTransactionStatuses` to populate `blockTimestamp` on each transaction when it is verified ([#1616](https://github.com/MetaMask/core/pull/1616))
 
 ## [9.0.0]
 ### Added

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
+- Bump dependency on `@metamask/controller-utils` to ^4.3.2
 - Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
 
 ## [9.0.0]

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.0.1]
-## Changed
+## [9.1.0]
+### Added
+- Add `blockTimestamp` to TransactionMetaBase ([#1616](https://github.com/MetaMask/core/pull/1616))
+
+### Changed
 - Bump dependency and peer dependency on `@metamask/approval-controller` to ^3.5.1
 - Bump dependency on `@metamask/base-controller` to ^3.2.1
 - Bump dependency and peer dependency on `@metamask/network-controller` to ^12.1.2
+- Update `queryTransactionStatuses` to populate `blockTimestamp` on each transaction when it is verified ([#1616](https://github.com/MetaMask/core/pull/1616))
 
 ## [9.0.0]
 ### Added
@@ -141,8 +145,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@9.0.1...HEAD
-[9.0.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@9.0.0...@metamask/transaction-controller@9.0.1
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@9.1.0...HEAD
+[9.1.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@9.0.0...@metamask/transaction-controller@9.1.0
 [9.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@8.0.1...@metamask/transaction-controller@9.0.0
 [8.0.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@8.0.0...@metamask/transaction-controller@8.0.1
 [8.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@7.1.0...@metamask/transaction-controller@8.0.0

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",
@@ -30,11 +30,11 @@
   "dependencies": {
     "@ethereumjs/common": "^3.2.0",
     "@ethereumjs/tx": "^4.2.0",
-    "@metamask/approval-controller": "^3.5.0",
-    "@metamask/base-controller": "^3.2.0",
+    "@metamask/approval-controller": "^3.5.1",
+    "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.1",
     "@metamask/eth-query": "^3.0.1",
-    "@metamask/network-controller": "^12.1.1",
+    "@metamask/network-controller": "^12.1.2",
     "@metamask/utils": "^6.2.0",
     "async-mutex": "^0.2.6",
     "eth-method-registry": "1.1.0",
@@ -58,8 +58,8 @@
     "typescript": "~4.6.3"
   },
   "peerDependencies": {
-    "@metamask/approval-controller": "^3.5.0",
-    "@metamask/network-controller": "^12.1.1",
+    "@metamask/approval-controller": "^3.5.1",
+    "@metamask/network-controller": "^12.1.2",
     "babel-runtime": "^6.26.0"
   },
   "engines": {

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -32,7 +32,7 @@
     "@ethereumjs/tx": "^4.2.0",
     "@metamask/approval-controller": "^3.5.1",
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/controller-utils": "^4.3.1",
+    "@metamask/controller-utils": "^4.3.2",
     "@metamask/eth-query": "^3.0.1",
     "@metamask/network-controller": "^12.1.2",
     "@metamask/utils": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,7 +1365,7 @@ __metadata:
     "@metamask/eth-query": ^3.0.1
     "@metamask/metamask-eth-abis": 3.0.0
     "@metamask/network-controller": ^12.1.2
-    "@metamask/preferences-controller": ^4.3.1
+    "@metamask/preferences-controller": ^4.4.0
     "@metamask/rpc-errors": ^5.1.1
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
@@ -1391,7 +1391,7 @@ __metadata:
   peerDependencies:
     "@metamask/approval-controller": ^3.5.1
     "@metamask/network-controller": ^12.1.2
-    "@metamask/preferences-controller": ^4.3.1
+    "@metamask/preferences-controller": ^4.4.0
   languageName: unknown
   linkType: soft
 
@@ -1778,7 +1778,7 @@ __metadata:
     "@metamask/eth-keyring-controller": ^13.0.0
     "@metamask/eth-sig-util": ^6.0.0
     "@metamask/message-manager": ^7.3.1
-    "@metamask/preferences-controller": ^4.3.1
+    "@metamask/preferences-controller": ^4.4.0
     "@metamask/scure-bip39": ^2.1.0
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
@@ -1795,7 +1795,7 @@ __metadata:
     typescript: ~4.6.3
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/preferences-controller": ^4.3.1
+    "@metamask/preferences-controller": ^4.4.0
   languageName: unknown
   linkType: soft
 
@@ -1971,7 +1971,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/preferences-controller@^4.3.1, @metamask/preferences-controller@workspace:packages/preferences-controller":
+"@metamask/preferences-controller@^4.4.0, @metamask/preferences-controller@workspace:packages/preferences-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/preferences-controller@workspace:packages/preferences-controller"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1298,7 +1298,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1361,7 +1361,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
     "@metamask/contract-metadata": ^2.3.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@metamask/eth-query": ^3.0.1
     "@metamask/metamask-eth-abis": 3.0.0
     "@metamask/network-controller": ^12.1.2
@@ -1460,7 +1460,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@^4.3.1, @metamask/controller-utils@workspace:packages/controller-utils":
+"@metamask/controller-utils@^4.3.2, @metamask/controller-utils@workspace:packages/controller-utils":
   version: 0.0.0-use.local
   resolution: "@metamask/controller-utils@workspace:packages/controller-utils"
   dependencies:
@@ -1550,7 +1550,7 @@ __metadata:
     "@ethersproject/providers": ^5.7.0
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@metamask/network-controller": ^12.1.2
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
@@ -1740,7 +1740,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@metamask/eth-query": ^3.0.1
     "@metamask/network-controller": ^12.1.2
     "@metamask/utils": ^6.2.0
@@ -1805,7 +1805,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -1823,7 +1823,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@metamask/eth-sig-util": ^6.0.0
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
@@ -1854,7 +1854,7 @@ __metadata:
     "@json-rpc-specification/meta-schema": ^1.0.6
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@metamask/eth-json-rpc-infura": ^8.1.1
     "@metamask/eth-json-rpc-middleware": ^11.0.0
     "@metamask/eth-json-rpc-provider": ^1.0.0
@@ -1929,7 +1929,7 @@ __metadata:
     "@metamask/approval-controller": ^3.5.1
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@metamask/utils": ^6.2.0
     "@types/deep-freeze-strict": ^1.1.0
     "@types/jest": ^27.4.1
@@ -1955,7 +1955,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@types/jest": ^27.4.1
     "@types/punycode": ^2.1.0
     deepmerge: ^4.2.2
@@ -1977,7 +1977,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -2047,7 +2047,7 @@ __metadata:
     "@metamask/approval-controller": ^3.5.1
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@metamask/message-manager": ^7.3.1
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
@@ -2082,7 +2082,7 @@ __metadata:
     "@metamask/approval-controller": ^3.5.1
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/controller-utils": ^4.3.1
+    "@metamask/controller-utils": ^4.3.2
     "@metamask/eth-query": ^3.0.1
     "@metamask/network-controller": ^12.1.2
     "@metamask/utils": ^6.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,7 +1297,7 @@ __metadata:
   resolution: "@metamask/address-book-controller@workspace:packages/address-book-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.1
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
@@ -1315,7 +1315,7 @@ __metadata:
   resolution: "@metamask/announcement-controller@workspace:packages/announcement-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     immer: ^9.0.6
@@ -1327,12 +1327,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/approval-controller@^3.5.0, @metamask/approval-controller@workspace:packages/approval-controller":
+"@metamask/approval-controller@^3.5.1, @metamask/approval-controller@workspace:packages/approval-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/approval-controller@workspace:packages/approval-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1357,15 +1357,15 @@ __metadata:
     "@ethersproject/contracts": ^5.7.0
     "@ethersproject/providers": ^5.7.0
     "@metamask/abi-utils": ^2.0.1
-    "@metamask/approval-controller": ^3.5.0
+    "@metamask/approval-controller": ^3.5.1
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/contract-metadata": ^2.3.1
     "@metamask/controller-utils": ^4.3.1
     "@metamask/eth-query": ^3.0.1
     "@metamask/metamask-eth-abis": 3.0.0
-    "@metamask/network-controller": ^12.1.1
-    "@metamask/preferences-controller": ^4.3.0
+    "@metamask/network-controller": ^12.1.2
+    "@metamask/preferences-controller": ^4.3.1
     "@metamask/rpc-errors": ^5.1.1
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
@@ -1389,9 +1389,9 @@ __metadata:
     typescript: ~4.6.3
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/approval-controller": ^3.5.0
-    "@metamask/network-controller": ^12.1.1
-    "@metamask/preferences-controller": ^4.3.0
+    "@metamask/approval-controller": ^3.5.1
+    "@metamask/network-controller": ^12.1.2
+    "@metamask/preferences-controller": ^4.3.1
   languageName: unknown
   linkType: soft
 
@@ -1409,7 +1409,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@^3.2.0, @metamask/base-controller@workspace:packages/base-controller":
+"@metamask/base-controller@^3.2.1, @metamask/base-controller@workspace:packages/base-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/base-controller@workspace:packages/base-controller"
   dependencies:
@@ -1440,7 +1440,7 @@ __metadata:
   resolution: "@metamask/composable-controller@workspace:packages/composable-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     immer: ^9.0.6
@@ -1549,9 +1549,9 @@ __metadata:
   dependencies:
     "@ethersproject/providers": ^5.7.0
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.1
-    "@metamask/network-controller": ^12.1.1
+    "@metamask/network-controller": ^12.1.2
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1563,7 +1563,7 @@ __metadata:
     typedoc-plugin-missing-exports: ^0.22.6
     typescript: ~4.6.3
   peerDependencies:
-    "@metamask/network-controller": ^12.1.1
+    "@metamask/network-controller": ^12.1.2
   languageName: unknown
   linkType: soft
 
@@ -1739,10 +1739,10 @@ __metadata:
   resolution: "@metamask/gas-fee-controller@workspace:packages/gas-fee-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.1
     "@metamask/eth-query": ^3.0.1
-    "@metamask/network-controller": ^12.1.1
+    "@metamask/network-controller": ^12.1.2
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
     "@types/jest-when": ^2.7.3
@@ -1761,7 +1761,7 @@ __metadata:
     typescript: ~4.6.3
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/network-controller": ^12.1.1
+    "@metamask/network-controller": ^12.1.2
   languageName: unknown
   linkType: soft
 
@@ -1774,11 +1774,11 @@ __metadata:
     "@keystonehq/bc-ur-registry-eth": ^0.9.0
     "@keystonehq/metamask-airgapped-keyring": ^0.13.1
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/eth-keyring-controller": ^13.0.0
     "@metamask/eth-sig-util": ^6.0.0
-    "@metamask/message-manager": ^7.3.0
-    "@metamask/preferences-controller": ^4.3.0
+    "@metamask/message-manager": ^7.3.1
+    "@metamask/preferences-controller": ^4.3.1
     "@metamask/scure-bip39": ^2.1.0
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
@@ -1795,7 +1795,7 @@ __metadata:
     typescript: ~4.6.3
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/preferences-controller": ^4.3.0
+    "@metamask/preferences-controller": ^4.3.1
   languageName: unknown
   linkType: soft
 
@@ -1804,7 +1804,7 @@ __metadata:
   resolution: "@metamask/logging-controller@workspace:packages/logging-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.1
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1817,12 +1817,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/message-manager@^7.3.0, @metamask/message-manager@workspace:packages/message-manager":
+"@metamask/message-manager@^7.3.1, @metamask/message-manager@workspace:packages/message-manager":
   version: 0.0.0-use.local
   resolution: "@metamask/message-manager@workspace:packages/message-manager"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.1
     "@metamask/eth-sig-util": ^6.0.0
     "@metamask/utils": ^6.2.0
@@ -1847,13 +1847,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@^12.1.1, @metamask/network-controller@workspace:packages/network-controller":
+"@metamask/network-controller@^12.1.2, @metamask/network-controller@workspace:packages/network-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/network-controller@workspace:packages/network-controller"
   dependencies:
     "@json-rpc-specification/meta-schema": ^1.0.6
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.1
     "@metamask/eth-json-rpc-infura": ^8.1.1
     "@metamask/eth-json-rpc-middleware": ^11.0.0
@@ -1888,7 +1888,7 @@ __metadata:
   resolution: "@metamask/notification-controller@workspace:packages/notification-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1926,9 +1926,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/permission-controller@workspace:packages/permission-controller"
   dependencies:
-    "@metamask/approval-controller": ^3.5.0
+    "@metamask/approval-controller": ^3.5.1
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.1
     "@metamask/utils": ^6.2.0
     "@types/deep-freeze-strict": ^1.1.0
@@ -1945,7 +1945,7 @@ __metadata:
     typedoc-plugin-missing-exports: ^0.22.6
     typescript: ~4.6.3
   peerDependencies:
-    "@metamask/approval-controller": ^3.5.0
+    "@metamask/approval-controller": ^3.5.1
   languageName: unknown
   linkType: soft
 
@@ -1954,7 +1954,7 @@ __metadata:
   resolution: "@metamask/phishing-controller@workspace:packages/phishing-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.1
     "@types/jest": ^27.4.1
     "@types/punycode": ^2.1.0
@@ -1971,12 +1971,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/preferences-controller@^4.3.0, @metamask/preferences-controller@workspace:packages/preferences-controller":
+"@metamask/preferences-controller@^4.3.1, @metamask/preferences-controller@workspace:packages/preferences-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/preferences-controller@workspace:packages/preferences-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.1
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1993,7 +1993,7 @@ __metadata:
   resolution: "@metamask/rate-limit-controller@workspace:packages/rate-limit-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     eth-rpc-errors: ^4.0.2
@@ -2044,11 +2044,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/signature-controller@workspace:packages/signature-controller"
   dependencies:
-    "@metamask/approval-controller": ^3.5.0
+    "@metamask/approval-controller": ^3.5.1
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.1
-    "@metamask/message-manager": ^7.3.0
+    "@metamask/message-manager": ^7.3.1
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -2062,7 +2062,7 @@ __metadata:
     typedoc-plugin-missing-exports: ^0.22.6
     typescript: ~4.6.3
   peerDependencies:
-    "@metamask/approval-controller": ^3.5.0
+    "@metamask/approval-controller": ^3.5.1
   languageName: unknown
   linkType: soft
 
@@ -2079,12 +2079,12 @@ __metadata:
   dependencies:
     "@ethereumjs/common": ^3.2.0
     "@ethereumjs/tx": ^4.2.0
-    "@metamask/approval-controller": ^3.5.0
+    "@metamask/approval-controller": ^3.5.1
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.2.0
+    "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.1
     "@metamask/eth-query": ^3.0.1
-    "@metamask/network-controller": ^12.1.1
+    "@metamask/network-controller": ^12.1.2
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
     "@types/node": ^16.18.24
@@ -2104,8 +2104,8 @@ __metadata:
     typescript: ~4.6.3
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/approval-controller": ^3.5.0
-    "@metamask/network-controller": ^12.1.1
+    "@metamask/approval-controller": ^3.5.1
+    "@metamask/network-controller": ^12.1.2
     babel-runtime: ^6.26.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This release is somewhat special. Most of these packages are just bumping dependencies on other packages within the monorepo. We recently made a change which ensures that if the version of a package A is bumped, then the new version of A is reflected in the manifest of packages that depend on A. This doesn't necessarily mean that those packages need to be released right away — it's fine if just A is released — but we are releasing every package right now to reduce the amount of changes that need to be published in the next release.