### PR TITLE
Fix SelectedNetworkController default metamask networkClientId

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -120,18 +120,15 @@ export class SelectedNetworkController extends BaseControllerV2<
       this.setNetworkClientIdForDomain.bind(this),
     );
 
-    // subscribe to NetworkController state change events
-    // set the value for the domain 'metamask' if not already initialized
-    // or update it if the selectedNetworkClientId has changed
+    // subscribe to networkController statechange:: selectedNetworkClientId changed
+    // update the value for the domain 'metamask'
     this.messagingSystem.subscribe(
       'NetworkController:stateChange',
       (state: NetworkState, patch: Patch[]) => {
         const isChangingNetwork = patch.some(
           (p) => p.path[0] === 'selectedNetworkClientId',
         );
-        const hasMetamaskNetworkClientId =
-          this.getNetworkClientIdForDomain(METAMASK_DOMAIN);
-        if (!isChangingNetwork && hasMetamaskNetworkClientId) {
+        if (!isChangingNetwork) {
           return;
         }
 
@@ -151,7 +148,11 @@ export class SelectedNetworkController extends BaseControllerV2<
     networkClientId: NetworkClientId,
   ) {
     this.update((state) => {
-      state.domains[domain] = networkClientId;
+      if (state.perDomainNetwork) {
+        state.domains[domain] = networkClientId;
+        return
+      }
+      state.domains[METAMASK_DOMAIN] = networkClientId
     });
   }
 

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -150,9 +150,9 @@ export class SelectedNetworkController extends BaseControllerV2<
     this.update((state) => {
       if (state.perDomainNetwork) {
         state.domains[domain] = networkClientId;
-        return
+        return;
       }
-      state.domains[METAMASK_DOMAIN] = networkClientId
+      state.domains[METAMASK_DOMAIN] = networkClientId;
     });
   }
 

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -128,7 +128,9 @@ export class SelectedNetworkController extends BaseControllerV2<
         const isChangingNetwork = patch.some(
           (p) => p.path[0] === 'selectedNetworkClientId',
         );
-        if (!isChangingNetwork) {
+        const hasMetamaskClient =
+          this.getNetworkClientIdForDomain(METAMASK_DOMAIN);
+        if (!isChangingNetwork && hasMetamaskClient) {
           return;
         }
 

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -120,17 +120,18 @@ export class SelectedNetworkController extends BaseControllerV2<
       this.setNetworkClientIdForDomain.bind(this),
     );
 
-    // subscribe to networkController statechange:: selectedNetworkClientId changed
-    // update the value for the domain 'metamask'
+    // subscribe to NetworkController state change events
+    // set the value for the domain 'metamask' if not already initialized
+    // or update it if the selectedNetworkClientId has changed
     this.messagingSystem.subscribe(
       'NetworkController:stateChange',
       (state: NetworkState, patch: Patch[]) => {
         const isChangingNetwork = patch.some(
           (p) => p.path[0] === 'selectedNetworkClientId',
         );
-        const hasMetamaskClient =
+        const hasMetamaskNetworkClientId =
           this.getNetworkClientIdForDomain(METAMASK_DOMAIN);
-        if (!isChangingNetwork && hasMetamaskClient) {
+        if (!isChangingNetwork && hasMetamaskNetworkClientId) {
           return;
         }
 

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -56,7 +56,7 @@ describe('SelectedNetworkController', () => {
       expect(result).toBe(networkClientId);
     });
 
-    it('it returns items other than the metamask domain, when the perDomainNetwork option is true', () => {
+    it('returns items other than the metamask domain, when the perDomainNetwork option is true', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
       };

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -72,6 +72,30 @@ describe('SelectedNetworkController', () => {
     });
   });
 
+  it('updates the networkClientId for the metamask domain if not already set when the networkControllers state changes', () => {
+    const messenger = buildMessenger();
+    const options: SelectedNetworkControllerOptions = {
+      messenger: buildSelectedNetworkControllerMessenger(messenger),
+    };
+    const controller = new SelectedNetworkController(options);
+    expect(controller.state.domains.metamask).toBeUndefined();
+
+    const patch = [
+      {
+        path: ['anythingelse'],
+        op: 'replace' as const,
+        value: 'abc',
+      },
+    ];
+
+    const state = {
+      ...networkControllerDefaultState,
+      selectedNetworkClientId: 'currentNetwork',
+    };
+    messenger.publish('NetworkController:stateChange', state, patch);
+    expect(controller.state.domains.metamask).toBe('currentNetwork');
+  });
+
   it('updates the networkClientId for the metamask domain when the networkControllers selectedNetworkClientId changes', () => {
     const messenger = buildMessenger();
     const options: SelectedNetworkControllerOptions = {

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -21,25 +21,26 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('setNetworkClientIdForDomain', () => {
-    it('can set the networkClientId for a domain', () => {
-      const options: SelectedNetworkControllerOptions = {
-        messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
-      };
-      const controller = new SelectedNetworkController(options);
-      const domain = 'example.com';
-      const networkClientId = 'network1';
-      controller.setNetworkClientIdForDomain(domain, networkClientId);
-      expect(controller.state.domains[domain]).toBe(networkClientId);
-    });
-
-    it('can set the networkClientId for the metamask domain specifically', () => {
+    it('sets the metamask domain when the perDomainNetwork option is false (default)', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
       };
       const controller = new SelectedNetworkController(options);
       const networkClientId = 'network2';
-      controller.setNetworkClientIdForMetamask(networkClientId);
+      controller.setNetworkClientIdForDomain('not-metamask', networkClientId);
       expect(controller.state.domains.metamask).toBe(networkClientId);
+    });
+
+    it('when the perDomainNetwork feature flag is on, it sets the networkClientId for the passed in domain', () => {
+      const options: SelectedNetworkControllerOptions = {
+        messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
+      };
+      const controller = new SelectedNetworkController(options);
+      controller.state.perDomainNetwork = true;
+      const domain = 'example.com';
+      const networkClientId = 'network1';
+      controller.setNetworkClientIdForDomain(domain, networkClientId);
+      expect(controller.state.domains[domain]).toBe(networkClientId);
     });
   });
 
@@ -70,30 +71,6 @@ describe('SelectedNetworkController', () => {
       expect(result1).toBe(networkClientId1);
       expect(result2).toBe(networkClientId2);
     });
-  });
-
-  it('updates the networkClientId for the metamask domain if not already set when the networkControllers state changes', () => {
-    const messenger = buildMessenger();
-    const options: SelectedNetworkControllerOptions = {
-      messenger: buildSelectedNetworkControllerMessenger(messenger),
-    };
-    const controller = new SelectedNetworkController(options);
-    expect(controller.state.domains.metamask).toBeUndefined();
-
-    const patch = [
-      {
-        path: ['anythingelse'],
-        op: 'replace' as const,
-        value: 'abc',
-      },
-    ];
-
-    const state = {
-      ...networkControllerDefaultState,
-      selectedNetworkClientId: 'currentNetwork',
-    };
-    messenger.publish('NetworkController:stateChange', state, patch);
-    expect(controller.state.domains.metamask).toBe('currentNetwork');
   });
 
   it('updates the networkClientId for the metamask domain when the networkControllers selectedNetworkClientId changes', () => {

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -21,7 +21,7 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('setNetworkClientIdForDomain', () => {
-    it('sets the metamask domain, when the perDomainNetwork option is false (default)', () => {
+    it('sets the networkClientId for the metamask domain, when the perDomainNetwork option is false (default)', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
       };
@@ -31,7 +31,7 @@ describe('SelectedNetworkController', () => {
       expect(controller.state.domains.metamask).toBe(networkClientId);
     });
 
-    it('sets the networkClientId for the passed in domain, when perDomainNetwork option is true ,', () => {
+    it('sets the networkClientId for the passed in domain, when the perDomainNetwork option is true ,', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
       };
@@ -45,7 +45,7 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('getNetworkClientIdForDomain', () => {
-    it('gives the metamask domain, when the perDomainNetwork option is false (default)', () => {
+    it('returns the networkClientId for the metamask domain, when the perDomainNetwork option is false (default)', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
       };
@@ -56,7 +56,7 @@ describe('SelectedNetworkController', () => {
       expect(result).toBe(networkClientId);
     });
 
-    it('returns items other than the metamask domain, when the perDomainNetwork option is true', () => {
+    it('returns the networkClientId for the passed in domain, when the perDomainNetwork option is true', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
       };

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -31,7 +31,7 @@ describe('SelectedNetworkController', () => {
       expect(controller.state.domains.metamask).toBe(networkClientId);
     });
 
-    it('when the perDomainNetwork feature flag is on, it sets the networkClientId for the passed in domain', () => {
+    it('it sets the networkClientId for the passed in domain, when perDomainNetwork state is set to true ,', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
       };

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -21,7 +21,7 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('setNetworkClientIdForDomain', () => {
-    it('sets the metamask domain when the perDomainNetwork option is false (default)', () => {
+    it('sets the metamask domain, when the perDomainNetwork option is false (default)', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
       };
@@ -31,7 +31,7 @@ describe('SelectedNetworkController', () => {
       expect(controller.state.domains.metamask).toBe(networkClientId);
     });
 
-    it('it sets the networkClientId for the passed in domain, when perDomainNetwork state is set to true ,', () => {
+    it('sets the networkClientId for the passed in domain, when perDomainNetwork option is true ,', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
       };
@@ -45,7 +45,7 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('getNetworkClientIdForDomain', () => {
-    it('gives the metamask domain when the perDomainNetwork option is false (default)', () => {
+    it('gives the metamask domain, when the perDomainNetwork option is false (default)', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
       };
@@ -56,7 +56,7 @@ describe('SelectedNetworkController', () => {
       expect(result).toBe(networkClientId);
     });
 
-    it('when the perDomainNetwork feature flag is on, it returns items other than the metamask domain', () => {
+    it('it returns items other than the metamask domain, when the perDomainNetwork option is true', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(), // Mock the messenger
       };


### PR DESCRIPTION
## Explanation

Currently, the SelectedNetworkController does not set a value for the default `metamask` domain on initial `NetworkController:stateChange` event because it does not count `selectedNetworkId` as actually changed in the patch yet. This manifests itself in extension with the SelectedNetworkMiddleware setting undefined for the `req.networkClientId` attribute. ~~This PR adds one more check to the event listener to ensure that the first `NetworkController:stateChange` event is used to populate the networkClientId for the default `metamask` domain.~~ See resolution in comments

## References

* Fixes https://github.com/MetaMask/MetaMask-planning/issues/1370

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/selected-network-controller`

- **FIXED**: `setNetworkClientIdForDomain()` will now ignore the passed in domain value and set the networkClientId for the `metamask` domain instead when the `state.perDomainNetwork` flag is false (default)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
