### PR TITLE
Align NetworkController provider type w/ eth-query

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 
 ## [18.0.0]
 ### Changed

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -39,7 +39,7 @@
     "@metamask/base-controller": "^3.2.3",
     "@metamask/contract-metadata": "^2.4.0",
     "@metamask/controller-utils": "^5.0.2",
-    "@metamask/eth-query": "^3.0.1",
+    "@metamask/eth-query": "^4.0.0",
     "@metamask/metamask-eth-abis": "3.0.0",
     "@metamask/network-controller": "^15.2.0",
     "@metamask/polling-controller": "^1.0.1",

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 
 ## [5.0.2]
 ### Changed

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.3",
-    "@metamask/eth-query": "^3.0.1",
+    "@metamask/eth-query": "^4.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 
 ## [10.0.0]
 ### Added

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@metamask/base-controller": "^3.2.3",
     "@metamask/controller-utils": "^5.0.2",
-    "@metamask/eth-query": "^3.0.1",
+    "@metamask/eth-query": "^4.0.0",
     "@metamask/network-controller": "^15.2.0",
     "@metamask/polling-controller": "^1.0.1",
     "@metamask/utils": "^8.2.0",

--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -348,7 +348,6 @@ export class GasFeeController extends PollingController<
     this.legacyAPIEndpoint = legacyAPIEndpoint;
     this.clientId = clientId;
 
-    // @ts-expect-error TODO: Provider type alignment
     this.ethQuery = new EthQuery(this.#getProvider());
 
     if (onNetworkStateChange && getChainId) {
@@ -435,7 +434,6 @@ export class GasFeeController extends PollingController<
       } catch {
         isEIP1559Compatible = false;
       }
-      // @ts-expect-error TODO: Provider type alignment
       ethQuery = new EthQuery(networkClient.provider);
     }
 
@@ -581,7 +579,6 @@ export class GasFeeController extends PollingController<
     const newChainId = networkControllerState.providerConfig.chainId;
 
     if (newChainId !== this.currentChainId) {
-      // @ts-expect-error TODO: Provider type alignment
       this.ethQuery = new EthQuery(this.#getProvider());
       await this.resetPolling();
 

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 
 ## [15.2.0]
 ### Changed

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -35,7 +35,7 @@
     "@metamask/eth-json-rpc-infura": "^9.0.0",
     "@metamask/eth-json-rpc-middleware": "^12.0.1",
     "@metamask/eth-json-rpc-provider": "^2.3.0",
-    "@metamask/eth-query": "^3.0.1",
+    "@metamask/eth-query": "^4.0.0",
     "@metamask/json-rpc-engine": "^7.3.0",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/swappable-obj-proxy": "^2.1.0",

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1013,7 +1013,6 @@ export class NetworkController extends BaseControllerV2<
     }
 
     const networkClient = this.getNetworkClientById(networkClientId);
-    // @ts-expect-error TODO: Provider type alignment
     const ethQuery = new EthQuery(networkClient.provider);
 
     return new Promise((resolve, reject) => {
@@ -1583,7 +1582,6 @@ export class NetworkController extends BaseControllerV2<
       });
     }
 
-    // @ts-expect-error TODO: Provider type alignment
     this.#ethQuery = new EthQuery(this.#providerProxy);
   }
 }

