### PR TITLE
For creating patch: Add method for adding params to transaction meta

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -3,9 +3,8 @@
  * https://jestjs.io/docs/configuration
  */
 
-const merge = require('deepmerge');
 const path = require('path');
-
+const merge = require('deepmerge');
 const baseConfig = require('../../jest.config.packages');
 
 const displayName = path.basename(__dirname);
@@ -17,10 +16,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 89.11,
-      functions: 94.76,
-      lines: 98.56,
-      statements: 98.58,
+      branches: 80.78,
+      functions: 98.86,
+      lines: 95.79,
+      statements: 95.97,
     },
   },
 

--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -3,8 +3,9 @@
  * https://jestjs.io/docs/configuration
  */
 
-const path = require('path');
 const merge = require('deepmerge');
+const path = require('path');
+
 const baseConfig = require('../../jest.config.packages');
 
 const displayName = path.basename(__dirname);
@@ -16,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 80.78,
-      functions: 98.86,
-      lines: 95.79,
-      statements: 95.97,
+      branches: 89.11,
+      functions: 94.76,
+      lines: 98.56,
+      statements: 98.58,
     },
   },
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -818,6 +818,25 @@ export class TransactionController extends BaseController<
   }
 
   /**
+   * Add params to transactionMeta.
+   *
+   * @param transactionMetaId - ID of the transaction.
+   * @param params - New params to be added to tarnsaction meta.
+   */
+  addTransactionMetaParams(
+    transactionMetaId: string,
+    params: Record<string, any>,
+  ) {
+    const { transactions } = this.state;
+    const index = this.state.transactions.findIndex(
+      ({ id }) => id === transactionMetaId,
+    );
+    const transactionMeta = transactions[index];
+    transactions[index] = { ...transactionMeta, ...params };
+    this.update({ transactions: this.trimTransactionsForState(transactions) });
+  }
+
+  /**
    * Removes all transactions from state, optionally based on the current network.
    *
    * @param ignoreNetwork - Determines whether to wipe all transactions, or just those on the

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -7,6 +7,7 @@ import Common from '@ethereumjs/common';
 import { TransactionFactory, TypedTransaction } from '@ethereumjs/tx';
 import { v1 as random } from 'uuid';
 import { Mutex } from 'async-mutex';
+import { merge } from 'lodash';
 import {
   BaseController,
   BaseConfig,
@@ -46,6 +47,7 @@ import {
 import { IncomingTransactionHelper } from './IncomingTransactionHelper';
 import { EtherscanRemoteTransactionSource } from './EtherscanRemoteTransactionSource';
 import {
+  SecurityAlertResponse,
   Transaction,
   TransactionMeta,
   TransactionStatus,
@@ -821,13 +823,13 @@ export class TransactionController extends BaseController<
    * Add params to transactionMeta.
    *
    * @param transactionMetaId - ID of the transaction.
-   * @param params - New params to be added to tarnsaction meta.
+   * @param securityAlertResponse - New params to be added to tarnsaction meta.
    */
-  addTransactionMetaParams(
+  updateSecurityAlertResponse(
     transactionMetaId: string,
-    params: Record<string, any>,
+    securityAlertResponse: SecurityAlertResponse,
   ) {
-    if (!transactionMetaId || !params) {
+    if (!transactionMetaId || !securityAlertResponse) {
       return;
     }
     const { transactions } = this.state;
@@ -836,8 +838,8 @@ export class TransactionController extends BaseController<
     );
     if (index >= 0) {
       const transactionMeta = transactions[index];
-      transactions[index] = { ...transactionMeta, ...params };
-      this.update({ transactions });
+      const updatedMeta = merge(transactionMeta, { securityAlertResponse });
+      this.updateTransaction(updatedMeta);
     }
   }
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -827,13 +827,18 @@ export class TransactionController extends BaseController<
     transactionMetaId: string,
     params: Record<string, any>,
   ) {
+    if (!transactionMetaId || !params) {
+      return;
+    }
     const { transactions } = this.state;
     const index = this.state.transactions.findIndex(
       ({ id }) => id === transactionMetaId,
     );
-    const transactionMeta = transactions[index];
-    transactions[index] = { ...transactionMeta, ...params };
-    this.update({ transactions: this.trimTransactionsForState(transactions) });
+    if (index >= 0) {
+      const transactionMeta = transactions[index];
+      transactions[index] = { ...transactionMeta, ...params };
+      this.update({ transactions });
+    }
   }
 
   /**

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -360,7 +360,7 @@ export class TransactionController extends BaseController<
     }: {
       deviceConfirmedOn?: WalletDevice;
       origin?: string;
-      securityAlertResponse?: Record<string, unknown>;
+      securityAlertResponse?: SecurityAlertResponse;
     } = {},
   ): Promise<Result> {
     const { providerConfig, networkId } = this.getNetworkState();
@@ -820,27 +820,28 @@ export class TransactionController extends BaseController<
   }
 
   /**
-   * Add params to transactionMeta.
+   * Update the security alert response for a transaction.
    *
-   * @param transactionMetaId - ID of the transaction.
-   * @param securityAlertResponse - New params to be added to tarnsaction meta.
+   * @param transactionId - ID of the transaction.
+   * @param securityAlertResponse - The new security alert response for the transaction.
    */
   updateSecurityAlertResponse(
-    transactionMetaId: string,
+    transactionId: string,
     securityAlertResponse: SecurityAlertResponse,
   ) {
-    if (!transactionMetaId || !securityAlertResponse) {
-      return;
+    if (!securityAlertResponse) {
+      throw new Error(
+        'updateSecurityAlertResponse: securityAlertResponse should not be null',
+      );
     }
-    const { transactions } = this.state;
-    const index = this.state.transactions.findIndex(
-      ({ id }) => id === transactionMetaId,
-    );
-    if (index >= 0) {
-      const transactionMeta = transactions[index];
-      const updatedMeta = merge(transactionMeta, { securityAlertResponse });
-      this.updateTransaction(updatedMeta);
+    const transactionMeta = this.getTransaction(transactionId);
+    if (!transactionMeta) {
+      throw new Error(
+        `Cannot update security alert response as no transaction metadata found`,
+      );
     }
+    const updatedMeta = merge(transactionMeta, { securityAlertResponse });
+    this.updateTransaction(updatedMeta);
   }
 
   /**

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -149,3 +149,10 @@ export interface RemoteTransactionSource {
     request: RemoteTransactionSourceRequest,
   ) => Promise<TransactionMeta[]>;
 }
+
+export type SecurityAlertResponse = {
+  reason: string;
+  features?: string[];
+  result_type: string;
+  providerRequestsCount?: Record<string, number>;
+};

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -44,7 +44,7 @@ type TransactionMetaBase = {
   /**
    * Response from security validator.
    */
-  securityAlertResponse?: Record<string, unknown>;
+  securityAlertResponse?: SecurityAlertResponse;
 };
 
 /**


### PR DESCRIPTION
## Explanation

Add function to uodate securityAlertResponse in a transaction.

Ref: 
https://github.com/MetaMask/core/pull/1985
https://github.com/MetaMask/metamask-mobile/pull/7680

## References

NA

## Changelog
NA

## Checklist
NA
