### PR TITLE
Add getAccountByAddress to AccountsController

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -35,10 +35,8 @@
     "@metamask/snaps-utils": "^1.0.1",
     "@metamask/utils": "^8.1.0",
     "deepmerge": "^4.2.2",
-    "eth-rpc-errors": "^4.0.2",
     "ethereumjs-util": "^7.0.10",
     "immer": "^9.0.6",
-    "nanoid": "^3.1.31",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1511,5 +1511,40 @@ describe('AccountsController', () => {
         expect(accountsController.updateAccounts).toHaveBeenCalledWith();
       });
     });
+
+    describe('getAccountByAddress', () => {
+      it('should return an account by address', async () => {
+        const accountsController = setupAccountsController({
+          initialState: {
+            internalAccounts: {
+              accounts: { [mockAccount.id]: mockAccount },
+              selectedAccount: mockAccount.id,
+            },
+          },
+        });
+
+        const account = accountsController.getAccountByAddress(
+          mockAccount.address,
+        );
+
+        expect(account).toStrictEqual(mockAccount);
+      });
+
+      it("should return undefined if there isn't an account with the address", () => {
+        const accountsController = setupAccountsController({
+          initialState: {
+            internalAccounts: {
+              accounts: { [mockAccount.id]: mockAccount },
+              selectedAccount: mockAccount.id,
+            },
+          },
+        });
+
+        const account =
+          accountsController.getAccountByAddress('unknown address');
+
+        expect(account).toBeUndefined();
+      });
+    });
   });
 });

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -14,6 +14,7 @@ import type {
   SnapControllerEvents,
   SnapControllerState,
 } from '@metamask/snaps-controllers';
+import type { Snap, ValidatedSnapId } from '@metamask/snaps-utils';
 import type { Keyring, Json } from '@metamask/utils';
 import { sha256FromString } from 'ethereumjs-util';
 import type { Patch } from 'immer';
@@ -230,6 +231,14 @@ export class AccountsController extends BaseControllerV2<
    */
   getSelectedAccount(): InternalAccount {
     return this.getAccountExpect(this.state.internalAccounts.selectedAccount);
+  }
+
+  getAccountByAddress(address: string): InternalAccount | undefined {
+    const internalAccount = this.listAccounts().find(
+      (account) => account.address.toLowerCase() === address.toLowerCase(),
+    );
+
+    return internalAccount;
   }
 
   /**
@@ -512,9 +521,12 @@ export class AccountsController extends BaseControllerV2<
         const currentAccount =
           currentState.internalAccounts.accounts[account.id];
         if (currentAccount.metadata.snap) {
-          currentAccount.metadata.snap.enabled =
-            snaps[currentAccount.metadata.snap.id].enabled &&
-            !snaps[currentAccount.metadata.snap.id].blocked;
+          const snapId = currentAccount.metadata.snap.id;
+          const storedSnap: Snap = snaps[snapId as ValidatedSnapId];
+          if (storedSnap) {
+            currentAccount.metadata.snap.enabled =
+              storedSnap.enabled && !storedSnap.blocked;
+          }
         }
       });
     });

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -234,11 +234,9 @@ export class AccountsController extends BaseControllerV2<
   }
 
   getAccountByAddress(address: string): InternalAccount | undefined {
-    const internalAccount = this.listAccounts().find(
+    return this.listAccounts().find(
       (account) => account.address.toLowerCase() === address.toLowerCase(),
     );
-
-    return internalAccount;
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,11 +1302,9 @@ __metadata:
     "@types/jest": ^27.4.1
     "@types/readable-stream": ^2.3.0
     deepmerge: ^4.2.2
-    eth-rpc-errors: ^4.0.2
     ethereumjs-util: ^7.0.10
     immer: ^9.0.6
     jest: ^27.5.1
-    nanoid: ^3.1.31
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0


### PR DESCRIPTION
## Explanation

This PR adds a new method, `getAccountByAddress` to the AccountsController and removes unused dependencies. 

## Changelog

### `@metamask/accounts-controller`

- **ADDED**: getAccountByAddress
- **REMOVED**: Unused dependencies,  `nanoid` `eth-rpc-errors`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
