### PR TITLE
Remove incoming transaction API key support

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 84.22,
-      functions: 92.95,
-      lines: 95.74,
-      statements: 95.82,
+      branches: 84.05,
+      functions: 92.3,
+      lines: 95.77,
+      statements: 95.86,
     },
   },
 

--- a/packages/transaction-controller/src/EtherscanRemoteTransactionSource.test.ts
+++ b/packages/transaction-controller/src/EtherscanRemoteTransactionSource.test.ts
@@ -190,6 +190,31 @@ describe('EtherscanRemoteTransactionSource', () => {
     });
   });
 
+  describe('getLastBlockVariations', () => {
+    it('returns normal if normal request', () => {
+      expect(
+        new EtherscanRemoteTransactionSource().getLastBlockVariations(),
+      ).toStrictEqual(['normal']);
+    });
+
+    it('returns token if token request', async () => {
+      const remoteSource = new EtherscanRemoteTransactionSource();
+      await remoteSource.fetchTransactions({} as any);
+
+      expect(remoteSource.getLastBlockVariations()).toStrictEqual(['token']);
+    });
+
+    it('always returns normal if token requests disabled', async () => {
+      const remoteSource = new EtherscanRemoteTransactionSource({
+        includeTokenTransfers: false,
+      });
+
+      await remoteSource.fetchTransactions({} as any);
+
+      expect(remoteSource.getLastBlockVariations()).toStrictEqual(['normal']);
+    });
+  });
+
   describe('fetchTransactions', () => {
     it('returns normalized transactions fetched from Etherscan', async () => {
       fetchEtherscanTransactionsMock.mockResolvedValueOnce(

--- a/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
@@ -28,15 +28,11 @@ import { TransactionStatus } from './types';
 export class EtherscanRemoteTransactionSource
   implements RemoteTransactionSource
 {
-  #apiKey?: string;
-
   #includeTokenTransfers: boolean;
 
   constructor({
-    apiKey,
     includeTokenTransfers,
-  }: { apiKey?: string; includeTokenTransfers?: boolean } = {}) {
-    this.#apiKey = apiKey;
+  }: { includeTokenTransfers?: boolean } = {}) {
     this.#includeTokenTransfers = includeTokenTransfers ?? true;
   }
 
@@ -49,7 +45,6 @@ export class EtherscanRemoteTransactionSource
   ): Promise<TransactionMeta[]> {
     const etherscanRequest: EtherscanTransactionRequest = {
       ...request,
-      apiKey: this.#apiKey,
       chainId: request.currentChainId,
     };
 

--- a/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
@@ -15,6 +15,7 @@ import {
   fetchEtherscanTokenTransactions,
   fetchEtherscanTransactions,
 } from './etherscan';
+import { incomingTransactionsLogger as log } from './logger';
 import type {
   RemoteTransactionSource,
   RemoteTransactionSourceRequest,
@@ -30,10 +31,13 @@ export class EtherscanRemoteTransactionSource
 {
   #includeTokenTransfers: boolean;
 
+  #isTokenRequestPending: boolean;
+
   constructor({
     includeTokenTransfers,
   }: { includeTokenTransfers?: boolean } = {}) {
     this.#includeTokenTransfers = includeTokenTransfers ?? true;
+    this.#isTokenRequestPending = false;
   }
 
   isSupportedNetwork(chainId: Hex, _networkId: string): boolean {
@@ -48,34 +52,64 @@ export class EtherscanRemoteTransactionSource
       chainId: request.currentChainId,
     };
 
-    const transactionPromise = fetchEtherscanTransactions(etherscanRequest);
+    const transactions = this.#isTokenRequestPending
+      ? await this.#fetchTokenTransactions(request, etherscanRequest)
+      : await this.#fetchNormalTransactions(request, etherscanRequest);
 
-    const tokenTransactionPromise = this.#includeTokenTransfers
-      ? fetchEtherscanTokenTransactions(etherscanRequest)
-      : Promise.resolve({
-          result: [] as EtherscanTokenTransactionMeta[],
-        } as EtherscanTransactionResponse<EtherscanTokenTransactionMeta>);
+    if (this.#includeTokenTransfers) {
+      this.#isTokenRequestPending = !this.#isTokenRequestPending;
+    }
 
-    const [etherscanTransactions, etherscanTokenTransactions] =
-      await Promise.all([transactionPromise, tokenTransactionPromise]);
+    return transactions;
+  }
 
-    const transactions = etherscanTransactions.result.map((tx) =>
-      this.#normalizeTransaction(
-        tx,
-        request.currentNetworkId,
-        request.currentChainId,
-      ),
+  #fetchNormalTransactions = async (
+    request: RemoteTransactionSourceRequest,
+    etherscanRequest: EtherscanTransactionRequest,
+  ) => {
+    const { currentNetworkId, currentChainId } = request;
+
+    const etherscanTransactions = await fetchEtherscanTransactions(
+      etherscanRequest,
     );
 
-    const tokenTransactions = etherscanTokenTransactions.result.map((tx) =>
-      this.#normalizeTokenTransaction(
-        tx,
-        request.currentNetworkId,
-        request.currentChainId,
-      ),
+    return this.#getResponseTransactions(etherscanTransactions).map((tx) =>
+      this.#normalizeTransaction(tx, currentNetworkId, currentChainId),
+    );
+  };
+
+  #fetchTokenTransactions = async (
+    request: RemoteTransactionSourceRequest,
+    etherscanRequest: EtherscanTransactionRequest,
+  ) => {
+    const { currentNetworkId, currentChainId } = request;
+
+    const etherscanTransactions = await fetchEtherscanTokenTransactions(
+      etherscanRequest,
     );
 
-    return [...transactions, ...tokenTransactions];
+    return this.#getResponseTransactions(etherscanTransactions).map((tx) =>
+      this.#normalizeTokenTransaction(tx, currentNetworkId, currentChainId),
+    );
+  };
+
+  #getResponseTransactions<T extends EtherscanTransactionMetaBase>(
+    response: EtherscanTransactionResponse<T>,
+  ): T[] {
+    let result = response.result as T[];
+
+    if (response.status === '0') {
+      result = [];
+
+      if (response.result.length) {
+        log('Ignored Etherscan request error', {
+          message: response.result,
+          type: this.#isTokenRequestPending ? 'token' : 'normal',
+        });
+      }
+    }
+
+    return result;
   }
 
   #normalizeTransaction(

--- a/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/EtherscanRemoteTransactionSource.ts
@@ -44,6 +44,10 @@ export class EtherscanRemoteTransactionSource
     return Object.keys(ETHERSCAN_SUPPORTED_NETWORKS).includes(chainId);
   }
 
