### PR TITLE
chore: Update `typedoc` and related packages

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -48,8 +48,8 @@
     "@types/readable-stream": "^2.3.0",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "peerDependencies": {

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -38,8 +38,8 @@
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -37,8 +37,8 @@
     "immer": "^9.0.6",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -41,8 +41,8 @@
     "jest": "^27.5.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -63,8 +63,8 @@
     "nock": "^13.3.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "peerDependencies": {

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -39,8 +39,8 @@
     "jest": "^27.5.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -38,8 +38,8 @@
     "jest": "^27.5.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -45,8 +45,8 @@
     "jest": "^27.5.1",
     "nock": "^13.3.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -42,8 +42,8 @@
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "peerDependencies": {

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -49,8 +49,8 @@
     "nock": "^13.3.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "peerDependencies": {

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -51,8 +51,8 @@
     "jest": "^27.5.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3",
     "uuid": "^8.3.2"
   },

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -38,8 +38,8 @@
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -43,8 +43,8 @@
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -38,8 +38,8 @@
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -56,8 +56,8 @@
     "nock": "^13.3.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -39,8 +39,8 @@
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -45,8 +45,8 @@
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "peerDependencies": {

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -42,8 +42,8 @@
     "nock": "^13.3.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -37,8 +37,8 @@
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -38,8 +38,8 @@
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "engines": {

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -42,8 +42,8 @@
     "nock": "^13.3.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "peerDependencies": {

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -46,8 +46,8 @@
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "peerDependencies": {

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -57,8 +57,8 @@
     "jest": "^27.5.1",
     "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.22.15",
-    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-missing-exports": "^0.23.0",
     "typescript": "~4.6.3"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1308,8 +1308,8 @@ __metadata:
     jest: ^27.5.1
     nanoid: ^3.1.31
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
     uuid: ^8.3.2
   peerDependencies:
@@ -1340,8 +1340,8 @@ __metadata:
     deepmerge: ^4.2.2
     jest: ^27.5.1
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   languageName: unknown
   linkType: soft
@@ -1357,8 +1357,8 @@ __metadata:
     immer: ^9.0.6
     jest: ^27.5.1
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   languageName: unknown
   linkType: soft
@@ -1378,8 +1378,8 @@ __metadata:
     nanoid: ^3.1.31
     sinon: ^9.2.4
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   languageName: unknown
   linkType: soft
@@ -1420,8 +1420,8 @@ __metadata:
     single-call-balance-checker-abi: ^1.0.0
     sinon: ^9.2.4
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
     uuid: ^8.3.2
   peerDependencies:
@@ -1458,8 +1458,8 @@ __metadata:
     jest: ^27.5.1
     sinon: ^9.2.4
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   languageName: unknown
   linkType: soft
@@ -1483,8 +1483,8 @@ __metadata:
     jest: ^27.5.1
     sinon: ^9.2.4
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   languageName: unknown
   linkType: soft
@@ -1515,8 +1515,8 @@ __metadata:
     jest: ^27.5.1
     nock: ^13.3.1
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   languageName: unknown
   linkType: soft
@@ -1595,8 +1595,8 @@ __metadata:
     jest: ^27.5.1
     punycode: ^2.1.1
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   peerDependencies:
     "@metamask/network-controller": ^13.0.0
@@ -1823,8 +1823,8 @@ __metadata:
     nock: ^13.3.1
     sinon: ^9.2.4
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
     uuid: ^8.3.2
   peerDependencies:
@@ -1912,8 +1912,8 @@ __metadata:
     jest: ^27.5.1
     sinon: ^9.2.4
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
     uuid: ^8.3.2
   peerDependencies:
@@ -1932,8 +1932,8 @@ __metadata:
     deepmerge: ^4.2.2
     jest: ^27.5.1
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
     uuid: ^8.3.2
   languageName: unknown
@@ -1955,8 +1955,8 @@ __metadata:
     jest: ^27.5.1
     jsonschema: ^1.2.4
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
     uuid: ^8.3.2
   languageName: unknown
@@ -1980,8 +1980,8 @@ __metadata:
     immer: ^9.0.6
     jest: ^27.5.1
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   languageName: unknown
   linkType: soft
@@ -2015,8 +2015,8 @@ __metadata:
     nock: ^13.3.1
     sinon: ^9.2.4
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
     uuid: ^8.3.2
   languageName: unknown
@@ -2035,8 +2035,8 @@ __metadata:
     jest: ^27.5.1
     nanoid: ^3.1.31
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   languageName: unknown
   linkType: soft
@@ -2091,8 +2091,8 @@ __metadata:
     json-rpc-engine: ^6.1.0
     nanoid: ^3.1.31
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   peerDependencies:
     "@metamask/approval-controller": ^3.5.1
@@ -2115,8 +2115,8 @@ __metadata:
     punycode: ^2.1.1
     sinon: ^9.2.4
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   languageName: unknown
   linkType: soft
@@ -2142,8 +2142,8 @@ __metadata:
     deepmerge: ^4.2.2
     jest: ^27.5.1
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   languageName: unknown
   linkType: soft
@@ -2218,8 +2218,8 @@ __metadata:
     immer: ^9.0.6
     jest: ^27.5.1
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   languageName: unknown
   linkType: soft
@@ -2320,8 +2320,8 @@ __metadata:
     nock: ^13.3.1
     sinon: ^9.2.4
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   peerDependencies:
     "@metamask/network-controller": ^13.0.0
@@ -2348,8 +2348,8 @@ __metadata:
     jest: ^27.5.1
     lodash: ^4.17.21
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
   peerDependencies:
     "@metamask/approval-controller": ^3.5.1
@@ -2580,8 +2580,8 @@ __metadata:
     nonce-tracker: ^1.1.0
     sinon: ^9.2.4
     ts-jest: ^27.1.4
-    typedoc: ^0.22.15
-    typedoc-plugin-missing-exports: ^0.22.6
+    typedoc: ^0.23.15
+    typedoc-plugin-missing-exports: ^0.23.0
     typescript: ~4.6.3
     uuid: ^8.3.2
   peerDependencies:
@@ -3555,6 +3555,13 @@ __metadata:
   version: 6.0.1
   resolution: "ansi-regex@npm:6.0.1"
   checksum: 1ff8b7667cded1de4fa2c9ae283e979fc87036864317da86a2e546725f96406746411d0d85e87a2d12fa5abd715d90006de7fa4fa0477c92321ad3b4c7d4e169
+  languageName: node
+  linkType: hard
+
+"ansi-sequence-parser@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "ansi-sequence-parser@npm:1.1.1"
+  checksum: ead5b15c596e8e85ca02951a844366c6776769dcc9fd1bd3a0db11bb21364554822c6a439877fb599e7e1ffa0b5f039f1e5501423950457f3dcb2f480c30b188
   languageName: node
   linkType: hard
 
@@ -6047,19 +6054,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.3":
-  version: 8.1.0
-  resolution: "glob@npm:8.1.0"
-  dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^5.0.1
-    once: ^1.3.0
-  checksum: 92fbea3221a7d12075f26f0227abac435de868dd0736a17170663783296d0dd8d3d532a5672b4488a439bf5d7fb85cdd07c11185d6cd39184f0385cbdfb86a47
-  languageName: node
-  linkType: hard
-
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -7650,7 +7644,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:^3.0.0":
+"jsonc-parser@npm:^3.2.0":
   version: 3.2.0
   resolution: "jsonc-parser@npm:3.2.0"
   checksum: 946dd9a5f326b745aa326d48a7257e3f4a4b62c5e98ec8e49fa2bdd8d96cef7e6febf1399f5c7016114fd1f68a1c62c6138826d5d90bc650448e3cf0951c53c7
@@ -7854,7 +7848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:^4.0.16":
+"marked@npm:^4.2.12":
   version: 4.3.0
   resolution: "marked@npm:4.3.0"
   bin:
@@ -7958,12 +7952,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^5.0.1, minimatch@npm:^5.1.0":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
+"minimatch@npm:^7.1.3":
+  version: 7.4.6
+  resolution: "minimatch@npm:7.4.6"
   dependencies:
     brace-expansion: ^2.0.1
-  checksum: 7564208ef81d7065a370f788d337cd80a689e981042cb9a1d0e6580b6c6a8c9279eba80010516e258835a988363f99f54a6f711a315089b8b42694f5da9d0d77
+  checksum: 1a6c8d22618df9d2a88aabeef1de5622eb7b558e9f8010be791cb6b0fa6e102d39b11c28d75b855a1e377b12edc7db8ff12a99c20353441caa6a05e78deb5da9
   languageName: node
   linkType: hard
 
@@ -9228,14 +9222,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shiki@npm:^0.10.1":
-  version: 0.10.1
-  resolution: "shiki@npm:0.10.1"
+"shiki@npm:^0.14.1":
+  version: 0.14.4
+  resolution: "shiki@npm:0.14.4"
   dependencies:
-    jsonc-parser: ^3.0.0
-    vscode-oniguruma: ^1.6.1
-    vscode-textmate: 5.2.0
-  checksum: fb746f3cb3de7e545e3b10a6cb658d3938f840e4ccc9a3c90ceb7e69a8f89dbb432171faac1e9f02a03f103684dad88ee5e54b5c4964fa6b579fca6e8e26424d
+    ansi-sequence-parser: ^1.1.0
+    jsonc-parser: ^3.2.0
+    vscode-oniguruma: ^1.7.0
+    vscode-textmate: ^8.0.0
+  checksum: 1173f6fa9531690a8cd4bf1d8e28c9eb9295af38a4c150cba6546e95f6e32bc96c7dd98826e39e688f1ca9d36b683a9a02ef77d51ce6495900b3a46ada64f828
   languageName: node
   linkType: hard
 
@@ -10031,29 +10026,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-missing-exports@npm:^0.22.6":
-  version: 0.22.6
-  resolution: "typedoc-plugin-missing-exports@npm:0.22.6"
+"typedoc-plugin-missing-exports@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "typedoc-plugin-missing-exports@npm:0.23.0"
   peerDependencies:
-    typedoc: 0.22.x
-  checksum: 012f44beaac05731b4d37c26bfba2d972ac48344eab6be793a95982712a207416e7dc3451279be4e4cebc8b6b99a16764d2d4aaa06e041fac60ce21cc22cf796
+    typedoc: 0.22.x || 0.23.x
+  checksum: b3fc9eccca88a9ffb686d1e9ba923178c54b4bb7e496823b7b971b6f6baa957263f7ccff058f5b0e579fee49c93da09dbdc3a4dafd713960d93b2832de8094e1
   languageName: node
   linkType: hard
 
-"typedoc@npm:^0.22.15":
-  version: 0.22.18
-  resolution: "typedoc@npm:0.22.18"
+"typedoc@npm:^0.23.15":
+  version: 0.23.28
+  resolution: "typedoc@npm:0.23.28"
   dependencies:
-    glob: ^8.0.3
     lunr: ^2.3.9
-    marked: ^4.0.16
-    minimatch: ^5.1.0
-    shiki: ^0.10.1
+    marked: ^4.2.12
+    minimatch: ^7.1.3
+    shiki: ^0.14.1
   peerDependencies:
-    typescript: 4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x
+    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
   bin:
     typedoc: bin/typedoc
-  checksum: b813d8129682f6ed5a4e96bacaf019e4da1d2744ca89fef850d6bb4c034616567ce67e6a7f5cfc5f00aac573f0b45d44b1427aafa262ab88dce6b460cb9e744c
+  checksum: 40eb4e207aac1b734e09400cf03f543642cc7b11000895198dd5a0d3166315759ccf4ac30a2915153597c5c186101c72bac2f1fc12b428184a9274d3a0e44c5e
   languageName: node
   linkType: hard
 
@@ -10235,17 +10229,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-oniguruma@npm:^1.6.1":
+"vscode-oniguruma@npm:^1.7.0":
   version: 1.7.0
   resolution: "vscode-oniguruma@npm:1.7.0"
   checksum: 53519d91d90593e6fb080260892e87d447e9b200c4964d766772b5053f5699066539d92100f77f1302c91e8fc5d9c772fbe40fe4c90f3d411a96d5a9b1e63f42
   languageName: node
   linkType: hard
 
-"vscode-textmate@npm:5.2.0":
-  version: 5.2.0
-  resolution: "vscode-textmate@npm:5.2.0"
-  checksum: 5449b42d451080f6f3649b66948f4b5ee4643c4e88cfe3558a3b31c84c78060cfdd288c4958c1690eaa5cd65d09992fa6b7c3bef9d4aa72b3651054a04624d20
+"vscode-textmate@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "vscode-textmate@npm:8.0.0"
+  checksum: 127780dfea89559d70b8326df6ec344cfd701312dd7f3f591a718693812b7852c30b6715e3cfc8b3200a4e2515b4c96f0843c0eacc0a3020969b5de262c2a4bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

The `typedoc` package has been updated to match the version used by the module template. This was done in preparation for updating the TypeScript version used by the core monorepo as well. The current version of `typedoc` we use doesn't support TypeScript v4.8.

The `typedoc-plugin-missing-exports` package required an update to maintain compatibility with `typedoc`.

In both cases, none of the breaking changes affect our usage of the package. Mostly they include improvements to the generated documentation, and dropping support for older Node.js and TypeScript versions.

`typedoc` changelog: https://github.com/TypeStrong/typedoc/releases/tag/v0.23.0
`typedoc-plugin-missing-exports` changelog: https://github.com/Gerrit0/typedoc-plugin-missing-exports/blob/main/CHANGELOG.md#0230-2022-06-26

## References

None

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
