### PR TITLE
Rename `executePoll` -> `_executePoll` + `stopPollingByNetworkClientId` -> `stopPollingByPollingToken`

### DIFF
--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -1294,7 +1294,7 @@ describe('TokenListController', () => {
     });
   });
 
-  describe('executePoll', () => {
+  describe('_executePoll', () => {
     it('should call fetchTokenListByChainId with the correct chainId', async () => {
       nock(tokenService.TOKEN_END_POINT_API)
         .get(`/tokens/${convertHexToDecimal(ChainId.sepolia)}`)
@@ -1326,7 +1326,7 @@ describe('TokenListController', () => {
         expiredCacheExistingState.tokenList,
       );
 
-      await controller.executePoll('sepolia');
+      await controller._executePoll('sepolia');
       expect(fetchTokenListByChainIdSpy.mock.calls[0]).toStrictEqual(
         expect.arrayContaining([ChainId.sepolia]),
       );

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -1294,8 +1294,9 @@ describe('TokenListController', () => {
     });
   });
 
-  describe('_executePoll', () => {
+  describe('startPollingByNetworkClient', () => {
     it('should call fetchTokenListByChainId with the correct chainId', async () => {
+      jest.useFakeTimers();
       nock(tokenService.TOKEN_END_POINT_API)
         .get(`/tokens/${convertHexToDecimal(ChainId.sepolia)}`)
         .reply(200, sampleSepoliaTokenList)
@@ -1315,28 +1316,27 @@ describe('TokenListController', () => {
           },
         }),
       );
+      const pollingIntervalTime = 1000;
       const messenger = getRestrictedMessenger(controllerMessenger);
       const controller = new TokenListController({
         chainId: ChainId.mainnet,
         preventPollingOnNetworkRestart: false,
         messenger,
         state: expiredCacheExistingState,
+        interval: pollingIntervalTime,
       });
       expect(controller.state.tokenList).toStrictEqual(
         expiredCacheExistingState.tokenList,
       );
 
-      await controller._executePoll('sepolia');
+      controller.startPollingByNetworkClientId('sepolia');
+      jest.advanceTimersByTime(pollingIntervalTime);
+      await flushPromises();
+
       expect(fetchTokenListByChainIdSpy.mock.calls[0]).toStrictEqual(
         expect.arrayContaining([ChainId.sepolia]),
       );
-      expect(controller.state.tokenList).toStrictEqual(
-        sampleSepoliaTokensChainCache,
-      );
     });
-  });
-
-  describe('startPollingByNetworkClient', () => {
     it('should start polling against the token list API at the interval passed to the constructor', async () => {
       jest.useFakeTimers();
       const pollingIntervalTime = 1000;

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -234,6 +234,7 @@ export class TokenListController extends PollingController<
   /**
    * Fetching token list from the Token Service API.
    *
+   * @private
    * @param networkClientId - The ID of the network client triggering the fetch.
    * @returns A promise that resolves when this operation completes.
    */

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -237,7 +237,7 @@ export class TokenListController extends PollingController<
    * @param networkClientId - The ID of the network client triggering the fetch.
    * @returns A promise that resolves when this operation completes.
    */
-  async executePoll(networkClientId: string): Promise<void> {
+  async _executePoll(networkClientId: string): Promise<void> {
     return this.fetchTokenList(networkClientId);
   }
 

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -868,7 +868,7 @@ describe('GasFeeController', () => {
       });
     });
   });
-  describe('executePoll', () => {
+  describe('_executePoll', () => {
     it('should call determineGasFeeCalculations with a URL that contains the chain ID', async () => {
       await setupGasFeeController({
         getIsEIP1559Compatible: jest.fn().mockResolvedValue(false),
@@ -896,8 +896,8 @@ describe('GasFeeController', () => {
         clientId: '99999',
       });
 
-      await gasFeeController.executePoll('mainnet');
-      await gasFeeController.executePoll('sepolia');
+      await gasFeeController._executePoll('mainnet');
+      await gasFeeController._executePoll('sepolia');
 
       expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -918,7 +918,7 @@ describe('GasFeeController', () => {
   });
 
   describe('polling (by networkClientId)', () => {
-    it('should call determineGasFeeCalculations (via executePoll) with a URL that contains the chain ID after the interval passed via the constructor', async () => {
+    it('should call determineGasFeeCalculations (via _executePoll) with a URL that contains the chain ID after the interval passed via the constructor', async () => {
       const pollingInterval = 10000;
       await setupGasFeeController({
         getIsEIP1559Compatible: jest.fn().mockResolvedValue(false),

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -873,54 +873,6 @@ describe('GasFeeController', () => {
       });
     });
   });
-  describe('_executePoll', () => {
-    it('should call determineGasFeeCalculations with a URL that contains the chain ID', async () => {
-      await setupGasFeeController({
-        getIsEIP1559Compatible: jest.fn().mockResolvedValue(false),
-        getCurrentNetworkLegacyGasAPICompatibility: jest
-          .fn()
-          .mockReturnValue(true),
-        legacyAPIEndpoint: 'https://some-legacy-endpoint/<chain_id>',
-        EIP1559APIEndpoint: 'https://some-eip-1559-endpoint/<chain_id>',
-        networkControllerState: {
-          networksMetadata: {
-            mainnet: {
-              EIPS: {
-                1559: true,
-              },
-              status: NetworkStatus.Available,
-            },
-            sepolia: {
-              EIPS: {
-                1559: true,
-              },
-              status: NetworkStatus.Available,
-            },
-          },
-        },
-        clientId: '99999',
-      });
-
-      await gasFeeController._executePoll('mainnet');
-      await gasFeeController._executePoll('sepolia');
-
-      expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
-        expect.objectContaining({
-          fetchGasEstimatesUrl: 'https://some-eip-1559-endpoint/1',
-        }),
-      );
-      expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
-        expect.objectContaining({
-          fetchGasEstimatesUrl: 'https://some-eip-1559-endpoint/11155111',
-        }),
-      );
-      expect(mockedDetermineGasFeeCalculations).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          fetchGasEstimatesUrl: 'https://some-eip-1559-endpoint/5',
-        }),
-      );
-    });
-  });
 
   describe('polling (by networkClientId)', () => {
     it('should call determineGasFeeCalculations (via _executePoll) with a URL that contains the chainId corresponding to the networkClientId after the interval passed via the constructor', async () => {

--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -548,7 +548,7 @@ export class GasFeeController extends PollingController<
     }, this.intervalDelay);
   }
 
-  async executePoll(networkClientId: string): Promise<void> {
+  async _executePoll(networkClientId: string): Promise<void> {
     await this.#fetchGasFeeEstimateForNetworkClientId(networkClientId);
   }
 

--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -548,6 +548,13 @@ export class GasFeeController extends PollingController<
     }, this.intervalDelay);
   }
 
+  /**
+   * Fetching token list from the Token Service API.
+   *
+   * @private
+   * @param networkClientId - The ID of the network client triggering the fetch.
+   * @returns A promise that resolves when this operation completes.
+   */
   async _executePoll(networkClientId: string): Promise<void> {
     await this.#fetchGasFeeEstimateForNetworkClientId(networkClientId);
   }

--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -400,7 +400,6 @@ export class GasFeeController extends PollingController<
       'NetworkController:getNetworkClientById',
       networkClientId,
     );
-
     const isLegacyGasAPICompatible =
       networkClient.configuration.chainId === '0x38';
 

--- a/packages/polling-controller/src/PollingController.test.ts
+++ b/packages/polling-controller/src/PollingController.test.ts
@@ -17,7 +17,7 @@ describe('PollingController', () => {
       jest.useFakeTimers();
 
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
 
@@ -30,14 +30,14 @@ describe('PollingController', () => {
       controller.startPollingByNetworkClientId('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
       controller.stopAllPolling();
-      expect(controller.executePoll).toHaveBeenCalledTimes(1);
+      expect(controller._executePoll).toHaveBeenCalledTimes(1);
     });
   });
   describe('stop', () => {
     it('should stop polling when called with a valid polling that was the only active pollingToken for a given networkClient', () => {
       jest.useFakeTimers();
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
 
@@ -49,15 +49,15 @@ describe('PollingController', () => {
       });
       const pollingToken = controller.startPollingByNetworkClientId('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
-      controller.stopPollingByNetworkClientId(pollingToken);
+      controller.stopPollingByPollingToken(pollingToken);
       jest.advanceTimersByTime(TICK_TIME);
-      expect(controller.executePoll).toHaveBeenCalledTimes(1);
+      expect(controller._executePoll).toHaveBeenCalledTimes(1);
       controller.stopAllPolling();
     });
     it('should not stop polling if called with one of multiple active polling tokens for a given networkClient', async () => {
       jest.useFakeTimers();
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
 
@@ -71,16 +71,16 @@ describe('PollingController', () => {
       controller.startPollingByNetworkClientId('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      controller.stopPollingByNetworkClientId(pollingToken1);
+      controller.stopPollingByPollingToken(pollingToken1);
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll).toHaveBeenCalledTimes(2);
+      expect(controller._executePoll).toHaveBeenCalledTimes(2);
       controller.stopAllPolling();
     });
     it('should error if no pollingToken is passed', () => {
       jest.useFakeTimers();
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
 
@@ -92,14 +92,14 @@ describe('PollingController', () => {
       });
       controller.startPollingByNetworkClientId('mainnet');
       expect(() => {
-        controller.stopPollingByNetworkClientId(undefined as unknown as any);
+        controller.stopPollingByPollingToken(undefined as unknown as any);
       }).toThrow('pollingToken required');
       controller.stopAllPolling();
     });
     it('should error if no matching pollingToken is found', () => {
       jest.useFakeTimers();
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
 
@@ -111,17 +111,17 @@ describe('PollingController', () => {
       });
       controller.startPollingByNetworkClientId('mainnet');
       expect(() => {
-        controller.stopPollingByNetworkClientId('potato');
+        controller.stopPollingByPollingToken('potato');
       }).toThrow('pollingToken not found');
       controller.stopAllPolling();
     });
   });
   describe('poll', () => {
-    it('should call executePoll if polling', async () => {
+    it('should call _executePoll if polling', async () => {
       jest.useFakeTimers();
 
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
 
@@ -136,13 +136,13 @@ describe('PollingController', () => {
       await Promise.resolve();
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll).toHaveBeenCalledTimes(2);
+      expect(controller._executePoll).toHaveBeenCalledTimes(2);
     });
-    it('should continue calling executePoll when start is called again with the same networkClientId', async () => {
+    it('should continue calling _executePoll when start is called again with the same networkClientId', async () => {
       jest.useFakeTimers();
 
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
 
@@ -158,14 +158,14 @@ describe('PollingController', () => {
       await Promise.resolve();
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll).toHaveBeenCalledTimes(2);
+      expect(controller._executePoll).toHaveBeenCalledTimes(2);
       controller.stopAllPolling();
     });
     it('should publish "pollingComplete" when stop is called', async () => {
       jest.useFakeTimers();
       const pollingComplete: any = jest.fn();
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const name = 'PollingController';
 
@@ -179,14 +179,14 @@ describe('PollingController', () => {
       });
       controller.onPollingCompleteByNetworkClientId('mainnet', pollingComplete);
       const pollingToken = controller.startPollingByNetworkClientId('mainnet');
-      controller.stopPollingByNetworkClientId(pollingToken);
+      controller.stopPollingByPollingToken(pollingToken);
       expect(pollingComplete).toHaveBeenCalledTimes(1);
     });
     it('should poll at the interval length when set via setIntervalLength', async () => {
       jest.useFakeTimers();
 
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
 
@@ -200,22 +200,22 @@ describe('PollingController', () => {
       controller.startPollingByNetworkClientId('mainnet');
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll).not.toHaveBeenCalled();
+      expect(controller._executePoll).not.toHaveBeenCalled();
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll).not.toHaveBeenCalled();
+      expect(controller._executePoll).not.toHaveBeenCalled();
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll).toHaveBeenCalledTimes(1);
+      expect(controller._executePoll).toHaveBeenCalledTimes(1);
       jest.advanceTimersByTime(TICK_TIME * 3);
       await Promise.resolve();
-      expect(controller.executePoll).toHaveBeenCalledTimes(2);
+      expect(controller._executePoll).toHaveBeenCalledTimes(2);
     });
     it('should start and stop polling sessions for different networkClientIds with the same options', async () => {
       jest.useFakeTimers();
 
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
 
@@ -232,12 +232,12 @@ describe('PollingController', () => {
       controller.startPollingByNetworkClientId('sepolia', { address: '0x2' });
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll).toHaveBeenCalledTimes(3);
-      controller.stopPollingByNetworkClientId(pollToken1);
+      expect(controller._executePoll).toHaveBeenCalledTimes(3);
+      controller.stopPollingByPollingToken(pollToken1);
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll).toHaveBeenCalledTimes(5);
-      expect(controller.executePoll.mock.calls).toMatchObject([
+      expect(controller._executePoll).toHaveBeenCalledTimes(5);
+      expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', { address: '0x1' }],
         ['mainnet', { address: '0x2' }],
         ['sepolia', { address: '0x2' }],
@@ -250,7 +250,7 @@ describe('PollingController', () => {
     it('should poll for each networkClientId', async () => {
       jest.useFakeTimers();
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
 
@@ -264,13 +264,13 @@ describe('PollingController', () => {
       controller.startPollingByNetworkClientId('rinkeby');
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll.mock.calls).toMatchObject([
+      expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['rinkeby', {}],
       ]);
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll.mock.calls).toMatchObject([
+      expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['rinkeby', {}],
         ['mainnet', {}],
@@ -283,7 +283,7 @@ describe('PollingController', () => {
       jest.useFakeTimers();
 
       class MyGasFeeController extends PollingController<any, any, any> {
-        executePoll = createExecutePollMock();
+        _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
 
@@ -298,28 +298,28 @@ describe('PollingController', () => {
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
       controller.startPollingByNetworkClientId('sepolia');
-      expect(controller.executePoll.mock.calls).toMatchObject([]);
+      expect(controller._executePoll.mock.calls).toMatchObject([]);
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll.mock.calls).toMatchObject([
+      expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
       ]);
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll.mock.calls).toMatchObject([
+      expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['sepolia', {}],
       ]);
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll.mock.calls).toMatchObject([
+      expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['sepolia', {}],
         ['mainnet', {}],
       ]);
       jest.advanceTimersByTime(TICK_TIME);
       await Promise.resolve();
-      expect(controller.executePoll.mock.calls).toMatchObject([
+      expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['sepolia', {}],
         ['mainnet', {}],


### PR DESCRIPTION
Fast-follow to https://github.com/MetaMask/core/pull/1776, just a few (breaking) naming cleanups

### CHANGED
- **BREAKING:** `executePoll` renamed to `_executePoll`
-  **BREAKING:** `stopPollingByNetworkClientId` renamed to `stopPollingByPollingToken`