### PR TITLE
Update the `onKeyringStateChange` and `onSnapStateChange` methods, and remove the `keyringApiEnabled` from the AccountsController

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,20 @@ This repository houses the following packages:
 - [`@metamask/composable-controller`](packages/composable-controller)
 - [`@metamask/controller-utils`](packages/controller-utils)
 - [`@metamask/ens-controller`](packages/ens-controller)
+- [`@metamask/eth-json-rpc-provider`](packages/eth-json-rpc-provider)
 - [`@metamask/gas-fee-controller`](packages/gas-fee-controller)
 - [`@metamask/keyring-controller`](packages/keyring-controller)
+- [`@metamask/logging-controller`](packages/logging-controller);
 - [`@metamask/message-manager`](packages/message-manager)
 - [`@metamask/name-controller`](packages/name-controller)
 - [`@metamask/network-controller`](packages/network-controller)
 - [`@metamask/notification-controller`](packages/notification-controller)
 - [`@metamask/permission-controller`](packages/permission-controller)
 - [`@metamask/phishing-controller`](packages/phishing-controller)
+- [`@metamask/polling-controller`](packages/polling-controller)
 - [`@metamask/preferences-controller`](packages/preferences-controller)
 - [`@metamask/rate-limit-controller`](packages/rate-limit-controller)
+- [`@metamask/selected-network-controller`](packages/selected-network-controller);
 - [`@metamask/signature-controller`](packages/signature-controller)
 - [`@metamask/transaction-controller`](packages/transaction-controller)
 
@@ -45,6 +49,7 @@ linkStyle default opacity:0.5
   composable_controller(["@metamask/composable-controller"]);
   controller_utils(["@metamask/controller-utils"]);
   ens_controller(["@metamask/ens-controller"]);
+  eth_json_rpc_provider(["@metamask/eth-json-rpc-provider"]);
   gas_fee_controller(["@metamask/gas-fee-controller"]);
   keyring_controller(["@metamask/keyring-controller"]);
   logging_controller(["@metamask/logging-controller"]);
@@ -69,13 +74,20 @@ linkStyle default opacity:0.5
   assets_controllers --> approval_controller;
   assets_controllers --> base_controller;
   assets_controllers --> controller_utils;
+  assets_controllers --> network_controller;
+  assets_controllers --> polling_controller;
+  assets_controllers --> preferences_controller;
   composable_controller --> base_controller;
   ens_controller --> base_controller;
   ens_controller --> controller_utils;
+  ens_controller --> network_controller;
   gas_fee_controller --> base_controller;
   gas_fee_controller --> controller_utils;
+  gas_fee_controller --> network_controller;
+  gas_fee_controller --> polling_controller;
   keyring_controller --> base_controller;
   keyring_controller --> message_manager;
+  keyring_controller --> preferences_controller;
   logging_controller --> base_controller;
   logging_controller --> controller_utils;
   message_manager --> base_controller;
@@ -83,6 +95,7 @@ linkStyle default opacity:0.5
   name_controller --> base_controller;
   network_controller --> base_controller;
   network_controller --> controller_utils;
+  network_controller --> eth_json_rpc_provider;
   notification_controller --> base_controller;
   permission_controller --> approval_controller;
   permission_controller --> base_controller;
@@ -91,18 +104,22 @@ linkStyle default opacity:0.5
   phishing_controller --> controller_utils;
   polling_controller --> base_controller;
   polling_controller --> controller_utils;
+  polling_controller --> network_controller;
   preferences_controller --> base_controller;
   preferences_controller --> controller_utils;
   rate_limit_controller --> base_controller;
   selected_network_controller --> base_controller;
+  selected_network_controller --> network_controller;
   signature_controller --> approval_controller;
   signature_controller --> base_controller;
   signature_controller --> controller_utils;
+  signature_controller --> logging_controller;
   signature_controller --> message_manager;
   signature_controller --> keyring_controller;
   transaction_controller --> approval_controller;
   transaction_controller --> base_controller;
   transaction_controller --> controller_utils;
