### PR TITLE
Adds `estimateGasBuffered` public method

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -950,6 +950,10 @@ describe('TransactionController', () => {
       const blockGasLimitMock = '0x1234';
       const expectedEstimatedGas = '0x12345';
       const multiplierMock = 1;
+      const transactionParamsMock = {
+        from: ACCOUNT_MOCK,
+        to: ACCOUNT_MOCK,
+      };
 
       const simulationFailsMock = {
         errorKey: 'testKey',
@@ -971,11 +975,14 @@ describe('TransactionController', () => {
       addGasBufferMock.mockReturnValue(expectedEstimatedGas);
 
       const { gas, simulationFails } = await controller.estimateGasBuffered(
-        {
-          from: ACCOUNT_MOCK,
-          to: ACCOUNT_MOCK,
-        },
+        transactionParamsMock,
         multiplierMock,
+      );
+
+      expect(estimateGasMock).toBeCalledTimes(1);
+      expect(estimateGasMock).toBeCalledWith(
+        transactionParamsMock,
+        expect.anything(),
       );
 
       expect(addGasBufferMock).toHaveBeenCalledTimes(1);

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -979,8 +979,8 @@ describe('TransactionController', () => {
         multiplierMock,
       );
 
-      expect(estimateGasMock).toBeCalledTimes(1);
-      expect(estimateGasMock).toBeCalledWith(
+      expect(estimateGasMock).toHaveBeenCalledTimes(1);
+      expect(estimateGasMock).toHaveBeenCalledWith(
         transactionParamsMock,
         expect.anything(),
       );

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -60,7 +60,7 @@ import {
   TransactionStatus,
 } from './types';
 import { validateConfirmedExternalTransaction } from './utils/external-transactions';
-import { estimateGas, updateGas } from './utils/gas';
+import { addGasBuffer, estimateGas, updateGas } from './utils/gas';
 import { updateGasFees } from './utils/gas-fees';
 import {
   addInitialHistorySnapshot,
@@ -980,6 +980,29 @@ export class TransactionController extends BaseController<
     );
 
     return { gas: estimatedGas, simulationFails };
+  }
+
+  /**
+   * Estimates required gas for a given transaction and add additional gas buffer with the given multiplier.
+   *
+   * @param transaction - The transaction params to estimate gas for.
+   * @param multiplier - The multiplier to use for the gas buffer.
+   */
+  async estimateGasBuffered(
+    transaction: TransactionParams,
+    multiplier: number,
+  ) {
+    const { blockGasLimit, estimatedGas, simulationFails } = await estimateGas(
+      transaction,
+      this.ethQuery,
+    );
+
+    const gas = addGasBuffer(estimatedGas, blockGasLimit, multiplier);
+
+    return {
+      gas,
+      simulationFails,
+    };
   }
 
   /**

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -24,6 +24,7 @@ export type UpdateGasRequest = {
 export const log = createModuleLogger(projectLogger, 'gas');
 
 export const FIXED_GAS = '0x5208';
+export const DEFAULT_GAS_MULTIPLIER = 1.5;
 
 export async function updateGas(request: UpdateGasRequest) {
   const { txMeta } = request;
@@ -87,6 +88,32 @@ export async function estimateGas(
   };
 }
 
+export function addGasBuffer(
+  estimatedGas: string,
+  blockGasLimit: string,
+  multiplier: number,
+) {
+  const estimatedGasBN = hexToBN(estimatedGas);
+  const maxGasBN = hexToBN(blockGasLimit).muln(0.9);
+  const paddedGasBN = estimatedGasBN.muln(multiplier);
+
+  if (estimatedGasBN.gt(maxGasBN)) {
+    const estimatedGasHex = addHexPrefix(estimatedGas);
+    log('Using estimated value', estimatedGasHex);
+    return estimatedGasHex;
+  }
+
+  if (paddedGasBN.lt(maxGasBN)) {
+    const paddedHex = addHexPrefix(BNToHex(paddedGasBN));
+    log('Using padded estimate', paddedHex, multiplier);
+    return paddedHex;
+  }
+
+  const maxHex = addHexPrefix(BNToHex(maxGasBN));
+  log('Using 90% of block gas limit', maxHex);
+  return maxHex;
+}
+
 async function getGas(
   request: UpdateGasRequest,
 ): Promise<[string, TransactionMeta['simulationFails']?]> {
@@ -107,26 +134,18 @@ async function getGas(
     request.ethQuery,
   );
 
-  const estimatedGasBN = hexToBN(estimatedGas);
-  const maxGasBN = hexToBN(blockGasLimit).muln(0.9);
-  const paddedGasBN = estimatedGasBN.muln(1.5);
-  const isCustomNetwork = providerConfig.type === NetworkType.rpc;
-
-  if (estimatedGasBN.gt(maxGasBN) || isCustomNetwork) {
-    const estimatedGasHex = addHexPrefix(estimatedGas);
-    log('Using estimated value', estimatedGasHex);
-    return [estimatedGasHex, simulationFails];
+  if (providerConfig.type === NetworkType.rpc) {
+    log('Using original estimate as custom network');
+    return [estimatedGas, simulationFails];
   }
 
-  if (paddedGasBN.lt(maxGasBN)) {
-    const paddedHex = addHexPrefix(BNToHex(paddedGasBN));
-    log('Using 150% of estimated value', paddedHex);
-    return [paddedHex, simulationFails];
-  }
+  const bufferedGas = addGasBuffer(
+    estimatedGas,
+    blockGasLimit,
+    DEFAULT_GAS_MULTIPLIER,
+  );
 
-  const maxHex = addHexPrefix(BNToHex(maxGasBN));
-  log('Using 90% of block gas limit', maxHex);
-  return [maxHex, simulationFails];
+  return [bufferedGas, simulationFails];
 }
 
 async function requiresFixedGas({


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR adds `estimateGasBuffered` public method to transaction controller in order to satisfy needs of `SwapsController` in extension: https://github.com/MetaMask/metamask-extension/blob/16592dd65d328a7fc72f479dbe9acce1ffd42d85/app/scripts/metamask-controller.js#L1527

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->
Ticket will be soon created

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **Added**: Added `estimateGasBuffered` public method

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've highlighted breaking changes using the "BREAKING" category above as appropriate
