### PR TITLE
Support rate limiting in name providers

### DIFF
--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -30,6 +30,8 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^3.2.1",
+    "@metamask/utils": "^6.2.0",
+    "async-mutex": "^0.2.6",
     "immer": "^9.0.6"
   },
   "devDependencies": {

--- a/packages/name-controller/src/logger.ts
+++ b/packages/name-controller/src/logger.ts
@@ -1,0 +1,5 @@
+import { createProjectLogger, createModuleLogger } from '@metamask/utils';
+
+export const projectLogger = createProjectLogger('name-controller');
+
+export { createModuleLogger };

--- a/packages/name-controller/src/providers/ens.test.ts
+++ b/packages/name-controller/src/providers/ens.test.ts
@@ -66,5 +66,23 @@ describe('ENSNameProvider', () => {
       expect(reverseLookupMock).toHaveBeenCalledTimes(1);
       expect(reverseLookupMock).toHaveBeenCalledWith(VALUE_MOCK, CHAIN_ID_MOCK);
     });
+
+    it('throws if callback fails', async () => {
+      const reverseLookupMock = jest.fn().mockImplementation(() => {
+        throw new Error('TestError');
+      });
+
+      const provider = new ENSNameProvider({
+        reverseLookup: reverseLookupMock,
+      });
+
+      await expect(
+        provider.getProposedNames({
+          value: VALUE_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          type: NameType.ETHEREUM_ADDRESS,
+        }),
+      ).rejects.toThrow('TestError');
+    });
   });
 });

--- a/packages/name-controller/src/providers/etherscan.test.ts
+++ b/packages/name-controller/src/providers/etherscan.test.ts
@@ -10,7 +10,6 @@ const CHAIN_ID_MOCK = '0x1';
 const SOURCE_ID = 'etherscan';
 const CONTRACT_NAME_MOCK = 'TestContractName';
 const CONTRACT_NAME_2_MOCK = 'TestContractName2';
-const API_KEY_MOCK = 'TestApiKey';
 
 describe('EtherscanNameProvider', () => {
   const handleFetchMock = jest.mocked(handleFetch);

--- a/packages/name-controller/src/providers/lens.test.ts
+++ b/packages/name-controller/src/providers/lens.test.ts
@@ -86,5 +86,21 @@ describe('LensNameProvider', () => {
         },
       });
     });
+
+    it('throws if request fails', async () => {
+      graphqlMock.mockImplementation(() => {
+        throw new Error('TestError');
+      });
+
+      const provider = new LensNameProvider();
+
+      await expect(
+        provider.getProposedNames({
+          value: VALUE_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          type: NameType.ETHEREUM_ADDRESS,
+        }),
+      ).rejects.toThrow('TestError');
+    });
   });
 });

--- a/packages/name-controller/src/providers/token.test.ts
+++ b/packages/name-controller/src/providers/token.test.ts
@@ -54,5 +54,39 @@ describe('TokenNameProvider', () => {
         `https://token-api.metaswap.codefi.network/token/${CHAIN_ID_MOCK}?address=${VALUE_MOCK}`,
       );
     });
+
+    it('returns empty array if no token name in infura response', async () => {
+      const provider = new TokenNameProvider();
+
+      handleFetchMock.mockResolvedValueOnce({ name: undefined });
+
+      const response = await provider.getProposedNames({
+        value: VALUE_MOCK,
+        chainId: CHAIN_ID_MOCK,
+        type: NameType.ETHEREUM_ADDRESS,
+      });
+
+      expect(response).toStrictEqual({
+        results: {
+          [SOURCE_ID]: { proposedNames: [] },
+        },
+      });
+    });
+
+    it('throws if request fails', async () => {
+      handleFetchMock.mockImplementation(() => {
+        throw new Error('TestError');
+      });
+
+      const provider = new TokenNameProvider();
+
+      await expect(
+        provider.getProposedNames({
+          value: VALUE_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          type: NameType.ETHEREUM_ADDRESS,
+        }),
+      ).rejects.toThrow('TestError');
+    });
   });
 });

--- a/packages/name-controller/src/providers/token.ts
+++ b/packages/name-controller/src/providers/token.ts
@@ -1,3 +1,4 @@
+import { createModuleLogger, projectLogger } from '../logger';
 import type {
   NameProvider,
   NameProviderMetadata,
@@ -9,6 +10,8 @@ import { handleFetch } from '../util';
 
 const ID = 'token';
 const LABEL = 'Blockchain (Token Name)';
+
+const log = createModuleLogger(projectLogger, 'token');
 
 export class TokenNameProvider implements NameProvider {
   getMetadata(): NameProviderMetadata {
@@ -23,15 +26,26 @@ export class TokenNameProvider implements NameProvider {
   ): Promise<NameProviderResult> {
     const { value, chainId } = request;
     const url = `https://token-api.metaswap.codefi.network/token/${chainId}?address=${value}`;
-    const responseData = await handleFetch(url);
-    const proposedName = responseData.name;
 
-    return {
-      results: {
-        [ID]: {
-          proposedNames: [proposedName],
+    log('Sending request', url);
+
+    try {
+      const responseData = await handleFetch(url);
+      const proposedName = responseData.name;
+      const proposedNames = proposedName ? [proposedName] : [];
+
+      log('New proposed names', proposedNames);
+
+      return {
+        results: {
+          [ID]: {
+            proposedNames,
+          },
         },
-      },
-    };
+      };
+    } catch (error) {
+      log('Request failed', error);
+      throw error;
+    }
   }
 }

--- a/packages/name-controller/src/types.ts
+++ b/packages/name-controller/src/types.ts
@@ -43,6 +43,12 @@ export type NameProviderSourceResult = {
   proposedNames?: string[];
 
   /**
+   * The delay in milliseconds before the next request to the source should be made.
+   * Can be used to avoid rate limiting for example.
+   */
+  retryDelay?: number;
+
+  /**
    * An error that occurred while fetching the proposed names from the source.
    * Undefined if there was no error.
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1977,6 +1977,7 @@ __metadata:
     "@metamask/base-controller": ^3.2.1
     "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
+    async-mutex: ^0.2.6
     deepmerge: ^4.2.2
     immer: ^9.0.6
     jest: ^27.5.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,6 +1975,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
+    "@metamask/utils": ^6.2.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     immer: ^9.0.6


### PR DESCRIPTION
## Explanation

Currently the extension UX only calls `updateProposedNames` for a given value if it has not been invoked in the last 10 minutes. This is tracked using the `proposedNamesLastUpdated` value in the `NameController` state.

This means if a `NameProvider` hits a rate limit and no proposed name is returned, then it will not be retried until the 10 minute delay has elapsed.

This PR allows each `NameProvider` to return a `retryDelay` value that recommends when the `NameProvider` should next be invoked.

Rather than the client UX reading this value, it is now handled by the `NameController` using the new `onlyUpdateAfterDelay` option in the `updateProposedNames` method.

If set to `true`, only the `NameProvider` sources where the `retryDelay` or default delay has elapsed, will be invoked. This is tracked using a new `lastRequestTime` property for each proposed name entry in the state.

## References

Fixes #1366

## Changelog

### `@metamask/name-controller`

[Pending]

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
