### PR TITLE
Remove `as` assertion casting `FakeBlockTracer` to `BlockTracker`

### DIFF
--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -27,7 +27,7 @@ import type {
   ProviderConfig,
 } from '../src/NetworkController';
 import { NetworkController } from '../src/NetworkController';
-import type { BlockTracker, Provider } from '../src/types';
+import type { Provider } from '../src/types';
 import { NetworkClientType } from '../src/types';
 import type { FakeProviderStub } from './fake-provider';
 import { FakeProvider } from './fake-provider';
@@ -6957,7 +6957,7 @@ function buildFakeClient(
       rpcUrl: 'https://test.network',
     },
     provider,
-    blockTracker: new FakeBlockTracker() as BlockTracker,
+    blockTracker: new FakeBlockTracker(),
     destroy: () => {
       // do nothing
     },


### PR DESCRIPTION
## Explanation

Removing unnecessary type casting.

## References

- See https://github.com/MetaMask/core/pull/1653#discussion_r1357296408

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
