### PR TITLE
feat(linea): support token detection on linea mainnet and linea goerli networks

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -35,6 +35,10 @@ export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID: Record<Hex, string> = {
     '0xD023D153a0DFa485130ECFdE2FAA7e612EF94818',
   [SupportedTokenDetectionNetworks.aurora]:
     '0x1286415D333855237f89Df27D388127181448538',
+  [SupportedTokenDetectionNetworks.linea_goerli]:
+    '0x10dAd7Ca3921471f616db788D9300DC97Db01783',
+  [SupportedTokenDetectionNetworks.linea_mainnet]:
+    '0xF62e6a41561b3650a69Bb03199C735e3E3328c0D',
 };
 
 export const MISSING_PROVIDER_ERROR =

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -146,6 +146,8 @@ export enum SupportedTokenDetectionNetworks {
   polygon = '0x89', // decimal: 137
   avax = '0xa86a', // decimal: 43114
   aurora = '0x4e454152', // decimal: 1313161554
+  linea_goerli = '0xe704', // decimal: 59140
+  linea_mainnet = '0xe708', // decimal: 59144
 }
 
 /**


### PR DESCRIPTION
## Explanation

The purpose of this PR is to enable token detection on Linea Mainnet and Linea Goerli networks.
[BalanceChecker](https://github.com/wbobeirne/eth-balance-checker) smart contract has been deployed on both networks
and its address needs to be indicated in AssetsContractController.ts.

## References

* Unblocks https://github.com/MetaMask/metamask-extension/pull/20698

## Changelog

### `'@metamask/assets-controllers`

- **ADDED**: Support token detection on Linea Mainnet and Linea Goerli networks 

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
