### PR TITLE
`eth-json-rpc-provider` migration - D: Repair breaking packages and finalize merge

### DIFF
--- a/packages/eth-json-rpc-provider/src/index.ts
+++ b/packages/eth-json-rpc-provider/src/index.ts
@@ -1,3 +1,3 @@
 export * from './provider-from-engine';
 export * from './provider-from-middleware';
-export type { SafeEventEmitterProvider } from './safe-event-emitter-provider';
+export { SafeEventEmitterProvider } from './safe-event-emitter-provider';

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -35,6 +35,7 @@
     "@metamask/eth-json-rpc-middleware": "^11.0.2",
     "@metamask/eth-json-rpc-provider": "^2.2.0",
     "@metamask/eth-query": "^3.0.1",
+    "@metamask/json-rpc-engine": "^7.1.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/utils": "^8.1.0",
     "async-mutex": "^0.2.6",

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -8,9 +8,12 @@ import {
   NetworkType,
   isSafeChainId,
 } from '@metamask/controller-utils';
-import EthQuery from '@metamask/eth-query';
+import EthQuery, { type Provider } from '@metamask/eth-query';
 import { createEventEmitterProxy } from '@metamask/swappable-obj-proxy';
-import type { SwappableProxy } from '@metamask/swappable-obj-proxy';
+import type {
+  EventEmitterLike,
+  SwappableProxy,
+} from '@metamask/swappable-obj-proxy';
 import type { Hex } from '@metamask/utils';
 import {
   assertIsStrictHexString,
@@ -32,7 +35,6 @@ import { projectLogger, createModuleLogger } from './logger';
 import { NetworkClientType } from './types';
 import type {
   BlockTracker,
-  Provider,
   CustomNetworkClientConfiguration,
   InfuraNetworkClientConfiguration,
   NetworkClientConfiguration,
@@ -357,7 +359,9 @@ export type BlockTrackerProxy = SwappableProxy<
  * selected network can change without consumers needing to refresh the object
  * reference to that network.)
  */
-export type ProviderProxy = SwappableProxy<ProxyWithAccessibleTarget<Provider>>;
+export type ProviderProxy =
+  | SwappableProxy<ProxyWithAccessibleTarget<Provider>>
+  | SwappableProxy<EventEmitterLike>;
 
 export type NetworkControllerStateChangeEvent = {
   type: `NetworkController:stateChange`;

--- a/packages/network-controller/src/create-auto-managed-network-client.ts
+++ b/packages/network-controller/src/create-auto-managed-network-client.ts
@@ -1,10 +1,12 @@
+import type {
+  Provider,
+  ProviderSendAsyncCallback,
+  SendAsyncPayload,
+} from '@metamask/eth-query';
+
 import type { NetworkClient } from './create-network-client';
 import { createNetworkClient } from './create-network-client';
-import type {
-  BlockTracker,
-  NetworkClientConfiguration,
-  Provider,
-} from './types';
+import type { BlockTracker, NetworkClientConfiguration } from './types';
 
 /**
  * The name of the method on both the provider and block tracker proxy which can
@@ -90,10 +92,13 @@ export function createAutoManagedNetworkClient<
           // Ensure that the method on the provider is called with `this` as
           // the target, *not* the proxy (which happens by default) —
           // this allows private properties to be accessed
-          return function (this: unknown, ...args: any[]) {
-            // @ts-expect-error We don't care that `this` may not be compatible
-            // with the signature of the method being called, as technically
-            // it can be anything.
+          return function (
+            this: unknown,
+            ...args: [
+              payload: SendAsyncPayload<unknown>,
+              callback: ProviderSendAsyncCallback<unknown>,
+            ]
+          ) {
             return value.apply(this === receiver ? provider : this, args);
           };
         }

--- a/packages/network-controller/src/index.ts
+++ b/packages/network-controller/src/index.ts
@@ -1,5 +1,7 @@
 export * from './NetworkController';
 export * from './constants';
-export type { BlockTracker, Provider } from './types';
-export type { NetworkClientConfiguration } from './types';
-export { NetworkClientType } from './types';
+export type {
+  BlockTracker,
+  NetworkClientConfiguration,
+  NetworkClientType,
+} from './types';

--- a/packages/network-controller/src/types.ts
+++ b/packages/network-controller/src/types.ts
@@ -1,9 +1,6 @@
 import type { InfuraNetworkType } from '@metamask/controller-utils';
-import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { Hex } from '@metamask/utils';
 import type { PollingBlockTracker } from 'eth-block-tracker';
-
-export type Provider = SafeEventEmitterProvider;
 
 export type BlockTracker = PollingBlockTracker;
 

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -7,6 +7,7 @@ import {
   NetworkType,
   toHex,
 } from '@metamask/controller-utils';
+import type { Provider } from '@metamask/eth-query';
 import assert from 'assert';
 import { ethErrors } from 'eth-rpc-errors';
 import type { Patch } from 'immer';
@@ -27,10 +28,8 @@ import type {
   ProviderConfig,
 } from '../src/NetworkController';
 import { NetworkController } from '../src/NetworkController';
-import type { Provider } from '../src/types';
 import { NetworkClientType } from '../src/types';
-import type { FakeProviderStub } from './fake-provider';
-import { FakeProvider } from './fake-provider';
+import { FakeProvider, type FakeProviderStub } from './fake-provider';
 
 jest.mock('../src/create-network-client');
 
@@ -978,9 +977,10 @@ describe('NetworkController', () => {
                 provider,
               );
               const response1 = await promisifiedSendAsync1({
-                id: '1',
+                id: 1,
                 jsonrpc: '2.0',
                 method: 'test',
+                params: [],
               });
               expect(response1.result).toBe('test response 1');
 
@@ -989,9 +989,10 @@ describe('NetworkController', () => {
                 provider,
               );
               const response2 = await promisifiedSendAsync2({
-                id: '2',
+                id: 2,
                 jsonrpc: '2.0',
                 method: 'test',
+                params: [],
               });
               expect(response2.result).toBe('test response 2');
             },
@@ -1072,9 +1073,10 @@ describe('NetworkController', () => {
               provider,
             );
             const response1 = await promisifiedSendAsync1({
-              id: '1',
+              id: 1,
               jsonrpc: '2.0',
               method: 'test',
+              params: [],
             });
             expect(response1.result).toBe('test response 1');
 
@@ -1083,9 +1085,10 @@ describe('NetworkController', () => {
               provider,
             );
             const response2 = await promisifiedSendAsync2({
-              id: '2',
+              id: 2,
               jsonrpc: '2.0',
               method: 'test',
+              params: [],
             });
             expect(response2.result).toBe('test response 2');
           },
@@ -4948,9 +4951,10 @@ describe('NetworkController', () => {
                   provider,
                 );
                 const response = await promisifiedSendAsync({
-                  id: '1',
+                  id: 1,
                   jsonrpc: '2.0',
                   method: 'test',
+                  params: [],
                 });
                 expect(response.result).toBe('test response');
               },
@@ -5431,10 +5435,10 @@ describe('NetworkController', () => {
                 // We only care about the first state change, because it
                 // happens before networkDidChange
                 count: 1,
-                operation: () => {
+                operation: async () => {
                   // Intentionally not awaited because we want to check state
                   // while this operation is in-progress
-                  controller.rollbackToPreviousProvider();
+                  await controller.rollbackToPreviousProvider();
                 },
                 beforeResolving: () => {
                   expect(
@@ -5502,9 +5506,10 @@ describe('NetworkController', () => {
                 provider,
               );
               const response = await promisifiedSendAsync({
-                id: '1',
+                id: 1,
                 jsonrpc: '2.0',
                 method: 'test',
+                params: [],
               });
               expect(response.result).toBe('test response');
             },

--- a/packages/network-controller/tests/fake-provider.ts
+++ b/packages/network-controller/tests/fake-provider.ts
@@ -1,6 +1,8 @@
-import { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider/dist/safe-event-emitter-provider';
-import type { JsonRpcRequest, JsonRpcResponse } from 'json-rpc-engine';
-import { JsonRpcEngine } from 'json-rpc-engine';
+import { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
+import type { ProviderSendAsyncResponse } from '@metamask/eth-query';
+import { JsonRpcEngine } from '@metamask/json-rpc-engine';
+import type { JsonRpcRequest } from '@metamask/utils';
+import type { JsonRpcResponse } from 'json-rpc-engine';
 import { inspect, isDeepStrictEqual } from 'util';
 
 // Store this in case it gets stubbed later
@@ -105,21 +107,30 @@ export class FakeProvider extends SafeEventEmitterProvider {
 
   send = (
     payload: JsonRpcRequest<any>,
-    callback: (error: unknown, response?: JsonRpcResponse<any>) => void,
+    callback: (
+      error: unknown,
+      response?: JsonRpcResponse<unknown> | ProviderSendAsyncResponse<unknown>,
+    ) => void,
   ) => {
     return this.#handleSend(payload, callback);
   };
 
   sendAsync = (
-    payload: JsonRpcRequest<any>,
-    callback: (error: unknown, response?: JsonRpcResponse<any>) => void,
+    payload: JsonRpcRequest,
+    callback: (
+      error: unknown,
+      response: JsonRpcResponse<unknown> | ProviderSendAsyncResponse<unknown>,
+    ) => void,
   ) => {
     return this.#handleSend(payload, callback);
   };
 
   #handleSend(
-    payload: JsonRpcRequest<any>,
-    callback: (error: unknown, response?: JsonRpcResponse<any>) => void,
+    payload: JsonRpcRequest,
+    callback: (
+      error: unknown,
+      response: JsonRpcResponse<unknown> | ProviderSendAsyncResponse<unknown>,
+    ) => void,
   ) {
     if (Array.isArray(payload)) {
       throw new Error("Arrays aren't supported");
@@ -173,7 +184,10 @@ export class FakeProvider extends SafeEventEmitterProvider {
 
   async #handleRequest(
     stub: FakeProviderStub,
-    callback: (error: unknown, response?: JsonRpcResponse<any>) => void,
+    callback: (
+      error: unknown,
+      response: JsonRpcResponse<unknown> | ProviderSendAsyncResponse<unknown>,
+    ) => void,
   ) {
     if (stub.beforeCompleting) {
       await stub.beforeCompleting();
@@ -199,7 +213,7 @@ export class FakeProvider extends SafeEventEmitterProvider {
         });
       }
     } else if ('error' in stub) {
-      return callback(stub.error);
+      return callback(stub.error, { result: undefined });
     }
 
     return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,6 +2120,7 @@ __metadata:
     "@metamask/eth-json-rpc-middleware": ^11.0.2
     "@metamask/eth-json-rpc-provider": ^2.2.0
     "@metamask/eth-query": ^3.0.1
+    "@metamask/json-rpc-engine": ^7.1.1
     "@metamask/swappable-obj-proxy": ^2.1.0
     "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1


### PR DESCRIPTION
## Explanation

This PR implements the following incremental step in the process for migrating `eth-json-rpc-provider` into the core monorepo:

***

### Phase D: Repair and merge

#### 1. Repair breaking code in downstream packages
  - [ ] `network-controller`
  - [ ] `selected-network-controller`
  - [ ] `transaction-controller`
  - [ ] `gas-fee-controller`

#### 2. Finalize merge
  - [ ] Check that all tests are passing in all subpackages of core and CI. 
  - [ ] Merge `packages/[package-name]` directory into core main branch.

***

See https://github.com/MetaMask/core/issues/1551#issuecomment-1745665740 for an outline of the entire process.

## References

- Contributes to #1685
- Contributes to #1551
- Related to https://github.com/MetaMask/core/pull/1653
- Related to https://github.com/MetaMask/eth-json-rpc-provider/pull/14
- Related to https://github.com/MetaMask/utils/pull/140

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/eth-json-rpc-provider`

- **ADDED**: Migrated into the core monorepo.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
