### PR TITLE
[`base-controller`] Fix single-letter type param names

### DIFF
--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -93,17 +93,17 @@ export type ControllerEvents<
  * Controller class that provides state management, subscriptions, and state metadata
  */
 export class BaseController<
-  N extends string,
-  S extends Record<string, Json>,
+  ControllerName extends string,
+  ControllerState extends Record<string, Json>,
   messenger extends RestrictedControllerMessenger<
-    N,
-    ActionConstraint | ControllerActions<N, S>,
-    EventConstraint | ControllerEvents<N, S>,
+    ControllerName,
+    ActionConstraint,
+    EventConstraint,
     string,
     string
   >,
 > {
-  private internalState: S;
+  private internalState: ControllerState;
 
   protected messagingSystem: messenger;
 
@@ -112,9 +112,9 @@ export class BaseController<
    *
    * This is used by the ComposableController to construct a composed application state.
    */
-  public readonly name: N;
+  public readonly name: ControllerName;
 
-  public readonly metadata: StateMetadata<S>;
+  public readonly metadata: StateMetadata<ControllerState>;
 
   /**
    * The existence of the `subscribe` property is how the ComposableController detects whether a
@@ -128,7 +128,7 @@ export class BaseController<
    *
    * @param options - Controller options.
    * @param options.messenger - Controller messaging system.
-   * @param options.metadata - State metadata, describing how to "anonymize" the state, and which
+   * @param options.metadata - ControllerState metadata, describing how to "anonymize" the state, and which
    * parts should be persisted.
    * @param options.name - The name of the controller, used as a namespace for events and actions.
    * @param options.state - Initial controller state.
@@ -140,9 +140,9 @@ export class BaseController<
     state,
   }: {
     messenger: messenger;
-    metadata: StateMetadata<S>;
-    name: N;
-    state: S;
+    metadata: StateMetadata<ControllerState>;
+    name: ControllerName;
+    state: ControllerState;
   }) {
     this.messagingSystem = messenger;
     this.name = name;
@@ -181,8 +181,10 @@ export class BaseController<
    * @returns An object that has the next state, patches applied in the update and inverse patches to
    * rollback the update.
    */
-  protected update(callback: (state: Draft<S>) => void | S): {
-    nextState: S;
+  protected update(
+    callback: (state: Draft<ControllerState>) => void | ControllerState,
+  ): {
+    nextState: ControllerState;
     patches: Patch[];
     inversePatches: Patch[];
   } {
@@ -190,9 +192,9 @@ export class BaseController<
     // produceWithPatches here.
     const [nextState, patches, inversePatches] = (
       produceWithPatches as unknown as (
-        state: S,
+        state: ControllerState,
         cb: typeof callback,
-      ) => [S, Patch[], Patch[]]
+      ) => [ControllerState, Patch[], Patch[]]
     )(this.internalState, callback);
 
     this.internalState = nextState;
@@ -247,9 +249,11 @@ export class BaseController<
  * anonymized state.
  * @returns The anonymized controller state.
  */
-export function getAnonymizedState<S extends Record<string, Json>>(
-  state: S,
-  metadata: StateMetadata<S>,
+export function getAnonymizedState<
+  ControllerState extends Record<string, Json>,
+>(
+  state: ControllerState,
+  metadata: StateMetadata<ControllerState>,
 ): Record<string, Json> {
   return deriveStateFromMetadata(state, metadata, 'anonymous');
 }
@@ -261,9 +265,11 @@ export function getAnonymizedState<S extends Record<string, Json>>(
  * @param metadata - The controller state metadata, which describes which pieces of state should be persisted.
  * @returns The subset of controller state that should be persisted.
  */
-export function getPersistentState<S extends Record<string, Json>>(
-  state: S,
-  metadata: StateMetadata<S>,
+export function getPersistentState<
+  ControllerState extends Record<string, Json>,
+>(
+  state: ControllerState,
+  metadata: StateMetadata<ControllerState>,
 ): Record<string, Json> {
   return deriveStateFromMetadata(state, metadata, 'persist');
 }
@@ -276,9 +282,9 @@ export function getPersistentState<S extends Record<string, Json>>(
  * @param metadataProperty - The metadata property to use to derive state.
  * @returns The metadata-derived controller state.
  */
-function deriveStateFromMetadata<S extends Record<string, Json>>(
-  state: S,
-  metadata: StateMetadata<S>,
+function deriveStateFromMetadata<ControllerState extends Record<string, Json>>(
+  state: ControllerState,
+  metadata: StateMetadata<ControllerState>,
   metadataProperty: 'anonymous' | 'persist',
 ): Record<string, Json> {
   return (Object.keys(state) as (keyof S)[]).reduce<

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -97,8 +97,8 @@ export class BaseController<
   ControllerState extends Record<string, Json>,
   messenger extends RestrictedControllerMessenger<
     ControllerName,
-    ActionConstraint,
-    EventConstraint,
+    ActionConstraint | ControllerActions<ControllerName, ControllerState>,
+    EventConstraint | ControllerEvents<ControllerName, ControllerState>,
     string,
     string
   >,
@@ -287,8 +287,8 @@ function deriveStateFromMetadata<ControllerState extends Record<string, Json>>(
   metadata: StateMetadata<ControllerState>,
   metadataProperty: 'anonymous' | 'persist',
 ): Record<string, Json> {
-  return (Object.keys(state) as (keyof S)[]).reduce<
-    Partial<Record<keyof S, Json>>
+  return (Object.keys(state) as (keyof ControllerState)[]).reduce<
+    Partial<Record<keyof ControllerState, Json>>
   >((persistedState, key) => {
     try {
       const stateMetadata = metadata[key];
@@ -311,5 +311,5 @@ function deriveStateFromMetadata<ControllerState extends Record<string, Json>>(
       });
       return persistedState;
     }
-  }, {}) as Record<keyof S, Json>;
+  }, {}) as Record<keyof ControllerState, Json>;
 }

--- a/packages/base-controller/src/ControllerMessenger.ts
+++ b/packages/base-controller/src/ControllerMessenger.ts
@@ -7,45 +7,45 @@ export type ActionHandler<
 
 export type ExtractActionParameters<
   Action extends ActionConstraint,
-  T = Action['type'],
+  ActionType = Action['type'],
 > = Action extends {
-  type: T;
-  handler: (...args: infer H) => unknown;
+  type: ActionType;
+  handler: (...args: infer HandlerArgs) => unknown;
 }
-  ? H
+  ? HandlerArgs
   : never;
 
 export type ExtractActionResponse<
   Action extends ActionConstraint,
-  T = Action['type'],
+  ActionType = Action['type'],
 > = Action extends {
-  type: T;
-  handler: (...args: infer _) => infer H;
+  type: ActionType;
+  handler: (...args: infer _) => infer HandlerReturnValue;
 }
-  ? H
+  ? HandlerReturnValue
   : never;
 
 export type ExtractEventHandler<
   Event extends EventConstraint,
-  T = Event['type'],
+  EventType = Event['type'],
 > = Event extends {
-  type: T;
-  payload: infer P;
+  type: EventType;
+  payload: infer Payload;
 }
-  ? P extends unknown[]
-    ? (...payload: P) => void
+  ? Payload extends unknown[]
+    ? (...payload: Payload) => void
     : never
   : never;
 
 export type ExtractEventPayload<
   Event extends EventConstraint,
-  T = Event['type'],
+  EventType = Event['type'],
 > = Event extends {
-  type: T;
-  payload: infer P;
+  type: EventType;
+  payload: infer Payload;
 }
-  ? P extends unknown[]
-    ? P
+  ? Payload extends unknown[]
+    ? Payload
     : never
   : never;
 
@@ -181,7 +181,7 @@ export class RestrictedControllerMessenger<
    * @param action - The action type. This is a unqiue identifier for this action.
    * @param handler - The action handler. This function gets called when the `call` method is
    * invoked with the given action type.
-* @throws Will throw if an action handler that is not in the current namespace is being registered.
+   * @throws Will throw if an action handler that is not in the current namespace is being registered.
    * @template ActionType - A type union of Action type strings that are namespaced by Namespace.
    */
   registerActionHandler<ActionType extends Action['type']>(

--- a/packages/base-controller/src/ControllerMessenger.ts
+++ b/packages/base-controller/src/ControllerMessenger.ts
@@ -207,9 +207,9 @@ export class RestrictedControllerMessenger<
    * @param action - The action type. This is a unqiue identifier for this action.
    * @template ActionType - A type union of Action type strings that are namespaced by Namespace.
    */
-  unregisterActionHandler<
-    ActionType extends Namespaced<Namespace, Action['type']>,
-  >(action: ActionType) {
+  unregisterActionHandler<ActionType extends NamespacedName<Namespace>>(
+    action: ActionType,
+  ) {
     /* istanbul ignore if */ // Branch unreachable with valid types
     if (!action.startsWith(`${this.controllerName}:`)) {
       throw new Error(
@@ -234,7 +234,7 @@ export class RestrictedControllerMessenger<
    * @template ActionType - A type union of allowed Action type strings.
    * @returns The action return value.
    */
-  call<ActionType extends AllowedAction & string>(
+  call<ActionType extends AllowedAction & NamespacedName>(
     action: ActionType,
     ...params: ExtractActionParameters<Action, ActionType>
   ): ExtractActionResponse<Action, ActionType> {
@@ -259,7 +259,7 @@ export class RestrictedControllerMessenger<
    * match the type of this payload.
    * @template EventType - A type union of Event type strings that are namespaced by Namespace.
    */
-  publish<EventType extends Namespaced<Namespace, Event['type']>>(
+  publish<EventType extends NamespacedName<Namespace>>(
     event: EventType,
     ...payload: ExtractEventPayload<Event, EventType>
   ) {
@@ -284,7 +284,7 @@ export class RestrictedControllerMessenger<
    * match the type of the payload for this event type.
    * @template EventType - A type union of Event type strings.
    */
-  subscribe<EventType extends AllowedEvent & string>(
+  subscribe<EventType extends AllowedEvent & NamespacedName>(
     eventType: EventType,
     handler: ExtractEventHandler<Event, EventType>,
   ): void;
@@ -308,7 +308,10 @@ export class RestrictedControllerMessenger<
    * @template EventType - A type union of Event type strings.
    * @template SelectorReturnValue - The selector return value.
    */
-  subscribe<EventType extends AllowedEvent & string, SelectorReturnValue>(
+  subscribe<
+    EventType extends AllowedEvent & NamespacedName,
+    SelectorReturnValue,
+  >(
     eventType: EventType,
     handler: SelectorEventHandler<SelectorReturnValue>,
     selector: SelectorFunction<
@@ -317,7 +320,10 @@ export class RestrictedControllerMessenger<
     >,
   ): void;
 
-  subscribe<EventType extends AllowedEvent & string, SelectorReturnValue>(
+  subscribe<
+    EventType extends AllowedEvent & NamespacedName,
+    SelectorReturnValue,
+  >(
     event: EventType,
     handler: ExtractEventHandler<Event, EventType>,
     selector?: SelectorFunction<
@@ -350,7 +356,7 @@ export class RestrictedControllerMessenger<
    * @throws Will throw when the given event handler is not registered for this event.
    * @template EventType - A type union of allowed Event type strings.
    */
-  unsubscribe<EventType extends AllowedEvent & string>(
+  unsubscribe<EventType extends AllowedEvent & NamespacedName>(
     event: EventType,
     handler: ExtractEventHandler<Event, EventType>,
   ) {
@@ -373,9 +379,9 @@ export class RestrictedControllerMessenger<
    * @param event - The event type. This is a unique identifier for this event.
    * @template EventType - A type union of Event type strings that are namespaced by Namespace.
    */
-  clearEventSubscriptions<
-    EventType extends Namespaced<Namespace, Event['type']>,
-  >(event: EventType) {
+  clearEventSubscriptions<EventType extends NamespacedName<Namespace>>(
+    event: EventType,
+  ) {
     /* istanbul ignore if */ // Branch unreachable with valid types
     if (!event.startsWith(`${this.controllerName}:`)) {
       throw new Error(

--- a/packages/base-controller/src/ControllerMessenger.ts
+++ b/packages/base-controller/src/ControllerMessenger.ts
@@ -79,28 +79,29 @@ type EventSubscriptionMap<
 /**
  * A namespaced string
  *
- * This type verifies that the string T is prefixed by the string Name followed by a colon.
+ * This type verifies that the string Name is prefixed by the string Name followed by a colon.
  *
- * @template Name - The namespace we're checking for.
- * @template T - The full string, including the namespace.
+ * @template Namespace - The namespace we're checking for.
+ * @template Name - The full string, including the namespace.
  */
-export type Namespaced<Name extends string, T> = T extends `${Name}:${string}`
-  ? T
-  : never;
+export type Namespaced<
+  Namespace extends string,
+  Name,
+> = Name extends `${Namespace}:${string}` ? Name : never;
 
 export type NamespacedName<Namespace extends string = string> =
   `${Namespace}:${string}`;
 
-type NarrowToNamespace<T, Namespace extends string> = T extends {
+type NarrowToNamespace<Name, Namespace extends string> = Name extends {
   type: `${Namespace}:${string}`;
 }
-  ? T
+  ? Name
   : never;
 
-type NarrowToAllowed<T, Allowed extends string> = T extends {
+type NarrowToAllowed<Name, Allowed extends string> = Name extends {
   type: Allowed;
 }
-  ? T
+  ? Name
   : never;
 
 /**
@@ -109,7 +110,7 @@ type NarrowToAllowed<T, Allowed extends string> = T extends {
  * This acts as a wrapper around the controller messenger instance that restricts access to actions
  * and events.
  *
- * @template N - The namespace for this messenger. Typically this is the name of the controller or
+ * @template Namespace - The namespace for this messenger. Typically this is the name of the controller or
  * module that this messenger has been created for. The authority to publish events and register
  * actions under this namespace is granted to this restricted messenger instance.
  * @template Action - A type union of all Action types.
@@ -118,7 +119,7 @@ type NarrowToAllowed<T, Allowed extends string> = T extends {
  * @template AllowedEvent - A type union of the 'type' string for any allowed events.
  */
 export class RestrictedControllerMessenger<
-  N extends string,
+  Namespace extends string,
   Action extends ActionConstraint,
   Event extends EventConstraint,
   AllowedAction extends string,
@@ -129,7 +130,7 @@ export class RestrictedControllerMessenger<
     EventConstraint
   >;
 
-  private readonly controllerName: N;
+  private readonly controllerName: Namespace;
 
   private readonly allowedActions: AllowedAction[] | null;
 
@@ -160,7 +161,7 @@ export class RestrictedControllerMessenger<
     allowedEvents,
   }: {
     controllerMessenger: ControllerMessenger<ActionConstraint, EventConstraint>;
-    name: N;
+    name: Namespace;
     allowedActions?: AllowedAction[];
     allowedEvents?: AllowedEvent[];
   }) {
@@ -180,12 +181,12 @@ export class RestrictedControllerMessenger<
    * @param action - The action type. This is a unqiue identifier for this action.
    * @param handler - The action handler. This function gets called when the `call` method is
    * invoked with the given action type.
-   * @throws Will throw if an action handler that is not in the current namespace is being registered.
-   * @template T - A type union of Action type strings that are namespaced by N.
+* @throws Will throw if an action handler that is not in the current namespace is being registered.
+   * @template ActionType - A type union of Action type strings that are namespaced by Namespace.
    */
-  registerActionHandler<T extends NamespacedName<N>>(
-    action: T,
-    handler: ActionHandler<Action, T>,
+  registerActionHandler<ActionType extends Action['type']>(
+    action: ActionType,
+    handler: ActionHandler<Action, ActionType>,
   ) {
     /* istanbul ignore if */ // Branch unreachable with valid types
     if (!action.startsWith(`${this.controllerName}:`)) {
@@ -204,9 +205,11 @@ export class RestrictedControllerMessenger<
    * The action type being unregistered *must* be in the current namespace.
    *
    * @param action - The action type. This is a unqiue identifier for this action.
-   * @template T - A type union of Action type strings that are namespaced by N.
+   * @template ActionType - A type union of Action type strings that are namespaced by Namespace.
    */
-  unregisterActionHandler<T extends NamespacedName<N>>(action: T) {
+  unregisterActionHandler<
+    ActionType extends Namespaced<Namespace, Action['type']>,
+  >(action: ActionType) {
     /* istanbul ignore if */ // Branch unreachable with valid types
     if (!action.startsWith(`${this.controllerName}:`)) {
       throw new Error(
@@ -228,13 +231,13 @@ export class RestrictedControllerMessenger<
    * @param params - The action parameters. These must match the type of the parameters of the
    * registered action handler.
    * @throws Will throw when no handler has been registered for the given type.
-   * @template T - A type union of allowed Action type strings.
+   * @template ActionType - A type union of allowed Action type strings.
    * @returns The action return value.
    */
-  call<T extends AllowedAction & NamespacedName>(
-    action: T,
-    ...params: ExtractActionParameters<Action, T>
-  ): ExtractActionResponse<Action, T> {
+  call<ActionType extends AllowedAction & string>(
+    action: ActionType,
+    ...params: ExtractActionParameters<Action, ActionType>
+  ): ExtractActionResponse<Action, ActionType> {
     /* istanbul ignore next */ // Branches unreachable with valid types
     if (this.allowedActions === null) {
       throw new Error('No actions allowed');
@@ -254,11 +257,11 @@ export class RestrictedControllerMessenger<
    * @param event - The event type. This is a unique identifier for this event.
    * @param payload - The event payload. The type of the parameters for each event handler must
    * match the type of this payload.
-   * @template E - A type union of Event type strings that are namespaced by N.
+   * @template EventType - A type union of Event type strings that are namespaced by Namespace.
    */
-  publish<E extends NamespacedName<N>>(
-    event: E,
-    ...payload: ExtractEventPayload<Event, E>
+  publish<EventType extends Namespaced<Namespace, Event['type']>>(
+    event: EventType,
+    ...payload: ExtractEventPayload<Event, EventType>
   ) {
     /* istanbul ignore if */ // Branch unreachable with valid types
     if (!event.startsWith(`${this.controllerName}:`)) {
@@ -279,11 +282,11 @@ export class RestrictedControllerMessenger<
    * @param eventType - The event type. This is a unique identifier for this event.
    * @param handler - The event handler. The type of the parameters for this event handler must
    * match the type of the payload for this event type.
-   * @template E - A type union of Event type strings.
+   * @template EventType - A type union of Event type strings.
    */
-  subscribe<E extends AllowedEvent & NamespacedName>(
-    eventType: E,
-    handler: ExtractEventHandler<Event, E>,
+  subscribe<EventType extends AllowedEvent & string>(
+    eventType: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
   ): void;
 
   /**
@@ -302,19 +305,25 @@ export class RestrictedControllerMessenger<
    * @param selector - The selector function used to select relevant data from
    * the event payload. The type of the parameters for this selector must match
    * the type of the payload for this event type.
-   * @template E - A type union of Event type strings.
-   * @template V - The selector return value.
+   * @template EventType - A type union of Event type strings.
+   * @template SelectorReturnValue - The selector return value.
    */
-  subscribe<E extends AllowedEvent & NamespacedName, V>(
-    eventType: E,
-    handler: SelectorEventHandler<V>,
-    selector: SelectorFunction<ExtractEventPayload<Event, E>, V>,
+  subscribe<EventType extends AllowedEvent & string, SelectorReturnValue>(
+    eventType: EventType,
+    handler: SelectorEventHandler<SelectorReturnValue>,
+    selector: SelectorFunction<
+      ExtractEventPayload<Event, EventType>,
+      SelectorReturnValue
+    >,
   ): void;
 
-  subscribe<E extends AllowedEvent & NamespacedName, V>(
-    event: E,
-    handler: ExtractEventHandler<Event, E>,
-    selector?: SelectorFunction<ExtractEventPayload<Event, E>, V>,
+  subscribe<EventType extends AllowedEvent & string, SelectorReturnValue>(
+    event: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
+    selector?: SelectorFunction<
+      ExtractEventPayload<Event, EventType>,
+      SelectorReturnValue
+    >,
   ) {
     /* istanbul ignore next */ // Branches unreachable with valid types
     if (this.allowedEvents === null) {
@@ -339,11 +348,11 @@ export class RestrictedControllerMessenger<
    * @param event - The event type. This is a unique identifier for this event.
    * @param handler - The event handler to unregister.
    * @throws Will throw when the given event handler is not registered for this event.
-   * @template T - A type union of allowed Event type strings.
+   * @template EventType - A type union of allowed Event type strings.
    */
-  unsubscribe<E extends AllowedEvent & NamespacedName>(
-    event: E,
-    handler: ExtractEventHandler<Event, E>,
+  unsubscribe<EventType extends AllowedEvent & string>(
+    event: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
   ) {
     /* istanbul ignore next */ // Branches unreachable with valid types
     if (this.allowedEvents === null) {
@@ -362,9 +371,11 @@ export class RestrictedControllerMessenger<
    * The event type being cleared *must* be in the current namespace.
    *
    * @param event - The event type. This is a unique identifier for this event.
-   * @template E - A type union of Event type strings that are namespaced by N.
+   * @template EventType - A type union of Event type strings that are namespaced by Namespace.
    */
-  clearEventSubscriptions<E extends NamespacedName<N>>(event: E) {
+  clearEventSubscriptions<
+    EventType extends Namespaced<Namespace, Event['type']>,
+  >(event: EventType) {
     /* istanbul ignore if */ // Branch unreachable with valid types
     if (!event.startsWith(`${this.controllerName}:`)) {
       throw new Error(
@@ -413,11 +424,11 @@ export class ControllerMessenger<
    * @param handler - The action handler. This function gets called when the `call` method is
    * invoked with the given action type.
    * @throws Will throw when a handler has been registered for this action type already.
-   * @template T - A type union of Action type strings.
+   * @template ActionType - A type union of Action type strings.
    */
-  registerActionHandler<T extends Action['type']>(
-    actionType: T,
-    handler: ActionHandler<Action, T>,
+  registerActionHandler<ActionType extends Action['type']>(
+    actionType: ActionType,
+    handler: ActionHandler<Action, ActionType>,
   ) {
     if (this.actions.has(actionType)) {
       throw new Error(
@@ -433,9 +444,11 @@ export class ControllerMessenger<
    * This will prevent this action from being called.
    *
    * @param actionType - The action type. This is a unqiue identifier for this action.
-   * @template T - A type union of Action type strings.
+   * @template ActionType - A type union of Action type strings.
    */
-  unregisterActionHandler<T extends Action['type']>(actionType: T) {
+  unregisterActionHandler<ActionType extends Action['type']>(
+    actionType: ActionType,
+  ) {
     this.actions.delete(actionType);
   }
 
@@ -458,14 +471,17 @@ export class ControllerMessenger<
    * @param params - The action parameters. These must match the type of the parameters of the
    * registered action handler.
    * @throws Will throw when no handler has been registered for the given type.
-   * @template T - A type union of Action type strings.
+   * @template ActionType - A type union of Action type strings.
    * @returns The action return value.
    */
-  call<T extends Action['type']>(
-    actionType: T,
-    ...params: ExtractActionParameters<Action, T>
-  ): ExtractActionResponse<Action, T> {
-    const handler = this.actions.get(actionType) as ActionHandler<Action, T>;
+  call<ActionType extends Action['type']>(
+    actionType: ActionType,
+    ...params: ExtractActionParameters<Action, ActionType>
+  ): ExtractActionResponse<Action, ActionType> {
+    const handler = this.actions.get(actionType) as ActionHandler<
+      Action,
+      ActionType
+    >;
     if (!handler) {
       throw new Error(`A handler for ${actionType} has not been registered`);
     }
@@ -483,11 +499,11 @@ export class ControllerMessenger<
    * @param eventType - The event type. This is a unique identifier for this event.
    * @param payload - The event payload. The type of the parameters for each event handler must
    * match the type of this payload.
-   * @template E - A type union of Event type strings.
+   * @template EventType - A type union of Event type strings.
    */
-  publish<E extends Event['type']>(
-    eventType: E,
-    ...payload: ExtractEventPayload<Event, E>
+  publish<EventType extends Event['type']>(
+    eventType: EventType,
+    ...payload: ExtractEventPayload<Event, EventType>
   ) {
     const subscribers = this.events.get(eventType);
 
@@ -524,11 +540,11 @@ export class ControllerMessenger<
    * @param eventType - The event type. This is a unique identifier for this event.
    * @param handler - The event handler. The type of the parameters for this event handler must
    * match the type of the payload for this event type.
-   * @template E - A type union of Event type strings.
+   * @template EventType - A type union of Event type strings.
    */
-  subscribe<E extends Event['type']>(
-    eventType: E,
-    handler: ExtractEventHandler<Event, E>,
+  subscribe<EventType extends Event['type']>(
+    eventType: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
   ): void;
 
   /**
@@ -545,19 +561,25 @@ export class ControllerMessenger<
    * @param selector - The selector function used to select relevant data from
    * the event payload. The type of the parameters for this selector must match
    * the type of the payload for this event type.
-   * @template E - A type union of Event type strings.
-   * @template V - The selector return value.
+   * @template EventType - A type union of Event type strings.
+   * @template SelectorReturnValue - The selector return value.
    */
-  subscribe<E extends Event['type'], V>(
-    eventType: E,
-    handler: SelectorEventHandler<V>,
-    selector: SelectorFunction<ExtractEventPayload<Event, E>, V>,
+  subscribe<EventType extends Event['type'], SelectorReturnValue>(
+    eventType: EventType,
+    handler: SelectorEventHandler<SelectorReturnValue>,
+    selector: SelectorFunction<
+      ExtractEventPayload<Event, EventType>,
+      SelectorReturnValue
+    >,
   ): void;
 
-  subscribe<E extends Event['type'], V>(
-    eventType: E,
-    handler: ExtractEventHandler<Event, E>,
-    selector?: SelectorFunction<ExtractEventPayload<Event, E>, V>,
+  subscribe<EventType extends Event['type'], SelectorReturnValue>(
+    eventType: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
+    selector?: SelectorFunction<
+      ExtractEventPayload<Event, EventType>,
+      SelectorReturnValue
+    >,
   ): void {
     let subscribers = this.events.get(eventType);
     if (!subscribers) {
@@ -576,11 +598,11 @@ export class ControllerMessenger<
    * @param eventType - The event type. This is a unique identifier for this event.
    * @param handler - The event handler to unregister.
    * @throws Will throw when the given event handler is not registered for this event.
-   * @template E - A type union of Event type strings.
+   * @template EventType - A type union of Event type strings.
    */
-  unsubscribe<E extends Event['type']>(
-    eventType: E,
-    handler: ExtractEventHandler<Event, E>,
+  unsubscribe<EventType extends Event['type']>(
+    eventType: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
   ) {
     const subscribers = this.events.get(eventType);
 
@@ -602,9 +624,11 @@ export class ControllerMessenger<
    * This will remove all subscribed handlers for this event.
    *
    * @param eventType - The event type. This is a unique identifier for this event.
-   * @template E - A type union of Event type strings.
+   * @template EventType - A type union of Event type strings.
    */
-  clearEventSubscriptions<E extends Event['type']>(eventType: E) {
+  clearEventSubscriptions<EventType extends Event['type']>(
+    eventType: EventType,
+  ) {
     this.events.delete(eventType);
   }
 
@@ -634,7 +658,7 @@ export class ControllerMessenger<
    * should be alowed to call.
    * @param options.allowedEvents - The list of events that this restricted controller messenger
    * should be allowed to subscribe to.
-   * @template N - The namespace for this messenger. Typically this is the name of the controller or
+   * @template Namespace - The namespace for this messenger. Typically this is the name of the controller or
    * module that this messenger has been created for. The authority to publish events and register
    * actions under this namespace is granted to this restricted messenger instance.
    * @template AllowedAction - A type union of the 'type' string for any allowed actions.
@@ -642,7 +666,7 @@ export class ControllerMessenger<
    * @returns The restricted controller messenger.
    */
   getRestricted<
-    N extends string,
+    Namespace extends string,
     AllowedAction extends string,
     AllowedEvent extends string,
   >({
@@ -650,20 +674,23 @@ export class ControllerMessenger<
     allowedActions,
     allowedEvents,
   }: {
-    name: N;
+    name: Namespace;
     allowedActions?: Extract<Action['type'], AllowedAction>[];
     allowedEvents?: Extract<Event['type'], AllowedEvent>[];
   }): RestrictedControllerMessenger<
-    N,
-    NarrowToNamespace<Action, N> | NarrowToAllowed<Action, AllowedAction>,
-    NarrowToNamespace<Event, N> | NarrowToAllowed<Event, AllowedEvent>,
+    Namespace,
+    | NarrowToNamespace<Action, Namespace>
+    | NarrowToAllowed<Action, AllowedAction>,
+    NarrowToNamespace<Event, Namespace> | NarrowToAllowed<Event, AllowedEvent>,
     AllowedAction,
     AllowedEvent
   > {
     return new RestrictedControllerMessenger<
-      N,
-      NarrowToNamespace<Action, N> | NarrowToAllowed<Action, AllowedAction>,
-      NarrowToNamespace<Event, N> | NarrowToAllowed<Event, AllowedEvent>,
+      Namespace,
+      | NarrowToNamespace<Action, Namespace>
+      | NarrowToAllowed<Action, AllowedAction>,
+      | NarrowToNamespace<Event, Namespace>
+      | NarrowToAllowed<Event, AllowedEvent>,
       AllowedAction,
       AllowedEvent
     >({


### PR DESCRIPTION
## Explanation

Renames all single-letter type parameter names in `base-controller` to be more descriptive.

## References

- Extracted from https://github.com/MetaMask/core/pull/1890

## Changelog

### `@metamask/base-controller`

- **CHANGED**: Renamed all single-letter generic parameter names to be descriptive

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
