### PR TITLE
Fix issue where mutex is acquired after state is read in `addToken` resulting in overwritten state with batched addToken/watchAsset calls

### DIFF
--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -299,6 +299,7 @@ export class TokensController extends BaseController<
     interactingAddress?: string;
     networkClientId?: NetworkClientId;
   }): Promise<Token[]> {
+    const releaseLock = await this.mutex.acquire();
     const { allTokens, allIgnoredTokens, allDetectedTokens } = this.state;
     const { chainId, selectedAddress } = this.config;
     let currentChainId = chainId;
@@ -309,7 +310,6 @@ export class TokensController extends BaseController<
 
     const accountAddress = interactingAddress || selectedAddress;
     const isInteractingWithWalletAccount = accountAddress === selectedAddress;
-    const releaseLock = await this.mutex.acquire();
 
     try {
       address = toChecksumHexAddress(address);

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -299,9 +299,9 @@ export class TokensController extends BaseController<
     interactingAddress?: string;
     networkClientId?: NetworkClientId;
   }): Promise<Token[]> {
+    const { chainId, selectedAddress } = this.config;
     const releaseLock = await this.mutex.acquire();
     const { allTokens, allIgnoredTokens, allDetectedTokens } = this.state;
-    const { chainId, selectedAddress } = this.config;
     let currentChainId = chainId;
     if (networkClientId) {
       currentChainId =
@@ -321,8 +321,10 @@ export class TokensController extends BaseController<
       const newTokens: Token[] = [...tokens];
       const [isERC721, tokenMetadata] = await Promise.all([
         this._detectIsERC721(address, networkClientId),
+        // TODO parameterize the token metadata fetch by networkClientId
         this.fetchTokenMetadata(address),
       ]);
+      // TODO remove this once this method is fully parameterized by networkClientId
       if (!networkClientId && currentChainId !== this.config.chainId) {
         throw new Error(
           'TokensController Error: Switched networks while adding token',


### PR DESCRIPTION
Fixes a subtle bug: when multiple `wallet_watchAsset` calls of ERC20 tokens are batched, only the last of the tokens added was getting added because the calls were not properly single threaded, since the mutex was acquired after reading state in the `addToken` call.

## TokensController
### Fixes
- Fixes bug where batched addToken calls overwrite each other because mutex is acquired after reading state