### PR TITLE
Moved parseStandardTokenTransactionData call.

### DIFF
--- a/packages/transaction-controller/src/utils/transaction-type.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.ts
@@ -27,7 +27,6 @@ export async function determineTransactionType(
   ethQuery: EthQuery,
 ): Promise<InferTransactionTypeResult> {
   const { data, to } = txParams;
-  const name = parseStandardTokenTransactionData(data)?.name;
 
   if (data && !to) {
     return { type: TransactionType.deployContract, getCodeResponse: undefined };
@@ -42,16 +41,19 @@ export async function determineTransactionType(
 
   const hasValue = txParams.value && Number(txParams.value) !== 0;
 
-  const tokenMethodName = [
-    TransactionType.tokenMethodApprove,
-    TransactionType.tokenMethodSetApprovalForAll,
-    TransactionType.tokenMethodTransfer,
-    TransactionType.tokenMethodTransferFrom,
-    TransactionType.tokenMethodSafeTransferFrom,
-  ].find((methodName) => methodName.toLowerCase() === name?.toLowerCase());
+  const name = parseStandardTokenTransactionData(data)?.name;
+  if (name !== undefined) {
+    const tokenMethodName = [
+      TransactionType.tokenMethodApprove,
+      TransactionType.tokenMethodSetApprovalForAll,
+      TransactionType.tokenMethodTransfer,
+      TransactionType.tokenMethodTransferFrom,
+      TransactionType.tokenMethodSafeTransferFrom,
+    ].find((methodName) => methodName.toLowerCase() === name.toLowerCase());
 
-  if (data && tokenMethodName && !hasValue) {
-    return { type: tokenMethodName, getCodeResponse: resultCode };
+    if (data && tokenMethodName && !hasValue) {
+      return { type: tokenMethodName, getCodeResponse: resultCode };
+    }
   }
 
   return {


### PR DESCRIPTION
## Explanation

Moved the call to parseStandardTokenTransactionData closer to where it gets used and clarified the use of the name variable.

## References

* Fixes #1968

## Changelog

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
