### PR TITLE
Revert "Bump postcss from 8.4.20 to 8.4.31 in /merged-packages/eth-json-rpc-provider"

### DIFF
--- a/merged-packages/eth-json-rpc-provider/yarn.lock
+++ b/merged-packages/eth-json-rpc-provider/yarn.lock
@@ -5232,12 +5232,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.6":
-  version: 3.3.6
-  resolution: "nanoid@npm:3.3.6"
+"nanoid@npm:^3.3.4":
+  version: 3.3.4
+  resolution: "nanoid@npm:3.3.4"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 7d0eda657002738aa5206107bd0580aead6c95c460ef1bdd0b1a87a9c7ae6277ac2e9b945306aaa5b32c6dcb7feaf462d0f552e7f8b5718abfc6ead5c94a71b3
+  checksum: 2fddd6dee994b7676f008d3ffa4ab16035a754f4bb586c61df5a22cf8c8c94017aadd360368f47d653829e0569a92b129979152ff97af23a558331e47e37cd9c
   languageName: node
   linkType: hard
 
@@ -5638,13 +5638,13 @@ __metadata:
   linkType: hard
 
 "postcss@npm:^8.1.10":
-  version: 8.4.31
-  resolution: "postcss@npm:8.4.31"
+  version: 8.4.20
+  resolution: "postcss@npm:8.4.20"
   dependencies:
-    nanoid: ^3.3.6
+    nanoid: ^3.3.4
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
-  checksum: 1d8611341b073143ad90486fcdfeab49edd243377b1f51834dc4f6d028e82ce5190e4f11bb2633276864503654fb7cab28e67abdc0fbf9d1f88cad4a0ff0beea
+  checksum: 1a5609ea1c1b204f9c2974a0019ae9eef2d99bf645c2c9aac675166c4cb1005be7b5e2ba196160bc771f5d9ac896ed883f236f888c891e835e59d28fff6651aa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

- The contents of `merged-packages/` shouldn't be altered, as it's a temporary directory used for migrating packages into the monorepo. 
- Any dependency updates for the migration target package need to be handled manually. The migration process involves aligning dependency versions with the monorepo (which may not use the latest version), removing dependencies that are defined in the monorepo root, and removing the `yarn.lock` file from the migration target subpackage.

## Reference

- Blocks https://github.com/MetaMask/core/pull/1764
- See https://github.com/MetaMask/core/issues/1079#issuecomment-1700126302 for context on the role of `merged-packages/`.

