### PR TITLE
Use networkClientId in AssetsContractController

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -5,7 +5,10 @@ import {
   IPFS_DEFAULT_GATEWAY_URL,
   NetworkType,
 } from '@metamask/controller-utils';
-import type { NetworkClientId, NetworkControllerMessenger } from '@metamask/network-controller';
+import type {
+  NetworkClientId,
+  NetworkControllerMessenger,
+} from '@metamask/network-controller';
 import {
   NetworkController,
   NetworkClientType,
@@ -19,8 +22,6 @@ import {
 } from './AssetsContractController';
 import { SupportedTokenDetectionNetworks } from './assetsUtil';
 import { mockNetwork } from '../../../tests/mock-network';
-import { NetworkClientConfiguration } from '@metamask/network-controller';
-import { CustomNetworkClientConfiguration } from '@metamask/network-controller/src/types';
 
 const ERC20_UNI_ADDRESS = '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984';
 const ERC20_SAI_ADDRESS = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359';
@@ -39,7 +40,7 @@ const TEST_ACCOUNT_PUBLIC_ADDRESS =
  *
  * @returns the objects.
  */
-export async function setupControllers() {
+async function setupControllers() {
   const networkClientConfiguration = {
     type: NetworkClientType.Infura,
     network: 'mainnet',
@@ -64,7 +65,7 @@ export async function setupControllers() {
   const preferences = new PreferencesController();
 
   const provider = new HttpProvider(
-    `https://mainnet.infura.io/v3/${networkClientConfiguration.infuraProjectId}`
+    `https://mainnet.infura.io/v3/${networkClientConfiguration.infuraProjectId}`,
   );
 
   const assetsContract = new AssetsContractController({
@@ -72,10 +73,11 @@ export async function setupControllers() {
     onPreferencesStateChange: (listener) => preferences.subscribe(listener),
     onNetworkStateChange: (listener) =>
       messenger.subscribe('NetworkController:stateChange', listener),
-    getNetworkClientById: (networkClientId: NetworkClientId) => ({
-      ...network.getNetworkClientById(networkClientId),
-      provider
-    } as any),
+    getNetworkClientById: (networkClientId: NetworkClientId) =>
+      ({
+        ...network.getNetworkClientById(networkClientId),
+        provider,
+      } as any),
   });
 
   return {
@@ -119,6 +121,9 @@ function mockNetworkWithDefaultChainId({
     ],
   });
 }
+
+// eslint-disable-next-line jest/no-export
+export { setupControllers, mockNetworkWithDefaultChainId };
 
 describe('AssetsContractController', () => {
   it('should set default config', async () => {

--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -5,7 +5,7 @@ import {
   IPFS_DEFAULT_GATEWAY_URL,
   NetworkType,
 } from '@metamask/controller-utils';
-import type { NetworkControllerMessenger } from '@metamask/network-controller';
+import type { NetworkClientId, NetworkControllerMessenger } from '@metamask/network-controller';
 import {
   NetworkController,
   NetworkClientType,
@@ -19,6 +19,8 @@ import {
 } from './AssetsContractController';
 import { SupportedTokenDetectionNetworks } from './assetsUtil';
 import { mockNetwork } from '../../../tests/mock-network';
+import { NetworkClientConfiguration } from '@metamask/network-controller';
+import { CustomNetworkClientConfiguration } from '@metamask/network-controller/src/types';
 
 const ERC20_UNI_ADDRESS = '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984';
 const ERC20_SAI_ADDRESS = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359';
@@ -60,15 +62,19 @@ async function setupControllers() {
     trackMetaMetricsEvent: jest.fn(),
   });
   const preferences = new PreferencesController();
+
+  const rpcUrl = `https://mainnet.infura.io/v3/${networkClientConfiguration.infuraProjectId}`
+  const provider = new HttpProvider(
+    rpcUrl
+  );
+
   const assetsContract = new AssetsContractController({
     chainId: ChainId.mainnet,
     onPreferencesStateChange: (listener) => preferences.subscribe(listener),
     onNetworkStateChange: (listener) =>
       messenger.subscribe('NetworkController:stateChange', listener),
+    getNetworkClientById: network.getNetworkClientById.bind(network),
   });
-  const provider = new HttpProvider(
-    `https://mainnet.infura.io/v3/${networkClientConfiguration.infuraProjectId}`,
-  );
 
   return {
     messenger,

--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -40,7 +40,7 @@ const TEST_ACCOUNT_PUBLIC_ADDRESS =
  *
  * @returns the objects.
  */
-async function setupControllers() {
+async function setupAssetContractControllers() {
   const networkClientConfiguration = {
     type: NetworkClientType.Infura,
     network: 'mainnet',
@@ -123,11 +123,11 @@ function mockNetworkWithDefaultChainId({
 }
 
 // eslint-disable-next-line jest/no-export
-export { setupControllers, mockNetworkWithDefaultChainId };
+export { setupAssetContractControllers, mockNetworkWithDefaultChainId };
 
 describe('AssetsContractController', () => {
   it('should set default config', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     expect(assetsContract.config).toStrictEqual({
       chainId: SupportedTokenDetectionNetworks.mainnet,
       ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,
@@ -137,7 +137,8 @@ describe('AssetsContractController', () => {
   });
 
   it('should update the ipfsGateWay config value when this value is changed in the preferences controller', async () => {
-    const { assetsContract, messenger, preferences } = await setupControllers();
+    const { assetsContract, messenger, preferences } =
+      await setupAssetContractControllers();
     expect(assetsContract.config).toStrictEqual({
       chainId: SupportedTokenDetectionNetworks.mainnet,
       ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,
@@ -155,7 +156,7 @@ describe('AssetsContractController', () => {
   });
 
   it('should throw when provider property is accessed', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     expect(() => console.log(assetsContract.provider)).toThrow(
       'Property only used for setting',
     );
@@ -163,7 +164,7 @@ describe('AssetsContractController', () => {
   });
 
   it('should throw missing provider error when getting ERC-20 token balance when missing provider', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     assetsContract.configure({ provider: undefined });
     await expect(
       assetsContract.getERC20BalanceOf(
@@ -175,7 +176,7 @@ describe('AssetsContractController', () => {
   });
 
   it('should throw missing provider error when getting ERC-20 token decimal when missing provider', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     assetsContract.configure({ provider: undefined });
     await expect(
       assetsContract.getERC20TokenDecimals(ERC20_UNI_ADDRESS),
@@ -185,7 +186,7 @@ describe('AssetsContractController', () => {
 
   it('should get balance of ERC-20 token contract correctly', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -239,7 +240,7 @@ describe('AssetsContractController', () => {
 
   it('should get ERC-721 NFT tokenId correctly', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -272,7 +273,7 @@ describe('AssetsContractController', () => {
   });
 
   it('should throw missing provider error when getting ERC-721 token standard and details when missing provider', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     assetsContract.configure({ provider: undefined });
     await expect(
       assetsContract.getTokenStandardAndDetails(
@@ -284,7 +285,8 @@ describe('AssetsContractController', () => {
   });
 
   it('should throw contract standard error when getting ERC-20 token standard and details when provided with invalid ERC-20 address', async () => {
-    const { assetsContract, messenger, provider } = await setupControllers();
+    const { assetsContract, messenger, provider } =
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     const error = 'Unable to determine contract standard';
     await expect(
@@ -298,7 +300,7 @@ describe('AssetsContractController', () => {
 
   it('should get ERC-721 token standard and details', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -363,7 +365,7 @@ describe('AssetsContractController', () => {
 
   it('should get ERC-1155 token standard and details', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -412,7 +414,7 @@ describe('AssetsContractController', () => {
 
   it('should get ERC-20 token standard and details', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -509,7 +511,7 @@ describe('AssetsContractController', () => {
 
   it('should get ERC-721 NFT tokenURI correctly', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -558,7 +560,7 @@ describe('AssetsContractController', () => {
 
   it('should throw an error when address given is not an ERC-721 NFT', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -594,7 +596,7 @@ describe('AssetsContractController', () => {
 
   it('should get ERC-721 NFT name', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -624,7 +626,7 @@ describe('AssetsContractController', () => {
 
   it('should get ERC-721 NFT symbol', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -655,7 +657,7 @@ describe('AssetsContractController', () => {
   });
 
   it('should throw missing provider error when getting ERC-721 NFT symbol when missing provider', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     await expect(
       assetsContract.getERC721AssetSymbol(ERC721_GODS_ADDRESS),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
@@ -664,7 +666,7 @@ describe('AssetsContractController', () => {
 
   it('should get ERC-20 token decimals', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -696,7 +698,7 @@ describe('AssetsContractController', () => {
 
   it('should get ERC-20 token name', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -728,7 +730,7 @@ describe('AssetsContractController', () => {
 
   it('should get ERC-721 NFT ownership', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -760,7 +762,7 @@ describe('AssetsContractController', () => {
   });
 
   it('should throw missing provider error when getting ERC-721 NFT ownership', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     await expect(
       assetsContract.getERC721OwnerOf(ERC721_GODS_ADDRESS, '148332'),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
@@ -769,7 +771,7 @@ describe('AssetsContractController', () => {
 
   it('should get balance of ERC-20 token in a single call on network with token detection support', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -807,7 +809,7 @@ describe('AssetsContractController', () => {
       network,
       provider,
       networkClientConfiguration,
-    } = await setupControllers();
+    } = await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -877,7 +879,7 @@ describe('AssetsContractController', () => {
   });
 
   it('should throw missing provider error when transfering single ERC-1155 when missing provider', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     assetsContract.configure({ provider: undefined });
     await expect(
       assetsContract.transferSingleERC1155(
@@ -893,7 +895,7 @@ describe('AssetsContractController', () => {
 
   it('should get the balance of a ERC-1155 NFT for a given address', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -926,7 +928,7 @@ describe('AssetsContractController', () => {
   });
 
   it('should throw missing provider error when getting the balance of a ERC-1155 NFT when missing provider', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     await expect(
       assetsContract.getERC1155BalanceOf(
         TEST_ACCOUNT_PUBLIC_ADDRESS,
@@ -939,7 +941,7 @@ describe('AssetsContractController', () => {
 
   it('should get the URI of a ERC-1155 NFT', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     assetsContract.configure({ provider });
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -145,6 +145,12 @@ export class AssetsContractController extends BaseController<
     throw new Error('Property only used for setting');
   }
 
+  /**
+   * Get the relevant provider instance.
+   *
+   * @param networkClientId - Network Client ID.
+   * @returns Web3Provider instance.
+   */
   getProvider(networkClientId?: NetworkClientId): Web3Provider {
     const provider = networkClientId
       ? this.getNetworkClientById(networkClientId).provider
@@ -157,10 +163,49 @@ export class AssetsContractController extends BaseController<
     return new Web3Provider(provider);
   }
 
+  /**
+   * Get the relevant chain ID.
+   *
+   * @param networkClientId - Network Client ID used to get the provider.
+   * @returns Hex chain ID.
+   */
   getChainId(networkClientId?: NetworkClientId): Hex {
     return networkClientId
       ? this.getNetworkClientById(networkClientId).configuration.chainId
       : this.config.chainId;
+  }
+
+  /**
+   * Get a ERC20Standard instance using the relevant provider instance.
+   *
+   * @param networkClientId - Network Client ID used to get the provider.
+   * @returns ERC20Standard instance.
+   */
+  getERC20Standard(networkClientId?: NetworkClientId): ERC20Standard {
+    const provider = this.getProvider(networkClientId);
+    return new ERC20Standard(provider);
+  }
+
+  /**
+   * Get a ERC721Standard instance using the relevant provider instance.
+   *
+   * @param networkClientId - Network Client ID used to get the provider.
+   * @returns ERC721Standard instance.
+   */
+  getERC721Standard(networkClientId?: NetworkClientId): ERC721Standard {
+    const provider = this.getProvider(networkClientId);
+    return new ERC721Standard(provider);
+  }
+
+  /**
+   * Get a ERC1155Standard instance using the relevant provider instance.
+   *
+   * @param networkClientId - Network Client ID used to get the provider.
+   * @returns ERC1155Standard instance.
+   */
+  getERC1155Standard(networkClientId?: NetworkClientId): ERC1155Standard {
+    const provider = this.getProvider(networkClientId);
+    return new ERC1155Standard(provider);
   }
 
   /**
@@ -176,9 +221,7 @@ export class AssetsContractController extends BaseController<
     selectedAddress: string,
     networkClientId?: NetworkClientId,
   ): Promise<BN> {
-    const provider = this.getProvider(networkClientId);
-    const erc20Standard = new ERC20Standard(provider);
-
+    const erc20Standard = this.getERC20Standard(networkClientId);
     return erc20Standard.getBalanceOf(address, selectedAddress);
   }
 
@@ -193,9 +236,7 @@ export class AssetsContractController extends BaseController<
     address: string,
     networkClientId?: NetworkClientId,
   ): Promise<string> {
-    const provider = this.getProvider(networkClientId);
-    const erc20Standard = new ERC20Standard(provider);
-
+    const erc20Standard = this.getERC20Standard(networkClientId);
     return erc20Standard.getTokenDecimals(address);
   }
 
@@ -210,9 +251,7 @@ export class AssetsContractController extends BaseController<
     address: string,
     networkClientId?: NetworkClientId,
   ): Promise<string> {
-    const provider = this.getProvider(networkClientId);
-    const erc20Standard = new ERC20Standard(provider);
-
+    const erc20Standard = this.getERC20Standard(networkClientId);
     return erc20Standard.getTokenName(address);
   }
 
@@ -231,9 +270,7 @@ export class AssetsContractController extends BaseController<
     index: number,
     networkClientId?: NetworkClientId,
   ): Promise<string> {
-    const provider = this.getProvider(networkClientId);
-    const erc721Standard = new ERC721Standard(provider);
-
+    const erc721Standard = this.getERC721Standard(networkClientId);
     return erc721Standard.getNftTokenId(address, selectedAddress, index);
   }
 
@@ -259,13 +296,14 @@ export class AssetsContractController extends BaseController<
     decimals?: string | undefined;
     balance?: BN | undefined;
   }> {
-    const provider = this.getProvider(networkClientId);
+    // Asserts provider is available
+    this.getProvider(networkClientId);
 
     const { ipfsGateway } = this.config;
 
     // ERC721
     try {
-      const erc721Standard = new ERC721Standard(provider);
+      const erc721Standard = this.getERC721Standard(networkClientId);
       return {
         ...(await erc721Standard.getDetails(
           tokenAddress,
@@ -279,7 +317,7 @@ export class AssetsContractController extends BaseController<
 
     // ERC1155
     try {
-      const erc1155Standard = new ERC1155Standard(provider);
+      const erc1155Standard = this.getERC1155Standard(networkClientId);
       return {
         ...(await erc1155Standard.getDetails(
           tokenAddress,
@@ -293,7 +331,7 @@ export class AssetsContractController extends BaseController<
 
     // ERC20
     try {
-      const erc20Standard = new ERC20Standard(provider);
+      const erc20Standard = this.getERC20Standard(networkClientId);
       return {
         ...(await erc20Standard.getDetails(tokenAddress, userAddress)),
       };
@@ -317,9 +355,7 @@ export class AssetsContractController extends BaseController<
     tokenId: string,
     networkClientId?: NetworkClientId,
   ): Promise<string> {
-    const provider = this.getProvider(networkClientId);
-    const erc721Standard = new ERC721Standard(provider);
-
+    const erc721Standard = this.getERC721Standard(networkClientId);
     return erc721Standard.getTokenURI(address, tokenId);
   }
 
@@ -334,9 +370,7 @@ export class AssetsContractController extends BaseController<
     address: string,
     networkClientId?: NetworkClientId,
   ): Promise<string> {
-    const provider = this.getProvider(networkClientId);
-    const erc721Standard = new ERC721Standard(provider);
-
+    const erc721Standard = this.getERC721Standard(networkClientId);
     return erc721Standard.getAssetName(address);
   }
 
@@ -351,9 +385,7 @@ export class AssetsContractController extends BaseController<
     address: string,
     networkClientId?: NetworkClientId,
   ): Promise<string> {
-    const provider = this.getProvider(networkClientId);
-    const erc721Standard = new ERC721Standard(provider);
-
+    const erc721Standard = this.getERC721Standard(networkClientId);
     return erc721Standard.getAssetSymbol(address);
   }
 
@@ -370,9 +402,7 @@ export class AssetsContractController extends BaseController<
     tokenId: string,
     networkClientId?: NetworkClientId,
   ): Promise<string> {
-    const provider = this.getProvider(networkClientId);
-    const erc721Standard = new ERC721Standard(provider);
-
+    const erc721Standard = this.getERC721Standard(networkClientId);
     return erc721Standard.getOwnerOf(address, tokenId);
   }
 
@@ -389,8 +419,7 @@ export class AssetsContractController extends BaseController<
     tokenId: string,
     networkClientId?: NetworkClientId,
   ): Promise<string> {
-    const provider = this.getProvider(networkClientId);
-    const erc1155Standard = new ERC1155Standard(provider);
+    const erc1155Standard = this.getERC1155Standard(networkClientId);
     return erc1155Standard.getTokenURI(address, tokenId);
   }
 
@@ -409,9 +438,7 @@ export class AssetsContractController extends BaseController<
     nftId: string,
     networkClientId?: NetworkClientId,
   ): Promise<BN> {
-    const provider = this.getProvider(networkClientId);
-    const erc1155Standard = new ERC1155Standard(provider);
-
+    const erc1155Standard = this.getERC1155Standard(networkClientId);
     return erc1155Standard.getBalanceOf(nftAddress, userAddress, nftId);
   }
 
@@ -434,9 +461,7 @@ export class AssetsContractController extends BaseController<
     qty: string,
     networkClientId?: NetworkClientId,
   ): Promise<void> {
-    const provider = this.getProvider(networkClientId);
-    const erc1155Standard = new ERC1155Standard(provider);
-
+    const erc1155Standard = this.getERC1155Standard(networkClientId);
     return erc1155Standard.transferSingle(
       nftAddress,
       senderAddress,

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -78,8 +78,6 @@ export class AssetsContractController extends BaseController<
 
   private readonly getNetworkClientById: NetworkController['getNetworkClientById'];
 
-  private readonly getNetworkClientRegistry: NetworkController['getNetworkClientRegistry'];
-
   /**
    * Creates a AssetsContractController instance.
    *
@@ -88,7 +86,6 @@ export class AssetsContractController extends BaseController<
    * @param options.onPreferencesStateChange - Allows subscribing to preference controller state changes.
    * @param options.onNetworkStateChange - Allows subscribing to network controller state changes.
    * @param options.getNetworkClientById - Gets the network client with the given id from the NetworkController.
-   * @param options.getNetworkClientRegistry - Gets the network client registry from the NetworkController.
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
    */
@@ -160,7 +157,7 @@ export class AssetsContractController extends BaseController<
     return new Web3Provider(provider);
   }
 
-  getChainId(networkClientId?: NetworkClientId): string {
+  getChainId(networkClientId?: NetworkClientId): Hex {
     return networkClientId
       ? this.getNetworkClientById(networkClientId).configuration.chainId
       : this.config.chainId;

--- a/packages/assets-controllers/src/AssetsContractControllerWithNetworkClientId.test.ts
+++ b/packages/assets-controllers/src/AssetsContractControllerWithNetworkClientId.test.ts
@@ -2,7 +2,7 @@ import { BUILT_IN_NETWORKS } from '@metamask/controller-utils';
 import { NetworkClientType } from '@metamask/network-controller';
 
 import {
-  setupControllers,
+  setupAssetContractControllers,
   mockNetworkWithDefaultChainId,
 } from './AssetsContractController.test';
 
@@ -19,31 +19,31 @@ const TEST_ACCOUNT_PUBLIC_ADDRESS =
 
 describe('AssetsContractController with NetworkClientId', () => {
   it('should throw when getting ERC-20 token balance when networkClientId is invalid', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     await expect(
       assetsContract.getERC20BalanceOf(
         ERC20_UNI_ADDRESS,
         TEST_ACCOUNT_PUBLIC_ADDRESS,
         'invalidNetworkClientId',
       ),
-    ).rejects.toThrow(expect.any(Error));
+    ).rejects.toThrow('No custom network client was found');
     messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw when getting ERC-20 token decimal when networkClientId is invalid', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     await expect(
       assetsContract.getERC20TokenDecimals(
         ERC20_UNI_ADDRESS,
         'invalidNetworkClientId',
       ),
-    ).rejects.toThrow(expect.any(Error));
+    ).rejects.toThrow('No custom network client was found');
     messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get balance of ERC-20 token contract correctly', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -98,7 +98,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should get ERC-721 NFT tokenId correctly', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -131,7 +131,7 @@ describe('AssetsContractController with NetworkClientId', () => {
   });
 
   it('should throw error when getting ERC-721 token standard and details when networkClientId is invalid', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     await expect(
       assetsContract.getTokenStandardAndDetails(
         ERC20_UNI_ADDRESS,
@@ -139,12 +139,12 @@ describe('AssetsContractController with NetworkClientId', () => {
         undefined,
         'invalidNetworkClientId',
       ),
-    ).rejects.toThrow(expect.any(Error));
+    ).rejects.toThrow('No custom network client was found');
     messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw contract standard error when getting ERC-20 token standard and details when provided with invalid ERC-20 address', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     const error = 'Unable to determine contract standard';
     await expect(
       assetsContract.getTokenStandardAndDetails(
@@ -159,7 +159,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should get ERC-721 token standard and details', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -225,7 +225,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should get ERC-1155 token standard and details', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -275,7 +275,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should get ERC-20 token standard and details', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -373,7 +373,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should get ERC-721 NFT tokenURI correctly', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -422,7 +422,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should throw an error when address given is not an ERC-721 NFT', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -458,7 +458,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should get ERC-721 NFT name', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -490,7 +490,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should get ERC-721 NFT symbol', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -521,19 +521,19 @@ describe('AssetsContractController with NetworkClientId', () => {
   });
 
   it('should throw error when getting ERC-721 NFT symbol when networkClientId is invalid', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     await expect(
       assetsContract.getERC721AssetSymbol(
         ERC721_GODS_ADDRESS,
         'invalidNetworkClientId',
       ),
-    ).rejects.toThrow(expect.any(Error));
+    ).rejects.toThrow('No custom network client was found');
     messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get ERC-20 token decimals', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -565,7 +565,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should get ERC-20 token name', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -599,7 +599,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should get ERC-721 NFT ownership', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -631,20 +631,20 @@ describe('AssetsContractController with NetworkClientId', () => {
   });
 
   it('should throw error when getting ERC-721 NFT ownership using networkClientId that is invalid', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     await expect(
       assetsContract.getERC721OwnerOf(
         ERC721_GODS_ADDRESS,
         '148332',
         'invalidNetworkClientId',
       ),
-    ).rejects.toThrow(expect.any(Error));
+    ).rejects.toThrow('No custom network client was found');
     messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get balance of ERC-20 token in a single call on network with token detection support', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -677,7 +677,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should not have balance in a single call after switching to network without token detection support', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -746,7 +746,7 @@ describe('AssetsContractController with NetworkClientId', () => {
   });
 
   it('should throw error when transfering single ERC-1155 when networkClientId is invalid', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     await expect(
       assetsContract.transferSingleERC1155(
         ERC1155_ADDRESS,
@@ -756,13 +756,13 @@ describe('AssetsContractController with NetworkClientId', () => {
         '1',
         'invalidNetworkClientId',
       ),
-    ).rejects.toThrow(expect.any(Error));
+    ).rejects.toThrow('No custom network client was found');
     messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get the balance of a ERC-1155 NFT for a given address', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [
@@ -794,8 +794,8 @@ describe('AssetsContractController with NetworkClientId', () => {
     messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
-  it('should throw missing provider error when getting the balance of a ERC-1155 NFT when networkClientId is invalid', async () => {
-    const { assetsContract, messenger } = await setupControllers();
+  it('should throw error when getting the balance of a ERC-1155 NFT when networkClientId is invalid', async () => {
+    const { assetsContract, messenger } = await setupAssetContractControllers();
     await expect(
       assetsContract.getERC1155BalanceOf(
         TEST_ACCOUNT_PUBLIC_ADDRESS,
@@ -803,13 +803,13 @@ describe('AssetsContractController with NetworkClientId', () => {
         ERC1155_ID,
         'invalidNetworkClientId',
       ),
-    ).rejects.toThrow(expect.any(Error));
+    ).rejects.toThrow('No custom network client was found');
     messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get the URI of a ERC-1155 NFT', async () => {
     const { assetsContract, messenger, networkClientConfiguration } =
-      await setupControllers();
+      await setupAssetContractControllers();
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
       mocks: [

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -175,6 +175,7 @@ function setupController({
     onPreferencesStateChange: (listener) => preferences.subscribe(listener),
     onNetworkStateChange: (listener) =>
       onNetworkStateChangeListeners.push(listener),
+    getNetworkClientById: jest.fn(),
   });
 
   const onNftAddedSpy = includeOnNftAdded ? jest.fn() : undefined;

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -38,6 +38,7 @@ describe('NftDetectionController', () => {
       chainId: ChainId.mainnet,
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: networkStateChangeNoop,
+      getNetworkClientById: jest.fn(),
     });
 
     nftController = new NftController({

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -232,6 +232,7 @@ describe('TokenBalancesController', () => {
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) =>
         messenger.subscribe('NetworkController:stateChange', listener),
+      getNetworkClientById: jest.fn(),
     });
     const tokensController = new TokensController({
       chainId: toHex(1),

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -11,12 +11,14 @@ import contractsMap from '@metamask/contract-metadata';
 import {
   toChecksumHexAddress,
   ERC721_INTERFACE_ID,
-  ORIGIN_METAMASK,
   ApprovalType,
   ERC20,
 } from '@metamask/controller-utils';
 import { abiERC721 } from '@metamask/metamask-eth-abis';
-import type { NetworkClientId, NetworkState } from '@metamask/network-controller';
+import type {
+  NetworkClientId,
+  NetworkState,
+} from '@metamask/network-controller';
 import type { PreferencesState } from '@metamask/preferences-controller';
 import type { Hex } from '@metamask/utils';
 import { AbortController as WhatwgAbortController } from 'abort-controller';

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -11,14 +11,12 @@ import contractsMap from '@metamask/contract-metadata';
 import {
   toChecksumHexAddress,
   ERC721_INTERFACE_ID,
+  ORIGIN_METAMASK,
   ApprovalType,
   ERC20,
 } from '@metamask/controller-utils';
 import { abiERC721 } from '@metamask/metamask-eth-abis';
-import type {
-  NetworkClientId,
-  NetworkState,
-} from '@metamask/network-controller';
+import type { NetworkState } from '@metamask/network-controller';
 import type { PreferencesState } from '@metamask/preferences-controller';
 import type { Hex } from '@metamask/utils';
 import { AbortController as WhatwgAbortController } from 'abort-controller';
@@ -52,7 +50,6 @@ import type { Token } from './TokenRatesController';
 export interface TokensConfig extends BaseConfig {
   selectedAddress: string;
   chainId: Hex;
-  selectedNetworkClientId: NetworkClientId;
   provider: any;
 }
 
@@ -243,13 +240,13 @@ export class TokensController extends BaseController<
       });
     });
 
-    onNetworkStateChange(({ selectedNetworkClientId, providerConfig }) => {
+    onNetworkStateChange(({ providerConfig }) => {
       const { allTokens, allIgnoredTokens, allDetectedTokens } = this.state;
       const { selectedAddress } = this.config;
       const { chainId } = providerConfig;
       this.abortController.abort();
       this.abortController = new WhatwgAbortController();
-      this.configure({ chainId, selectedNetworkClientId });
+      this.configure({ chainId });
       this.ethersProvider = this._instantiateNewEthersProvider();
       this.update({
         tokens: allTokens[chainId]?.[selectedAddress] || [],
@@ -267,7 +264,6 @@ export class TokensController extends BaseController<
   }
 
   _instantiateNewEthersProvider(): any {
-    // is config.provider ever set?
     return new Web3Provider(this.config?.provider);
   }
 
@@ -814,7 +810,7 @@ export class TokensController extends BaseController<
       'ApprovalController:addRequest',
       {
         id: suggestedAssetMeta.id,
-        networkClientId: this.config.selectedNetworkClientId,
+        origin: ORIGIN_METAMASK,
         type: ApprovalType.WatchAsset,
         requestData: {
           id: suggestedAssetMeta.id,

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -453,10 +453,16 @@ export type NetworkControllerGetEthQueryAction = {
   handler: () => EthQuery | undefined;
 };
 
+export type NetworkControllerGetNetworkClientByIdAction = {
+  type: `NetworkController:getNetworkClientById`;
+  handler: NetworkController['getNetworkClientById'];
+};
+
 export type NetworkControllerActions =
   | NetworkControllerGetStateAction
   | NetworkControllerGetProviderConfigAction
-  | NetworkControllerGetEthQueryAction;
+  | NetworkControllerGetEthQueryAction
+  | NetworkControllerGetNetworkClientByIdAction;
 
 export type NetworkControllerMessenger = RestrictedControllerMessenger<
   typeof name,
@@ -599,6 +605,11 @@ export class NetworkController extends BaseControllerV2<
       () => {
         return this.#ethQuery;
       },
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${this.name}:getNetworkClientById`,
+      this.getNetworkClientById.bind(this),
     );
 
     this.#previousProviderConfig = this.state.providerConfig;


### PR DESCRIPTION
## Explanation

`AssetsContractController` currently relies on the proxied provider and `onNetworkStateChange` listener to ensure it is performing checks against the correct network. As part of multichain efforts, we want to decouple this controller from the notion of a single active network. We do this by adding an optional `networkClientId` argument to each of the external facing methods. This arg is used to resolve to a `NetworkClient` from the `NetworkController` when set. 


<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

* Fixes [mmp-1021](https://github.com/MetaMask/MetaMask-planning/issues/1021)

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/network-controller`

- **ADDED**: `NetworkController` exposes `getNetworkClientById()` in a `NetworkController:getNetworkClientById` action

### `@metamask/assets-controllers`

- **ADDED**: `AssetsContractController` constructor options requires `getNetworkClientById`
- **CHANGED**: `AssetsContractController.getERC20BalanceOf()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.getERC20TokenDecimals()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.getERC20TokenName()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.getERC721NftTokenId()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.getTokenStandardAndDetails()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.getERC721TokenURI()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.getERC721AssetName()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.getERC721AssetSymbol()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.getERC721OwnerOf()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.getERC1155TokenURI()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.getERC1155BalanceOf()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.transferSingleERC1155()` accepts optional `networkClientId`
- **CHANGED**: `AssetsContractController.getBalancesInSingleCall()` accepts optional `networkClientId`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
