### PR TITLE
Advance time utility function

### DIFF
--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -3,12 +3,12 @@ import {
   ChainId,
   NetworkType,
   NetworksTicker,
-  advanceTime,
 } from '@metamask/controller-utils';
 import type { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
 import nock from 'nock';
 import { useFakeTimers } from 'sinon';
 
+import { advanceTime } from '../../../tests/helpers';
 import type {
   CurrencyRateStateChange,
   GetCurrencyRateState,

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -3,9 +3,11 @@ import {
   ChainId,
   NetworkType,
   NetworksTicker,
+  advanceTime,
 } from '@metamask/controller-utils';
 import type { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
 import nock from 'nock';
+import { useFakeTimers } from 'sinon';
 
 import type {
   CurrencyRateStateChange,
@@ -65,24 +67,15 @@ const getStubbedDate = () => {
   return new Date('2019-04-07T10:20:30Z').getTime();
 };
 
-/**
- * Resolve all pending promises.
- * This method is used for async tests that use fake timers.
- * See https://stackoverflow.com/a/58716087 and https://jestjs.io/docs/timer-mocks.
- */
-function flushPromises(): Promise<unknown> {
-  return new Promise(jest.requireActual('timers').setImmediate);
-}
-
 describe('CurrencyRateController', () => {
+  let clock: sinon.SinonFakeTimers;
   beforeEach(() => {
-    jest.useFakeTimers('legacy');
+    clock = useFakeTimers();
   });
 
   afterEach(() => {
+    clock.restore();
     jest.restoreAllMocks();
-    jest.clearAllTimers();
-    jest.useRealTimers();
   });
 
   it('should set default state', () => {
@@ -134,8 +127,7 @@ describe('CurrencyRateController', () => {
       messenger,
     });
 
-    jest.advanceTimersByTime(200);
-    await flushPromises();
+    await advanceTime({ clock, duration: 200, stepSize: 50 });
 
     expect(fetchExchangeRateStub).not.toHaveBeenCalled();
 
@@ -165,8 +157,7 @@ describe('CurrencyRateController', () => {
     });
 
     controller.startPollingByNetworkClientId('mainnet');
-    jest.advanceTimersByTime(0);
-    await flushPromises();
+    await advanceTime({ clock, duration: 0 });
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
     expect(controller.state.currencyRates).toStrictEqual({
       ETH: {
@@ -175,11 +166,12 @@ describe('CurrencyRateController', () => {
         usdConversionRate: 11,
       },
     });
-    jest.advanceTimersByTime(99);
-    await flushPromises();
+    await advanceTime({ clock, duration: 99, stepSize: 50 });
+
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
-    jest.advanceTimersByTime(1);
-    await flushPromises();
+
+    await advanceTime({ clock, duration: 1 });
+
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(2);
     expect(controller.state.currencyRates).toStrictEqual({
       ETH: {
@@ -202,15 +194,15 @@ describe('CurrencyRateController', () => {
     });
 
     controller.startPollingByNetworkClientId('sepolia');
-    jest.advanceTimersByTime(0);
-    await flushPromises();
+
+    await advanceTime({ clock, duration: 0 });
+
     controller.stopAllPolling();
 
     // called once upon initial start
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
 
-    jest.advanceTimersByTime(150);
-    await flushPromises();
+    await advanceTime({ clock, duration: 150, stepSize: 50 });
 
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
 
@@ -227,21 +219,19 @@ describe('CurrencyRateController', () => {
       messenger,
     });
     controller.startPollingByNetworkClientId('sepolia');
-    jest.advanceTimersByTime(0);
-    await flushPromises();
+    await advanceTime({ clock, duration: 0 });
+
     controller.stopAllPolling();
 
     // called once upon initial start
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
 
     controller.startPollingByNetworkClientId('sepolia');
+    await advanceTime({ clock, duration: 0 });
 
-    jest.advanceTimersByTime(0);
-    await flushPromises();
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(2);
 
-    jest.advanceTimersByTime(100);
-    await flushPromises();
+    await advanceTime({ clock, duration: 100 });
 
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(3);
   });
@@ -366,7 +356,7 @@ describe('CurrencyRateController', () => {
       },
     });
 
-    await flushPromises();
+    await advanceTime({ clock, duration: 0 });
 
     expect(controller.state).toStrictEqual({
       currentCurrency: 'CAD',

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -127,7 +127,7 @@ describe('CurrencyRateController', () => {
       messenger,
     });
 
-    await advanceTime({ clock, duration: 200, stepSize: 50 });
+    await advanceTime({ clock, duration: 200 });
 
     expect(fetchExchangeRateStub).not.toHaveBeenCalled();
 
@@ -166,7 +166,7 @@ describe('CurrencyRateController', () => {
         usdConversionRate: 11,
       },
     });
-    await advanceTime({ clock, duration: 99, stepSize: 50 });
+    await advanceTime({ clock, duration: 99 });
 
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
 

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -1,15 +1,11 @@
 import type { AddApprovalRequest } from '@metamask/approval-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
-import {
-  OPENSEA_PROXY_URL,
-  ChainId,
-  toHex,
-  advanceTime,
-} from '@metamask/controller-utils';
+import { OPENSEA_PROXY_URL, ChainId, toHex } from '@metamask/controller-utils';
 import { PreferencesController } from '@metamask/preferences-controller';
 import nock from 'nock';
 import * as sinon from 'sinon';
 
+import { advanceTime } from '../../../tests/helpers';
 import { AssetsContractController } from './AssetsContractController';
 import type { NftControllerMessenger } from './NftController';
 import { NftController } from './NftController';

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -94,58 +94,6 @@ describe('NftDetectionController', () => {
     preferences.setUseNftDetection(true);
 
     nock(OPENSEA_PROXY_URL)
-      .get(`/assets?owner=0x2&offset=0&limit=50`)
-      .reply(200, {
-        assets: [
-          {
-            asset_contract: {
-              address: '0x1d963688fe2209a98db35c67a041524822cf04ff',
-              schema_name: 'ERC721',
-            },
-            collection: {
-              name: 'Collection 2577',
-              image_url: 'url',
-            },
-            description: 'Description 2577',
-            image_original_url: 'image/2577.png',
-            name: 'ID 2577',
-            token_id: '2577',
-          },
-        ],
-      })
-      .get(`/assets?owner=0x2&offset=50&limit=50`)
-      .reply(200, {
-        assets: [],
-      })
-      .persist();
-
-    nock(OPENSEA_PROXY_URL)
-      .get(`/asset_contract/0x1d963688FE2209A98dB35C67A041524822Cf04ff`)
-      .reply(200, {
-        description: 'Description',
-        image_url: 'url',
-        name: 'Name',
-        symbol: 'FOO',
-        total_supply: 0,
-        collection: {
-          image_url: 'url',
-          name: 'Name',
-        },
-      })
-      .get(`/asset_contract/0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD`)
-      .reply(200, {
-        description: 'Description HH',
-        symbol: 'HH',
-        total_supply: 10,
-        collection: {
-          image_url: 'url HH',
-          name: 'Name HH',
-        },
-      })
-      .get(`/asset_contract/0xCE7ec4B2DfB30eB6c0BB5656D33aAd6BFb4001Fc`)
-      .replyWithError(new Error('Failed to fetch'))
-      .get(`/asset_contract/0x0B0fa4fF58D28A88d63235bd0756EDca69e49e6d`)
-      .replyWithError(new Error('Failed to fetch'))
       .get(`/assets?owner=0x1&offset=0&limit=50`)
       .reply(200, {
         assets: [
@@ -198,7 +146,6 @@ describe('NftDetectionController', () => {
         assets: [],
       })
       .get(`/assets?owner=0x9&offset=0&limit=50`)
-      .delay(800)
       .reply(200, {
         assets: [
           {
@@ -221,6 +168,34 @@ describe('NftDetectionController', () => {
       .reply(200, {
         assets: [],
       });
+
+    nock(OPENSEA_PROXY_URL)
+      .get(`/asset_contract/0x1d963688FE2209A98dB35C67A041524822Cf04ff`)
+      .reply(200, {
+        description: 'Description',
+        image_url: 'url',
+        name: 'Name',
+        symbol: 'FOO',
+        total_supply: 0,
+        collection: {
+          image_url: 'url',
+          name: 'Name',
+        },
+      })
+      .get(`/asset_contract/0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD`)
+      .reply(200, {
+        description: 'Description HH',
+        symbol: 'HH',
+        total_supply: 10,
+        collection: {
+          image_url: 'url HH',
+          name: 'Name HH',
+        },
+      })
+      .get(`/asset_contract/0xCE7ec4B2DfB30eB6c0BB5656D33aAd6BFb4001Fc`)
+      .replyWithError(new Error('Failed to fetch'))
+      .get(`/asset_contract/0x0B0fa4fF58D28A88d63235bd0756EDca69e49e6d`)
+      .replyWithError(new Error('Failed to fetch'));
   });
 
   afterEach(() => {
@@ -483,6 +458,44 @@ describe('NftDetectionController', () => {
   });
 
   it('should not autodetect NFTs that exist in the ignoreList', async () => {
+    nock(OPENSEA_PROXY_URL, {
+      encodedQueryParams: true,
+    })
+      .persist()
+      .get('/assets')
+      .query({
+        owner: '0x2',
+        offset: '0',
+        limit: '50',
+      })
+      .reply(200, {
+        assets: [
+          {
+            asset_contract: {
+              address: '0x1d963688fe2209a98db35c67a041524822cf04ff',
+              schema_name: 'ERC721',
+            },
+            collection: {
+              name: 'Collection 2577',
+              image_url: 'url',
+            },
+            description: 'Description 2577',
+            image_original_url: 'image/2577.png',
+            name: 'ID 2577',
+            token_id: '2577',
+          },
+        ],
+      })
+      .get('/assets')
+      .query({
+        owner: '0x2',
+        offset: '50',
+        limit: '50',
+      })
+      .reply(200, {
+        assets: [],
+      });
+
     const selectedAddress = '0x2';
     nftDetection.configure({
       chainId: ChainId.mainnet,

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -259,13 +259,11 @@ describe('NftDetectionController', () => {
     await advanceTime({
       clock,
       duration: 0,
-      stepSize: 5,
     });
     expect(mockNfts.calledOnce).toBe(true);
     await advanceTime({
       clock,
       duration: 10,
-      stepSize: 5,
     });
     expect(mockNfts.calledTwice).toBe(true);
   });
@@ -304,21 +302,19 @@ describe('NftDetectionController', () => {
       address: '0x1',
     });
 
-    await advanceTime({ clock, duration: 0, stepSize: 5000 });
+    await advanceTime({ clock, duration: 0 });
     expect(spy.mock.calls).toHaveLength(1);
     await advanceTime({
       clock,
       duration: DEFAULT_INTERVAL / 2,
-      stepSize: 5000,
     });
     expect(spy.mock.calls).toHaveLength(1);
     await advanceTime({
       clock,
       duration: DEFAULT_INTERVAL / 2,
-      stepSize: 5000,
     });
     expect(spy.mock.calls).toHaveLength(2);
-    await advanceTime({ clock, duration: DEFAULT_INTERVAL, stepSize: 5000 });
+    await advanceTime({ clock, duration: DEFAULT_INTERVAL });
     expect(spy.mock.calls).toMatchObject([
       ['mainnet', '0x1'],
       ['mainnet', '0x1'],
@@ -536,7 +532,7 @@ describe('NftDetectionController', () => {
     nftDetection.detectNfts();
     nftDetection.configure({ selectedAddress: '0x12' });
     nftController.configure({ selectedAddress: '0x12' });
-    await advanceTime({ clock, duration: 1000, stepSize: 500 });
+    await advanceTime({ clock, duration: 1000 });
     expect(nftDetection.config.selectedAddress).toBe('0x12');
 
     expect(

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -1,11 +1,12 @@
 import { ControllerMessenger } from '@metamask/base-controller';
-import { advanceTime, toHex } from '@metamask/controller-utils';
+import { toHex } from '@metamask/controller-utils';
 import type { NetworkControllerMessenger } from '@metamask/network-controller';
 import { NetworkController } from '@metamask/network-controller';
 import { PreferencesController } from '@metamask/preferences-controller';
 import { BN } from 'ethereumjs-util';
 import * as sinon from 'sinon';
 
+import { advanceTime } from '../../../tests/helpers';
 import { AssetsContractController } from './AssetsContractController';
 import {
   BN as exportedBn,

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -1,5 +1,5 @@
 import { ControllerMessenger } from '@metamask/base-controller';
-import { toHex } from '@metamask/controller-utils';
+import { advanceTime, toHex } from '@metamask/controller-utils';
 import type { NetworkControllerMessenger } from '@metamask/network-controller';
 import { NetworkController } from '@metamask/network-controller';
 import { PreferencesController } from '@metamask/preferences-controller';
@@ -24,6 +24,7 @@ const stubCreateEthers = (ctrl: TokensController, res: boolean) => {
 };
 
 describe('TokenBalancesController', () => {
+  let clock: sinon.SinonFakeTimers;
   const getToken = (
     tokenBalances: TokenBalancesController,
     address: string,
@@ -31,8 +32,12 @@ describe('TokenBalancesController', () => {
     const { tokens } = tokenBalances.config;
     return tokens.find((token) => token.address === address);
   };
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+  });
 
   afterEach(() => {
+    clock.restore();
     sinon.restore();
   });
 
@@ -62,26 +67,23 @@ describe('TokenBalancesController', () => {
   });
 
   it('should poll and update balances in the right interval', async () => {
-    await new Promise<void>((resolve) => {
-      const mock = sinon.stub(
-        TokenBalancesController.prototype,
-        'updateBalances',
-      );
-      new TokenBalancesController(
-        {
-          onTokensStateChange: sinon.stub(),
-          getSelectedAddress: () => '0x1234',
-          getERC20BalanceOf: sinon.stub(),
-        },
-        { interval: 10 },
-      );
-      expect(mock.called).toBe(true);
-      expect(mock.calledTwice).toBe(false);
-      setTimeout(() => {
-        expect(mock.calledTwice).toBe(true);
-        resolve();
-      }, 15);
-    });
+    const mock = sinon.stub(
+      TokenBalancesController.prototype,
+      'updateBalances',
+    );
+    new TokenBalancesController(
+      {
+        onTokensStateChange: sinon.stub(),
+        getSelectedAddress: () => '0x1234',
+        getERC20BalanceOf: sinon.stub(),
+      },
+      { interval: 10 },
+    );
+    expect(mock.called).toBe(true);
+    expect(mock.calledTwice).toBe(false);
+
+    await advanceTime({ clock, duration: 15 });
+    expect(mock.calledTwice).toBe(true);
   });
 
   it('should not update rates if disabled', async () => {
@@ -111,13 +113,9 @@ describe('TokenBalancesController', () => {
       },
       { interval: 1337 },
     );
-    await new Promise<void>((resolve) => {
-      setTimeout(() => {
-        tokenBalances.poll(1338);
-        expect(mock.called).toBe(true);
-        resolve();
-      }, 100);
-    });
+    await tokenBalances.poll(1338);
+    await advanceTime({ clock, duration: 1339 });
+    expect(mock.called).toBe(true);
   });
 
   const setupControllers = () => {

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -3,6 +3,7 @@ import {
   ChainId,
   NetworkType,
   NetworksTicker,
+  advanceTime,
   convertHexToDecimal,
   toHex,
 } from '@metamask/controller-utils';
@@ -121,10 +122,6 @@ const setupTokenListController = (
   });
 
   return { tokenList, tokenListMessenger };
-};
-
-const flushPromises = () => {
-  return new Promise(jest.requireActual('timers').setImmediate);
 };
 
 describe('TokenDetectionController', () => {
@@ -597,8 +594,16 @@ describe('TokenDetectionController', () => {
   });
 
   describe('startPollingByNetworkClientId', () => {
+    let clock: sinon.SinonFakeTimers;
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
     it('should call detect tokens with networkClientId and address params', async () => {
-      jest.useFakeTimers();
       const spy = jest
         .spyOn(tokenDetection, 'detectTokens')
         .mockImplementation(() => {
@@ -613,17 +618,23 @@ describe('TokenDetectionController', () => {
       tokenDetection.startPollingByNetworkClientId('goerli', {
         address: '0x3',
       });
-      await Promise.all([
-        jest.advanceTimersByTime(DEFAULT_INTERVAL),
-        flushPromises(),
-      ]);
+
+      await advanceTime({ clock, duration: 0 });
       expect(spy.mock.calls).toMatchObject([
         [{ networkClientId: 'mainnet', accountAddress: '0x1' }],
         [{ networkClientId: 'sepolia', accountAddress: '0xdeadbeef' }],
         [{ networkClientId: 'goerli', accountAddress: '0x3' }],
       ]);
+      await advanceTime({ clock, duration: DEFAULT_INTERVAL });
+      expect(spy.mock.calls).toMatchObject([
+        [{ networkClientId: 'mainnet', accountAddress: '0x1' }],
+        [{ networkClientId: 'sepolia', accountAddress: '0xdeadbeef' }],
+        [{ networkClientId: 'goerli', accountAddress: '0x3' }],
+        [{ networkClientId: 'mainnet', accountAddress: '0x1' }],
+        [{ networkClientId: 'sepolia', accountAddress: '0xdeadbeef' }],
+        [{ networkClientId: 'goerli', accountAddress: '0x3' }],
+      ]);
       tokenDetection.stopAllPolling();
-      jest.useRealTimers();
       spy.mockRestore();
     });
   });

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -3,7 +3,6 @@ import {
   ChainId,
   NetworkType,
   NetworksTicker,
-  advanceTime,
   convertHexToDecimal,
   toHex,
 } from '@metamask/controller-utils';
@@ -18,6 +17,7 @@ import { BN } from 'ethereumjs-util';
 import nock from 'nock';
 import * as sinon from 'sinon';
 
+import { advanceTime } from '../../../tests/helpers';
 import type { AssetsContractController } from './AssetsContractController';
 import {
   formatAggregatorNames,

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -131,6 +131,7 @@ export class TokenDetectionController extends PollingControllerV1<
     };
 
     this.initialize();
+    this.setIntervalLength(this.config.interval);
     this.getTokensState = getTokensState;
     this.getTokenListState = getTokenListState;
     this.addDetectedTokens = addDetectedTokens;

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -3,7 +3,6 @@ import {
   ChainId,
   NetworkType,
   NetworksTicker,
-  advanceTime,
   convertHexToDecimal,
   toHex,
 } from '@metamask/controller-utils';
@@ -17,6 +16,7 @@ import { NetworkStatus } from '@metamask/network-controller';
 import nock from 'nock';
 import * as sinon from 'sinon';
 
+import { advanceTime } from '../../../tests/helpers';
 import * as tokenService from './token-service';
 import type {
   TokenListStateChange,

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -1293,7 +1293,7 @@ describe('TokenListController', () => {
 
   describe('startPollingByNetworkClient', () => {
     let clock: sinon.SinonFakeTimers;
-    const pollingIntervalTime = 1000
+    const pollingIntervalTime = 1000;
     beforeEach(() => {
       clock = sinon.useFakeTimers();
     });
@@ -1460,7 +1460,6 @@ describe('TokenListController', () => {
       // start polling for binance
       controller.startPollingByNetworkClientId('binance-network-client-id');
       await advanceTime({ clock, duration: pollingIntervalTime });
-
 
       // expect fetchTokenListByChain to be called for binance, but not for sepolia
       // because the cache for the recently fetched sepolia token list is still valid

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -3,6 +3,7 @@ import {
   ChainId,
   NetworkType,
   NetworksTicker,
+  advanceTime,
   convertHexToDecimal,
   toHex,
 } from '@metamask/controller-utils';
@@ -27,10 +28,6 @@ import { TokenListController } from './TokenListController';
 
 const name = 'TokenListController';
 const timestamp = Date.now();
-
-const flushPromises = () => {
-  return new Promise(jest.requireActual('timers').setImmediate);
-};
 
 const sampleMainnetTokenList = [
   {
@@ -1295,8 +1292,17 @@ describe('TokenListController', () => {
   });
 
   describe('startPollingByNetworkClient', () => {
+    let clock: sinon.SinonFakeTimers;
+    const pollingIntervalTime = 1000
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
     it('should call fetchTokenListByChainId with the correct chainId', async () => {
-      jest.useFakeTimers();
       nock(tokenService.TOKEN_END_POINT_API)
         .get(`/tokens/${convertHexToDecimal(ChainId.sepolia)}`)
         .reply(200, sampleSepoliaTokenList)
@@ -1316,7 +1322,6 @@ describe('TokenListController', () => {
           },
         }),
       );
-      const pollingIntervalTime = 1000;
       const messenger = getRestrictedMessenger(controllerMessenger);
       const controller = new TokenListController({
         chainId: ChainId.mainnet,
@@ -1330,16 +1335,14 @@ describe('TokenListController', () => {
       );
 
       controller.startPollingByNetworkClientId('sepolia');
-      jest.advanceTimersByTime(pollingIntervalTime);
-      await flushPromises();
+      await advanceTime({ clock, duration: 0 });
 
       expect(fetchTokenListByChainIdSpy.mock.calls[0]).toStrictEqual(
         expect.arrayContaining([ChainId.sepolia]),
       );
     });
+
     it('should start polling against the token list API at the interval passed to the constructor', async () => {
-      jest.useFakeTimers();
-      const pollingIntervalTime = 1000;
       const fetchTokenListByChainIdSpy = jest.spyOn(
         tokenService,
         'fetchTokenListByChainId',
@@ -1368,32 +1371,21 @@ describe('TokenListController', () => {
       );
 
       controller.startPollingByNetworkClientId('goerli');
-      jest.advanceTimersByTime(0);
-      await flushPromises();
+      await advanceTime({ clock, duration: 0 });
+
       expect(fetchTokenListByChainIdSpy).toHaveBeenCalledTimes(1);
-      await Promise.all([
-        jest.advanceTimersByTime(pollingIntervalTime / 2),
-        flushPromises(),
-      ]);
+      await advanceTime({ clock, duration: pollingIntervalTime / 2 });
+
       expect(fetchTokenListByChainIdSpy).toHaveBeenCalledTimes(1);
-      await Promise.all([
-        jest.advanceTimersByTime(pollingIntervalTime / 2),
-        jest.runOnlyPendingTimers(),
-        flushPromises(),
-      ]);
+      await advanceTime({ clock, duration: pollingIntervalTime / 2 });
 
       expect(fetchTokenListByChainIdSpy).toHaveBeenCalledTimes(2);
-      await Promise.all([
-        jest.advanceTimersByTime(pollingIntervalTime),
-        flushPromises(),
-      ]);
+      await advanceTime({ clock, duration: pollingIntervalTime });
 
-      await Promise.all([jest.runOnlyPendingTimers(), flushPromises()]);
       expect(fetchTokenListByChainIdSpy).toHaveBeenCalledTimes(3);
     });
 
     it('should update tokenList state and tokensChainsCache', async () => {
-      jest.useFakeTimers();
       const startingState: TokenListState = {
         tokenList: {},
         tokensChainsCache: {},
@@ -1436,7 +1428,6 @@ describe('TokenListController', () => {
           }
         }),
       );
-      const pollingIntervalTime = 1000;
       const messenger = getRestrictedMessenger(controllerMessenger);
       const controller = new TokenListController({
         chainId: ChainId.mainnet,
@@ -1451,8 +1442,7 @@ describe('TokenListController', () => {
       // start polling for sepolia
       const pollingToken = controller.startPollingByNetworkClientId('sepolia');
       // wait a polling interval
-      jest.advanceTimersByTime(pollingIntervalTime);
-      await flushPromises();
+      await advanceTime({ clock, duration: pollingIntervalTime });
 
       expect(fetchTokenListByChainIdSpy).toHaveBeenCalledTimes(1);
       // expect the state to be updated with the sepolia token list
@@ -1469,8 +1459,8 @@ describe('TokenListController', () => {
 
       // start polling for binance
       controller.startPollingByNetworkClientId('binance-network-client-id');
-      jest.advanceTimersByTime(pollingIntervalTime);
-      await flushPromises();
+      await advanceTime({ clock, duration: pollingIntervalTime });
+
 
       // expect fetchTokenListByChain to be called for binance, but not for sepolia
       // because the cache for the recently fetched sepolia token list is still valid

--- a/packages/assets-controllers/tsconfig.json
+++ b/packages/assets-controllers/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.packages.json",
   "compilerOptions": {
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "../.."
   },
   "references": [
     { "path": "../approval-controller" },
@@ -11,5 +12,5 @@
     { "path": "../preferences-controller" },
     { "path": "../polling-controller" }
   ],
-  "include": ["../../types", "./src"]
+  "include": ["../../types", "./src", "../../tests"]
 }

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -568,11 +568,11 @@ export async function advanceTime({
   duration: number;
   stepSize?: number;
 }): Promise<void> {
-  stepSize ??= duration / 4 ?? 1;
+  // if stepSize is not provided, default to 1/4 of the duration
+  stepSize ??= duration / 4;
   do {
-    const amountToTick = duration < stepSize ? duration : stepSize;
-    await clock.tickAsync(amountToTick);
+    await clock.tickAsync(stepSize);
     await flushPromises();
-    duration -= amountToTick;
+    duration -= stepSize;
   } while (duration > 0);
 }

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -539,4 +539,3 @@ function logOrRethrowError(error: any, codesToCatch: number[] = []) {
     throw error;
   }
 }
-

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -540,6 +540,11 @@ function logOrRethrowError(error: any, codesToCatch: number[] = []) {
   }
 }
 
+/**
+ * Resolve all pending promises.
+ * This method is used for async tests that use fake timers.
+ * See https://stackoverflow.com/a/58716087 and https://jestjs.io/docs/timer-mocks.
+ */
 const flushPromises = () => {
   return new Promise(jest.requireActual('timers').setImmediate);
 };
@@ -557,12 +562,13 @@ const flushPromises = () => {
 export async function advanceTime({
   clock,
   duration,
-  stepSize = 1,
+  stepSize,
 }: {
   clock: sinon.SinonFakeTimers;
   duration: number;
   stepSize?: number;
 }): Promise<void> {
+  stepSize ??= duration / 4 ?? 1;
   do {
     const amountToTick = duration < stepSize ? duration : stepSize;
     await clock.tickAsync(amountToTick);

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -540,38 +540,3 @@ function logOrRethrowError(error: any, codesToCatch: number[] = []) {
   }
 }
 
-/**
- * Resolve all pending promises.
- * This method is used for async tests that use fake timers.
- * See https://stackoverflow.com/a/58716087 and https://jestjs.io/docs/timer-mocks.
- */
-const flushPromises = () => {
-  return new Promise(jest.requireActual('timers').setImmediate);
-};
-
-/**
- * Advances the provided fake timer by a specified duration in incremental steps.
- * Between each step, any enqueued promises are processed. This function is especially
- * useful for ensuring that chained promises and timers are fully processed within tests.
- * @param options - The options object.
- * @param options.clock - The Sinon fake timer instance used to manipulate time in tests.
- * @param options.duration - The total amount of time (in milliseconds) to advance the timer by.
- * @param options.stepSize - The incremental step size (in milliseconds) by which the timer is advanced in each iteration. Default is 2000ms.
- */
-export async function advanceTime({
-  clock,
-  duration,
-  stepSize,
-}: {
-  clock: sinon.SinonFakeTimers;
-  duration: number;
-  stepSize?: number;
-}): Promise<void> {
-  // if stepSize is not provided, default to 1/4 of the duration
-  stepSize ??= duration / 4;
-  do {
-    await clock.tickAsync(stepSize);
-    await flushPromises();
-    duration -= stepSize;
-  } while (duration > 0);
-}

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -552,8 +552,7 @@ const flushPromises = () => {
 /**
  * Advances the provided fake timer by a specified duration in incremental steps.
  * Between each step, any enqueued promises are processed. This function is especially
- * useful for ensuring that chained promises and timers are fully processed within
- * tests.
+ * useful for ensuring that chained promises and timers are fully processed within tests.
  * @param options - The options object.
  * @param options.clock - The Sinon fake timer instance used to manipulate time in tests.
  * @param options.duration - The total amount of time (in milliseconds) to advance the timer by.

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -43,6 +43,7 @@
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
+    "sinon": "^9.2.4",
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",

--- a/packages/polling-controller/src/PollingController.test.ts
+++ b/packages/polling-controller/src/PollingController.test.ts
@@ -1,4 +1,6 @@
 import { ControllerMessenger } from '@metamask/base-controller';
+import { advanceTime } from '@metamask/controller-utils';
+import { useFakeTimers } from 'sinon';
 
 import { PollingController, PollingControllerOnly } from './PollingController';
 
@@ -12,11 +14,36 @@ const createExecutePollMock = () => {
 };
 
 describe('PollingController', () => {
+  let clock: sinon.SinonFakeTimers;
+  beforeEach(() => {
+    clock = useFakeTimers();
+  });
+  afterEach(() => {
+    clock.restore();
+  });
   describe('start', () => {
     it('should start polling if not polling', async () => {
-      jest.useFakeTimers();
-
       class MyGasFeeController extends PollingController<any, any, any> {
+        constructor({
+          messenger,
+          metadata,
+          name,
+          state,
+        }: {
+          messenger: ControllerMessenger<any, any>;
+          metadata: any;
+          name: string;
+          state: any;
+        }) {
+          super({
+            messenger,
+            metadata,
+            name,
+            state,
+          });
+          this.setIntervalLength(TICK_TIME);
+        }
+
         _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();
@@ -28,17 +55,15 @@ describe('PollingController', () => {
         state: { foo: 'bar' },
       });
       controller.startPollingByNetworkClientId('mainnet');
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
       expect(controller._executePoll).toHaveBeenCalledTimes(1);
-      jest.advanceTimersByTime(TICK_TIME);
-      controller.stopAllPolling();
-      expect(controller._executePoll).toHaveBeenCalledTimes(2);
+      // await advanceTime({ clock, duration: TICK_TIME });
+      // expect(controller._executePoll).toHaveBeenCalledTimes(2);
+      // controller.stopAllPolling();
     });
   });
   describe('stop', () => {
     it('should stop polling when called with a valid polling that was the only active pollingToken for a given networkClient', async () => {
-      jest.useFakeTimers();
       class MyGasFeeController extends PollingController<any, any, any> {
         _executePoll = createExecutePollMock();
       }
@@ -51,17 +76,15 @@ describe('PollingController', () => {
         state: { foo: 'bar' },
       });
       const pollingToken = controller.startPollingByNetworkClientId('mainnet');
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
       expect(controller._executePoll).toHaveBeenCalledTimes(1);
-      jest.advanceTimersByTime(TICK_TIME);
+      await advanceTime({ clock, duration: TICK_TIME });
       controller.stopPollingByPollingToken(pollingToken);
-      jest.advanceTimersByTime(TICK_TIME);
+      await advanceTime({ clock, duration: TICK_TIME });
       expect(controller._executePoll).toHaveBeenCalledTimes(2);
       controller.stopAllPolling();
     });
     it('should not stop polling if called with one of multiple active polling tokens for a given networkClient', async () => {
-      jest.useFakeTimers();
       class MyGasFeeController extends PollingController<any, any, any> {
         _executePoll = createExecutePollMock();
       }
@@ -74,20 +97,17 @@ describe('PollingController', () => {
         state: { foo: 'bar' },
       });
       const pollingToken1 = controller.startPollingByNetworkClientId('mainnet');
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
+
       controller.startPollingByNetworkClientId('mainnet');
       expect(controller._executePoll).toHaveBeenCalledTimes(1);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME });
       controller.stopPollingByPollingToken(pollingToken1);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME });
       expect(controller._executePoll).toHaveBeenCalledTimes(3);
       controller.stopAllPolling();
     });
     it('should error if no pollingToken is passed', () => {
-      jest.useFakeTimers();
       class MyGasFeeController extends PollingController<any, any, any> {
         _executePoll = createExecutePollMock();
       }
@@ -106,7 +126,6 @@ describe('PollingController', () => {
       controller.stopAllPolling();
     });
     it('should error if no matching pollingToken is found', () => {
-      jest.useFakeTimers();
       class MyGasFeeController extends PollingController<any, any, any> {
         _executePoll = createExecutePollMock();
       }
@@ -127,8 +146,6 @@ describe('PollingController', () => {
   });
   describe('startPollingByNetworkClientId', () => {
     it('should call _executePoll immediately and on interval if polling', async () => {
-      jest.useFakeTimers();
-
       class MyGasFeeController extends PollingController<any, any, any> {
         _executePoll = createExecutePollMock();
       }
@@ -141,18 +158,12 @@ describe('PollingController', () => {
         state: { foo: 'bar' },
       });
       controller.startPollingByNetworkClientId('mainnet');
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
       expect(controller._executePoll).toHaveBeenCalledTimes(1);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME * 2 });
       expect(controller._executePoll).toHaveBeenCalledTimes(3);
     });
     it('should call _executePoll immediately once and continue calling _executePoll on interval when start is called again with the same networkClientId', async () => {
-      jest.useFakeTimers();
-
       class MyGasFeeController extends PollingController<any, any, any> {
         _executePoll = createExecutePollMock();
       }
@@ -165,21 +176,18 @@ describe('PollingController', () => {
         state: { foo: 'bar' },
       });
       controller.startPollingByNetworkClientId('mainnet');
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
+
       controller.startPollingByNetworkClientId('mainnet');
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
+
       expect(controller._executePoll).toHaveBeenCalledTimes(1);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME * 2 });
+
       expect(controller._executePoll).toHaveBeenCalledTimes(3);
       controller.stopAllPolling();
     });
     it('should publish "pollingComplete" when stop is called', async () => {
-      jest.useFakeTimers();
       const pollingComplete: any = jest.fn();
       class MyGasFeeController extends PollingController<any, any, any> {
         _executePoll = createExecutePollMock();
@@ -200,8 +208,6 @@ describe('PollingController', () => {
       expect(pollingComplete).toHaveBeenCalledTimes(1);
     });
     it('should poll at the interval length when set via setIntervalLength', async () => {
-      jest.useFakeTimers();
-
       class MyGasFeeController extends PollingController<any, any, any> {
         _executePoll = createExecutePollMock();
       }
@@ -215,19 +221,16 @@ describe('PollingController', () => {
       });
       controller.setIntervalLength(TICK_TIME);
       controller.startPollingByNetworkClientId('mainnet');
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
       expect(controller._executePoll).toHaveBeenCalledTimes(1);
-      jest.advanceTimersByTime(TICK_TIME / 2);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME / 2 });
+
       expect(controller._executePoll).toHaveBeenCalledTimes(1);
-      jest.advanceTimersByTime(TICK_TIME / 2);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME / 2 });
+
       expect(controller._executePoll).toHaveBeenCalledTimes(2);
     });
     it('should start and stop polling sessions for different networkClientIds with the same options', async () => {
-      jest.useFakeTimers();
-
       class MyGasFeeController extends PollingController<any, any, any> {
         _executePoll = createExecutePollMock();
       }
@@ -243,18 +246,18 @@ describe('PollingController', () => {
         address: '0x1',
       });
       controller.startPollingByNetworkClientId('mainnet', { address: '0x2' });
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
+
       controller.startPollingByNetworkClientId('sepolia', { address: '0x2' });
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
+
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', { address: '0x1' }],
         ['mainnet', { address: '0x2' }],
         ['sepolia', { address: '0x2' }],
       ]);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME });
+
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', { address: '0x1' }],
         ['mainnet', { address: '0x2' }],
@@ -264,8 +267,8 @@ describe('PollingController', () => {
         ['sepolia', { address: '0x2' }],
       ]);
       controller.stopPollingByPollingToken(pollToken1);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME });
+
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', { address: '0x1' }],
         ['mainnet', { address: '0x2' }],
@@ -280,7 +283,6 @@ describe('PollingController', () => {
   });
   describe('multiple networkClientIds', () => {
     it('should poll for each networkClientId', async () => {
-      jest.useFakeTimers();
       class MyGasFeeController extends PollingController<any, any, any> {
         _executePoll = createExecutePollMock();
       }
@@ -293,25 +295,25 @@ describe('PollingController', () => {
         state: { foo: 'bar' },
       });
       controller.startPollingByNetworkClientId('mainnet');
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
+
       controller.startPollingByNetworkClientId('rinkeby');
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
+
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['rinkeby', {}],
       ]);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME });
+
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['rinkeby', {}],
         ['mainnet', {}],
         ['rinkeby', {}],
       ]);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME });
+
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['rinkeby', {}],
@@ -324,8 +326,6 @@ describe('PollingController', () => {
     });
 
     it('should poll multiple networkClientIds when setting interval length', async () => {
-      jest.useFakeTimers();
-
       class MyGasFeeController extends PollingController<any, any, any> {
         _executePoll = createExecutePollMock();
       }
@@ -339,46 +339,46 @@ describe('PollingController', () => {
       });
       controller.setIntervalLength(TICK_TIME * 2);
       controller.startPollingByNetworkClientId('mainnet');
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
+
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
       ]);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME });
+
       controller.startPollingByNetworkClientId('sepolia');
-      jest.advanceTimersByTime(0);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: 0 });
+
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['sepolia', {}],
       ]);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME });
+
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['sepolia', {}],
         ['mainnet', {}],
       ]);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
-      expect(controller._executePoll.mock.calls).toMatchObject([
-        ['mainnet', {}],
-        ['sepolia', {}],
-        ['mainnet', {}],
-        ['sepolia', {}],
-      ]);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME });
+
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['sepolia', {}],
         ['mainnet', {}],
         ['sepolia', {}],
+      ]);
+      await advanceTime({ clock, duration: TICK_TIME });
+
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}],
+        ['sepolia', {}],
+        ['mainnet', {}],
+        ['sepolia', {}],
         ['mainnet', {}],
       ]);
-      jest.advanceTimersByTime(TICK_TIME);
-      await Promise.resolve();
+      await advanceTime({ clock, duration: TICK_TIME });
+
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
         ['sepolia', {}],

--- a/packages/polling-controller/src/PollingController.test.ts
+++ b/packages/polling-controller/src/PollingController.test.ts
@@ -24,26 +24,6 @@ describe('PollingController', () => {
   describe('start', () => {
     it('should start polling if not polling', async () => {
       class MyGasFeeController extends PollingController<any, any, any> {
-        constructor({
-          messenger,
-          metadata,
-          name,
-          state,
-        }: {
-          messenger: ControllerMessenger<any, any>;
-          metadata: any;
-          name: string;
-          state: any;
-        }) {
-          super({
-            messenger,
-            metadata,
-            name,
-            state,
-          });
-          this.setIntervalLength(TICK_TIME);
-        }
-
         _executePoll = createExecutePollMock();
       }
       const mockMessenger = new ControllerMessenger<any, any>();

--- a/packages/polling-controller/src/PollingController.test.ts
+++ b/packages/polling-controller/src/PollingController.test.ts
@@ -57,9 +57,9 @@ describe('PollingController', () => {
       controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
       expect(controller._executePoll).toHaveBeenCalledTimes(1);
-      // await advanceTime({ clock, duration: TICK_TIME });
-      // expect(controller._executePoll).toHaveBeenCalledTimes(2);
-      // controller.stopAllPolling();
+      await advanceTime({ clock, duration: TICK_TIME });
+      expect(controller._executePoll).toHaveBeenCalledTimes(2);
+      controller.stopAllPolling();
     });
   });
   describe('stop', () => {

--- a/packages/polling-controller/src/PollingController.test.ts
+++ b/packages/polling-controller/src/PollingController.test.ts
@@ -1,7 +1,7 @@
 import { ControllerMessenger } from '@metamask/base-controller';
-import { advanceTime } from '@metamask/controller-utils';
 import { useFakeTimers } from 'sinon';
 
+import { advanceTime } from '../../../tests/helpers';
 import { PollingController, PollingControllerOnly } from './PollingController';
 
 const TICK_TIME = 1000;

--- a/packages/polling-controller/tsconfig.json
+++ b/packages/polling-controller/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "extends": "../../tsconfig.packages.json",
   "compilerOptions": {
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": ",../.."
   },
   "references": [
     { "path": "../base-controller" },
     { "path": "../controller-utils" },
     { "path": "../network-controller" }
   ],
-  "include": ["../../types", "./src"]
+  "include": ["../../types", "./src", "../../tests"]
 }

--- a/packages/polling-controller/tsconfig.json
+++ b/packages/polling-controller/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.packages.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "rootDir": ",../.."
+    "rootDir": "../.."
   },
   "references": [
     { "path": "../base-controller" },

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolve all pending promises.
+ * This method is used for async tests that use fake timers.
+ * See https://stackoverflow.com/a/58716087 and https://jestjs.io/docs/timer-mocks.
+ */
+const flushPromises = () => {
+  return new Promise(jest.requireActual('timers').setImmediate);
+};
+
+/**
+ * Advances the provided fake timer by a specified duration in incremental steps.
+ * Between each step, any enqueued promises are processed. This function is especially
+ * useful for ensuring that chained promises and timers are fully processed within tests.
+ * @param options - The options object.
+ * @param options.clock - The Sinon fake timer instance used to manipulate time in tests.
+ * @param options.duration - The total amount of time (in milliseconds) to advance the timer by.
+ * @param options.stepSize - The incremental step size (in milliseconds) by which the timer is advanced in each iteration. Default is 2000ms.
+ */
+export async function advanceTime({
+  clock,
+  duration,
+  stepSize,
+}: {
+  clock: sinon.SinonFakeTimers;
+  duration: number;
+  stepSize?: number;
+}): Promise<void> {
+  // if stepSize is not provided, default to 1/4 of the duration
+  stepSize ??= duration / 4;
+  do {
+    await clock.tickAsync(stepSize);
+    await flushPromises();
+    duration -= stepSize;
+  } while (duration > 0);
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -9,24 +9,25 @@ const flushPromises = () => {
 
 /**
  * Advances the provided fake timer by a specified duration in incremental steps.
- * Between each step, any enqueued promises are processed. This function is especially
- * useful for ensuring that chained promises and timers are fully processed within tests.
+ * Between each step, any enqueued promises are processed. Fake timers in testing libraries
+ * allow simulation of time without actually waiting. However, they don't always account for
+ * promises or other asynchronous operations that may get enqueued during the timer's duration.
+ * By advancing time in incremental steps and flushing promises between each step,
+ * this function ensures that both timers and promises are comprehensively processed.
  * @param options - The options object.
  * @param options.clock - The Sinon fake timer instance used to manipulate time in tests.
  * @param options.duration - The total amount of time (in milliseconds) to advance the timer by.
- * @param options.stepSize - The incremental step size (in milliseconds) by which the timer is advanced in each iteration. Default is 2000ms.
+ * @param options.stepSize - The incremental step size (in milliseconds) by which the timer is advanced in each iteration. Default is 1/4 of the duration.
  */
 export async function advanceTime({
   clock,
   duration,
-  stepSize,
+  stepSize = duration / 4,
 }: {
   clock: sinon.SinonFakeTimers;
   duration: number;
   stepSize?: number;
 }): Promise<void> {
-  // if stepSize is not provided, default to 1/4 of the duration
-  stepSize ??= duration / 4;
   do {
     await clock.tickAsync(stepSize);
     await flushPromises();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,6 +2183,7 @@ __metadata:
     deepmerge: ^4.2.2
     fast-json-stable-stringify: ^2.1.0
     jest: ^27.5.1
+    sinon: ^9.2.4
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0


### PR DESCRIPTION
This PR introduces an `advanceTime` utility function to @metamask/controller-utils for unifying our testing patterns when using fake timers with controllers that execute asynchronous code in setTimeout/setInterval loops (controllers that poll) and ensuring that chained promises and timers are comprehensively processed within tests.

This new function and pattern is added to the test suites for the following controllers:
- `PollingController`,
- `CurrencyRateController`
- `NFTDetectionController`,
- `TokenListController`
- `TokenDetectionController`

Changelog Entry:

## @metamask/assets-controllers

### Fixed
- Fixes issue where interval was not getting set on the TokenDetectionController for the PollingController mixin.