+  getLastBlockVariations(): string[] {
+    return [this.#isTokenRequestPending ? 'token' : 'normal'];
+  }
+
   async fetchTransactions(
     request: RemoteTransactionSourceRequest,
   ): Promise<TransactionMeta[]> {

--- a/packages/transaction-controller/src/IncomingTransactionHelper.test.ts
+++ b/packages/transaction-controller/src/IncomingTransactionHelper.test.ts
@@ -30,6 +30,7 @@ const NETWORK_STATE_MOCK: NetworkState = {
 const ADDERSS_MOCK = '0x1';
 const FROM_BLOCK_HEX_MOCK = '0x20';
 const FROM_BLOCK_DECIMAL_MOCK = 32;
+const LAST_BLOCK_VARIATION_MOCK = 'test-variation';
 
 const BLOCK_TRACKER_MOCK = {
   addListener: jest.fn(),
@@ -68,9 +69,17 @@ const createRemoteTransactionSourceMock = (
   {
     isSupportedNetwork,
     error,
-  }: { isSupportedNetwork?: boolean; error?: boolean } = {},
+    noGetLastBlockVariations,
+  }: {
+    isSupportedNetwork?: boolean;
+    error?: boolean;
+    noGetLastBlockVariations?: boolean;
+  } = {},
 ): RemoteTransactionSource => ({
   isSupportedNetwork: jest.fn(() => isSupportedNetwork ?? true),
+  getLastBlockVariations: noGetLastBlockVariations
+    ? undefined
+    : jest.fn(() => [LAST_BLOCK_VARIATION_MOCK]),
   fetchTransactions: jest.fn(() =>
     error
       ? Promise.reject(new Error('Test Error'))
@@ -202,7 +211,7 @@ describe('IncomingTransactionHelper', () => {
           ...CONTROLLER_ARGS_MOCK,
           remoteTransactionSource,
           getLastFetchedBlockNumbers: () => ({
-            [`${NETWORK_STATE_MOCK.providerConfig.chainId}#${ADDERSS_MOCK}`]:
+            [`${NETWORK_STATE_MOCK.providerConfig.chainId}#${ADDERSS_MOCK}#${LAST_BLOCK_VARIATION_MOCK}`]:
               FROM_BLOCK_DECIMAL_MOCK,
           }),
         });
@@ -469,7 +478,7 @@ describe('IncomingTransactionHelper', () => {
         );
 
         expect(lastFetchedBlockNumbers).toStrictEqual({
-          [`${NETWORK_STATE_MOCK.providerConfig.chainId}#${ADDERSS_MOCK}`]:
+          [`${NETWORK_STATE_MOCK.providerConfig.chainId}#${ADDERSS_MOCK}#${LAST_BLOCK_VARIATION_MOCK}`]:
             parseInt(TRANSACTION_MOCK_2.blockNumber as string, 10),
         });
       });
@@ -527,7 +536,7 @@ describe('IncomingTransactionHelper', () => {
             TRANSACTION_MOCK_2,
           ]),
           getLastFetchedBlockNumbers: () => ({
-            [`${NETWORK_STATE_MOCK.providerConfig.chainId}#${ADDERSS_MOCK}`]:
+            [`${NETWORK_STATE_MOCK.providerConfig.chainId}#${ADDERSS_MOCK}#${LAST_BLOCK_VARIATION_MOCK}`]:
               parseInt(TRANSACTION_MOCK_2.blockNumber as string, 10),
           }),
         });
@@ -537,6 +546,25 @@ describe('IncomingTransactionHelper', () => {
         );
 
         expect(blockNumberListener).not.toHaveBeenCalled();
+      });
+
+      it('using no additional last block keys if remote source does not implement method', async () => {
+        const helper = new IncomingTransactionHelper({
+          ...CONTROLLER_ARGS_MOCK,
+          remoteTransactionSource: createRemoteTransactionSourceMock(
+            [TRANSACTION_MOCK_2],
+            { noGetLastBlockVariations: true },
+          ),
+        });
+
+        const { lastFetchedBlockNumbers } = await emitBlockTrackerLatestEvent(
+          helper,
+        );
+
+        expect(lastFetchedBlockNumbers).toStrictEqual({
+          [`${NETWORK_STATE_MOCK.providerConfig.chainId}#${ADDERSS_MOCK}`]:
+            parseInt(TRANSACTION_MOCK_2.blockNumber as string, 10),
+        });
       });
     });
   });

