### PR TITLE
Support token detection on Arbitrum and Optimism

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -39,6 +39,10 @@ export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID: Record<Hex, string> = {
     '0x10dAd7Ca3921471f616db788D9300DC97Db01783',
   [SupportedTokenDetectionNetworks.linea_mainnet]:
     '0xF62e6a41561b3650a69Bb03199C735e3E3328c0D',
+  [SupportedTokenDetectionNetworks.arbitrum]:
+    '0x151E24A486D7258dd7C33Fb67E4bB01919B7B32c',
+  [SupportedTokenDetectionNetworks.optimism]:
+    '0xB1c568e9C3E6bdaf755A60c7418C269eb11524FC',
 };
 
 export const MISSING_PROVIDER_ERROR =

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -148,6 +148,8 @@ export enum SupportedTokenDetectionNetworks {
   aurora = '0x4e454152', // decimal: 1313161554
   linea_goerli = '0xe704', // decimal: 59140
   linea_mainnet = '0xe708', // decimal: 59144
+  arbitrum = '0xa4b1', // decimal: 42161
+  optimism = '0xa', // decimal: 10
 }
 
 /**


### PR DESCRIPTION
## Explanation

Adds support for token detection on arbitrum and optimism.  The goal is to eventually support token detection on MetaMask's top 10 most popular networks.

Token lists are available for both chains:
- https://token-api.metaswap.codefi.network/tokens/42161
- https://token-api.metaswap.codefi.network/tokens/10

As well as the ERC20 balance checker:
- https://github.com/wbobeirne/eth-balance-checker#deployed-addresses

Related PR to extension (depends on this PR): 

## References

Related issues:
- https://github.com/MetaMask/metamask-extension/issues/17697
- https://github.com/MetaMask/metamask-extension/issues/16496

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **ADDED**: Token detection support for Arbitrum and Optimism

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
