### PR TITLE
Add missing TS dep to eth-json-rpc-provider

### DIFF
--- a/packages/eth-json-rpc-provider/package.json
+++ b/packages/eth-json-rpc-provider/package.json
@@ -49,7 +49,8 @@
     "jest": "^27.5.1",
     "jest-it-up": "^2.0.2",
     "ts-jest": "^27.1.4",
-    "typedoc": "^0.24.8"
+    "typedoc": "^0.24.8",
+    "typescript": "~4.8.4"
   },
   "packageManager": "yarn@3.3.0",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,6 +1824,7 @@ __metadata:
     jest-it-up: ^2.0.2
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION


## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

When running `yarn install`, I'm getting this warning:

    ➤ YN0002: │ @metamask/eth-json-rpc-provider@workspace:packages/eth-json-rpc-provider doesn't provide typescript (pa8d7f), requested by ts-jest
    ➤ YN0002: │ @metamask/eth-json-rpc-provider@workspace:packages/eth-json-rpc-provider doesn't provide typescript (p270b9), requested by typedoc

This is happening because `typescript` needs to be added as a development dependency for `eth-json-rpc-provider`.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

(No consumer-facing changes)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
