### PR TITLE
Add `sendFlowHistory` to transactionMeta and `updateTransactionSendFlowHistory` function to public API

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 84.08,
-      functions: 93.66,
-      lines: 95.94,
-      statements: 96.02,
+      branches: 84.25,
+      functions: 93.05,
+      lines: 95.84,
+      statements: 95.92,
     },
   },
 

--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 84.22,
-      functions: 92.95,
-      lines: 95.74,
-      statements: 95.82,
+      branches: 84.08,
+      functions: 93.66,
+      lines: 95.94,
+      statements: 96.02,
     },
   },
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2020,6 +2020,41 @@ describe('TransactionController', () => {
         mockSendFlowHistory,
       );
     });
+
+    it('appends sendFlowHistory entries to existing entries in transaction meta', async () => {
+      const controller = newController();
+      const mockSendFlowHistory = [
+        {
+          entry:
+            'sendFlow - user selected transfer to my accounts on recipient screen',
+          timestamp: 1650663928211,
+        },
+      ];
+      const mockExistingSendFlowHistory = [
+        {
+          entry: 'sendFlow - user selected transfer to my accounts',
+          timestamp: 1650663928210,
+        },
+      ];
+      await controller.addTransaction({
+        from: ACCOUNT_MOCK,
+        to: ACCOUNT_MOCK,
+      }, {
+        sendFlowHistory: mockExistingSendFlowHistory,
+      });
+      const addedTxId = controller.state.transactions[0].id;
+      controller.updateTransactionSendFlowHistory(
+        addedTxId,
+        1,
+        mockSendFlowHistory,
+      );
+
+      expect(controller.state.transactions[0].sendFlowHistory).toStrictEqual([
+        ...mockExistingSendFlowHistory,
+        ...mockSendFlowHistory,
+      ]);
+    });
+
     it('doesnt append if current sendFlowHistory lengths doesnt match', async () => {
       const controller = newController();
       const mockSendFlowHistory = [
@@ -2044,6 +2079,7 @@ describe('TransactionController', () => {
         [],
       );
     });
+
     it('throws if sendFlowHistory persistence is disabled', async () => {
       const controller = newController({
         options: { disableSendFlowHistory: true },
@@ -2067,9 +2103,10 @@ describe('TransactionController', () => {
           mockSendFlowHistory,
         ),
       ).toThrow(
-        'Send flow history is disabled for the current transaction controller.',
+        'Send flow history is disabled for the current transaction controller',
       );
     });
+
     it('throws if transactionMeta is not found', async () => {
       const controller = newController();
       const mockSendFlowHistory = [
@@ -2089,6 +2126,7 @@ describe('TransactionController', () => {
         'Cannot update send flow history as no transaction metadata found',
       );
     });
+
     it('throws if the transaction is not unapproved status', async () => {
       const controller = newController();
       const mockSendFlowHistory = [

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2154,7 +2154,7 @@ describe('TransactionController', () => {
           mockSendFlowHistory,
         ),
       )
-        .toThrow(`TransactionsController: Can only call updateTransactionSendFlowHistory on an unapproved transaction.
+        .toThrow(`Can only call updateTransactionSendFlowHistory on an unapproved transaction.
       Current tx status: submitted`);
     });
   });

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2067,7 +2067,7 @@ describe('TransactionController', () => {
           mockSendFlowHistory,
         ),
       ).toThrow(
-        'TransactionsController: Send flow history is disabled for this instance of the controller.',
+        'Send flow history is disabled for the current transaction controller.',
       );
     });
     it('throws if transactionMeta is not found', async () => {
@@ -2086,7 +2086,7 @@ describe('TransactionController', () => {
           mockSendFlowHistory,
         ),
       ).toThrow(
-        'TransactionsController: updateTransactionSendFlowHistory called but transactionMeta not found.',
+        'Cannot update send flow history as no transaction metadata found',
       );
     });
     it('throws if the transaction is not unapproved status', async () => {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2036,12 +2036,15 @@ describe('TransactionController', () => {
           timestamp: 1650663928210,
         },
       ];
-      await controller.addTransaction({
-        from: ACCOUNT_MOCK,
-        to: ACCOUNT_MOCK,
-      }, {
-        sendFlowHistory: mockExistingSendFlowHistory,
-      });
+      await controller.addTransaction(
+        {
+          from: ACCOUNT_MOCK,
+          to: ACCOUNT_MOCK,
+        },
+        {
+          sendFlowHistory: mockExistingSendFlowHistory,
+        },
+      );
       const addedTxId = controller.state.transactions[0].id;
       controller.updateTransactionSendFlowHistory(
         addedTxId,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -924,7 +924,13 @@ describe('TransactionController', () => {
           operator: '0x92a3b9773b1763efa556f55ccbeb20441962d9b2',
         },
       };
-
+      const mockSendFlowHistory = [
+        {
+          entry:
+            'sendFlow - user selected transfer to my accounts on recipient screen',
+          timestamp: 1650663928211,
+        },
+      ];
       await controller.addTransaction(
         {
           from: ACCOUNT_MOCK,
@@ -934,6 +940,7 @@ describe('TransactionController', () => {
           deviceConfirmedOn: mockDeviceConfirmedOn,
           origin: mockOrigin,
           securityAlertResponse: mockSecurityAlertResponse,
+          sendFlowHistory: mockSendFlowHistory,
         },
       );
 
@@ -951,6 +958,9 @@ describe('TransactionController', () => {
         mockSecurityAlertResponse,
       );
       expect(transactionMeta.originalGasEstimate).toBe('0x0');
+      expect(controller.state.transactions[0].sendFlowHistory).toStrictEqual(
+        mockSendFlowHistory,
+      );
     });
 
     describe('adds dappSuggestedGasFees to transaction', () => {
@@ -1982,6 +1992,129 @@ describe('TransactionController', () => {
       expect(failedTx?.replacedById).toBe(externalTransactionId);
 
       expect(failedTx?.replacedBy).toBe(externalTransactionHash);
+    });
+  });
+
+  describe('updateTransactionSendFlowHistory', () => {
+    it('appends sendFlowHistory entries to transaction meta', async () => {
+      const controller = newController();
+      const mockSendFlowHistory = [
+        {
+          entry:
+            'sendFlow - user selected transfer to my accounts on recipient screen',
+          timestamp: 1650663928211,
+        },
+      ];
+      await controller.addTransaction({
+        from: ACCOUNT_MOCK,
+        to: ACCOUNT_MOCK,
+      });
+      const addedTxId = controller.state.transactions[0].id;
+      controller.updateTransactionSendFlowHistory(
+        addedTxId,
+        0,
+        mockSendFlowHistory,
+      );
+
+      expect(controller.state.transactions[0].sendFlowHistory).toStrictEqual(
+        mockSendFlowHistory,
+      );
+    });
+    it('doesnt append if current sendFlowHistory lengths doesnt match', async () => {
+      const controller = newController();
+      const mockSendFlowHistory = [
+        {
+          entry:
+            'sendFlow - user selected transfer to my accounts on recipient screen',
+          timestamp: 1650663928211,
+        },
+      ];
+      await controller.addTransaction({
+        from: ACCOUNT_MOCK,
+        to: ACCOUNT_MOCK,
+      });
+      const addedTxId = controller.state.transactions[0].id;
+      controller.updateTransactionSendFlowHistory(
+        addedTxId,
+        5,
+        mockSendFlowHistory,
+      );
+
+      expect(controller.state.transactions[0].sendFlowHistory).toStrictEqual(
+        [],
+      );
+    });
+    it('throws if sendFlowHistory persistence is disabled', async () => {
+      const controller = newController({
+        options: { disableSendFlowHistory: true },
+      });
+      const mockSendFlowHistory = [
+        {
+          entry:
+            'sendFlow - user selected transfer to my accounts on recipient screen',
+          timestamp: 1650663928211,
+        },
+      ];
+      await controller.addTransaction({
+        from: ACCOUNT_MOCK,
+        to: ACCOUNT_MOCK,
+      });
+      const addedTxId = controller.state.transactions[0].id;
+      expect(() =>
+        controller.updateTransactionSendFlowHistory(
+          addedTxId,
+          0,
+          mockSendFlowHistory,
+        ),
+      ).toThrow(
+        'TransactionsController: Send flow history is disabled for this instance of the controller.',
+      );
+    });
+    it('throws if transactionMeta is not found', async () => {
+      const controller = newController();
+      const mockSendFlowHistory = [
+        {
+          entry:
+            'sendFlow - user selected transfer to my accounts on recipient screen',
+          timestamp: 1650663928211,
+        },
+      ];
+      expect(() =>
+        controller.updateTransactionSendFlowHistory(
+          'foo',
+          0,
+          mockSendFlowHistory,
+        ),
+      ).toThrow(
+        'TransactionsController: updateTransactionSendFlowHistory called but transactionMeta not found.',
+      );
+    });
+    it('throws if the transaction is not unapproved status', async () => {
+      const controller = newController();
+      const mockSendFlowHistory = [
+        {
+          entry:
+            'sendFlow - user selected transfer to my accounts on recipient screen',
+          timestamp: 1650663928211,
+        },
+      ];
+      controller.state.transactions.push({
+        from: MOCK_PREFERENCES.state.selectedAddress,
+        id: 'foo',
+        networkID: '5',
+        chainId: toHex(5),
+        status: TransactionStatus.submitted,
+        transactionHash: '1337',
+      } as any);
+      expect(() =>
+        controller.updateTransactionSendFlowHistory(
+          'foo',
+          0,
+          mockSendFlowHistory,
+        ),
+      )
+        .toThrow(`TransactionsController: Can only call updateTransactionSendFlowHistory on an unapproved transaction.
+      Current tx status: submitted`);
     });
   });
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -993,7 +993,7 @@ export class TransactionController extends BaseController<
   ): TransactionMeta {
     if (this.isSendFlowHistoryDisabled) {
       throw new Error(
-        'TransactionsController: Send flow history is disabled for this instance of the controller.',
+        'Send flow history is disabled for the current transaction controller',
       );
     }
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1001,7 +1001,7 @@ export class TransactionController extends BaseController<
 
     if (!transactionMeta) {
       throw new Error(
-        `TransactionsController: updateTransactionSendFlowHistory called but transactionMeta not found.`,
+        `Cannot update send flow history as no transaction metadata found`,
       );
     }
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -978,8 +978,7 @@ export class TransactionController extends BaseController<
   }
 
   /**
-   * Appends new sendFlowHistoryToAdd to the transaction with the given transactionID
-   * if transaction is unapproved. Returns the updated transactionMeta.
+   * Append new send flow history to a transaction.
    *
    * @param transactionID - The ID of the transaction to update.
    * @param currentSendFlowHistoryLength - The length of the current sendFlowHistory array.

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -162,7 +162,7 @@ export type SendFlowHistoryEntry = {
 
   /**
    * Timestamp associated with this entry.
-   */ 
+   */
   timestamp: number;
 };
 

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -99,6 +99,12 @@ type TransactionMetaBase = {
   replacedById?: string;
 
   /**
+   * An array of entries that describe the user's journey through the send flow.
+   * This is purely attached to state logs for troubleshooting and support.
+   */
+  sendFlowHistory?: SendFlowHistoryEntry[];
+
+  /**
    * The time the transaction was submitted to the network, in Unix epoch time (ms).
    */
   submittedTime?: number;
@@ -358,4 +364,9 @@ export interface DappSuggestedGasFees {
   gasPrice?: string;
   maxFeePerGas?: string;
   maxPriorityFeePerGas?: string;
+}
+
+export interface SendFlowHistoryEntry {
+  entry: string;
+  timestamp: number;
 }

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -154,6 +154,18 @@ type TransactionMetaBase = {
   securityAlertResponse?: Record<string, unknown>;
 };
 
+export type SendFlowHistoryEntry = {
+  /**
+   * String to indicate user interaction information.
+   */
+  entry: string;
+
+  /**
+   * Timestamp associated with this entry.
+   */ 
+  timestamp: number;
+};
+
 /**
  * The status of the transaction. Each status represents the state of the transaction internally
  * in the wallet. Some of these correspond with the state of the transaction on the network, but
@@ -364,9 +376,4 @@ export interface DappSuggestedGasFees {
   gasPrice?: string;
   maxFeePerGas?: string;
   maxPriorityFeePerGas?: string;
-}
-
-export interface SendFlowHistoryEntry {
-  entry: string;
-  timestamp: number;
 }

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -246,7 +246,7 @@ export function validateIfTransactionUnapproved(
 ) {
   if (transactionMeta?.status !== TransactionStatus.unapproved) {
     throw new Error(
-      `TransactionsController: Can only call ${fnName} on an unapproved transaction.
+      `Can only call ${fnName} on an unapproved transaction.
       Current tx status: ${transactionMeta?.status}`,
     );
   }

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -10,7 +10,8 @@ import type {
   GasPriceValue,
   FeeMarketEIP1559Values,
 } from './TransactionController';
-import type { TransactionStatus, Transaction, TransactionMeta } from './types';
+import { TransactionStatus } from './types';
+import type { Transaction, TransactionMeta } from './types';
 
 export const ESTIMATE_GAS_ERROR = 'eth_estimateGas rpc method error';
 
@@ -230,4 +231,23 @@ export function transactionMatchesNetwork(
     return transaction.networkID === networkId;
   }
   return false;
+}
+
+/**
+ * Validates that a transaction is unapproved.
+ * Throws if the transaction is not unapproved.
+ *
+ * @param transactionMeta - The transaction metadata to check.
+ * @param fnName - The name of the function calling this helper.
+ */
+export function validateIfTransactionUnapproved(
+  transactionMeta: TransactionMeta | undefined,
+  fnName: string,
+) {
+  if (transactionMeta?.status !== TransactionStatus.unapproved) {
+    throw new Error(
+      `TransactionsController: Can only call ${fnName} on an unapproved transaction.
+      Current tx status: ${transactionMeta?.status}`,
+    );
+  }
 }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This PR aims to add `sendFlowHistory` property to the transaction metadata. 
`updateTransactionSendFlowHistory` also added in this PR which appends given `sendFlowHistory` with current state. 

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

Closes https://github.com/MetaMask/MetaMask-planning/issues/1096

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **BREAKING**: `disableSendFlowHistory` option added to the constructor.
  - This determines whether generate sendFlowHistory or not. 
  - This option should be explicitly set to `true` in mobile. (This is a BC for mobile)
  - Defaults to `false`
- **ADDED**:  Add `sendFlowHistory` property to transaction meta.
- **ADDED**:  Add `updateTransactionSendFlowHistory` function to the public API of the controller.

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've highlighted breaking changes using the "BREAKING" category above as appropriate
