### PR TITLE
Add getSelectedAccount and getAccountByAddress actions to AccountsController

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -155,6 +155,8 @@ function buildAccountsControllerMessenger(messenger = buildMessenger()) {
       'AccountsController:setAccountName',
       'AccountsController:setSelectedAccount',
       'AccountsController:updateAccounts',
+      'AccountsController:getSelectedAccount',
+      'AccountsController:getAccountByAddress',
     ],
   });
 }
@@ -1407,12 +1409,48 @@ describe('AccountsController', () => {
     });
   });
 
+  describe('getAccountByAddress', () => {
+    it('should return an account by address', async () => {
+      const accountsController = setupAccountsController({
+        initialState: {
+          internalAccounts: {
+            accounts: { [mockAccount.id]: mockAccount },
+            selectedAccount: mockAccount.id,
+          },
+        },
+      });
+
+      const account = accountsController.getAccountByAddress(
+        mockAccount.address,
+      );
+
+      expect(account).toStrictEqual(mockAccount);
+    });
+
+    it("should return undefined if there isn't an account with the address", () => {
+      const accountsController = setupAccountsController({
+        initialState: {
+          internalAccounts: {
+            accounts: { [mockAccount.id]: mockAccount },
+            selectedAccount: mockAccount.id,
+          },
+        },
+      });
+
+      const account = accountsController.getAccountByAddress('unknown address');
+
+      expect(account).toBeUndefined();
+    });
+  });
+
   describe('actions', () => {
     beforeEach(() => {
       jest.spyOn(AccountsController.prototype, 'setSelectedAccount');
       jest.spyOn(AccountsController.prototype, 'listAccounts');
       jest.spyOn(AccountsController.prototype, 'setAccountName');
       jest.spyOn(AccountsController.prototype, 'updateAccounts');
+      jest.spyOn(AccountsController.prototype, 'getAccountByAddress');
+      jest.spyOn(AccountsController.prototype, 'getSelectedAccount');
     });
 
     describe('setSelectedAccount', () => {
@@ -1513,7 +1551,9 @@ describe('AccountsController', () => {
     });
 
     describe('getAccountByAddress', () => {
-      it('should return an account by address', async () => {
+      it('should get account by address', async () => {
+        const messenger = buildMessenger();
+
         const accountsController = setupAccountsController({
           initialState: {
             internalAccounts: {
@@ -1521,29 +1561,39 @@ describe('AccountsController', () => {
               selectedAccount: mockAccount.id,
             },
           },
+          messenger,
         });
 
-        const account = accountsController.getAccountByAddress(
+        const account = messenger.call(
+          'AccountsController:getAccountByAddress',
           mockAccount.address,
         );
-
+        expect(accountsController.getAccountByAddress).toHaveBeenCalledWith(
+          mockAccount.address,
+        );
         expect(account).toStrictEqual(mockAccount);
       });
 
-      it("should return undefined if there isn't an account with the address", () => {
-        const accountsController = setupAccountsController({
-          initialState: {
-            internalAccounts: {
-              accounts: { [mockAccount.id]: mockAccount },
-              selectedAccount: mockAccount.id,
+      describe('getSelectedAccount', () => {
+        it('should get account by address', async () => {
+          const messenger = buildMessenger();
+
+          const accountsController = setupAccountsController({
+            initialState: {
+              internalAccounts: {
+                accounts: { [mockAccount.id]: mockAccount },
+                selectedAccount: mockAccount.id,
+              },
             },
-          },
+            messenger,
+          });
+
+          const account = messenger.call(
+            'AccountsController:getSelectedAccount',
+          );
+          expect(accountsController.getSelectedAccount).toHaveBeenCalledWith();
+          expect(account).toStrictEqual(mockAccount);
         });
-
-        const account =
-          accountsController.getAccountByAddress('unknown address');
-
-        expect(account).toBeUndefined();
       });
     });
   });

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -34,32 +34,43 @@ export type AccountsControllerGetStateAction = {
   handler: () => AccountsControllerState;
 };
 
-export type AccountsControllerSetSelectedAccount = {
+export type AccountsControllerSetSelectedAccountAction = {
   type: `${typeof controllerName}:setSelectedAccount`;
   handler: AccountsController['setSelectedAccount'];
 };
 
-export type AccountsControllerSetAccountName = {
+export type AccountsControllerSetAccountNameAction = {
   type: `${typeof controllerName}:setAccountName`;
   handler: AccountsController['setAccountName'];
 };
 
-export type AccountsControllerListAccounts = {
+export type AccountsControllerListAccountsAction = {
   type: `${typeof controllerName}:listAccounts`;
   handler: AccountsController['listAccounts'];
 };
 
-export type AccountsControllerUpdateAccounts = {
+export type AccountsControllerUpdateAccountsAction = {
   type: `${typeof controllerName}:updateAccounts`;
   handler: AccountsController['updateAccounts'];
 };
 
+export type AccountsControllerGetSelectedAccountAction = {
+  type: `${typeof controllerName}:getSelectedAccount`;
+  handler: AccountsController['getSelectedAccount'];
+};
+
+export type AccountsControllerGetAccountByAddressAction = {
+  type: `${typeof controllerName}:getAccountByAddress`;
+  handler: AccountsController['getAccountByAddress'];
+};
 export type AccountsControllerActions =
   | AccountsControllerGetStateAction
-  | AccountsControllerSetSelectedAccount
-  | AccountsControllerListAccounts
-  | AccountsControllerSetAccountName
-  | AccountsControllerUpdateAccounts
+  | AccountsControllerSetSelectedAccountAction
+  | AccountsControllerListAccountsAction
+  | AccountsControllerSetAccountNameAction
+  | AccountsControllerUpdateAccountsAction
+  | AccountsControllerGetAccountByAddressAction
+  | AccountsControllerGetSelectedAccountAction
   | KeyringControllerGetKeyringForAccountAction
   | KeyringControllerGetKeyringsByTypeAction
   | KeyringControllerGetAccountsAction;
@@ -573,6 +584,16 @@ export class AccountsController extends BaseControllerV2<
     this.messagingSystem.registerActionHandler(
       `${controllerName}:updateAccounts`,
       this.updateAccounts.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${controllerName}:getSelectedAccount`,
+      this.getSelectedAccount.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${controllerName}:getAccountByAddress`,
+      this.getAccountByAddress.bind(this),
     );
   }
 }


### PR DESCRIPTION
## Explanation

This PR adds the following actions to the AccountsController, `getSelectedAccount` and `getAccountByAddress`

## References

Resolves https://github.com/MetaMask/metamask-extension/issues/21398

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/accounts-controller`

- **ADDED**: `getSelectedAccount` action
- **ADDED**: `getAccountByAddress` action

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