+  transaction_controller --> network_controller;
 ```
 
 <!-- end dependency graph -->

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^3.2.3",
-    "@metamask/eth-snap-keyring": "^1.0.0",
+    "@metamask/eth-snap-keyring": "^2.0.0",
     "@metamask/keyring-api": "^1.0.0",
     "@metamask/snaps-utils": "^3.0.0",
     "@metamask/utils": "^8.1.0",

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1,6 +1,7 @@
 import { ControllerMessenger } from '@metamask/base-controller';
 import type { InternalAccount } from '@metamask/keyring-api';
 import { EthAccountType, EthMethod } from '@metamask/keyring-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
 import type { SnapControllerState } from '@metamask/snaps-controllers';
 import { SnapStatus } from '@metamask/snaps-utils';
 import * as uuid from 'uuid';
@@ -35,7 +36,7 @@ const mockAccount: InternalAccount = {
   type: EthAccountType.Eoa,
   metadata: {
     name: 'Account 1',
-    keyring: { type: 'HD Key Tree' },
+    keyring: { type: KeyringTypes.hd },
     lastSelected: 1691565967656,
   },
 };
@@ -48,7 +49,7 @@ const mockAccount2: InternalAccount = {
   type: EthAccountType.Eoa,
   metadata: {
     name: 'Account 2',
-    keyring: { type: 'HD Key Tree' },
+    keyring: { type: KeyringTypes.hd },
     lastSelected: 1955565967656,
   },
 };
@@ -61,7 +62,7 @@ const mockAccount3: InternalAccount = {
   type: EthAccountType.Eoa,
   metadata: {
     name: '',
-    keyring: { type: 'Snap Keyring' },
+    keyring: { type: KeyringTypes.snap },
     snap: {
       enabled: true,
       id: 'mock-snap-id',
@@ -79,7 +80,7 @@ const mockAccount4: InternalAccount = {
   type: EthAccountType.Eoa,
   metadata: {
     name: 'Custom Name',
-    keyring: { type: 'Snap Keyring' },
+    keyring: { type: KeyringTypes.snap },
     snap: {
       enabled: true,
       id: 'mock-snap-id',
@@ -243,7 +244,7 @@ describe('AccountsController', () => {
         id: 'mock-id',
         name: 'Snap Account 1',
         address: '0x0',
-        keyringType: 'Snap Keyring',
+        keyringType: KeyringTypes.snap,
         snapId: 'mock-snap',
         snapEnabled: false,
       });
@@ -284,7 +285,7 @@ describe('AccountsController', () => {
         id: 'mock-id',
         name: 'Snap Account 1',
         address: '0x0',
-        keyringType: 'Snap Keyring',
+        keyringType: KeyringTypes.snap,
         snapId: 'mock-snap',
       });
       const mockSnapChangeState = {
@@ -324,7 +325,7 @@ describe('AccountsController', () => {
         id: 'mock-id',
         name: 'Snap Account 1',
         address: '0x0',
-        keyringType: 'Snap Keyring',
+        keyringType: KeyringTypes.snap,
         snapId: 'mock-snap',
       });
       const mockSnapChangeState = {
@@ -371,7 +372,7 @@ describe('AccountsController', () => {
         keyrings: [
           {
             accounts: [mockAccount.address, mockAccount2.address],
-            type: 'HD Key Tree',
+            type: KeyringTypes.hd,
           },
         ],
       };
@@ -408,7 +409,7 @@ describe('AccountsController', () => {
           isUnlocked: true,
           keyrings: [
             {
-              type: 'HD Key Tree',
+              type: KeyringTypes.hd,
               accounts: [mockAccount.address, mockAccount2.address],
             },
           ],
@@ -448,7 +449,7 @@ describe('AccountsController', () => {
           'KeyringController:getKeyringsByType',
           mockGetKeyringByType.mockReturnValue([
             {
-              type: 'Snap Keyring',
+              type: KeyringTypes.snap,
               getAccountByAddress: jest
                 .fn()
                 .mockReturnValueOnce(mockAccount3)
@@ -461,11 +462,11 @@ describe('AccountsController', () => {
           isUnlocked: true,
           keyrings: [
             {
-              type: 'HD Key Tree',
+              type: KeyringTypes.hd,
               accounts: [mockAccount.address],
             },
             {
-              type: 'Snap Keyring',
+              type: KeyringTypes.snap,
               accounts: [mockAccount3.address, mockAccount4.address],
             },
           ],
@@ -514,7 +515,7 @@ describe('AccountsController', () => {
           'KeyringController:getKeyringsByType',
           mockGetKeyringByType.mockReturnValue([
             {
-              type: 'Snap Keyring',
+              type: KeyringTypes.snap,
               getAccountByAddress: jest
                 .fn()
                 .mockReturnValueOnce(null)
@@ -527,11 +528,11 @@ describe('AccountsController', () => {
           isUnlocked: true,
           keyrings: [
             {
-              type: 'HD Key Tree',
+              type: KeyringTypes.hd,
               accounts: [mockAccount.address],
             },
             {
-              type: 'Snap Keyring',
+              type: KeyringTypes.snap,
               accounts: [mockAccount3.address, mockAccount4.address],
             },
           ],
@@ -576,7 +577,7 @@ describe('AccountsController', () => {
           isUnlocked: true,
           keyrings: [
             {
-              type: 'HD Key Tree',
+              type: KeyringTypes.hd,
               accounts: [
                 mockAccount.address,
                 mockAccount2.address,
@@ -614,7 +615,7 @@ describe('AccountsController', () => {
               id: 'mock-id3',
               name: 'Account 3',
               address: mockAccount3.address,
-              keyringType: 'HD Key Tree',
+              keyringType: KeyringTypes.hd,
             }),
           ),
         ]);
@@ -632,14 +633,14 @@ describe('AccountsController', () => {
           id: 'mock-id2',
           name: 'Custom Name',
           address: mockAccount2.address,
-          keyringType: 'HD Key Tree',
+          keyringType: KeyringTypes.hd,
         });
 
         const mockNewKeyringState = {
           isUnlocked: true,
           keyrings: [
             {
-              type: 'HD Key Tree',
+              type: KeyringTypes.hd,
               accounts: [
                 mockAccount.address,
                 mockAccount2.address,
@@ -677,7 +678,7 @@ describe('AccountsController', () => {
               id: 'mock-id3',
               name: 'Account 3',
               address: mockAccount3.address,
-              keyringType: 'HD Key Tree',
+              keyringType: KeyringTypes.hd,
             }),
           ),
         ]);
@@ -691,7 +692,7 @@ describe('AccountsController', () => {
           'KeyringController:getKeyringsByType',
           mockGetKeyringByType.mockReturnValue([
             {
-              type: 'Snap Keyring',
+              type: KeyringTypes.snap,
               getAccountByAddress: jest.fn().mockReturnValueOnce(null),
             },
           ]),
@@ -701,11 +702,11 @@ describe('AccountsController', () => {
           isUnlocked: true,
           keyrings: [
             {
-              type: 'HD Key Tree',
+              type: KeyringTypes.hd,
               accounts: [],
             },
             {
-              type: 'Snap Keyring',
+              type: KeyringTypes.snap,
               accounts: [mockAccount3.address],
             },
           ],
@@ -742,7 +743,7 @@ describe('AccountsController', () => {
           isUnlocked: true,
           keyrings: [
             {
-              type: 'HD Key Tree',
+              type: KeyringTypes.hd,
               accounts: [mockAccount2.address],
             },
           ],
@@ -786,7 +787,7 @@ describe('AccountsController', () => {
           isUnlocked: true,
           keyrings: [
             {
-              type: 'HD Key Tree',
+              type: KeyringTypes.hd,
               accounts: [mockAccount.address, mockAccount2.address],
             },
           ],
@@ -800,7 +801,7 @@ describe('AccountsController', () => {
                   address: '0x999',
                   metadata: {
                     keyring: {
-                      type: 'HD Key Tree',
+                      type: KeyringTypes.hd,
                     },
                   },
                 } as unknown as InternalAccount,
@@ -849,7 +850,7 @@ describe('AccountsController', () => {
           isUnlocked: true,
           keyrings: [
             {
-              type: 'HD Key Tree',
+              type: KeyringTypes.hd,
               accounts: [mockAccount.address, mockAccount2.address],
             },
           ],
@@ -863,7 +864,7 @@ describe('AccountsController', () => {
                   address: '0x999',
                   metadata: {
                     keyring: {
-                      type: 'HD Key Tree',
+                      type: KeyringTypes.hd,
                     },
                   },
                 } as unknown as InternalAccount,
@@ -917,7 +918,7 @@ describe('AccountsController', () => {
           isUnlocked: true,
           keyrings: [
             {
-              type: 'HD Key Tree',
+              type: KeyringTypes.hd,
               accounts: [
                 mockAccountWithoutLastSelected.address,
                 mockAccount2.address,
@@ -934,7 +935,7 @@ describe('AccountsController', () => {
                   address: '0x999',
                   metadata: {
                     keyring: {
-                      type: 'HD Key Tree',
+                      type: KeyringTypes.hd,
                     },
                   },
                   [mockAccount2.id]: mockAccount2WithoutLastSelected,
@@ -972,13 +973,13 @@ describe('AccountsController', () => {
         id: 'mock-id',
         name: 'Account 1',
         address: '0x123',
-        keyringType: 'HD Key Tree',
+        keyringType: KeyringTypes.hd,
       });
       const mockReinitialisedAccount = createExpectedInternalAccount({
         id: 'mock-id2',
         name: 'Account 1',
         address: '0x456',
-        keyringType: 'HD Key Tree',
+        keyringType: KeyringTypes.hd,
       });
       mockUUID
         .mockReturnValueOnce('mock-id2') // call to check if its a new account
@@ -988,7 +989,7 @@ describe('AccountsController', () => {
         isUnlocked: true,
         keyrings: [
           {
-            type: 'HD Key Tree',
+            type: KeyringTypes.hd,
             accounts: [mockReinitialisedAccount.address],
           },
         ],
@@ -1034,7 +1035,7 @@ describe('AccountsController', () => {
           metadata: {
             ...mockAccount.metadata,
             keyring: {
-              type: 'Snap Keyring',
+              type: KeyringTypes.snap,
             },
             snap: {
               enabled: true,
@@ -1051,7 +1052,7 @@ describe('AccountsController', () => {
           metadata: {
             ...mockAccount2.metadata,
             keyring: {
-              type: 'Snap Keyring',
+              type: KeyringTypes.snap,
             },
             snap: {
               enabled: true,
@@ -1078,14 +1079,14 @@ describe('AccountsController', () => {
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringForAccount',
-        mockGetKeyringForAccount.mockResolvedValue({ type: 'HD Key Tree' }),
+        mockGetKeyringForAccount.mockResolvedValue({ type: KeyringTypes.hd }),
       );
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
         mockGetKeyringByType.mockReturnValue([
           {
-            type: 'Snap Keyring',
+            type: KeyringTypes.snap,
             listAccounts: async () => [],
           },
         ]),
@@ -1105,13 +1106,13 @@ describe('AccountsController', () => {
           name: 'Account 1',
           id: 'mock-id',
           address: mockAddress1,
-          keyringType: 'HD Key Tree',
+          keyringType: KeyringTypes.hd,
         }),
         createExpectedInternalAccount({
           name: 'Account 2',
           id: 'mock-id2',
           address: mockAddress2,
-          keyringType: 'HD Key Tree',
+          keyringType: KeyringTypes.hd,
         }),
       ];
 
@@ -1131,7 +1132,7 @@ describe('AccountsController', () => {
         'KeyringController:getKeyringsByType',
         mockGetKeyringByType.mockReturnValue([
           {
-            type: 'Snap Keyring',
+            type: KeyringTypes.snap,
             listAccounts: async () => [mockSnapAccount, mockSnapAccount2],
           },
         ]),
@@ -1211,14 +1212,14 @@ describe('AccountsController', () => {
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringForAccount',
-        mockGetKeyringForAccount.mockResolvedValue({ type: 'HD Key Tree' }),
+        mockGetKeyringForAccount.mockResolvedValue({ type: KeyringTypes.hd }),
       );
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
         mockGetKeyringByType.mockReturnValue([
           {
-            type: 'Snap Keyring',
+            type: KeyringTypes.snap,
             listAccounts: async () => [],
           },
         ]),
@@ -1241,7 +1242,7 @@ describe('AccountsController', () => {
           name: 'Account 2',
           id: 'mock-id2',
           address: mockAddress2,
-          keyringType: 'HD Key Tree',
+          keyringType: KeyringTypes.hd,
         }),
       ];
 
@@ -1257,7 +1258,7 @@ describe('AccountsController', () => {
         'KeyringController:getKeyringsByType',
         mockGetKeyringByType.mockReturnValueOnce([
           {
-            type: 'Snap Keyring',
+            type: KeyringTypes.snap,
             listAccounts: async () => [mockSnapAccount2],
           },
         ]),
@@ -1271,8 +1272,8 @@ describe('AccountsController', () => {
       messenger.registerActionHandler(
         'KeyringController:getKeyringForAccount',
         mockGetKeyringForAccount
-          .mockResolvedValueOnce({ type: 'HD Key Tree' })
-          .mockResolvedValueOnce({ type: 'Snap Keyring' }),
+          .mockResolvedValueOnce({ type: KeyringTypes.hd })
+          .mockResolvedValueOnce({ type: KeyringTypes.snap }),
       );
 
       const accountsController = setupAccountsController({
@@ -1289,13 +1290,13 @@ describe('AccountsController', () => {
           name: 'Account 1',
           id: 'mock-id',
           address: mockAddress1,
-          keyringType: 'HD Key Tree',
+          keyringType: KeyringTypes.hd,
         }),
         createExpectedInternalAccount({
           name: 'Snap Account 1', // it is Snap Account 1 because it is the only snap account
           id: mockSnapAccount2.id,
           address: mockSnapAccount2.address,
-          keyringType: 'Snap Keyring',
+          keyringType: KeyringTypes.snap,
           snapId: 'mock-snap-id2',
         }),
       ];
@@ -1312,7 +1313,7 @@ describe('AccountsController', () => {
         'KeyringController:getKeyringsByType',
         mockGetKeyringByType.mockReturnValueOnce([
           {
-            type: 'Snap Keyring',
+            type: KeyringTypes.snap,
             listAccounts: async () => [mockSnapAccount2],
           },
         ]),
@@ -1326,8 +1327,8 @@ describe('AccountsController', () => {
       messenger.registerActionHandler(
         'KeyringController:getKeyringForAccount',
         mockGetKeyringForAccount
-          .mockResolvedValueOnce({ type: 'Snap Keyring' })
-          .mockResolvedValueOnce({ type: 'HD Key Tree' }),
+          .mockResolvedValueOnce({ type: KeyringTypes.snap })
+          .mockResolvedValueOnce({ type: KeyringTypes.hd }),
       );
 
       const accountsController = setupAccountsController({
@@ -1344,13 +1345,13 @@ describe('AccountsController', () => {
           name: 'Account 1',
           id: 'mock-id',
           address: mockAddress1,
-          keyringType: 'HD Key Tree',
+          keyringType: KeyringTypes.hd,
         }),
         createExpectedInternalAccount({
           name: 'Snap Account 1', // it is Snap Account 1 because it is the only snap account
           id: mockSnapAccount2.id,
           address: mockSnapAccount2.address,
-          keyringType: 'Snap Keyring',
+          keyringType: KeyringTypes.snap,
           snapId: 'mock-snap-id2',
           snapEnabled: true,
         }),
@@ -1362,13 +1363,13 @@ describe('AccountsController', () => {
     });
 
     it.each([
-      'Simple Key Pair',
-      'HD Key Tree',
-      'Trezor Hardware',
-      'Ledger Hardware',
-      'Lattice Hardware',
-      'QR Hardware Wallet Device',
-      'Custody',
+      KeyringTypes.simple,
+      KeyringTypes.hd,
+      KeyringTypes.trezor,
+      KeyringTypes.ledger,
+      KeyringTypes.lattice,
+      KeyringTypes.qr,
+      KeyringTypes.custody,
     ])('should add accounts for %s type', async (keyringType) => {
       mockUUID.mockReturnValue('mock-id');
 
@@ -1386,7 +1387,7 @@ describe('AccountsController', () => {
         'KeyringController:getKeyringsByType',
         mockGetKeyringByType.mockReturnValue([
           {
-            type: 'Snap Keyring',
+            type: KeyringTypes.snap,
             listAccounts: async () => [],
           },
         ]),
@@ -1433,7 +1434,7 @@ describe('AccountsController', () => {
         'KeyringController:getKeyringsByType',
         mockGetKeyringByType.mockReturnValue([
           {
-            type: 'Snap Keyring',
+            type: KeyringTypes.snap,
             listAccounts: async () => [],
           },
         ]),
@@ -1734,6 +1735,70 @@ describe('AccountsController', () => {
     });
   });
 
+  describe('#getNextAccountNumber', () => {
+    it('should return the next account number', async () => {
+      const messenger = buildMessenger();
+      mockUUID
+        .mockReturnValueOnce('mock-id') // call to check if its a new account
+        .mockReturnValueOnce('mock-id2') // call to check if its a new account
+        .mockReturnValueOnce('mock-id3') // call to check if its a new account
+        .mockReturnValueOnce('mock-id2') // call to add account
+        .mockReturnValueOnce('mock-id3'); // call to add account
+
+      const mockSimpleKeyring1 = createExpectedInternalAccount({
+        id: 'mock-id2',
+        name: 'Account 2',
+        address: '0x555',
+        keyringType: 'Simple Key Pair',
+      });
+      const mockSimpleKeyring2 = createExpectedInternalAccount({
+        id: 'mock-id3',
+        name: 'Account 3',
+        address: '0x666',
+        keyringType: 'Simple Key Pair',
+      });
+
+      const mockNewKeyringState = {
+        isUnlocked: true,
+        keyrings: [
+          {
+            type: 'HD Key Tree',
+            accounts: [mockAccount.address],
+          },
+          {
+            type: 'Simple Key Pair',
+            accounts: [mockSimpleKeyring1.address, mockSimpleKeyring2.address],
+          },
+        ],
+      };
+      const accountsController = setupAccountsController({
+        initialState: {
+          internalAccounts: {
+            accounts: {
+              [mockAccount.id]: mockAccount,
+            },
+            selectedAccount: mockAccount.id,
+          },
+        },
+        messenger,
+      });
+
+      messenger.publish(
+        'KeyringController:stateChange',
+        mockNewKeyringState,
+        [],
+      );
+
+      const accounts = accountsController.listAccounts();
+
+      expect(accounts).toStrictEqual([
+        mockAccount,
+        setLastSelectedAsAny(mockSimpleKeyring1),
+        setLastSelectedAsAny(mockSimpleKeyring2),
+      ]);
+    });
+  });
+
   describe('getAccountByAddress', () => {
     it('should return an account by address', async () => {
       const accountsController = setupAccountsController({
@@ -1791,10 +1856,7 @@ describe('AccountsController', () => {
           messenger,
         });
 
-        await messenger.call(
-          'AccountsController:setSelectedAccount',
-          'mock-id',
-        );
+        messenger.call('AccountsController:setSelectedAccount', 'mock-id');
         expect(accountsController.setSelectedAccount).toHaveBeenCalledWith(
           'mock-id',
         );
@@ -1814,7 +1876,7 @@ describe('AccountsController', () => {
           messenger,
         });
 
-        await messenger.call('AccountsController:listAccounts');
+        messenger.call('AccountsController:listAccounts');
         expect(accountsController.listAccounts).toHaveBeenCalledWith();
       });
     });
@@ -1832,7 +1894,7 @@ describe('AccountsController', () => {
           messenger,
         });
 
-        await messenger.call(
+        messenger.call(
           'AccountsController:setAccountName',
           'mock-id',
           'new name',
@@ -1898,27 +1960,25 @@ describe('AccountsController', () => {
         );
         expect(account).toStrictEqual(mockAccount);
       });
+    });
 
-      describe('getSelectedAccount', () => {
-        it('should get account by address', async () => {
-          const messenger = buildMessenger();
+    describe('getSelectedAccount', () => {
+      it('should get account by address', async () => {
+        const messenger = buildMessenger();
 
-          const accountsController = setupAccountsController({
-            initialState: {
-              internalAccounts: {
-                accounts: { [mockAccount.id]: mockAccount },
-                selectedAccount: mockAccount.id,
-              },
+        const accountsController = setupAccountsController({
+          initialState: {
+            internalAccounts: {
+              accounts: { [mockAccount.id]: mockAccount },
+              selectedAccount: mockAccount.id,
             },
-            messenger,
-          });
-
-          const account = messenger.call(
-            'AccountsController:getSelectedAccount',
-          );
-          expect(accountsController.getSelectedAccount).toHaveBeenCalledWith();
-          expect(account).toStrictEqual(mockAccount);
+          },
+          messenger,
         });
+
+        const account = messenger.call('AccountsController:getSelectedAccount');
+        expect(accountsController.getSelectedAccount).toHaveBeenCalledWith();
+        expect(account).toStrictEqual(mockAccount);
       });
     });
   });

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -488,8 +488,6 @@ describe('AccountsController', () => {
           [],
         );
 
-        await new Promise((resolve) => setTimeout(resolve, 500));
-
         const accounts = accountsController.listAccounts();
 
         expect(accounts).toStrictEqual([
@@ -726,8 +724,6 @@ describe('AccountsController', () => {
           mockNewKeyringState,
           [],
         );
-
-        await new Promise((resolve) => setTimeout(resolve, 1000));
 
         const { selectedAccount } = accountsController.state.internalAccounts;
 
@@ -1789,8 +1785,6 @@ describe('AccountsController', () => {
         mockNewKeyringState,
         [],
       );
-
-      await new Promise((resolve) => setTimeout(resolve, 500));
 
       const accounts = accountsController.listAccounts();
 

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -206,17 +206,14 @@ function buildAccountsControllerMessenger(messenger = buildMessenger()) {
  *
  * @param options - The options object.
  * @param [options.initialState] - The initial state to use for the AccountsController.
- * @param [options.keyringApiEnabled] - Whether or not the keyring API is enabled.
  * @param [options.messenger] - Messenger to use for the AccountsController.
  * @returns An instance of the AccountsController class.
  */
 function setupAccountsController({
   initialState = {},
-  keyringApiEnabled = true,
   messenger = buildMessenger(),
 }: {
   initialState?: Partial<AccountsControllerState>;
-  keyringApiEnabled?: boolean;
   messenger?: ControllerMessenger<
     AccountsControllerActions,
     AccountsControllerEvents
@@ -228,7 +225,6 @@ function setupAccountsController({
   const accountsController = new AccountsController({
     messenger: accountsControllerMessenger,
     state: { ...defaultState, ...initialState },
-    keyringApiEnabled,
   });
   return accountsController;
 }
@@ -239,29 +235,6 @@ describe('AccountsController', () => {
   });
 
   describe('onSnapStateChange', () => {
-    it('should not be used when keyringApiEnabled is false', async () => {
-      const messenger = buildMessenger();
-      const snapStateChangeSpy = jest.fn();
-      setupAccountsController({
-        initialState: {
-          internalAccounts: {
-            accounts: {},
-            selectedAccount: '',
-          },
-        },
-        keyringApiEnabled: false,
-        messenger,
-      });
-
-      messenger.publish(
-        'SnapController:stateChange',
-        {} as any as SnapControllerState,
-        [],
-      );
-
-      expect(snapStateChangeSpy).not.toHaveBeenCalled();
-    });
-
     it('should be used enable an account if the snap is enabled and not blocked', async () => {
       const messenger = buildMessenger();
       const mockSnapAccount = createExpectedInternalAccount({
@@ -291,7 +264,6 @@ describe('AccountsController', () => {
             selectedAccount: mockSnapAccount.id,
           },
         },
-        keyringApiEnabled: true,
         messenger,
       });
 
@@ -332,7 +304,6 @@ describe('AccountsController', () => {
             selectedAccount: mockSnapAccount.id,
           },
         },
-        keyringApiEnabled: true,
         messenger,
       });
 
@@ -373,7 +344,6 @@ describe('AccountsController', () => {
             selectedAccount: mockSnapAccount.id,
           },
         },
-        keyringApiEnabled: true,
         messenger,
       });
 
@@ -410,7 +380,6 @@ describe('AccountsController', () => {
             selectedAccount: '',
           },
         },
-        keyringApiEnabled: true,
         messenger,
       });
 
@@ -452,7 +421,6 @@ describe('AccountsController', () => {
               selectedAccount: mockAccount.id,
             },
           },
-          keyringApiEnabled: false,
           messenger,
         });
 
@@ -511,7 +479,6 @@ describe('AccountsController', () => {
               selectedAccount: mockAccount.id,
             },
           },
-          keyringApiEnabled: false,
           messenger,
         });
 
@@ -580,7 +547,6 @@ describe('AccountsController', () => {
               selectedAccount: mockAccount.id,
             },
           },
-          keyringApiEnabled: false,
           messenger,
         });
 
@@ -629,7 +595,6 @@ describe('AccountsController', () => {
               selectedAccount: mockAccount.id,
             },
           },
-          keyringApiEnabled: false,
           messenger,
         });
 
@@ -693,7 +658,6 @@ describe('AccountsController', () => {
               selectedAccount: mockAccount.id,
             },
           },
-          keyringApiEnabled: false,
           messenger,
         });
 
@@ -754,7 +718,6 @@ describe('AccountsController', () => {
               selectedAccount: 'missing',
             },
           },
-          keyringApiEnabled: false,
           messenger,
         });
 
@@ -796,7 +759,6 @@ describe('AccountsController', () => {
               selectedAccount: mockAccount.id,
             },
           },
-          keyringApiEnabled: false,
           messenger,
         });
 
@@ -850,7 +812,6 @@ describe('AccountsController', () => {
               selectedAccount: 'missing-account',
             },
           },
-          keyringApiEnabled: false,
           messenger,
         });
 
@@ -914,7 +875,6 @@ describe('AccountsController', () => {
               selectedAccount: 'missing-account',
             },
           },
-          keyringApiEnabled: false,
           messenger,
         });
 
@@ -987,7 +947,6 @@ describe('AccountsController', () => {
               selectedAccount: 'missing-account',
             },
           },
-          keyringApiEnabled: false,
           messenger,
         });
 
@@ -1045,7 +1004,6 @@ describe('AccountsController', () => {
             selectedAccount: mockInitialAccount.id,
           },
         },
-        keyringApiEnabled: false,
         messenger,
       });
 
@@ -1125,6 +1083,16 @@ describe('AccountsController', () => {
         mockGetKeyringForAccount.mockResolvedValue({ type: 'HD Key Tree' }),
       );
 
+      messenger.registerActionHandler(
+        'KeyringController:getKeyringsByType',
+        mockGetKeyringByType.mockReturnValue([
+          {
+            type: 'Snap Keyring',
+            listAccounts: async () => [],
+          },
+        ]),
+      );
+
       const accountsController = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -1132,7 +1100,6 @@ describe('AccountsController', () => {
             selectedAccount: '',
           },
         },
-        keyringApiEnabled: false,
         messenger,
       });
       const expectedAccounts = [
@@ -1179,7 +1146,6 @@ describe('AccountsController', () => {
             selectedAccount: '',
           },
         },
-        keyringApiEnabled: true,
         messenger,
       });
 
@@ -1227,7 +1193,6 @@ describe('AccountsController', () => {
             selectedAccount: '',
           },
         },
-        keyringApiEnabled: true,
         messenger,
       });
 
@@ -1251,6 +1216,16 @@ describe('AccountsController', () => {
         mockGetKeyringForAccount.mockResolvedValue({ type: 'HD Key Tree' }),
       );
 
+      messenger.registerActionHandler(
+        'KeyringController:getKeyringsByType',
+        mockGetKeyringByType.mockReturnValue([
+          {
+            type: 'Snap Keyring',
+            listAccounts: async () => [],
+          },
+        ]),
+      );
+
       const accountsController = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -1260,7 +1235,6 @@ describe('AccountsController', () => {
             selectedAccount: mockAccount.id,
           },
         },
-        keyringApiEnabled: false,
         messenger,
       });
       const expectedAccounts = [
@@ -1310,7 +1284,6 @@ describe('AccountsController', () => {
             selectedAccount: '',
           },
         },
-        keyringApiEnabled: true,
         messenger,
       });
       const expectedAccounts = [
@@ -1366,7 +1339,6 @@ describe('AccountsController', () => {
             selectedAccount: '',
           },
         },
-        keyringApiEnabled: true,
         messenger,
       });
       const expectedAccounts = [
@@ -1412,6 +1384,16 @@ describe('AccountsController', () => {
         mockGetKeyringForAccount.mockResolvedValue({ type: keyringType }),
       );
 
+      messenger.registerActionHandler(
+        'KeyringController:getKeyringsByType',
+        mockGetKeyringByType.mockReturnValue([
+          {
+            type: 'Snap Keyring',
+            listAccounts: async () => [],
+          },
+        ]),
+      );
+
       const accountsController = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -1419,7 +1401,6 @@ describe('AccountsController', () => {
             selectedAccount: '',
           },
         },
-        keyringApiEnabled: false,
         messenger,
       });
 
@@ -1450,6 +1431,16 @@ describe('AccountsController', () => {
         mockGetKeyringForAccount.mockResolvedValue({ type: 'unknown' }),
       );
 
+      messenger.registerActionHandler(
+        'KeyringController:getKeyringsByType',
+        mockGetKeyringByType.mockReturnValue([
+          {
+            type: 'Snap Keyring',
+            listAccounts: async () => [],
+          },
+        ]),
+      );
+
       const accountsController = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -1457,7 +1448,6 @@ describe('AccountsController', () => {
             selectedAccount: '',
           },
         },
-        keyringApiEnabled: false,
         messenger,
       });
 
@@ -1791,7 +1781,6 @@ describe('AccountsController', () => {
             selectedAccount: mockAccount.id,
           },
         },
-        keyringApiEnabled: false,
         messenger,
       });
 

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -654,6 +654,11 @@ export class AccountsController extends BaseControllerV2<
     });
   }
 
+  /**
+   * Returns the next account number for a given keyring type.
+   * @param keyringType - The type of keyring.
+   * @returns An object containing the account prefix and index to use.
+   */
   #getNextAccountNumber(keyringType: string): {
     accountPrefix: string;
     indexToUse: number;

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -153,8 +153,7 @@ export class AccountsController extends BaseControllerV2<
 
     this.messagingSystem.subscribe(
       'KeyringController:stateChange',
-      async (keyringState) =>
-        await this.#handleOnKeyringStateChange(keyringState),
+      (keyringState) => this.#handleOnKeyringStateChange(keyringState),
     );
 
     this.#registerMessageHandlers();
@@ -241,9 +240,7 @@ export class AccountsController extends BaseControllerV2<
   setSelectedAccount(accountId: string): void {
     const account = this.getAccount(accountId);
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-    this.update((currentState: AccountsControllerState) => {
+    this.update((currentState: WritableDraft<AccountsControllerState>) => {
       if (account) {
         currentState.internalAccounts.accounts[
           account.id
@@ -346,9 +343,7 @@ export class AccountsController extends BaseControllerV2<
       return internalAccountMap;
     }, {} as Record<string, InternalAccount>);
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-    this.update((currentState: AccountsControllerState) => {
+    this.update((currentState: WritableDraft<AccountsControllerState>) => {
       currentState.internalAccounts.accounts = accounts;
     });
   }
@@ -360,9 +355,7 @@ export class AccountsController extends BaseControllerV2<
    */
   loadBackup(backup: AccountsControllerState): void {
     if (backup.internalAccounts) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-      this.update((currentState: AccountsControllerState) => {
+      this.update((currentState: WritableDraft<AccountsControllerState>) => {
         currentState.internalAccounts = backup.internalAccounts;
       });
     }
@@ -472,11 +465,8 @@ export class AccountsController extends BaseControllerV2<
    * Handles changes in the keyring state, specifically when new accounts are added or removed.
    *
    * @param keyringState - The new state of the keyring controller.
-   * @returns A Promise that resolves when the function has finished executing.
    */
-  async #handleOnKeyringStateChange(
-    keyringState: KeyringControllerState,
-  ): Promise<void> {
+  #handleOnKeyringStateChange(keyringState: KeyringControllerState): void {
     // check if there are any new accounts added
     // TODO: change when accountAdded event is added to the keyring controller
 
@@ -585,7 +575,7 @@ export class AccountsController extends BaseControllerV2<
 
       if (addedAccounts.length > 0) {
         for (const account of addedAccounts) {
-          await this.#handleNewAccountAdded(account);
+          this.#handleNewAccountAdded(account);
         }
       }
 
@@ -620,9 +610,7 @@ export class AccountsController extends BaseControllerV2<
       (account) => account.metadata.snap,
     );
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-    this.update((currentState: AccountsControllerState) => {
+    this.update((currentState: WritableDraft<AccountsControllerState>) => {
       accounts.forEach((account) => {
         const currentAccount =
           currentState.internalAccounts.accounts[account.id];
@@ -719,9 +707,7 @@ export class AccountsController extends BaseControllerV2<
 
     const accountName = `${accountPrefix} ${indexToUse}`;
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-    this.update((currentState: AccountsControllerState) => {
+    this.update((currentState: WritableDraft<AccountsControllerState>) => {
       currentState.internalAccounts.accounts[newAccount.id] = {
         ...newAccount,
         metadata: {
@@ -740,9 +726,7 @@ export class AccountsController extends BaseControllerV2<
    * @param accountId - The ID of the account to be removed.
    */
   #handleAccountRemoved(accountId: string) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-    this.update((currentState: AccountsControllerState) => {
+    this.update((currentState: WritableDraft<AccountsControllerState>) => {
       delete currentState.internalAccounts.accounts[accountId];
     });
   }

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -3,6 +3,7 @@ import { BaseControllerV2 } from '@metamask/base-controller';
 import { SnapKeyring } from '@metamask/eth-snap-keyring';
 import type { InternalAccount } from '@metamask/keyring-api';
 import { EthAccountType } from '@metamask/keyring-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
 import type {
   KeyringControllerState,
   KeyringControllerEvents,
@@ -468,7 +469,7 @@ export class AccountsController extends BaseControllerV2<
     }
 
     return internalAccounts.filter(
-      (account) => account.metadata.keyring.type !== 'Snap Keyring',
+      (account) => account.metadata.keyring.type !== KeyringTypes.snap,
     );
   }
 
@@ -486,7 +487,7 @@ export class AccountsController extends BaseControllerV2<
       const updatedSnapKeyringAddresses: AddressAndKeyringTypeObject[] = [];
 
       for (const keyring of keyringState.keyrings) {
-        if (keyring.type === 'Snap Keyring') {
+        if (keyring.type === KeyringTypes.snap) {
           updatedSnapKeyringAddresses.push(
             ...keyring.accounts.map((address) => {
               return {
@@ -510,7 +511,7 @@ export class AccountsController extends BaseControllerV2<
       const { previousNormalInternalAccounts, previousSnapInternalAccounts } =
         this.listAccounts().reduce(
           (accumulator, account) => {
-            if (account.metadata.keyring.type === 'Snap Keyring') {
+            if (account.metadata.keyring.type === KeyringTypes.snap) {
               accumulator.previousSnapInternalAccounts.push(account);
             } else {
               accumulator.previousNormalInternalAccounts.push(account);
@@ -650,12 +651,12 @@ export class AccountsController extends BaseControllerV2<
     const previousKeyringAccounts = this.listAccounts().filter(
       (internalAccount) => {
         if (
-          keyringType === 'HD Key Tree' ||
-          keyringType === 'Simple Key Pair'
+          keyringType === KeyringTypes.hd ||
+          keyringType === KeyringTypes.simple
         ) {
           return (
-            internalAccount.metadata.keyring.type === 'HD Key Tree' ||
-            internalAccount.metadata.keyring.type === 'Simple Key Pair'
+            internalAccount.metadata.keyring.type === KeyringTypes.hd ||
+            internalAccount.metadata.keyring.type === KeyringTypes.simple
           );
         }
         return internalAccount.metadata.keyring.type === keyringType;
@@ -690,7 +691,7 @@ export class AccountsController extends BaseControllerV2<
    */
   #handleNewAccountAdded(account: AddressAndKeyringTypeObject) {
     let newAccount: InternalAccount;
-    if (account.type !== 'Snap Keyring') {
+    if (account.type !== KeyringTypes.snap) {
       newAccount = this.#generateInternalAccountForNonSnapAccount(
         account.address,
         account.type,

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -291,8 +291,7 @@ export class AccountsController extends BaseControllerV2<
       throw new Error('Account name already exists');
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
+    // @ts-expect-error TODO: align BaseController state update callback type
     this.update((currentState: AccountsControllerState) => {
       currentState.internalAccounts.accounts[accountId] = {
         ...account,
@@ -689,7 +688,7 @@ export class AccountsController extends BaseControllerV2<
    * If the account is a Snap Keyring account, retrieves the account from the keyring and adds it to the controller.
    * @param account - The address and keyring type object of the new account.
    */
-  async #handleNewAccountAdded(account: AddressAndKeyringTypeObject) {
+  #handleNewAccountAdded(account: AddressAndKeyringTypeObject) {
     let newAccount: InternalAccount;
     if (account.type !== 'Snap Keyring') {
       newAccount = this.#generateInternalAccountForNonSnapAccount(
@@ -702,9 +701,9 @@ export class AccountsController extends BaseControllerV2<
         SnapKeyring.type,
       );
 
-      newAccount = (await (snapKeyring as SnapKeyring).getAccountByAddress(
+      newAccount = (snapKeyring as SnapKeyring).getAccountByAddress(
         account.address,
-      )) as InternalAccount;
+      ) as InternalAccount;
 
       // The snap deleted the account before the keyring controller could add it
       if (!newAccount) {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -420,7 +420,7 @@ export class AccountsController extends BaseControllerV2<
       return [];
     }
 
-    const snapAccounts = await (snapKeyring as SnapKeyring).listAccounts();
+    const snapAccounts = (snapKeyring as SnapKeyring).listAccounts();
 
     return snapAccounts;
   }

--- a/packages/accounts-controller/src/index.ts
+++ b/packages/accounts-controller/src/index.ts
@@ -1,1 +1,2 @@
 export * from './AccountsController';
+export * from './utils';

--- a/packages/accounts-controller/src/utils.ts
+++ b/packages/accounts-controller/src/utils.ts
@@ -1,0 +1,54 @@
+import { sha256FromString } from 'ethereumjs-util';
+import { v4 as uuid } from 'uuid';
+
+/**
+ * Returns the name of the keyring type.
+ *
+ * @param keyringType - The type of the keyring.
+ * @returns The name of the keyring type.
+ */
+export function keyringTypeToName(keyringType: string): string {
+  switch (keyringType) {
+    case 'Simple Key Pair': {
+      return 'Account';
+    }
+    case 'HD Key Tree': {
+      return 'Account';
+    }
+    case 'Trezor Hardware': {
+      return 'Trezor';
+    }
+    case 'Ledger Hardware': {
+      return 'Ledger';
+    }
+    case 'Lattice Hardware': {
+      return 'Lattice';
+    }
+    case 'QR Hardware Wallet Device': {
+      return 'QR';
+    }
+    case 'Snap Keyring': {
+      return 'Snap Account';
+    }
+    case 'Custody': {
+      return 'Custody';
+    }
+    default: {
+      throw new Error(`Unknown keyring ${keyringType}`);
+    }
+  }
+}
+
+/**
+ * Generates a UUID from a given Ethereum address.
+ * @param address - The Ethereum address to generate the UUID from.
+ * @returns The generated UUID.
+ */
+export function getUUIDFromAddressOfNormalAccount(address: string): string {
+  const v4options = {
+    random: sha256FromString(address).slice(0, 16),
+  };
+
+  const test = uuid(v4options);
+  return test;
+}

--- a/packages/accounts-controller/src/utils.ts
+++ b/packages/accounts-controller/src/utils.ts
@@ -50,6 +50,5 @@ export function getUUIDFromAddressOfNormalAccount(address: string): string {
     random: sha256FromString(address).slice(0, 16),
   };
 
-  const test = uuid(v4options);
-  return test;
+  return uuid(v4options);
 }

--- a/packages/accounts-controller/src/utils.ts
+++ b/packages/accounts-controller/src/utils.ts
@@ -1,3 +1,4 @@
+import { KeyringTypes } from '@metamask/keyring-controller';
 import { sha256FromString } from 'ethereumjs-util';
 import { v4 as uuid } from 'uuid';
 
@@ -9,28 +10,28 @@ import { v4 as uuid } from 'uuid';
  */
 export function keyringTypeToName(keyringType: string): string {
   switch (keyringType) {
-    case 'Simple Key Pair': {
+    case KeyringTypes.simple: {
       return 'Account';
     }
-    case 'HD Key Tree': {
+    case KeyringTypes.hd: {
       return 'Account';
     }
-    case 'Trezor Hardware': {
+    case KeyringTypes.trezor: {
       return 'Trezor';
     }
-    case 'Ledger Hardware': {
+    case KeyringTypes.ledger: {
       return 'Ledger';
     }
-    case 'Lattice Hardware': {
+    case KeyringTypes.lattice: {
       return 'Lattice';
     }
-    case 'QR Hardware Wallet Device': {
+    case KeyringTypes.qr: {
       return 'QR';
     }
-    case 'Snap Keyring': {
+    case KeyringTypes.snap: {
       return 'Snap Account';
     }
-    case 'Custody': {
+    case KeyringTypes.custody: {
       return 'Custody';
     }
     default: {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -34,6 +34,11 @@ export enum KeyringTypes {
   simple = 'Simple Key Pair',
   hd = 'HD Key Tree',
   qr = 'QR Hardware Wallet Device',
+  trezor = 'Trezor Hardware',
+  ledger = 'Ledger Hardware',
+  lattice = 'Lattice Hardware',
+  snap = 'Snap Keyring',
+  custody = 'Custody',
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1397,7 +1397,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": ^3.2.3
-    "@metamask/eth-snap-keyring": ^1.0.0
+    "@metamask/eth-snap-keyring": ^2.0.0
     "@metamask/keyring-api": ^1.0.0
     "@metamask/keyring-controller": ^8.0.3
     "@metamask/snaps-controllers": ^3.0.0
@@ -1906,9 +1906,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-snap-keyring@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/eth-snap-keyring@npm:1.0.0"
+"@metamask/eth-snap-keyring@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/eth-snap-keyring@npm:2.0.0"
   dependencies:
     "@ethereumjs/tx": ^4.2.0
     "@metamask/eth-sig-util": ^7.0.0
@@ -1918,7 +1918,7 @@ __metadata:
     "@types/uuid": ^9.0.1
     superstruct: ^1.0.3
     uuid: ^9.0.0
-  checksum: 979e6b0f6a4108f3562b501c2393fc25bcf8d7ecfe8e37fd49a49a7a82c0e71d56f56efe7ed517db845826c932df9a48c905cc3cc13a8700f9b5fd948254cfa8
+  checksum: 02a4f523fbc129f817c99906fe4b4b53762d49db8eb1a24f965508d6eec5634eb90c37a88ab8181254abcb6969893cea314832a515c79d6c3656428c779da7d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

This PR refactors how the `AccountsController` handles the subscription to keyring state changes and removes the `keyringApiEnabled` flag


## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

### `@metamask/accounts-controller`

- **REMOVED**: keyringApiEnabled flag
- **CHANGED**: `onSnapStateChange` and `onKeyringStateChange` handlers to be sync instead of async

### `@metamask/keyring-controller`

- **ADDED**: `trezor`, `ledger`, `custody`, `lattice`, `snap`  to `KeyringTypes`

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
