### PR TITLE
Update contributing doc: remove yarn v3 install step

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,8 @@
 
 - Install [Node.js](https://nodejs.org) version 16.
   - If you're using [NVM](https://github.com/creationix/nvm#installation) (recommended), `nvm use` will ensure that the right version is installed.
-- Install [Yarn v3](https://yarnpkg.com/getting-started/install).
+- Enable Corepack by executing the command `corepack enable` from the project root directory.
+  - Corepack is a utility included with Node.js by default. It manages Yarn on a per-project basis, using the version specified by the `packageManager` property in the project's package.json file.
 - Run `yarn install` to install dependencies and run any required post-install scripts.
 - Run `yarn simple-git-hooks` to add a [Git hook](https://github.com/toplenboren/simple-git-hooks#what-is-a-git-hook) to your local development environment which will ensure that all files pass linting before you push a branch.
 


### PR DESCRIPTION

## Explanation

- In the contributing doc, replaces yarn v3 install step with `corepack enable` command. 
- See: https://github.com/MetaMask/metamask-extension/pull/20713

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
