### PR TITLE
Remove dormant proposed names

### DIFF
--- a/packages/name-controller/src/NameController.test.ts
+++ b/packages/name-controller/src/NameController.test.ts
@@ -227,6 +227,51 @@ describe('NameController', () => {
       });
     });
 
+    it('can clear saved name', () => {
+      const provider1 = createMockProvider(1);
+
+      const controller = new NameController({
+        ...CONTROLLER_ARGS_MOCK,
+        providers: [provider1],
+      });
+
+      controller.state.names = {
+        [NameType.ETHEREUM_ADDRESS]: {
+          [VALUE_MOCK]: {
+            [CHAIN_ID_MOCK]: {
+              name: NAME_MOCK,
+              sourceId: SOURCE_ID_MOCK,
+              proposedNamesLastUpdated: null,
+              proposedNames: {
+                [SOURCE_ID_MOCK]: [PROPOSED_NAME_MOCK, PROPOSED_NAME_2_MOCK],
+              },
+            },
+          },
+        },
+      };
+
+      controller.setName({
+        value: VALUE_MOCK,
+        type: NameType.ETHEREUM_ADDRESS,
+        name: null,
+      });
+
+      expect(controller.state.names).toStrictEqual({
+        [NameType.ETHEREUM_ADDRESS]: {
+          [VALUE_MOCK]: {
+            [CHAIN_ID_MOCK]: {
+              name: null,
+              sourceId: null,
+              proposedNamesLastUpdated: null,
+              proposedNames: {
+                [SOURCE_ID_MOCK]: [PROPOSED_NAME_MOCK, PROPOSED_NAME_2_MOCK],
+              },
+            },
+          },
+        },
+      });
+    });
+
     describe('throws if', () => {
       it.each([
         ['missing', undefined],
@@ -278,7 +323,7 @@ describe('NameController', () => {
             type: NameType.ETHEREUM_ADDRESS,
             name,
           } as any),
-        ).toThrow('Must specify a non-empty string for name.');
+        ).toThrow('Must specify a non-empty string or null for name.');
       });
 
       it.each([
@@ -309,6 +354,21 @@ describe('NameController', () => {
           } as any),
         ).toThrow(
           `Unknown source ID for type '${NameType.ETHEREUM_ADDRESS}': ${SOURCE_ID_MOCK}`,
+        );
+      });
+
+      it('source ID is set but name is being cleared', () => {
+        const controller = new NameController(CONTROLLER_ARGS_MOCK);
+
+        expect(() =>
+          controller.setName({
+            value: VALUE_MOCK,
+            type: NameType.ETHEREUM_ADDRESS,
+            name: null,
+            sourceId: SOURCE_ID_MOCK,
+          } as any),
+        ).toThrow(
+          `Cannot specify a source ID when clearing the saved name: ${SOURCE_ID_MOCK}`,
         );
       });
     });
@@ -398,7 +458,6 @@ describe('NameController', () => {
               proposedNames: {
                 [`${SOURCE_ID_MOCK}1`]: ['ShouldBeDeleted1'],
                 [`${SOURCE_ID_MOCK}2`]: ['ShouldBeDeleted2'],
-                [`${SOURCE_ID_MOCK}3`]: ['ShouldNotBeDeleted3'],
               },
             },
           },
@@ -426,7 +485,6 @@ describe('NameController', () => {
                   `${PROPOSED_NAME_MOCK}2`,
                   `${PROPOSED_NAME_MOCK}2_2`,
                 ],
-                [`${SOURCE_ID_MOCK}3`]: ['ShouldNotBeDeleted3'],
               },
             },
           },
@@ -448,6 +506,58 @@ describe('NameController', () => {
               `${PROPOSED_NAME_MOCK}2_2`,
             ],
             error: undefined,
+          },
+        },
+      });
+    });
+
+    it('removes proposed names if source ID not used by any provider', async () => {
+      const provider1 = createMockProvider(1);
+      const provider2 = createMockProvider(2);
+
+      const controller = new NameController({
+        ...CONTROLLER_ARGS_MOCK,
+        providers: [provider1, provider2],
+      });
+
+      controller.state.names = {
+        [NameType.ETHEREUM_ADDRESS]: {
+          [VALUE_MOCK]: {
+            [CHAIN_ID_MOCK]: {
+              name: null,
+              sourceId: null,
+              proposedNamesLastUpdated: 12,
+              proposedNames: {
+                [`${SOURCE_ID_MOCK}3`]: ['ShouldBeDeleted3'],
+              },
+            },
+          },
+        },
+      };
+
+      await controller.updateProposedNames({
+        value: VALUE_MOCK,
+        type: NameType.ETHEREUM_ADDRESS,
+      });
+
+      expect(controller.state.names).toStrictEqual({
+        [NameType.ETHEREUM_ADDRESS]: {
+          [VALUE_MOCK]: {
+            [CHAIN_ID_MOCK]: {
+              name: null,
+              sourceId: null,
+              proposedNamesLastUpdated: TIME_MOCK,
+              proposedNames: {
+                [`${SOURCE_ID_MOCK}1`]: [
+                  `${PROPOSED_NAME_MOCK}1`,
+                  `${PROPOSED_NAME_MOCK}1_2`,
+                ],
+                [`${SOURCE_ID_MOCK}2`]: [
+                  `${PROPOSED_NAME_MOCK}2`,
+                  `${PROPOSED_NAME_MOCK}2_2`,
+                ],
+              },
+            },
           },
         },
       });
@@ -848,10 +958,11 @@ describe('NameController', () => {
       it('updates entry using matching providers only', async () => {
         const provider1 = createMockProvider(1);
         const provider2 = createMockProvider(2);
+        const provider3 = createMockProvider(3);
 
         const controller = new NameController({
           ...CONTROLLER_ARGS_MOCK,
-          providers: [provider1, provider2],
+          providers: [provider1, provider2, provider3],
         });
 
         controller.state.names = {

--- a/packages/name-controller/src/NameController.ts
+++ b/packages/name-controller/src/NameController.ts
@@ -139,7 +139,7 @@ export class NameController extends BaseControllerV2<
     const { value, type, name, sourceId: requestSourceId } = request;
     const sourceId = requestSourceId ?? null;
 
-    this.#updateEntry(value, type, { name, sourceId: sourceId });
+    this.#updateEntry(value, type, { name, sourceId });
   }
 
   /**


### PR DESCRIPTION
## Explanation

Currently all proposed names are persisted in state until overridden with a new value. This means when a provider stops using a source ID, such as with the snaps provider, any associated proposed names persist indefinitely.

This change makes `updateProposeNames` remove any proposed names for any source IDs that are no longer used by any of the providers for the specified `type` such as `NameType.ETHEREUM_ADDRESS`.

Also updates the `SetNameRequest` type and associated validation to support removing a saved name using a `null` value.

## Changelog

### `@metamask/name-controller`

- **CHANGED**: Dormant proposed names are automatically removed when calling `updateProposedNames`.
- **CHANGED**: The `setName` method accepts a `null` value for the `name` property to enable removing saved names.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
