### PR TITLE
Remove selectedAccount from AccountsControllerMetadata

### DIFF
--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -92,10 +92,6 @@ const accountsControllerMetadata = {
     persist: true,
     anonymous: false,
   },
-  selectedAccount: {
-    persist: true,
-    anonymous: false,
-  },
 };
 
 const defaultState: AccountsControllerState = {


### PR DESCRIPTION
## Explanation

Removes `selectedAccount` from the metadata of AccountsControllerMetadata because it is a nested value in `internalAccounts`

## Changelog
### `@metamask/accounts-controller`

- **Removed**: 
`selectedAccount` from `AccountsControllerMetadata`

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
