### PR TITLE
Parameterize `NftController.addNft` by `networkClientId`

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -155,7 +155,6 @@ export class AssetsContractController extends BaseController<
     const provider = networkClientId
       ? this.getNetworkClientById(networkClientId).provider
       : this._provider;
-
     if (provider === undefined) {
       throw new Error(MISSING_PROVIDER_ERROR);
     }

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -155,6 +155,7 @@ export class AssetsContractController extends BaseController<
     const provider = networkClientId
       ? this.getNetworkClientById(networkClientId).provider
       : this._provider;
+
     if (provider === undefined) {
       throw new Error(MISSING_PROVIDER_ERROR);
     }

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -781,9 +781,7 @@ describe('NftController', () => {
       const { nftController } = setupController();
 
       const { selectedAddress, chainId } = nftController.config;
-      await nftController.addNft({
-        tokenAddress: '0x01',
-        tokenId: '1',
+      await nftController.addNft('0x01', '1', {
         nftMetadata: {
           name: 'name',
           image: 'image',
@@ -823,9 +821,7 @@ describe('NftController', () => {
         includeOnNftAdded: true,
       });
 
-      await nftController.addNft({
-        tokenAddress: '0x01',
-        tokenId: '1',
+      await nftController.addNft('0x01', '1', {
         nftMetadata: {
           name: 'name',
           image: 'image',
@@ -850,9 +846,7 @@ describe('NftController', () => {
       });
 
       const detectedUserAddress = '0x123';
-      await nftController.addNft({
-        tokenAddress: '0x01',
-        tokenId: '2',
+      await nftController.addNft('0x01', '2', {
         nftMetadata: {
           name: 'name',
           image: 'image',
@@ -906,11 +900,13 @@ describe('NftController', () => {
       const { selectedAddress, chainId } = nftController.config;
 
       await nftController.addNft('0x01', '1', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'standard',
-        favorite: false,
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+          favorite: false,
+        },
       });
 
       expect(
@@ -927,11 +923,13 @@ describe('NftController', () => {
       });
 
       await nftController.addNft('0x01', '1', {
-        name: 'name',
-        image: 'image-updated',
-        description: 'description',
-        standard: 'standard',
-        favorite: false,
+        nftMetadata: {
+          name: 'name',
+          image: 'image-updated',
+          description: 'description',
+          standard: 'standard',
+          favorite: false,
+        },
       });
 
       expect(
@@ -952,19 +950,23 @@ describe('NftController', () => {
       const { nftController } = setupController();
       const { selectedAddress, chainId } = nftController.config;
       await nftController.addNft('0x01', '1', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'standard',
-        favorite: false,
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+          favorite: false,
+        },
       });
 
       await nftController.addNft('0x01', '1', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'standard',
-        favorite: false,
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+          favorite: false,
+        },
       });
 
       expect(
@@ -1483,13 +1485,11 @@ describe('NftController', () => {
         description: 'description',
       });
 
-      await nftController.addNft(
-        '0x01234abcdefg',
-        '1234',
-        undefined,
-        { chainId: GOERLI.chainId, userAddress: '0x123' },
-        Source.Dapp,
-      );
+      await nftController.addNft('0x01234abcdefg', '1234', {
+        chainId: GOERLI.chainId,
+        userAddress: '0x123',
+        source: Source.Dapp,
+      });
 
       expect(nftController.state.allNftContracts).toStrictEqual({
         '0x123': {
@@ -1555,12 +1555,11 @@ describe('NftController', () => {
       await nftController.addNft(
         '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
         '123',
-        undefined,
         {
           userAddress: selectedAddress,
           chainId,
+          source: Source.Detected,
         },
-        Source.Detected,
       );
 
       expect(
@@ -1571,16 +1570,11 @@ describe('NftController', () => {
         nftController.state.allNftContracts[selectedAddress]?.[chainId],
       ).toBeUndefined();
 
-      await nftController.addNft(
-        ERC721_KUDOSADDRESS,
-        ERC721_KUDOS_TOKEN_ID,
-        undefined,
-        {
-          userAddress: selectedAddress,
-          chainId,
-        },
-        Source.Detected,
-      );
+      await nftController.addNft(ERC721_KUDOSADDRESS, ERC721_KUDOS_TOKEN_ID, {
+        userAddress: selectedAddress,
+        chainId,
+        source: Source.Detected,
+      });
 
       expect(
         nftController.state.allNfts[selectedAddress][chainId],
@@ -1642,24 +1636,18 @@ describe('NftController', () => {
       await nftController.addNft(
         '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
         '123',
-        undefined,
         {
           userAddress: selectedAddress,
           chainId,
+          source: Source.Detected,
         },
-        Source.Detected,
       );
 
-      await nftController.addNft(
-        ERC721_KUDOSADDRESS,
-        ERC721_KUDOS_TOKEN_ID,
-        undefined,
-        {
-          userAddress: selectedAddress,
-          chainId,
-        },
-        Source.Detected,
-      );
+      await nftController.addNft(ERC721_KUDOSADDRESS, ERC721_KUDOS_TOKEN_ID, {
+        userAddress: selectedAddress,
+        chainId,
+        source: Source.Detected,
+      });
 
       expect(nftController.state.allNfts).toStrictEqual({});
 
@@ -1673,17 +1661,21 @@ describe('NftController', () => {
       const { selectedAddress, chainId } = nftController.config;
 
       await nftController.addNft('0x01', '1', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'standard',
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+        },
       });
 
       await nftController.addNft('0x01', '2', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'standard',
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+        },
       });
 
       expect(
@@ -1698,10 +1690,12 @@ describe('NftController', () => {
       expect(nftController.state.ignoredNfts).toHaveLength(1);
 
       await nftController.addNft('0x01', '1', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'standard',
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+        },
       });
 
       expect(
@@ -2015,10 +2009,12 @@ describe('NftController', () => {
       const { selectedAddress, chainId } = nftController.config;
 
       await nftController.addNft('0x01', '1', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'standard',
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+        },
       });
       nftController.removeNft('0x01', '1');
       expect(
@@ -2035,17 +2031,21 @@ describe('NftController', () => {
       const { selectedAddress, chainId } = nftController.config;
 
       await nftController.addNft('0x01', '1', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'standard',
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+        },
       });
 
       await nftController.addNft('0x01', '2', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'standard',
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+        },
       });
       nftController.removeNft('0x01', '1');
       expect(
@@ -2125,11 +2125,13 @@ describe('NftController', () => {
     const { selectedAddress, chainId } = nftController.config;
 
     await nftController.addNft('0x02', '1', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
-      favorite: false,
+      nftMetadata: {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+        favorite: false,
+      },
     });
 
     expect(nftController.state.allNfts[selectedAddress][chainId]).toHaveLength(
@@ -2457,10 +2459,12 @@ describe('NftController', () => {
         ERC721_DEPRESSIONIST_ADDRESS,
         ERC721_DEPRESSIONIST_ID,
         {
-          image: 'new_image',
-          name: 'new_name',
-          description: 'new_description',
-          standard: 'ERC721',
+          nftMetadata: {
+            image: 'new_image',
+            name: 'new_name',
+            description: 'new_description',
+            standard: 'ERC721',
+          },
         },
       );
 
@@ -2506,10 +2510,12 @@ describe('NftController', () => {
         ERC721_DEPRESSIONIST_ADDRESS,
         ERC721_DEPRESSIONIST_ID,
         {
-          image: 'new_image',
-          name: 'new_name',
-          description: 'new_description',
-          standard: 'ERC721',
+          nftMetadata: {
+            image: 'new_image',
+            name: 'new_name',
+            description: 'new_description',
+            standard: 'ERC721',
+          },
         },
       );
 
@@ -2540,11 +2546,13 @@ describe('NftController', () => {
 
           const { selectedAddress, chainId } = nftController.config;
           await nftController.addNft('0x02', '1', {
-            name: 'name',
-            image: 'image',
-            description: 'description',
-            standard: 'standard',
-            favorite: false,
+            nftMetadata: {
+              name: 'name',
+              image: 'image',
+              description: 'description',
+              standard: 'standard',
+              favorite: false,
+            },
           });
 
           expect(
@@ -2566,11 +2574,13 @@ describe('NftController', () => {
 
         const { selectedAddress, chainId } = nftController.config;
         await nftController.addNft('0x02', '1', {
-          name: 'name',
-          image: 'image',
-          description: 'description',
-          standard: 'standard',
-          favorite: false,
+          nftMetadata: {
+            name: 'name',
+            image: 'image',
+            description: 'description',
+            standard: 'standard',
+            favorite: false,
+          },
         });
 
         expect(
@@ -2593,11 +2603,13 @@ describe('NftController', () => {
 
         const { selectedAddress, chainId } = nftController.config;
         await nftController.addNft('0x02', '1', {
-          name: 'name',
-          image: 'image',
-          description: 'description',
-          standard: 'standard',
-          favorite: false,
+          nftMetadata: {
+            name: 'name',
+            image: 'image',
+            description: 'description',
+            standard: 'standard',
+            favorite: false,
+          },
         });
 
         expect(
@@ -2626,7 +2638,9 @@ describe('NftController', () => {
             favorite: false,
           };
 
-          await nftController.addNft(nft.address, nft.tokenId, nft);
+          await nftController.addNft(nft.address, nft.tokenId, {
+            nftMetadata: nft,
+          });
 
           expect(
             nftController.state.allNfts[selectedAddress][chainId][0]
@@ -2660,7 +2674,9 @@ describe('NftController', () => {
           favorite: false,
         };
 
-        await nftController.addNft(nft.address, nft.tokenId, nft);
+        await nftController.addNft(nft.address, nft.tokenId, {
+          nftMetadata: nft,
+        });
 
         expect(
           nftController.state.allNfts[selectedAddress][chainId][0]
@@ -2697,7 +2713,9 @@ describe('NftController', () => {
           favorite: false,
         };
 
-        await nftController.addNft(nft.address, nft.tokenId, nft);
+        await nftController.addNft(nft.address, nft.tokenId, {
+          nftMetadata: nft,
+        });
 
         expect(
           nftController.state.allNfts[selectedAddress][chainId][0]

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -212,6 +212,7 @@ function setupController({
     getERC1155TokenURI:
       getERC1155TokenURIStub ??
       assetsContract.getERC1155TokenURI.bind(assetsContract),
+    getNetworkClientById: jest.fn(),
     onNftAdded: onNftAddedSpy,
     messenger: nftControllerMessenger,
   });
@@ -780,12 +781,16 @@ describe('NftController', () => {
       const { nftController } = setupController();
 
       const { selectedAddress, chainId } = nftController.config;
-      await nftController.addNft('0x01', '1', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'standard',
-        favorite: false,
+      await nftController.addNft({
+        tokenAddress: '0x01',
+        tokenId: '1',
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+          favorite: false,
+        },
       });
 
       expect(
@@ -818,12 +823,16 @@ describe('NftController', () => {
         includeOnNftAdded: true,
       });
 
-      await nftController.addNft('0x01', '1', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'ERC1155',
-        favorite: false,
+      await nftController.addNft({
+        tokenAddress: '0x01',
+        tokenId: '1',
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'ERC1155',
+          favorite: false,
+        },
       });
 
       expect(onNftAddedSpy).toHaveBeenCalledWith({
@@ -841,19 +850,20 @@ describe('NftController', () => {
       });
 
       const detectedUserAddress = '0x123';
-      await nftController.addNft(
-        '0x01',
-        '2',
-        {
+      await nftController.addNft({
+        tokenAddress: '0x01',
+        tokenId: '2',
+        nftMetadata: {
           name: 'name',
           image: 'image',
           description: 'description',
           standard: 'ERC721',
           favorite: false,
         },
-        { userAddress: detectedUserAddress, chainId: toHex(2) },
-        Source.Detected,
-      );
+        userAddress: detectedUserAddress,
+        chainId: toHex(2),
+        source: Source.Detected,
+      });
 
       expect(onNftAddedSpy).toHaveBeenCalledWith({
         source: 'detected',

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -596,7 +596,6 @@ describe('NftController', () => {
       // change the network and selectedAddress before accepting the request
       preferences.setSelectedAddress('0xDifferentAddress');
       changeNetwork(SEPOLIA);
-
       // now accept the request
       approvalController.accept(requestId);
       await acceptedRequest;

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -1965,7 +1965,7 @@ describe('NftController', () => {
       });
     });
 
-    it('should, when passed a networkClientId, add an NFT with the correct chainId and metadata fetched using networkClientId', async () => {
+    it('should add an NFT with the correct chainId and metadata when passed a networkClientId', async () => {
       nock('https://testtokenuri-1.com')
         .get('/')
         .reply(
@@ -2041,11 +2041,7 @@ describe('NftController', () => {
               },
             };
           default:
-            return {
-              configuration: {
-                chainId: '0x1',
-              },
-            };
+            throw new Error('Invalid network client id');
         }
       });
 
@@ -2365,7 +2361,6 @@ describe('NftController', () => {
   });
 
   describe('isNftOwner', () => {
-    // ANCHOR
     it('should verify the ownership of an NFT when passed a networkClientId', async () => {
       nock('https://sepolia.infura.io:443', { encodedQueryParams: true })
         .post('/v3/ad3a368836ff4596becc3be8e2f137ac', {
@@ -2387,12 +2382,10 @@ describe('NftController', () => {
             '0x0000000000000000000000005a3CA5cD63807Ce5e4d7841AB32Ce6B6d9BbBa2D',
         });
       const { nftController, getNetworkClientByIdSpy } = setupController();
-      // const contractAddress = '0x2b26675403a063d92ccad0293d387485471a7d3a';
       getNetworkClientByIdSpy.mockImplementation(() => ({
         provider: SEPOLIA_PROVIDER,
       }));
 
-      // assetsContract.configure({ provider: MAINNET_PROVIDER });
       const isOwner = await nftController.isNftOwner(
         OWNER_ADDRESS,
         '0x2b26675403a063d92ccad0293d387485471a7d3a',

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1109,7 +1109,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
 
   // temporary method to get the correct chainId until we remove chainId from the config & the chainId arg from the detection logic
   // Just a helper method to prefer the networkClient chainId first then the chainId argument and then finally the config chainId
-  getCorrectChainId({
+  private getCorrectChainId({
     chainId,
     networkClientId,
   }: {
@@ -1210,10 +1210,15 @@ export class NftController extends BaseController<NftConfig, NftState> {
   ): Promise<boolean> {
     // Checks the ownership for ERC-721.
     try {
-      const owner = await this.getERC721OwnerOf(nftAddress, tokenId);
+      const owner = await this.getERC721OwnerOf(
+        nftAddress,
+        tokenId,
+        networkClientId,
+      );
       return ownerAddress.toLowerCase() === owner.toLowerCase();
       // eslint-disable-next-line no-empty
-    } catch {
+    } catch (e) {
+      console.log('ERRRROR:', e);
       // Ignore ERC-721 contract error
     }
 

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -276,7 +276,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     contractAddress: string,
     tokenId: string,
   ): Promise<NftMetadata> {
-    // TODO Parameterize this by chainId
+    // TODO Parameterize this by chainId for non-mainnet token detection
     // Attempt to fetch the data with the proxy
     const nftInformation: ApiNft | undefined = await fetchWithErrorHandling({
       url: this.getNftApi({

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -599,13 +599,14 @@ export class NftController extends BaseController<NftConfig, NftState> {
       );
     });
 
-    let { chainId } = this.config;
-    if (networkClientId) {
-      chainId =
-        this.getNetworkClientById(networkClientId).configuration.chainId;
-    }
+    const { chainId } = this.config;
+    const getCurrentChainId = this.getCorrectChainId({
+      chainId,
+      networkClientId,
+    });
+
     let openSeaContractData: Partial<ApiNftContract> | undefined;
-    if (this.config.openSeaEnabled && chainId === '0x1') {
+    if (this.config.openSeaEnabled && getCurrentChainId === '0x1') {
       openSeaContractData = await safelyExecute(async () => {
         return await this.getNftContractInformationFromApi(contractAddress);
       });
@@ -748,7 +749,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     chainId,
     userAddress,
     networkClientId,
-    source,
+    source = Source.Custom,
   }: {
     tokenAddress: string;
     chainId?: Hex;
@@ -1247,11 +1248,13 @@ export class NftController extends BaseController<NftConfig, NftState> {
    * @param address - Hex address of the NFT contract.
    * @param tokenId - The NFT identifier.
    * @param networkClientId - The networkClientId that can be used to identify the network client to use for this request.
+   * @param source - Whether the NFT was detected, added manually or suggested by a dapp.
    */
   async addNftVerifyOwnership(
     address: string,
     tokenId: string,
     networkClientId?: NetworkClientId,
+    source?: Source,
   ) {
     const { selectedAddress } = this.config;
     if (
@@ -1264,7 +1267,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     ) {
       throw new Error('This NFT is not owned by the user');
     }
-    await this.addNft(address, tokenId, { networkClientId });
+    await this.addNft(address, tokenId, { networkClientId, source });
   }
 
   /**

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1281,8 +1281,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     tokenId: string,
     {
       nftMetadata,
-      // TODO remove and replace chainId arg with fetch chainId using getNetworkClientById(networkClientId).configuration.chainId once polling refactor is complete
-      chainId,
+      chainId, // TODO remove and replace chainId arg with fetch chainId using getNetworkClientById(networkClientId).configuration.chainId once polling refactor is complete
       userAddress,
       source,
       networkClientId,

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1289,7 +1289,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
       userAddress?: string;
       source?: Source;
       networkClientId?: NetworkClientId;
-    } = { source: Source.Custom },
+    } = {},
   ) {
     tokenAddress = toChecksumHexAddress(tokenAddress);
 

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -658,7 +658,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     nftContract,
     chainId,
     userAddress,
-    source = Source.Custom,
+    source,
   }: {
     tokenAddress: string;
     tokenId: string;
@@ -749,7 +749,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
     chainId,
     userAddress,
     networkClientId,
-    source = Source.Custom,
+    source,
   }: {
     tokenAddress: string;
     chainId?: Hex;
@@ -1294,7 +1294,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
       networkClientId,
     }: {
       nftMetadata?: NftMetadata;
-      chainId?: Hex; // TODO remove
+      chainId?: Hex;
       userAddress?: string;
       source?: Source;
       networkClientId?: NetworkClientId;
@@ -1310,7 +1310,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
       chainId: currentChainId,
       userAddress: selectedAddress,
       networkClientId,
-      source,
+      source: source ?? Source.Custom,
     });
 
     nftMetadata =
@@ -1332,7 +1332,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
         nftContract,
         userAddress: selectedAddress,
         chainId: currentChainId,
-        source,
+        source: source ?? Source.Custom,
       });
     }
   }

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1217,8 +1217,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
       );
       return ownerAddress.toLowerCase() === owner.toLowerCase();
       // eslint-disable-next-line no-empty
-    } catch (e) {
-      console.log('ERRRROR:', e);
+    } catch {
       // Ignore ERC-721 contract error
     }
 

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -641,33 +641,24 @@ export class NftController extends BaseController<NftConfig, NftState> {
   /**
    * Adds an individual NFT to the stored NFT list.
    *
-   * @param options - options.
-   * @param options.tokenAddress - Hex address of the NFT contract.
-   * @param options.tokenId - The NFT identifier.
-   * @param options.nftMetadata - NFT optional information (name, image and description).
-   * @param options.nftContract - An object containing contract data of the NFT being added.
-   * @param options.chainId - The chainId of the network where the NFT is being added.
-   * @param options.userAddress - The address of the account where the NFT is being added.
-   * @param options.source - Whether the NFT was detected, added manually or suggested by a dapp.
+   * @param tokenAddress - Hex address of the NFT contract.
+   * @param tokenId - The NFT identifier.
+   * @param nftMetadata - NFT optional information (name, image and description).
+   * @param nftContract - An object containing contract data of the NFT being added.
+   * @param chainId - The chainId of the network where the NFT is being added.
+   * @param userAddress - The address of the account where the NFT is being added.
+   * @param source - Whether the NFT was detected, added manually or suggested by a dapp.
    * @returns Promise resolving to the current NFT list.
    */
-  private async addIndividualNft({
-    tokenAddress,
-    tokenId,
-    nftMetadata,
-    nftContract,
-    chainId,
-    userAddress,
-    source,
-  }: {
-    tokenAddress: string;
-    tokenId: string;
-    nftMetadata: NftMetadata;
-    nftContract: NftContract;
-    chainId: Hex;
-    userAddress: string;
-    source?: Source;
-  }): Promise<Nft[]> {
+  private async addIndividualNft(
+    tokenAddress: string,
+    tokenId: string,
+    nftMetadata: NftMetadata,
+    nftContract: NftContract,
+    chainId: Hex,
+    userAddress: string,
+    source: Source,
+  ): Promise<Nft[]> {
     // TODO: Remove unused return
     const releaseLock = await this.mutex.acquire();
     try {
@@ -723,7 +714,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
           symbol: nftContract.symbol,
           tokenId: tokenId.toString(),
           standard: nftMetadata.standard,
-          source: source ?? Source.Custom,
+          source,
         });
       }
 
@@ -1290,7 +1281,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
       nftMetadata,
       chainId, // TODO remove and replace chainId arg with fetch chainId using getNetworkClientById(networkClientId).configuration.chainId once polling refactor is complete
       userAddress,
-      source,
+      source = Source.Custom,
       networkClientId,
     }: {
       nftMetadata?: NftMetadata;
@@ -1310,7 +1301,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
       chainId: currentChainId,
       userAddress: selectedAddress,
       networkClientId,
-      source: source ?? Source.Custom,
+      source,
     });
 
     nftMetadata =
@@ -1325,15 +1316,15 @@ export class NftController extends BaseController<NftConfig, NftState> {
 
     // If NFT contract information, add individual NFT
     if (nftContract) {
-      await this.addIndividualNft({
+      await this.addIndividualNft(
         tokenAddress,
         tokenId,
         nftMetadata,
         nftContract,
-        userAddress: selectedAddress,
-        chainId: currentChainId,
-        source: source ?? Source.Custom,
-      });
+        currentChainId,
+        selectedAddress,
+        source,
+      );
     }
   }
 

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -723,7 +723,7 @@ export class NftController extends BaseController<NftConfig, NftState> {
           symbol: nftContract.symbol,
           tokenId: tokenId.toString(),
           standard: nftMetadata.standard,
-          source,
+          source: source ?? Source.Custom,
         });
       }
 

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -56,6 +56,7 @@ describe('NftDetectionController', () => {
       getERC1155TokenURI:
         assetsContract.getERC1155TokenURI.bind(assetsContract),
       onNftAdded: jest.fn(),
+      getNetworkClientById: jest.fn(),
       messenger,
     });
 
@@ -346,10 +347,12 @@ describe('NftDetectionController', () => {
       '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',
       '2573',
       {
-        description: 'Description 2573',
-        image: 'image/2573.png',
-        name: 'ID 2573',
-        standard: 'ERC721',
+        nftMetadata: {
+          description: 'Description 2573',
+          image: 'image/2573.png',
+          name: 'ID 2573',
+          standard: 'ERC721',
+        },
       },
     );
 

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -372,9 +372,7 @@ export class NftDetectionController extends BaseController<
           last_sale && { lastSale: last_sale },
         );
 
-        await this.addNft({
-          tokenAddress: address,
-          tokenId: token_id,
+        await this.addNft(address, token_id, {
           nftMetadata,
           userAddress: selectedAddress,
           chainId,

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -372,16 +372,14 @@ export class NftDetectionController extends BaseController<
           last_sale && { lastSale: last_sale },
         );
 
-        await this.addNft(
-          address,
-          token_id,
+        await this.addNft({
+          tokenAddress: address,
+          tokenId: token_id,
           nftMetadata,
-          {
-            userAddress: selectedAddress,
-            chainId,
-          },
-          Source.Detected,
-        );
+          userAddress: selectedAddress,
+          chainId,
+          source: Source.Detected,
+        });
       }
     });
     await Promise.all(addNftPromises);


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/MetaMask-planning/issues/1022

# Changelog

## @metamask/assets-controllers

- **BREAKING:** `NFTController` now expects `getNetworkClientById` in constructor options
- **BREAKING:** `NftController. addNft()` function signature has changed:
   - Previously 
   ```
    address: string,
    tokenId: string,
    nftMetadata?: NftMetadata,
    accountParams?: {
       userAddress: string;
       chainId: Hex;
    },
    source = Source.Custom,
   ```
   now:
   ```
    tokenAddress: string,
    tokenId: string,
      {
      nftMetadata?: NftMetadata;
      chainId?: Hex; // extracts from AccountParams
      userAddress?: string // extracted from AccountParams
      source?: Source;
      networkClientId?: NetworkClientId; // new
    },
    ```
    
- CHANGED: `NftController.addNftVerifyOwnership`: now accepts optional `networkClientId` which is used to fetch NFT metadata and determine by which chainId the added NFT should be stored in state.
- CHANGED: `NftController.isNftOwner`:  now accepts optional `networkClientId` which is used to instantiate the provider for the correct chain and call the NFT contract to verify ownership.
- CHANGED: `NftController. addNft()` will use the chainId value derived from `networkClientId` if provided
- CHANGED: `NftController. watchNft()` options now accepts optional `networkClientId` which is used to fetch NFT metadata and determine by which chainId the added NFT should be stored in state.

