### PR TITLE
Fix issue where @metamask/polling-controller was mistakenly omitted from @metamask/assets-controller dependencies

### DIFF
--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -41,6 +41,7 @@
     "@metamask/eth-query": "^3.0.1",
     "@metamask/metamask-eth-abis": "3.0.0",
     "@metamask/network-controller": "^14.0.0",
+    "@metamask/polling-controller": "^0.1.0",
     "@metamask/preferences-controller": "^4.4.2",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/utils": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1412,6 +1412,7 @@ __metadata:
     "@metamask/eth-query": ^3.0.1
     "@metamask/metamask-eth-abis": 3.0.0
     "@metamask/network-controller": ^14.0.0
+    "@metamask/polling-controller": ^0.1.0
     "@metamask/preferences-controller": ^4.4.2
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/utils": ^8.1.0


### PR DESCRIPTION
Fix issue where `@metamask/polling-controller` was mistakenly omitted from `@metamask/assets-controller` dependencies