### PR TITLE
Add EIP-1559 compatibility validation for transaction creation

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -466,6 +466,8 @@ describe('TransactionController', () => {
       {
         blockTracker: finalNetwork.blockTracker,
         getNetworkState: () => finalNetwork.state,
+        getCurrentAccountEIP1559Compatibility: () => true,
+        getCurrentNetworkEIP1559Compatibility: () => true,
         messenger,
         onNetworkStateChange: finalNetwork.subscribe,
         provider: finalNetwork.provider,

--- a/packages/transaction-controller/src/utils.test.ts
+++ b/packages/transaction-controller/src/utils.test.ts
@@ -212,7 +212,7 @@ describe('utils', () => {
           false,
         ),
       ).toThrow(
-        ethErrors.rpc.invalidParams(
+        rpcErrors.invalidParams(
           'Invalid transaction params: params specify an EIP-1559 transaction but the current network does not support EIP-1559',
         ),
       );

--- a/packages/transaction-controller/src/utils.test.ts
+++ b/packages/transaction-controller/src/utils.test.ts
@@ -1,3 +1,4 @@
+import { ethErrors } from 'eth-rpc-errors';
 import type { Transaction as NonceTrackerTransaction } from 'nonce-tracker/dist/NonceTracker';
 
 import type {
@@ -141,6 +142,23 @@ describe('utils', () => {
           value: '1',
         } as any),
       ).not.toThrow();
+    });
+
+    it('throws if params specifies an EIP-1559 transaction but the current network does not support EIP-1559', () => {
+      expect(() =>
+        util.validateTxParams(
+          {
+            from: '0x3244e191f1b4903970224322180f1fbbc415696b',
+            maxFeePerGas: '2',
+            maxPriorityFeePerGas: '3',
+          } as any,
+          false,
+        ),
+      ).toThrow(
+        ethErrors.rpc.invalidParams(
+          'Invalid transaction params: params specify an EIP-1559 transaction but the current network does not support EIP-1559',
+        ),
+      );
     });
   });
 

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -71,7 +71,7 @@ export function validateTxParams(
   }
 
   if (isEIP1559Transaction(txParams) && !isEIP1559Compatible) {
-    throw ethErrors.rpc.invalidParams(
+    throw rpcErrors.invalidParams(
       'Invalid transaction params: params specify an EIP-1559 transaction but the current network does not support EIP-1559',
     );
   }

--- a/packages/transaction-controller/src/utils.ts
+++ b/packages/transaction-controller/src/utils.ts
@@ -3,6 +3,7 @@ import {
   isValidHexAddress,
 } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
+import { ethErrors } from 'eth-rpc-errors';
 import { addHexPrefix, isHexString } from 'ethereumjs-util';
 import type { Transaction as NonceTrackerTransaction } from 'nonce-tracker/dist/NonceTracker';
 
@@ -53,8 +54,12 @@ export function normalizeTxParams(txParams: TransactionParams) {
  * the event of any validation error.
  *
  * @param txParams - Transaction params object to validate.
+ * @param isEIP1559Compatible - whether or not the current network supports EIP-1559 transactions.
  */
-export function validateTxParams(txParams: TransactionParams) {
+export function validateTxParams(
+  txParams: TransactionParams,
+  isEIP1559Compatible = true,
+) {
   if (
     !txParams.from ||
     typeof txParams.from !== 'string' ||
@@ -62,6 +67,12 @@ export function validateTxParams(txParams: TransactionParams) {
   ) {
     throw new Error(
       `Invalid "from" address: ${txParams.from} must be a valid string.`,
+    );
+  }
+
+  if (isEIP1559Transaction(txParams) && !isEIP1559Compatible) {
+    throw ethErrors.rpc.invalidParams(
+      'Invalid transaction params: params specify an EIP-1559 transaction but the current network does not support EIP-1559',
     );
   }
 
@@ -111,14 +122,14 @@ export function validateTxParams(txParams: TransactionParams) {
  * @param txParams - Transaction params object to add.
  * @returns Boolean that is true if the transaction is EIP-1559 (has maxFeePerGas and maxPriorityFeePerGas), otherwise returns false.
  */
-export const isEIP1559Transaction = (txParams: TransactionParams): boolean => {
+export function isEIP1559Transaction(txParams: TransactionParams): boolean {
   const hasOwnProp = (obj: TransactionParams, key: string) =>
     Object.prototype.hasOwnProperty.call(obj, key);
   return (
     hasOwnProp(txParams, 'maxFeePerGas') &&
     hasOwnProp(txParams, 'maxPriorityFeePerGas')
   );
-};
+}
 
 export const validateGasValues = (
   gasValues: GasPriceValue | FeeMarketEIP1559Values,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR aims to include a validation existent in the Extension in the `TransactionController` core. The validation gets the current network and current account to check if they support EIP-1559 transactions. If the transaction is an EIP-1559 transaction, meaning it contains `maxFeePerGas` and `maxPriorityFeePerGas` values, but the network or account does not support EIP-1559, then an error is thrown.

In order to support it two callbacks are passed to the controller constructor  `getCurrentAccountEIP1559Compatibility`  and `getCurrentNetworkEIP1559Compatibility`.

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **BREAKING**: Add required `getCurrentAccountEIP1559Compatibility`  and `getCurrentNetworkEIP1559Compatibility` callback arguments to constructor.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
