### PR TITLE
Adding response from security validator to transaction

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -710,6 +710,16 @@ describe('TransactionController', () => {
 
       const mockDeviceConfirmedOn = WalletDevice.OTHER;
       const mockOrigin = 'origin';
+      const mockSecurityAlertResponse = {
+        resultType: 'Malicious',
+        reason: 'blur_farming',
+        description:
+          'A SetApprovalForAll request was made on {contract}. We found the operator {operator} to be malicious',
+        args: {
+          contract: '0xa7206d878c5c3871826dfdb42191c49b1d11f466',
+          operator: '0x92a3b9773b1763efa556f55ccbeb20441962d9b2',
+        },
+      };
 
       await controller.addTransaction(
         {
@@ -719,6 +729,7 @@ describe('TransactionController', () => {
         {
           deviceConfirmedOn: mockDeviceConfirmedOn,
           origin: mockOrigin,
+          securityAlertResponse: mockSecurityAlertResponse,
         },
       );
 
@@ -737,6 +748,9 @@ describe('TransactionController', () => {
       expect(controller.state.transactions[0].origin).toBe(mockOrigin);
       expect(controller.state.transactions[0].status).toBe(
         TransactionStatus.unapproved,
+      );
+      expect(controller.state.transactions[0].securityAlertResponse).toBe(
+        mockSecurityAlertResponse,
       );
     });
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -385,6 +385,7 @@ export class TransactionController extends BaseController<
    * @param opts.deviceConfirmedOn - An enum to indicate what device confirmed the transaction.
    * @param opts.origin - The origin of the transaction request, such as a dApp hostname.
    * @param opts.requireApproval - Whether the transaction requires approval by the user, defaults to true unless explicitly disabled.
+   * @param opts.securityAlertResponse - Response from security validator.
    * @returns Object containing a promise resolving to the transaction hash if approved.
    */
   async addTransaction(
@@ -393,10 +394,12 @@ export class TransactionController extends BaseController<
       deviceConfirmedOn,
       origin,
       requireApproval,
+      securityAlertResponse,
     }: {
       deviceConfirmedOn?: WalletDevice;
       origin?: string;
       requireApproval?: boolean | undefined;
+      securityAlertResponse?: Record<string, unknown>;
     } = {},
   ): Promise<Result> {
     const { chainId, networkId } = this.getChainAndNetworkId();
@@ -420,6 +423,7 @@ export class TransactionController extends BaseController<
       deviceConfirmedOn,
       verifiedOnBlockchain: false,
       dappSuggestedGasFees,
+      securityAlertResponse,
     };
 
     try {

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -106,6 +106,11 @@ type TransactionMetaBase = {
    * Whether the transaction is verified on the blockchain.
    */
   verifiedOnBlockchain?: boolean;
+
+  /**
+   * Response from security validator.
+   */
+  securityAlertResponse?: Record<string, unknown>;
 };
 
 /**


### PR DESCRIPTION
Adding `securityAlertResponse` to traansaction.