### PR TITLE
Add check the network status whenever signing a transaction

### DIFF
--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -25,10 +25,11 @@ import {
   convertHexToDecimal,
 } from '@metamask/controller-utils';
 import EthQuery from '@metamask/eth-query';
-import type {
-  BlockTracker,
-  NetworkState,
-  Provider,
+import {
+  NetworkStatus,
+  type BlockTracker,
+  type NetworkState,
+  type Provider,
 } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
@@ -1590,7 +1591,12 @@ export class TransactionController extends BaseController<
     const {
       networkId,
       providerConfig: { type: chain, chainId, nickname: name },
+      networksMetadata,
     } = this.getNetworkState();
+
+    const networkStatus = networkId
+      ? networksMetadata[networkId]?.status
+      : NetworkStatus.Unknown;
 
     if (
       chain !== RPC &&
@@ -1603,7 +1609,10 @@ export class TransactionController extends BaseController<
     const customChainParams: Partial<ChainConfig> = {
       name,
       chainId: parseInt(chainId, 16),
-      networkId: networkId === null ? NaN : parseInt(networkId, undefined),
+      networkId:
+        networkId && networkStatus === NetworkStatus.Available
+          ? parseInt(networkId, undefined)
+          : 0,
       defaultHardfork: HARDFORK,
     };
 


### PR DESCRIPTION
## Explanation

This PR aims to modify `getCommonConfiguration` to check if `networkStatus.Available`.

**Context**
The extension `TransactionController` checks the network status whenever signing a transaction and if it is not `NetworkStatus.Available` the chain ID of the request is set to `0`. This causes the `@ethereumjs/tx` package to throw an error when building the transaction as it will not match the generated network configuration.

The behaviour is the same as before just an additional check to help reduce the difference between the core and the extension `TransactionController`.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **CHANGED**: update `getCommonConfiguration` to check if `networkStatus.Available` whenever signing a transaction. 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
