### PR TITLE
Add getKeyringsByType getKeyringForAccount getAccounts actions

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2033,6 +2033,64 @@ describe('KeyringController', () => {
         );
       });
     });
+
+    describe('getKeyringsByType', () => {
+      beforeEach(() => {
+        jest
+          .spyOn(KeyringController.prototype, 'getKeyringsByType')
+          .mockReturnValue([
+            {
+              type: 'HD Key Tree',
+              accounts: ['0x1234'],
+            },
+          ]);
+      });
+
+      it('should return correct keyring by type', async () => {
+        await withController(async ({ controller, messenger }) => {
+          messenger.call('KeyringController:getKeyringsByType', 'HD Key Tree');
+
+          expect(controller.getKeyringsByType).toHaveBeenCalledWith(
+            'HD Key Tree',
+          );
+        });
+      });
+    });
+
+    describe('getKeyringForAccount', () => {
+      beforeEach(() => {
+        jest
+          .spyOn(KeyringController.prototype, 'getKeyringForAccount')
+          .mockResolvedValue({
+            type: 'HD Key Tree',
+            accounts: ['0x1234'],
+          });
+      });
+
+      it('should return the keyring for the account', async () => {
+        await withController(async ({ controller, messenger }) => {
+          await messenger.call('KeyringController:getKeyringForAccount', '0x0');
+
+          expect(controller.getKeyringForAccount).toHaveBeenCalledWith('0x0');
+        });
+      });
+    });
+
+    describe('getAccounts', () => {
+      beforeEach(() => {
+        jest
+          .spyOn(KeyringController.prototype, 'getAccounts')
+          .mockResolvedValue(['0x1234']);
+      });
+
+      it('should return all accounts', async () => {
+        await withController(async ({ controller, messenger }) => {
+          await messenger.call('KeyringController:getAccounts');
+
+          expect(controller.getAccounts).toHaveBeenCalledWith();
+        });
+      });
+    });
   });
 });
 
@@ -2091,6 +2149,9 @@ function buildKeyringControllerMessenger(messenger = buildMessenger()) {
       'KeyringController:signTypedMessage',
       'KeyringController:decryptMessage',
       'KeyringController:getEncryptionPublicKey',
+      'KeyringController:getKeyringsByType',
+      'KeyringController:getKeyringForAccount',
+      'KeyringController:getAccounts',
     ],
     allowedEvents: [
       'KeyringController:stateChange',

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2035,7 +2035,7 @@ describe('KeyringController', () => {
     });
 
     describe('getKeyringsByType', () => {
-      beforeEach(() => {
+      it('should return correct keyring by type', async () => {
         jest
           .spyOn(KeyringController.prototype, 'getKeyringsByType')
           .mockReturnValue([
@@ -2044,9 +2044,6 @@ describe('KeyringController', () => {
               accounts: ['0x1234'],
             },
           ]);
-      });
-
-      it('should return correct keyring by type', async () => {
         await withController(async ({ controller, messenger }) => {
           messenger.call('KeyringController:getKeyringsByType', 'HD Key Tree');
 
@@ -2058,16 +2055,13 @@ describe('KeyringController', () => {
     });
 
     describe('getKeyringForAccount', () => {
-      beforeEach(() => {
+      it('should return the keyring for the account', async () => {
         jest
           .spyOn(KeyringController.prototype, 'getKeyringForAccount')
           .mockResolvedValue({
             type: 'HD Key Tree',
             accounts: ['0x1234'],
           });
-      });
-
-      it('should return the keyring for the account', async () => {
         await withController(async ({ controller, messenger }) => {
           await messenger.call('KeyringController:getKeyringForAccount', '0x0');
 
@@ -2077,13 +2071,10 @@ describe('KeyringController', () => {
     });
 
     describe('getAccounts', () => {
-      beforeEach(() => {
+      it('should return all accounts', async () => {
         jest
           .spyOn(KeyringController.prototype, 'getAccounts')
           .mockResolvedValue(['0x1234']);
-      });
-
-      it('should return all accounts', async () => {
         await withController(async ({ controller, messenger }) => {
           await messenger.call('KeyringController:getAccounts');
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -90,6 +90,21 @@ export type KeyringControllerGetEncryptionPublicKeyAction = {
   handler: KeyringController['getEncryptionPublicKey'];
 };
 
+export type KeyringControllerGetKeyringsByTypeAction = {
+  type: `${typeof name}:getKeyringsByType`;
+  handler: KeyringController['getKeyringsByType'];
+};
+
+export type KeyringControllerGetKeyringForAccountAction = {
+  type: `${typeof name}:getKeyringForAccount`;
+  handler: KeyringController['getKeyringForAccount'];
+};
+
+export type KeyringControllerGetAccountsAction = {
+  type: `${typeof name}:getAccounts`;
+  handler: KeyringController['getAccounts'];
+};
+
 export type KeyringControllerStateChangeEvent = {
   type: `${typeof name}:stateChange`;
   payload: [KeyringControllerState, Patch[]];
@@ -116,7 +131,10 @@ export type KeyringControllerActions =
   | KeyringControllerSignPersonalMessageAction
   | KeyringControllerSignTypedMessageAction
   | KeyringControllerDecryptMessageAction
-  | KeyringControllerGetEncryptionPublicKeyAction;
+  | KeyringControllerGetEncryptionPublicKeyAction
+  | KeyringControllerGetAccountsAction
+  | KeyringControllerGetKeyringsByTypeAction
+  | KeyringControllerGetKeyringForAccountAction;
 
 export type KeyringControllerEvents =
   | KeyringControllerStateChangeEvent
@@ -966,6 +984,21 @@ export class KeyringController extends BaseControllerV2<
     this.messagingSystem.registerActionHandler(
       `${name}:getEncryptionPublicKey`,
       this.getEncryptionPublicKey.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${name}:getAccounts`,
+      this.getAccounts.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${name}:getKeyringsByType`,
+      this.getKeyringsByType.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${name}:getKeyringForAccount`,
+      this.getKeyringForAccount.bind(this),
     );
   }
 


### PR DESCRIPTION
## Explanation

This PR adds actions to the KeyringController messenger to:

getKeyringsByType, getKeyringForAccount, getAccount actions to be used by the AccountsController in the extension.

## Changelog


### `@metamask/keyring-controller`

- **ADDED**: Keyring controller messenger actions:
- KeyringController:getKeyringsByType
- KeyringController:getKeyringForAccount
- KeyringController:getAccounts


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
