### PR TITLE
Typing fixes for #1806 (Request Queue Controller)

### DIFF
--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -33,8 +33,10 @@
     "@metamask/controller-utils": "^5.0.2",
     "@metamask/json-rpc-engine": "^7.1.1",
     "@metamask/network-controller": "^15.0.0",
+    "@metamask/rpc-errors": "6.1.0",
     "@metamask/selected-network-controller": "^3.0.0",
-    "@metamask/swappable-obj-proxy": "^2.1.0"
+    "@metamask/swappable-obj-proxy": "^2.1.0",
+    "@metamask/utils": "8.1.0"
   },
   "devDependencies": {
     "@metamask/approval-controller": "^4.0.1",

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -33,10 +33,10 @@
     "@metamask/controller-utils": "^5.0.2",
     "@metamask/json-rpc-engine": "^7.1.1",
     "@metamask/network-controller": "^15.0.0",
-    "@metamask/rpc-errors": "6.1.0",
+    "@metamask/rpc-errors": "^6.1.0",
     "@metamask/selected-network-controller": "^3.0.0",
     "@metamask/swappable-obj-proxy": "^2.1.0",
-    "@metamask/utils": "8.1.0"
+    "@metamask/utils": "^8.1.0"
   },
   "devDependencies": {
     "@metamask/approval-controller": "^4.0.1",

--- a/packages/queued-request-controller/src/QueuedRequestController.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.ts
@@ -1,5 +1,6 @@
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
 import { BaseControllerV2 } from '@metamask/base-controller';
+import type { Json } from '@metamask/utils';
 import type { Patch } from 'immer';
 
 const controllerName = 'QueuedRequestController';
@@ -21,7 +22,7 @@ export const QueuedRequestControllerEventTypes = {
 };
 
 export type QueuedRequestControllerState = {
-  [k: string]: any;
+  [k: string]: Json;
 };
 
 export type QueuedRequestControllerStateChangeEvent = {

--- a/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
+++ b/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
@@ -18,6 +18,7 @@ import type {
   NetworkControllerSetActiveNetworkAction,
   NetworkControllerSetProviderTypeAction,
 } from '@metamask/network-controller';
+import type { CustomNetworkClientConfiguration } from '@metamask/network-controller/src/types';
 import type { SelectedNetworkControllerSetNetworkClientIdForDomainAction } from '@metamask/selected-network-controller';
 import { SelectedNetworkControllerActionTypes } from '@metamask/selected-network-controller';
 import type { Json } from '@metamask/utils';
@@ -78,7 +79,10 @@ export const createQueuedRequestMiddleware = (
         }
 
         const isBuiltIn = isNetworkType(networkClientIdForRequest);
-        let networkConfigurationForRequest;
+        let networkConfigurationForRequest:
+          | ((typeof BUILT_IN_NETWORKS)[keyof typeof BUILT_IN_NETWORKS] &
+              Record<string, Json>)
+          | CustomNetworkClientConfiguration;
         if (isBuiltIn) {
           const builtIn = BUILT_IN_NETWORKS[networkClientIdForRequest];
           if (builtIn.chainId) {

--- a/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
+++ b/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
@@ -1,4 +1,7 @@
-import type { AddApprovalRequest } from '@metamask/approval-controller';
+import type {
+  AddApprovalRequest,
+  ApprovalRequest,
+} from '@metamask/approval-controller';
 import type { ControllerMessenger } from '@metamask/base-controller';
 import type { InfuraNetworkType } from '@metamask/controller-utils';
 import {
@@ -6,7 +9,6 @@ import {
   BUILT_IN_NETWORKS,
   isNetworkType,
 } from '@metamask/controller-utils';
-import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
 import type {
   NetworkClientId,
@@ -112,7 +114,7 @@ export const createQueuedRequestMiddleware = (
         };
 
         try {
-          const approvedRequestData = await messenger.call(
+          const approvedRequestData = (await messenger.call(
             'ApprovalController:addRequest',
             {
               origin,
@@ -120,17 +122,19 @@ export const createQueuedRequestMiddleware = (
               requestData,
             },
             true,
-          );
+          )) as ApprovalRequest<typeof requestData> & {
+            type: InfuraNetworkType;
+          };
 
           if (isBuiltIn) {
             await messenger.call(
               'NetworkController:setProviderType',
-              (approvedRequestData as { type: InfuraNetworkType }).type,
+              approvedRequestData.type,
             );
           } else {
             await messenger.call(
               'NetworkController:setActiveNetwork',
-              (approvedRequestData as { id: NetworkClientId }).id,
+              approvedRequestData.id,
             );
           }
 

--- a/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
+++ b/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
@@ -19,6 +19,7 @@ import type {
 import type { SelectedNetworkControllerSetNetworkClientIdForDomainAction } from '@metamask/selected-network-controller';
 import { SelectedNetworkControllerActionTypes } from '@metamask/selected-network-controller';
 import type { Json } from '@metamask/utils';
+import { isJsonRpcError } from '@metamask/utils';
 
 import type { QueuedRequestControllerEnqueueRequestAction } from './QueuedRequestController';
 import { QueuedRequestControllerActionTypes } from './QueuedRequestController';
@@ -139,7 +140,9 @@ export const createQueuedRequestMiddleware = (
             networkClientIdForRequest ?? '',
           );
         } catch (error) {
-          res.error = error;
+          if (isJsonRpcError(error)) {
+            res.error = error;
+          }
           return error;
         }
 

--- a/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
+++ b/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
@@ -90,12 +90,10 @@ export const createQueuedRequestMiddleware = (
           }
         }
 
-        networkConfigurationForRequest =
-          networkConfigurationForRequest ||
-          messenger.call(
-            'NetworkController:getNetworkClientById',
-            networkClientIdForRequest ?? '',
-          ).configuration;
+        networkConfigurationForRequest ??= messenger.call(
+          'NetworkController:getNetworkClientById',
+          networkClientIdForRequest ?? '',
+        ).configuration;
 
         const currentProviderConfig = messenger.call(
           'NetworkController:getState',

--- a/packages/queued-request-controller/tests/QueuedRequestMiddleware.test.ts
+++ b/packages/queued-request-controller/tests/QueuedRequestMiddleware.test.ts
@@ -107,7 +107,7 @@ describe('createQueuedRequesMitddleware', () => {
 
     const req = {
       ...requestDefaults,
-      origin: 'example.com',
+      params: { origin: 'example.com' },
     };
 
     await new Promise((resolve) => middleware(req, {} as any, resolve, noop));
@@ -122,7 +122,7 @@ describe('createQueuedRequesMitddleware', () => {
 
     const req = {
       ...requestDefaults,
-      origin: 'example.com',
+      params: { origin: 'example.com' },
       method: 'eth_chainId',
     };
 
@@ -139,7 +139,7 @@ describe('createQueuedRequesMitddleware', () => {
 
       const req = {
         ...requestDefaults,
-        origin: 'example.com',
+        params: { origin: 'example.com' },
         method: 'eth_sendTransaction',
       };
 
@@ -158,7 +158,7 @@ describe('createQueuedRequesMitddleware', () => {
 
       const req = {
         ...requestDefaults,
-        origin: 'example.com',
+        params: { origin: 'example.com' },
         method: 'wallet_switchEthereumChain',
       };
 
@@ -217,7 +217,7 @@ describe('createQueuedRequesMitddleware', () => {
 
         const req = {
           ...requestDefaults,
-          origin: 'example.com',
+          params: { origin: 'example.com' },
           method: 'eth_sendTransaction',
         };
 
@@ -245,9 +245,8 @@ describe('createQueuedRequesMitddleware', () => {
 
         const req = {
           ...requestDefaults,
-          origin: 'example.com',
+          params: { origin: 'example.com', networkClientId: 'mainnet' },
           method: 'eth_sendTransaction',
-          networkClientId: 'mainnet',
         };
 
         await new Promise((resolve) =>
@@ -276,9 +275,11 @@ describe('createQueuedRequesMitddleware', () => {
 
         const req = {
           ...requestDefaults,
-          origin: 'example.com',
+          params: {
+            origin: 'example.com',
+            networkClientId: 'https://some-rpc-url.com',
+          },
           method: 'eth_sendTransaction',
-          networkClientId: 'https://some-rpc-url.com',
         };
 
         await new Promise((resolve) =>
@@ -313,13 +314,13 @@ describe('createQueuedRequesMitddleware', () => {
 
       const req1 = {
         ...requestDefaults,
-        origin: 'example.com',
+        params: { origin: 'example.com' },
         method: 'eth_sendTransaction',
       };
 
       const req2 = {
         ...requestDefaults,
-        origin: 'example.com',
+        params: { origin: 'example.com' },
         method: 'eth_sendTransaction',
       };
 

--- a/packages/queued-request-controller/tests/QueuedRequestMiddleware.test.ts
+++ b/packages/queued-request-controller/tests/QueuedRequestMiddleware.test.ts
@@ -6,6 +6,7 @@ import type {
   NetworkControllerSetActiveNetworkAction,
   NetworkControllerSetProviderTypeAction,
 } from '@metamask/network-controller';
+import { JsonRpcError } from '@metamask/rpc-errors';
 import type { SelectedNetworkControllerSetNetworkClientIdForDomainAction } from '@metamask/selected-network-controller';
 import { SelectedNetworkControllerActionTypes } from '@metamask/selected-network-controller';
 
@@ -185,7 +186,7 @@ describe('createQueuedRequesMitddleware', () => {
 
         const req = {
           ...requestDefaults,
-          origin: 'example.com',
+          params: { origin: 'example.com' },
           method: 'eth_sendTransaction',
         };
 
@@ -203,7 +204,7 @@ describe('createQueuedRequesMitddleware', () => {
       it('if the switchEthConfirmation is rejected, the original request is rejected', async () => {
         const messenger = buildMessenger();
         const middleware = createQueuedRequestMiddleware(messenger, () => true);
-        const rejected = new Error('big bad rejected');
+        const rejected = new JsonRpcError(1, 'big bad rejected');
         const mockAddRequest = jest.fn().mockRejectedValue(rejected);
         const mockGetProviderConfig = jest.fn().mockReturnValue({
           providerConfig: {
@@ -295,7 +296,7 @@ describe('createQueuedRequesMitddleware', () => {
     it('rejecting one call does not cause others to be rejected', async () => {
       const messenger = buildMessenger();
       const middleware = createQueuedRequestMiddleware(messenger, () => true);
-      const rejectedError = new Error('big bad rejected');
+      const rejectedError = new JsonRpcError(1, 'big bad rejected');
       const mockAddRequest = jest
         .fn()
         .mockRejectedValueOnce(rejectedError)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,10 +2350,10 @@ __metadata:
     "@metamask/controller-utils": ^5.0.2
     "@metamask/json-rpc-engine": ^7.1.1
     "@metamask/network-controller": ^15.0.0
-    "@metamask/rpc-errors": 6.1.0
+    "@metamask/rpc-errors": ^6.1.0
     "@metamask/selected-network-controller": ^3.0.0
     "@metamask/swappable-obj-proxy": ^2.1.0
-    "@metamask/utils": 8.1.0
+    "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     immer: ^9.0.6
@@ -2389,7 +2389,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/rpc-errors@npm:6.1.0, @metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0":
+"@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0":
   version: 6.1.0
   resolution: "@metamask/rpc-errors@npm:6.1.0"
   dependencies:
@@ -2646,20 +2646,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:8.1.0, @metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "@metamask/utils@npm:8.1.0"
-  dependencies:
-    "@ethereumjs/tx": ^4.1.2
-    "@noble/hashes": ^1.3.1
-    "@types/debug": ^4.1.7
-    debug: ^4.3.4
-    semver: ^7.5.4
-    superstruct: ^1.0.3
-  checksum: 4cbee36d0c227f3e528930e83f75a0c6b71b55b332c3e162f0e87f3dd86ae017d0b20405d76ea054ab99e4d924d3d9b8b896ed12a12aae57b090350e5a625999
-  languageName: node
-  linkType: hard
-
 "@metamask/utils@npm:^5.0.0, @metamask/utils@npm:^5.0.2":
   version: 5.0.2
   resolution: "@metamask/utils@npm:5.0.2"
@@ -2684,6 +2670,20 @@ __metadata:
     semver: ^7.3.8
     superstruct: ^1.0.3
   checksum: 0bc675358ecc09b3bc04da613d73666295d7afa51ff6b8554801585966900b24b8545bd93b8b2e9a17db867ebe421fe884baf3558ec4ca3199fa65504f677c1b
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@metamask/utils@npm:8.1.0"
+  dependencies:
+    "@ethereumjs/tx": ^4.1.2
+    "@noble/hashes": ^1.3.1
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    semver: ^7.5.4
+    superstruct: ^1.0.3
+  checksum: 4cbee36d0c227f3e528930e83f75a0c6b71b55b332c3e162f0e87f3dd86ae017d0b20405d76ea054ab99e4d924d3d9b8b896ed12a12aae57b090350e5a625999
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,8 +2350,10 @@ __metadata:
     "@metamask/controller-utils": ^5.0.2
     "@metamask/json-rpc-engine": ^7.1.1
     "@metamask/network-controller": ^15.0.0
+    "@metamask/rpc-errors": 6.1.0
     "@metamask/selected-network-controller": ^3.0.0
     "@metamask/swappable-obj-proxy": ^2.1.0
+    "@metamask/utils": 8.1.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     immer: ^9.0.6
@@ -2387,7 +2389,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0":
+"@metamask/rpc-errors@npm:6.1.0, @metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0":
   version: 6.1.0
   resolution: "@metamask/rpc-errors@npm:6.1.0"
   dependencies:
@@ -2644,6 +2646,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/utils@npm:8.1.0, @metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@metamask/utils@npm:8.1.0"
+  dependencies:
+    "@ethereumjs/tx": ^4.1.2
+    "@noble/hashes": ^1.3.1
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    semver: ^7.5.4
+    superstruct: ^1.0.3
+  checksum: 4cbee36d0c227f3e528930e83f75a0c6b71b55b332c3e162f0e87f3dd86ae017d0b20405d76ea054ab99e4d924d3d9b8b896ed12a12aae57b090350e5a625999
+  languageName: node
+  linkType: hard
+
 "@metamask/utils@npm:^5.0.0, @metamask/utils@npm:^5.0.2":
   version: 5.0.2
   resolution: "@metamask/utils@npm:5.0.2"
@@ -2668,20 +2684,6 @@ __metadata:
     semver: ^7.3.8
     superstruct: ^1.0.3
   checksum: 0bc675358ecc09b3bc04da613d73666295d7afa51ff6b8554801585966900b24b8545bd93b8b2e9a17db867ebe421fe884baf3558ec4ca3199fa65504f677c1b
-  languageName: node
-  linkType: hard
-
-"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "@metamask/utils@npm:8.1.0"
-  dependencies:
-    "@ethereumjs/tx": ^4.1.2
-    "@noble/hashes": ^1.3.1
-    "@types/debug": ^4.1.7
-    debug: ^4.3.4
-    semver: ^7.5.4
-    superstruct: ^1.0.3
-  checksum: 4cbee36d0c227f3e528930e83f75a0c6b71b55b332c3e162f0e87f3dd86ae017d0b20405d76ea054ab99e4d924d3d9b8b896ed12a12aae57b090350e5a625999
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

Removes `any`, `as` usage in `QueuedRequestMiddleware.ts`. 

- **BREAKING**: Aligns `QueuedRequestMiddleware` type with `JsonRpcMiddleware` by moving request parameters `networkClientId` and `origin` from `req` into `req.params`. 
- Improves typing for `approvedRequestData` to enable full intellisense and avoid lossy type casting.
- Adjusts tests
  - Add `params` property to request objects.
  - Use `new JsonRpcError()` instead of `new Error()`

## References

- See #1806

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
