### PR TITLE
Add `history` to `transactionMeta`

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 84.11,
-      functions: 93.83,
-      lines: 96.17,
-      statements: 96.25,
+      branches: 84.36,
+      functions: 93.24,
+      lines: 95.79,
+      statements: 95.87,
     },
   },
 

--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 84.36,
-      functions: 93.24,
-      lines: 95.79,
-      statements: 95.87,
+      branches: 84.38,
+      functions: 93.33,
+      lines: 96.02,
+      statements: 96.1,
     },
   },
 

--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 84.25,
-      functions: 93.05,
-      lines: 95.84,
-      statements: 95.92,
+      branches: 84.11,
+      functions: 93.83,
+      lines: 96.17,
+      statements: 96.25,
     },
   },
 

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -40,6 +40,8 @@
     "eth-method-registry": "1.1.0",
     "eth-rpc-errors": "^4.0.2",
     "ethereumjs-util": "^7.0.10",
+    "fast-json-patch": "^3.1.1",
+    "lodash": "^4.17.21",
     "nonce-tracker": "^1.1.0",
     "uuid": "^8.3.2"
   },

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1977,7 +1977,7 @@ describe('TransactionController', () => {
       const controller = newController({
         options: {
           disableHistory: true,
-        }
+        },
       });
       const externalTransactionId = '1';
       const externalTransactionHash = '0x1';

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -977,6 +977,7 @@ describe('TransactionController', () => {
         origin: undefined,
         originalGasEstimate: expect.any(String),
         securityAlertResponse: undefined,
+        sendFlowHistory: expect.any(Array),
         status: TransactionStatus.unapproved,
         time: expect.any(Number),
         transaction: expect.anything(),

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -959,6 +959,36 @@ describe('TransactionController', () => {
       );
     });
 
+    it('adds initial history', async () => {
+      const controller = newController();
+
+      await controller.addTransaction({
+        from: ACCOUNT_MOCK,
+        to: ACCOUNT_MOCK,
+      });
+
+      expect(controller.state.transactions[0]?.history).toBeDefined();
+      // Atleast 1 history item (initial snapshot)
+      expect(controller.state.transactions[0]?.history?.length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    it('doesnt populate history if history explicitly disabled', async () => {
+      const controller = newController({
+        options: {
+          disableHistory: true,
+        },
+      });
+
+      await controller.addTransaction({
+        from: ACCOUNT_MOCK,
+        to: ACCOUNT_MOCK,
+      });
+
+      expect(controller.state.transactions[0]?.history).toBeUndefined();
+    });
+
     describe('adds dappSuggestedGasFees to transaction', () => {
       it.each([
         ['origin is MM', ORIGIN_METAMASK],
@@ -1876,6 +1906,14 @@ describe('TransactionController', () => {
       expect(controller.state.transactions[0]?.txReceipt?.gasUsed).toBe(
         externalTransactionReceipt.gasUsed,
       );
+      expect(controller.state.transactions[0]?.history).toBeDefined();
+      // Atleast 1 history item (initial snapshot)
+      expect(controller.state.transactions[0]?.history?.length).toBeGreaterThan(
+        0,
+      );
+      expect(
+        controller.state.transactions[0]?.history?.[1][0].timestamp,
+      ).toBeLessThanOrEqual(Date.now());
     });
 
     it('marks the same nonce local transactions statuses as dropped and defines replacedBy properties', async () => {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -967,11 +967,25 @@ describe('TransactionController', () => {
         to: ACCOUNT_MOCK,
       });
 
-      expect(controller.state.transactions[0]?.history).toBeDefined();
-      // Atleast 1 history item (initial snapshot)
-      expect(controller.state.transactions[0]?.history?.length).toBeGreaterThan(
-        0,
-      );
+      const expectedInitialSnapshot = {
+        actionId: undefined,
+        chainId: expect.any(String),
+        dappSuggestedGasFees: undefined,
+        deviceConfirmedOn: undefined,
+        id: expect.any(String),
+        networkID: expect.any(String),
+        origin: undefined,
+        securityAlertResponse: undefined,
+        status: TransactionStatus.unapproved,
+        time: expect.any(Number),
+        transaction: expect.anything(),
+        verifiedOnBlockchain: expect.any(Boolean),
+      };
+
+      // Expect initial snapshot to be in place
+      expect(controller.state.transactions[0]?.history).toEqual([
+        expectedInitialSnapshot,
+      ]);
     });
 
     it('doesnt populate history if history explicitly disabled', async () => {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -975,6 +975,7 @@ describe('TransactionController', () => {
         id: expect.any(String),
         networkID: expect.any(String),
         origin: undefined,
+        originalGasEstimate: expect.any(String),
         securityAlertResponse: undefined,
         status: TransactionStatus.unapproved,
         time: expect.any(Number),

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1974,7 +1974,11 @@ describe('TransactionController', () => {
     });
 
     it('marks the same nonce local transactions statuses as dropped and defines replacedBy properties', async () => {
-      const controller = newController();
+      const controller = newController({
+        options: {
+          disableHistory: true,
+        }
+      });
       const externalTransactionId = '1';
       const externalTransactionHash = '0x1';
       const externalTransactionToConfirm = {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -42,15 +42,13 @@ import { v1 as random } from 'uuid';
 import { EtherscanRemoteTransactionSource } from './EtherscanRemoteTransactionSource';
 import { validateConfirmedExternalTransaction } from './external-transactions';
 import {
-  generateHistoryEntry,
-  replayHistory,
+  updateTransactionHistory,
   snapshotFromTransactionMeta,
-} from './history-utils';
+} from './history';
 import { IncomingTransactionHelper } from './IncomingTransactionHelper';
 import type {
   DappSuggestedGasFees,
   Transaction,
-  TransactionHistory,
   TransactionMeta,
   TransactionReceipt,
   SendFlowHistoryEntry,
@@ -908,7 +906,7 @@ export class TransactionController extends BaseController<
     );
     validateTransaction(transactionMeta.transaction);
     if (!this.isHistoryDisabled) {
-      this.updateTransactionHistory(transactionMeta, note);
+      updateTransactionHistory(transactionMeta, note);
     }
     const index = transactions.findIndex(({ id }) => transactionMeta.id === id);
     transactions[index] = transactionMeta;
@@ -1711,32 +1709,6 @@ export class TransactionController extends BaseController<
         resolve(txMeta);
       });
     });
-  }
-
-  /**
-   * Compares and adds history entry to the provided transactionMeta history.
-   *
-   * @param transactionMeta - TransactionMeta to add history entry to.
-   * @param note - Note to add to history entry.
-   */
-  private updateTransactionHistory(
-    transactionMeta: TransactionMeta,
-    note: string,
-  ): void {
-    const currentState = snapshotFromTransactionMeta(transactionMeta);
-    const previousState = replayHistory(
-      transactionMeta.history as TransactionHistory,
-    );
-
-    const historyEntry = generateHistoryEntry(
-      previousState,
-      currentState,
-      note,
-    );
-
-    if (historyEntry.length) {
-      transactionMeta?.history?.push(historyEntry);
-    }
   }
 
   /**

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -244,9 +244,9 @@ export class TransactionController extends BaseController<
    *
    * @param options - The controller options.
    * @param options.blockTracker - The block tracker used to poll for new blocks data.
+   * @param options.disableHistory - Whether to disable storing history in transaction metadata.
    * @param options.disableSendFlowHistory - Explicitly disable transaction metadata history.
    * @param options.getNetworkState - Gets the state of the network controller.
-   * @param options.disableHistory - Whether to disable storing history in transaction metadata.
    * @param options.getSelectedAddress - Gets the address of the currently selected account.
    * @param options.incomingTransactions - Configuration options for incoming transaction support.
    * @param options.incomingTransactions.apiKey - An optional API key to use when fetching remote transaction data.

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -899,7 +899,7 @@ export class TransactionController extends BaseController<
    * Updates an existing transaction in state.
    *
    * @param transactionMeta - The new transaction to store in state.
-   * @param note - A note of update reason to add the transaction history.
+   * @param note - A note or update reason to include in the transaction history.
    */
   updateTransaction(transactionMeta: TransactionMeta, note: string) {
     const { transactions } = this.state;

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1036,7 +1036,10 @@ export class TransactionController extends BaseController<
         ...(transactionMeta?.sendFlowHistory ?? []),
         ...sendFlowHistoryToAdd,
       ];
-      this.updateTransaction(transactionMeta);
+      this.updateTransaction(
+        transactionMeta,
+        'TransactionController:updateTransactionSendFlowHistory - sendFlowHistory updated',
+      );
     }
 
     return this.getTransaction(transactionID) as TransactionMeta;

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -995,7 +995,7 @@ export class TransactionController extends BaseController<
         'TransactionController:confirmExternalTransaction - Add external transaction',
       );
     } catch (error) {
-      console.log("asddsaadsads")
+      console.log('asddsaadsads');
       console.error(error);
     }
   }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -246,7 +246,7 @@ export class TransactionController extends BaseController<
    * @param options.blockTracker - The block tracker used to poll for new blocks data.
    * @param options.disableSendFlowHistory - Explicitly disable transaction metadata history.
    * @param options.getNetworkState - Gets the state of the network controller.
-   * @param options.disableHistory - Explicitly disable transaction metadata history.
+   * @param options.disableHistory - Whether to disable storing history in transaction metadata.
    * @param options.getSelectedAddress - Gets the address of the currently selected account.
    * @param options.incomingTransactions - Configuration options for incoming transaction support.
    * @param options.incomingTransactions.apiKey - An optional API key to use when fetching remote transaction data.

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -995,7 +995,6 @@ export class TransactionController extends BaseController<
         'TransactionController:confirmExternalTransaction - Add external transaction',
       );
     } catch (error) {
-      console.log('asddsaadsads');
       console.error(error);
     }
   }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1687,7 +1687,7 @@ export class TransactionController extends BaseController<
     transactionMeta.status = TransactionStatus.dropped;
     this.updateTransaction(
       transactionMeta,
-      'TransactionController#setTransactionStatusDropped - transaction dropped',
+      'TransactionController#setTransactionStatusDropped - Transaction dropped',
     );
   }
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -41,10 +41,7 @@ import { v1 as random } from 'uuid';
 
 import { EtherscanRemoteTransactionSource } from './EtherscanRemoteTransactionSource';
 import { validateConfirmedExternalTransaction } from './external-transactions';
-import {
-  updateTransactionHistory,
-  snapshotFromTransactionMeta,
-} from './history';
+import { addInitialHistorySnapshot, updateTransactionHistory } from './history';
 import { IncomingTransactionHelper } from './IncomingTransactionHelper';
 import type {
   DappSuggestedGasFees,
@@ -479,7 +476,7 @@ export class TransactionController extends BaseController<
       }
       // Initial history push
       if (!this.isHistoryDisabled) {
-        this.addInitialHistorySnapshot(transactionMeta);
+        addInitialHistorySnapshot(transactionMeta);
       }
       transactions.push(transactionMeta);
       this.update({
@@ -1627,7 +1624,7 @@ export class TransactionController extends BaseController<
     // Make sure provided external transaction has non empty history array
     if (!(transactionMeta.history ?? []).length) {
       if (!this.isHistoryDisabled) {
-        this.addInitialHistorySnapshot(transactionMeta);
+        addInitialHistorySnapshot(transactionMeta);
       }
     }
 
@@ -1706,16 +1703,6 @@ export class TransactionController extends BaseController<
         resolve(txMeta);
       });
     });
