### PR TITLE
Update `@metamask/json-rpc-engine` README to reflect migration into monorepo subpackage

### DIFF
--- a/packages/json-rpc-engine/README.md
+++ b/packages/json-rpc-engine/README.md
@@ -2,6 +2,14 @@
 
 A tool for processing JSON-RPC requests and responses.
 
+## Installation
+
+`yarn add @metamask/json-rpc-engine`
+
+or
+
+`npm install @metamask/json-rpc-engine`
+
 ## Usage
 
 ```js
@@ -191,14 +199,6 @@ engine.push(function (req, res, next, end) {
 });
 ```
 
-## Running tests
+## Contributing
 
-Build the project if not already built:
-
-```bash
-yarn build
-```
-
-```bash
-yarn test
-```
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).


### PR DESCRIPTION
## Explanation

Adds an "Installation" and "Contributing" section to the `@metamask/json-rpc-engine` README, as it has been migrated into the monorepo.

In future migrations, this step will be performed in "Phase B" (see https://github.com/MetaMask/core/issues/1551#issuecomment-1745665740), while the package is being staged in the `merged-packages/` temporary directory.

## References

- Partially implements https://github.com/MetaMask/core/issues/1981.

## Changelog

N/A 

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
