### PR TITLE
Add `test:clean` build script that clears jest cache before running tests

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -257,6 +257,10 @@ gen_enforced_field(WorkspaceCwd, 'scripts.changelog:validate', ProperChangelogVa
 gen_enforced_field(WorkspaceCwd, 'scripts.test', 'jest') :-
   WorkspaceCwd \= '.'.
 
+% All non-root packages must have the same "test:clean" script.
+gen_enforced_field(WorkspaceCwd, 'scripts.test:clean', 'jest --clearCache') :-
+  WorkspaceCwd \= '.'.
+
 % All non-root packages must have the same "test:watch" script.
 gen_enforced_field(WorkspaceCwd, 'scripts.test:watch', 'jest --watch') :-
   WorkspaceCwd \= '.'.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "prepare-preview-builds": "./scripts/prepare-preview-builds.sh",
     "publish-previews": "yarn workspaces foreach --parallel --verbose run publish:preview",
     "setup": "yarn install",
-    "test": "yarn workspaces foreach --parallel --verbose run test"
+    "test": "yarn workspaces foreach --parallel --verbose run test",
+    "test:clean": "yarn workspaces foreach --parallel --verbose run test:clean && yarn test"
   },
   "simple-git-hooks": {
     "pre-push": "yarn lint"

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/accounts-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/address-book-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/announcement-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/approval-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/assets-controllers",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/base-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/composable-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/controller-utils",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/ens-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/gas-fee-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/keyring-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/logging-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/message-manager",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -26,6 +26,7 @@
     "prepare-manifest:preview": "../../scripts/prepare-preview-manifest.sh",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/network-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/notification-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/permission-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/phishing-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/polling-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/preferences-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/rate-limit-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/selected-network-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/signature-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -25,6 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/transaction-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
+    "test:clean": "jest --clearCache",
     "test:watch": "jest --watch"
   },
   "dependencies": {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

### Motivation
Clearing jest cache can be necessary for debugging, especially when dealing with dependency version changes. Adding this functionality as a build script will make it more visible to future contributors as an available option for troubleshooting. 

### Additions
- A new `test:clean` build script that runs `jest --clearCache` in every submodule of the monorepo, and then runs the existing `test` script. 
  - Originally attempted to have each submodule run `jest --clearCache && jest`, but this causes issues with failed tests due to concurrent read/writes to the jest cache directory. 
- A `constraint.pro` entry that will enforce the addition of a `test:clean` script in future submodules. 

## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
