### PR TITLE
Use API key only with Etherscan domain

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 83.91,
-      functions: 92.68,
-      lines: 95.35,
-      statements: 95.46,
+      branches: 84.79,
+      functions: 92.06,
+      lines: 95.4,
+      statements: 95.5,
     },
   },
 

--- a/packages/transaction-controller/src/IncomingTransactionHelper.ts
+++ b/packages/transaction-controller/src/IncomingTransactionHelper.ts
@@ -5,6 +5,8 @@ import EventEmitter from 'events';
 
 import type { RemoteTransactionSource, TransactionMeta } from './types';
 
+const RECENT_HISTORY_BLOCK_RANGE = 10;
+
 const UPDATE_CHECKS: ((txMeta: TransactionMeta) => any)[] = [
   (txMeta) => txMeta.status,
   (txMeta) => txMeta.transaction.gasUsed,
@@ -17,6 +19,8 @@ export class IncomingTransactionHelper {
 
   #getCurrentAccount: () => string;
 
+  #getLastFetchedBlockNumbers: () => Record<string, number>;
+
   #getLocalTransactions: () => TransactionMeta[];
 
   #getNetworkState: () => NetworkState;
@@ -25,11 +29,11 @@ export class IncomingTransactionHelper {
 
   #isRunning: boolean;
 
-  #lastFetchedBlockNumbers: Record<string, number>;
-
   #mutex = new Mutex();
 
   #onLatestBlock: (blockNumberHex: Hex) => Promise<void>;
+
+  #queryEntireHistory: boolean;
 
   #remoteTransactionSource: RemoteTransactionSource;
 
@@ -40,20 +44,22 @@ export class IncomingTransactionHelper {
   constructor({
     blockTracker,
     getCurrentAccount,
+    getLastFetchedBlockNumbers,
     getLocalTransactions,
     getNetworkState,
     isEnabled,
-    lastFetchedBlockNumbers,
+    queryEntireHistory,
     remoteTransactionSource,
     transactionLimit,
     updateTransactions,
   }: {
     blockTracker: BlockTracker;
     getCurrentAccount: () => string;
-    getNetworkState: () => NetworkState;
+    getLastFetchedBlockNumbers: () => Record<string, number>;
     getLocalTransactions?: () => TransactionMeta[];
+    getNetworkState: () => NetworkState;
     isEnabled?: () => boolean;
-    lastFetchedBlockNumbers?: Record<string, number>;
+    queryEntireHistory?: boolean;
     remoteTransactionSource: RemoteTransactionSource;
     transactionLimit?: number;
     updateTransactions?: boolean;
@@ -62,11 +68,12 @@ export class IncomingTransactionHelper {
 
     this.#blockTracker = blockTracker;
     this.#getCurrentAccount = getCurrentAccount;
+    this.#getLastFetchedBlockNumbers = getLastFetchedBlockNumbers;
     this.#getLocalTransactions = getLocalTransactions || (() => []);
     this.#getNetworkState = getNetworkState;
     this.#isEnabled = isEnabled ?? (() => true);
     this.#isRunning = false;
-    this.#lastFetchedBlockNumbers = lastFetchedBlockNumbers ?? {};
+    this.#queryEntireHistory = queryEntireHistory ?? true;
     this.#remoteTransactionSource = remoteTransactionSource;
     this.#transactionLimit = transactionLimit;
     this.#updateTransactions = updateTransactions ?? false;
@@ -207,19 +214,19 @@ export class IncomingTransactionHelper {
     );
   }
 
-  #getFromBlock(latestBlockNumber: number): number {
+  #getFromBlock(latestBlockNumber: number): number | undefined {
     const lastFetchedKey = this.#getBlockNumberKey();
 
     const lastFetchedBlockNumber =
-      this.#lastFetchedBlockNumbers[lastFetchedKey];
+      this.#getLastFetchedBlockNumbers()[lastFetchedKey];
 
     if (lastFetchedBlockNumber) {
       return lastFetchedBlockNumber + 1;
     }
 
-    // Avoid using latest block as remote transaction source
-    // may not have indexed it yet
-    return Math.max(latestBlockNumber - 10, 0);
+    return this.#queryEntireHistory
+      ? undefined
+      : latestBlockNumber - RECENT_HISTORY_BLOCK_RANGE;
   }
 
   #updateLastFetchedBlockNumber(remoteTxs: TransactionMeta[]) {
@@ -241,16 +248,17 @@ export class IncomingTransactionHelper {
     }
 
     const lastFetchedKey = this.#getBlockNumberKey();
-    const previousValue = this.#lastFetchedBlockNumbers[lastFetchedKey];
+    const lastFetchedBlockNumbers = this.#getLastFetchedBlockNumbers();
+    const previousValue = lastFetchedBlockNumbers[lastFetchedKey];
 
     if (previousValue === lastFetchedBlockNumber) {
       return;
     }
 
-    this.#lastFetchedBlockNumbers[lastFetchedKey] = lastFetchedBlockNumber;
+    lastFetchedBlockNumbers[lastFetchedKey] = lastFetchedBlockNumber;
 
     this.hub.emit('updatedLastFetchedBlockNumbers', {
-      lastFetchedBlockNumbers: this.#lastFetchedBlockNumbers,
+      lastFetchedBlockNumbers,
       blockNumber: lastFetchedBlockNumber,
     });
   }

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1187,7 +1187,7 @@ describe('TransactionController', () => {
         expect(transaction.from).toBe(ACCOUNT_MOCK);
         expect(transaction.nonce).toBe(`0x${NONCE_MOCK.toString(16)}`);
         expect(status).toBe(TransactionStatus.submitted);
-        expect(submittedTime).toEqual(expect.any(Number));
+        expect(submittedTime).toStrictEqual(expect.any(Number));
       });
 
       it('reports success to approval acceptor', async () => {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -422,6 +422,7 @@ describe('TransactionController', () => {
   let approveTransaction: () => void;
   let getNonceLockSpy: jest.Mock;
   let incomingTransactionHelperMock: jest.Mocked<IncomingTransactionHelper>;
+  let timeCounter = 0;
 
   const incomingTransactionHelperClassMock =
     IncomingTransactionHelper as jest.MockedClass<
@@ -489,6 +490,11 @@ describe('TransactionController', () => {
   }
 
   beforeEach(() => {
+    jest.spyOn(Date, 'now').mockImplementation(() => {
+      timeCounter += 1;
+      return timeCounter;
+    });
+
     for (const key in mockFlags) {
       mockFlags[key] = null;
     }

--- a/packages/transaction-controller/src/constants.ts
+++ b/packages/transaction-controller/src/constants.ts
@@ -20,8 +20,8 @@ export const CHAIN_IDS = {
   GNOSIS: '0x64',
 } as const;
 
-const DEFAULT_ETHERSCAN_DOMAIN = 'etherscan.io';
-const DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX = 'api';
+export const DEFAULT_ETHERSCAN_DOMAIN = 'etherscan.io';
+export const DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX = 'api';
 
 export const ETHERSCAN_SUPPORTED_NETWORKS = {
   [CHAIN_IDS.GOERLI]: {

--- a/packages/transaction-controller/src/etherscan.test.ts
+++ b/packages/transaction-controller/src/etherscan.test.ts
@@ -66,7 +66,33 @@ describe('Etherscan', () => {
           `&startBlock=${REQUEST_MOCK.fromBlock}` +
           `&apikey=${REQUEST_MOCK.apiKey}` +
           `&offset=${REQUEST_MOCK.limit}` +
-          `&order=desc` +
+          `&sort=desc` +
+          `&action=${action}` +
+          `&tag=latest` +
+          `&page=1`,
+      );
+    });
+
+    it('does not include API key in request if chain does not use standard Etherscan domain', async () => {
+      handleFetchMock.mockResolvedValueOnce(RESPONSE_MOCK);
+
+      await (Etherscan as any)[method]({
+        ...REQUEST_MOCK,
+        chainId: CHAIN_IDS.LINEA_MAINNET,
+      });
+
+      expect(handleFetchMock).toHaveBeenCalledTimes(1);
+      expect(handleFetchMock).toHaveBeenCalledWith(
+        `https://${
+          ETHERSCAN_SUPPORTED_NETWORKS[CHAIN_IDS.LINEA_MAINNET].subdomain
+        }.${
+          ETHERSCAN_SUPPORTED_NETWORKS[CHAIN_IDS.LINEA_MAINNET].domain
+        }/api?` +
+          `module=account` +
+          `&address=${REQUEST_MOCK.address}` +
+          `&startBlock=${REQUEST_MOCK.fromBlock}` +
+          `&offset=${REQUEST_MOCK.limit}` +
+          `&sort=desc` +
           `&action=${action}` +
           `&tag=latest` +
           `&page=1`,
@@ -91,7 +117,7 @@ describe('Etherscan', () => {
           `&startBlock=${REQUEST_MOCK.fromBlock}` +
           `&apikey=${REQUEST_MOCK.apiKey}` +
           `&offset=${REQUEST_MOCK.limit}` +
-          `&order=desc` +
+          `&sort=desc` +
           `&action=${action}` +
           `&tag=latest` +
           `&page=1`,
@@ -140,7 +166,7 @@ describe('Etherscan', () => {
         }/api?` +
           `module=account` +
           `&address=${REQUEST_MOCK.address}` +
-          `&order=desc` +
+          `&sort=desc` +
           `&action=${action}` +
           `&tag=latest` +
           `&page=1`,

--- a/packages/transaction-controller/src/etherscan.ts
+++ b/packages/transaction-controller/src/etherscan.ts
@@ -1,7 +1,10 @@
 import { handleFetch } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 
-import { ETHERSCAN_SUPPORTED_NETWORKS } from './constants';
+import {
+  DEFAULT_ETHERSCAN_DOMAIN,
+  ETHERSCAN_SUPPORTED_NETWORKS,
+} from './constants';
 
 export interface EtherscanTransactionMetaBase {
   blockNumber: string;
@@ -148,7 +151,7 @@ async function fetchTransactions<T extends EtherscanTransactionMetaBase>(
     startBlock: fromBlock?.toString(),
     apikey: apiKey,
     offset: limit?.toString(),
-    order: 'desc',
+    sort: 'desc',
   };
 
   const etherscanTxUrl = getEtherscanApiUrl(chainId, {
@@ -188,6 +191,11 @@ function getEtherscanApiUrl(
 
   const apiUrl = `https://${networkInfo.subdomain}.${networkInfo.domain}`;
   let url = `${apiUrl}/api?`;
+
+  // We only support API keys for the Etherscan domain
+  if (networkInfo.domain !== DEFAULT_ETHERSCAN_DOMAIN) {
+    urlParams.apikey = undefined;
+  }
 
   // eslint-disable-next-line guard-for-in
   for (const paramKey in urlParams) {


### PR DESCRIPTION
## Explanation

Update the incoming transaction support in the `TransactionController` to include the API key (if specified) in the Etherscan request only if the domain is the standard `etherscan.io`.

Currently only the mobile client provides an API key however this is specifically for the Etherscan domain rather than the same software on alternate hosts such as `lineascan.build`.

This PR also includes incoming transaction fixes already patched in the mobile client including:

- Querying the entire transaction history if no last fetched block numbers are found, unless the new `queryEntireHistory` option is set to `false`.
- Using the correct `sort` parameter rather than `order` in Etherscan requests.
- Sorting the transactions when trimming.
- Replacing the `lastFetchedBlockNumbers` otpion with a callback in the `IncomingTransactionHelper`.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **ADDED**: Add the `incomingTransactions.queryEntireHistory` constructor option.
  - Determines if the entire transaction history is searched when fetching remote transactions and there is no saved last fetched block number.
  - If `false`, the previous 10 blocks are queried in order to give the remote source sufficient time to index new transactions. 
  - Defaults to `true`.
- **CHANGED**: Only use the `incomingTransactions.apiKey` when querying the standard Etherscan domain.
- **FIXED**: Fix the sorting of incoming and updated transactions.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
