### PR TITLE
Adding code changes to include blockaid response to transaction metadata to transaction controller patch branch

### DIFF
--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -346,6 +346,7 @@ export class TransactionController extends BaseController<
    * @param opts - Additional options to control how the transaction is added.
    * @param opts.deviceConfirmedOn - An enum to indicate what device confirmed the transaction.
    * @param opts.origin - The origin of the transaction request, such as a dApp hostname.
+   * @param opts.securityAlertResponse - Response from security validator.
    * @returns Object containing a promise resolving to the transaction hash if approved.
    */
   async addTransaction(
@@ -353,9 +354,11 @@ export class TransactionController extends BaseController<
     {
       deviceConfirmedOn,
       origin,
+      securityAlertResponse,
     }: {
       deviceConfirmedOn?: WalletDevice;
       origin?: string;
+      securityAlertResponse?: Record<string, unknown>;
     } = {},
   ): Promise<Result> {
     const { providerConfig, network } = this.getNetworkState();
@@ -373,6 +376,7 @@ export class TransactionController extends BaseController<
       transaction,
       deviceConfirmedOn,
       verifiedOnBlockchain: false,
+      securityAlertResponse,
     };
 
     try {

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -40,6 +40,11 @@ type TransactionMetaBase = {
   blockNumber?: string;
   deviceConfirmedOn?: WalletDevice;
   verifiedOnBlockchain?: boolean;
+
+  /**
+   * Response from security validator.
+   */
+  securityAlertResponse?: Record<string, unknown>;
 };
 
 /**


### PR DESCRIPTION
Cherry-picking https://github.com/MetaMask/core/pull/1636 into branch `refactor/transaction-controller-patch-mobile` used to create transaction controller patches.