### PR TITLE
Typing fixes for `PermissionLogController`

### DIFF
--- a/packages/permission-log-controller/src/PermissionLog.ts
+++ b/packages/permission-log-controller/src/PermissionLog.ts
@@ -5,6 +5,7 @@ import type {
   JsonRpcEngineNextCallback,
 } from '@metamask/json-rpc-engine';
 import type {
+  Json,
   JsonRpcParams,
   JsonRpcRequest,
   PendingJsonRpcResponse,
@@ -264,7 +265,7 @@ export class PermissionLogController extends BaseControllerV2<
     request: JsonRpcRequestWithOrigin,
     isInternal: boolean,
   ): PermissionActivityLog {
-    const activityEntry: PermissionActivityLog = {
+    const activityEntry: PermissionActivityLog & { params: Json[] } = {
       id: request.id,
       method: request.method,
       methodType: isInternal
@@ -274,6 +275,7 @@ export class PermissionLogController extends BaseControllerV2<
       requestTime: Date.now(),
       responseTime: null,
       success: null,
+      params: [],
     };
     this.commitNewActivity(activityEntry);
     return activityEntry;

--- a/packages/permission-log-controller/src/PermissionLog.ts
+++ b/packages/permission-log-controller/src/PermissionLog.ts
@@ -423,7 +423,7 @@ export class PermissionLogController extends BaseControllerV2<
       // we may intend to update just the accounts, not the permission
       // itself
       const lastApproved =
-        newEthAccountsEntry.lastApproved ||
+        newEthAccountsEntry.lastApproved ??
         existingEthAccountsEntry.lastApproved;
 
       // merge old and new eth_accounts history entries

--- a/packages/permission-log-controller/src/permissions.ts
+++ b/packages/permission-log-controller/src/permissions.ts
@@ -156,14 +156,14 @@ export const getters = deepFreeze({
      *
      * @param origin - The origin of the request
      * @param method - The request method
-     * @param params - The request parameters
+     * @param [params] - The request parameters
      * @param [id] - The request id
      * @returns An RPC request object
      */
     custom: (
       origin: string,
       method: string,
-      params?: any[],
+      params?: Json[],
       id?: string,
     ): JsonRpcRequestWithOrigin => {
       const req: JsonRpcRequestWithOrigin = {
@@ -278,7 +278,7 @@ export const getters = deepFreeze({
     metamask_sendDomainMetadata: (
       origin: string,
       name: string,
-      ...args: any[]
+      ...args: Json[]
     ): JsonRpcRequestWithOrigin => {
       return {
         ...JsonRpcRequestStruct.TYPE,

--- a/packages/permission-log-controller/src/permissions.ts
+++ b/packages/permission-log-controller/src/permissions.ts
@@ -1,3 +1,4 @@
+import { type Json, JsonRpcRequestStruct } from '@metamask/utils';
 import deepFreeze from 'deep-freeze-strict';
 
 import type { JsonRpcRequestWithOrigin, Permission } from './PermissionLog';
@@ -166,10 +167,10 @@ export const getters = deepFreeze({
       id?: string,
     ): JsonRpcRequestWithOrigin => {
       const req: JsonRpcRequestWithOrigin = {
+        ...JsonRpcRequestStruct.TYPE,
         origin,
         method,
-        jsonrpc: '2.0',
-        params: params || [],
+        params: params ?? [],
         id: id ?? null,
       };
       return req;
@@ -183,8 +184,8 @@ export const getters = deepFreeze({
      */
     eth_accounts: (origin: string): JsonRpcRequestWithOrigin => {
       return {
+        ...JsonRpcRequestStruct.TYPE,
         id: null,
-        jsonrpc: '2.0',
         origin,
         method: 'eth_accounts',
         params: [],
@@ -200,8 +201,8 @@ export const getters = deepFreeze({
      */
     test_method: (origin: string, param = false): JsonRpcRequestWithOrigin => {
       return {
+        ...JsonRpcRequestStruct.TYPE,
         id: null,
-        jsonrpc: '2.0',
         origin,
         method: 'test_method',
         params: [param],
@@ -216,8 +217,8 @@ export const getters = deepFreeze({
      */
     eth_requestAccounts: (origin: string): JsonRpcRequestWithOrigin => {
       return {
+        ...JsonRpcRequestStruct.TYPE,
         id: null,
-        jsonrpc: '2.0',
         origin,
         method: 'eth_requestAccounts',
         params: [],
@@ -237,9 +238,9 @@ export const getters = deepFreeze({
       permissionName: 'eth_accounts' | 'test_method' | 'does_not_exist',
     ): JsonRpcRequestWithOrigin => {
       return {
+        ...JsonRpcRequestStruct.TYPE,
         id: null,
         origin,
-        jsonrpc: '2.0',
         method: 'wallet_requestPermissions',
         params: [PERMS.requests[permissionName]()],
       };
@@ -258,9 +259,9 @@ export const getters = deepFreeze({
       permissions = {},
     ): JsonRpcRequestWithOrigin => {
       return {
+        ...JsonRpcRequestStruct.TYPE,
         id: null,
         origin,
-        jsonrpc: '2.0',
         method: 'wallet_requestPermissions',
         params: [permissions],
       };
@@ -280,8 +281,8 @@ export const getters = deepFreeze({
       ...args: any[]
     ): JsonRpcRequestWithOrigin => {
       return {
+        ...JsonRpcRequestStruct.TYPE,
         id: null,
-        jsonrpc: '2.0',
         origin,
         method: 'metamask_sendDomainMetadata',
         params: {


### PR DESCRIPTION
## Explanation

Typing fixes for the `PermissionLogController`:
- Removes `any`, adds null checks. 
- Derive request type from JsonRpcRequestStruct.TYPE instead of hardcoding `jsonrpc` version to "2.0".
- Narrow `req.params` type to `Json[]` where appropriate. 

@cryptodev-2s Feel free to cherry-pick, merge, or disregard!

## Status

- TypeScript compiles without errors.
- Failing same tests as parent PR: https://github.com/MetaMask/core/actions/runs/6632538517/job/18018504013?pr=1908

## References

- See https://github.com/MetaMask/core/pull/1871

## Changelog

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
