### PR TITLE
Added SelectedNetworkController

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Or, in graph form [^fn1]:
 
 <!-- start dependency graph -->
 
-``` mermaid
+```mermaid
 %%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
 graph LR;
 linkStyle default opacity:0.5

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Or, in graph form [^fn1]:
 
 <!-- start dependency graph -->
 
-```mermaid
+``` mermaid
 %%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
 graph LR;
 linkStyle default opacity:0.5
@@ -54,6 +54,7 @@ linkStyle default opacity:0.5
   phishing_controller(["@metamask/phishing-controller"]);
   preferences_controller(["@metamask/preferences-controller"]);
   rate_limit_controller(["@metamask/rate-limit-controller"]);
+  selected_network_controller(["@metamask/selected-network-controller"]);
   signature_controller(["@metamask/signature-controller"]);
   transaction_controller(["@metamask/transaction-controller"]);
   address_book_controller --> base_controller;
@@ -91,6 +92,8 @@ linkStyle default opacity:0.5
   preferences_controller --> base_controller;
   preferences_controller --> controller_utils;
   rate_limit_controller --> base_controller;
+  selected_network_controller --> base_controller;
+  selected_network_controller --> network_controller;
   signature_controller --> approval_controller;
   signature_controller --> base_controller;
   signature_controller --> controller_utils;

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/core/

--- a/packages/selected-network-controller/LICENSE
+++ b/packages/selected-network-controller/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2018 MetaMask
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE

--- a/packages/selected-network-controller/LICENSE
+++ b/packages/selected-network-controller/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 MetaMask
+Copyright (c) 2023 MetaMask
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/selected-network-controller/README.md
+++ b/packages/selected-network-controller/README.md
@@ -1,0 +1,20 @@
+# `@metamask/selected-network-controller`
+
+Provides an interface to the currently selected networkClientId for a given domain.
+
+Domain here means one of two things:
+
+- either the jsonrpc request originated from a dapp (domain is the origin/url of the dapp)
+- the jsonrpc request originated interally to metamask (the domain is here is 'metamask')
+
+## Installation
+
+`yarn add @metamask/selected-network-controller`
+
+or
+
+`npm install @metamask/selected-network-controller`
+
+## Contributing
+
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).

--- a/packages/selected-network-controller/README.md
+++ b/packages/selected-network-controller/README.md
@@ -4,7 +4,7 @@ Provides an interface to the currently selected networkClientId for a given doma
 
 Domain here means one of two things:
 
-- either the jsonrpc request originated from a dapp (domain is the origin/url of the dapp)
+- the jsonrpc request originated from a dapp (domain is the origin/url of the dapp)
 - the jsonrpc request originated interally to metamask (the domain is here is 'metamask')
 
 ## Installation

--- a/packages/selected-network-controller/jest.config.js
+++ b/packages/selected-network-controller/jest.config.js
@@ -1,0 +1,30 @@
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+const merge = require('deepmerge');
+const path = require('path');
+
+const baseConfig = require('../../jest.config.packages');
+
+const displayName = path.basename(__dirname);
+
+module.exports = merge(baseConfig, {
+  // The display name when running multiple projects
+  displayName,
+
+  // An object that configures minimum threshold enforcement for coverage results
+  coverageThreshold: {
+    global: {
+      branches: 71.11,
+      functions: 78.57,
+      lines: 85.1,
+      statements: 85.1,
+    },
+  },
+
+  // Currently the tests for NetworkController have a race condition which
+  // causes intermittent failures. This seems to fix it.
+  testEnvironment: 'jsdom',
+});

--- a/packages/selected-network-controller/jest.config.js
+++ b/packages/selected-network-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 71.11,
-      functions: 78.57,
-      lines: 85.1,
-      statements: 85.1,
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
     },
   },
 

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@metamask/selected-network-controller",
+  "version": "0.0.0",
+  "description": "Provides an interface to the currently selected networkClientId for a given domain",
+  "keywords": [
+    "MetaMask",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/core/tree/main/packages/selected-network-controller#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/core/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/core.git"
+  },
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build:docs": "typedoc",
+    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/selected-network-controller",
+    "publish:preview": "yarn npm publish --tag preview",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "@metamask/base-controller": "^3.2.1",
+    "@metamask/network-controller": "^12.1.2",
+    "json-rpc-engine": "^6.1.0"
+  },
+  "devDependencies": {
+    "@metamask/auto-changelog": "^3.1.0",
+    "@types/jest": "^27.4.1",
+    "deepmerge": "^4.2.2",
+    "immer": "^9.0.6",
+    "jest": "^27.5.1",
+    "lodash": "^4.17.21",
+    "nock": "^13.3.1",
+    "sinon": "^9.2.4",
+    "ts-jest": "^27.1.4",
+    "typedoc": "^0.22.15",
+    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typescript": "~4.6.3"
+  },
+  "peerDependencies": {
+    "@metamask/network-controller": "^12.1.2"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -106,10 +106,10 @@ export class SelectedNetworkController extends BaseControllerV2<
       messenger,
       state: getDefaultState(),
     });
