### PR TITLE
bump `@metamask/auto-changelog` to `^3.4.2`

### DIFF
--- a/merged-packages/json-rpc-engine/package.json
+++ b/merged-packages/json-rpc-engine/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^29.5.0",
     "deepmerge": "^4.2.2",
     "depcheck": "^1.4.3",

--- a/merged-packages/json-rpc-engine/package.json
+++ b/merged-packages/json-rpc-engine/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^29.5.0",
     "deepmerge": "^4.2.2",
     "depcheck": "^1.4.3",

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -40,7 +40,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@metamask/keyring-controller": "^8.0.3",
     "@metamask/snaps-controllers": "^3.0.0",
     "@types/jest": "^27.4.1",

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -40,7 +40,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@metamask/keyring-controller": "^8.0.3",
     "@metamask/snaps-controllers": "^3.0.0",
     "@types/jest": "^27.4.1",

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -34,7 +34,7 @@
     "@metamask/utils": "^8.1.0"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -34,7 +34,7 @@
     "@metamask/utils": "^8.1.0"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -32,7 +32,7 @@
     "@metamask/base-controller": "^3.2.3"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -32,7 +32,7 @@
     "@metamask/base-controller": "^3.2.3"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -36,7 +36,7 @@
     "nanoid": "^3.1.31"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -36,7 +36,7 @@
     "nanoid": "^3.1.31"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -54,7 +54,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.18.54",
     "deepmerge": "^4.2.2",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -54,7 +54,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.18.54",
     "deepmerge": "^4.2.2",

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -33,7 +33,7 @@
     "immer": "^9.0.6"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "@types/sinon": "^9.0.10",
     "deepmerge": "^4.2.2",

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -33,7 +33,7 @@
     "immer": "^9.0.6"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "@types/sinon": "^9.0.10",
     "deepmerge": "^4.2.2",

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -32,7 +32,7 @@
     "@metamask/base-controller": "^3.2.3"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -32,7 +32,7 @@
     "@metamask/base-controller": "^3.2.3"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -37,7 +37,7 @@
     "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@metamask/eth-query": "^3.0.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -37,7 +37,7 @@
     "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@metamask/eth-query": "^3.0.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -38,7 +38,7 @@
     "punycode": "^2.1.1"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -38,7 +38,7 @@
     "punycode": "^2.1.1"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/eth-json-rpc-provider/package.json
+++ b/packages/eth-json-rpc-provider/package.json
@@ -41,7 +41,7 @@
     "@metamask/utils": "^8.1.0"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "depcheck": "^1.4.3",

--- a/packages/eth-json-rpc-provider/package.json
+++ b/packages/eth-json-rpc-provider/package.json
@@ -41,7 +41,7 @@
     "@metamask/utils": "^8.1.0"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "depcheck": "^1.4.3",

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -42,7 +42,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "@types/jest-when": "^2.7.3",
     "deepmerge": "^4.2.2",

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -42,7 +42,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "@types/jest-when": "^2.7.3",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -44,7 +44,7 @@
     "@ethereumjs/common": "^3.2.0",
     "@ethereumjs/tx": "^4.2.0",
     "@keystonehq/bc-ur-registry-eth": "^0.9.0",
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@metamask/eth-sig-util": "^7.0.0",
     "@metamask/scure-bip39": "^2.1.0",
     "@types/jest": "^27.4.1",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -44,7 +44,7 @@
     "@ethereumjs/common": "^3.2.0",
     "@ethereumjs/tx": "^4.2.0",
     "@keystonehq/bc-ur-registry-eth": "^0.9.0",
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@metamask/eth-sig-util": "^7.0.0",
     "@metamask/scure-bip39": "^2.1.0",
     "@types/jest": "^27.4.1",

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -34,7 +34,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -34,7 +34,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -39,7 +39,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -39,7 +39,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -36,7 +36,7 @@
     "immer": "^9.0.6"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -36,7 +36,7 @@
     "immer": "^9.0.6"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@json-rpc-specification/meta-schema": "^1.0.6",
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "@types/jest-when": "^2.7.3",
     "@types/lodash": "^4.14.191",

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@json-rpc-specification/meta-schema": "^1.0.6",
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "@types/jest-when": "^2.7.3",
     "@types/lodash": "^4.14.191",

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -35,7 +35,7 @@
     "nanoid": "^3.1.31"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -35,7 +35,7 @@
     "nanoid": "^3.1.31"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -41,7 +41,7 @@
     "nanoid": "^3.1.31"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -41,7 +41,7 @@
     "nanoid": "^3.1.31"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -36,7 +36,7 @@
     "punycode": "^2.1.1"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -36,7 +36,7 @@
     "punycode": "^2.1.1"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -38,7 +38,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -38,7 +38,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -33,7 +33,7 @@
     "@metamask/controller-utils": "^5.0.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -33,7 +33,7 @@
     "@metamask/controller-utils": "^5.0.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@metamask/approval-controller": "^4.1.0",
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@metamask/approval-controller": "^4.1.0",
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -34,7 +34,7 @@
     "immer": "^9.0.6"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -34,7 +34,7 @@
     "immer": "^9.0.6"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -35,7 +35,7 @@
     "@metamask/swappable-obj-proxy": "^2.1.0"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -35,7 +35,7 @@
     "@metamask/swappable-obj-proxy": "^2.1.0"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@metamask/keyring-controller": "^8.0.3",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@metamask/keyring-controller": "^8.0.3",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -50,7 +50,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.1",
