### PR TITLE
Rename transaction object to txParams in the persisted transaction metadata

### DIFF
--- a/packages/transaction-controller/src/EtherscanRemoteTransactionSource.test.ts
+++ b/packages/transaction-controller/src/EtherscanRemoteTransactionSource.test.ts
@@ -93,7 +93,7 @@ const EXPECTED_NORMALISED_TRANSACTION_BASE = {
   networkID: undefined,
   status: TransactionStatus.confirmed,
   time: 1543596356000,
-  transaction: {
+  txParams: {
     from: ETHERSCAN_TRANSACTION_SUCCESS_MOCK.from,
     gas: '0x51d68',
     gasPrice: '0x4a817c800',
@@ -108,8 +108,8 @@ const EXPECTED_NORMALISED_TRANSACTION_BASE = {
 
 const EXPECTED_NORMALISED_TRANSACTION_SUCCESS = {
   ...EXPECTED_NORMALISED_TRANSACTION_BASE,
-  transaction: {
-    ...EXPECTED_NORMALISED_TRANSACTION_BASE.transaction,
+  txParams: {
+    ...EXPECTED_NORMALISED_TRANSACTION_BASE.txParams,
     data: ETHERSCAN_TRANSACTION_SUCCESS_MOCK.input,
   },
 };

--- a/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
@@ -96,8 +96,8 @@ export class EtherscanRemoteTransactionSource
 
     return {
       ...base,
-      transaction: {
-        ...base.transaction,
+      txParams: {
+        ...base.txParams,
         data: txMeta.input,
       },
       ...(txMeta.isError === '0'
@@ -145,7 +145,7 @@ export class EtherscanRemoteTransactionSource
       networkID: currentNetworkId,
       status: TransactionStatus.confirmed,
       time,
-      transaction: {
+      txParams: {
         from: txMeta.from,
         gas: BNToHex(new BN(txMeta.gas)),
         gasPrice: BNToHex(new BN(txMeta.gasPrice)),

--- a/packages/transaction-controller/src/IncomingTransactionHelper.test.ts
+++ b/packages/transaction-controller/src/IncomingTransactionHelper.test.ts
@@ -47,7 +47,7 @@ const TRANSACTION_MOCK: TransactionMeta = {
   chainId: '0x1',
   status: TransactionStatus.submitted,
   time: 0,
-  transaction: { to: '0x1', gasUsed: '0x1' },
+  txParams: { to: '0x1', gasUsed: '0x1' },
   transactionHash: '0x1',
 } as unknown as TransactionMeta;
 
@@ -55,7 +55,7 @@ const TRANSACTION_MOCK_2: TransactionMeta = {
   blockNumber: '234',
   chainId: '0x1',
   time: 1,
-  transaction: { to: '0x1' },
+  txParams: { to: '0x1' },
   transactionHash: '0x2',
 } as unknown as TransactionMeta;
 
@@ -215,8 +215,8 @@ describe('IncomingTransactionHelper', () => {
       it('if new outgoing transaction fetched and update transactions enabled', async () => {
         const outgoingTransaction = {
           ...TRANSACTION_MOCK_2,
-          transaction: {
-            ...TRANSACTION_MOCK_2.transaction,
+          txParams: {
+            ...TRANSACTION_MOCK_2.txParams,
             from: '0x1',
             to: '0x2',
           },
@@ -264,8 +264,8 @@ describe('IncomingTransactionHelper', () => {
       it('if existing transaction fetched with different gas used and update transactions enabled', async () => {
         const updatedTransaction = {
           ...TRANSACTION_MOCK,
-          transaction: {
-            ...TRANSACTION_MOCK.transaction,
+          txParams: {
+            ...TRANSACTION_MOCK.txParams,
             gasUsed: '0x2',
           },
         } as TransactionMeta;
@@ -380,11 +380,11 @@ describe('IncomingTransactionHelper', () => {
           remoteTransactionSource: createRemoteTransactionSourceMock([
             {
               ...TRANSACTION_MOCK,
-              transaction: { to: '0x2' },
+              txParams: { to: '0x2' },
             } as TransactionMeta,
             {
               ...TRANSACTION_MOCK,
-              transaction: { to: undefined },
+              txParams: { to: undefined },
             } as TransactionMeta,
           ]),
         });
@@ -482,7 +482,7 @@ describe('IncomingTransactionHelper', () => {
           remoteTransactionSource: createRemoteTransactionSourceMock([
             {
               ...TRANSACTION_MOCK_2,
-              transaction: { to: '0x2' },
+              txParams: { to: '0x2' },
             } as TransactionMeta,
           ]),
         });

--- a/packages/transaction-controller/src/IncomingTransactionHelper.ts
+++ b/packages/transaction-controller/src/IncomingTransactionHelper.ts
@@ -7,7 +7,7 @@ import type { RemoteTransactionSource, TransactionMeta } from './types';
 
 const UPDATE_CHECKS: ((txMeta: TransactionMeta) => any)[] = [
   (txMeta) => txMeta.status,
-  (txMeta) => txMeta.transaction.gasUsed,
+  (txMeta) => txMeta.txParams.gasUsed,
 ];
 
 export class IncomingTransactionHelper {
@@ -135,7 +135,7 @@ export class IncomingTransactionHelper {
 
       if (!this.#updateTransactions) {
         remoteTransactions = remoteTransactions.filter(
-          (tx) => tx.transaction.to?.toLowerCase() === address.toLowerCase(),
+          (tx) => tx.txParams.to?.toLowerCase() === address.toLowerCase(),
         );
       }
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1724,7 +1724,7 @@ describe('TransactionController', () => {
 
       const { transactions } = controller.state;
       expect(transactions).toHaveLength(2);
-      expect(transactions[1].transaction.gasPrice).toBe('0x62DEF4DA');
+      expect(transactions[1].txParams.gasPrice).toBe('0x62DEF4DA');
     });
 
     it('uses the same nonce', async () => {
@@ -1840,7 +1840,7 @@ describe('TransactionController', () => {
         networkID: '1',
         chainId: toHex(1),
         status: TransactionStatus.confirmed,
-        transaction: {
+        txParams: {
           gasUsed: undefined,
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
@@ -1880,7 +1880,7 @@ describe('TransactionController', () => {
         networkID: '5',
         chainId: toHex(5),
         status: TransactionStatus.confirmed,
-        transaction: {
+        txParams: {
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
           nonce: NONCE_MOCK,
@@ -1900,7 +1900,7 @@ describe('TransactionController', () => {
         networkID: '5',
         chainId: toHex(5),
         status: TransactionStatus.unapproved,
-        transaction: {
+        txParams: {
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
           nonce: NONCE_MOCK,
@@ -1936,7 +1936,7 @@ describe('TransactionController', () => {
         networkID: '5',
         chainId: toHex(5),
         status: TransactionStatus.confirmed,
-        transaction: {
+        txParams: {
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
           nonce: NONCE_MOCK,
@@ -1956,7 +1956,7 @@ describe('TransactionController', () => {
         networkID: '5',
         chainId: toHex(5),
         status: TransactionStatus.failed,
-        transaction: {
+        txParams: {
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
           nonce: NONCE_MOCK,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -980,7 +980,7 @@ describe('TransactionController', () => {
         sendFlowHistory: expect.any(Array),
         status: TransactionStatus.unapproved,
         time: expect.any(Number),
-        transaction: expect.anything(),
+        txParams: expect.anything(),
         verifiedOnBlockchain: expect.any(Boolean),
       };
 
@@ -1820,7 +1820,7 @@ describe('TransactionController', () => {
 
   describe('initApprovals', () => {
     it('creates approvals for all unapproved transaction', async () => {
-      const transaction = {
+      const txParams = {
         from: ACCOUNT_MOCK,
         hash: '1337',
         id: 'mocked',
@@ -1828,9 +1828,9 @@ describe('TransactionController', () => {
         status: TransactionStatus.unapproved,
       };
       const controller = newController();
-      controller.state.transactions.push(transaction as any);
+      controller.state.transactions.push(txParams as any);
       controller.state.transactions.push({
-        ...transaction,
+        ...txParams,
         id: 'mocked1',
         hash: '1338',
       } as any);
@@ -1919,7 +1919,7 @@ describe('TransactionController', () => {
         networkID: '1',
         chainId: toHex(1),
         status: TransactionStatus.confirmed,
-        transaction: {
+        txParams: {
           gasUsed: undefined,
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
@@ -1943,7 +1943,7 @@ describe('TransactionController', () => {
         networkID: '1',
         status: TransactionStatus.confirmed,
         to: ACCOUNT_2_MOCK,
-        transaction: {
+        txParams: {
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
           gasUsed: undefined,
@@ -1959,7 +1959,7 @@ describe('TransactionController', () => {
         {
           note: expect.any(String),
           op: 'remove',
-          path: '/transaction/gasUsed',
+          path: '/txParams/gasUsed',
           timestamp: expect.any(Number),
         },
         {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -400,7 +400,7 @@ const ACTION_ID_MOCK = '123456';
 
 const TRANSACTION_META_MOCK = {
   status: TransactionStatus.confirmed,
-  transaction: {
+  txParams: {
     from: ACCOUNT_MOCK,
   },
   transactionHash: '0x1',
@@ -409,7 +409,7 @@ const TRANSACTION_META_MOCK = {
 
 const TRANSACTION_META_2_MOCK = {
   status: TransactionStatus.confirmed,
-  transaction: {
+  txParams: {
     from: '0x3',
   },
   transactionHash: '0x2',
@@ -931,9 +931,7 @@ describe('TransactionController', () => {
         },
       );
 
-      expect(controller.state.transactions[0].transaction.from).toBe(
-        ACCOUNT_MOCK,
-      );
+      expect(controller.state.transactions[0].txParams.from).toBe(ACCOUNT_MOCK);
       expect(controller.state.transactions[0].networkID).toBe(
         MOCK_NETWORK.state.networkId,
       );
@@ -1032,7 +1030,7 @@ describe('TransactionController', () => {
           to: ACCOUNT_MOCK,
         });
 
-        expect(controller.state.transactions[0].transaction.from).toBe(
+        expect(controller.state.transactions[0].txParams.from).toBe(
           ACCOUNT_MOCK,
         );
         expect(controller.state.transactions[0].networkID).toBe(
@@ -1092,11 +1090,11 @@ describe('TransactionController', () => {
       expect(controller.state.transactions).toHaveLength(2);
       const secondTransaction = controller.state.transactions[1];
 
-      expect(firstTransaction.transaction.nonce).toBe(
+      expect(firstTransaction.txParams.nonce).toBe(
         `0x${NONCE_MOCK.toString(16)}`,
       );
 
-      expect(secondTransaction.transaction.nonce).toBe(
+      expect(secondTransaction.txParams.nonce).toBe(
         `0x${(NONCE_MOCK + 1).toString(16)}`,
       );
     });
@@ -1155,7 +1153,7 @@ describe('TransactionController', () => {
         });
 
         const {
-          transaction: { estimateGasError },
+          txParams: { estimateGasError },
         } = controller.state.transactions[0];
 
         expect(estimateGasError).toBe(ESTIMATE_GAS_ERROR);
@@ -1176,10 +1174,10 @@ describe('TransactionController', () => {
 
         await result;
 
-        const { transaction, status, submittedTime } =
+        const { txParams, status, submittedTime } =
           controller.state.transactions[0];
-        expect(transaction.from).toBe(ACCOUNT_MOCK);
-        expect(transaction.nonce).toBe(`0x${NONCE_MOCK.toString(16)}`);
+        expect(txParams.from).toBe(ACCOUNT_MOCK);
+        expect(txParams.nonce).toBe(`0x${NONCE_MOCK.toString(16)}`);
         expect(status).toBe(TransactionStatus.submitted);
         expect(submittedTime).toBeLessThanOrEqual(Date.now());
       });
@@ -1235,9 +1233,9 @@ describe('TransactionController', () => {
 
           await expect(result).rejects.toThrow(expectedError);
 
-          const { transaction, status } = controller.state.transactions[0];
-          expect(transaction.from).toBe(ACCOUNT_MOCK);
-          expect(transaction.to).toBe(ACCOUNT_MOCK);
+          const { txParams, status } = controller.state.transactions[0];
+          expect(txParams.from).toBe(ACCOUNT_MOCK);
+          expect(txParams.to).toBe(ACCOUNT_MOCK);
           expect(status).toBe(TransactionStatus.failed);
         }
 
@@ -1350,8 +1348,8 @@ describe('TransactionController', () => {
 
         await expect(result).rejects.toThrow('User rejected the transaction');
 
-        const { transaction, status } = await finishedPromise;
-        expect(transaction.from).toBe(ACCOUNT_MOCK);
+        const { txParams, status } = await finishedPromise;
+        expect(txParams.from).toBe(ACCOUNT_MOCK);
         expect(status).toBe(TransactionStatus.rejected);
       });
     });
@@ -1405,7 +1403,7 @@ describe('TransactionController', () => {
       controller.state.transactions.push({
         id: '1',
         chainId: mockCurrentChainId,
-        transaction: {
+        txParams: {
           from: mockFromAccount1,
         },
       } as any);
@@ -1413,7 +1411,7 @@ describe('TransactionController', () => {
       controller.state.transactions.push({
         id: '2',
         chainId: mockCurrentChainId,
-        transaction: {
+        txParams: {
           from: mockFromAccount2,
         },
       } as any);
@@ -1436,7 +1434,7 @@ describe('TransactionController', () => {
       controller.state.transactions.push({
         id: '1',
         chainId: mockCurrentChainId,
-        transaction: {
+        txParams: {
           from: mockFromAccount1,
         },
       } as any);
@@ -1444,7 +1442,7 @@ describe('TransactionController', () => {
       controller.state.transactions.push({
         id: '4',
         chainId: mockDifferentChainId,
-        transaction: {
+        txParams: {
           from: mockFromAccount1,
         },
       } as any);
@@ -1534,7 +1532,7 @@ describe('TransactionController', () => {
         status: TransactionStatus.confirmed,
         transactionHash: '1337',
         verifiedOnBlockchain: false,
-        transaction: {
+        txParams: {
           gasUsed: undefined,
         },
       } as any);
@@ -1543,7 +1541,7 @@ describe('TransactionController', () => {
 
       const transactionMeta = controller.state.transactions[0];
       expect(transactionMeta.verifiedOnBlockchain).toBe(true);
-      expect(transactionMeta.transaction.gasUsed).toBe('0x5208');
+      expect(transactionMeta.txParams.gasUsed).toBe('0x5208');
       expect(transactionMeta.blockTimestamp).toBe('628dc0c8');
       expect(transactionMeta.baseFeePerGas).toBe('0x14');
       expect(transactionMeta.txReceipt?.transactionIndex).toBe(1337);
@@ -1702,7 +1700,7 @@ describe('TransactionController', () => {
 
       const { transactions } = controller.state;
       expect(transactions).toHaveLength(2);
-      expect(transactions[1].transaction.gasPrice).toBe(
+      expect(transactions[1].txParams.gasPrice).toBe(
         '0x5916a6d6', // 1.1 * 0x50fd51da
       );
     });
@@ -1748,9 +1746,9 @@ describe('TransactionController', () => {
       const { transactions } = controller.state;
       expect(getNonceLockSpy).toHaveBeenCalledTimes(1);
       expect(transactions).toHaveLength(2);
-      expect(transactions[0].transaction.nonce).toBeDefined();
-      expect(transactions[0].transaction.nonce).toStrictEqual(
-        transactions[1].transaction.nonce,
+      expect(transactions[0].txParams.nonce).toBeDefined();
+      expect(transactions[0].txParams.nonce).toStrictEqual(
+        transactions[1].txParams.nonce,
       );
       expect(transactions[1].estimatedBaseFee).toBe('0x123');
     });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1501,10 +1501,10 @@ export class TransactionController extends BaseController<
   private async addExternalTransaction(transactionMeta: TransactionMeta) {
     const { networkId, chainId } = this.getChainAndNetworkId();
     const { transactions } = this.state;
-    const fromAddress = transactionMeta?.transaction?.from;
+    const fromAddress = transactionMeta?.txParams?.from;
     const sameFromAndNetworkTransactions = transactions.filter(
       (transaction) =>
-        transaction.transaction.from === fromAddress &&
+        transaction.txParams.from === fromAddress &&
         transactionMatchesNetwork(transaction, chainId, networkId),
     );
     const confirmedTxs = sameFromAndNetworkTransactions.filter(
@@ -1535,12 +1535,12 @@ export class TransactionController extends BaseController<
   private markNonceDuplicatesDropped(transactionId: string) {
     const { networkId, chainId } = this.getChainAndNetworkId();
     const transactionMeta = this.getTransaction(transactionId);
-    const nonce = transactionMeta?.transaction?.nonce;
-    const from = transactionMeta?.transaction?.from;
+    const nonce = transactionMeta?.txParams?.nonce;
+    const from = transactionMeta?.txParams?.from;
     const sameNonceTxs = this.state.transactions.filter(
       (transaction) =>
-        transaction.transaction.from === from &&
-        transaction.transaction.nonce === nonce &&
+        transaction.txParams.from === from &&
+        transaction.txParams.nonce === nonce &&
         transactionMatchesNetwork(transaction, chainId, networkId),
     );
 

--- a/packages/transaction-controller/src/external-transactions.test.ts
+++ b/packages/transaction-controller/src/external-transactions.test.ts
@@ -8,17 +8,17 @@ describe('validateConfirmedExternalTransaction', () => {
   const mockTransactionMeta = (status: TransactionStatus, nonce: string) => {
     const meta = {
       status,
-      transaction: { nonce },
+      txParams: { nonce },
     } as TransactionMeta;
     return meta;
   };
 
-  it('should throw if transactionMeta or transaction is missing', () => {
+  it('should throw if transactionMeta or txParams is missing', () => {
     expect(() =>
       validateConfirmedExternalTransaction(undefined, [], []),
     ).toThrow(
       ethErrors.rpc.invalidParams(
-        '"transactionMeta" or "transactionMeta.transaction" is missing',
+        '"transactionMeta" or "transactionMeta.txParams" is missing',
       ),
     );
 
@@ -26,7 +26,7 @@ describe('validateConfirmedExternalTransaction', () => {
       validateConfirmedExternalTransaction({} as TransactionMeta, [], []),
     ).toThrow(
       ethErrors.rpc.invalidParams(
-        '"transactionMeta" or "transactionMeta.transaction" is missing',
+        '"transactionMeta" or "transactionMeta.txParams" is missing',
       ),
     );
   });

--- a/packages/transaction-controller/src/external-transactions.ts
+++ b/packages/transaction-controller/src/external-transactions.ts
@@ -16,9 +16,9 @@ export function validateConfirmedExternalTransaction(
   confirmedTxs?: TransactionMeta[],
   pendingTxs?: TransactionMeta[],
 ) {
-  if (!transactionMeta || !transactionMeta.transaction) {
+  if (!transactionMeta || !transactionMeta.txParams) {
     throw ethErrors.rpc.invalidParams(
-      '"transactionMeta" or "transactionMeta.transaction" is missing',
+      '"transactionMeta" or "transactionMeta.txParams" is missing',
     );
   }
 
@@ -28,10 +28,10 @@ export function validateConfirmedExternalTransaction(
     );
   }
 
-  const externalTxNonce = transactionMeta.transaction.nonce;
+  const externalTxNonce = transactionMeta.txParams.nonce;
   if (pendingTxs && pendingTxs.length > 0) {
     const foundPendingTxByNonce = pendingTxs.find(
-      (tx) => tx.transaction?.nonce === externalTxNonce,
+      (tx) => tx.txParams?.nonce === externalTxNonce,
     );
     if (foundPendingTxByNonce) {
       throw ethErrors.rpc.invalidParams(
@@ -42,7 +42,7 @@ export function validateConfirmedExternalTransaction(
 
   if (confirmedTxs && confirmedTxs.length > 0) {
     const foundConfirmedTxByNonce = confirmedTxs.find(
-      (tx) => tx.transaction?.nonce === externalTxNonce,
+      (tx) => tx.txParams?.nonce === externalTxNonce,
     );
     if (foundConfirmedTxByNonce) {
       throw ethErrors.rpc.invalidParams(

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -109,11 +109,6 @@ type TransactionMetaBase = {
   toSmartContract?: boolean;
 
   /**
-   * Underlying Transaction object.
-   */
-  transaction: Transaction;
-
-  /**
    * Hash of a successful transaction.
    */
   transactionHash?: string;
@@ -126,6 +121,11 @@ type TransactionMetaBase = {
     decimals: number;
     symbol: string;
   };
+
+  /**
+   * Underlying Transaction object.
+   */
+  txParams: TransactionParams;
 
   /**
    * Transaction receipt.
@@ -172,7 +172,7 @@ export enum WalletDevice {
 /**
  * Standard data concerning a transaction to be processed by the blockchain.
  */
-export interface Transaction {
+export interface TransactionParams {
   /**
    * Network ID as per EIP-155.
    */

--- a/packages/transaction-controller/src/utils.test.ts
+++ b/packages/transaction-controller/src/utils.test.ts
@@ -4,7 +4,7 @@ import type {
   GasPriceValue,
   FeeMarketEIP1559Values,
 } from './TransactionController';
-import type { Transaction, TransactionMeta } from './types';
+import type { TransactionParams, TransactionMeta } from './types';
 import { TransactionStatus } from './types';
 import * as util from './utils';
 import {
@@ -19,8 +19,8 @@ const FAIL = 'lol';
 const PASS = '0x1';
 
 describe('utils', () => {
-  it('normalizeTransaction', () => {
-    const normalized = util.normalizeTransaction({
+  it('normalizeTxParams', () => {
+    const normalized = util.normalizeTxParams({
       data: 'data',
       from: 'FROM',
       gas: 'gas',
@@ -46,35 +46,35 @@ describe('utils', () => {
     });
   });
 
-  describe('validateTransaction', () => {
+  describe('validateTxParams', () => {
     it('should throw if no from address', () => {
-      expect(() => util.validateTransaction({} as any)).toThrow(
+      expect(() => util.validateTxParams({} as any)).toThrow(
         'Invalid "from" address: undefined must be a valid string.',
       );
     });
 
     it('should throw if non-string from address', () => {
-      expect(() => util.validateTransaction({ from: 1337 } as any)).toThrow(
+      expect(() => util.validateTxParams({ from: 1337 } as any)).toThrow(
         'Invalid "from" address: 1337 must be a valid string.',
       );
     });
 
     it('should throw if invalid from address', () => {
-      expect(() => util.validateTransaction({ from: '1337' } as any)).toThrow(
+      expect(() => util.validateTxParams({ from: '1337' } as any)).toThrow(
         'Invalid "from" address: 1337 must be a valid string.',
       );
     });
 
     it('should throw if no data', () => {
       expect(() =>
-        util.validateTransaction({
+        util.validateTxParams({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '0x',
         } as any),
       ).toThrow('Invalid "to" address: 0x must be a valid string.');
 
       expect(() =>
-        util.validateTransaction({
+        util.validateTxParams({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
         } as any),
       ).toThrow('Invalid "to" address: undefined must be a valid string.');
@@ -86,13 +86,13 @@ describe('utils', () => {
         from: '0x3244e191f1b4903970224322180f1fbbc415696b',
         to: '0x',
       };
-      util.validateTransaction(transaction);
+      util.validateTxParams(transaction);
       expect(transaction.to).toBeUndefined();
     });
 
     it('should throw if invalid to address', () => {
       expect(() =>
-        util.validateTransaction({
+        util.validateTxParams({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '1337',
         } as any),
@@ -101,7 +101,7 @@ describe('utils', () => {
 
     it('should throw if value is invalid', () => {
       expect(() =>
-        util.validateTransaction({
+        util.validateTxParams({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '0x3244e191f1b4903970224322180f1fbbc415696b',
           value: '133-7',
@@ -109,7 +109,7 @@ describe('utils', () => {
       ).toThrow('Invalid "value": 133-7 is not a positive number.');
 
       expect(() =>
-        util.validateTransaction({
+        util.validateTxParams({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '0x3244e191f1b4903970224322180f1fbbc415696b',
           value: '133.7',
@@ -117,7 +117,7 @@ describe('utils', () => {
       ).toThrow('Invalid "value": 133.7 number must be denominated in wei.');
 
       expect(() =>
-        util.validateTransaction({
+        util.validateTxParams({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '0x3244e191f1b4903970224322180f1fbbc415696b',
           value: 'hello',
@@ -125,7 +125,7 @@ describe('utils', () => {
       ).toThrow('Invalid "value": hello number must be a valid number.');
 
       expect(() =>
-        util.validateTransaction({
+        util.validateTxParams({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '0x3244e191f1b4903970224322180f1fbbc415696b',
           value: 'one million dollar$',
@@ -135,7 +135,7 @@ describe('utils', () => {
       );
 
       expect(() =>
-        util.validateTransaction({
+        util.validateTxParams({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '0x3244e191f1b4903970224322180f1fbbc415696b',
           value: '1',
@@ -146,8 +146,8 @@ describe('utils', () => {
 
   describe('isEIP1559Transaction', () => {
     it('should detect EIP1559 transaction', () => {
-      const tx: Transaction = { from: '' };
-      const eip1559tx: Transaction = {
+      const tx: TransactionParams = { from: '' };
+      const eip1559tx: TransactionParams = {
         ...tx,
         maxFeePerGas: '2',
         maxPriorityFeePerGas: '3',
@@ -256,7 +256,7 @@ describe('utils', () => {
         {
           id: '1',
           time: 123456,
-          transaction: {
+          txParams: {
             from: fromAddress,
             gas: '0x100',
             value: '0x200',
@@ -267,7 +267,7 @@ describe('utils', () => {
         {
           id: '2',
           time: 123457,
-          transaction: {
+          txParams: {
             from: '0x124',
             gas: '0x101',
             value: '0x201',
@@ -278,7 +278,7 @@ describe('utils', () => {
         {
           id: '3',
           time: 123458,
-          transaction: {
+          txParams: {
             from: fromAddress,
             gas: '0x102',
             value: '0x202',
@@ -316,7 +316,7 @@ describe('utils', () => {
       networkID: '1',
       id: '1',
       time: 123456,
-      transaction: {
+      txParams: {
         from: '0x123',
         gas: '0x100',
         value: '0x200',

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -10,11 +10,15 @@ import type {
   GasPriceValue,
   FeeMarketEIP1559Values,
 } from './TransactionController';
-import type { TransactionStatus, Transaction, TransactionMeta } from './types';
+import type {
+  TransactionParams,
+  TransactionMeta,
+  TransactionStatus,
+} from './types';
 
 export const ESTIMATE_GAS_ERROR = 'eth_estimateGas rpc method error';
 
-const NORMALIZERS: { [param in keyof Transaction]: any } = {
+const NORMALIZERS: { [param in keyof TransactionParams]: any } = {
   data: (data: string) => addHexPrefix(data),
   from: (from: string) => addHexPrefix(from).toLowerCase(),
   gas: (gas: string) => addHexPrefix(gas),
@@ -30,58 +34,55 @@ const NORMALIZERS: { [param in keyof Transaction]: any } = {
 };
 
 /**
- * Normalizes properties on a Transaction object.
+ * Normalizes properties on transaction params.
  *
- * @param transaction - Transaction object to normalize.
- * @returns Normalized Transaction object.
+ * @param txParams - The transaction params to normalize.
+ * @returns Normalized transaction params.
  */
-export function normalizeTransaction(transaction: Transaction) {
-  const normalizedTransaction: Transaction = { from: '' };
-  let key: keyof Transaction;
+export function normalizeTxParams(txParams: TransactionParams) {
+  const normalizedTxParams: TransactionParams = { from: '' };
+  let key: keyof TransactionParams;
   for (key in NORMALIZERS) {
-    if (transaction[key as keyof Transaction]) {
-      normalizedTransaction[key] = NORMALIZERS[key](transaction[key]) as never;
+    if (txParams[key as keyof TransactionParams]) {
+      normalizedTxParams[key] = NORMALIZERS[key](txParams[key]) as never;
     }
   }
-  return normalizedTransaction;
+  return normalizedTxParams;
 }
 
 /**
- * Validates a Transaction object for required properties and throws in
+ * Validates the transaction params for required properties and throws in
  * the event of any validation error.
  *
- * @param transaction - Transaction object to validate.
+ * @param txParams - Transaction params object to validate.
  */
-export function validateTransaction(transaction: Transaction) {
+export function validateTxParams(txParams: TransactionParams) {
   if (
-    !transaction.from ||
-    typeof transaction.from !== 'string' ||
-    !isValidHexAddress(transaction.from)
+    !txParams.from ||
+    typeof txParams.from !== 'string' ||
+    !isValidHexAddress(txParams.from)
   ) {
     throw new Error(
-      `Invalid "from" address: ${transaction.from} must be a valid string.`,
+      `Invalid "from" address: ${txParams.from} must be a valid string.`,
     );
   }
 
-  if (transaction.to === '0x' || transaction.to === undefined) {
-    if (transaction.data) {
-      delete transaction.to;
+  if (txParams.to === '0x' || txParams.to === undefined) {
+    if (txParams.data) {
+      delete txParams.to;
     } else {
       throw new Error(
-        `Invalid "to" address: ${transaction.to} must be a valid string.`,
+        `Invalid "to" address: ${txParams.to} must be a valid string.`,
       );
     }
-  } else if (
-    transaction.to !== undefined &&
-    !isValidHexAddress(transaction.to)
-  ) {
+  } else if (txParams.to !== undefined && !isValidHexAddress(txParams.to)) {
     throw new Error(
-      `Invalid "to" address: ${transaction.to} must be a valid string.`,
+      `Invalid "to" address: ${txParams.to} must be a valid string.`,
     );
   }
 
-  if (transaction.value !== undefined) {
-    const value = transaction.value.toString();
+  if (txParams.value !== undefined) {
+    const value = txParams.value.toString();
     if (value.includes('-')) {
       throw new Error(`Invalid "value": ${value} is not a positive number.`);
     }
@@ -91,7 +92,7 @@ export function validateTransaction(transaction: Transaction) {
         `Invalid "value": ${value} number must be denominated in wei.`,
       );
     }
-    const intValue = parseInt(transaction.value, 10);
+    const intValue = parseInt(txParams.value, 10);
     const isValid =
       Number.isFinite(intValue) &&
       !Number.isNaN(intValue) &&
@@ -109,15 +110,15 @@ export function validateTransaction(transaction: Transaction) {
  * Checks if a transaction is EIP-1559 by checking for the existence of
  * maxFeePerGas and maxPriorityFeePerGas within its parameters.
  *
- * @param transaction - Transaction object to add.
+ * @param txParams - Transaction params object to add.
  * @returns Boolean that is true if the transaction is EIP-1559 (has maxFeePerGas and maxPriorityFeePerGas), otherwise returns false.
  */
-export const isEIP1559Transaction = (transaction: Transaction): boolean => {
-  const hasOwnProp = (obj: Transaction, key: string) =>
+export const isEIP1559Transaction = (txParams: TransactionParams): boolean => {
+  const hasOwnProp = (obj: TransactionParams, key: string) =>
     Object.prototype.hasOwnProperty.call(obj, key);
   return (
-    hasOwnProp(transaction, 'maxFeePerGas') &&
-    hasOwnProp(transaction, 'maxPriorityFeePerGas')
+    hasOwnProp(txParams, 'maxFeePerGas') &&
+    hasOwnProp(txParams, 'maxPriorityFeePerGas')
   );
 };
 
@@ -188,11 +189,11 @@ export function getAndFormatTransactionsForNonceTracker(
 ): NonceTrackerTransaction[] {
   return transactions
     .filter(
-      ({ status, transaction: { from } }) =>
+      ({ status, txParams: { from } }) =>
         status === transactionStatus &&
         from.toLowerCase() === fromAddress.toLowerCase(),
     )
-    .map(({ status, transaction: { from, gas, value, nonce } }) => {
+    .map(({ status, txParams: { from, gas, value, nonce } }) => {
       // the only value we care about is the nonce
       // but we need to return the other values to satisfy the type
       // TODO: refactor nonceTracker to not require this


### PR DESCRIPTION
## Explanation
Rename the `transaction` object to `txParams` in the persisted transaction metadata as part of the unification initiative between the core and extension. 

The following task will take place to handle the migration and adoption of the patch/release in the mobile client.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->


## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **BREAKING**:  rename the `transaction` object to `txParams` in the persisted `TransactionMeta`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
