### PR TITLE
Normalize addresses in name controller

### DIFF
--- a/packages/name-controller/src/NameController.test.ts
+++ b/packages/name-controller/src/NameController.test.ts
@@ -7,7 +7,7 @@ const PROPOSED_NAME_MOCK = 'TestProposedName';
 const PROPOSED_NAME_2_MOCK = 'TestProposedName2';
 const SOURCE_ID_MOCK = 'TestSourceId';
 const SOURCE_LABEL_MOCK = 'TestSourceLabel';
-const VALUE_MOCK = 'TestValue';
+const VALUE_MOCK = 'testvalue';
 const CHAIN_ID_MOCK = '0x1';
 const GET_CHAIN_ID_MOCK = () => CHAIN_ID_MOCK;
 const TIME_MOCK = 123;
@@ -287,6 +287,58 @@ describe('NameController', () => {
             [CHAIN_ID_MOCK]: {
               name: null,
               sourceId: null,
+              proposedNames: {
+                [SOURCE_ID_MOCK]: {
+                  proposedNames: [PROPOSED_NAME_MOCK, PROPOSED_NAME_2_MOCK],
+                  lastRequestTime: null,
+                  updateDelay: null,
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('stores address as lowercase', () => {
+      const provider1 = createMockProvider(1);
+
+      const controller = new NameController({
+        ...CONTROLLER_ARGS_MOCK,
+        providers: [provider1],
+      });
+
+      controller.state.names = {
+        [NameType.ETHEREUM_ADDRESS]: {
+          [VALUE_MOCK]: {
+            [CHAIN_ID_MOCK]: {
+              name: null,
+              sourceId: null,
+              proposedNames: {
+                [SOURCE_ID_MOCK]: {
+                  proposedNames: [PROPOSED_NAME_MOCK, PROPOSED_NAME_2_MOCK],
+                  lastRequestTime: null,
+                  updateDelay: null,
+                },
+              },
+            },
+          },
+        },
+      };
+
+      controller.setName({
+        value: 'tESTvALue',
+        type: NameType.ETHEREUM_ADDRESS,
+        name: NAME_MOCK,
+        sourceId: `${SOURCE_ID_MOCK}1`,
+      });
+
+      expect(controller.state.names).toStrictEqual({
+        [NameType.ETHEREUM_ADDRESS]: {
+          [VALUE_MOCK]: {
+            [CHAIN_ID_MOCK]: {
+              name: NAME_MOCK,
+              sourceId: `${SOURCE_ID_MOCK}1`,
               proposedNames: {
                 [SOURCE_ID_MOCK]: {
                   proposedNames: [PROPOSED_NAME_MOCK, PROPOSED_NAME_2_MOCK],
@@ -942,6 +994,59 @@ describe('NameController', () => {
               `${PROPOSED_NAME_MOCK}1_2`,
             ],
             error: undefined,
+          },
+        },
+      });
+    });
+
+    it('stores address as lowercase', async () => {
+      const provider1 = createMockProvider(1);
+
+      const controller = new NameController({
+        ...CONTROLLER_ARGS_MOCK,
+        providers: [provider1],
+      });
+
+      controller.state.names = {
+        [NameType.ETHEREUM_ADDRESS]: {
+          [VALUE_MOCK]: {
+            [CHAIN_ID_MOCK]: {
+              name: NAME_MOCK,
+              sourceId: `${SOURCE_ID_MOCK}1`,
+              proposedNames: {
+                [`${SOURCE_ID_MOCK}1`]: {
+                  proposedNames: [],
+                  lastRequestTime: null,
+                  updateDelay: null,
+                },
+              },
+            },
+          },
+        },
+      };
+
+      await controller.updateProposedNames({
+        value: 'tESTvALue',
+        type: NameType.ETHEREUM_ADDRESS,
+      });
+
+      expect(controller.state.names).toStrictEqual({
+        [NameType.ETHEREUM_ADDRESS]: {
+          [VALUE_MOCK]: {
+            [CHAIN_ID_MOCK]: {
+              name: NAME_MOCK,
+              sourceId: `${SOURCE_ID_MOCK}1`,
+              proposedNames: {
+                [`${SOURCE_ID_MOCK}1`]: {
+                  proposedNames: [
+                    `${PROPOSED_NAME_MOCK}1`,
+                    `${PROPOSED_NAME_MOCK}1_2`,
+                  ],
+                  lastRequestTime: TIME_MOCK,
+                  updateDelay: null,
+                },
+              },
+            },
           },
         },
       });

--- a/packages/name-controller/src/NameController.test.ts
+++ b/packages/name-controller/src/NameController.test.ts
@@ -9,7 +9,6 @@ const SOURCE_ID_MOCK = 'TestSourceId';
 const SOURCE_LABEL_MOCK = 'TestSourceLabel';
 const VALUE_MOCK = 'testvalue';
 const CHAIN_ID_MOCK = '0x1';
-const GET_CHAIN_ID_MOCK = () => CHAIN_ID_MOCK;
 const TIME_MOCK = 123;
 
 const MESSENGER_MOCK = {
@@ -18,7 +17,6 @@ const MESSENGER_MOCK = {
 } as any;
 
 const CONTROLLER_ARGS_MOCK = {
-  getChainId: GET_CHAIN_ID_MOCK,
   messenger: MESSENGER_MOCK,
   providers: [],
 };
@@ -79,6 +77,7 @@ describe('NameController', () => {
         type: NameType.ETHEREUM_ADDRESS,
         name: NAME_MOCK,
         sourceId: `${SOURCE_ID_MOCK}1`,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -125,6 +124,7 @@ describe('NameController', () => {
         type: NameType.ETHEREUM_ADDRESS,
         name: NAME_MOCK,
         sourceId: `${SOURCE_ID_MOCK}1`,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -171,6 +171,7 @@ describe('NameController', () => {
         value: VALUE_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
         name: NAME_MOCK,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -192,13 +193,12 @@ describe('NameController', () => {
       });
     });
 
-    it('stores alternate name for each ethereum address for each chain ID', () => {
+    it('stores alternate name for each ethereum address for each variation', () => {
       const alternateChainId = `${CHAIN_ID_MOCK}2`;
       const alternateName = `${NAME_MOCK}2`;
 
       const controller = new NameController({
         ...CONTROLLER_ARGS_MOCK,
-        getChainId: () => alternateChainId,
       });
 
       controller.state.names = {
@@ -223,6 +223,7 @@ describe('NameController', () => {
         value: VALUE_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
         name: alternateName,
+        variation: alternateChainId,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -279,6 +280,7 @@ describe('NameController', () => {
         value: VALUE_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
         name: null,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -331,6 +333,7 @@ describe('NameController', () => {
         type: NameType.ETHEREUM_ADDRESS,
         name: NAME_MOCK,
         sourceId: `${SOURCE_ID_MOCK}1`,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -365,6 +368,7 @@ describe('NameController', () => {
             value,
             type: NameType.ETHEREUM_ADDRESS,
             name: NAME_MOCK,
+            variation: CHAIN_ID_MOCK,
           } as any),
         ).toThrow('Must specify a non-empty string for value.');
       });
@@ -382,6 +386,7 @@ describe('NameController', () => {
             value: VALUE_MOCK,
             type,
             name: NAME_MOCK,
+            variation: CHAIN_ID_MOCK,
           } as any),
         ).toThrow(
           `Must specify one of the following types: ${Object.values(
@@ -402,6 +407,7 @@ describe('NameController', () => {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
             name,
+            variation: CHAIN_ID_MOCK,
           } as any),
         ).toThrow('Must specify a non-empty string or null for name.');
       });
@@ -418,8 +424,29 @@ describe('NameController', () => {
             type: NameType.ETHEREUM_ADDRESS,
             name: NAME_MOCK,
             sourceId,
+            variation: CHAIN_ID_MOCK,
           } as any),
         ).toThrow('Must specify a non-empty string for sourceId.');
+      });
+
+      it.each([
+        ['missing', undefined],
+        ['empty', ''],
+        ['not a string', 12],
+        ['not a hexadecimal chain ID', '0x1gh'],
+      ])('variation is %s and type is Ethereum address', (_, variation) => {
+        const controller = new NameController(CONTROLLER_ARGS_MOCK);
+
+        expect(() =>
+          controller.setName({
+            value: VALUE_MOCK,
+            type: NameType.ETHEREUM_ADDRESS,
+            name: NAME_MOCK,
+            variation,
+          } as any),
+        ).toThrow(
+          `Must specify a chain ID in hexidecimal format for variation when using '${NameType.ETHEREUM_ADDRESS}' type.`,
+        );
       });
 
       it('source ID is unrecognised for type', () => {
@@ -431,6 +458,7 @@ describe('NameController', () => {
             type: NameType.ETHEREUM_ADDRESS,
             name: NAME_MOCK,
             sourceId: SOURCE_ID_MOCK,
+            variation: CHAIN_ID_MOCK,
           } as any),
         ).toThrow(
           `Unknown source ID for type '${NameType.ETHEREUM_ADDRESS}': ${SOURCE_ID_MOCK}`,
@@ -446,6 +474,7 @@ describe('NameController', () => {
             type: NameType.ETHEREUM_ADDRESS,
             name: null,
             sourceId: SOURCE_ID_MOCK,
+            variation: CHAIN_ID_MOCK,
           } as any),
         ).toThrow(
           `Cannot specify a source ID when clearing the saved name: ${SOURCE_ID_MOCK}`,
@@ -474,6 +503,7 @@ describe('NameController', () => {
         const result = await controller.updateProposedNames({
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -561,6 +591,7 @@ describe('NameController', () => {
       const result = await controller.updateProposedNames({
         value: VALUE_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -642,6 +673,7 @@ describe('NameController', () => {
       await controller.updateProposedNames({
         value: VALUE_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -695,6 +727,7 @@ describe('NameController', () => {
       const result = await controller.updateProposedNames({
         value: VALUE_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -761,6 +794,7 @@ describe('NameController', () => {
       await controller.updateProposedNames({
         value: VALUE_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.nameSources).toStrictEqual({
@@ -779,14 +813,13 @@ describe('NameController', () => {
       });
     });
 
-    it('stores alternate proposed names for each ethereum address for each chain ID', async () => {
+    it('stores alternate proposed names for each ethereum address for each variation', async () => {
       const provider1 = createMockProvider(1);
       const provider2 = createMockProvider(2);
       const alternateChainId = `${CHAIN_ID_MOCK}2`;
 
       const controller = new NameController({
         ...CONTROLLER_ARGS_MOCK,
-        getChainId: () => alternateChainId,
         providers: [provider1, provider2],
       });
 
@@ -821,6 +854,7 @@ describe('NameController', () => {
       await controller.updateProposedNames({
         value: VALUE_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
+        variation: alternateChainId,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -902,6 +936,7 @@ describe('NameController', () => {
       const result = await controller.updateProposedNames({
         value: VALUE_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -963,6 +998,7 @@ describe('NameController', () => {
       const result = await controller.updateProposedNames({
         value: VALUE_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -1028,6 +1064,7 @@ describe('NameController', () => {
       await controller.updateProposedNames({
         value: 'tESTvALue',
         type: NameType.ETHEREUM_ADDRESS,
+        variation: CHAIN_ID_MOCK,
       });
 
       expect(controller.state.names).toStrictEqual({
@@ -1098,6 +1135,7 @@ describe('NameController', () => {
         await controller.updateProposedNames({
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -1162,6 +1200,7 @@ describe('NameController', () => {
         await controller.updateProposedNames({
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -1221,6 +1260,7 @@ describe('NameController', () => {
         await controller.updateProposedNames({
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -1259,6 +1299,7 @@ describe('NameController', () => {
         const result = await controller.updateProposedNames({
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -1322,6 +1363,7 @@ describe('NameController', () => {
         const result = await controller.updateProposedNames({
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -1388,6 +1430,7 @@ describe('NameController', () => {
         const result = await controller.updateProposedNames({
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -1477,6 +1520,7 @@ describe('NameController', () => {
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
           sourceIds: [`${SOURCE_ID_MOCK}2`],
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -1525,7 +1569,7 @@ describe('NameController', () => {
         expect(provider1.getProposedNames).not.toHaveBeenCalled();
         expect(provider2.getProposedNames).toHaveBeenCalledTimes(1);
         expect(provider2.getProposedNames).toHaveBeenCalledWith({
-          chainId: CHAIN_ID_MOCK,
+          variation: CHAIN_ID_MOCK,
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
           sourceIds: [`${SOURCE_ID_MOCK}2`],
@@ -1545,11 +1589,12 @@ describe('NameController', () => {
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
           sourceIds: [`${SOURCE_ID_MOCK}1`, `${SOURCE_ID_MOCK}2`],
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(provider1.getProposedNames).toHaveBeenCalledTimes(1);
         expect(provider1.getProposedNames).toHaveBeenCalledWith({
-          chainId: CHAIN_ID_MOCK,
+          variation: CHAIN_ID_MOCK,
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
           sourceIds: [`${SOURCE_ID_MOCK}1`],
@@ -1557,7 +1602,7 @@ describe('NameController', () => {
 
         expect(provider2.getProposedNames).toHaveBeenCalledTimes(1);
         expect(provider2.getProposedNames).toHaveBeenCalledWith({
-          chainId: CHAIN_ID_MOCK,
+          variation: CHAIN_ID_MOCK,
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
           sourceIds: [`${SOURCE_ID_MOCK}2`],
@@ -1593,6 +1638,7 @@ describe('NameController', () => {
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
           sourceIds: [`${SOURCE_ID_MOCK}1`],
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -1647,6 +1693,7 @@ describe('NameController', () => {
           controller.updateProposedNames({
             value,
             type: NameType.ETHEREUM_ADDRESS,
+            variation: CHAIN_ID_MOCK,
           } as any),
         ).rejects.toThrow('Must specify a non-empty string for value.');
       });
@@ -1668,6 +1715,7 @@ describe('NameController', () => {
           controller.updateProposedNames({
             value: VALUE_MOCK,
             type,
+            variation: CHAIN_ID_MOCK,
           } as any),
         ).rejects.toThrow(
           `Must specify one of the following types: ${Object.values(
@@ -1675,6 +1723,28 @@ describe('NameController', () => {
           ).join(', ')}`,
         );
       });
+
+      it.each([
+        ['missing', undefined],
+        ['empty', ''],
+        ['not a string', 12],
+        ['not a hexadecimal chain ID', '0x1gh'],
+      ])(
+        'variation is %s and type is Ethereum address',
+        async (_, variation) => {
+          const controller = new NameController(CONTROLLER_ARGS_MOCK);
+
+          await expect(() =>
+            controller.updateProposedNames({
+              value: VALUE_MOCK,
+              type: NameType.ETHEREUM_ADDRESS,
+              variation,
+            } as any),
+          ).rejects.toThrow(
+            `Must specify a chain ID in hexidecimal format for variation when using '${NameType.ETHEREUM_ADDRESS}' type.`,
+          );
+        },
+      );
 
       it('throws if missing sources', async () => {
         const provider1 = createMockProvider(1);
@@ -1689,6 +1759,7 @@ describe('NameController', () => {
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
             sourceIds: [`${SOURCE_ID_MOCK}2`, `${SOURCE_ID_MOCK}3`],
+            variation: CHAIN_ID_MOCK,
           }),
         ).rejects.toThrow(
           `Unknown source IDs for type '${NameType.ETHEREUM_ADDRESS}': ${SOURCE_ID_MOCK}2, ${SOURCE_ID_MOCK}3`,
@@ -1711,6 +1782,7 @@ describe('NameController', () => {
           controller.updateProposedNames({
             value: VALUE_MOCK,
             type: NameType.ETHEREUM_ADDRESS,
+            variation: CHAIN_ID_MOCK,
           }),
         ).rejects.toThrow(
           `Duplicate source IDs found for type '${NameType.ETHEREUM_ADDRESS}': ${SOURCE_ID_MOCK}1, ${SOURCE_ID_MOCK}2`,
@@ -1756,6 +1828,7 @@ describe('NameController', () => {
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
           onlyUpdateAfterDelay: true,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -1822,6 +1895,7 @@ describe('NameController', () => {
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
           onlyUpdateAfterDelay: true,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -1889,6 +1963,7 @@ describe('NameController', () => {
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
           onlyUpdateAfterDelay: true,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -1976,6 +2051,7 @@ describe('NameController', () => {
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
           onlyUpdateAfterDelay: true,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({
@@ -2042,6 +2118,7 @@ describe('NameController', () => {
           value: VALUE_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
           onlyUpdateAfterDelay: true,
+          variation: CHAIN_ID_MOCK,
         });
 
         expect(controller.state.names).toStrictEqual({

--- a/packages/name-controller/src/NameController.ts
+++ b/packages/name-controller/src/NameController.ts
@@ -302,10 +302,10 @@ export class NameController extends BaseControllerV2<
     }
 
     const providerRequest: NameProviderRequest = {
-      value,
+      value: this.#normalizeValue(value, type),
       type,
       sourceIds: requestedSourceIds ? matchingSourceIds : undefined,
-      variation: variationKey,
+      variation: this.#normalizeVariation(variationKey, type),
     };
 
     let responseError: unknown | undefined;
@@ -373,13 +373,22 @@ export class NameController extends BaseControllerV2<
   #normalizeValue(value: string, type: NameType): string {
     /* istanbul ignore next */
     switch (type) {
-      case NameType.ETHEREUM_ADDRESS: {
+      case NameType.ETHEREUM_ADDRESS:
         return value.toLowerCase();
-      }
 
-      default: {
+      default:
         return value;
-      }
+    }
+  }
+
+  #normalizeVariation(variation: string, type: NameType): string {
+    /* istanbul ignore next */
+    switch (type) {
+      case NameType.ETHEREUM_ADDRESS:
+        return variation.toLowerCase();
+
+      default:
+        return variation;
     }
   }
 
@@ -392,6 +401,7 @@ export class NameController extends BaseControllerV2<
     /* istanbul ignore next */
     const variationKey = variation ?? DEFAULT_VARIATION;
     const normalizedValue = this.#normalizeValue(value, type);
+    const normalizedVariation = this.#normalizeVariation(variationKey, type);
 
     this.update((state) => {
       const typeEntries = state.names[type] || {};
@@ -400,12 +410,12 @@ export class NameController extends BaseControllerV2<
       const variationEntries = typeEntries[normalizedValue] || {};
       typeEntries[normalizedValue] = variationEntries;
 
-      const entry = variationEntries[variationKey] ?? {
+      const entry = variationEntries[normalizedVariation] ?? {
         proposedNames: {},
         name: null,
         sourceId: null,
       };
-      variationEntries[variationKey] = entry;
+      variationEntries[normalizedVariation] = entry;
 
       callback(entry);
     });

--- a/packages/name-controller/src/NameController.ts
+++ b/packages/name-controller/src/NameController.ts
@@ -277,6 +277,7 @@ export class NameController extends BaseControllerV2<
     const variationKey = variation ?? DEFAULT_VARIATION;
     const supportedSourceIds = this.#getSourceIds(provider, type);
     const currentTime = this.#getCurrentTimeSeconds();
+    const normalizedValue = this.#normalizeValue(value, type);
 
     const matchingSourceIds = supportedSourceIds.filter((sourceId) => {
       if (requestedSourceIds && !requestedSourceIds.includes(sourceId)) {
@@ -284,7 +285,8 @@ export class NameController extends BaseControllerV2<
       }
 
       if (onlyUpdateAfterDelay) {
-        const entry = this.state.names[type]?.[value]?.[variationKey] ?? {};
+        const entry =
+          this.state.names[type]?.[normalizedValue]?.[variationKey] ?? {};
         const proposedNamesEntry = entry.proposedNames?.[sourceId] ?? {};
         const lastRequestTime = proposedNamesEntry.lastRequestTime ?? 0;
         const updateDelay = proposedNamesEntry.updateDelay ?? this.#updateDelay;

--- a/packages/name-controller/src/NameController.ts
+++ b/packages/name-controller/src/NameController.ts
@@ -374,19 +374,33 @@ export class NameController extends BaseControllerV2<
     };
   }
 
+  #normalizeValue(value: string, type: NameType): string {
+    /* istanbul ignore next */
+    switch (type) {
+      case NameType.ETHEREUM_ADDRESS: {
+        return value.toLowerCase();
+      }
+
+      default: {
+        return value;
+      }
+    }
+  }
+
   #updateEntry(
     value: string,
     type: NameType,
     callback: (entry: NameEntry) => void,
   ) {
     const variationKey = this.#getTypeVariationKey(type);
+    const normalizedValue = this.#normalizeValue(value, type);
 
     this.update((state) => {
       const typeEntries = state.names[type] || {};
       state.names[type] = typeEntries;
 
-      const variationEntries = typeEntries[value] || {};
-      typeEntries[value] = variationEntries;
+      const variationEntries = typeEntries[normalizedValue] || {};
+      typeEntries[normalizedValue] = variationEntries;
 
       const entry = variationEntries[variationKey] ?? {
         proposedNames: {},

--- a/packages/name-controller/src/NameController.ts
+++ b/packages/name-controller/src/NameController.ts
@@ -144,6 +144,7 @@ export class NameController extends BaseControllerV2<
    * @param request.sourceId - Optional ID of the source of the proposed name.
    * @param request.type - Type of value to set the name for.
    * @param request.value - Value to set the name for.
+   * @param request.variation - Variation of the raw value to set the name for. The chain ID if the type is Ethereum address.
    */
   setName(request: SetNameRequest) {
     this.#validateSetNameRequest(request);
@@ -164,6 +165,7 @@ export class NameController extends BaseControllerV2<
    * @param request.value - Value to update the proposed names for.
    * @param request.type - Type of value to update the proposed names for.
    * @param request.sourceIds - Optional array of source IDs to limit which sources are used by the providers. If not provided, all sources in all providers will be used.
+   * @param request.variation - Variation of the raw value to update proposed names for. The chain ID if the type is Ethereum address.
    * @returns The updated proposed names for the value.
    */
   async updateProposedNames(

--- a/packages/name-controller/src/providers/ens.test.ts
+++ b/packages/name-controller/src/providers/ens.test.ts
@@ -39,7 +39,7 @@ describe('ENSNameProvider', () => {
 
       const response = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -59,7 +59,7 @@ describe('ENSNameProvider', () => {
 
       await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -75,7 +75,7 @@ describe('ENSNameProvider', () => {
 
       const response = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -96,7 +96,7 @@ describe('ENSNameProvider', () => {
       await expect(
         provider.getProposedNames({
           value: VALUE_MOCK,
-          chainId: CHAIN_ID_MOCK,
+          variation: CHAIN_ID_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
         }),
       ).rejects.toThrow('TestError');

--- a/packages/name-controller/src/providers/ens.ts
+++ b/packages/name-controller/src/providers/ens.ts
@@ -55,7 +55,7 @@ export class ENSNameProvider implements NameProvider {
       };
     }
 
-    const { value, chainId } = request;
+    const { value, variation: chainId } = request;
 
     log('Invoking callback', { value, chainId });
 

--- a/packages/name-controller/src/providers/etherscan.test.ts
+++ b/packages/name-controller/src/providers/etherscan.test.ts
@@ -50,7 +50,7 @@ describe('EtherscanNameProvider', () => {
 
       const response = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -80,7 +80,7 @@ describe('EtherscanNameProvider', () => {
 
         const response = await provider.getProposedNames({
           value: VALUE_MOCK,
-          chainId: CHAIN_ID_MOCK,
+          variation: CHAIN_ID_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
         });
 
@@ -110,7 +110,7 @@ describe('EtherscanNameProvider', () => {
 
       await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_IDS.LINEA_GOERLI,
+        variation: CHAIN_IDS.LINEA_GOERLI,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -127,7 +127,7 @@ describe('EtherscanNameProvider', () => {
       await expect(
         provider.getProposedNames({
           value: VALUE_MOCK,
-          chainId: invalidChainId,
+          variation: invalidChainId,
           type: NameType.ETHEREUM_ADDRESS,
         }),
       ).rejects.toThrow(
@@ -140,13 +140,13 @@ describe('EtherscanNameProvider', () => {
 
       await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
       const result = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -168,7 +168,7 @@ describe('EtherscanNameProvider', () => {
 
       const result = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -188,7 +188,7 @@ describe('EtherscanNameProvider', () => {
 
       const response = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -207,7 +207,7 @@ describe('EtherscanNameProvider', () => {
       await expect(
         provider.getProposedNames({
           value: VALUE_MOCK,
-          chainId: CHAIN_ID_MOCK,
+          variation: CHAIN_ID_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
         }),
       ).rejects.toThrow('TestError');

--- a/packages/name-controller/src/providers/etherscan.ts
+++ b/packages/name-controller/src/providers/etherscan.ts
@@ -75,7 +75,7 @@ export class EtherscanNameProvider implements NameProvider {
     const releaseLock = await this.#mutex.acquire();
 
     try {
-      const { value, chainId } = request;
+      const { value, variation: chainId } = request;
 
       const time = Date.now();
       const timeSinceLastRequest = time - this.#lastRequestTime;

--- a/packages/name-controller/src/providers/lens.test.ts
+++ b/packages/name-controller/src/providers/lens.test.ts
@@ -51,7 +51,7 @@ describe('LensNameProvider', () => {
 
       const response = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -74,7 +74,7 @@ describe('LensNameProvider', () => {
 
       const response = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -94,7 +94,7 @@ describe('LensNameProvider', () => {
 
       const response = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -113,7 +113,7 @@ describe('LensNameProvider', () => {
       await expect(
         provider.getProposedNames({
           value: VALUE_MOCK,
-          chainId: CHAIN_ID_MOCK,
+          variation: CHAIN_ID_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
         }),
       ).rejects.toThrow('TestError');

--- a/packages/name-controller/src/providers/token.test.ts
+++ b/packages/name-controller/src/providers/token.test.ts
@@ -39,7 +39,7 @@ describe('TokenNameProvider', () => {
 
       const response = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -62,7 +62,7 @@ describe('TokenNameProvider', () => {
 
       const response = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -80,7 +80,7 @@ describe('TokenNameProvider', () => {
 
       const response = await provider.getProposedNames({
         value: VALUE_MOCK,
-        chainId: CHAIN_ID_MOCK,
+        variation: CHAIN_ID_MOCK,
         type: NameType.ETHEREUM_ADDRESS,
       });
 
@@ -99,7 +99,7 @@ describe('TokenNameProvider', () => {
       await expect(
         provider.getProposedNames({
           value: VALUE_MOCK,
-          chainId: CHAIN_ID_MOCK,
+          variation: CHAIN_ID_MOCK,
           type: NameType.ETHEREUM_ADDRESS,
         }),
       ).rejects.toThrow('TestError');

--- a/packages/name-controller/src/providers/token.ts
+++ b/packages/name-controller/src/providers/token.ts
@@ -42,7 +42,7 @@ export class TokenNameProvider implements NameProvider {
       };
     }
 
-    const { value, chainId } = request;
+    const { value, variation: chainId } = request;
     const url = `https://token-api.metaswap.codefi.network/token/${chainId}?address=${value}`;
 
     log('Sending request', url);

--- a/packages/name-controller/src/types.ts
+++ b/packages/name-controller/src/types.ts
@@ -21,9 +21,6 @@ export type NameProviderMetadata = {
 
 /** The request data to get proposed names from a name provider. */
 export type NameProviderRequest = {
-  /** The current chain ID of the client. */
-  chainId: string;
-
   /** The optional list of source IDs to get proposed names from. */
   sourceIds?: string[];
 
@@ -32,6 +29,12 @@ export type NameProviderRequest = {
 
   /** The raw value to get proposed names for. */
   value: string;
+
+  /**
+   * The variation of the raw value to get proposed names for.
+   * For example, the chain ID if the raw value is an Ethereum address.
+   */
+  variation: string;
 };
 
 /** The resulting data after requesting proposed names from a name provider, for a single source. */


### PR DESCRIPTION
## Explanation

Normalize addresses and chain IDs in the `NameController` state by storing them in lowercase, to avoid persisting multiple names for the same address. The UI components in the extension won't display the lowercase address but instead will render the checksummed address.

Also replace the `getChainId` callback with the `variation` option in the `SetNameRequest` and `UpdateProposedNamesRequest`. This decouples the controller from the selected network and supports requests on any chain.

## Changelog

### `@metamask/name-controller`

- **BREAKING**: Save addresses and chain IDs as lowercase in state.
- **BREAKING**: Remove `getChainId` constructor callback.
- **BREAKING**: Require a `variation` property when calling `setName` or `updateProposedNames` with the address type.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