+    "@metamask/auto-changelog": "^3.4.2",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.18.54",
     "babel-runtime": "^6.26.0",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -50,7 +50,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.4.0",
+    "@metamask/auto-changelog": "^3.4.1",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.18.54",
     "babel-runtime": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1404,7 +1404,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/accounts-controller@workspace:packages/accounts-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/eth-snap-keyring": ^2.0.0
     "@metamask/keyring-api": ^1.0.0
@@ -1443,7 +1443,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/address-book-controller@workspace:packages/address-book-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/utils": ^8.1.0
@@ -1461,7 +1461,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/announcement-controller@workspace:packages/announcement-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1478,7 +1478,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/approval-controller@workspace:packages/approval-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/utils": ^8.1.0
@@ -1518,7 +1518,7 @@ __metadata:
     "@ethersproject/providers": ^5.7.0
     "@metamask/abi-utils": ^2.0.2
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/contract-metadata": ^2.3.1
     "@metamask/controller-utils": ^5.0.2
@@ -1555,11 +1555,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/auto-changelog@npm:^3.4.1":
-  version: 3.4.1
-  resolution: "@metamask/auto-changelog@npm:3.4.1"
+"@metamask/auto-changelog@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "@metamask/auto-changelog@npm:3.4.2"
   dependencies:
-    "@metamask/utils": ^8.1.0
     diff: ^5.0.0
     execa: ^5.1.1
     prettier: ^2.8.8
@@ -1567,7 +1566,7 @@ __metadata:
     yargs: ^17.0.1
   bin:
     auto-changelog: dist/cli.js
-  checksum: f79decfc6334eafd80486777f56d60fec27de027a9a6c8a089d52fc5e13eb005807aedb8d8a8c9b4e5ba5821203117e87336bfad3eb8f7837fc6305c68de8087
+  checksum: b922db20b3ff8a1957b71128d481c08fdf5ae465a89a03bccacf31cba227e56e48f6b1654ff4c78150cc0cfd3ae57a615d3ab5ab6760f7437e0b9e8aa6aec390
   languageName: node
   linkType: hard
 
@@ -1575,7 +1574,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/base-controller@workspace:packages/base-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     "@types/sinon": ^9.0.10
@@ -1601,7 +1600,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/composable-controller@workspace:packages/composable-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1626,7 +1625,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/controller-utils@workspace:packages/controller-utils"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/eth-query": ^3.0.1
     "@metamask/utils": ^8.1.0
     "@spruceid/siwe-parser": 1.1.3