-    this.registerMessageHandlers();
+    this.#registerMessageHandlers();
   }
 
-  private registerMessageHandlers(): void {
+  #registerMessageHandlers(): void {
     this.messagingSystem.registerActionHandler(
       SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
       this.getNetworkClientIdForDomain.bind(this),

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -37,9 +37,11 @@ export const SelectedNetworkControllerEventTypes = {
 
 export type SelectedNetworkControllerState = {
   domains: Record<Domain, NetworkClientId>;
-  // Feature flag to start returning networkClientId based on the domain.
-  // when the flag is false, the 'metamask' domain will always be used.
-  // defaults to false
+  /**
+   * Feature flag to start returning networkClientId based on the domain.
+   * when the flag is false, the 'metamask' domain will always be used.
+   * defaults to false
+   */
   perDomainNetwork: boolean;
 };
 

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -145,7 +145,7 @@ export default class SelectedNetworkController extends BaseControllerV2<
   }
 
   setNetworkClientIdForMetamask(networkClientId: NetworkClientId) {
-    return this.setNetworkClientIdForDomain(METAMASK_DOMAIN, networkClientId);
+    this.setNetworkClientIdForDomain(METAMASK_DOMAIN, networkClientId);
   }
 
   setNetworkClientIdForDomain(

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -65,18 +65,18 @@ export type SelectedNetworkControllerSetNetworkClientIdForDomainAction = {
   handler: (domain: string, NetworkClientId: NetworkClientId) => void;
 };
 
-export type SelectedNetworkControllerActions =
+export type SelectedNetworkControllerAction =
   | SelectedNetworkControllerGetSelectedNetworkStateAction
   | SelectedNetworkControllerGetNetworkClientIdForDomainAction
   | SelectedNetworkControllerSetNetworkClientIdForDomainAction;
 
-export type SelectedNetworkControllerEvents =
+export type SelectedNetworkControllerEvent =
   SelectedNetworkControllerStateChangeEvent;
 
 export type SelectedNetworkControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
-  SelectedNetworkControllerActions,
-  NetworkControllerStateChangeEvent | SelectedNetworkControllerEvents,
+  SelectedNetworkControllerAction,
+  NetworkControllerStateChangeEvent | SelectedNetworkControllerEvent,
   string,
   string
 >;

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -139,13 +139,6 @@ export class SelectedNetworkController extends BaseControllerV2<
     );
   }
 
-  /**
-   * Reset the controller state to the initial state.
-   */
-  resetState() {
-    this.update(getDefaultState);
-  }
-
   setNetworkClientIdForMetamask(networkClientId: NetworkClientId) {
     this.setNetworkClientIdForDomain(METAMASK_DOMAIN, networkClientId);
   }

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -88,7 +88,7 @@ export type SelectedNetworkControllerOptions = {
 /**
  * Controller for getting and setting the network for a particular domain.
  */
-export default class SelectedNetworkController extends BaseControllerV2<
+export class SelectedNetworkController extends BaseControllerV2<
   typeof controllerName,
   SelectedNetworkControllerState,
   SelectedNetworkControllerMessenger

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -1,0 +1,166 @@
+import type { RestrictedControllerMessenger } from '@metamask/base-controller';
+import { BaseControllerV2 } from '@metamask/base-controller';
+import type {
+  NetworkClientId,
+  NetworkControllerStateChangeEvent,
+  NetworkState,
+} from '@metamask/network-controller';
+import type { Patch } from 'immer';
+
+const controllerName = 'SelectedNetworkController';
+
+const stateMetadata = {
+  domains: { persist: true, anonymous: false },
+  perDomainNetwork: { persist: true, anonymous: false },
+};
+
+const getDefaultState = () => ({
+  domains: {},
+  perDomainNetwork: false,
+});
+
+type Domain = string;
+
+const METAMASK_DOMAIN = 'metamask' as const;
+
+export const SelectedNetworkControllerActionTypes = {
+  getState: `${controllerName}:getState` as const,
+  getNetworkClientIdForDomain:
+    `${controllerName}:getNetworkClientIdForDomain` as const,
+  setNetworkClientIdForDomain:
+    `${controllerName}:setNetworkClientIdForDomain` as const,
+};
+
+export const SelectedNetworkControllerEventTypes = {
+  stateChange: `${controllerName}:stateChange` as const,
+};
+
+export type SelectedNetworkControllerState = {
+  domains: Record<Domain, NetworkClientId>;
+  // Feature flag to start returning networkClientId based on the domain.
+  // when the flag is false, the 'metamask' domain will always be used.
+  // defaults to false
+  perDomainNetwork: boolean;
+};
+
+export type SelectedNetworkControllerStateChangeEvent = {
+  type: typeof SelectedNetworkControllerEventTypes.stateChange;
+  payload: [SelectedNetworkControllerState, Patch[]];
+};
+
+export type SelectedNetworkControllerGetSelectedNetworkStateAction = {
+  type: typeof SelectedNetworkControllerActionTypes.getState;
+  handler: () => SelectedNetworkControllerState;
+};
+
+export type SelectedNetworkControllerGetNetworkClientIdForDomainAction = {
+  type: typeof SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain;
+  handler: (domain: string) => NetworkClientId;
+};
+
+export type SelectedNetworkControllerSetNetworkClientIdForDomainAction = {
+  type: typeof SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain;
+  handler: (domain: string, NetworkClientId: NetworkClientId) => void;
+};
+
+export type SelectedNetworkControllerActions =
+  | SelectedNetworkControllerGetSelectedNetworkStateAction
+  | SelectedNetworkControllerGetNetworkClientIdForDomainAction
+  | SelectedNetworkControllerSetNetworkClientIdForDomainAction;
+
+export type SelectedNetworkControllerEvents =
+  SelectedNetworkControllerStateChangeEvent;
+
+export type SelectedNetworkControllerMessenger = RestrictedControllerMessenger<
+  typeof controllerName,
+  SelectedNetworkControllerActions,
+  NetworkControllerStateChangeEvent | SelectedNetworkControllerEvents,
+  string,
+  string
+>;
+
+export type SelectedNetworkControllerOptions = {
+  messenger: SelectedNetworkControllerMessenger;
+};
+
+/**
+ * Controller for getting and setting the network for a particular domain.
+ */
+export default class SelectedNetworkController extends BaseControllerV2<
+  typeof controllerName,
+  SelectedNetworkControllerState,
+  SelectedNetworkControllerMessenger
+> {
+  /**
+   * Construct a SelectedNetworkController controller.
+   *
+   * @param options - The controller options.
+   * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
+   */
+  constructor({ messenger }: SelectedNetworkControllerOptions) {
+    super({
+      name: controllerName,
+      metadata: stateMetadata,
+      messenger,
+      state: getDefaultState(),
+    });
+    this.registerMessageHandlers();
+  }
+
+  private registerMessageHandlers(): void {
+    this.messagingSystem.registerActionHandler(
+      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
+      this.getNetworkClientIdForDomain.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,
+      this.setNetworkClientIdForDomain.bind(this),
+    );
+
+    // subscribe to networkController statechange:: selectedNetworkClientId changed
+    // update the value for the domain 'metamask'
+    this.messagingSystem.subscribe(
+      'NetworkController:stateChange',
+      (state: NetworkState, patch: Patch[]) => {
+        const isChangingNetwork = patch.some(
+          (p) => p.path[0] === 'selectedNetworkClientId',
+        );
+        if (!isChangingNetwork) {
+          return;
+        }
+
+        // set it for the 'global' network to preserve functionality for the
+        // selectedNetworkController.perDomainNetwork feature flag being off
+        this.setNetworkClientIdForMetamask(state.selectedNetworkClientId);
+      },
+    );
+  }
+
+  /**
+   * Reset the controller state to the initial state.
+   */
+  resetState() {
+    this.update(getDefaultState);
+  }
+
+  setNetworkClientIdForMetamask(networkClientId: NetworkClientId) {
+    return this.setNetworkClientIdForDomain(METAMASK_DOMAIN, networkClientId);
+  }
+
+  setNetworkClientIdForDomain(
+    domain: Domain,
+    networkClientId: NetworkClientId,
+  ) {
+    this.update((state) => {
+      state.domains[domain] = networkClientId;
+    });
+  }
+
+  getNetworkClientIdForDomain(domain: Domain) {
+    if (this.state.perDomainNetwork) {
+      return this.state.domains[domain];
+    }
+    return this.state.domains[METAMASK_DOMAIN];
+  }
+}

--- a/packages/selected-network-controller/src/SelectedNetworkMiddleware.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkMiddleware.ts
@@ -1,0 +1,44 @@
+import type {
+  NetworkClientId,
+  NetworkControllerMessenger,
+} from '@metamask/network-controller';
+import type { JsonRpcMiddleware } from 'json-rpc-engine';
+
+import type { SelectedNetworkControllerMessenger } from './SelectedNetworkController';
+import { SelectedNetworkControllerActionTypes } from './SelectedNetworkController';
+
+const createSelectedNetworkMiddleware = (
+  selectedNetworkControllerMessenger: SelectedNetworkControllerMessenger,
+  networkControllerMessenger: NetworkControllerMessenger,
+): JsonRpcMiddleware<any, any> => {
+  const getNetworkClientIdForDomain = (origin: string) =>
+    selectedNetworkControllerMessenger.call(
+      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
+      origin,
+    );
+
+  const setNetworkClientIdForDomain = (
+    origin: string,
+    networkClientId: NetworkClientId,
+  ) =>
+    selectedNetworkControllerMessenger.call(
+      SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,
+      origin,
+      networkClientId,
+    );
+
+  const getDefaultNetworkClientId = () =>
+    networkControllerMessenger.call('NetworkController:getState')
+      .selectedNetworkClientId;
+
+  return (req: any, _, next) => {
+    if (getNetworkClientIdForDomain(req.origin) === undefined) {
+      setNetworkClientIdForDomain(req.origin, getDefaultNetworkClientId());
+    }
+
+    req.networkClientId = getNetworkClientIdForDomain(req.origin);
+    return next();
+  };
+};
+
+export default createSelectedNetworkMiddleware;

--- a/packages/selected-network-controller/src/SelectedNetworkMiddleware.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkMiddleware.ts
@@ -7,7 +7,7 @@ import type { JsonRpcMiddleware } from 'json-rpc-engine';
 import type { SelectedNetworkControllerMessenger } from './SelectedNetworkController';
 import { SelectedNetworkControllerActionTypes } from './SelectedNetworkController';
 
-const createSelectedNetworkMiddleware = (
+export const createSelectedNetworkMiddleware = (
   selectedNetworkControllerMessenger: SelectedNetworkControllerMessenger,
   networkControllerMessenger: NetworkControllerMessenger,
 ): JsonRpcMiddleware<any, any> => {
@@ -40,5 +40,3 @@ const createSelectedNetworkMiddleware = (
     return next();
   };
 };
-
-export default createSelectedNetworkMiddleware;

--- a/packages/selected-network-controller/src/SelectedNetworkMiddleware.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkMiddleware.ts
@@ -1,18 +1,26 @@
+import type { ControllerMessenger } from '@metamask/base-controller';
 import type {
   NetworkClientId,
-  NetworkControllerMessenger,
+  NetworkControllerGetStateAction,
 } from '@metamask/network-controller';
 import type { JsonRpcMiddleware } from 'json-rpc-engine';
 
-import type { SelectedNetworkControllerMessenger } from './SelectedNetworkController';
+import type {
+  SelectedNetworkControllerGetNetworkClientIdForDomainAction,
+  SelectedNetworkControllerSetNetworkClientIdForDomainAction,
+} from './SelectedNetworkController';
 import { SelectedNetworkControllerActionTypes } from './SelectedNetworkController';
 
 export const createSelectedNetworkMiddleware = (
-  selectedNetworkControllerMessenger: SelectedNetworkControllerMessenger,
-  networkControllerMessenger: NetworkControllerMessenger,
+  messenger: ControllerMessenger<
+    | SelectedNetworkControllerGetNetworkClientIdForDomainAction
+    | SelectedNetworkControllerSetNetworkClientIdForDomainAction
+    | NetworkControllerGetStateAction,
+    never
+  >,
 ): JsonRpcMiddleware<any, any> => {
   const getNetworkClientIdForDomain = (origin: string) =>
-    selectedNetworkControllerMessenger.call(
+    messenger.call(
       SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
       origin,
     );
@@ -21,15 +29,14 @@ export const createSelectedNetworkMiddleware = (
     origin: string,
     networkClientId: NetworkClientId,
   ) =>
-    selectedNetworkControllerMessenger.call(
+    messenger.call(
       SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,
       origin,
       networkClientId,
     );
 
   const getDefaultNetworkClientId = () =>
-    networkControllerMessenger.call('NetworkController:getState')
-      .selectedNetworkClientId;
+    messenger.call('NetworkController:getState').selectedNetworkClientId;
 
   return (req: any, _, next) => {
     if (getNetworkClientIdForDomain(req.origin) === undefined) {

--- a/packages/selected-network-controller/src/index.ts
+++ b/packages/selected-network-controller/src/index.ts
@@ -1,3 +1,3 @@
 export * from './SelectedNetworkController';
-export { default as SelectedNetworkController } from './SelectedNetworkController';
-export { default as SelectedNetworkMiddleware } from './SelectedNetworkMiddleware';
+export * from './SelectedNetworkController';
+export * from './SelectedNetworkMiddleware';

--- a/packages/selected-network-controller/src/index.ts
+++ b/packages/selected-network-controller/src/index.ts
@@ -1,3 +1,2 @@
 export * from './SelectedNetworkController';
-export * from './SelectedNetworkController';
 export * from './SelectedNetworkMiddleware';

--- a/packages/selected-network-controller/src/index.ts
+++ b/packages/selected-network-controller/src/index.ts
@@ -1,0 +1,3 @@
+export * from './SelectedNetworkController';
+export { default as SelectedNetworkController } from './SelectedNetworkController';
+export { default as SelectedNetworkMiddleware } from './SelectedNetworkMiddleware';

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -36,21 +36,6 @@ describe('SelectedNetworkController', () => {
     expect(controller.state.domains.metamask).toBe(networkClientId);
   });
 
-  it('can reset the state / selections to the default state', () => {
-    const options: SelectedNetworkControllerOptions = {
-      messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
-    };
-    const controller = new SelectedNetworkController(options);
-    controller.setNetworkClientIdForDomain('example.com', 'network1');
-    controller.setNetworkClientIdForDomain('test.com', 'network2');
-    controller.setNetworkClientIdForMetamask('network3');
-    controller.resetState();
-    expect(controller.state).toStrictEqual({
-      domains: {},
-      perDomainNetwork: false,
-    });
-  });
-
   describe('getNetworkClientIdForDomain', () => {
     it('gives the metamask domain when the perDomainNetwork option is false (default)', () => {
       const options: SelectedNetworkControllerOptions = {

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -1,0 +1,138 @@
+import { buildSelectedNetworkControllerMessenger } from './utils';
+import type { SelectedNetworkControllerOptions } from '../src/SelectedNetworkController';
+import SelectedNetworkController from '../src/SelectedNetworkController';
+
+describe('SelectedNetworkController', () => {
+  it('can be instantiated with default values', () => {
+    const options: SelectedNetworkControllerOptions = {
+      messenger: buildSelectedNetworkControllerMessenger(),
+    };
+
+    const controller = new SelectedNetworkController(options);
+    expect(controller.state).toStrictEqual({
+      domains: {},
+      perDomainNetwork: false,
+    });
+  });
+
+  it('can set the networkClientId for a domain', () => {
+    const options: SelectedNetworkControllerOptions = {
+      messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
+    };
+    const controller = new SelectedNetworkController(options);
+    const domain = 'example.com';
+    const networkClientId = 'network1';
+    controller.setNetworkClientIdForDomain(domain, networkClientId);
+    expect(controller.state.domains[domain]).toBe(networkClientId);
+  });
+
+  it('can set the networkClientId for the metamask domain specifically', () => {
+    const options: SelectedNetworkControllerOptions = {
+      messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
+    };
+    const controller = new SelectedNetworkController(options);
+    const networkClientId = 'network2';
+    controller.setNetworkClientIdForMetamask(networkClientId);
+    expect(controller.state.domains.metamask).toBe(networkClientId);
+  });
+
+  it('can reset the state / selections to the default state', () => {
+    const options: SelectedNetworkControllerOptions = {
+      messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
+    };
+    const controller = new SelectedNetworkController(options);
+    controller.setNetworkClientIdForDomain('example.com', 'network1');
+    controller.setNetworkClientIdForDomain('test.com', 'network2');
+    controller.setNetworkClientIdForMetamask('network3');
+    controller.resetState();
+    expect(controller.state).toStrictEqual({
+      domains: {},
+      perDomainNetwork: false,
+    });
+  });
+
+  describe('getNetworkClientIdForDomain', () => {
+    it('gives the metamask domain when the perDomainNetwork option is false (default)', () => {
+      const options: SelectedNetworkControllerOptions = {
+        messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
+      };
+      const controller = new SelectedNetworkController(options);
+      const networkClientId = 'network4';
+      controller.setNetworkClientIdForMetamask(networkClientId);
+      const result = controller.getNetworkClientIdForDomain('example.com');
+      expect(result).toBe(networkClientId);
+    });
+
+    it('when the perDomainNetwork feature flag is on, it returns items other than the metamask domain', () => {
+      const options: SelectedNetworkControllerOptions = {
+        messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
+      };
+      const controller = new SelectedNetworkController(options);
+      controller.state.perDomainNetwork = true;
+      const networkClientId1 = 'network5';
+      const networkClientId2 = 'network6';
+      controller.setNetworkClientIdForDomain('example.com', networkClientId1);
+      controller.setNetworkClientIdForDomain('test.com', networkClientId2);
+      const result1 = controller.getNetworkClientIdForDomain('example.com');
+      const result2 = controller.getNetworkClientIdForDomain('test.com');
+      expect(result1).toBe(networkClientId1);
+      expect(result2).toBe(networkClientId2);
+    });
+  });
+
+  it('updates the networkClientId for the metamask domain when the networkControllers selectedNetworkClientId changes', () => {
+    const mockMessagingSystem = {
+      registerActionHandler: jest.fn(),
+      subscribe: jest.fn(),
+      publish: () => jest.fn(),
+    };
+    const options: SelectedNetworkControllerOptions = {
+      messenger: mockMessagingSystem as any,
+    };
+    const controller = new SelectedNetworkController(options);
+    controller.setNetworkClientIdForMetamask('oldNetwork');
+    expect(controller.state.domains.metamask).toBe('oldNetwork');
+
+    const stateChangeHandler = mockMessagingSystem.subscribe.mock.calls[0][1];
+    const state: any = {
+      selectedNetworkClientId: 'newNetwork',
+    };
+    const patch: any = [
+      {
+        path: ['selectedNetworkClientId'],
+        op: 'replace',
+        value: 'newNetwork',
+      },
+    ];
+    stateChangeHandler(state, patch);
+    expect(controller.state.domains.metamask).toBe('newNetwork');
+  });
+
+  it('if the network controller state changes, but the selected network hasnt, no update occurs', () => {
+    const mockMessagingSystem = {
+      registerActionHandler: jest.fn(),
+      subscribe: jest.fn(),
+      publish: () => jest.fn(),
+    };
+    const options: SelectedNetworkControllerOptions = {
+      messenger: mockMessagingSystem as any,
+    };
+    const controller = new SelectedNetworkController(options);
+    controller.setNetworkClientIdForMetamask('oldNetwork');
+    expect(controller.state.domains.metamask).toBe('oldNetwork');
+
+    const stateChangeHandler = mockMessagingSystem.subscribe.mock.calls[0][1];
+    const state: any = {
+      selectedNetworkClientId: 'newNetwork',
+    };
+    const patch: any = [
+      {
+        path: ['anythingelse'],
+        op: 'replace',
+        value: 'abc',
+      },
+    ];
+    stateChangeHandler(state, patch);
+    expect(controller.state.domains.metamask).toBe('oldNetwork');
+  });
+});

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -1,6 +1,6 @@
 import { buildSelectedNetworkControllerMessenger } from './utils';
 import type { SelectedNetworkControllerOptions } from '../src/SelectedNetworkController';
-import SelectedNetworkController from '../src/SelectedNetworkController';
+import { SelectedNetworkController } from '../src/SelectedNetworkController';
 
 describe('SelectedNetworkController', () => {
   it('can be instantiated with default values', () => {

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -108,7 +108,7 @@ describe('SelectedNetworkController', () => {
     expect(controller.state.domains.metamask).toBe('newNetwork');
   });
 
-  it('if the network controller state changes, but the selected network hasnt, no update occurs', () => {
+  it("does not update the state if the network controller state changes but the selected network hasn't", () => {
     const mockMessagingSystem = {
       registerActionHandler: jest.fn(),
       subscribe: jest.fn(),

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -82,7 +82,7 @@ describe('SelectedNetworkController', () => {
     const state: any = {
       selectedNetworkClientId: 'newNetwork',
     };
-    const patch: any = [
+    const patch = [
       {
         path: ['selectedNetworkClientId'],
         op: 'replace',
@@ -110,7 +110,7 @@ describe('SelectedNetworkController', () => {
     const state: any = {
       selectedNetworkClientId: 'newNetwork',
     };
-    const patch: any = [
+    const patch = [
       {
         path: ['anythingelse'],
         op: 'replace',

--- a/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
@@ -91,10 +91,12 @@ describe('createSelectedNetworkMiddleware', () => {
       next();
     });
     engine.push(createSelectedNetworkMiddleware(messenger));
-    const mockNextMiddleware = jest.fn().mockImplementation((req, res, _, end) => {
-      res.result = req.networkClientId;
-      end();
-    });
+    const mockNextMiddleware = jest
+      .fn()
+      .mockImplementation((req, res, _, end) => {
+        res.result = req.networkClientId;
+        end();
+      });
     engine.push(mockNextMiddleware);
     const testNetworkId = 'testNetworkId';
     const mockGetNetworkClientIdForDomain = jest
@@ -105,15 +107,21 @@ describe('createSelectedNetworkMiddleware', () => {
       mockGetNetworkClientIdForDomain,
     );
 
-    const result = await engine.handle({ id: 1, jsonrpc: '2.0', method: 'hello' });
+    const result = await engine.handle({
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'hello',
+    });
     expect(mockNextMiddleware).toHaveBeenCalledWith(
       expect.objectContaining({
-        networkClientId: testNetworkId
+        networkClientId: testNetworkId,
       }),
       expect.any(Object),
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Function),
     );
-    expect(result).toStrictEqual(expect.objectContaining({ result: testNetworkId }));
+    expect(result).toStrictEqual(
+      expect.objectContaining({ result: testNetworkId }),
+    );
   });
 });

--- a/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
@@ -6,7 +6,7 @@ import type {
 
 import { buildSelectedNetworkControllerMessenger } from './utils';
 import { SelectedNetworkControllerActionTypes } from '../src/SelectedNetworkController';
-import createSelectedNetworkMiddleware from '../src/SelectedNetworkMiddleware';
+import { createSelectedNetworkMiddleware } from '../src/SelectedNetworkMiddleware';
 
 const buildMessenger = () => {
   return new ControllerMessenger<

--- a/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
@@ -1,0 +1,103 @@
+import { ControllerMessenger } from '@metamask/base-controller';
+import type {
+  NetworkControllerEvents,
+  NetworkControllerActions,
+} from '@metamask/network-controller';
+
+import { buildSelectedNetworkControllerMessenger } from './utils';
+import { SelectedNetworkControllerActionTypes } from '../src/SelectedNetworkController';
+import createSelectedNetworkMiddleware from '../src/SelectedNetworkMiddleware';
+
+const buildMessenger = () => {
+  return new ControllerMessenger<
+    NetworkControllerActions,
+    NetworkControllerEvents
+  >();
+};
+
+const buildNetworkControllerMessenger = (messenger = buildMessenger()) => {
+  return messenger.getRestricted({
+    name: 'NetworkController',
+    allowedActions: ['NetworkController:getState'],
+    allowedEvents: ['NetworkController:stateChange'],
+  });
+};
+
+const noop = jest.fn();
+
+describe('createSelectedNetworkMiddleware', () => {
+  it('puts networkClientId on request', async () => {
+    const selectedNetworkControllerMessenger =
+      buildSelectedNetworkControllerMessenger();
+    const networkControllerMessenger = buildNetworkControllerMessenger();
+    const middleware = createSelectedNetworkMiddleware(
+      selectedNetworkControllerMessenger,
+      networkControllerMessenger,
+    );
+
+    const req = {
+      origin: 'example.com',
+    } as any;
+
+    const mockGetNetworkClientIdForDomain = jest
+      .fn()
+      .mockReturnValue('mockNetworkClientId');
+
+    selectedNetworkControllerMessenger.registerActionHandler(
+      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
+      mockGetNetworkClientIdForDomain,
+    );
+
+    await new Promise((resolve) => middleware(req, {} as any, resolve, noop));
+
+    expect(req.networkClientId).toBe('mockNetworkClientId');
+  });
+
+  it('sets the networkClientId for the domain to the current network from networkController if one is not set', async () => {
+    const selectedNetworkControllerMessenger =
+      buildSelectedNetworkControllerMessenger();
+    const networkControllerMessenger = buildNetworkControllerMessenger();
+    const middleware = createSelectedNetworkMiddleware(
+      selectedNetworkControllerMessenger,
+      networkControllerMessenger,
+    );
+
+    const req = {
+      origin: 'example.com',
+    } as any;
+
+    const mockGetNetworkClientIdForDomain = jest.fn();
+    // 1st check its not set
+    mockGetNetworkClientIdForDomain.mockReturnValueOnce(undefined);
+    // 2nd check is after calling set
+    mockGetNetworkClientIdForDomain.mockReturnValueOnce(
+      'defaultNetworkClientId',
+    );
+    const mockSetNetworkClientIdForDomain = jest.fn();
+    const mockNetworkControllerGetState = jest.fn().mockReturnValue({
+      selectedNetworkClientId: 'defaultNetworkClientId',
+    });
+    selectedNetworkControllerMessenger.registerActionHandler(
+      SelectedNetworkControllerActionTypes.getNetworkClientIdForDomain,
+      mockGetNetworkClientIdForDomain,
+    );
+    selectedNetworkControllerMessenger.registerActionHandler(
+      SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,
+      mockSetNetworkClientIdForDomain,
+    );
+    networkControllerMessenger.registerActionHandler(
+      'NetworkController:getState',
+      mockNetworkControllerGetState,
+    );
+
+    await new Promise((resolve) => middleware(req, {} as any, resolve, noop));
+
+    expect(mockGetNetworkClientIdForDomain).toHaveBeenCalledWith('example.com');
+    expect(mockNetworkControllerGetState).toHaveBeenCalled();
+    expect(mockSetNetworkClientIdForDomain).toHaveBeenCalledWith(
+      'example.com',
+      'defaultNetworkClientId',
+    );
+    expect(req.networkClientId).toBe('defaultNetworkClientId');
+  });
+});

--- a/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
@@ -66,13 +66,10 @@ describe('createSelectedNetworkMiddleware', () => {
       origin: 'example.com',
     } as any;
 
-    const mockGetNetworkClientIdForDomain = jest.fn();
-    // 1st check its not set
-    mockGetNetworkClientIdForDomain.mockReturnValueOnce(undefined);
-    // 2nd check is after calling set
-    mockGetNetworkClientIdForDomain.mockReturnValueOnce(
-      'defaultNetworkClientId',
-    );
+    const mockGetNetworkClientIdForDomain = jest
+      .fn()
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce('defaultNetworkClientId');
     const mockSetNetworkClientIdForDomain = jest.fn();
     const mockNetworkControllerGetState = jest.fn().mockReturnValue({
       selectedNetworkClientId: 'defaultNetworkClientId',

--- a/packages/selected-network-controller/tests/utils.ts
+++ b/packages/selected-network-controller/tests/utils.ts
@@ -2,8 +2,8 @@ import { ControllerMessenger } from '@metamask/base-controller';
 import type { NetworkControllerStateChangeEvent } from '@metamask/network-controller';
 
 import type {
-  SelectedNetworkControllerActions,
-  SelectedNetworkControllerEvents,
+  SelectedNetworkControllerAction,
+  SelectedNetworkControllerEvent,
 } from '../src/SelectedNetworkController';
 import { SelectedNetworkControllerActionTypes } from '../src/SelectedNetworkController';
 
@@ -15,8 +15,8 @@ import { SelectedNetworkControllerActionTypes } from '../src/SelectedNetworkCont
  */
 function buildMessenger() {
   return new ControllerMessenger<
-    SelectedNetworkControllerActions,
-    SelectedNetworkControllerEvents | NetworkControllerStateChangeEvent
+    SelectedNetworkControllerAction,
+    SelectedNetworkControllerEvent | NetworkControllerStateChangeEvent
   >();
 }
 /**

--- a/packages/selected-network-controller/tests/utils.ts
+++ b/packages/selected-network-controller/tests/utils.ts
@@ -13,7 +13,7 @@ import { SelectedNetworkControllerActionTypes } from '../src/SelectedNetworkCont
  *
  * @returns The controller messenger.
  */
-function buildMessenger() {
+export function buildMessenger() {
   return new ControllerMessenger<
     SelectedNetworkControllerAction,
     SelectedNetworkControllerEvent | NetworkControllerStateChangeEvent

--- a/packages/selected-network-controller/tests/utils.ts
+++ b/packages/selected-network-controller/tests/utils.ts
@@ -1,0 +1,36 @@
+import { ControllerMessenger } from '@metamask/base-controller';
+import type { NetworkControllerStateChangeEvent } from '@metamask/network-controller';
+
+import type {
+  SelectedNetworkControllerActions,
+  SelectedNetworkControllerEvents,
+} from '../src/SelectedNetworkController';
+import { SelectedNetworkControllerActionTypes } from '../src/SelectedNetworkController';
+
+/**
+ * Build a controller messenger that includes all events used by the selected network
+ * controller.
+ *
+ * @returns The controller messenger.
+ */
+function buildMessenger() {
+  return new ControllerMessenger<
+    SelectedNetworkControllerActions,
+    SelectedNetworkControllerEvents | NetworkControllerStateChangeEvent
+  >();
+}
+/**
+ * Build a restricted controller messenger for the selected network controller.
+ *
+ * @param messenger - A controller messenger.
+ * @returns The network controller restricted messenger.
+ */
+export function buildSelectedNetworkControllerMessenger(
+  messenger = buildMessenger(),
+) {
+  return messenger.getRestricted({
+    name: 'SelectedNetworkController',
+    allowedActions: Object.values(SelectedNetworkControllerActionTypes),
+    allowedEvents: ['NetworkController:stateChange'],
+  });
+}

--- a/packages/selected-network-controller/tsconfig.build.json
+++ b/packages/selected-network-controller/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.packages.build.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [
+    { "path": "../base-controller/tsconfig.build.json" },
+    { "path": "../network-controller/tsconfig.build.json" }
+  ],
+  "include": ["../../types", "./src"]
+}

--- a/packages/selected-network-controller/tsconfig.json
+++ b/packages/selected-network-controller/tsconfig.json
@@ -9,9 +9,6 @@
       "path": "../base-controller"
     },
     {
-      "path": "../controller-utils"
-    },
-    {
       "path": "../network-controller"
     }
   ],

--- a/packages/selected-network-controller/tsconfig.json
+++ b/packages/selected-network-controller/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "../.."
+  },
+  "references": [
+    {
+      "path": "../base-controller"
+    },
+    {
+      "path": "../controller-utils"
+    },
+    {
+      "path": "../network-controller"
+    }
+  ],
+  "include": ["../../types", "../../tests", "./src", "./tests"]
+}

--- a/packages/selected-network-controller/typedoc.json
+++ b/packages/selected-network-controller/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "out": "docs",
+  "tsconfig": "./tsconfig.build.json"
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -43,6 +43,9 @@
       "path": "./packages/network-controller/tsconfig.build.json"
     },
     {
+      "path": "./packages/selected-network-controller/tsconfig.build.json"
+    },
+    {
       "path": "./packages/notification-controller/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,6 +44,9 @@
       "path": "./packages/network-controller"
     },
     {
+      "path": "./packages/selected-network-controller"
+    },
+    {
       "path": "./packages/notification-controller"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2057,6 +2057,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/selected-network-controller@workspace:packages/selected-network-controller":
+  version: 0.0.0-use.local
+  resolution: "@metamask/selected-network-controller@workspace:packages/selected-network-controller"
+  dependencies:
+    "@metamask/auto-changelog": ^3.1.0
+    "@metamask/base-controller": ^3.2.1
+    "@metamask/network-controller": ^12.1.2
+    "@types/jest": ^27.4.1
+    deepmerge: ^4.2.2
+    immer: ^9.0.6
+    jest: ^27.5.1
+    json-rpc-engine: ^6.1.0
+    lodash: ^4.17.21
+    nock: ^13.3.1
+    sinon: ^9.2.4
+    ts-jest: ^27.1.4
+    typedoc: ^0.22.15
+    typedoc-plugin-missing-exports: ^0.22.6
+    typescript: ~4.6.3
+  peerDependencies:
+    "@metamask/network-controller": ^12.1.2
+  languageName: unknown
+  linkType: soft
+
 "@metamask/signature-controller@workspace:packages/signature-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/signature-controller@workspace:packages/signature-controller"


### PR DESCRIPTION
## Explanation

This is a PR which moves the [proposed Selected Network Controller](https://github.com/MetaMask/metamask-extension/pull/20456) out of extension. 

It also adds tests (coverage @ 100%)

## References

fixes https://github.com/MetaMask/MetaMask-planning/issues/1006

## Changelog

### `@metamask/selected-network-controller`

- **ADDED**: starting implementation

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
