### PR TITLE
Update typescript v4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "rimraf": "^3.0.2",
     "simple-git-hooks": "^2.8.0",
     "ts-node": "^10.9.1",
-    "typescript": "~4.6.3",
+    "typescript": "~4.8.4",
     "which": "^3.0.0"
   },
   "packageManager": "yarn@3.3.0",

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -50,7 +50,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^8.0.0"

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -40,7 +40,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -39,7 +39,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -43,7 +43,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -64,7 +64,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^3.5.1",

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -41,7 +41,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -40,7 +40,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -46,7 +46,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -44,7 +44,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^13.0.0"

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -51,7 +51,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^13.0.0"

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3",
+    "typescript": "~4.8.4",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -40,7 +40,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -45,7 +45,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -42,7 +42,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/name-controller/src/providers/etherscan.ts
+++ b/packages/name-controller/src/providers/etherscan.ts
@@ -9,7 +9,7 @@ import type {
   NameProviderResult,
 } from '../types';
 import { NameType } from '../types';
-import { handleFetch } from '../util';
+import { handleFetch, assertIsError } from '../util';
 
 const ID = 'etherscan';
 const LABEL = 'Etherscan (Verified Contract Name)';
@@ -134,7 +134,10 @@ export class EtherscanNameProvider implements NameProvider {
     }
   }
 
