### PR TITLE
Add `submittedTime` to transaction meta

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1176,10 +1176,12 @@ describe('TransactionController', () => {
 
         await result;
 
-        const { transaction, status } = controller.state.transactions[0];
+        const { transaction, status, submittedTime } =
+          controller.state.transactions[0];
         expect(transaction.from).toBe(ACCOUNT_MOCK);
         expect(transaction.nonce).toBe(`0x${NONCE_MOCK.toString(16)}`);
         expect(status).toBe(TransactionStatus.submitted);
+        expect(submittedTime).toBeLessThanOrEqual(Date.now());
       });
 
       it('reports success to approval acceptor', async () => {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1121,6 +1121,7 @@ export class TransactionController extends BaseController<
       ]);
       transactionMeta.transactionHash = transactionHash;
       transactionMeta.status = TransactionStatus.submitted;
+      transactionMeta.submittedTime = new Date().getTime();
       this.updateTransaction(transactionMeta);
       this.hub.emit(`${transactionMeta.id}:finished`, transactionMeta);
     } catch (error: any) {

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -94,6 +94,11 @@ type TransactionMetaBase = {
   replacedById?: string;
 
   /**
+   * The time the transaction was submitted to the network, in Unix epoch time (ms).
+   */
+  submittedTime?: number;
+
+  /**
    * Timestamp associated with this transaction.
    */
   time: number;


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR aims to add `submittedTime` to transactionMeta while tx submitted to network.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **ADDED**: Add `submittedTime` to transaction meta

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've highlighted breaking changes using the "BREAKING" category above as appropriate
