### PR TITLE
Add originalGasEstimate to transaction metadata

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -931,25 +931,20 @@ describe('TransactionController', () => {
         },
       );
 
-      expect(controller.state.transactions[0].transaction.from).toBe(
-        ACCOUNT_MOCK,
-      );
-      expect(controller.state.transactions[0].networkID).toBe(
-        MOCK_NETWORK.state.networkId,
-      );
-      expect(controller.state.transactions[0].chainId).toBe(
+      const transactionMeta = controller.state.transactions[0];
+
+      expect(transactionMeta.transaction.from).toBe(ACCOUNT_MOCK);
+      expect(transactionMeta.networkID).toBe(MOCK_NETWORK.state.networkId);
+      expect(transactionMeta.chainId).toBe(
         MOCK_NETWORK.state.providerConfig.chainId,
       );
-      expect(controller.state.transactions[0].deviceConfirmedOn).toBe(
-        mockDeviceConfirmedOn,
-      );
-      expect(controller.state.transactions[0].origin).toBe(mockOrigin);
-      expect(controller.state.transactions[0].status).toBe(
-        TransactionStatus.unapproved,
-      );
-      expect(controller.state.transactions[0].securityAlertResponse).toBe(
+      expect(transactionMeta.deviceConfirmedOn).toBe(mockDeviceConfirmedOn);
+      expect(transactionMeta.origin).toBe(mockOrigin);
+      expect(transactionMeta.status).toBe(TransactionStatus.unapproved);
+      expect(transactionMeta.securityAlertResponse).toBe(
         mockSecurityAlertResponse,
       );
+      expect(transactionMeta.originalGasEstimate).toBe('0x0');
     });
 
     describe('adds dappSuggestedGasFees to transaction', () => {
@@ -1732,7 +1727,7 @@ describe('TransactionController', () => {
 
       const { transactionMeta, result } = await controller.addTransaction({
         from: ACCOUNT_MOCK,
-        gas: '0x0',
+        gas: '0x1',
         gasPrice: '0x50fd51da',
         to: ACCOUNT_MOCK,
         value: '0x0',
@@ -1751,6 +1746,7 @@ describe('TransactionController', () => {
         transactions[1].transaction.nonce,
       );
       expect(transactions[1].estimatedBaseFee).toBe('0x123');
+      expect(transactions[1].originalGasEstimate).toBe('0x1');
     });
 
     it('allows transaction count to exceed txHistorylimit', async () => {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -439,6 +439,7 @@ export class TransactionController extends BaseController<
       const { gas, estimateGasError } = await this.estimateGas(transaction);
       transaction.gas = gas;
       transaction.estimateGasError = estimateGasError;
+      transactionMeta.originalGasEstimate = gas;
     } catch (error: any) {
       this.failTransaction(transactionMeta, error);
       return Promise.reject(error);
@@ -714,6 +715,7 @@ export class TransactionController extends BaseController<
       time: Date.now(),
       transactionHash,
       actionId,
+      originalGasEstimate: transactionMeta.transaction.gas,
     };
     const newTransactionMeta =
       newMaxFeePerGas && newMaxPriorityFeePerGas
@@ -768,7 +770,7 @@ export class TransactionController extends BaseController<
     ]);
 
     // 2. If to is not defined or this is not a contract address, and there is no data use 0x5208 / 21000.
-    // If the newtwork is a custom network then bypass this check and fetch 'estimateGas'.
+    // If the network is a custom network then bypass this check and fetch 'estimateGas'.
     /* istanbul ignore next */
     const code = to ? await query(this.ethQuery, 'getCode', [to]) : undefined;
     /* istanbul ignore next */

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -79,6 +79,11 @@ type TransactionMetaBase = {
   origin?: string;
 
   /**
+   * The original gas estimation of the transaction.
+   */
+  originalGasEstimate?: string;
+
+  /**
    * Hex representation of the underlying transaction.
    */
   rawTransaction?: string;


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR aims to persist `originalGasEstimate` in `addTransaction` and `speedUpTransaction`. 

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **ADDED**: Persist `originalGasEstimate` in transaction metadata.

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've highlighted breaking changes using the "BREAKING" category above as appropriate