-  async #sendRequest(url: string) {
+  async #sendRequest(url: string): Promise<{
+    responseData?: EtherscanGetSourceCodeResponse;
+    error?: Error;
+  }> {
     try {
       log('Sending request', url);
 
@@ -144,6 +147,7 @@ export class EtherscanNameProvider implements NameProvider {
 
       return { responseData };
     } catch (error) {
+      assertIsError(error);
       return { error };
     } finally {
       this.#lastRequestTime = Date.now();

--- a/packages/name-controller/src/util.ts
+++ b/packages/name-controller/src/util.ts
@@ -69,7 +69,7 @@ export async function successfulFetch(request: string, options?: RequestInit) {
  */
 export function assertIsError(error: unknown): asserts error is Error {
   if (error instanceof Error) {
-    return
+    return;
   }
   throw new Error(`Invalid error of type '${typeof error}'`);
 }

--- a/packages/name-controller/src/util.ts
+++ b/packages/name-controller/src/util.ts
@@ -64,6 +64,7 @@ export async function successfulFetch(request: string, options?: RequestInit) {
  *
  * TODO: Migrate this to @metamask/utils
  *
+ * @param error - The value that we expect to be an error.
  * @throws Throws an error wrapping the given value if it's not an error.
  */
 export function assertIsError(error: unknown): asserts error is Error {

--- a/packages/name-controller/src/util.ts
+++ b/packages/name-controller/src/util.ts
@@ -57,3 +57,18 @@ export async function successfulFetch(request: string, options?: RequestInit) {
   }
   return response;
 }
+
+/**
+ * Assert that a value is an error. If it's not an error, throw an
+ * error that wraps the given value.
+ *
+ * TODO: Migrate this to @metamask/utils
+ *
+ * @throws Throws an error wrapping the given value if it's not an error.
+ */
+export function assertIsError(error: unknown): asserts error is Error {
+  if (error instanceof Error) {
+    return
+  }
+  throw new Error(`Invalid error of type '${typeof error}'`);
+}

--- a/packages/name-controller/src/utils.test.ts
+++ b/packages/name-controller/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { graphQL } from './util';
+import { assertIsError, graphQL } from './util';
 
 describe('Utils', () => {
   describe('graphQL', () => {
@@ -48,6 +48,18 @@ describe('Utils', () => {
         graphQL(URL_MOCK, QUERY_MOCK, VARIABLES_MOCK),
       ).rejects.toThrow(
         `Fetch failed with status '500' for request '${URL_MOCK}'`,
+      );
+    });
+  });
+
+  describe('assertIsError', () => {
+    it('does not throw if given an error', () => {
+      expect(() => assertIsError(new Error('test'))).not.toThrow();
+    });
+
+    it('throws if passed something that is not an error', () => {
+      expect(() => assertIsError('test')).toThrow(
+        `Invalid error of type 'string'`,
       );
     });
   });

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -58,7 +58,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -41,7 +41,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -47,7 +47,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^3.5.1"

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -44,7 +44,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -43,7 +43,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^13.0.0"

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -39,7 +39,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -40,7 +40,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -44,7 +44,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^13.0.0"

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -48,7 +48,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^3.5.1",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -59,7 +59,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.23.15",
     "typedoc-plugin-missing-exports": "^0.23.0",
-    "typescript": "~4.6.3"
+    "typescript": "~4.8.4"
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,7 +2137,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/network-controller": ^13.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1310,7 +1310,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/keyring-controller": ^8.0.0
@@ -1342,7 +1342,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -1359,7 +1359,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -1380,7 +1380,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -1421,7 +1421,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/approval-controller": ^3.5.1
@@ -1459,7 +1459,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -1484,7 +1484,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -1515,7 +1515,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -1553,7 +1553,7 @@ __metadata:
     rimraf: ^3.0.2
     simple-git-hooks: ^2.8.0
     ts-node: ^10.9.1
-    typescript: ~4.6.3
+    typescript: ~4.8.4
     which: ^3.0.0
   languageName: unknown
   linkType: soft
@@ -1595,7 +1595,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   peerDependencies:
     "@metamask/network-controller": ^13.0.0
   languageName: unknown
@@ -1823,7 +1823,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/network-controller": ^13.0.0
@@ -1912,7 +1912,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/preferences-controller": ^4.4.1
@@ -1932,7 +1932,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -1955,7 +1955,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -1982,7 +1982,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -2017,7 +2017,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -2037,7 +2037,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -2093,7 +2093,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   peerDependencies:
     "@metamask/approval-controller": ^3.5.1
   languageName: unknown
@@ -2117,7 +2117,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -2167,7 +2167,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -2243,7 +2243,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -2335,7 +2335,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   peerDependencies:
     "@metamask/network-controller": ^13.0.0
   languageName: unknown
@@ -2363,7 +2363,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
   peerDependencies:
     "@metamask/approval-controller": ^3.5.1
     "@metamask/logging-controller": ^1.0.2
@@ -2595,7 +2595,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.23.15
     typedoc-plugin-missing-exports: ^0.23.0
-    typescript: ~4.6.3
+    typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/approval-controller": ^3.5.1
@@ -10048,23 +10048,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.6.3":
-  version: 4.6.4
-  resolution: "typescript@npm:4.6.4"
+"typescript@npm:~4.8.4":
+  version: 4.8.4
+  resolution: "typescript@npm:4.8.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: e7bfcc39cd4571a63a54e5ea21f16b8445268b9900bf55aee0e02ad981be576acc140eba24f1af5e3c1457767c96cea6d12861768fb386cf3ffb34013718631a
+  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.6.3#~builtin<compat/typescript>":
-  version: 4.6.4
-  resolution: "typescript@patch:typescript@npm%3A4.6.4#~builtin<compat/typescript>::version=4.6.4&hash=5d3a66"
+"typescript@patch:typescript@~4.8.4#~builtin<compat/typescript>":
+  version: 4.8.4
+  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=0102e9"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 1cb434fbc637d347be90e3a0c6cd05e33c38f941713c8786d3031faf1842c2c148ba91d2fac01e7276b0ae3249b8633f1660e32686cc7a8c6a8fd5361dc52c66
+  checksum: 301459fc3eb3b1a38fe91bf96d98eb55da88a9cb17b4ef80b4d105d620f4d547ba776cc27b44cc2ef58b66eda23fe0a74142feb5e79a6fb99f54fc018a696afa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

The `typescript` package has been updated to v4.8.4 to align with the module template. This was done to simplify the process of migrating libraries into the monorepo.

## References

None

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