--- a/packages/transaction-controller/src/IncomingTransactionHelper.ts
+++ b/packages/transaction-controller/src/IncomingTransactionHelper.ts
@@ -3,8 +3,8 @@ import type { Hex } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 import EventEmitter from 'events';
 
+import { incomingTransactionsLogger as log } from './logger';
 import type { RemoteTransactionSource, TransactionMeta } from './types';
-import { incomingTransactionsLogger } from './logger';
 
 const RECENT_HISTORY_BLOCK_RANGE = 10;
 
@@ -12,8 +12,6 @@ const UPDATE_CHECKS: ((txMeta: TransactionMeta) => any)[] = [
   (txMeta) => txMeta.status,
   (txMeta) => txMeta.transaction.gasUsed,
 ];
-
-const log = incomingTransactionsLogger;
 
 export class IncomingTransactionHelper {
   hub: EventEmitter;

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -76,16 +76,6 @@ export interface Result {
   transactionMeta: TransactionMeta;
 }
 
-/**
- * @type Fetch All Options
- * @property fromBlock - String containing a specific block decimal number
- * @property etherscanApiKey - API key to be used to fetch token transactions
- */
-export interface FetchAllOptions {
-  fromBlock?: string;
-  etherscanApiKey?: string;
-}
-
 export interface GasPriceValue {
   gasPrice: string;
 }
@@ -232,7 +222,6 @@ export class TransactionController extends BaseController<
    * @param options.getNetworkState - Gets the state of the network controller.
    * @param options.getSelectedAddress - Gets the address of the currently selected account.
    * @param options.incomingTransactions - Configuration options for incoming transaction support.
-   * @param options.incomingTransactions.apiKey - An optional API key to use when fetching remote transaction data.
    * @param options.incomingTransactions.includeTokenTransfers - Whether or not to include ERC20 token transfers.
    * @param options.incomingTransactions.isEnabled - Whether or not incoming transaction retrieval is enabled.
    * @param options.incomingTransactions.queryEntireHistory - Whether to initially query the entire transaction history or only recent blocks.
@@ -257,7 +246,6 @@ export class TransactionController extends BaseController<
       getNetworkState: () => NetworkState;
       getSelectedAddress: () => string;
       incomingTransactions: {
-        apiKey?: string;
         includeTokenTransfers?: boolean;
         isEnabled?: () => boolean;
         queryEntireHistory?: boolean;
@@ -316,7 +304,6 @@ export class TransactionController extends BaseController<
       isEnabled: incomingTransactions.isEnabled,
       queryEntireHistory: incomingTransactions.queryEntireHistory,
       remoteTransactionSource: new EtherscanRemoteTransactionSource({
-        apiKey: incomingTransactions.apiKey,
         includeTokenTransfers: incomingTransactions.includeTokenTransfers,
       }),
       transactionLimit: this.config.txHistoryLimit,

--- a/packages/transaction-controller/src/etherscan.test.ts
+++ b/packages/transaction-controller/src/etherscan.test.ts
@@ -23,6 +23,7 @@ const REQUEST_MOCK: EtherscanTransactionRequest = {
 };
 
 const RESPONSE_MOCK: EtherscanTransactionResponse<EtherscanTransactionMeta> = {
+  status: '1',
   result: [
     { from: ADDERSS_MOCK, nonce: '0x1' } as EtherscanTransactionMeta,
     { from: ADDERSS_MOCK, nonce: '0x2' } as EtherscanTransactionMeta,
@@ -91,18 +92,6 @@ describe('Etherscan', () => {
           `&tag=latest` +
           `&page=1`,
       );
-    });
-
-    it('returns empty result if message is not ok', async () => {
-      handleFetchMock.mockResolvedValueOnce({
-        status: '0',
-        message: 'NOTOK',
-        result: 'test error',
-      });
-
-      const result = await (Etherscan as any)[method](REQUEST_MOCK);
-
-      expect(result).toStrictEqual({ result: [] });
     });
 
     it('throws if chain is not supported', async () => {

--- a/packages/transaction-controller/src/etherscan.test.ts
+++ b/packages/transaction-controller/src/etherscan.test.ts
@@ -20,7 +20,6 @@ const REQUEST_MOCK: EtherscanTransactionRequest = {
   chainId: CHAIN_IDS.GOERLI,
   limit: 3,
   fromBlock: 2,
-  apiKey: 'testApiKey',
 };
 
 const RESPONSE_MOCK: EtherscanTransactionResponse<EtherscanTransactionMeta> = {
@@ -62,33 +61,6 @@ describe('Etherscan', () => {
           `module=account` +
           `&address=${REQUEST_MOCK.address}` +
           `&startBlock=${REQUEST_MOCK.fromBlock}` +
-          `&apikey=${REQUEST_MOCK.apiKey}` +
-          `&offset=${REQUEST_MOCK.limit}` +
-          `&sort=desc` +
-          `&action=${action}` +
-          `&tag=latest` +
-          `&page=1`,
-      );
-    });
-
-    it('does not include API key in request if chain does not use standard Etherscan domain', async () => {
-      handleFetchMock.mockResolvedValueOnce(RESPONSE_MOCK);
-
-      await (Etherscan as any)[method]({
-        ...REQUEST_MOCK,
-        chainId: CHAIN_IDS.LINEA_MAINNET,
-      });
-
-      expect(handleFetchMock).toHaveBeenCalledTimes(1);
-      expect(handleFetchMock).toHaveBeenCalledWith(
-        `https://${
-          ETHERSCAN_SUPPORTED_NETWORKS[CHAIN_IDS.LINEA_MAINNET].subdomain
-        }.${
-          ETHERSCAN_SUPPORTED_NETWORKS[CHAIN_IDS.LINEA_MAINNET].domain
-        }/api?` +
-          `module=account` +
-          `&address=${REQUEST_MOCK.address}` +
-          `&startBlock=${REQUEST_MOCK.fromBlock}` +
           `&offset=${REQUEST_MOCK.limit}` +
           `&sort=desc` +
           `&action=${action}` +
@@ -113,7 +85,6 @@ describe('Etherscan', () => {
           `module=account` +
           `&address=${REQUEST_MOCK.address}` +
           `&startBlock=${REQUEST_MOCK.fromBlock}` +
-          `&apikey=${REQUEST_MOCK.apiKey}` +
           `&offset=${REQUEST_MOCK.limit}` +
           `&sort=desc` +
           `&action=${action}` +
@@ -122,16 +93,16 @@ describe('Etherscan', () => {
       );
     });
 
-    it('throws if message is not ok', async () => {
+    it('returns empty result if message is not ok', async () => {
       handleFetchMock.mockResolvedValueOnce({
         status: '0',
         message: 'NOTOK',
         result: 'test error',
       });
 
-      await expect((Etherscan as any)[method](REQUEST_MOCK)).rejects.toThrow(
-        'Etherscan request failed - test error',
-      );
+      const result = await (Etherscan as any)[method](REQUEST_MOCK);
+
+      expect(result).toStrictEqual({ result: [] });
     });
 
     it('throws if chain is not supported', async () => {
@@ -153,7 +124,6 @@ describe('Etherscan', () => {
       await (Etherscan as any)[method]({
         ...REQUEST_MOCK,
         fromBlock: undefined,
-        apiKey: undefined,
         limit: undefined,
       });
 

--- a/packages/transaction-controller/src/logger.ts
+++ b/packages/transaction-controller/src/logger.ts
@@ -1,0 +1,10 @@
+import { createProjectLogger, createModuleLogger } from '@metamask/utils';
+
+export const projectLogger = createProjectLogger('transaction-controller');
+
+export const incomingTransactionsLogger = createModuleLogger(
+  projectLogger,
+  'incoming-transactions',
+);
+
+export { createModuleLogger };

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -308,11 +308,6 @@ export interface RemoteTransactionSourceRequest {
   address: string;
 
   /**
-   * API key if required by the remote source.
-   */
-  apiKey?: string;
-
-  /**
    * The chainId of the current network.
    */
   currentChainId: Hex;

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -333,8 +333,22 @@ export interface RemoteTransactionSourceRequest {
  * Used by the IncomingTransactionHelper to retrieve remote transaction data.
  */
 export interface RemoteTransactionSource {
+  /**
+   * @param chainId - The chainId of the current network.
+   * @param networkId - The networkId of the current network.
+   * @returns Whether the remote transaction source supports the specified network.
+   */
   isSupportedNetwork: (chainId: Hex, networkId: string) => boolean;
 
+  /**
+   * @returns An array of additional keys to use when caching the last fetched block number.
+   */
+  getLastBlockVariations?: () => string[];
+
+  /**
+   * @param request - A request object containing data such as the address and chain ID.
+   * @returns An array of transaction metadata for the retrieved transactions.
+   */
   fetchTransactions: (
     request: RemoteTransactionSourceRequest,
   ) => Promise<TransactionMeta[]>;


### PR DESCRIPTION
## Explanation

Addresses legacy issues from the mobile client concerning incoming transactions, specifically:

- Removes support for Etherscan API keys as no client is using them in production.
- Prevents rate limit errors in Etherscan requests by alternating between normal and token requests on each poll.
- Updates the last fetched block cache to maintain separate entries for `normal` and `token` transactions.
- Moves Etherscan error parsing to `EtherscanRemoteTransactionSource` for better encapsulation.
- Adds optional logging to the incoming transactions logic for easier debug.

## Changelog

### `@metamask/transaction-controller`

- **BREAKING**: Remove `apiKey` property from `RemoteTransactionSourceRequest` type.
- **BREAKING**: Remove unused `FetchAllOptions` type from `TransactionController`.
- **BREAKING**: Remove `incomingTransactions.apiKey` property from `TransactionController` constructor arguments.
- **ADDED**: Add optional `getLastBlockVariations` method to `RemoteTransactionSource` type.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
