### PR TITLE
use network confiurations always

### DIFF
--- a/packages/queued-request-controller/src/QueuedRequestMiddleware.test.ts
+++ b/packages/queued-request-controller/src/QueuedRequestMiddleware.test.ts
@@ -211,8 +211,7 @@ describe('createQueuedRequestMiddleware', () => {
       );
 
       expect(mocks.enqueueRequest).toHaveBeenCalled();
-      // infura networks do not use getNetworkClientById
-      expect(mocks.getNetworkClientById).not.toHaveBeenCalled();
+      expect(mocks.getNetworkClientById).toHaveBeenCalledWith('mainnet');
     });
 
     it('should resolve requests that require confirmations for custom networks', async () => {

--- a/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
+++ b/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
@@ -1,14 +1,6 @@
-import type {
-  AddApprovalRequest,
-  ApprovalRequest,
-} from '@metamask/approval-controller';
+import type { AddApprovalRequest } from '@metamask/approval-controller';
 import type { ControllerMessenger } from '@metamask/base-controller';
-import type { InfuraNetworkType } from '@metamask/controller-utils';
-import {
-  ApprovalType,
-  BUILT_IN_NETWORKS,
-  isNetworkType,
-} from '@metamask/controller-utils';
+import { ApprovalType, isNetworkType } from '@metamask/controller-utils';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
 import type {
@@ -105,16 +97,7 @@ export const createQueuedRequestMiddleware = ({
           }
 
           const isBuiltIn = isNetworkType(networkClientIdForRequest);
-          let networkConfigurationForRequest;
-          if (isBuiltIn) {
-            const builtIn = BUILT_IN_NETWORKS[networkClientIdForRequest];
-            if (builtIn.chainId) {
-              // only the infura provided ones have chainid (rpc doesnt)
-              networkConfigurationForRequest = builtIn;
-            }
-          }
-
-          networkConfigurationForRequest ??= messenger.call(
+          const networkConfigurationForRequest = messenger.call(
             'NetworkController:getNetworkClientById',
             networkClientIdForRequest,
           ).configuration;
@@ -142,7 +125,7 @@ export const createQueuedRequestMiddleware = ({
           };
 
           try {
-            const approvedRequestData = (await messenger.call(
+            await messenger.call(
               'ApprovalController:addRequest',
               {
                 origin,
@@ -150,21 +133,14 @@ export const createQueuedRequestMiddleware = ({
                 requestData,
               },
               true,
-            )) as ApprovalRequest<typeof requestData> & {
-              type: InfuraNetworkType;
-            };
+            );
 
-            if (isBuiltIn) {
-              await messenger.call(
-                'NetworkController:setProviderType',
-                approvedRequestData.type,
-              );
-            } else {
-              await messenger.call(
-                'NetworkController:setActiveNetwork',
-                approvedRequestData.id,
-              );
-            }
+            const method = isBuiltIn ? 'setProviderType' : 'setActiveNetwork';
+
+            await messenger.call(
+              `NetworkController:${method}`,
+              networkClientIdForRequest,
+            );
 
             messenger.call(
               SelectedNetworkControllerActionTypes.setNetworkClientIdForDomain,


### PR DESCRIPTION
## Explanation

ATM the queued request middleware is not receiving the correct info back from the approval controller. Further, it really should not be using the data returned by the approval controller since we already have the required details.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/queued-request-controller`

- **FIXED**: issue where switching chain would ultimately fail due to the wrong networkClientId / type

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
