### PR TITLE
Fix `addNewAccountForKeyring` for `CustodyKeyring`

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -35,6 +35,7 @@ import {
   KeyringTypes,
 } from './KeyringController';
 import MockEncryptor, { mockKey } from '../tests/mocks/mockEncryptor';
+import MockShallowGetAccountsKeyring from '../tests/mocks/mockShallowGetAccountsKeyring';
 
 jest.mock('uuid', () => {
   return {
@@ -173,6 +174,37 @@ describe('KeyringController', () => {
               preferences.updateIdentities.calledWith(
                 controller.state.keyrings[0].accounts,
               ),
+            ).toBe(true);
+            expect(preferences.setSelectedAddress.called).toBe(false);
+          },
+        );
+      });
+
+      it('should not throw when `keyring.getAccounts()` returns a shallow copy', async () => {
+        await withController(
+          {
+            keyringBuilders: [
+              keyringBuilderFactory(MockShallowGetAccountsKeyring),
+            ],
+          },
+          async ({ controller, initialState, preferences }) => {
+            const mockKeyring = await controller.addNewKeyring(
+              MockShallowGetAccountsKeyring.type,
+            );
+
+            const addedAccountAddress =
+              await controller.addNewAccountForKeyring(mockKeyring);
+
+            expect(controller.state.keyrings).toHaveLength(2);
+            expect(controller.state.keyrings[1].accounts).toHaveLength(1);
+            expect(addedAccountAddress).toBe(
+              controller.state.keyrings[1].accounts[0],
+            );
+            expect(
+              preferences.updateIdentities.calledWith([
+                ...initialState.keyrings[0].accounts,
+                addedAccountAddress,
+              ]),
             ).toBe(true);
             expect(preferences.setSelectedAddress.called).toBe(false);
           },

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -368,17 +368,21 @@ export class KeyringController extends BaseControllerV2<
     keyring: Keyring<Json>,
     accountCount?: number,
   ): Promise<Hex> {
-    const oldAccounts = await keyring.getAccounts();
+    const oldAccounts = await this.getAccounts();
 
     if (accountCount && oldAccounts.length !== accountCount) {
       if (accountCount > oldAccounts.length) {
         throw new Error('Account out of sequence');
       }
-      return oldAccounts[accountCount];
+
+      const existingAccount = oldAccounts[accountCount];
+      assertIsStrictHexString(existingAccount);
+
+      return existingAccount;
     }
 
     await this.#keyring.addNewAccount(keyring);
-    const addedAccountAddress = (await keyring.getAccounts()).find(
+    const addedAccountAddress = (await this.getAccounts()).find(
       (selectedAddress) => !oldAccounts.includes(selectedAddress),
     );
     assertIsStrictHexString(addedAccountAddress);

--- a/packages/keyring-controller/tests/mocks/mockShallowGetAccountsKeyring.ts
+++ b/packages/keyring-controller/tests/mocks/mockShallowGetAccountsKeyring.ts
@@ -1,0 +1,51 @@
+import type { Keyring, Json, Hex } from '@metamask/utils';
+
+/**
+ * A test keyring that returns a shallow copy of the accounts array
+ * when calling getAccounts().
+ *
+ * This is used to test the `KeyringController`'s behavior when using this
+ * keyring, to make sure that, for example, the keyring's
+ * accounts array is not not used to determinate the added account after
+ * an operation.
+ */
+export default class MockShallowGetAccountsKeyring implements Keyring<Json> {
+  static type = 'Mock Shallow getAccounts Keyring';
+
+  public type = MockShallowGetAccountsKeyring.type;
+
+  public accounts: Hex[];
+
+  constructor(_: any) {
+    this.accounts = [];
+  }
+
+  async serialize(): Promise<Json> {
+    return {};
+  }
+
+  async deserialize(state: { accounts: Hex[] }) {
+    if (state) {
+      this.accounts = state.accounts || [];
+    }
+  }
+
+  /**
+   * This method returns a shallow copy of the accounts array.
+   * This means that when mutating the internal account array, the
+   * array returned by this method could be also mutated, and vice-versa.
+   *
+   * @returns a shallow copy of the accounts array
+   */
+  async getAccounts(): Promise<Hex[]> {
+    // Shallow copy
+    return this.accounts;
+  }
+
+  // this fake method works only with n = 1
+  async addAccounts(_: number): Promise<Hex[]> {
+    const newAddress = `0x68612830F5E3e285E8EAcc06f19a31aEB446C5Ee`;
+    this.accounts.push(newAddress);
+    return [newAddress];
+  }
+}


### PR DESCRIPTION
## Explanation
Currently, the `addNewAccountForKeyring` method calls `keyring.getAccounts()` (where `keyring` is the arg passed to the func) to store a list of accounts and later diff it with a new one to determine the account added in the operation, and then return it.

### Problem
This strategy to find the new account does not work with `CustodyKeyring`:
`CustodyKeyring.getAccounts()` returns a *reference* to its `this.accounts` state property, which is stored in `oldAccounts`.  The reference is created [here](https://github.com/consensys-vertical-apps/metamask-institutional/blob/15610d6d184e11a47cb8b2bbb0d93b9c12763172/packages/custodyKeyring/src/CustodyKeyring.ts#L172).
As this is a reference, when we call `CustodyKeyring.getAccounts()` the second time and compare it with `oldAccounts`, what we are actually doing is compare an object with itself (instead of _an old version of itself_): this makes `addedAccountAddress` undefined, and the later `assertIsStrictHexString` throws an error.

### Solution
The easy solution could be, as this PR suggests, to use `this.getAccounts()` instead of `keyring.getAccounts()`, as the array returned by KeyringController will be a copied object, and we will be able to later call `this.getAccounts()` and compare the two copies, that will present hopefully a difference of one address that will be assigned to `addedAccountAddress` 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->
* Fixes #1700 

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/keyring-controller`

- **FIXED**: Fixed `addNewAccountForKeyring` for Keyrings like `CustodyKeyring`, which returns referenced objects when calling `getAccounts()`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
