### PR TITLE
Changed Pollingcontroller method names

### DIFF
--- a/packages/polling-controller/src/PollingController.test.ts
+++ b/packages/polling-controller/src/PollingController.test.ts
@@ -27,9 +27,9 @@ describe('PollingController', () => {
         name: 'PollingController',
         state: { foo: 'bar' },
       });
-      controller.start('mainnet');
+      controller.startPollingByNetworkClientId('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
-      controller.stopAll();
+      controller.stopAllPolling();
       expect(controller.executePoll).toHaveBeenCalledTimes(1);
     });
   });
@@ -47,12 +47,12 @@ describe('PollingController', () => {
         name: 'PollingController',
         state: { foo: 'bar' },
       });
-      const pollingToken = controller.start('mainnet');
+      const pollingToken = controller.startPollingByNetworkClientId('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
-      controller.stop(pollingToken);
+      controller.stopPollingByNetworkClientId(pollingToken);
       jest.advanceTimersByTime(TICK_TIME);
       expect(controller.executePoll).toHaveBeenCalledTimes(1);
-      controller.stopAll();
+      controller.stopAllPolling();
     });
     it('should not stop polling if called with one of multiple active polling tokens for a given networkClient', async () => {
       jest.useFakeTimers();
@@ -67,15 +67,15 @@ describe('PollingController', () => {
         name: 'PollingController',
         state: { foo: 'bar' },
       });
-      const pollingToken1 = controller.start('mainnet');
-      controller.start('mainnet');
+      const pollingToken1 = controller.startPollingByNetworkClientId('mainnet');
+      controller.startPollingByNetworkClientId('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      controller.stop(pollingToken1);
+      controller.stopPollingByNetworkClientId(pollingToken1);
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
       expect(controller.executePoll).toHaveBeenCalledTimes(2);
-      controller.stopAll();
+      controller.stopAllPolling();
     });
     it('should error if no pollingToken is passed', () => {
       jest.useFakeTimers();
@@ -90,11 +90,11 @@ describe('PollingController', () => {
         name: 'PollingController',
         state: { foo: 'bar' },
       });
-      controller.start('mainnet');
+      controller.startPollingByNetworkClientId('mainnet');
       expect(() => {
-        controller.stop(undefined as unknown as any);
+        controller.stopPollingByNetworkClientId(undefined as unknown as any);
       }).toThrow('pollingToken required');
-      controller.stopAll();
+      controller.stopAllPolling();
     });
     it('should error if no matching pollingToken is found', () => {
       jest.useFakeTimers();
@@ -109,11 +109,11 @@ describe('PollingController', () => {
         name: 'PollingController',
         state: { foo: 'bar' },
       });
-      controller.start('mainnet');
+      controller.startPollingByNetworkClientId('mainnet');
       expect(() => {
-        controller.stop('potato');
+        controller.stopPollingByNetworkClientId('potato');
       }).toThrow('pollingToken not found');
-      controller.stopAll();
+      controller.stopAllPolling();
     });
   });
   describe('poll', () => {
@@ -131,7 +131,7 @@ describe('PollingController', () => {
         name: 'PollingController',
         state: { foo: 'bar' },
       });
-      controller.start('mainnet');
+      controller.startPollingByNetworkClientId('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
       jest.advanceTimersByTime(TICK_TIME);
@@ -152,14 +152,14 @@ describe('PollingController', () => {
         name: 'PollingController',
         state: { foo: 'bar' },
       });
-      controller.start('mainnet');
-      controller.start('mainnet');
+      controller.startPollingByNetworkClientId('mainnet');
+      controller.startPollingByNetworkClientId('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
       expect(controller.executePoll).toHaveBeenCalledTimes(2);
-      controller.stopAll();
+      controller.stopAllPolling();
     });
     it('should publish "pollingComplete" when stop is called', async () => {
       jest.useFakeTimers();
@@ -177,9 +177,9 @@ describe('PollingController', () => {
         name,
         state: { foo: 'bar' },
       });
-      controller.onPollingComplete('mainnet', pollingComplete);
-      const pollingToken = controller.start('mainnet');
-      controller.stop(pollingToken);
+      controller.onPollingCompleteByNetworkClientId('mainnet', pollingComplete);
+      const pollingToken = controller.startPollingByNetworkClientId('mainnet');
+      controller.stopPollingByNetworkClientId(pollingToken);
       expect(pollingComplete).toHaveBeenCalledTimes(1);
     });
     it('should poll at the interval length when set via setIntervalLength', async () => {
@@ -197,7 +197,7 @@ describe('PollingController', () => {
         state: { foo: 'bar' },
       });
       controller.setIntervalLength(TICK_TIME * 3);
-      controller.start('mainnet');
+      controller.startPollingByNetworkClientId('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
       expect(controller.executePoll).not.toHaveBeenCalled();
@@ -226,8 +226,8 @@ describe('PollingController', () => {
         name: 'PollingController',
         state: { foo: 'bar' },
       });
-      controller.start('mainnet');
-      controller.start('rinkeby');
+      controller.startPollingByNetworkClientId('mainnet');
+      controller.startPollingByNetworkClientId('rinkeby');
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
       expect(controller.executePoll.mock.calls).toMatchObject([
@@ -242,7 +242,7 @@ describe('PollingController', () => {
         ['mainnet'],
         ['rinkeby'],
       ]);
-      controller.stopAll();
+      controller.stopAllPolling();
     });
 
     it('should poll multiple networkClientIds when setting interval length', async () => {
@@ -260,10 +260,10 @@ describe('PollingController', () => {
         state: { foo: 'bar' },
       });
       controller.setIntervalLength(TICK_TIME * 2);
-      controller.start('mainnet');
+      controller.startPollingByNetworkClientId('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      controller.start('sepolia');
+      controller.startPollingByNetworkClientId('sepolia');
       expect(controller.executePoll.mock.calls).toMatchObject([]);
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();

--- a/packages/polling-controller/src/PollingController.ts
+++ b/packages/polling-controller/src/PollingController.ts
@@ -51,7 +51,7 @@ function PollingControllerMixin<TBase extends Constructor>(Base: TBase) {
      * @param networkClientId - The networkClientId to start polling for
      * @returns void
      */
-    start(networkClientId: NetworkClientId) {
+    startPollingByNetworkClientId(networkClientId: NetworkClientId) {
       const innerPollToken = random();
       if (this.#networkClientIdTokensMap.has(networkClientId)) {
         const set = this.#networkClientIdTokensMap.get(networkClientId);
@@ -68,10 +68,10 @@ function PollingControllerMixin<TBase extends Constructor>(Base: TBase) {
     /**
      * Stops polling for all networkClientIds
      */
-    stopAll() {
+    stopAllPolling() {
       this.#networkClientIdTokensMap.forEach((tokens, _networkClientId) => {
         tokens.forEach((token) => {
-          this.stop(token);
+          this.stopPollingByNetworkClientId(token);
         });
       });
     }
@@ -81,7 +81,7 @@ function PollingControllerMixin<TBase extends Constructor>(Base: TBase) {
      *
      * @param pollingToken - The polling token to stop polling for
      */
-    stop(pollingToken: string) {
+    stopPollingByNetworkClientId(pollingToken: string) {
       if (!pollingToken) {
         throw new Error('pollingToken required');
       }
@@ -139,7 +139,7 @@ function PollingControllerMixin<TBase extends Constructor>(Base: TBase) {
      * @param networkClientId - The networkClientId to listen for polling complete events
      * @param callback - The callback to execute when polling is complete
      */
-    onPollingComplete(
+    onPollingCompleteByNetworkClientId(
       networkClientId: NetworkClientId,
       callback: (networkClientId: NetworkClientId) => void,
     ) {

--- a/packages/polling-controller/src/index.ts
+++ b/packages/polling-controller/src/index.ts
@@ -1,1 +1,1 @@
-export { default as PollingController } from './PollingController';
+export { PollingController, PollingControllerV1 } from './PollingController';


### PR DESCRIPTION
## Explanation

`start/stop` were a good start but are proving difficult when trying to not break existing apis with v1 controllers that use start/stop for their own polling. the interface is too different to work nicely with our merged mixin class.