### PR TITLE
Adds `constraints.pro` rule that removes `prepack` build scripts

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -251,6 +251,10 @@ gen_enforced_field(WorkspaceCwd, 'scripts.build:docs', 'typedoc') :-
 gen_enforced_field(WorkspaceCwd, 'scripts.publish:preview', 'yarn npm publish --tag preview') :-
   \+ workspace_field(WorkspaceCwd, 'private', true).
 
+% All published packages must not have a "prepack" script.
+gen_enforced_field(WorkspaceCwd, 'scripts.prepack', null) :-
+  \+ workspace_field(WorkspaceCwd, 'private', true).
+
 % The "changelog:validate" script for each published package must run a common
 % script with the name of the package as an argument.
 gen_enforced_field(WorkspaceCwd, 'scripts.changelog:validate', ProperChangelogValidationScript) :-


### PR DESCRIPTION
## Explanation

The `prepack` build script from incoming migration packages interfere with the release CI and need to be replaced with the `prepack` script in the root `package.json`. 

This `constraints.pro` rule enforces that redundant `prepack` scripts in non-root packages are removed. 

## References

- See https://github.com/MetaMask/core/pull/1902
- See https://github.com/MetaMask/core/actions/runs/6629214754/job/18008299892?pr=1897
- Closes https://github.com/MetaMask/core/issues/1906

## Changelog

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
