### PR TITLE
fix: remove call to `removeIdentity`

### DIFF
--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 98,
+      branches: 100,
       functions: 100,
-      lines: 99.49,
-      statements: 99.49,
+      lines: 100,
+      statements: 100,
     },
   },
 });

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -22,8 +22,6 @@ import { bufferToHex } from 'ethereumjs-util';
 import * as sinon from 'sinon';
 import * as uuid from 'uuid';
 
-import MockEncryptor, { mockKey } from '../tests/mocks/mockEncryptor';
-import MockShallowGetAccountsKeyring from '../tests/mocks/mockShallowGetAccountsKeyring';
 import type {
   KeyringControllerEvents,
   KeyringControllerMessenger,
@@ -36,6 +34,8 @@ import {
   KeyringController,
   KeyringTypes,
 } from './KeyringController';
+import MockEncryptor, { mockKey } from '../tests/mocks/mockEncryptor';
+import MockShallowGetAccountsKeyring from '../tests/mocks/mockShallowGetAccountsKeyring';
 
 jest.mock('uuid', () => {
   return {
@@ -2256,7 +2256,6 @@ type WithControllerCallback<ReturnValue> = ({
   controller: KeyringController;
   preferences: {
     setAccountLabel: sinon.SinonStub;
-    removeIdentity: sinon.SinonStub;
     syncIdentities: sinon.SinonStub;
     updateIdentities: sinon.SinonStub;
     setSelectedAddress: sinon.SinonStub;
@@ -2332,7 +2331,6 @@ async function withController<ReturnValue>(
   const encryptor = new MockEncryptor();
   const preferences = {
     setAccountLabel: sinon.stub(),
-    removeIdentity: sinon.stub(),
     syncIdentities: sinon.stub(),
     updateIdentities: sinon.stub(),
     setSelectedAddress: sinon.stub(),

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -22,6 +22,8 @@ import { bufferToHex } from 'ethereumjs-util';
 import * as sinon from 'sinon';
 import * as uuid from 'uuid';
 
+import MockEncryptor, { mockKey } from '../tests/mocks/mockEncryptor';
+import MockShallowGetAccountsKeyring from '../tests/mocks/mockShallowGetAccountsKeyring';
 import type {
   KeyringControllerEvents,
   KeyringControllerMessenger,
@@ -34,8 +36,6 @@ import {
   KeyringController,
   KeyringTypes,
 } from './KeyringController';
-import MockEncryptor, { mockKey } from '../tests/mocks/mockEncryptor';
-import MockShallowGetAccountsKeyring from '../tests/mocks/mockShallowGetAccountsKeyring';
 
 jest.mock('uuid', () => {
   return {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -157,7 +157,6 @@ export type KeyringControllerMessenger = RestrictedControllerMessenger<
 >;
 
 export type KeyringControllerOptions = {
-  removeIdentity: PreferencesController['removeIdentity'];
   syncIdentities: PreferencesController['syncIdentities'];
   updateIdentities: PreferencesController['updateIdentities'];
   setSelectedAddress: PreferencesController['setSelectedAddress'];
@@ -240,8 +239,6 @@ export class KeyringController extends BaseControllerV2<
 > {
   private readonly mutex = new Mutex();
 
-  private readonly removeIdentity: PreferencesController['removeIdentity'];
-
   private readonly syncIdentities: PreferencesController['syncIdentities'];
 
   private readonly updateIdentities: PreferencesController['updateIdentities'];
@@ -260,7 +257,6 @@ export class KeyringController extends BaseControllerV2<
    * Creates a KeyringController instance.
    *
    * @param opts - Initial options used to configure this controller
-   * @param opts.removeIdentity - Remove the identity with the given address.
    * @param opts.syncIdentities - Sync identities with the given list of addresses.
    * @param opts.updateIdentities - Generate an identity for each address given that doesn't already have an identity.
    * @param opts.setSelectedAddress - Set the selected address.
@@ -272,7 +268,6 @@ export class KeyringController extends BaseControllerV2<
    * @param opts.state - Initial state to set on this controller.
    */
   constructor({
-    removeIdentity,
     syncIdentities,
     updateIdentities,
     setSelectedAddress,
@@ -310,7 +305,6 @@ export class KeyringController extends BaseControllerV2<
     this.#keyring.on('lock', this.#handleLock.bind(this));
     this.#keyring.on('unlock', this.#handleUnlock.bind(this));
 
-    this.removeIdentity = removeIdentity;
     this.syncIdentities = syncIdentities;
     this.updateIdentities = updateIdentities;
     this.setSelectedAddress = setSelectedAddress;
@@ -680,7 +674,6 @@ export class KeyringController extends BaseControllerV2<
    * @returns Promise resolving current state when this account removal completes.
    */
   async removeAccount(address: Hex): Promise<KeyringControllerMemState> {
-    this.removeIdentity(address);
     await this.#keyring.removeAccount(address);
     this.messagingSystem.publish(`${name}:accountRemoved`, address);
     return this.#getMemState();


### PR DESCRIPTION
## Explanation
As we now emit the `KeyringController:accountRemoved` event, used by `PreferencesController` to remove identities each time it is emitted, we don't need to also call `this.removeIdentity` on KeyringController - or the account will be already absent when the event will reach `PreferencesController`.

As each controller should be responsible for its own state, the correct behavior is to let `PreferencesController` handle account removal events.

Unrelated to this fix, I also noticed that jest had a lower coverage thresholds - I set them to 100 since that's `KeyringController` current coverage

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not be obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/keyring-controller`

- **FIXED**:  Removed call to `PreferencesController.removeIdentity` as PreferencesController already handles account removal side effects through messenger events.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
