### PR TITLE
Fixed PollingController to be a mixin so it can be used with both V1 and V2 controllers

### DIFF
--- a/packages/polling-controller/src/PollingController.test.ts
+++ b/packages/polling-controller/src/PollingController.test.ts
@@ -1,7 +1,7 @@
 import { ControllerMessenger } from '@metamask/base-controller';
 
 import type { PollingCompleteType } from './PollingController';
-import PollingController from './PollingController';
+import { PollingController } from './PollingController';
 
 const TICK_TIME = 1000;
 
@@ -27,7 +27,6 @@ describe('PollingController', () => {
         metadata: {},
         name: 'PollingController',
         state: { foo: 'bar' },
-        pollingIntervalLength: TICK_TIME,
       });
       controller.start('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
@@ -48,7 +47,6 @@ describe('PollingController', () => {
         metadata: {},
         name: 'PollingController',
         state: { foo: 'bar' },
-        pollingIntervalLength: TICK_TIME,
       });
       const pollingToken = controller.start('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
@@ -69,7 +67,6 @@ describe('PollingController', () => {
         metadata: {},
         name: 'PollingController',
         state: { foo: 'bar' },
-        pollingIntervalLength: TICK_TIME,
       });
       const pollingToken1 = controller.start('mainnet');
       controller.start('mainnet');
@@ -93,7 +90,6 @@ describe('PollingController', () => {
         metadata: {},
         name: 'PollingController',
         state: { foo: 'bar' },
-        pollingIntervalLength: TICK_TIME,
       });
       controller.start('mainnet');
       expect(() => {
@@ -113,7 +109,6 @@ describe('PollingController', () => {
         metadata: {},
         name: 'PollingController',
         state: { foo: 'bar' },
-        pollingIntervalLength: TICK_TIME,
       });
       controller.start('mainnet');
       expect(() => {
@@ -136,7 +131,6 @@ describe('PollingController', () => {
         metadata: {},
         name: 'PollingController',
         state: { foo: 'bar' },
-        pollingIntervalLength: TICK_TIME,
       });
       controller.start('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
@@ -158,7 +152,6 @@ describe('PollingController', () => {
         metadata: {},
         name: 'PollingController',
         state: { foo: 'bar' },
-        pollingIntervalLength: TICK_TIME,
       });
       controller.start('mainnet');
       controller.start('mainnet');
@@ -182,20 +175,19 @@ describe('PollingController', () => {
         PollingCompleteType<typeof name>
       >();
 
-      mockMessenger.subscribe(`${name}:pollingComplete`, pollingComplete);
 
       const controller = new MyGasFeeController({
         messenger: mockMessenger,
         metadata: {},
         name,
         state: { foo: 'bar' },
-        pollingIntervalLength: TICK_TIME,
       });
+      controller.onPollingComplete(pollingComplete);
       const pollingToken = controller.start('mainnet');
       controller.stop(pollingToken);
       expect(pollingComplete).toHaveBeenCalledTimes(1);
     });
-    it('should poll at the interval length passed via the constructor', async () => {
+    it('should poll at the interval length when set via setIntervalLength', async () => {
       jest.useFakeTimers();
 
       class MyGasFeeController extends PollingController<any, any, any> {
@@ -208,8 +200,8 @@ describe('PollingController', () => {
         metadata: {},
         name: 'PollingController',
         state: { foo: 'bar' },
-        pollingIntervalLength: TICK_TIME * 3,
       });
+      controller.setIntervalLength(TICK_TIME * 3);
       controller.start('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
@@ -238,7 +230,6 @@ describe('PollingController', () => {
         metadata: {},
         name: 'PollingController',
         state: { foo: 'bar' },
-        pollingIntervalLength: TICK_TIME,
       });
       controller.start('mainnet');
       controller.start('rinkeby');
@@ -259,7 +250,7 @@ describe('PollingController', () => {
       controller.stopAll();
     });
 
-    it('should poll multiple networkClientIds at the interval length passed via the constructor', async () => {
+    it('should poll multiple networkClientIds when setting interval length', async () => {
       jest.useFakeTimers();
 
       class MyGasFeeController extends PollingController<any, any, any> {
@@ -272,8 +263,8 @@ describe('PollingController', () => {
         metadata: {},
         name: 'PollingController',
         state: { foo: 'bar' },
-        pollingIntervalLength: TICK_TIME * 2,
       });
+      controller.setIntervalLength(TICK_TIME * 2);
       controller.start('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();

--- a/packages/polling-controller/src/PollingController.ts
+++ b/packages/polling-controller/src/PollingController.ts
@@ -1,10 +1,5 @@
-import { BaseControllerV2 } from '@metamask/base-controller';
-import type {
-  RestrictedControllerMessenger,
-  StateMetadata,
-} from '@metamask/base-controller';
+import { BaseController, BaseControllerV2 } from '@metamask/base-controller';
 import type { NetworkClientId } from '@metamask/network-controller';
-import type { Json } from '@metamask/utils';
 import { v4 as random } from 'uuid';
 
 export type PollingCompleteType<N extends string> = {
@@ -12,139 +7,130 @@ export type PollingCompleteType<N extends string> = {
   payload: [string];
 };
 
+type Constructor = new (...args: any[]) => {};
+
 /**
- * PollingController is an abstract class that implements the polling
- * functionality for a controller. It is meant to be extended by a controller
- * that needs to poll for data by networkClientId.
+ * PollingControllerMixin
  *
+ * @param Base - The base class to mix onto.
+ * @returns The mixin.
  */
-export default abstract class PollingController<
-  Name extends string,
-  State extends Record<string, Json>,
-  messenger extends RestrictedControllerMessenger<
-    Name,
-    any,
-    PollingCompleteType<Name> | any,
-    string,
-    string
-  >,
-> extends BaseControllerV2<Name, State, messenger> {
-  readonly #intervalLength: number;
-
-  private readonly networkClientIdTokensMap: Map<NetworkClientId, Set<string>> =
-    new Map();
-
-  private readonly intervalIds: Record<NetworkClientId, NodeJS.Timeout> = {};
-
-  constructor({
-    name,
-    state,
-    messenger,
-    metadata,
-    pollingIntervalLength,
-  }: {
-    name: Name;
-    state: State;
-    metadata: StateMetadata<State>;
-    messenger: messenger;
-    pollingIntervalLength: number;
-  }) {
-    super({
-      name,
-      state,
-      messenger,
-      metadata,
-    });
-
-    if (!pollingIntervalLength) {
-      throw new Error('pollingIntervalLength required for PollingController');
-    }
-
-    this.#intervalLength = pollingIntervalLength;
-  }
-
+function PollingControllerMixin<TBase extends Constructor>(Base: TBase) {
   /**
-   * Starts polling for a networkClientId
+   * PollingController is an abstract class that implements the polling
+   * functionality for a controller. It is meant to be extended by a controller
+   * that needs to poll for data by networkClientId.
    *
-   * @param networkClientId - The networkClientId to start polling for
-   * @returns void
    */
-  start(networkClientId: NetworkClientId) {
-    const innerPollToken = random();
-    if (this.networkClientIdTokensMap.has(networkClientId)) {
-      const set = this.networkClientIdTokensMap.get(networkClientId);
-      set?.add(innerPollToken);
-    } else {
-      const set = new Set<string>();
-      set.add(innerPollToken);
-      this.networkClientIdTokensMap.set(networkClientId, set);
-    }
-    this.#poll(networkClientId);
-    return innerPollToken;
-  }
+  abstract class PollingControllerBase extends Base {
+    readonly #networkClientIdTokensMap: Map<NetworkClientId, Set<string>> =
+      new Map();
 
-  /**
-   * Stops polling for all networkClientIds
-   */
-  stopAll() {
-    this.networkClientIdTokensMap.forEach((tokens, _networkClientId) => {
-      tokens.forEach((token) => {
-        this.stop(token);
-      });
-    });
-  }
+    readonly #intervalIds: Record<NetworkClientId, NodeJS.Timeout> = {};
 
-  /**
-   * Stops polling for a networkClientId
-   *
-   * @param pollingToken - The polling token to stop polling for
-   */
-  stop(pollingToken: string) {
-    if (!pollingToken) {
-      throw new Error('pollingToken required');
-    }
-    let found = false;
-    this.networkClientIdTokensMap.forEach((tokens, networkClientId) => {
-      if (tokens.has(pollingToken)) {
-        found = true;
-        this.networkClientIdTokensMap
-          .get(networkClientId)
-          ?.delete(pollingToken);
-        if (this.networkClientIdTokensMap.get(networkClientId)?.size === 0) {
-          clearTimeout(this.intervalIds[networkClientId]);
-          delete this.intervalIds[networkClientId];
-          this.networkClientIdTokensMap.delete(networkClientId);
-          this.messagingSystem.publish(
-            `${this.name}:pollingComplete`,
-            networkClientId,
-          );
-        }
-      }
-    });
-    if (!found) {
-      throw new Error('pollingToken not found');
-    }
-  }
+    #callbacks: Set<(networkClientId: NetworkClientId) => void> = new Set();
 
-  /**
-   * Executes the poll for a networkClientId
-   *
-   * @param networkClientId - The networkClientId to execute the poll for
-   */
-  abstract executePoll(networkClientId: NetworkClientId): Promise<void>;
+    #intervalLength = 1000;
 
-  #poll(networkClientId: NetworkClientId) {
-    if (this.intervalIds[networkClientId]) {
-      clearTimeout(this.intervalIds[networkClientId]);
-      delete this.intervalIds[networkClientId];
+    getIntervalLength() {
+      return this.#intervalLength;
     }
-    this.intervalIds[networkClientId] = setTimeout(async () => {
-      try {
-        await this.executePoll(networkClientId);
-      } catch (error) {
-        console.error(error);
+
+    setIntervalLength(length: number) {
+      this.#intervalLength = length;
+    }
+
+    /**
+     * Starts polling for a networkClientId
+     *
+     * @param networkClientId - The networkClientId to start polling for
+     * @returns void
+     */
+    start(networkClientId: NetworkClientId) {
+      const innerPollToken = random();
+      if (this.#networkClientIdTokensMap.has(networkClientId)) {
+        const set = this.#networkClientIdTokensMap.get(networkClientId);
+        set?.add(innerPollToken);
+      } else {
+        const set = new Set<string>();
+        set.add(innerPollToken);
+        this.#networkClientIdTokensMap.set(networkClientId, set);
       }
       this.#poll(networkClientId);
-    }, this.#intervalLength);
+      return innerPollToken;
+    }
+
+    /**
+     * Stops polling for all networkClientIds
+     */
+    stopAll() {
+      this.#networkClientIdTokensMap.forEach((tokens, _networkClientId) => {
+        tokens.forEach((token) => {
+          this.stop(token);
+        });
+      });
+    }
+
+    /**
+     * Stops polling for a networkClientId
+     *
+     * @param pollingToken - The polling token to stop polling for
+     */
+    stop(pollingToken: string) {
+      if (!pollingToken) {
+        throw new Error('pollingToken required');
+      }
+      let found = false;
+      this.#networkClientIdTokensMap.forEach((tokens, networkClientId) => {
+        if (tokens.has(pollingToken)) {
+          found = true;
+          this.#networkClientIdTokensMap
+            .get(networkClientId)
+            ?.delete(pollingToken);
+          if (this.#networkClientIdTokensMap.get(networkClientId)?.size === 0) {
+            clearTimeout(this.#intervalIds[networkClientId]);
+            delete this.#intervalIds[networkClientId];
+            this.#networkClientIdTokensMap.delete(networkClientId);
+            this.#callbacks.forEach((callback) => {
+              callback(networkClientId);
+            });
+            this.#callbacks.clear();
+          }
+        }
+      });
+      if (!found) {
+        throw new Error('pollingToken not found');
+      }
+    }
+
+    /**
+     * Executes the poll for a networkClientId
+     *
+     * @param networkClientId - The networkClientId to execute the poll for
+     */
+    abstract executePoll(networkClientId: NetworkClientId): Promise<void>;
+
+    #poll(networkClientId: NetworkClientId) {
+      if (this.#intervalIds[networkClientId]) {
+        clearTimeout(this.#intervalIds[networkClientId]);
+        delete this.#intervalIds[networkClientId];
+      }
+      this.#intervalIds[networkClientId] = setTimeout(async () => {
+        try {
+          await this.executePoll(networkClientId);
+        } catch (error) {
+          console.error(error);
+        }
+        this.#poll(networkClientId);
+      }, this.#intervalLength);
+    }
+
+    onPollingComplete(callback: (networkClientId: NetworkClientId) => void) {
+      this.#callbacks.add(callback);
+    }
   }
+  return PollingControllerBase;
 }
+
+export const PollingController = PollingControllerMixin(BaseControllerV2);
+export const PollingControllerV1 = PollingControllerMixin(BaseController);


### PR DESCRIPTION

## Explanation
- Currently the PollingController extends from BaseControllerV2 but we need to use it for both V1 and V2 controllers.
- This PR uses typescript [mixins](https://www.typescriptlang.org/docs/handbook/mixins.html) to achieve a faux multiple inheritance that works nicely with typescript. I've added a V1 and a V2 version of the PollingController that can be used almost the same way as the original `PollingController`.
