### PR TITLE
Add persistAllKeyrings action to KeyringController

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2243,6 +2243,19 @@ describe('KeyringController', () => {
         });
       });
     });
+
+    describe('persistAllKeyrings', () => {
+      it('should call persistAllKeyrings', async () => {
+        jest
+          .spyOn(KeyringController.prototype, 'persistAllKeyrings')
+          .mockResolvedValue(true);
+        await withController(async ({ controller, messenger }) => {
+          await messenger.call('KeyringController:persistAllKeyrings');
+
+          expect(controller.persistAllKeyrings).toHaveBeenCalledWith();
+        });
+      });
+    });
   });
 });
 
@@ -2303,6 +2316,7 @@ function buildKeyringControllerMessenger(messenger = buildMessenger()) {
       'KeyringController:getKeyringsByType',
       'KeyringController:getKeyringForAccount',
       'KeyringController:getAccounts',
+      'KeyringController:persistAllKeyrings',
     ],
     allowedEvents: [
       'KeyringController:stateChange',

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -110,6 +110,11 @@ export type KeyringControllerGetAccountsAction = {
   handler: KeyringController['getAccounts'];
 };
 
+export type KeyringControllerPersistAllKeyringsAction = {
+  type: `${typeof name}:persistAllKeyrings`;
+  handler: KeyringController['persistAllKeyrings'];
+};
+
 export type KeyringControllerStateChangeEvent = {
   type: `${typeof name}:stateChange`;
   payload: [KeyringControllerState, Patch[]];
@@ -144,7 +149,8 @@ export type KeyringControllerActions =
   | KeyringControllerGetEncryptionPublicKeyAction
   | KeyringControllerGetAccountsAction
   | KeyringControllerGetKeyringsByTypeAction
-  | KeyringControllerGetKeyringForAccountAction;
+  | KeyringControllerGetKeyringForAccountAction
+  | KeyringControllerPersistAllKeyringsAction;
 
 export type KeyringControllerEvents =
   | KeyringControllerStateChangeEvent
@@ -1042,6 +1048,11 @@ export class KeyringController extends BaseControllerV2<
     this.messagingSystem.registerActionHandler(
       `${name}:getKeyringForAccount`,
       this.getKeyringForAccount.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${name}:persistAllKeyrings`,
+      this.persistAllKeyrings.bind(this),
     );
   }
 


### PR DESCRIPTION
## Explanation

This PR adds the `persistAllKeyrings` action to the KeyringController.

## References

Resolves the action task of 
https://github.com/MetaMask/accounts-planning/issues/139

## Changelog

### `@metamask/keyring-controller`

- **ADDED**: persistAllKeyrings action

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
