### PR TITLE
Subscribe to `QRKeyring` store and publish updates

### DIFF
--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -889,11 +889,7 @@ export class KeyringController extends BaseControllerV2<
    * @returns The added keyring
    */
   async getOrAddQRKeyring(): Promise<QRKeyring> {
-    const keyring =
-      (this.#keyring.getKeyringsByType(
-        KeyringTypes.qr,
-      )[0] as unknown as QRKeyring) || (await this.#addQRKeyring());
-    return keyring;
+    return this.getQRKeyring() || (await this.#addQRKeyring());
   }
 
   async restoreQRKeyring(serialized: any): Promise<void> {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1,7 +1,7 @@
 import type { TxData, TypedTransaction } from '@ethereumjs/tx';
-import {
-  type MetaMaskKeyring as QRKeyring,
-  type IKeyringState as IQRKeyringState,
+import type {
+  MetaMaskKeyring as QRKeyring,
+  IKeyringState as IQRKeyringState,
 } from '@keystonehq/metamask-airgapped-keyring';
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
 import { BaseControllerV2 } from '@metamask/base-controller';
@@ -125,6 +125,11 @@ export type KeyringControllerUnlockEvent = {
   payload: [];
 };
 
+export type KeyringControllerQRKeyringStateChangeEvent = {
+  type: `${typeof name}:qrKeyringStateChange`;
+  payload: [ReturnType<IQRKeyringState['getState']>];
+};
+
 export type KeyringControllerActions =
   | KeyringControllerGetStateAction
   | KeyringControllerSignMessageAction
@@ -140,7 +145,8 @@ export type KeyringControllerEvents =
   | KeyringControllerStateChangeEvent
   | KeyringControllerLockEvent
   | KeyringControllerUnlockEvent
-  | KeyringControllerAccountRemovedEvent;
+  | KeyringControllerAccountRemovedEvent
+  | KeyringControllerQRKeyringStateChangeEvent;
 
 export type KeyringControllerMessenger = RestrictedControllerMessenger<
   typeof name,
@@ -245,6 +251,10 @@ export class KeyringController extends BaseControllerV2<
   private readonly setAccountLabel?: PreferencesController['setAccountLabel'];
 
   #keyring: EthKeyringController;
+
+  #qrKeyringStateListener?: (
+    state: ReturnType<IQRKeyringState['getState']>,
+  ) => void;
 
   /**
    * Creates a KeyringController instance.
@@ -467,7 +477,11 @@ export class KeyringController extends BaseControllerV2<
   async addNewKeyring(
     type: KeyringTypes | string,
     opts?: unknown,
-  ): Promise<Keyring<Json>> {
+  ): Promise<unknown> {
+    if (type === KeyringTypes.qr) {
+      return this.getOrAddQRKeyring();
+    }
+
     return this.#keyring.addNewKeyring(type, opts);
   }
 
@@ -678,6 +692,7 @@ export class KeyringController extends BaseControllerV2<
    * @returns Promise resolving to current state.
    */
   async setLocked(): Promise<KeyringControllerMemState> {
+    this.#unsubscribeFromQRKeyringsEvents();
     await this.#keyring.setLocked();
     return this.#getMemState();
   }
@@ -771,6 +786,14 @@ export class KeyringController extends BaseControllerV2<
     encryptionSalt: string,
   ): Promise<KeyringControllerMemState> {
     await this.#keyring.submitEncryptionKey(encryptionKey, encryptionSalt);
+
+    const qrKeyring = this.getQRKeyring();
+    if (qrKeyring) {
+      // if there is a QR keyring, we need to subscribe
+      // to its events after unlocking the vault
+      this.#subscribeToQRKeyringEvents(qrKeyring);
+    }
+
     return this.#getMemState();
   }
 
@@ -784,6 +807,14 @@ export class KeyringController extends BaseControllerV2<
   async submitPassword(password: string): Promise<KeyringControllerMemState> {
     await this.#keyring.submitPassword(password);
     const accounts = await this.#keyring.getAccounts();
+
+    const qrKeyring = this.getQRKeyring();
+    if (qrKeyring) {
+      // if there is a QR keyring, we need to subscribe
+      // to its events after unlocking the vault
+      this.#subscribeToQRKeyringEvents(qrKeyring);
+    }
+
     await this.syncIdentities(accounts);
     return this.#getMemState();
   }
@@ -841,7 +872,19 @@ export class KeyringController extends BaseControllerV2<
   // QR Hardware related methods
 
   /**
-   * Get qr hardware keyring.
+   * Get QR Hardware keyring.
+   *
+   * @returns The QR Keyring if defined, otherwise undefined
+   */
+  getQRKeyring(): QRKeyring | undefined {
+    // QRKeyring is not yet compatible with Keyring type from @metamask/utils
+    return this.#keyring.getKeyringsByType(
+      KeyringTypes.qr,
+    )[0] as unknown as QRKeyring;
+  }
+
+  /**
+   * Get QR hardware keyring. If it doesn't exist, add it.
    *
    * @returns The added keyring
    */
