### PR TITLE
Record CHANGELOG entries from `@metamask/json-rpc-{engine,middleware-stream}` migrations

### DIFF
--- a/packages/eth-json-rpc-provider/CHANGELOG.md
+++ b/packages/eth-json-rpc-provider/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate `@metamask/eth-json-rpc-provider` into the core monorepo ([#1738](https://github.com/MetaMask/core/pull/1738))
 
 ### Changed
-- Export `SafeEventEmitterProvider` as class instead of type ([4c8fea70c5d753b6bb0cf17fc640e2aaed16fd52](https://github.com/MetaMask/core/pull/1738/commits/4c8fea70c5d753b6bb0cf17fc640e2aaed16fd52))
+- Export `SafeEventEmitterProvider` as class instead of type ([#1738](https://github.com/MetaMask/core/pull/1738))
 - Bump `@metamask/json-rpc-engine` from `^7.1.0` to `^7.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))
+- Bump `@metamask/utils` from `^8.1.0` to `^8.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))
 
 ## [2.2.0]
 ### Changed

--- a/packages/eth-json-rpc-provider/CHANGELOG.md
+++ b/packages/eth-json-rpc-provider/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Migrate `@metamask/eth-json-rpc-provider` into the core monorepo ([#1738](https://github.com/MetaMask/core/pull/1738))
-
 ### Changed
 - Export `SafeEventEmitterProvider` as class instead of type ([4c8fea70c5d753b6bb0cf17fc640e2aaed16fd52](https://github.com/MetaMask/core/pull/1738/commits/4c8fea70c5d753b6bb0cf17fc640e2aaed16fd52))
+- Bump `@metamask/json-rpc-engine` from `^7.1.0` to `^7.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))
 
 ## [2.2.0]
 ### Changed

--- a/packages/eth-json-rpc-provider/CHANGELOG.md
+++ b/packages/eth-json-rpc-provider/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Migrate `@metamask/eth-json-rpc-provider` into the core monorepo ([#1738](https://github.com/MetaMask/core/pull/1738))
+
 ### Changed
 - Export `SafeEventEmitterProvider` as class instead of type ([4c8fea70c5d753b6bb0cf17fc640e2aaed16fd52](https://github.com/MetaMask/core/pull/1738/commits/4c8fea70c5d753b6bb0cf17fc640e2aaed16fd52))
 - Bump `@metamask/json-rpc-engine` from `^7.1.0` to `^7.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))

--- a/packages/json-rpc-engine/CHANGELOG.md
+++ b/packages/json-rpc-engine/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bump `@metamask/utils` from `^8.1.0` to `^8.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))
+- Bump `@metamask/rpc-errors` from `^6.0.0` to `^6.1.0` ([#1882](https://github.com/MetaMask/core/pull/1882))
 
 ## [7.2.0]
 ### Added

--- a/packages/json-rpc-engine/CHANGELOG.md
+++ b/packages/json-rpc-engine/CHANGELOG.md
@@ -5,11 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added 
+### Added
 - Migrate `@metamask/json-rpc-engine` into the core monorepo ([#1895](https://github.com/MetaMask/core/pull/1895))
+
 ### Changed
 - Bump `@metamask/utils` from `^8.1.0` to `^8.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))
-
 
 ## [7.2.0]
 ### Added

--- a/packages/json-rpc-engine/CHANGELOG.md
+++ b/packages/json-rpc-engine/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added 
+- Migrate `@metamask/json-rpc-engine` into the core monorepo ([#1895](https://github.com/MetaMask/core/pull/1895))
+### Changed
+- Bump `@metamask/utils` from `^8.1.0` to `^8.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))
+
 
 ## [7.2.0]
 ### Added

--- a/packages/json-rpc-middleware-stream/CHANGELOG.md
+++ b/packages/json-rpc-middleware-stream/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Migrate `@metamask/json-rpc-engine` into the core monorepo ([#1762](https://github.com/MetaMask/core/pull/1762))
+
 ## Changed
 - **BREAKING**: Rename package from `json-rpc-middleware-stream` to `@metamask/json-rpc-middleware-stream` ([#1762](https://github.com/MetaMask/core/pull/1762))
 - Bump `@metamask/json-rpc-engine` from `^7.1.0` to `^7.2.0` ([#1762](https://github.com/MetaMask/core/pull/1762))

--- a/packages/json-rpc-middleware-stream/CHANGELOG.md
+++ b/packages/json-rpc-middleware-stream/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Migrate `@metamask/json-rpc-engine` into the core monorepo ([#1762](https://github.com/MetaMask/core/pull/1762))
+## Changed
+- **BREAKING**: Rename package from `json-rpc-middleware-stream` to `@metamask/json-rpc-middleware-stream` ([#1762](https://github.com/MetaMask/core/pull/1762))
+- Bump `@metamask/json-rpc-engine` from `^7.1.0` to `^7.2.0` ([#1762](https://github.com/MetaMask/core/pull/1762))
+- Bump `@metamask/utils` from `^8.1.0` to `^8.2.0` ([#1762](https://github.com/MetaMask/core/pull/1762))
 
 ## [5.0.1]
 ### Changed

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump `@metamask/json-rpc-engine` from `^7.1.0` to `^7.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))
 
 ## [5.0.1]
 ### Changed

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump `@metamask/json-rpc-engine` from `^7.1.0` to `^7.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))
 
 ## [0.1.2]
 ### Fixed

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- Bump `@metamask/json-rpc-engine` from `^7.1.0` to `^7.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))
 
 ## [0.1.3]
 ### Changed

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump `@metamask/json-rpc-engine` from `^7.1.0` to `^7.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))
 
 ## [3.1.0]
 ### Added


### PR DESCRIPTION
## Explanation

Records CHANGELOG entries from `@metamask/json-rpc-engine` and `@metamask/json-rpc-middleware-stream` migrations under "Unreleased" headers for reference during the next version release.

- [x] Records updates made to the `@metamask/json-rpc-engine` and `@metamask/json-rpc-middleware-stream` packages since its last release, and during the migration process.
- [x] Lists these migrations as ADDED changes.
- [x] Records version bumps of the migrated packages in downstream repos.
- ~Records changes made to downstream repos.~

## References

- Partially implements https://github.com/MetaMask/core/issues/1981
- Partially implements https://github.com/MetaMask/core/issues/1982

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