--- a/packages/network-controller/tests/provider-api-tests/helpers.ts
+++ b/packages/network-controller/tests/provider-api-tests/helpers.ts
@@ -462,7 +462,6 @@ export async function withNetworkClient(
 
   const { provider, blockTracker } = clientUnderTest;
 
-  // @ts-expect-error TODO: Provider type alignment
   const ethQuery = new EthQuery(provider);
   const curriedMakeRpcCall = (request: Request) =>
     makeRpcCall(ethQuery, request);

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 
 ## [16.0.0]
 ### Changed

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -36,7 +36,7 @@
     "@metamask/approval-controller": "^4.1.0",
     "@metamask/base-controller": "^3.2.3",
     "@metamask/controller-utils": "^5.0.2",
-    "@metamask/eth-query": "^3.0.1",
+    "@metamask/eth-query": "^4.0.0",
     "@metamask/gas-fee-controller": "^10.0.0",
     "@metamask/metamask-eth-abis": "^3.0.0",
     "@metamask/network-controller": "^15.2.0",

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -435,7 +435,6 @@ export class TransactionController extends BaseController<
     this.provider = provider;
     this.messagingSystem = messenger;
     this.getNetworkState = getNetworkState;
-    // @ts-expect-error TODO: Provider type alignment
     this.ethQuery = new EthQuery(provider);
     this.isSendFlowHistoryDisabled = disableSendFlowHistory ?? false;
     this.isHistoryDisabled = disableHistory ?? false;
@@ -523,7 +522,6 @@ export class TransactionController extends BaseController<
     this.addPendingTransactionTrackerListeners();
 
     onNetworkStateChange(() => {
-      // @ts-expect-error TODO: Provider type alignment
       this.ethQuery = new EthQuery(this.provider);
       this.registry = new MethodRegistry({ provider: this.provider });
       this.onBootCleanup();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1474,7 +1474,7 @@ __metadata:
     "@metamask/base-controller": ^3.2.3
     "@metamask/contract-metadata": ^2.4.0
     "@metamask/controller-utils": ^5.0.2
-    "@metamask/eth-query": ^3.0.1
+    "@metamask/eth-query": ^4.0.0
     "@metamask/metamask-eth-abis": 3.0.0
     "@metamask/network-controller": ^15.2.0
     "@metamask/polling-controller": ^1.0.1
@@ -1578,7 +1578,7 @@ __metadata:
   resolution: "@metamask/controller-utils@workspace:packages/controller-utils"
   dependencies:
     "@metamask/auto-changelog": ^3.4.3
-    "@metamask/eth-query": ^3.0.1
+    "@metamask/eth-query": ^4.0.0
     "@metamask/utils": ^8.2.0
     "@spruceid/siwe-parser": 1.1.3
     "@types/jest": ^27.4.1
@@ -1806,13 +1806,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-query@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@metamask/eth-query@npm:3.0.1"
+"@metamask/eth-query@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@metamask/eth-query@npm:4.0.0"
   dependencies:
     json-rpc-random-id: ^1.0.0
     xtend: ^4.0.1
-  checksum: b9a323dff67328eace7d54fc8b0bc4dd763bf15760870656cbd5aad5380d1ee4489fb5c59506290d5f77cf55e74e530ee97b52702a329f1090ec03a6158434b7
+  checksum: f2e529cf2aa362c20b81433f69840c2830444b3e060a3d9cc778235b8f595f4e1e3a6505b7f14930c4e1566efc9de0ee879e4566f3a6ab184521bdf40f5895d4
   languageName: node
   linkType: hard
 
@@ -1867,7 +1867,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.3
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
-    "@metamask/eth-query": ^3.0.1
+    "@metamask/eth-query": ^4.0.0
     "@metamask/network-controller": ^15.2.0
     "@metamask/polling-controller": ^1.0.1
     "@metamask/utils": ^8.2.0
@@ -2077,7 +2077,7 @@ __metadata:
     "@metamask/eth-json-rpc-infura": ^9.0.0
     "@metamask/eth-json-rpc-middleware": ^12.0.1
     "@metamask/eth-json-rpc-provider": ^2.3.0
-    "@metamask/eth-query": ^3.0.1
+    "@metamask/eth-query": ^4.0.0
     "@metamask/json-rpc-engine": ^7.3.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/swappable-obj-proxy": ^2.1.0
@@ -2629,7 +2629,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.3
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
-    "@metamask/eth-query": ^3.0.1
+    "@metamask/eth-query": ^4.0.0
     "@metamask/gas-fee-controller": ^10.0.0
     "@metamask/metamask-eth-abis": ^3.0.0
     "@metamask/network-controller": ^15.2.0


### PR DESCRIPTION


## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Recent changes in `@metamask/utils` caused SafeEventEmitterProvider, the type of the provider that NetworkController exposes, to no longer align with the provider that `@metamask/eth-query` expects. We temporarily worked around this with the use of `// @ts-expect-error`, but this merely hid the problem. A fix was made in `@metamask/eth-query`, so this commit bumps that package and removes the associated `// @ts-expect-error` lines.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes #1823.

Also see: https://github.com/MetaMask/eth-query/pull/21

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

(See updates to changelogs in this PR.)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