@@ -1708,7 +1707,7 @@ __metadata:
   resolution: "@metamask/ens-controller@workspace:packages/ens-controller"
   dependencies:
     "@ethersproject/providers": ^5.7.0
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/network-controller": ^15.0.0
@@ -1824,7 +1823,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/eth-json-rpc-provider@workspace:packages/eth-json-rpc-provider"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/json-rpc-engine": ^7.1.1
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.1.0
@@ -1927,7 +1926,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/gas-fee-controller@workspace:packages/gas-fee-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/eth-query": ^3.0.1
@@ -2004,7 +2003,7 @@ __metadata:
     "@ethereumjs/tx": ^4.2.0
     "@keystonehq/bc-ur-registry-eth": ^0.9.0
     "@keystonehq/metamask-airgapped-keyring": ^0.13.1
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/eth-keyring-controller": ^13.0.1
     "@metamask/eth-sig-util": ^7.0.0
@@ -2034,7 +2033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/logging-controller@workspace:packages/logging-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@types/jest": ^27.4.1
@@ -2052,7 +2051,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/message-manager@workspace:packages/message-manager"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/eth-sig-util": ^7.0.0
@@ -2082,7 +2081,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/name-controller@workspace:packages/name-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
@@ -2102,7 +2101,7 @@ __metadata:
   resolution: "@metamask/network-controller@workspace:packages/network-controller"
   dependencies:
     "@json-rpc-specification/meta-schema": ^1.0.6
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/eth-json-rpc-infura": ^9.0.0
@@ -2137,7 +2136,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/notification-controller@workspace:packages/notification-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
@@ -2208,7 +2207,7 @@ __metadata:
   resolution: "@metamask/permission-controller@workspace:packages/permission-controller"
   dependencies:
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/json-rpc-engine": ^7.1.1
@@ -2234,7 +2233,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/phishing-controller@workspace:packages/phishing-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@types/jest": ^27.4.1
@@ -2256,7 +2255,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/polling-controller@workspace:packages/polling-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/network-controller": ^15.0.0
@@ -2290,7 +2289,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/preferences-controller@workspace:packages/preferences-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@types/jest": ^27.4.1
@@ -2346,7 +2345,7 @@ __metadata:
   resolution: "@metamask/queued-request-controller@workspace:packages/queued-request-controller"
   dependencies:
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/json-rpc-engine": ^7.1.1
@@ -2376,7 +2375,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/rate-limit-controller@workspace:packages/rate-limit-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/rpc-errors": ^6.1.0
     "@types/jest": ^27.4.1
@@ -2445,7 +2444,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/selected-network-controller@workspace:packages/selected-network-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/json-rpc-engine": ^7.1.1
     "@metamask/network-controller": ^15.0.0
@@ -2471,7 +2470,7 @@ __metadata:
   resolution: "@metamask/signature-controller@workspace:packages/signature-controller"
   dependencies:
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/keyring-controller": ^8.0.3
@@ -2607,7 +2606,7 @@ __metadata:
     "@ethereumjs/tx": ^4.2.0
     "@ethersproject/abi": ^5.7.0
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/auto-changelog": ^3.4.1
+    "@metamask/auto-changelog": ^3.4.2
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/eth-query": ^3.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1404,7 +1404,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/accounts-controller@workspace:packages/accounts-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/eth-snap-keyring": ^2.0.0
     "@metamask/keyring-api": ^1.0.0
@@ -1443,7 +1443,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/address-book-controller@workspace:packages/address-book-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/utils": ^8.1.0
@@ -1461,7 +1461,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/announcement-controller@workspace:packages/announcement-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1478,7 +1478,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/approval-controller@workspace:packages/approval-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/utils": ^8.1.0
@@ -1518,7 +1518,7 @@ __metadata:
     "@ethersproject/providers": ^5.7.0
     "@metamask/abi-utils": ^2.0.2
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/contract-metadata": ^2.3.1
     "@metamask/controller-utils": ^5.0.2
@@ -1555,10 +1555,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/auto-changelog@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@metamask/auto-changelog@npm:3.4.0"
+"@metamask/auto-changelog@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "@metamask/auto-changelog@npm:3.4.1"
   dependencies:
+    "@metamask/utils": ^8.1.0
     diff: ^5.0.0
     execa: ^5.1.1
     prettier: ^2.8.8
@@ -1566,7 +1567,7 @@ __metadata:
     yargs: ^17.0.1
   bin:
     auto-changelog: dist/cli.js