-  }
-
-  /**
-   * Add initial history snapshot to the provided transactionMeta history.
-   *
-   * @param transactionMeta - TransactionMeta to add initial history snapshot to.
-   */
-  private addInitialHistorySnapshot(transactionMeta: TransactionMeta) {
-    const snapshot = snapshotFromTransactionMeta(transactionMeta);
-    transactionMeta.history = [snapshot];
   }
 }
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1625,10 +1625,7 @@ export class TransactionController extends BaseController<
     );
 
     // Make sure provided external transaction has non empty history array
-    if (
-      !Array.isArray(transactionMeta.history) ||
-      !transactionMeta.history.length
-    ) {
+    if (!(transactionMeta.history ?? []).length) {
       if (!this.isHistoryDisabled) {
         this.addInitialHistorySnapshot(transactionMeta);
       }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -995,6 +995,7 @@ export class TransactionController extends BaseController<
         'TransactionController:confirmExternalTransaction - Add external transaction',
       );
     } catch (error) {
+      console.log("asddsaadsads")
       console.error(error);
     }
   }

--- a/packages/transaction-controller/src/history-utils.ts
+++ b/packages/transaction-controller/src/history-utils.ts
@@ -1,0 +1,64 @@
+import jsonDiffer from 'fast-json-patch';
+import { cloneDeep } from 'lodash';
+
+import type {
+  TransactionMeta,
+  ExtendedHistoryOperation,
+  TransactionHistory,
+} from './types';
+
+/**
+ * Generates a history entry from the previous and new transaction metadata.
+ *
+ * @param previousState - The previous transaction metadata.
+ * @param currentState - The new transaction metadata.
+ * @param note - A note for the transaction metada update.
+ * @returns An array of history operation.
+ */
+export function generateHistoryEntry(
+  previousState: any,
+  currentState: TransactionMeta,
+  note: string,
+): ExtendedHistoryOperation[] {
+  const historyOperationsEntry = jsonDiffer.compare(
+    previousState,
+    currentState,
+  ) as ExtendedHistoryOperation[];
+  // Add a note to the first operation, since it breaks if we append it to the entry
+  if (historyOperationsEntry[0]) {
+    if (note) {
+      historyOperationsEntry[0].note = note;
+    }
+    historyOperationsEntry[0].timestamp = Date.now();
+  }
+  return historyOperationsEntry;
+}
+
+/**
+ * Recovers previous transactionMeta from passed history array.
+ *
+ * @param transactionHistory - The transaction metadata to replay.
+ * @returns The transaction metadata.
+ */
+export function replayHistory(
+  transactionHistory: TransactionHistory,
+): TransactionMeta {
+  const shortHistory = cloneDeep(transactionHistory);
+  return shortHistory.reduce(
+    (val, entry: any) => jsonDiffer.applyPatch(val, entry).newDocument,
+  ) as TransactionMeta;
+}
+
+/**
+ * Clone the transaction meta data without the history property.
+ *
+ * @param transactionMeta - The transaction metadata to snapshot.
+ * @returns A deep clone of transaction metadata without history property.
+ */
+export function snapshotFromTransactionMeta(
+  transactionMeta: TransactionMeta,
+): TransactionMeta {
+  const snapshot = { ...transactionMeta };
+  delete snapshot.history;
+  return cloneDeep(snapshot);
+}

