### PR TITLE
Add accountAdded event to keyring controller

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -245,7 +245,9 @@ describe('KeyringController', () => {
             messenger.subscribe('KeyringController:accountAdded', listener);
 
             const addedAccountAddress =
-              await controller.addNewAccountForKeyring(mockKeyring);
+              await controller.addNewAccountForKeyring(
+                mockKeyring as Keyring<Json>,
+              );
 
             expect(listener.calledWith(addedAccountAddress)).toBe(true);
           },
@@ -335,7 +337,9 @@ describe('KeyringController', () => {
             messenger.subscribe('KeyringController:accountAdded', listener);
 
             const addedAccountAddress =
-              await controller.addNewAccountForKeyring(mockKeyring);
+              await controller.addNewAccountForKeyring(
+                mockKeyring as Keyring<Json>,
+              );
 
             expect(listener.calledWith(addedAccountAddress)).toBe(true);
           },

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -94,6 +94,15 @@ describe('KeyringController', () => {
           },
         );
       });
+
+      it('should emit accountAdded', async () => {
+        await withController(async ({ controller, messenger }) => {
+          const listener = sinon.spy();
+          messenger.subscribe('KeyringController:accountAdded', listener);
+          const { addedAccountAddress } = await controller.addNewAccount();
+          expect(listener.calledWith(addedAccountAddress)).toBe(true);
+        });
+      });
     });
 
     describe('when accountCount is provided', () => {
@@ -144,6 +153,15 @@ describe('KeyringController', () => {
           expect(controller.state.keyrings[0].accounts).toHaveLength(
             accountCount + 1,
           );
+        });
+      });
+
+      it('should emit accountAdded', async () => {
+        await withController(async ({ controller, messenger }) => {
+          const listener = sinon.spy();
+          messenger.subscribe('KeyringController:accountAdded', listener);
+          const { addedAccountAddress } = await controller.addNewAccount();
+          expect(listener.calledWith(addedAccountAddress)).toBe(true);
         });
       });
     });
@@ -207,6 +225,29 @@ describe('KeyringController', () => {
               ]),
             ).toBe(true);
             expect(preferences.setSelectedAddress.called).toBe(false);
+          },
+        );
+      });
+
+      it('should emit accountAdded', async () => {
+        await withController(
+          {
+            keyringBuilders: [
+              keyringBuilderFactory(MockShallowGetAccountsKeyring),
+            ],
+          },
+          async ({ controller, messenger }) => {
+            const mockKeyring = await controller.addNewKeyring(
+              MockShallowGetAccountsKeyring.type,
+            );
+
+            const listener = sinon.spy();
+            messenger.subscribe('KeyringController:accountAdded', listener);
+
+            const addedAccountAddress =
+              await controller.addNewAccountForKeyring(mockKeyring);
+
+            expect(listener.calledWith(addedAccountAddress)).toBe(true);
           },
         );
       });
@@ -277,6 +318,29 @@ describe('KeyringController', () => {
           );
         });
       });
+
+      it('should emit accountAdded', async () => {
+        await withController(
+          {
+            keyringBuilders: [
+              keyringBuilderFactory(MockShallowGetAccountsKeyring),
+            ],
+          },
+          async ({ controller, messenger }) => {
+            const mockKeyring = await controller.addNewKeyring(
+              MockShallowGetAccountsKeyring.type,
+            );
+
+            const listener = sinon.spy();
+            messenger.subscribe('KeyringController:accountAdded', listener);
+
+            const addedAccountAddress =
+              await controller.addNewAccountForKeyring(mockKeyring);
+
+            expect(listener.calledWith(addedAccountAddress)).toBe(true);
+          },
+        );
+      });
     });
   });
 
@@ -299,6 +363,19 @@ describe('KeyringController', () => {
           );
         },
       );
+    });
+
+    it('should emit accountAdded', async () => {
+      await withController(async ({ controller, messenger }) => {
+        const listener = sinon.spy();
+        messenger.subscribe('KeyringController:accountAdded', listener);
+
+        await controller.addNewAccountWithoutUpdate();
+
+        const newAccounts = controller.state.keyrings[0].accounts;
+
+        expect(listener.calledWith(newAccounts[1])).toBe(true);
+      });
     });
   });
 
@@ -2310,6 +2387,7 @@ function buildKeyringControllerMessenger(messenger = buildMessenger()) {
       'KeyringController:lock',
       'KeyringController:unlock',
       'KeyringController:accountRemoved',
+      'KeyringController:accountAdded',
       'KeyringController:qrKeyringStateChange',
     ],
   });


### PR DESCRIPTION
## Explanation

This PR adds the event `accountAdded` to the KeyringController messenger to:

## Changelog

### `@metamask/keyring-controller`

- **ADDED**: Keyring controller messenger events:
- KeyringController:accountAdded

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
