### PR TITLE
Update root README dependency graph with `eth-json-rpc-provider` and changes from recent releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository houses the following packages:
 - [`@metamask/composable-controller`](packages/composable-controller)
 - [`@metamask/controller-utils`](packages/controller-utils)
 - [`@metamask/ens-controller`](packages/ens-controller)
+- [`@metamask/eth-json-rpc-provider`](packages/eth-json-rpc-provider)
 - [`@metamask/gas-fee-controller`](packages/gas-fee-controller)
 - [`@metamask/keyring-controller`](packages/keyring-controller)
 - [`@metamask/message-manager`](packages/message-manager)

--- a/README.md
+++ b/README.md
@@ -18,14 +18,17 @@ This repository houses the following packages:
 - [`@metamask/eth-json-rpc-provider`](packages/eth-json-rpc-provider)
 - [`@metamask/gas-fee-controller`](packages/gas-fee-controller)
 - [`@metamask/keyring-controller`](packages/keyring-controller)
+- [`@metamask/logging-controller`](packages/logging-controller);
 - [`@metamask/message-manager`](packages/message-manager)
 - [`@metamask/name-controller`](packages/name-controller)
 - [`@metamask/network-controller`](packages/network-controller)
 - [`@metamask/notification-controller`](packages/notification-controller)
 - [`@metamask/permission-controller`](packages/permission-controller)
 - [`@metamask/phishing-controller`](packages/phishing-controller)
+- [`@metamask/polling-controller`](packages/polling-controller)
 - [`@metamask/preferences-controller`](packages/preferences-controller)
 - [`@metamask/rate-limit-controller`](packages/rate-limit-controller)
+- [`@metamask/selected-network-controller`](packages/selected-network-controller);
 - [`@metamask/signature-controller`](packages/signature-controller)
 - [`@metamask/transaction-controller`](packages/transaction-controller)
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ linkStyle default opacity:0.5
   composable_controller(["@metamask/composable-controller"]);
   controller_utils(["@metamask/controller-utils"]);
   ens_controller(["@metamask/ens-controller"]);
+  eth_json_rpc_provider(["@metamask/eth-json-rpc-provider"]);
   gas_fee_controller(["@metamask/gas-fee-controller"]);
   keyring_controller(["@metamask/keyring-controller"]);
   logging_controller(["@metamask/logging-controller"]);
@@ -69,13 +70,20 @@ linkStyle default opacity:0.5
   assets_controllers --> approval_controller;
   assets_controllers --> base_controller;
   assets_controllers --> controller_utils;
+  assets_controllers --> network_controller;
+  assets_controllers --> polling_controller;
+  assets_controllers --> preferences_controller;
   composable_controller --> base_controller;
   ens_controller --> base_controller;
   ens_controller --> controller_utils;
+  ens_controller --> network_controller;
   gas_fee_controller --> base_controller;
   gas_fee_controller --> controller_utils;
+  gas_fee_controller --> network_controller;
+  gas_fee_controller --> polling_controller;
   keyring_controller --> base_controller;
   keyring_controller --> message_manager;
+  keyring_controller --> preferences_controller;
   logging_controller --> base_controller;
   logging_controller --> controller_utils;
   message_manager --> base_controller;
@@ -83,6 +91,7 @@ linkStyle default opacity:0.5
   name_controller --> base_controller;
   network_controller --> base_controller;
   network_controller --> controller_utils;
+  network_controller --> eth_json_rpc_provider;
   notification_controller --> base_controller;
   permission_controller --> approval_controller;
   permission_controller --> base_controller;
@@ -91,18 +100,22 @@ linkStyle default opacity:0.5
   phishing_controller --> controller_utils;
   polling_controller --> base_controller;
   polling_controller --> controller_utils;
+  polling_controller --> network_controller;
   preferences_controller --> base_controller;
   preferences_controller --> controller_utils;
   rate_limit_controller --> base_controller;
   selected_network_controller --> base_controller;
+  selected_network_controller --> network_controller;
   signature_controller --> approval_controller;
   signature_controller --> base_controller;
   signature_controller --> controller_utils;
+  signature_controller --> logging_controller;
   signature_controller --> message_manager;
   signature_controller --> keyring_controller;
   transaction_controller --> approval_controller;
   transaction_controller --> base_controller;
   transaction_controller --> controller_utils;
+  transaction_controller --> network_controller;
 ```
 
 <!-- end dependency graph -->


### PR DESCRIPTION
## Explanation

- Updating root README to include @metamask/eth-json-rpc-provider.
- Updating dependency graph to reflect changes made between releases v78.0.0 through v81.0.0.

## References

- See https://github.com/MetaMask/core/pull/1738

## Changelog

### `core`

- **CHANGED**: Updated README dependency graph.


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
