### PR TITLE
accounts-controller: remove support for major node versions 16-17,19

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -56,7 +56,7 @@
     "@metamask/keyring-controller": "^8.1.0"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": "^18.16 || >=20"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Explanation


## References

- For context on why bumping this package ahead of others, see dependency graph: #1699


## Changelog

### `@metamask/accounts-controller`

- **CHANGED**: **BREAKING**: Increase minimum Node.js version from 16 to 18.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
