### PR TITLE
chore: Remove AbortController polyfill

### DIFF
--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -44,7 +44,6 @@
     "@metamask/rpc-errors": "^5.1.1",
     "@metamask/utils": "^6.2.0",
     "@types/uuid": "^8.3.0",
-    "abort-controller": "^3.0.0",
     "async-mutex": "^0.2.6",
     "ethereumjs-util": "^7.0.10",
     "immer": "^9.0.6",

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -6,7 +6,6 @@ import type {
   NetworkState,
 } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
-import { AbortController as WhatwgAbortController } from 'abort-controller';
 import { Mutex } from 'async-mutex';
 import type { Patch } from 'immer';
 
@@ -96,7 +95,7 @@ export class TokenListController extends BaseControllerV2<
 
   private chainId: Hex;
 
-  private abortController: WhatwgAbortController;
+  private abortController: AbortController;
 
   /**
    * Creates a TokenListController instance.
@@ -139,7 +138,7 @@ export class TokenListController extends BaseControllerV2<
     this.cacheRefreshThreshold = cacheRefreshThreshold;
     this.chainId = chainId;
     this.updatePreventPollingOnNetworkRestart(preventPollingOnNetworkRestart);
-    this.abortController = new WhatwgAbortController();
+    this.abortController = new AbortController();
     if (onNetworkStateChange) {
       onNetworkStateChange(async (networkControllerState) => {
         await this.#onNetworkControllerStateChange(networkControllerState);
@@ -163,7 +162,7 @@ export class TokenListController extends BaseControllerV2<
   async #onNetworkControllerStateChange(networkControllerState: NetworkState) {
     if (this.chainId !== networkControllerState.providerConfig.chainId) {
       this.abortController.abort();
-      this.abortController = new WhatwgAbortController();
+      this.abortController = new AbortController();
       this.chainId = networkControllerState.providerConfig.chainId;
       if (this.state.preventPollingOnNetworkRestart) {
         this.clearingTokenListData();

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -23,7 +23,6 @@ import type {
 } from '@metamask/network-controller';
 import type { PreferencesState } from '@metamask/preferences-controller';
 import type { Hex } from '@metamask/utils';
-import { AbortController as WhatwgAbortController } from 'abort-controller';
 import { Mutex } from 'async-mutex';
 import { EventEmitter } from 'events';
 import { v1 as random } from 'uuid';
@@ -125,7 +124,7 @@ export class TokensController extends BaseController<
 > {
   private readonly mutex = new Mutex();
 
-  private abortController: WhatwgAbortController;
+  private abortController: AbortController;
 
   private readonly messagingSystem: TokensControllerMessenger;
 
@@ -231,7 +230,7 @@ export class TokensController extends BaseController<
     };
 
     this.initialize();
-    this.abortController = new WhatwgAbortController();
+    this.abortController = new AbortController();
     this.getERC20TokenName = getERC20TokenName;
     this.getNetworkClientById = getNetworkClientById;
 
@@ -253,7 +252,7 @@ export class TokensController extends BaseController<
       const { selectedAddress } = this.config;
       const { chainId } = providerConfig;
       this.abortController.abort();
-      this.abortController = new WhatwgAbortController();
+      this.abortController = new AbortController();
       this.configure({ chainId });
       this.update({
         tokens: allTokens[chainId]?.[selectedAddress] || [],

--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -1,5 +1,4 @@
 import { toHex } from '@metamask/controller-utils';
-import { AbortController as WhatwgAbortController } from 'abort-controller';
 import nock from 'nock';
 
 import {
@@ -140,7 +139,7 @@ const sampleChainId = toHex(sampleDecimalChainId);
 describe('Token service', () => {
   describe('fetchTokenList', () => {
     it('should call the tokens api and return the list of tokens', async () => {
-      const { signal } = new WhatwgAbortController();
+      const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${sampleDecimalChainId}`)
         .reply(200, sampleTokenList)
@@ -152,7 +151,7 @@ describe('Token service', () => {
     });
 
     it('should return undefined if the fetch is aborted', async () => {
-      const abortController = new WhatwgAbortController();
+      const abortController = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${sampleDecimalChainId}`)
         // well beyond time it will take to abort
@@ -170,7 +169,7 @@ describe('Token service', () => {
     });
 
     it('should return undefined if the fetch fails with a network error', async () => {
-      const { signal } = new WhatwgAbortController();
+      const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${sampleDecimalChainId}`)
         .replyWithError('Example network error')
@@ -182,7 +181,7 @@ describe('Token service', () => {
     });
 
     it('should return undefined if the fetch fails with an unsuccessful status code', async () => {
-      const { signal } = new WhatwgAbortController();
+      const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${sampleDecimalChainId}`)
         .reply(500)
@@ -194,7 +193,7 @@ describe('Token service', () => {
     });
 
     it('should return undefined if the fetch fails with a timeout', async () => {
-      const { signal } = new WhatwgAbortController();
+      const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${sampleDecimalChainId}`)
         // well beyond timeout
@@ -212,7 +211,7 @@ describe('Token service', () => {
 
   describe('fetchTokenMetadata', () => {
     it('should call the api to return the token metadata for eth address provided', async () => {
-      const { signal } = new WhatwgAbortController();
+      const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(
           `/token/${sampleDecimalChainId}?address=0x514910771af9ca656af840dff83e8264ecf986ca`,
@@ -230,7 +229,7 @@ describe('Token service', () => {
     });
 
     it('should return undefined if the fetch is aborted', async () => {
-      const abortController = new WhatwgAbortController();
+      const abortController = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${sampleDecimalChainId}`)
         // well beyond time it will take to abort
@@ -249,7 +248,7 @@ describe('Token service', () => {
     });
 
     it('should return undefined if the fetch fails with a network error', async () => {
-      const { signal } = new WhatwgAbortController();
+      const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${sampleDecimalChainId}`)
         .replyWithError('Example network error')
@@ -265,7 +264,7 @@ describe('Token service', () => {
     });
 
     it('should return undefined if the fetch fails with an unsuccessful status code', async () => {
-      const { signal } = new WhatwgAbortController();
+      const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${sampleDecimalChainId}`)
         .reply(500)
@@ -281,7 +280,7 @@ describe('Token service', () => {
     });
 
     it('should return undefined if the fetch fails with a timeout', async () => {
-      const { signal } = new WhatwgAbortController();
+      const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${sampleDecimalChainId}`)
         // well beyond timeout
@@ -300,7 +299,7 @@ describe('Token service', () => {
     });
 
     it('should throw error if fetching from non supported network', async () => {
-      const { signal } = new WhatwgAbortController();
+      const { signal } = new AbortController();
       await expect(
         fetchTokenMetadata(
           toHex(5),
@@ -312,7 +311,7 @@ describe('Token service', () => {
   });
 
   it('should call the tokens api and return undefined', async () => {
-    const { signal } = new WhatwgAbortController();
+    const { signal } = new AbortController();
     nock(TOKEN_END_POINT_API)
       .get(`/tokens/${sampleDecimalChainId}`)
       .reply(404, undefined)

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^27.4.1",
-    "abort-controller": "^3.0.0",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "nock": "^13.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,7 +1407,6 @@ __metadata:
     "@types/jest": ^27.4.1
     "@types/node": ^16.18.24
     "@types/uuid": ^8.3.0
-    abort-controller: ^3.0.0
     async-mutex: ^0.2.6
     deepmerge: ^4.2.2
     ethereumjs-util: ^7.0.10
@@ -1505,7 +1504,6 @@ __metadata:
     "@metamask/utils": ^6.2.0
     "@spruceid/siwe-parser": 1.1.3
     "@types/jest": ^27.4.1
-    abort-controller: ^3.0.0
     deepmerge: ^4.2.2
     eth-ens-namehash: ^2.0.8
     eth-rpc-errors: ^4.0.2
@@ -3446,15 +3444,6 @@ __metadata:
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
   checksum: a4a97ec07d7ea112c517036882b2ac22f3109b7b19077dc656316d07d308438aac28e4d9746dc4d84bf6b1e75b4a7b0a5f3cb30592419f128ca9a8cee3bcfa17
-  languageName: node
-  linkType: hard
-
-"abort-controller@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "abort-controller@npm:3.0.0"
-  dependencies:
-    event-target-shim: ^5.0.0
-  checksum: 170bdba9b47b7e65906a28c8ce4f38a7a369d78e2271706f020849c1bfe0ee2067d4261df8bbb66eb84f79208fd5b710df759d64191db58cfba7ce8ef9c54b75
   languageName: node
   linkType: hard
 
@@ -5593,13 +5582,6 @@ __metadata:
     js-sha3: 0.5.5
     number-to-bn: 1.7.0
   checksum: aa4e69ce4b5db75f8869850ba97199fbee086d0e1a228002a599bdf5617ff1fc914f7552ed25d7c916cf0457d3cbc5d4385f6ea20890b67762eed93a0ef74851
-  languageName: node
-  linkType: hard
-
-"event-target-shim@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "event-target-shim@npm:5.0.1"
-  checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

The `AbortController` polyfill has not been required since updating to a minimum Node.js version of v16 in #1262. This API has been [built into Node.js since v15.4.0](https://nodejs.org/docs/latest-v16.x/api/globals.html#class-abortcontroller), and is included in all versions of v16. It is also supported by [all browsers that our extension supports](https://developer.mozilla.org/en-US/docs/Web/API/AbortController#browser_compatibility), and has been [supported by React Native since v0.60.0](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#v0600).

This helps unblock the TypeScript update to v4.8.4. The update resulted in some type errors from this polyfill package.

## References
None

## Changelog

### `@metamask/assets-controllers`

### Removed
- **BREAKING:** Remove AbortController polyfill
  - This package now assumes that the AbortController global exists

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
