### PR TITLE
Parameterize `TokenListController` by `NetworkClientId` + Integrate `PollingController`

### DIFF
--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -1535,30 +1535,45 @@ describe('TokenListController', () => {
       // jest.runOnlyPendingTimers();
       // await flushPromises();
       // await Promise.all([jest.runOnlyPendingTimers(), flushPromises()]);
-      expect(controller.state).toStrictEqual({
-        preventPollingOnNetworkRestart: false,
-        tokenList: sampleBinanceTokensChainsCache,
-        tokenChainsCache: {
-          [toHex(56)]: {
-            timestamp: expect.any(Number),
-            data: sampleBinanceTokensChainsCache,
-          },
-          [ChainId.sepolia]: {
-            timestamp: expect.any(Number),
-            data: sampleSepoliaTokensChainCache,
-          },
-        },
-      });
-
-      console.log(
-        'sampleBinanceTokensChainsCache:',
-        sampleBinanceTokensChainsCache,
-      );
-      console.log('controller.state', controller.state);
       console.log(
         'controller.stat.tokensChainsCache:',
         controller.state.tokensChainsCache,
       );
+      console.log('controller.state.tokenList:', controller.state.tokenList);
+
+      // expect(controller.state.tokenList).toStrictEqual(
+      //   sampleBinanceTokensChainsCache,
+      // );
+      expect(controller.state.tokensChainsCache).toStrictEqual({
+        [toHex(56)]: {
+          timestamp: expect.any(Number),
+          data: sampleBinanceTokensChainsCache,
+        },
+        [ChainId.sepolia]: {
+          timestamp: expect.any(Number),
+          data: sampleSepoliaTokensChainCache,
+        },
+      });
+      // expect(controller.state).toStrictEqual({
+      //   preventPollingOnNetworkRestart: false,
+      //   tokenList: sampleBinanceTokensChainsCache,
+      //   tokenChainsCache: {
+      //     [toHex(56)]: {
+      //       timestamp: expect.any(Number),
+      //       data: sampleBinanceTokensChainsCache,
+      //     },
+      //     [ChainId.sepolia]: {
+      //       timestamp: expect.any(Number),
+      //       data: sampleSepoliaTokensChainCache,
+      //     },
+      //   },
+      // });
+
+      // console.log(
+      //   'sampleBinanceTokensChainsCache:',
+      //   sampleBinanceTokensChainsCache,
+      // );
+      // console.log('controller.state', controller.state);
     });
   });
 });

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -320,24 +320,24 @@ const sampleSepoliaTokenList = [
     decimals: 8,
     name: 'Wrapped BTC',
     iconUrl:
-      'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/wbtc.svg',
+      'https://static.metafi.codefi.network/api/v1/tokenIcons/11155111/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599.png',
     type: 'erc20',
     aggregators: [
-      'metamask',
-      'aave',
-      'bancor',
-      'cmc',
-      'cryptocom',
-      'coinGecko',
-      'oneInch',
-      'pmm',
-      'sushiswap',
-      'zerion',
-      'lifi',
-      'openswap',
-      'sonarwatch',
-      'uniswapLabs',
-      'coinmarketcap',
+      'Metamask',
+      'Aave',
+      'Bancor',
+      'Cmc',
+      'Cryptocom',
+      'CoinGecko',
+      'OneInch',
+      'Pmm',
+      'Sushiswap',
+      'Zerion',
+      'Lifi',
+      'Openswap',
+      'Sonarwatch',
+      'UniswapLabs',
+      'Coinmarketcap',
     ],
     occurrences: 15,
     fees: {},
@@ -351,22 +351,22 @@ const sampleSepoliaTokenList = [
     decimals: 18,
     name: 'UMA',
     iconUrl:
-      'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/uma.svg',
+      'https://static.metafi.codefi.network/api/v1/tokenIcons/11155111/0x04fa0d235c4abf4bcf4787af4cf447de572ef828.png',
     type: 'erc20',
     aggregators: [
-      'metamask',
-      'bancor',
-      'cmc',
-      'cryptocom',
-      'coinGecko',
-      'oneInch',
-      'pmm',
-      'sushiswap',
-      'zerion',
-      'openswap',
-      'sonarwatch',
-      'uniswapLabs',
-      'coinmarketcap',
+      'Metamask',
+      'Bancor',
+      'CMC',
+      'Crypto.com',
+      'CoinGecko',
+      '1inch',
+      'PMM',
+      'Sushiswap',
+      'Zerion',
+      'Openswap',
+      'Sonarwatch',
+      'UniswapLabs',
+      'Coinmarketcap',
     ],
     occurrences: 13,
     fees: {},
@@ -377,21 +377,21 @@ const sampleSepoliaTokenList = [
     decimals: 18,
     name: 'Gnosis Token',
     iconUrl:
-      'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/gnosis.svg',
+      'https://static.metafi.codefi.network/api/v1/tokenIcons/11155111/0x6810e776880c02933d47db1b9fc05908e5386b96.png',
     type: 'erc20',
     aggregators: [
-      'metamask',
-      'bancor',
-      'cmc',
-      'coinGecko',
-      'oneInch',
-      'sushiswap',
-      'zerion',
-      'lifi',
-      'openswap',
-      'sonarwatch',
-      'uniswapLabs',
-      'coinmarketcap',
+      'Metamask',
+      'Bancor',
+      'CMC',
+      'CoinGecko',
+      '1inch',
+      'Sushiswap',
+      'Zerion',
+      'Lifi',
+      'Openswap',
+      'Sonarwatch',
+      'UniswapLabs',
+      'Coinmarketcap',
     ],
     occurrences: 12,
     fees: {},
@@ -405,89 +405,6 @@ const sampleSepoliaTokensChainCache = sampleSepoliaTokenList.reduce(
   },
   {} as TokenListMap,
 );
-
-// const sampleSepoliaTokensChainCache = {
-//   '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599': {
-//     address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
-//     symbol: 'WBTC',
-//     decimals: 8,
-//     name: 'Wrapped BTC',
-//     iconUrl:
-//       'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599.png',
-//     type: 'erc20',
-//     aggregators: [
-//       'Metamask',
-//       'Aave',
-//       'Bancor',
-//       'CMC',
-//       'Crypto.com',
-//       'CoinGecko',
-//       '1inch',
-//       'PMM',
-//       'Sushiswap',
-//       'Zerion',
-//       'Lifi',
-//       'Openswap',
-//       'Sonarwatch',
-//       'UniswapLabs',
-//       'Coinmarketcap',
-//     ],
-//     occurrences: 15,
-//     fees: {},
-//     storage: { balance: 0 },
-//   },
-//   '0x04fa0d235c4abf4bcf4787af4cf447de572ef828': {
-//     address: '0x04fa0d235c4abf4bcf4787af4cf447de572ef828',
-//     symbol: 'UMA',
-//     decimals: 18,
-//     name: 'UMA',
-//     iconUrl:
-//       'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x04fa0d235c4abf4bcf4787af4cf447de572ef828.png',
-//     type: 'erc20',
-//     aggregators: [
-//       'Metamask',
-//       'Bancor',
-//       'CMC',
-//       'Crypto.com',
-//       'CoinGecko',
-//       '1inch',
-//       'PMM',
-//       'Sushiswap',
-//       'Zerion',
-//       'Openswap',
-//       'Sonarwatch',
-//       'UniswapLabs',
-//       'Coinmarketcap',
-//     ],
-//     occurrences: 13,
-//     fees: {},
-//   },
-//   '0x6810e776880c02933d47db1b9fc05908e5386b96': {
-//     address: '0x6810e776880c02933d47db1b9fc05908e5386b96',
-//     symbol: 'GNO',
-//     decimals: 18,
-//     name: 'Gnosis Token',
-//     iconUrl:
-//       'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x6810e776880c02933d47db1b9fc05908e5386b96.png',
-//     type: 'erc20',
-//     aggregators: [
-//       'Metamask',
-//       'Bancor',
-//       'CMC',
-//       'CoinGecko',
-//       '1inch',
-//       'Sushiswap',
-//       'Zerion',
-//       'Lifi',
-//       'Openswap',
-//       'Sonarwatch',
-//       'UniswapLabs',
-//       'Coinmarketcap',
-//     ],
-//     occurrences: 12,
-//     fees: {},
-//   },
-// };
 
 const sampleTwoChainState = {
   tokenList: {
@@ -1461,7 +1378,7 @@ describe('TokenListController', () => {
       expect(spy).toHaveBeenCalledTimes(2);
     });
 
-    it.only('should update tokenList state and tokensChainsCache', async () => {
+    it('should update tokenList state and tokensChainsCache', async () => {
       jest.useFakeTimers();
       const startingState: TokenListState = {
         tokenList: {},
@@ -1469,7 +1386,7 @@ describe('TokenListController', () => {
         preventPollingOnNetworkRestart: false,
       };
 
-      jest
+      const fetchTokenListSpy = jest
         .spyOn(tokenService, 'fetchTokenList')
         .mockImplementation(async (chainId) => {
           switch (chainId) {
@@ -1481,9 +1398,6 @@ describe('TokenListController', () => {
               throw new Error('Invalid chainId');
           }
         });
-
-      const pollingIntervalTime = 1000;
-
       const controllerMessenger = getControllerMessenger();
       controllerMessenger.registerActionHandler(
         'NetworkController:getNetworkClientById',
@@ -1508,6 +1422,7 @@ describe('TokenListController', () => {
           }
         }),
       );
+      const pollingIntervalTime = 1000;
       const messenger = getRestrictedMessenger(controllerMessenger);
       const controller = new TokenListController({
         chainId: ChainId.mainnet,
@@ -1519,31 +1434,41 @@ describe('TokenListController', () => {
 
       expect(controller.state).toStrictEqual(startingState);
 
+      // start polling for sepolia
       await controller.startPollingByNetworkClientId('sepolia');
-      // await Promise.all([
-      //   jest.advanceTimersByTime(pollingIntervalTime),
-      //   flushPromises(),
-      // ]);
+      // wait a polling interval
       jest.advanceTimersByTime(pollingIntervalTime);
       await flushPromises();
+
+      expect(fetchTokenListSpy).toHaveBeenCalledTimes(1);
+      // expect the state to be updated with the sepolia token list
+      expect(controller.state.tokenList).toStrictEqual(
+        sampleSepoliaTokensChainCache,
+      );
+      expect(controller.state.tokensChainsCache).toStrictEqual({
+        [ChainId.sepolia]: {
+          timestamp: expect.any(Number),
+          data: sampleSepoliaTokensChainCache,
+        },
+      });
+      // start polling for binance
       await controller.startPollingByNetworkClientId(
         'binance-network-client-id',
       );
-
       jest.advanceTimersByTime(pollingIntervalTime);
       await flushPromises();
-      // jest.runOnlyPendingTimers();
-      // await flushPromises();
-      // await Promise.all([jest.runOnlyPendingTimers(), flushPromises()]);
-      console.log(
-        'controller.stat.tokensChainsCache:',
-        controller.state.tokensChainsCache,
-      );
-      console.log('controller.state.tokenList:', controller.state.tokenList);
 
-      // expect(controller.state.tokenList).toStrictEqual(
-      //   sampleBinanceTokensChainsCache,
-      // );
+      // expect fetchTokenList to be called for binance, but not for sepolia
+      // because the cache for the recently fetched sepolia token list is still valid
+      expect(fetchTokenListSpy).toHaveBeenCalledTimes(2);
+
+      // expect tokenList to be updated with the binance token list
+      // and the cache to now contain both the binance token list and the sepolia token list
+      expect(controller.state.tokenList).toStrictEqual(
+        sampleBinanceTokensChainsCache,
+      );
+      // once we adopt this polling pattern we should no longer access the root tokenList state
+      // but rather access from the cache with a chainId selector.
       expect(controller.state.tokensChainsCache).toStrictEqual({
         [toHex(56)]: {
           timestamp: expect.any(Number),
@@ -1554,26 +1479,6 @@ describe('TokenListController', () => {
           data: sampleSepoliaTokensChainCache,
         },
       });
-      // expect(controller.state).toStrictEqual({
-      //   preventPollingOnNetworkRestart: false,
-      //   tokenList: sampleBinanceTokensChainsCache,
-      //   tokenChainsCache: {
-      //     [toHex(56)]: {
-      //       timestamp: expect.any(Number),
-      //       data: sampleBinanceTokensChainsCache,
-      //     },
-      //     [ChainId.sepolia]: {
-      //       timestamp: expect.any(Number),
-      //       data: sampleSepoliaTokensChainCache,
-      //     },
-      //   },
-      // });
-
-      // console.log(
-      //   'sampleBinanceTokensChainsCache:',
-      //   sampleBinanceTokensChainsCache,
-      // );
-      // console.log('controller.state', controller.state);
     });
   });
 });

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -28,9 +28,9 @@ import { TokenListController } from './TokenListController';
 const name = 'TokenListController';
 const timestamp = Date.now();
 
-function flushPromises(): Promise<unknown> {
+const flushPromises = () => {
   return new Promise(jest.requireActual('timers').setImmediate);
-}
+};
 
 const sampleMainnetTokenList = [
   {
@@ -228,6 +228,15 @@ const sampleBinanceTokenList = [
       'https://static.metafi.codefi.network/api/v1/tokenIcons/56/0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3.png',
   },
 ];
+
+const sampleBinanceTokensChainsCache = sampleBinanceTokenList.reduce(
+  (output, current) => {
+    output[current.address] = current;
+    return output;
+  },
+  {} as TokenListMap,
+);
+
 const sampleSingleChainState = {
   tokenList: {
     '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f': {
@@ -304,13 +313,181 @@ const sampleSingleChainState = {
   },
 };
 
-const sampleBinanceTokensChainsCache = sampleBinanceTokenList.reduce(
+const sampleSepoliaTokenList = [
+  {
+    address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+    symbol: 'WBTC',
+    decimals: 8,
+    name: 'Wrapped BTC',
+    iconUrl:
+      'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/wbtc.svg',
+    type: 'erc20',
+    aggregators: [
+      'metamask',
+      'aave',
+      'bancor',
+      'cmc',
+      'cryptocom',
+      'coinGecko',
+      'oneInch',
+      'pmm',
+      'sushiswap',
+      'zerion',
+      'lifi',
+      'openswap',
+      'sonarwatch',
+      'uniswapLabs',
+      'coinmarketcap',
+    ],
+    occurrences: 15,
+    fees: {},
+    storage: {
+      balance: 0,
+    },
+  },
+  {
+    address: '0x04fa0d235c4abf4bcf4787af4cf447de572ef828',
+    symbol: 'UMA',
+    decimals: 18,
+    name: 'UMA',
+    iconUrl:
+      'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/uma.svg',
+    type: 'erc20',
+    aggregators: [
+      'metamask',
+      'bancor',
+      'cmc',
+      'cryptocom',
+      'coinGecko',
+      'oneInch',
+      'pmm',
+      'sushiswap',
+      'zerion',
+      'openswap',
+      'sonarwatch',
+      'uniswapLabs',
+      'coinmarketcap',
+    ],
+    occurrences: 13,
+    fees: {},
+  },
+  {
+    address: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+    symbol: 'GNO',
+    decimals: 18,
+    name: 'Gnosis Token',
+    iconUrl:
+      'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/gnosis.svg',
+    type: 'erc20',
+    aggregators: [
+      'metamask',
+      'bancor',
+      'cmc',
+      'coinGecko',
+      'oneInch',
+      'sushiswap',
+      'zerion',
+      'lifi',
+      'openswap',
+      'sonarwatch',
+      'uniswapLabs',
+      'coinmarketcap',
+    ],
+    occurrences: 12,
+    fees: {},
+  },
+];
+
+const sampleSepoliaTokensChainCache = sampleSepoliaTokenList.reduce(
   (output, current) => {
     output[current.address] = current;
     return output;
   },
   {} as TokenListMap,
 );
+
+// const sampleSepoliaTokensChainCache = {
+//   '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599': {
+//     address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+//     symbol: 'WBTC',
+//     decimals: 8,
+//     name: 'Wrapped BTC',
+//     iconUrl:
+//       'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599.png',
+//     type: 'erc20',
+//     aggregators: [
+//       'Metamask',
+//       'Aave',
+//       'Bancor',
+//       'CMC',
+//       'Crypto.com',
+//       'CoinGecko',
+//       '1inch',
+//       'PMM',
+//       'Sushiswap',
+//       'Zerion',
+//       'Lifi',
+//       'Openswap',
+//       'Sonarwatch',
+//       'UniswapLabs',
+//       'Coinmarketcap',
+//     ],
+//     occurrences: 15,
+//     fees: {},
+//     storage: { balance: 0 },
+//   },
+//   '0x04fa0d235c4abf4bcf4787af4cf447de572ef828': {
+//     address: '0x04fa0d235c4abf4bcf4787af4cf447de572ef828',
+//     symbol: 'UMA',
+//     decimals: 18,
+//     name: 'UMA',
+//     iconUrl:
+//       'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x04fa0d235c4abf4bcf4787af4cf447de572ef828.png',
+//     type: 'erc20',
+//     aggregators: [
+//       'Metamask',
+//       'Bancor',
+//       'CMC',
+//       'Crypto.com',
+//       'CoinGecko',
+//       '1inch',
+//       'PMM',
+//       'Sushiswap',
+//       'Zerion',
+//       'Openswap',
+//       'Sonarwatch',
+//       'UniswapLabs',
+//       'Coinmarketcap',
+//     ],
+//     occurrences: 13,
+//     fees: {},
+//   },
+//   '0x6810e776880c02933d47db1b9fc05908e5386b96': {
+//     address: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+//     symbol: 'GNO',
+//     decimals: 18,
+//     name: 'Gnosis Token',
+//     iconUrl:
+//       'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x6810e776880c02933d47db1b9fc05908e5386b96.png',
+//     type: 'erc20',
+//     aggregators: [
+//       'Metamask',
+//       'Bancor',
+//       'CMC',
+//       'CoinGecko',
+//       '1inch',
+//       'Sushiswap',
+//       'Zerion',
+//       'Lifi',
+//       'Openswap',
+//       'Sonarwatch',
+//       'UniswapLabs',
+//       'Coinmarketcap',
+//     ],
+//     occurrences: 12,
+//     fees: {},
+//   },
+// };
 
 const sampleTwoChainState = {
   tokenList: {
@@ -1202,173 +1379,6 @@ describe('TokenListController', () => {
 
   describe('executePoll', () => {
     it('should call fetchTokenList with the correct chainId', async () => {
-      const sampleSepoliaTokenList = [
-        {
-          address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
-          symbol: 'WBTC',
-          decimals: 8,
-          name: 'Wrapped BTC',
-          iconUrl:
-            'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/wbtc.svg',
-          type: 'erc20',
-          aggregators: [
-            'metamask',
-            'aave',
-            'bancor',
-            'cmc',
-            'cryptocom',
-            'coinGecko',
-            'oneInch',
-            'pmm',
-            'sushiswap',
-            'zerion',
-            'lifi',
-            'openswap',
-            'sonarwatch',
-            'uniswapLabs',
-            'coinmarketcap',
-          ],
-          occurrences: 15,
-          fees: {},
-          storage: {
-            balance: 0,
-          },
-        },
-        {
-          address: '0x04fa0d235c4abf4bcf4787af4cf447de572ef828',
-          symbol: 'UMA',
-          decimals: 18,
-          name: 'UMA',
-          iconUrl:
-            'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/uma.svg',
-          type: 'erc20',
-          aggregators: [
-            'metamask',
-            'bancor',
-            'cmc',
-            'cryptocom',
-            'coinGecko',
-            'oneInch',
-            'pmm',
-            'sushiswap',
-            'zerion',
-            'openswap',
-            'sonarwatch',
-            'uniswapLabs',
-            'coinmarketcap',
-          ],
-          occurrences: 13,
-          fees: {},
-        },
-        {
-          address: '0x6810e776880c02933d47db1b9fc05908e5386b96',
-          symbol: 'GNO',
-          decimals: 18,
-          name: 'Gnosis Token',
-          iconUrl:
-            'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/gnosis.svg',
-          type: 'erc20',
-          aggregators: [
-            'metamask',
-            'bancor',
-            'cmc',
-            'coinGecko',
-            'oneInch',
-            'sushiswap',
-            'zerion',
-            'lifi',
-            'openswap',
-            'sonarwatch',
-            'uniswapLabs',
-            'coinmarketcap',
-          ],
-          occurrences: 12,
-          fees: {},
-        },
-      ];
-
-      const expectedSepoliaTokenListFormatted = {
-        '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599': {
-          address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
-          symbol: 'WBTC',
-          decimals: 8,
-          name: 'Wrapped BTC',
-          iconUrl:
-            'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599.png',
-          type: 'erc20',
-          aggregators: [
-            'Metamask',
-            'Aave',
-            'Bancor',
-            'CMC',
-            'Crypto.com',
-            'CoinGecko',
-            '1inch',
-            'PMM',
-            'Sushiswap',
-            'Zerion',
-            'Lifi',
-            'Openswap',
-            'Sonarwatch',
-            'UniswapLabs',
-            'Coinmarketcap',
-          ],
-          occurrences: 15,
-          fees: {},
-          storage: { balance: 0 },
-        },
-        '0x04fa0d235c4abf4bcf4787af4cf447de572ef828': {
-          address: '0x04fa0d235c4abf4bcf4787af4cf447de572ef828',
-          symbol: 'UMA',
-          decimals: 18,
-          name: 'UMA',
-          iconUrl:
-            'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x04fa0d235c4abf4bcf4787af4cf447de572ef828.png',
-          type: 'erc20',
-          aggregators: [
-            'Metamask',
-            'Bancor',
-            'CMC',
-            'Crypto.com',
-            'CoinGecko',
-            '1inch',
-            'PMM',
-            'Sushiswap',
-            'Zerion',
-            'Openswap',
-            'Sonarwatch',
-            'UniswapLabs',
-            'Coinmarketcap',
-          ],
-          occurrences: 13,
-          fees: {},
-        },
-        '0x6810e776880c02933d47db1b9fc05908e5386b96': {
-          address: '0x6810e776880c02933d47db1b9fc05908e5386b96',
-          symbol: 'GNO',
-          decimals: 18,
-          name: 'Gnosis Token',
-          iconUrl:
-            'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x6810e776880c02933d47db1b9fc05908e5386b96.png',
-          type: 'erc20',
-          aggregators: [
-            'Metamask',
-            'Bancor',
-            'CMC',
-            'CoinGecko',
-            '1inch',
-            'Sushiswap',
-            'Zerion',
-            'Lifi',
-            'Openswap',
-            'Sonarwatch',
-            'UniswapLabs',
-            'Coinmarketcap',
-          ],
-          occurrences: 12,
-          fees: {},
-        },
-      };
       nock(tokenService.TOKEN_END_POINT_API)
         .get(`/tokens/${convertHexToDecimal(ChainId.sepolia)}`)
         .reply(200, sampleSepoliaTokenList)
@@ -1401,15 +1411,13 @@ describe('TokenListController', () => {
         expect.arrayContaining([ChainId.sepolia]),
       );
       expect(controller.state.tokenList).toStrictEqual(
-        expectedSepoliaTokenListFormatted,
+        sampleSepoliaTokensChainCache,
       );
     });
   });
 
-  describe.only('stopPollingByNetworkClientId', () => {
-    it('should stop polling for the network client id', async () => {
-      // TODO think through how if, at all we want to modify the state of the controller
-      // So looks like this cache is keyed by chainId so need to think through how we want to handle this
+  describe('startPollingByNetworkClient', () => {
+    it('should start polling against the token list API at the interval passed to the constructor', async () => {
       jest.useFakeTimers();
       const pollingIntervalTime = 1000;
       const spy = jest.spyOn(tokenService, 'fetchTokenList');
@@ -1442,13 +1450,115 @@ describe('TokenListController', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       jest.advanceTimersByTime(pollingIntervalTime / 2);
       await flushPromises();
-      expect(spy.mock.calls[0]).toStrictEqual(
-        expect.arrayContaining([ChainId.goerli]),
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      await Promise.all([
+        jest.advanceTimersByTime(pollingIntervalTime),
+        flushPromises(),
+      ]);
+
+      await Promise.all([jest.runOnlyPendingTimers(), flushPromises()]);
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it.only('should update tokenList state and tokensChainsCache', async () => {
+      jest.useFakeTimers();
+      const startingState: TokenListState = {
+        tokenList: {},
+        tokensChainsCache: {},
+        preventPollingOnNetworkRestart: false,
+      };
+
+      jest
+        .spyOn(tokenService, 'fetchTokenList')
+        .mockImplementation(async (chainId) => {
+          switch (chainId) {
+            case ChainId.sepolia:
+              return sampleSepoliaTokenList;
+            case toHex(56):
+              return sampleBinanceTokenList;
+            default:
+              throw new Error('Invalid chainId');
+          }
+        });
+
+      const pollingIntervalTime = 1000;
+
+      const controllerMessenger = getControllerMessenger();
+      controllerMessenger.registerActionHandler(
+        'NetworkController:getNetworkClientById',
+        jest.fn().mockImplementation((networkClientId) => {
+          switch (networkClientId) {
+            case 'sepolia':
+              return {
+                configuration: {
+                  type: NetworkType.sepolia,
+                  chainId: ChainId.sepolia,
+                },
+              };
+            case 'binance-network-client-id':
+              return {
+                configuration: {
+                  type: NetworkType.rpc,
+                  chainId: toHex(56),
+                },
+              };
+            default:
+              throw new Error('Invalid networkClientId');
+          }
+        }),
       );
-      console.log('conroller.state', controller.state);
-      // expect(controller.state.tokenList).toStrictEqual(
-      //   expectedSepoliaTokenListFormatted,
-      // );
+      const messenger = getRestrictedMessenger(controllerMessenger);
+      const controller = new TokenListController({
+        chainId: ChainId.mainnet,
+        preventPollingOnNetworkRestart: false,
+        messenger,
+        state: startingState,
+        interval: pollingIntervalTime,
+      });
+
+      expect(controller.state).toStrictEqual(startingState);
+
+      await controller.startPollingByNetworkClientId('sepolia');
+      // await Promise.all([
+      //   jest.advanceTimersByTime(pollingIntervalTime),
+      //   flushPromises(),
+      // ]);
+      jest.advanceTimersByTime(pollingIntervalTime);
+      await flushPromises();
+      await controller.startPollingByNetworkClientId(
+        'binance-network-client-id',
+      );
+
+      jest.advanceTimersByTime(pollingIntervalTime);
+      await flushPromises();
+      // jest.runOnlyPendingTimers();
+      // await flushPromises();
+      // await Promise.all([jest.runOnlyPendingTimers(), flushPromises()]);
+      expect(controller.state).toStrictEqual({
+        preventPollingOnNetworkRestart: false,
+        tokenList: sampleBinanceTokensChainsCache,
+        tokenChainsCache: {
+          [toHex(56)]: {
+            timestamp: expect.any(Number),
+            data: sampleBinanceTokensChainsCache,
+          },
+          [ChainId.sepolia]: {
+            timestamp: expect.any(Number),
+            data: sampleSepoliaTokensChainCache,
+          },
+        },
+      });
+
+      console.log(
+        'sampleBinanceTokensChainsCache:',
+        sampleBinanceTokensChainsCache,
+      );
+      console.log('controller.state', controller.state);
+      console.log(
+        'controller.stat.tokensChainsCache:',
+        controller.state.tokensChainsCache,
+      );
     });
   });
 });

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -1195,7 +1195,179 @@ describe('TokenListController', () => {
   });
 
   describe('executePoll', () => {
-    it('should execute the poll', async () => {
+    it('should call fetchTokenList with the correct chainId', async () => {
+      const sampleSepoliaTokenList = [
+        {
+          address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+          symbol: 'WBTC',
+          decimals: 8,
+          name: 'Wrapped BTC',
+          iconUrl:
+            'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/wbtc.svg',
+          type: 'erc20',
+          aggregators: [
+            'metamask',
+            'aave',
+            'bancor',
+            'cmc',
+            'cryptocom',
+            'coinGecko',
+            'oneInch',
+            'pmm',
+            'sushiswap',
+            'zerion',
+            'lifi',
+            'openswap',
+            'sonarwatch',
+            'uniswapLabs',
+            'coinmarketcap',
+          ],
+          occurrences: 15,
+          fees: {},
+          storage: {
+            balance: 0,
+          },
+        },
+        {
+          address: '0x04fa0d235c4abf4bcf4787af4cf447de572ef828',
+          symbol: 'UMA',
+          decimals: 18,
+          name: 'UMA',
+          iconUrl:
+            'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/uma.svg',
+          type: 'erc20',
+          aggregators: [
+            'metamask',
+            'bancor',
+            'cmc',
+            'cryptocom',
+            'coinGecko',
+            'oneInch',
+            'pmm',
+            'sushiswap',
+            'zerion',
+            'openswap',
+            'sonarwatch',
+            'uniswapLabs',
+            'coinmarketcap',
+          ],
+          occurrences: 13,
+          fees: {},
+        },
+        {
+          address: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+          symbol: 'GNO',
+          decimals: 18,
+          name: 'Gnosis Token',
+          iconUrl:
+            'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/gnosis.svg',
+          type: 'erc20',
+          aggregators: [
+            'metamask',
+            'bancor',
+            'cmc',
+            'coinGecko',
+            'oneInch',
+            'sushiswap',
+            'zerion',
+            'lifi',
+            'openswap',
+            'sonarwatch',
+            'uniswapLabs',
+            'coinmarketcap',
+          ],
+          occurrences: 12,
+          fees: {},
+        },
+      ];
+
+      const expectedSepoliaTokenListFormatted = {
+        '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599': {
+          address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+          symbol: 'WBTC',
+          decimals: 8,
+          name: 'Wrapped BTC',
+          iconUrl:
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599.png',
+          type: 'erc20',
+          aggregators: [
+            'Metamask',
+            'Aave',
+            'Bancor',
+            'CMC',
+            'Crypto.com',
+            'CoinGecko',
+            '1inch',
+            'PMM',
+            'Sushiswap',
+            'Zerion',
+            'Lifi',
+            'Openswap',
+            'Sonarwatch',
+            'UniswapLabs',
+            'Coinmarketcap',
+          ],
+          occurrences: 15,
+          fees: {},
+          storage: { balance: 0 },
+        },
+        '0x04fa0d235c4abf4bcf4787af4cf447de572ef828': {
+          address: '0x04fa0d235c4abf4bcf4787af4cf447de572ef828',
+          symbol: 'UMA',
+          decimals: 18,
+          name: 'UMA',
+          iconUrl:
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x04fa0d235c4abf4bcf4787af4cf447de572ef828.png',
+          type: 'erc20',
+          aggregators: [
+            'Metamask',
+            'Bancor',
+            'CMC',
+            'Crypto.com',
+            'CoinGecko',
+            '1inch',
+            'PMM',
+            'Sushiswap',
+            'Zerion',
+            'Openswap',
+            'Sonarwatch',
+            'UniswapLabs',
+            'Coinmarketcap',
+          ],
+          occurrences: 13,
+          fees: {},
+        },
+        '0x6810e776880c02933d47db1b9fc05908e5386b96': {
+          address: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+          symbol: 'GNO',
+          decimals: 18,
+          name: 'Gnosis Token',
+          iconUrl:
+            'https://static.metafi.codefi.network/api/v1/tokenIcons/1/0x6810e776880c02933d47db1b9fc05908e5386b96.png',
+          type: 'erc20',
+          aggregators: [
+            'Metamask',
+            'Bancor',
+            'CMC',
+            'CoinGecko',
+            '1inch',
+            'Sushiswap',
+            'Zerion',
+            'Lifi',
+            'Openswap',
+            'Sonarwatch',
+            'UniswapLabs',
+            'Coinmarketcap',
+          ],
+          occurrences: 12,
+          fees: {},
+        },
+      };
+      nock(tokenService.TOKEN_END_POINT_API)
+        .get(`/tokens/${convertHexToDecimal(ChainId.sepolia)}`)
+        .reply(200, sampleSepoliaTokenList)
+        .persist();
+
       const spy = jest.spyOn(tokenService, 'fetchTokenList');
       const controllerMessenger = getControllerMessenger();
       controllerMessenger.registerActionHandler(
@@ -1214,10 +1386,55 @@ describe('TokenListController', () => {
         messenger,
         state: expiredCacheExistingState,
       });
+      expect(controller.state.tokenList).toStrictEqual(
+        expiredCacheExistingState.tokenList,
+      );
+
       await controller.executePoll('sepolia');
       expect(spy.mock.calls[0]).toStrictEqual(
         expect.arrayContaining([ChainId.sepolia]),
       );
+      expect(controller.state.tokenList).toStrictEqual(
+        expectedSepoliaTokenListFormatted,
+      );
+    });
+  });
+
+  describe('stopPollingByNetworkClientId', () => {
+    it('should stop polling for the network client id', async () => {
+
+      // TODO think through how if, at all we want to modify the state of the controller
+      // So looks like this cache is keyed by chainId so need to think through how we want to handle this
+
+      const spy = jest.spyOn(tokenService, 'fetchTokenList');
+      const controllerMessenger = getControllerMessenger();
+      controllerMessenger.registerActionHandler(
+        'NetworkController:getNetworkClientById',
+        jest.fn().mockReturnValue({
+          configuration: {
+            type: NetworkType.sepolia,
+            chainId: ChainId.sepolia,
+          },
+        }),
+      );
+      const messenger = getRestrictedMessenger(controllerMessenger);
+      const controller = new TokenListController({
+        chainId: ChainId.mainnet,
+        preventPollingOnNetworkRestart: false,
+        messenger,
+        state: expiredCacheExistingState,
+      });
+      expect(controller.state.tokenList).toStrictEqual(
+        expiredCacheExistingState.tokenList,
+      );
+
+      await controller.executePoll('sepolia');
+      expect(spy.mock.calls[0]).toStrictEqual(
+        expect.arrayContaining([ChainId.sepolia]),
+      );
+      // expect(controller.state.tokenList).toStrictEqual(
+      //   expectedSepoliaTokenListFormatted,
+      // );
     });
   });
 });

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -268,9 +268,9 @@ export class TokenListController extends PollingController<
         tokenList = { ...cachedTokens };
       } else {
         // Fetch fresh token list
-        const tokensFromAPI: TokenListToken[] = await safelyExecute(() =>
-          fetchTokenList(chainId, this.abortController.signal),
-        );
+        const tokensFromAPI: TokenListToken[] = await safelyExecute(() => {
+          return fetchTokenList(chainId, this.abortController.signal);
+        });
 
         if (!tokensFromAPI) {
           // Fallback to expired cached tokens

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -258,6 +258,9 @@ export class TokenListController extends PollingController<
     const chainId = networkClient?.configuration.chainId ?? this.chainId;
     const releaseLock = await this.mutex.acquire();
     try {
+      // TODO document somewhere that this cache system already gives us multichain support no need to modify state
+      // other than perhaps remove the tokenList property from state and make the cache the default since there needn't be a single
+      // globally selected tokenList anymore
       const { tokensChainsCache } = this.state;
       let tokenList: TokenListMap = {};
       const cachedTokens: TokenListMap = await safelyExecute(() =>

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -254,7 +254,6 @@ export class TokenListController extends PollingController<
         networkClientId,
       );
     }
-    
     const chainId = networkClient?.configuration.chainId ?? this.chainId;
     const releaseLock = await this.mutex.acquire();
     try {
@@ -274,11 +273,9 @@ export class TokenListController extends PollingController<
         const tokensFromAPI: TokenListToken[] = await safelyExecute(() => {
           return fetchTokenList(chainId, this.abortController.signal);
         });
-
         if (!tokensFromAPI) {
           // Fallback to expired cached tokens
           tokenList = { ...(tokensChainsCache[chainId]?.data || {}) };
-
           this.update(() => {
             return {
               ...this.state,

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -285,6 +285,7 @@ export class TokenListController extends PollingController<
           });
           return;
         }
+        // TODO pull this out into a helper function
         // Filtering out tokens with less than 3 occurrences and native tokens
         const filteredTokenList = tokensFromAPI.filter(
           (token) =>

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -39,7 +39,7 @@ type DataCache = {
   timestamp: number;
   data: TokenListMap;
 };
-type TokensChainsCache = {
+export type TokensChainsCache = {
   [chainId: Hex]: DataCache;
 };
 
@@ -247,6 +247,7 @@ export class TokenListController extends PollingController<
    * @param networkClientId - The ID of the network client triggering the fetch.
    */
   async fetchTokenList(networkClientId?: NetworkClientId): Promise<void> {
+    const releaseLock = await this.mutex.acquire();
     let networkClient;
     if (networkClientId) {
       networkClient = this.messagingSystem.call(
@@ -255,7 +256,6 @@ export class TokenListController extends PollingController<
       );
     }
     const chainId = networkClient?.configuration.chainId ?? this.chainId;
-    const releaseLock = await this.mutex.acquire();
     try {
       // TODO document somewhere that this cache system already gives us multichain support no need to modify state
       // other than perhaps remove the tokenList property from state and make the cache the default since there needn't be a single
@@ -285,7 +285,6 @@ export class TokenListController extends PollingController<
           });
           return;
         }
-        // TODO pull this out into a helper function
         // Filtering out tokens with less than 3 occurrences and native tokens
         const filteredTokenList = tokensFromAPI.filter(
           (token) =>

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -39,7 +39,7 @@ type DataCache = {
   timestamp: number;
   data: TokenListMap;
 };
-export type TokensChainsCache = {
+type TokensChainsCache = {
   [chainId: Hex]: DataCache;
 };
 
@@ -257,9 +257,6 @@ export class TokenListController extends PollingController<
     }
     const chainId = networkClient?.configuration.chainId ?? this.chainId;
     try {
-      // TODO document somewhere that this cache system already gives us multichain support no need to modify state
-      // other than perhaps remove the tokenList property from state and make the cache the default since there needn't be a single
-      // globally selected tokenList anymore
       const { tokensChainsCache } = this.state;
       let tokenList: TokenListMap = {};
       const cachedTokens: TokenListMap = await safelyExecute(() =>

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -16,7 +16,7 @@ import {
   formatAggregatorNames,
   formatIconUrlWithProxy,
 } from './assetsUtil';
-import { fetchTokenList } from './token-service';
+import { fetchTokenListByChainId } from './token-service';
 
 const DEFAULT_INTERVAL = 24 * 60 * 60 * 1000;
 const DEFAULT_THRESHOLD = 24 * 60 * 60 * 1000;
@@ -271,7 +271,7 @@ export class TokenListController extends PollingController<
       } else {
         // Fetch fresh token list
         const tokensFromAPI: TokenListToken[] = await safelyExecute(() => {
-          return fetchTokenList(chainId, this.abortController.signal);
+          return fetchTokenListByChainId(chainId, this.abortController.signal);
         });
         if (!tokensFromAPI) {
           // Fallback to expired cached tokens

--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -2,7 +2,7 @@ import { toHex } from '@metamask/controller-utils';
 import nock from 'nock';
 
 import {
-  fetchTokenList,
+  fetchTokenListByChainId,
   fetchTokenMetadata,
   TOKEN_END_POINT_API,
   TOKEN_METADATA_NO_SUPPORT_ERROR,
@@ -137,7 +137,7 @@ const sampleDecimalChainId = 1;
 const sampleChainId = toHex(sampleDecimalChainId);
 
 describe('Token service', () => {
-  describe('fetchTokenList', () => {
+  describe('fetchTokenListByChainId', () => {
     it('should call the tokens api and return the list of tokens', async () => {
       const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
@@ -145,7 +145,7 @@ describe('Token service', () => {
         .reply(200, sampleTokenList)
         .persist();
 
-      const tokens = await fetchTokenList(sampleChainId, signal);
+      const tokens = await fetchTokenListByChainId(sampleChainId, signal);
 
       expect(tokens).toStrictEqual(sampleTokenList);
     });
@@ -159,7 +159,7 @@ describe('Token service', () => {
         .reply(200, sampleTokenList)
         .persist();
 
-      const fetchPromise = fetchTokenList(
+      const fetchPromise = fetchTokenListByChainId(
         sampleChainId,
         abortController.signal,
       );
@@ -175,7 +175,7 @@ describe('Token service', () => {
         .replyWithError('Example network error')
         .persist();
 
-      const result = await fetchTokenList(sampleChainId, signal);
+      const result = await fetchTokenListByChainId(sampleChainId, signal);
 
       expect(result).toBeUndefined();
     });
@@ -187,7 +187,7 @@ describe('Token service', () => {
         .reply(500)
         .persist();
 
-      const result = await fetchTokenList(sampleChainId, signal);
+      const result = await fetchTokenListByChainId(sampleChainId, signal);
 
       expect(result).toBeUndefined();
     });
@@ -201,7 +201,7 @@ describe('Token service', () => {
         .reply(200, sampleTokenList)
         .persist();
 
-      const result = await fetchTokenList(sampleChainId, signal, {
+      const result = await fetchTokenListByChainId(sampleChainId, signal, {
         timeout: ONE_MILLISECOND,
       });
 
@@ -317,7 +317,7 @@ describe('Token service', () => {
       .reply(404, undefined)
       .persist();
 
-    const tokens = await fetchTokenList(sampleChainId, signal);
+    const tokens = await fetchTokenListByChainId(sampleChainId, signal);
 
     expect(tokens).toBeUndefined();
   });

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -46,7 +46,7 @@ const defaultTimeout = tenSecondsInMilliseconds;
  * @param options.timeout - The fetch timeout.
  * @returns The token list, or `undefined` if the request was cancelled.
  */
-export async function fetchTokenList(
+export async function fetchTokenListByChainId(
   chainId: Hex,
   abortSignal: AbortSignal,
   { timeout = defaultTimeout } = {},

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -51,6 +51,7 @@ export async function fetchTokenList(
   abortSignal: AbortSignal,
   { timeout = defaultTimeout } = {},
 ): Promise<unknown> {
+  console.log('fetchTokenList', chainId);
   const tokenURL = getTokensURL(chainId);
   const response = await queryApi(tokenURL, abortSignal, timeout);
   if (response) {

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -51,6 +51,7 @@ export async function fetchTokenList(
   abortSignal: AbortSignal,
   { timeout = defaultTimeout } = {},
 ): Promise<unknown> {
+  console.log('chainId:', chainId);
   const tokenURL = getTokensURL(chainId);
   const response = await queryApi(tokenURL, abortSignal, timeout);
   if (response) {

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -51,7 +51,6 @@ export async function fetchTokenList(
   abortSignal: AbortSignal,
   { timeout = defaultTimeout } = {},
 ): Promise<unknown> {
-  console.log('fetchTokenList', chainId);
   const tokenURL = getTokensURL(chainId);
   const response = await queryApi(tokenURL, abortSignal, timeout);
   if (response) {

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -51,7 +51,6 @@ export async function fetchTokenList(
   abortSignal: AbortSignal,
   { timeout = defaultTimeout } = {},
 ): Promise<unknown> {
-  console.log('chainId:', chainId);
   const tokenURL = getTokensURL(chainId);
   const response = await queryApi(tokenURL, abortSignal, timeout);
   if (response) {

--- a/packages/assets-controllers/tsconfig.build.json
+++ b/packages/assets-controllers/tsconfig.build.json
@@ -10,7 +10,8 @@
     { "path": "../base-controller/tsconfig.build.json" },
     { "path": "../controller-utils/tsconfig.build.json" },
     { "path": "../network-controller/tsconfig.build.json" },
-    { "path": "../preferences-controller/tsconfig.build.json" }
+    { "path": "../preferences-controller/tsconfig.build.json" },
+    { "path": "../polling-controller/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/assets-controllers/tsconfig.json
+++ b/packages/assets-controllers/tsconfig.json
@@ -8,7 +8,8 @@
     { "path": "../base-controller" },
     { "path": "../controller-utils" },
     { "path": "../network-controller" },
-    { "path": "../preferences-controller" }
+    { "path": "../preferences-controller" },
+    { "path": "../polling-controller" }
   ],
   "include": ["../../types", "./src"]
 }


### PR DESCRIPTION
Resolves: https://github.com/MetaMask/MetaMask-planning/issues/1032

Integrates new `PollingController` abstraction into the `TokenListController`, implements the `executePoll` method and parameterizes the `fetchTokenList` method by `networkClientId` such that tokenLists can be fetched and cached for different networks via concurrent polling sessions. 

**A note:** As is our current controller refactor strategy, these changes are additive, backwards compatible and coexist alongside the existing globally selected network pattern. Once we fully adopt this polling pattern we should no longer access the root `tokenList` state but rather access from the cache with a chainId selector.