--- a/packages/transaction-controller/src/history.ts
+++ b/packages/transaction-controller/src/history.ts
@@ -2,9 +2,9 @@ import jsonDiffer from 'fast-json-patch';
 import { cloneDeep } from 'lodash';
 
 import type {
-  TransactionMeta,
-  ExtendedHistoryOperation,
   TransactionHistory,
+  TransactionHistoryEntry,
+  TransactionMeta,
 } from './types';
 
 /**
@@ -19,11 +19,11 @@ function generateHistoryEntry(
   previousState: any,
   currentState: TransactionMeta,
   note: string,
-): ExtendedHistoryOperation[] {
+): TransactionHistoryEntry {
   const historyOperationsEntry = jsonDiffer.compare(
     previousState,
     currentState,
-  ) as ExtendedHistoryOperation[];
+  ) as TransactionHistoryEntry;
   // Add a note to the first operation, since it breaks if we append it to the entry
   if (historyOperationsEntry[0]) {
     if (note) {

--- a/packages/transaction-controller/src/history.ts
+++ b/packages/transaction-controller/src/history.ts
@@ -8,6 +8,38 @@ import type {
 } from './types';
 
 /**
+ * Add initial history snapshot to the provided transactionMeta history.
+ *
+ * @param transactionMeta - TransactionMeta to add initial history snapshot to.
+ */
+export function addInitialHistorySnapshot(transactionMeta: TransactionMeta) {
+  const snapshot = snapshotFromTransactionMeta(transactionMeta);
+  transactionMeta.history = [snapshot];
+}
+
+/**
+ * Compares and adds history entry to the provided transactionMeta history.
+ *
+ * @param transactionMeta - TransactionMeta to add history entry to.
+ * @param note - Note to add to history entry.
+ */
+export function updateTransactionHistory(
+  transactionMeta: TransactionMeta,
+  note: string,
+): void {
+  const currentState = snapshotFromTransactionMeta(transactionMeta);
+  const previousState = replayHistory(
+    transactionMeta.history as TransactionHistory,
+  );
+
+  const historyEntry = generateHistoryEntry(previousState, currentState, note);
+
+  if (historyEntry.length) {
+    transactionMeta?.history?.push(historyEntry);
+  }
+}
+
+/**
  * Generates a history entry from the previous and new transaction metadata.
  *
  * @param previousState - The previous transaction metadata.
@@ -35,28 +67,6 @@ function generateHistoryEntry(
 }
 
 /**
- * Compares and adds history entry to the provided transactionMeta history.
- *
- * @param transactionMeta - TransactionMeta to add history entry to.
- * @param note - Note to add to history entry.
- */
-export function updateTransactionHistory(
-  transactionMeta: TransactionMeta,
-  note: string,
-): void {
-  const currentState = snapshotFromTransactionMeta(transactionMeta);
-  const previousState = replayHistory(
-    transactionMeta.history as TransactionHistory,
-  );
-
-  const historyEntry = generateHistoryEntry(previousState, currentState, note);
-
-  if (historyEntry.length) {
-    transactionMeta?.history?.push(historyEntry);
-  }
-}
-
-/**
  * Recovers previous transactionMeta from passed history array.
  *
  * @param transactionHistory - The transaction metadata to replay.
@@ -77,7 +87,7 @@ function replayHistory(
  * @param transactionMeta - The transaction metadata to snapshot.
  * @returns A deep clone of transaction metadata without history property.
  */
