### PR TITLE
Add r, s, v to TransactionMeta

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1707,6 +1707,37 @@ describe('TransactionController', () => {
       );
     });
 
+    it('verifies s,r and v values are correctly populated', async () => {
+      const controller = newController({
+        network: MOCK_LINEA_MAINNET_NETWORK,
+        config: {
+          sign: async (transaction: any) => {
+            transaction.r = '1b';
+            transaction.s = 'abc';
+            transaction.v = '123';
+            return transaction;
+          },
+        },
+      });
+
+      const { transactionMeta } = await controller.addTransaction({
+        from: ACCOUNT_MOCK,
+        gas: '0x0',
+        gasPrice: '0x50fd51da',
+        to: ACCOUNT_MOCK,
+        value: '0x0',
+      });
+
+      await controller.speedUpTransaction(transactionMeta.id);
+
+      const { transactions } = controller.state;
+      expect(transactions).toHaveLength(2);
+      const speedUpTransaction = transactions[1];
+      expect(speedUpTransaction.r).toBe('0x1b');
+      expect(speedUpTransaction.s).toBe('0xabc');
+      expect(speedUpTransaction.v).toBe('0x123');
+    });
+
     it('creates additional transaction specifying the gasPrice', async () => {
       const controller = newController({
         network: MOCK_LINEA_MAINNET_NETWORK,

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -79,6 +79,11 @@ type TransactionMetaBase = {
   origin?: string;
 
   /**
+   * The transaction's 'r' value as a hex string.
+   */
+  r?: string;
+
+  /**
    * Hex representation of the underlying transaction.
    */
   rawTx?: string;
@@ -92,6 +97,16 @@ type TransactionMetaBase = {
    * When the transaction is dropped, this is the replacement transaction ID.
    */
   replacedById?: string;
+
+  /**
+   * The transaction's 's' value as a hex string.
+   */
+  s?: string;
+
+  /**
+   * Response from security validator.
+   */
+  securityAlertResponse?: Record<string, unknown>;
 
   /**
    * The time the transaction was submitted to the network, in Unix epoch time (ms).
@@ -133,14 +148,14 @@ type TransactionMetaBase = {
   txReceipt?: TransactionReceipt;
 
   /**
+   * The transaction's 'v' value as a hex string.
+   */
+  v?: string;
+
+  /**
    * Whether the transaction is verified on the blockchain.
    */
   verifiedOnBlockchain?: boolean;
-
-  /**
-   * Response from security validator.
-   */
-  securityAlertResponse?: Record<string, unknown>;
 };
 
 /**


### PR DESCRIPTION
## Explanation
This PR aims to add `r`, `s` and `v` properties to `TransactionMeta` for context it has been included because the extension `TransactionController` populates `r`, `s`, and `v` values on the state after each signed transaction. 
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- ADDED: `r`, `s` and `v`  properties to `TransactionMeta`.
  - These properties are populated after a transaction is signed. 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
