### PR TITLE
fix v16 changelog

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add way to start and stop different polling sessions for the same network client ID by providing extra scoping data ([#1776](https://github.com/MetaMask/core/pull/1776))
   - Add optional second argument to `stopPollingByPollingToken` (formerly `stopPollingByNetworkClientId`)
   - Add optional second argument to `onPollingCompleteByNetworkClientId`
+- Add support for token detection for Linea mainnet and Linea Goerli
 
 ### Changed
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^15.0.0
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing dependency on `@metamask/polling-controller` ([#1831](https://github.com/MetaMask/core/pull/1831))
 - Bump dependency and peer dependency on `@metamask/approval-controller` to ^4.0.1
 - Bump dependency and peer dependency on `@metamask/preferences-controller` to ^4.4.3
+- Fix support for NFT metadata stored outside IPFS
 
 ## [15.0.0]
 ### Changed

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add way to start and stop different polling sessions for the same network client ID by providing extra scoping data ([#1776](https://github.com/MetaMask/core/pull/1776))
   - Add optional second argument to `stopPollingByPollingToken` (formerly `stopPollingByNetworkClientId`)
   - Add optional second argument to `onPollingCompleteByNetworkClientId`
-- Add support for token detection for Linea mainnet and Linea Goerli
+- Add support for token detection for Linea mainnet and Linea Goerli ([#1799](https://github.com/MetaMask/core/pull/1799))
 
 ### Changed
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^15.0.0
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing dependency on `@metamask/polling-controller` ([#1831](https://github.com/MetaMask/core/pull/1831))
 - Bump dependency and peer dependency on `@metamask/approval-controller` to ^4.0.1
 - Bump dependency and peer dependency on `@metamask/preferences-controller` to ^4.4.3
-- Fix support for NFT metadata stored outside IPFS
+- Fix support for NFT metadata stored outside IPFS ([#1772](https://github.com/MetaMask/core/pull/1772))
 
 ## [15.0.0]
 ### Changed


### PR DESCRIPTION
## Explanation

Currently, the v16 [changelog](https://github.com/MetaMask/core/blob/ba7d8327bddc6f652e787670280f1f6251ab6873/packages/assets-controllers/CHANGELOG.md#added) incorrectly missed information about [two commits](https://github.com/MetaMask/core/compare/@metamask/assets-controllers@15.0.0...@metamask/assets-controllers@16.0.0): [bc04f49](https://github.com/MetaMask/core/commit/bc04f496f494defc8496b4c9229ad59af541e086) and [deb9317](https://github.com/MetaMask/core/commit/deb9317bff171883a8b7f140aa6cf391d200bc27).

This PR introduces those lines retroactively into the changelog.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
