### PR TITLE
Add transaction type when normalising transaction object

### DIFF
--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -237,6 +237,12 @@ export interface Transaction {
    * Value associated with this transaction.
    */
   value?: string;
+
+  /**
+   * Type of transaction.
+   * 0x0 indicates a legacy transaction.
+   */
+  type?: string;
 }
 
 /**

--- a/packages/transaction-controller/src/utils.test.ts
+++ b/packages/transaction-controller/src/utils.test.ts
@@ -19,18 +19,22 @@ const FAIL = 'lol';
 const PASS = '0x1';
 
 describe('utils', () => {
+  const commonInput = {
+    data: 'data',
+    from: 'FROM',
+    gas: 'gas',
+    gasPrice: 'gasPrice',
+    nonce: 'nonce',
+    to: 'TO',
+    value: 'value',
+    maxFeePerGas: 'maxFeePerGas',
+    maxPriorityFeePerGas: 'maxPriorityFeePerGas',
+    estimatedBaseFee: 'estimatedBaseFee',
+  };
+
   it('normalizeTransaction', () => {
     const normalized = util.normalizeTransaction({
-      data: 'data',
-      from: 'FROM',
-      gas: 'gas',
-      gasPrice: 'gasPrice',
-      nonce: 'nonce',
-      to: 'TO',
-      value: 'value',
-      maxFeePerGas: 'maxFeePerGas',
-      maxPriorityFeePerGas: 'maxPriorityFeePerGas',
-      estimatedBaseFee: 'estimatedBaseFee',
+      ...commonInput,
     });
     expect(normalized).toStrictEqual({
       data: '0xdata',
@@ -43,6 +47,25 @@ describe('utils', () => {
       maxFeePerGas: '0xmaxFeePerGas',
       maxPriorityFeePerGas: '0xmaxPriorityFeePerGas',
       estimatedBaseFee: '0xestimatedBaseFee',
+    });
+  });
+  it('normalizeTransaction if type is zero', () => {
+    const normalized = util.normalizeTransaction({
+      ...commonInput,
+      type: '0x0',
+    });
+    expect(normalized).toStrictEqual({
+      data: '0xdata',
+      from: '0xfrom',
+      gas: '0xgas',
+      gasPrice: '0xgasPrice',
+      nonce: '0xnonce',
+      to: '0xto',
+      value: '0xvalue',
+      maxFeePerGas: '0xmaxFeePerGas',
+      maxPriorityFeePerGas: '0xmaxPriorityFeePerGas',
+      estimatedBaseFee: '0xestimatedBaseFee',
+      type: '0x0',
     });
   });
 

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -43,6 +43,10 @@ export function normalizeTransaction(transaction: Transaction) {
       normalizedTransaction[key] = NORMALIZERS[key](transaction[key]) as never;
     }
   }
+
+  if (transaction?.type === '0x0') {
+    normalizedTransaction.type = '0x0';
+  }
   return normalizedTransaction;
 }
 


### PR DESCRIPTION
## Explanation
This PR includes transaction type if it's `0x0` when normalising transactions

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

<!--
## References


Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **ADDED**: Includ `transaction?.type` when normalising transaction.


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
