### PR TITLE
Typing fixes for `TransactionController.test.ts`

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -30,7 +30,12 @@ import type {
   TransactionConfig,
 } from './TransactionController';
 import { TransactionController } from './TransactionController';
-import type { TransactionMeta, DappSuggestedGasFees } from './types';
+import type {
+  TransactionMeta,
+  DappSuggestedGasFees,
+  TransactionParams,
+  TransactionHistoryEntry,
+} from './types';
 import { WalletDevice, TransactionStatus, TransactionType } from './types';
 import { estimateGas, updateGas } from './utils/gas';
 import { updateGasFees } from './utils/gas-fees';
@@ -187,7 +192,7 @@ function buildMockMessenger({
 }): {
   messenger: TransactionControllerMessenger;
   approve: () => void;
-  reject: (reason: any) => void;
+  reject: (reason: unknown) => void;
 } {
   let approve, reject;
   let promise: Promise<AddResult>;
@@ -218,8 +223,8 @@ function buildMockMessenger({
 
   return {
     messenger,
-    approve: approve as any,
-    reject: reject as any,
+    approve: approve as unknown as () => void,
+    reject: reject as unknown as (reason: unknown) => void,
   };
 }
 
@@ -395,7 +400,7 @@ const ACTION_ID_MOCK = '123456';
 
 const TRANSACTION_META_MOCK = {
   hash: '0x1',
-  status: TransactionStatus.confirmed,
+  status: TransactionStatus.confirmed as const,
   time: 123456789,
   txParams: {
     from: ACCOUNT_MOCK,
@@ -404,7 +409,7 @@ const TRANSACTION_META_MOCK = {
 
 const TRANSACTION_META_2_MOCK = {
   hash: '0x2',
-  status: TransactionStatus.confirmed,
+  status: TransactionStatus.confirmed as const,
   time: 987654321,
   txParams: {
     from: '0x3',
@@ -540,14 +545,14 @@ describe('TransactionController', () => {
       hub: {
         on: jest.fn(),
       },
-    } as any;
+    } as unknown as jest.Mocked<IncomingTransactionHelper>;
 
     pendingTransactionTrackerMock = {
       start: jest.fn(),
       hub: {
         on: jest.fn(),
       },
-    } as any;
+    } as unknown as jest.Mocked<PendingTransactionTracker>;
 
     incomingTransactionHelperClassMock.mockReturnValue(
       incomingTransactionHelperMock,
@@ -778,7 +783,7 @@ describe('TransactionController', () => {
         expectedSignCalledTimes,
       ) => {
         const controller = newController();
-        const signSpy = jest.spyOn(controller, 'sign' as any);
+        const signSpy = jest.spyOn(controller, 'sign');
 
         const { transactionMeta } = await controller.addTransaction({
           from: ACCOUNT_MOCK,
@@ -872,7 +877,7 @@ describe('TransactionController', () => {
         origin: undefined,
         securityAlertResponse: undefined,
         sendFlowHistory: expect.any(Array),
-        status: TransactionStatus.unapproved,
+        status: TransactionStatus.unapproved as const,
         time: expect.any(Number),
         txParams: expect.anything(),
         userEditedGasLimit: false,
@@ -907,31 +912,34 @@ describe('TransactionController', () => {
         ).toBeUndefined();
       });
 
-      it.each([
+      it.each<[keyof DappSuggestedGasFees]>([
         ['gasPrice'],
         ['maxFeePerGas'],
         ['maxPriorityFeePerGas'],
         ['gas'],
-      ])('if %s is defined', async (gasPropName) => {
-        const controller = newController();
-        const mockDappOrigin = 'MockDappOrigin';
-        const mockGasValue = '0x1';
-        await controller.addTransaction(
-          {
-            from: ACCOUNT_MOCK,
-            to: ACCOUNT_MOCK,
-            [gasPropName]: mockGasValue,
-          },
-          {
-            origin: mockDappOrigin,
-          },
-        );
-        expect(
-          controller.state.transactions[0]?.dappSuggestedGasFees?.[
-            gasPropName as keyof DappSuggestedGasFees
-          ],
-        ).toBe(mockGasValue);
-      });
+      ])(
+        'if %s is defined',
+        async (gasPropName: keyof DappSuggestedGasFees) => {
+          const controller = newController();
+          const mockDappOrigin = 'MockDappOrigin';
+          const mockGasValue = '0x1';
+          await controller.addTransaction(
+            {
+              from: ACCOUNT_MOCK,
+              to: ACCOUNT_MOCK,
+              [gasPropName]: mockGasValue,
+            },
+            {
+              origin: mockDappOrigin,
+            },
+          );
+          expect(
+            controller.state.transactions[0]?.dappSuggestedGasFees?.[
+              gasPropName
+            ],
+          ).toBe(mockGasValue);
+        },
+      );
     });
 
     it.each([
@@ -980,9 +988,9 @@ describe('TransactionController', () => {
 
     it('throws if address invalid', async () => {
       const controller = newController();
-      await expect(
-        controller.addTransaction({ from: 'foo' } as any),
-      ).rejects.toThrow('Invalid "from" address');
+      await expect(controller.addTransaction({ from: 'foo' })).rejects.toThrow(
+        'Invalid "from" address',
+      );
     });
 
     it('increments nonce when adding a new non-cancel non-speedup transaction', async () => {
@@ -1345,7 +1353,7 @@ describe('TransactionController', () => {
             {
               from: notSelectedFromAddress,
               to: ACCOUNT_MOCK,
-            } as any,
+            },
             { origin: ORIGIN_METAMASK },
           ),
         ).rejects.toThrow(
@@ -1403,18 +1411,22 @@ describe('TransactionController', () => {
       controller.state.transactions.push({
         id: '1',
         chainId: mockCurrentChainId,
+        status: TransactionStatus.confirmed as const,
+        time: 123456789,
         txParams: {
           from: mockFromAccount1,
         },
-      } as any);
+      });
 
       controller.state.transactions.push({
         id: '2',
         chainId: mockCurrentChainId,
+        status: TransactionStatus.confirmed as const,
+        time: 987654321,
         txParams: {
           from: mockFromAccount2,
         },
-      } as any);
+      });
 
       controller.wipeTransactions(true, mockFromAccount2);
 
@@ -1437,7 +1449,9 @@ describe('TransactionController', () => {
         txParams: {
           from: mockFromAccount1,
         },
-      } as any);
+        status: TransactionStatus.confirmed as const,
+        time: 123456789,
+      });
 
       controller.state.transactions.push({
         id: '4',
@@ -1445,7 +1459,9 @@ describe('TransactionController', () => {
         txParams: {
           from: mockFromAccount1,
         },
-      } as any);
+        status: TransactionStatus.confirmed as const,
+        time: 987654321,
+      });
 
       controller.wipeTransactions(false, mockFromAccount1);
 
@@ -1527,7 +1543,10 @@ describe('TransactionController', () => {
 
       await controller.handleMethodData('0xf39b5b9b');
 
-      const registryLookup = jest.spyOn(controller, 'registryLookup' as any);
+      const registryLookup = jest.spyOn<TransactionController, never>(
+        controller,
+        'registryLookup' as never,
+      );
 
       await controller.handleMethodData('0xf39b5b9b');
 
@@ -1575,7 +1594,7 @@ describe('TransactionController', () => {
         gasPrice: '0x1',
       });
 
-      const signSpy = jest.spyOn(controller, 'sign' as any);
+      const signSpy = jest.spyOn(controller, 'sign');
 
       expect(signSpy).toHaveBeenCalledTimes(0);
     });
@@ -1743,9 +1762,9 @@ describe('TransactionController', () => {
       hash: '1337',
       id: 'mocked',
       chainId: toHex(5),
-      status: TransactionStatus.unapproved,
+      status: TransactionStatus.unapproved as const,
       txParams: { data: '0x', from: ACCOUNT_MOCK },
-      time: 0,
+      time: 123456789,
     };
     it('creates approvals for all unapproved transaction', async () => {
       const controller = newController();
@@ -1843,17 +1862,16 @@ describe('TransactionController', () => {
       const controller = newController();
 
       const externalTransactionToConfirm = {
-        from: ACCOUNT_MOCK,
-        to: ACCOUNT_2_MOCK,
         id: '1',
         chainId: toHex(1),
-        status: TransactionStatus.confirmed,
+        time: 123456789,
+        status: TransactionStatus.confirmed as const,
         txParams: {
           gasUsed: undefined,
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
         },
-      } as any;
+      };
       const externalTransactionReceipt = {
         gasUsed: '0x5208',
       };
@@ -1884,13 +1902,14 @@ describe('TransactionController', () => {
         to: ACCOUNT_2_MOCK,
         id: '1',
         chainId: toHex(1),
-        status: TransactionStatus.confirmed,
+        status: TransactionStatus.confirmed as const,
+        time: 123456789,
         txParams: {
           gasUsed: undefined,
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
         },
-      } as any;
+      };
 
       const externalTransactionReceipt = {
         gasUsed: '0x5208',
@@ -1908,7 +1927,8 @@ describe('TransactionController', () => {
         chainId: '0x1',
         from: ACCOUNT_MOCK,
         id: '1',
-        status: TransactionStatus.confirmed,
+        time: 123456789,
+        status: TransactionStatus.confirmed as const,
         to: ACCOUNT_2_MOCK,
         txParams: {
           from: ACCOUNT_MOCK,
@@ -1956,13 +1976,14 @@ describe('TransactionController', () => {
         hash: externalTransactionHash,
         id: externalTransactionId,
         chainId: toHex(5),
-        status: TransactionStatus.confirmed,
+        status: TransactionStatus.confirmed as const,
+        time: 123456789,
         txParams: {
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
-          nonce: NONCE_MOCK,
+          nonce: String(NONCE_MOCK),
         },
-      } as any;
+      };
       const externalTransactionReceipt = {
         gasUsed: '0x5208',
       };
@@ -1971,17 +1992,16 @@ describe('TransactionController', () => {
       // Submitted local unapproved transaction
       const localTransactionIdWithSameNonce = '9';
       controller.state.transactions.push({
-        from: ACCOUNT_MOCK,
-        to: ACCOUNT_2_MOCK,
         id: localTransactionIdWithSameNonce,
         chainId: toHex(5),
-        status: TransactionStatus.unapproved,
+        status: TransactionStatus.unapproved as const,
+        time: 123456789,
         txParams: {
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
-          nonce: NONCE_MOCK,
+          nonce: String(NONCE_MOCK),
         },
-      } as any);
+      });
 
       await controller.confirmExternalTransaction(
         externalTransactionToConfirm,
@@ -2010,13 +2030,14 @@ describe('TransactionController', () => {
         hash: externalTransactionHash,
         id: externalTransactionId,
         chainId: toHex(5),
-        status: TransactionStatus.confirmed,
+        status: TransactionStatus.confirmed as const,
+        time: 123456789,
         txParams: {
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
-          nonce: NONCE_MOCK,
+          nonce: String(NONCE_MOCK),
         },
-      } as any;
+      };
       const externalTransactionReceipt = {
         gasUsed: '0x5208',
       };
@@ -2025,17 +2046,17 @@ describe('TransactionController', () => {
       // Off-chain failed local transaction
       const localTransactionIdWithSameNonce = '9';
       controller.state.transactions.push({
-        from: ACCOUNT_MOCK,
-        to: ACCOUNT_2_MOCK,
         id: localTransactionIdWithSameNonce,
         chainId: toHex(5),
-        status: TransactionStatus.failed,
+        status: TransactionStatus.failed as const,
+        error: new Error('mock error'),
+        time: 123456789,
         txParams: {
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
-          nonce: NONCE_MOCK,
+          nonce: String(NONCE_MOCK),
         },
-      } as any);
+      });
 
       await controller.confirmExternalTransaction(
         externalTransactionToConfirm,
@@ -2200,12 +2221,15 @@ describe('TransactionController', () => {
         },
       ];
       controller.state.transactions.push({
-        from: MOCK_PREFERENCES.state.selectedAddress,
         id: 'foo',
         chainId: toHex(5),
-        status: TransactionStatus.submitted,
-        transactionHash: '1337',
-      } as any);
+        hash: '1337',
+        status: TransactionStatus.submitted as const,
+        time: 123456789,
+        txParams: {
+          from: MOCK_PREFERENCES.state.selectedAddress,
+        },
+      });
       expect(() =>
         controller.updateTransactionSendFlowHistory(
           'foo',
@@ -2326,7 +2350,11 @@ describe('TransactionController', () => {
       controller.state.transactions.push({
         id: transactionId,
         status,
-      } as any);
+        error: new Error('mock error'),
+        chainId: '0x1',
+        time: 123456789,
+        txParams: {} as TransactionParams,
+      });
       expect(() =>
         controller.updateTransactionGasFees(transactionId, {
           gasPrice: '0x1',
@@ -2353,13 +2381,18 @@ describe('TransactionController', () => {
 
       controller.state.transactions.push({
         id: transactionId,
-        status: TransactionStatus.unapproved,
-        history: [{}],
+        chainId: '0x1',
+        time: 123456789,
+        status: TransactionStatus.unapproved as const,
+        history: [
+          {} as TransactionMeta,
+          ...([{}] as TransactionHistoryEntry[]),
+        ],
         txParams: {
           from: ACCOUNT_MOCK,
           to: ACCOUNT_2_MOCK,
         },
-      } as any);
+      });
 
       controller.updateTransactionGasFees(transactionId, {
         gas,

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -4,11 +4,11 @@ import type { Operation } from 'fast-json-patch';
 /**
  * Representation of transaction metadata.
  */
-export type TransactionMeta =
-  | ({
-      status: Exclude<TransactionStatus, TransactionStatus.failed>;
-    } & TransactionMetaBase)
-  | ({ status: TransactionStatus.failed; error: Error } & TransactionMetaBase);
+export type TransactionMeta = TransactionMetaBase &
+  (
+    | { status: Exclude<TransactionStatus, TransactionStatus.failed> }
+    | { status: TransactionStatus.failed; error: Error }
+  );
 
 /**
  * Information about a single transaction such as status and block number.


### PR DESCRIPTION
## Explanation

With the Transaction Controller under active development, it's important to ensure that its tests are valid. This PR improves typing in the tests by removing `any` usage and fixing `as` assertions, mainly by enforcing that `TransactionMeta` mock objects correctly conform to the type they're intended to test. 

Typing mock objects as `any` can be convenient for omitting required but non-essential properties, but it also keeps TypeScript from alerting us when objects with invalid shapes are being used for tests. If necessary, type assertions that don't use `any` e.g. `as TransactionMeta` are a much better compromise.

- Fixed test mock object typing:
  - `TransactionMeta` with failed status should contain an error property.
  - `from`, `to` should be located in the `txParams` property (or the mock object typed as `TransactionMeta & { from: Hex; to: Hex }`)
- Removed `any` usage that's become unnecessary (a key problem with `any` is that it doesn't tell you when it's no longer needed, and continues to suppress any changed or new errors).
- Changed `TransactionMeta` definition to equivalent but more readable expression.

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