-  checksum: 7f87012c25d35ca50429535c0a71bed5675e9e5d9449ed9a7a5ce58c6558db80da5375223557fc4c6d5a13062a9e294860386ee196815bf5ef933062ea77f3dc
+  checksum: f79decfc6334eafd80486777f56d60fec27de027a9a6c8a089d52fc5e13eb005807aedb8d8a8c9b4e5ba5821203117e87336bfad3eb8f7837fc6305c68de8087
   languageName: node
   linkType: hard
 
@@ -1574,7 +1575,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/base-controller@workspace:packages/base-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
     "@types/sinon": ^9.0.10
@@ -1600,7 +1601,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/composable-controller@workspace:packages/composable-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1625,7 +1626,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/controller-utils@workspace:packages/controller-utils"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/eth-query": ^3.0.1
     "@metamask/utils": ^8.1.0
     "@spruceid/siwe-parser": 1.1.3
@@ -1707,7 +1708,7 @@ __metadata:
   resolution: "@metamask/ens-controller@workspace:packages/ens-controller"
   dependencies:
     "@ethersproject/providers": ^5.7.0
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/network-controller": ^15.0.0
@@ -1823,7 +1824,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/eth-json-rpc-provider@workspace:packages/eth-json-rpc-provider"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/json-rpc-engine": ^7.1.1
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.1.0
@@ -1926,7 +1927,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/gas-fee-controller@workspace:packages/gas-fee-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/eth-query": ^3.0.1
@@ -2003,7 +2004,7 @@ __metadata:
     "@ethereumjs/tx": ^4.2.0
     "@keystonehq/bc-ur-registry-eth": ^0.9.0
     "@keystonehq/metamask-airgapped-keyring": ^0.13.1
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/eth-keyring-controller": ^13.0.1
     "@metamask/eth-sig-util": ^7.0.0
@@ -2033,7 +2034,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/logging-controller@workspace:packages/logging-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@types/jest": ^27.4.1
@@ -2051,7 +2052,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/message-manager@workspace:packages/message-manager"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/eth-sig-util": ^7.0.0
@@ -2081,7 +2082,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/name-controller@workspace:packages/name-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
@@ -2101,7 +2102,7 @@ __metadata:
   resolution: "@metamask/network-controller@workspace:packages/network-controller"
   dependencies:
     "@json-rpc-specification/meta-schema": ^1.0.6
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/eth-json-rpc-infura": ^9.0.0
@@ -2136,7 +2137,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/notification-controller@workspace:packages/notification-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/utils": ^8.1.0
     "@types/jest": ^27.4.1
@@ -2207,7 +2208,7 @@ __metadata:
   resolution: "@metamask/permission-controller@workspace:packages/permission-controller"
   dependencies:
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/json-rpc-engine": ^7.1.1
@@ -2233,7 +2234,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/phishing-controller@workspace:packages/phishing-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@types/jest": ^27.4.1
@@ -2255,7 +2256,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/polling-controller@workspace:packages/polling-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/network-controller": ^15.0.0
@@ -2289,7 +2290,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/preferences-controller@workspace:packages/preferences-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@types/jest": ^27.4.1
@@ -2345,7 +2346,7 @@ __metadata:
   resolution: "@metamask/queued-request-controller@workspace:packages/queued-request-controller"
   dependencies:
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/json-rpc-engine": ^7.1.1
@@ -2375,7 +2376,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/rate-limit-controller@workspace:packages/rate-limit-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/rpc-errors": ^6.1.0
     "@types/jest": ^27.4.1
@@ -2444,7 +2445,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/selected-network-controller@workspace:packages/selected-network-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/json-rpc-engine": ^7.1.1
     "@metamask/network-controller": ^15.0.0
@@ -2470,7 +2471,7 @@ __metadata:
   resolution: "@metamask/signature-controller@workspace:packages/signature-controller"
   dependencies:
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/keyring-controller": ^8.0.3
@@ -2606,7 +2607,7 @@ __metadata:
     "@ethereumjs/tx": ^4.2.0
     "@ethersproject/abi": ^5.7.0
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/auto-changelog": ^3.4.0
+    "@metamask/auto-changelog": ^3.4.1
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/eth-query": ^3.0.1


### PR DESCRIPTION
## Explanation

Bumps all `packages/` usage of `auto-changelog` from `3.4.0` to `3.4.2`

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
