### PR TITLE
Use spread operator instead of `delete` on frozen `messageParams`

### DIFF
--- a/packages/message-manager/src/MessageManager.ts
+++ b/packages/message-manager/src/MessageManager.ts
@@ -109,8 +109,10 @@ export class MessageManager extends AbstractMessageManager<
   prepMessageForSigning(
     messageParams: MessageParamsMetamask,
   ): Promise<MessageParams> {
-    delete messageParams.metamaskId;
-    return Promise.resolve(messageParams);
+    // Using delete operation will throw an error on frozen messageParams
+    const { metamaskId: _metamaskId, ...messageParamsWithoutId } =
+      messageParams;
+    return Promise.resolve(messageParamsWithoutId);
   }
 }
 

--- a/packages/message-manager/src/PersonalMessageManager.ts
+++ b/packages/message-manager/src/PersonalMessageManager.ts
@@ -117,8 +117,10 @@ export class PersonalMessageManager extends AbstractMessageManager<
   prepMessageForSigning(
     messageParams: PersonalMessageParamsMetamask,
   ): Promise<PersonalMessageParams> {
-    delete messageParams.metamaskId;
-    return Promise.resolve(messageParams);
+    // Using delete operation will throw an error on frozen messageParams
+    const { metamaskId: _metamaskId, ...messageParamsWithoutId } =
+      messageParams;
+    return Promise.resolve(messageParamsWithoutId);
   }
 }
 

--- a/packages/message-manager/src/TypedMessageManager.ts
+++ b/packages/message-manager/src/TypedMessageManager.ts
@@ -169,9 +169,13 @@ export class TypedMessageManager extends AbstractMessageManager<
   prepMessageForSigning(
     messageParams: TypedMessageParamsMetamask,
   ): Promise<TypedMessageParams> {
-    delete messageParams.metamaskId;
-    delete messageParams.version;
-    return Promise.resolve(messageParams);
+    // Using delete operation will throw an error on frozen messageParams
+    const {
+      metamaskId: _metamaskId,
+      version: _version,
+      ...messageParamsWithoutId
+    } = messageParams;
+    return Promise.resolve(messageParamsWithoutId);
   }
 }
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR has no functional change, it removes `delete` operator and uses spread in order to mitigate a potential issue while making preparation before signing operations.

## References

Blocker for https://github.com/MetaMask/MetaMask-planning/issues/1321

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/message-manager`

- **Fixes**: Removes `delete` operator and uses spread in order to mitigate an issue on removing a property from frozen `messageParams` object

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've highlighted breaking changes using the "BREAKING" category above as appropriate