@@ -1015,7 +1058,39 @@ export class KeyringController extends BaseControllerV2<
    */
   async #addQRKeyring(): Promise<QRKeyring> {
     // QRKeyring is not yet compatible with Keyring type from @metamask/utils
-    return this.#keyring.addNewKeyring(KeyringTypes.qr) as unknown as QRKeyring;
+    const qrKeyring = (await this.#keyring.addNewKeyring(
+      KeyringTypes.qr,
+    )) as unknown as QRKeyring;
+
+    this.#subscribeToQRKeyringEvents(qrKeyring);
+
+    return qrKeyring;
+  }
+
+  /**
+   * Subscribe to a QRKeyring state change events and
+   * forward them through the messaging system.
+   *
+   * @param qrKeyring - The QRKeyring instance to subscribe to
+   */
+  #subscribeToQRKeyringEvents(qrKeyring: QRKeyring) {
+    this.#qrKeyringStateListener = (state) => {
+      this.messagingSystem.publish(`${name}:qrKeyringStateChange`, state);
+    };
+
+    qrKeyring.getMemStore().subscribe(this.#qrKeyringStateListener);
+  }
+
+  #unsubscribeFromQRKeyringsEvents() {
+    const qrKeyrings = this.#keyring.getKeyringsByType(
+      KeyringTypes.qr,
+    ) as unknown as QRKeyring[];
+
+    qrKeyrings.forEach((qrKeyring) => {
+      if (this.#qrKeyringStateListener) {
+        qrKeyring.getMemStore().unsubscribe(this.#qrKeyringStateListener);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
## Explanation
Currently, the extension is directly subscribing to the `QRKeyring` store, to determine whether to open the modal for syncing and signing. 

This raises concerns when the instance of the QRKeyring will be held by `KeyringController` instead of the client because it will be tricky to handle `subscribe` and `unsubscribe` in the keyring's lifecycle, risking to have multiple subscriptions to the same QRKeyring instance or even no subscriptions at all!

This PR gives this responsibility to `KeyringController`.
`KeyringController` will subscribe to the QRKeyring instance in these methods:
- `submitPassword` - because here we unlock the vault and potentially find a QRKeyring (even in case of re-construction from backup)
- `submitEncryptionKey` - same as above
- `getOrAddQRKeyring` - because here we explicitly create a new QRKeyring if it doesn't exist
- `addNewKeyring(type)` - when `type` is of a QRKeyring then it will return `getOrAddQRKeyring`, to avoid creating multiple keyring instances (and multiple subscriptions)

`KeyringController` will unsubscribe from the `QRKeyring` instance (if there's one ) when calling `setLocked()`.

Moreover, `KeyringController:qrKeyringStateChange` event is now available on the messenger

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

* Related to https://github.com/MetaMask/metamask-extension/issues/18776
* Related to https://github.com/MetaMask/metamask-extension/pull/20502

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/keyring-controller`

- **BREAKING**: `addNewKeyring(type)` return type changed from `Promise<Keyring<Json>>` to `Promise<unknown>`
  - When calling with QRKeyring `type` the keyring instance is retrieved or created (no multiple QRKeyring instances possible)
- **ADDED**: Add `getQRKeyring(): QRKeyring | undefined` method
- **ADDED**: Add `KeyringController:qrKeyringStateChange` messenger event
  The event emits updates from the internal `QRKeyring` instance, if there's one

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
