### PR TITLE
Update `@metamask/json-rpc-engine` and `@metamask/utils`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@metamask/eslint-config-nodejs": "^12.0.0",
     "@metamask/eslint-config-typescript": "^12.0.0",
     "@metamask/eth-json-rpc-provider": "^1.0.0",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "@types/node": "^16.18.24",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -32,7 +32,7 @@
     "@metamask/eth-snap-keyring": "^0.2.2",
     "@metamask/keyring-api": "^0.2.5",
     "@metamask/snaps-utils": "^1.0.1",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "deepmerge": "^4.2.2",
     "eth-rpc-errors": "^4.0.2",
     "ethereumjs-util": "^7.0.10",

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.2",
-    "@metamask/utils": "^6.2.0"
+    "@metamask/utils": "^8.1.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.1.0",

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "eth-rpc-errors": "^4.0.2",
     "immer": "^9.0.6",
     "nanoid": "^3.1.31"

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -42,7 +42,7 @@
     "@metamask/network-controller": "^12.2.0",
     "@metamask/preferences-controller": "^4.4.0",
     "@metamask/rpc-errors": "^5.1.1",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "@types/uuid": "^8.3.0",
     "abort-controller": "^3.0.0",
     "async-mutex": "^0.2.6",

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "immer": "^9.0.6"
   },
   "devDependencies": {

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/eth-query": "^3.0.1",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "@spruceid/siwe-parser": "1.1.3",
     "eth-ens-namehash": "^2.0.8",
     "eth-rpc-errors": "^4.0.2",

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -32,7 +32,7 @@
     "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.2",
     "@metamask/network-controller": "^12.2.0",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "ethereum-ens-network-map": "^1.0.2",
     "punycode": "^2.1.1"
   },

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -32,7 +32,7 @@
     "@metamask/controller-utils": "^4.3.2",
     "@metamask/eth-query": "^3.0.1",
     "@metamask/network-controller": "^12.2.0",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "@types/uuid": "^8.3.0",
     "ethereumjs-util": "^7.0.10",
     "ethjs-unit": "^0.1.6",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -33,7 +33,7 @@
     "@metamask/eth-keyring-controller": "^13.0.1",
     "@metamask/message-manager": "^7.3.2",
     "@metamask/preferences-controller": "^4.4.0",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "async-mutex": "^0.2.6",
     "ethereumjs-util": "^7.0.10",
     "ethereumjs-wallet": "^1.0.1",

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -31,7 +31,7 @@
     "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.2",
     "@metamask/eth-sig-util": "^7.0.0",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "@types/uuid": "^8.3.0",
     "ethereumjs-util": "^7.0.10",
     "jsonschema": "^1.2.4",

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -35,7 +35,7 @@
     "@metamask/eth-json-rpc-provider": "^1.0.0",
     "@metamask/eth-query": "^3.0.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "async-mutex": "^0.2.6",
     "eth-block-tracker": "^7.0.1",
     "eth-rpc-errors": "^4.0.2",

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^3.2.1",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "immer": "^9.0.6",
     "nanoid": "^3.1.31"
   },

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -31,12 +31,12 @@
     "@metamask/approval-controller": "^3.5.1",
     "@metamask/base-controller": "^3.2.1",
     "@metamask/controller-utils": "^4.3.2",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/json-rpc-engine": "^7.1.1",
+    "@metamask/utils": "^8.1.0",
     "@types/deep-freeze-strict": "^1.1.0",
     "deep-freeze-strict": "^1.1.1",
     "eth-rpc-errors": "^4.0.2",
     "immer": "^9.0.6",
