### PR TITLE
Migrate `PhishingController` to BaseControllerV2

### DIFF
--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -1,3 +1,4 @@
+import { ControllerMessenger } from '@metamask/base-controller';
 import { strict as assert } from 'assert';
 import nock from 'nock';
 import * as sinon from 'sinon';
@@ -8,16 +9,15 @@ import {
   METAMASK_STALELIST_FILE,
   PhishingController,
   PHISHING_CONFIG_BASE_URL,
-  PhishingControllerActions,
-  PhishingControllerOptions,
+  type PhishingControllerActions,
+  type PhishingControllerOptions,
 } from './PhishingController';
-import { ControllerMessenger } from '@metamask/base-controller';
-
-const defaultHotlistRefreshInterval = 30 * 60;
-const defaultStalelistRefreshInterval = 4 * 24 * 60 * 60;
 
 const controllerName = 'PhishingController';
 
+/**
+ *
+ */
 function getRestrictedMessenger() {
   const controllerMessenger = new ControllerMessenger<
     PhishingControllerActions,
@@ -35,6 +35,10 @@ function getRestrictedMessenger() {
   return messenger;
 }
 
+/**
+ *
+ * @param options
+ */
 function getPhishingController(options?: Partial<PhishingControllerOptions>) {
   return new PhishingController({
     messenger: getRestrictedMessenger(),
@@ -56,14 +60,6 @@ describe('PhishingController', () => {
     const controller = getPhishingController();
     expect(controller.state.whitelist).toStrictEqual([]);
   });
-
-  // it('should use default stalelist & hotlist refresh intervals', () => {
-  //   const controller = getPhishingController();
-  //   expect(controller.config).toStrictEqual({
-  //     stalelistRefreshInterval: defaultStalelistRefreshInterval,
-  //     hotlistRefreshInterval: defaultHotlistRefreshInterval,
-  //   });
-  // });
 
   it('does not call update stalelist or hotlist upon construction', async () => {
     const nockScope = nock(PHISHING_CONFIG_BASE_URL)
@@ -1046,70 +1042,6 @@ describe('PhishingController', () => {
         },
       ]);
     });
-
-    // it('should not update stale list if disabled', async () => {
-    //   const controller = getPhishingController(
-    //     { disabled: true },
-    //     {
-    //       phishingLists: [
-    //         {
-    //           allowlist: [],
-    //           blocklist: [],
-    //           fuzzylist: [],
-    //           tolerance: 3,
-    //           version: 1,
-    //           name: ListNames.MetaMask,
-    //           lastUpdated: 0,
-    //         },
-    //       ],
-    //     },
-    //   );
-    //   await controller.updateStalelist();
-
-    //   expect(controller.state.phishingLists).toStrictEqual([
-    //     {
-    //       allowlist: [],
-    //       blocklist: [],
-    //       fuzzylist: [],
-    //       tolerance: 3,
-    //       version: 1,
-    //       name: ListNames.MetaMask,
-    //       lastUpdated: 0,
-    //     },
-    //   ]);
-    // });
-
-    // it.todo('should not update hotlist lists if disabled', async () => {
-    //   const controller = getPhishingController(
-    //     { disabled: true },
-    //     {
-    //       phishingLists: [
-    //         {
-    //           allowlist: [],
-    //           blocklist: [],
-    //           fuzzylist: [],
-    //           tolerance: 3,
-    //           version: 1,
-    //           name: ListNames.MetaMask,
-    //           lastUpdated: 0,
-    //         },
-    //       ],
-    //     },
-    //   );
-    //   await controller.updateHotlist();
-
-    //   expect(controller.state.phishingLists).toStrictEqual([
-    //     {
-    //       allowlist: [],
-    //       blocklist: [],
-    //       fuzzylist: [],
-    //       tolerance: 3,
-    //       version: 1,
-    //       name: ListNames.MetaMask,
-    //       lastUpdated: 0,
-    //     },
-    //   ]);
-    // });
 
     it('should not update phishing lists if fetch returns 304', async () => {
       nock(PHISHING_CONFIG_BASE_URL)

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -335,7 +335,7 @@ describe('PhishingController', () => {
         stalelistRefreshInterval: 10,
       });
       await controller.updateStalelist();
-      await clock.tick(1000 * 5);
+      clock.tick(1000 * 5);
 
       expect(controller.isStalelistOutOfDate()).toBe(false);
     });
@@ -412,7 +412,7 @@ describe('PhishingController', () => {
         hotlistRefreshInterval: 10,
       });
       await controller.updateHotlist();
-      await clock.tick(1000 * 5);
+      clock.tick(1000 * 5);
 
       expect(controller.isHotlistOutOfDate()).toBe(false);
     });

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -16,7 +16,9 @@ import {
 const controllerName = 'PhishingController';
 
 /**
+ * Constructs a restricted controller messenger.
  *
+ * @returns A restricted controller messenger.
  */
 function getRestrictedMessenger() {
   const controllerMessenger = new ControllerMessenger<
@@ -36,8 +38,9 @@ function getRestrictedMessenger() {
 }
 
 /**
- *
- * @param options
+ * Contruct a Phishing Controller with the given options if any.
+ * @param options - The Phishing Controller options.
+ * @returns The contstructed Phishing Controller.
  */
 function getPhishingController(options?: Partial<PhishingControllerOptions>) {
   return new PhishingController({

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -224,7 +224,12 @@ export type MaybeUpdateState = {
   handler: PhishingController['maybeUpdateState'];
 };
 
-export type PhishingControllerActions = MaybeUpdateState;
+export type TestOrigin = {
+  type: `${typeof controllerName}:testOrigin`;
+  handler: PhishingController['test'];
+};
+
+export type PhishingControllerActions = MaybeUpdateState | TestOrigin;
 
 export type PhishingControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -171,13 +171,17 @@ export const phishingListKeyNameMap = {
 
 const controllerName = 'PhishingController';
 
-const stateMetadata = {
+const metadata = {
   phishingLists: { persist: false, anonymous: false },
   whitelist: { persist: false, anonymous: false },
   hotlistLastFetched: { persist: false, anonymous: false },
   stalelistLastFetched: { persist: false, anonymous: false },
 };
 
+/**
+ * Get a default empty state for the controller.
+ * @returns The default empty state.
+ */
 const getDefaultState = (): PhishingControllerState => {
   return {
     phishingLists: [],
@@ -257,11 +261,10 @@ export class PhishingController extends BaseController<
    * Construct a Phishing Controller.
    *
    * @param config - Initial options used to configure this controller.
-   * @param config.stalelistRefreshInterval
-   * @param state - Initial state to set on this controller.
-   * @param config.hotlistRefreshInterval
-   * @param config.messenger
-   * @param config.state
+   * @param config.stalelistRefreshInterval - Polling interval used to fetch stale list.
+   * @param config.hotlistRefreshInterval - Polling interval used to fetch hotlist diff list.
+   * @param config.messenger - The controller restricted messenger.
+   * @param config.state - Initial state to set on this controller.
    */
   constructor({
     stalelistRefreshInterval = STALELIST_REFRESH_INTERVAL,
@@ -271,7 +274,7 @@ export class PhishingController extends BaseController<
   }: PhishingControllerOptions) {
     super({
       name: controllerName,
-      metadata: stateMetadata,
+      metadata,
       messenger,
       state: {
         ...getDefaultState(),


### PR DESCRIPTION
## Explanation

This migrates the `PhishingController` to `BaseControllerV2`

## Changelog

### Added
- Add `maybeUpdateState` and `testOrigin` actions

### Changed
- **BREAKING:** `PhishingController` now inherits from BaseControllerV2
- **BREAKING:** `PhishingController`now expects a `messenger` option (and corresponding type `PhishingControllerMessenger` is now available)
-  **BREAKING:**  The constructor takes a single argument, an options bag, instead of three arguments
- **BREAKING:**  The `disabled` configuration is no longer supported

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