-export function snapshotFromTransactionMeta(
+function snapshotFromTransactionMeta(
   transactionMeta: TransactionMeta,
 ): TransactionMeta {
   const snapshot = { ...transactionMeta };

--- a/packages/transaction-controller/src/history.ts
+++ b/packages/transaction-controller/src/history.ts
@@ -15,7 +15,7 @@ import type {
  * @param note - A note for the transaction metada update.
  * @returns An array of history operation.
  */
-export function generateHistoryEntry(
+function generateHistoryEntry(
   previousState: any,
   currentState: TransactionMeta,
   note: string,
@@ -35,12 +35,34 @@ export function generateHistoryEntry(
 }
 
 /**
+ * Compares and adds history entry to the provided transactionMeta history.
+ *
+ * @param transactionMeta - TransactionMeta to add history entry to.
+ * @param note - Note to add to history entry.
+ */
+export function updateTransactionHistory(
+  transactionMeta: TransactionMeta,
+  note: string,
+): void {
+  const currentState = snapshotFromTransactionMeta(transactionMeta);
+  const previousState = replayHistory(
+    transactionMeta.history as TransactionHistory,
+  );
+
+  const historyEntry = generateHistoryEntry(previousState, currentState, note);
+
+  if (historyEntry.length) {
+    transactionMeta?.history?.push(historyEntry);
+  }
+}
+
+/**
  * Recovers previous transactionMeta from passed history array.
  *
  * @param transactionHistory - The transaction metadata to replay.
  * @returns The transaction metadata.
  */
-export function replayHistory(
+function replayHistory(
   transactionHistory: TransactionHistory,
 ): TransactionMeta {
   const shortHistory = cloneDeep(transactionHistory);

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -389,11 +389,11 @@ type ExtendedHistoryOperation = Operation & {
 
 /**
  * A transaction history entry that includes the ExtendedHistoryOperation as the first element.
- */ 
+ */
 export type TransactionHistoryEntry = [
   ExtendedHistoryOperation,
-  ...Operation[]
-]
+  ...Operation[],
+];
 
 /**
  * A transaction history that includes the transaction meta as the first element.

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1,4 +1,5 @@
 import type { Hex } from '@metamask/utils';
+import type { Operation } from 'fast-json-patch';
 
 /**
  * Representation of transaction metadata.
@@ -57,6 +58,11 @@ type TransactionMetaBase = {
    * A hex string of the transaction hash, used to identify the transaction on the network.
    */
   hash?: string;
+
+  /**
+   * A history of mutations to TransactionMeta.
+   */
+  history?: TransactionHistory;
 
   /**
    * Generated UUID associated with this transaction.
@@ -372,3 +378,20 @@ export interface DappSuggestedGasFees {
   maxFeePerGas?: string;
   maxPriorityFeePerGas?: string;
 }
+
+/**
+ * A transaction history operation that includes a note and timestamp.
+ */
+export type ExtendedHistoryOperation = Operation & {
+  note?: string;
+  timestamp?: number;
+};
+
+/**
+ * A transaction history that includes the transaction meta as the first element.
+ * And the rest of the elements are the operation arrays that were applied to the transaction meta.
+ */
+export type TransactionHistory = [
+  TransactionMeta,
+  ...ExtendedHistoryOperation[][],
+];

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -382,10 +382,18 @@ export interface DappSuggestedGasFees {
 /**
  * A transaction history operation that includes a note and timestamp.
  */
-export type ExtendedHistoryOperation = Operation & {
+type ExtendedHistoryOperation = Operation & {
   note?: string;
   timestamp?: number;
 };
+
+/**
+ * A transaction history entry that includes the ExtendedHistoryOperation as the first element.
+ */ 
+export type TransactionHistoryEntry = [
+  ExtendedHistoryOperation,
+  ...Operation[]
+]
 
 /**
  * A transaction history that includes the transaction meta as the first element.
@@ -393,5 +401,5 @@ export type ExtendedHistoryOperation = Operation & {
  */
 export type TransactionHistory = [
   TransactionMeta,
-  ...ExtendedHistoryOperation[][],
+  ...TransactionHistoryEntry[],
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2152,7 +2152,9 @@ __metadata:
     eth-rpc-errors: ^4.0.2
     ethereumjs-util: ^7.0.10
     ethjs-provider-http: ^0.1.6
+    fast-json-patch: ^3.1.1
     jest: ^27.5.1
+    lodash: ^4.17.21
     nonce-tracker: ^1.1.0
     sinon: ^9.2.4
     ts-jest: ^27.1.4
@@ -5097,6 +5099,13 @@ __metadata:
     merge2: ^1.3.0
     micromatch: ^4.0.4
   checksum: 20df62be28eb5426fe8e40e0d05601a63b1daceb7c3d87534afcad91bdcf1e4b1743cf2d5247d6e225b120b46df0b9053a032b2691ba34ee121e033acd81f547
+  languageName: node
+  linkType: hard
+
+"fast-json-patch@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "fast-json-patch@npm:3.1.1"
+  checksum: c4525b61b2471df60d4b025b4118b036d99778a93431aa44d1084218182841d82ce93056f0f3bbd731a24e6a8e69820128adf1873eb2199a26c62ef58d137833
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This PR aims to add `history` property to the transaction metadata. 

There are few points that history is extended or added.
- While using public `addTransaction` function it adds initial history.
- While using public `confirmExternalTransaction` function. First it checks if the history property is in place, if not it initiates as it in the `addTransaction`. (Please note that there were no checks/tests in extension for this case)
- Since history is useful for debugging, all the `updateTransaction` calls will add operation entry array of what is changed.

Transaction history adds considerable space in the persisted state (and this is unwanted in mobile), `TransactionController` now has new option called `disableHistory` boolean flag to prevent history generation.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **BREAKING**: `disableHistory` option added to the constructor.
  - This determines whether generate history or not. 
  - This option should be explicitly set to `true` in mobile.
  - Defaults to `false`

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've highlighted breaking changes using the "BREAKING" category above as appropriate