-    "json-rpc-engine": "^6.1.0",
     "nanoid": "^3.1.31"
   },
   "devDependencies": {

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -3,7 +3,7 @@ import type {
   EventConstraint,
 } from '@metamask/base-controller';
 import type { NonEmptyArray } from '@metamask/controller-utils';
-import type { Json } from '@metamask/utils';
+import type { Json, JsonRpcParams } from '@metamask/utils';
 import { nanoid } from 'nanoid';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -210,7 +210,7 @@ type RestrictedMethodContext = Readonly<{
   [key: string]: any;
 }>;
 
-export type RestrictedMethodParameters = Json[] | Record<string, Json> | void;
+export type RestrictedMethodParameters = JsonRpcParams;
 
 /**
  * The arguments passed to a restricted method implementation.

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -6,11 +6,10 @@ import type {
 } from '@metamask/approval-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
 import { isPlainObject } from '@metamask/controller-utils';
-import type { Json } from '@metamask/utils';
+import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import { hasProperty } from '@metamask/utils';
+import type { Json, PendingJsonRpcResponse } from '@metamask/utils';
 import assert from 'assert';
-import { JsonRpcEngine } from 'json-rpc-engine';
-import type { PendingJsonRpcResponse } from 'json-rpc-engine';
 
 import type {
   AsyncRestrictedMethod,

--- a/packages/permission-controller/src/permission-middleware.ts
+++ b/packages/permission-controller/src/permission-middleware.ts
@@ -1,13 +1,15 @@
-import type { Json } from '@metamask/utils';
-import { createAsyncMiddleware } from 'json-rpc-engine';
+import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
 import type {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   JsonRpcEngine,
   JsonRpcMiddleware,
   AsyncJsonRpcEngineNextCallback,
-  PendingJsonRpcResponse,
+} from '@metamask/json-rpc-engine';
+import type {
+  Json,
   JsonRpcRequest,
-} from 'json-rpc-engine';
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
 
 import type {
   GenericPermissionController,
@@ -60,7 +62,7 @@ export function getPermissionMiddlewareFactory({
     }
 
     const permissionsMiddleware = async (
-      req: JsonRpcRequest<RestrictedMethodParameters>,
+      req: JsonRpcRequest,
       res: PendingJsonRpcResponse<Json>,
       next: AsyncJsonRpcEngineNextCallback,
     ): Promise<void> => {

--- a/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
@@ -1,4 +1,4 @@
-import { JsonRpcEngine } from 'json-rpc-engine';
+import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 
 import { getPermissionsHandler } from './getPermissions';
 

--- a/packages/permission-controller/src/rpc-methods/getPermissions.ts
+++ b/packages/permission-controller/src/rpc-methods/getPermissions.ts
@@ -1,5 +1,5 @@
-import type { PendingJsonRpcResponse } from '@metamask/utils';
-import type { JsonRpcEngineEndCallback } from 'json-rpc-engine';
+import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
+import type { JsonRpcParams, PendingJsonRpcResponse } from '@metamask/utils';
 
 import type { PermissionConstraint } from '../Permission';
 import type { SubjectPermissions } from '../PermissionController';
@@ -8,7 +8,7 @@ import { MethodNames } from '../utils';
 
 export const getPermissionsHandler: PermittedHandlerExport<
   GetPermissionsHooks,
-  undefined,
+  JsonRpcParams,
   PermissionConstraint[]
 > = {
   methodNames: [MethodNames.getPermissions],

--- a/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
@@ -1,5 +1,8 @@
+import {
+  JsonRpcEngine,
+  createAsyncMiddleware,
+} from '@metamask/json-rpc-engine';
 import { ethErrors, serializeError } from 'eth-rpc-errors';
-import { JsonRpcEngine, createAsyncMiddleware } from 'json-rpc-engine';
 
 import { requestPermissionsHandler } from './requestPermissions';
 

--- a/packages/permission-controller/src/rpc-methods/requestPermissions.ts
+++ b/packages/permission-controller/src/rpc-methods/requestPermissions.ts
@@ -1,7 +1,7 @@
 import { isPlainObject } from '@metamask/controller-utils';
+import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
 import type { JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
-import type { JsonRpcEngineEndCallback } from 'json-rpc-engine';
 
 import { invalidParams } from '../errors';
 import type { PermissionConstraint, RequestedPermissions } from '../Permission';

--- a/packages/permission-controller/src/utils.ts
+++ b/packages/permission-controller/src/utils.ts
@@ -1,13 +1,13 @@
 import type {
+  JsonRpcEngineEndCallback,
+  JsonRpcEngineNextCallback,
+} from '@metamask/json-rpc-engine';
+import type {
   Json,
   JsonRpcParams,
   JsonRpcRequest,
   PendingJsonRpcResponse,
 } from '@metamask/utils';
-import type {
-  JsonRpcEngineEndCallback,
-  JsonRpcEngineNextCallback,
-} from 'json-rpc-engine';
 
 import type {
   CaveatSpecificationConstraint,

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -33,7 +33,7 @@
     "@metamask/controller-utils": "^4.3.2",
     "@metamask/logging-controller": "^1.0.1",
     "@metamask/message-manager": "^7.3.2",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "eth-rpc-errors": "^4.0.2",
     "ethereumjs-util": "^7.0.10",
     "immer": "^9.0.6",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -37,7 +37,7 @@
     "@metamask/eth-query": "^3.0.1",
     "@metamask/metamask-eth-abis": "^3.0.0",
     "@metamask/network-controller": "^12.2.0",
-    "@metamask/utils": "^6.2.0",
+    "@metamask/utils": "^8.1.0",
     "async-mutex": "^0.2.6",
     "eth-method-registry": "1.1.0",
     "eth-rpc-errors": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1298,7 +1298,7 @@ __metadata:
     "@metamask/keyring-controller": ^7.5.0
     "@metamask/snaps-controllers": ^1.0.1
     "@metamask/snaps-utils": ^1.0.1
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     "@types/readable-stream": ^2.3.0
     deepmerge: ^4.2.2
@@ -1335,7 +1335,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.2
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -1369,7 +1369,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     eth-rpc-errors: ^4.0.2
@@ -1403,7 +1403,7 @@ __metadata:
     "@metamask/network-controller": ^12.2.0
     "@metamask/preferences-controller": ^4.4.0
     "@metamask/rpc-errors": ^5.1.1
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     "@types/node": ^16.18.24
     "@types/uuid": ^8.3.0
@@ -1450,7 +1450,7 @@ __metadata:
   resolution: "@metamask/base-controller@workspace:packages/base-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     "@types/sinon": ^9.0.10
     deepmerge: ^4.2.2
@@ -1502,7 +1502,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/eth-query": ^3.0.1
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@spruceid/siwe-parser": 1.1.3
     "@types/jest": ^27.4.1
     abort-controller: ^3.0.0
@@ -1532,7 +1532,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.0.0
     "@metamask/eslint-config-typescript": ^12.0.0
     "@metamask/eth-json-rpc-provider": ^1.0.0
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/node": ^16.18.24
     "@typescript-eslint/eslint-plugin": ^5.30.7
     "@typescript-eslint/parser": ^5.30.7
@@ -1588,7 +1588,7 @@ __metadata:
     "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.2
     "@metamask/network-controller": ^12.2.0
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     ethereum-ens-network-map: ^1.0.2
@@ -1810,7 +1810,7 @@ __metadata:
     "@metamask/controller-utils": ^4.3.2
     "@metamask/eth-query": ^3.0.1
     "@metamask/network-controller": ^12.2.0
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     "@types/jest-when": ^2.7.3
     "@types/uuid": ^8.3.0
@@ -1902,7 +1902,7 @@ __metadata:
     "@metamask/message-manager": ^7.3.2
     "@metamask/preferences-controller": ^4.4.0
     "@metamask/scure-bip39": ^2.1.0
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     async-mutex: ^0.2.6
     deepmerge: ^4.2.2
@@ -1947,7 +1947,7 @@ __metadata:
     "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.2
     "@metamask/eth-sig-util": ^7.0.0
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     "@types/uuid": ^8.3.0
     deepmerge: ^4.2.2
@@ -1999,7 +1999,7 @@ __metadata:
     "@metamask/eth-json-rpc-provider": ^1.0.0
     "@metamask/eth-query": ^3.0.1
     "@metamask/swappable-obj-proxy": ^2.1.0
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     "@types/jest-when": ^2.7.3
     "@types/lodash": ^4.14.191
@@ -2028,7 +2028,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     immer: ^9.0.6
@@ -2080,7 +2080,8 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.1
     "@metamask/controller-utils": ^4.3.2
-    "@metamask/utils": ^6.2.0
+    "@metamask/json-rpc-engine": ^7.1.1
+    "@metamask/utils": ^8.1.0
     "@types/deep-freeze-strict": ^1.1.0
     "@types/jest": ^27.4.1
     deep-freeze-strict: ^1.1.1
@@ -2088,7 +2089,6 @@ __metadata:
     eth-rpc-errors: ^4.0.2
     immer: ^9.0.6
     jest: ^27.5.1
-    json-rpc-engine: ^6.1.0
     nanoid: ^3.1.31
     ts-jest: ^27.1.4
     typedoc: ^0.22.15
@@ -2339,7 +2339,7 @@ __metadata:
     "@metamask/keyring-controller": ^7.5.0
     "@metamask/logging-controller": ^1.0.1
     "@metamask/message-manager": ^7.3.2
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     eth-rpc-errors: ^4.0.2
@@ -2564,7 +2564,7 @@ __metadata:
     "@metamask/eth-query": ^3.0.1
     "@metamask/metamask-eth-abis": ^3.0.0
     "@metamask/network-controller": ^12.2.0
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     "@types/node": ^16.18.24
     async-mutex: ^0.2.6
@@ -2623,7 +2623,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^6.0.1, @metamask/utils@npm:^6.2.0":
+"@metamask/utils@npm:^6.0.1":
   version: 6.2.0
   resolution: "@metamask/utils@npm:6.2.0"
   dependencies:


### PR DESCRIPTION
## Explanation

This bumps `@metamask/json-rpc-engine` (previously `json-rpc-engine`) and `@metamask/utils` to the latest versions. This is required to be able to use the latest versions of `@metamask/json-rpc-engine` and `@metamask/eth-json-rpc-middleware` in Snaps.

The updated version of `@metamask/json-rpc-engine` is functionally equivalent to the previous version, but has improved types. To be able to bump it, it also required a bump of `@metamask/utils`.

## Changelog

### `@metamask/accounts-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/address-book-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/approval-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/assets-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/base-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/controller-utils`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/ens-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/gas-fee-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/keyring-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/message-manager`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/network-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/notification-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/permission-controller`

- **BREAKING**: `RestrictedMethodParameters` no longer accepts `void` as type.
- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`
- **CHANGED**: Bump `@metamask/json-rpc-engine` from `^6.1.0` to `^7.1.1`

### `@metamask/signature-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

### `@metamask/transaction-controller`

- **CHANGED**: Bump `@metamask/utils` from `^6.2.0` to `^8.1.0`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
