### PR TITLE
Typing fixes for #1839 (Feat/update on keyring state change in accounts controller)

### DIFF
--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -342,6 +342,8 @@ export class AccountsController extends BaseControllerV2<
     }, {} as Record<string, InternalAccount>);
 
     this.update((currentState: Draft<AccountsControllerState>) => {
+      (currentState as AccountsControllerState).internalAccounts.accounts =
+        accounts;
     });
   }
 
@@ -353,6 +355,8 @@ export class AccountsController extends BaseControllerV2<
   loadBackup(backup: AccountsControllerState): void {
     if (backup.internalAccounts) {
       this.update((currentState: Draft<AccountsControllerState>) => {
+        (currentState as AccountsControllerState).internalAccounts =
+          backup.internalAccounts;
       });
     }
   }
@@ -707,7 +711,9 @@ export class AccountsController extends BaseControllerV2<
     const accountName = `${accountPrefix} ${indexToUse}`;
 
     this.update((currentState: Draft<AccountsControllerState>) => {
-      currentState.internalAccounts.accounts[newAccount.id] = {
+      (currentState as AccountsControllerState).internalAccounts.accounts[
+        newAccount.id
+      ] = {
         ...newAccount,
         metadata: {
           ...newAccount.metadata,

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -281,12 +281,13 @@ export class AccountsController extends BaseControllerV2<
     }
 
     this.update((currentState: Draft<AccountsControllerState>) => {
+      const internalAccount = {
         ...account,
-        metadata: {
-          ...account.metadata,
-          name: accountName,
-        },
+        metadata: { ...account.metadata, name: accountName },
       };
+      currentState.internalAccounts.accounts[accountId] =
+        // @ts-expect-error Assigning a complex type `T` to `Draft<T>` causes an excessive type instantiation depth error.
+        internalAccount as Draft<InternalAccount>;
     });
   }
 

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -17,7 +17,7 @@ import type {
 import type { Snap, ValidatedSnapId } from '@metamask/snaps-utils';
 import type { Keyring, Json } from '@metamask/utils';
 import { sha256FromString } from 'ethereumjs-util';
-import { type Patch } from 'immer';
+import type { Patch, Draft } from 'immer';
 import { v4 as uuid } from 'uuid';
 
 import { getUUIDFromAddressOfNormalAccount, keyringTypeToName } from './utils';
@@ -241,9 +241,7 @@ export class AccountsController extends BaseControllerV2<
   setSelectedAccount(accountId: string): void {
     const account = this.getAccount(accountId);
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-    this.update((currentState: AccountsControllerState) => {
+    this.update((currentState: Draft<AccountsControllerState>) => {
       if (account) {
         currentState.internalAccounts.accounts[
           account.id
@@ -282,10 +280,7 @@ export class AccountsController extends BaseControllerV2<
       throw new Error('Account name already exists');
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-    this.update((currentState: AccountsControllerState) => {
-      currentState.internalAccounts.accounts[accountId] = {
+    this.update((currentState: Draft<AccountsControllerState>) => {
         ...account,
         metadata: {
           ...account.metadata,
@@ -346,10 +341,7 @@ export class AccountsController extends BaseControllerV2<
       return internalAccountMap;
     }, {} as Record<string, InternalAccount>);
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-    this.update((currentState: AccountsControllerState) => {
-      currentState.internalAccounts.accounts = accounts;
+    this.update((currentState: Draft<AccountsControllerState>) => {
     });
   }
 
@@ -360,10 +352,7 @@ export class AccountsController extends BaseControllerV2<
    */
   loadBackup(backup: AccountsControllerState): void {
     if (backup.internalAccounts) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-      this.update((currentState: AccountsControllerState) => {
-        currentState.internalAccounts = backup.internalAccounts;
+      this.update((currentState: Draft<AccountsControllerState>) => {
       });
     }
   }
@@ -620,9 +609,7 @@ export class AccountsController extends BaseControllerV2<
       (account) => account.metadata.snap,
     );
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-    this.update((currentState: AccountsControllerState) => {
+    this.update((currentState: Draft<AccountsControllerState>) => {
       accounts.forEach((account) => {
         const currentAccount =
           currentState.internalAccounts.accounts[account.id];
@@ -719,9 +706,7 @@ export class AccountsController extends BaseControllerV2<
 
     const accountName = `${accountPrefix} ${indexToUse}`;
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-    this.update((currentState: AccountsControllerState) => {
+    this.update((currentState: Draft<AccountsControllerState>) => {
       currentState.internalAccounts.accounts[newAccount.id] = {
         ...newAccount,
         metadata: {
@@ -740,9 +725,7 @@ export class AccountsController extends BaseControllerV2<
    * @param accountId - The ID of the account to be removed.
    */
   #handleAccountRemoved(accountId: string) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type instantiation is excessively deep and possibly infinite.
-    this.update((currentState: AccountsControllerState) => {
+    this.update((currentState: Draft<AccountsControllerState>) => {
       delete currentState.internalAccounts.accounts[accountId];
     });
   }


### PR DESCRIPTION
## Explanation

Removes `@ts-ignore` directives in `AccountsController.ts`

- Types `currentState` as `Draft<AccountsControllerState>` to align with input argument type expected by `BaseController.update()`
- Resolves "Type instantiation is excessively deep" errors triggered by assigning a complex type `T` to `Draft<T>`, by casting `Draft<T>` to `T`.
- Marks one remaining error with `@ts-expect-error`. Narrowed down source of error as much as possible.

## References

- See #1839
