### PR TITLE
Add `json-rpc-middleware-stream` to root `tsconfig` files

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -37,6 +37,9 @@
       "path": "./packages/json-rpc-engine/tsconfig.build.json"
     },
     {
+      "path": "./packages/json-rpc-middleware-stream/tsconfig.build.json"
+    },
+    {
       "path": "./packages/keyring-controller/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,9 @@
       "path": "./packages/json-rpc-engine"
     },
     {
+      "path": "./packages/json-rpc-middleware-stream"
+    },
+    {
       "path": "./packages/keyring-controller"
     },
     {


### PR DESCRIPTION
## Explanation

- Fixes missing `json-rpc-middleware-stream` entries in root tsconfig files that causes build failure during release workflow.

- Will add note in migration process guide (https://github.com/MetaMask/core/issues/1551#issuecomment-1745665740) about the importance of step C-2.

## References

- See https://github.com/MetaMask/core/issues/1552

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
