### PR TITLE
Fix misaligned mock eth query types in controller tests

### DIFF
--- a/packages/controller-utils/src/util.test.ts
+++ b/packages/controller-utils/src/util.test.ts
@@ -1,7 +1,8 @@
-import EthQuery, { type Provider } from '@metamask/eth-query';
+import EthQuery from '@metamask/eth-query';
 import { BN } from 'ethereumjs-util';
 import nock from 'nock';
 
+import { FakeProvider } from '../../../tests/fake-provider';
 import { MAX_SAFE_CHAIN_ID } from './constants';
 import * as util from './util';
 
@@ -443,7 +444,7 @@ describe('util', () => {
           }
         }
         const result = await util.query(
-          new MockEthQuery({} as Provider),
+          new MockEthQuery(new FakeProvider()),
           'getBlockByHash',
           ['0x1234'],
         );
@@ -457,7 +458,7 @@ describe('util', () => {
           }
         }
         await expect(
-          util.query(new MockEthQuery({} as Provider), 'getBlockByHash', [
+          util.query(new MockEthQuery(new FakeProvider()), 'getBlockByHash', [
             '0x1234',
           ]),
         ).rejects.toThrow('uh oh');
@@ -475,7 +476,7 @@ describe('util', () => {
           }
         }
         const result = await util.query(
-          new MockEthQuery({} as Provider),
+          new MockEthQuery(new FakeProvider()),
           'eth_getBlockByHash',
           ['0x1234'],
         );
@@ -489,9 +490,11 @@ describe('util', () => {
           }
         }
         await expect(
-          util.query(new MockEthQuery({} as Provider), 'eth_getBlockByHash', [
-            '0x1234',
-          ]),
+          util.query(
+            new MockEthQuery(new FakeProvider()),
+            'eth_getBlockByHash',
+            ['0x1234'],
+          ),
         ).rejects.toThrow('uh oh');
       });
     });

--- a/packages/controller-utils/src/util.test.ts
+++ b/packages/controller-utils/src/util.test.ts
@@ -1,3 +1,4 @@
+import EthQuery, { type Provider } from '@metamask/eth-query';
 import { BN } from 'ethereumjs-util';
 import nock from 'nock';
 
@@ -436,34 +437,36 @@ describe('util', () => {
   describe('query', () => {
     describe('when the given method exists directly on the EthQuery', () => {
       it('should call the method on the EthQuery and, if it is successful, return a promise that resolves to the result', async () => {
-        class EthQuery {
+        class MockEthQuery extends EthQuery {
           getBlockByHash(blockId: any, cb: any) {
             cb(null, { id: blockId });
           }
         }
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        const result = await util.query(new EthQuery(), 'getBlockByHash', [
-          '0x1234',
-        ]);
+        const result = await util.query(
+          new MockEthQuery({} as Provider),
+          'getBlockByHash',
+          ['0x1234'],
+        );
         expect(result).toStrictEqual({ id: '0x1234' });
       });
 
       it('should call the method on the EthQuery and, if it errors, return a promise that is rejected with the error', async () => {
-        class EthQuery {
+        class MockEthQuery extends EthQuery {
           getBlockByHash(_blockId: any, cb: any) {
             cb(new Error('uh oh'), null);
           }
         }
         await expect(
-          // @ts-expect-error Mock eth query does not fulfill type requirements
-          util.query(new EthQuery(), 'getBlockByHash', ['0x1234']),
+          util.query(new MockEthQuery({} as Provider), 'getBlockByHash', [
+            '0x1234',
+          ]),
         ).rejects.toThrow('uh oh');
       });
     });
 
     describe('when the given method does not exist directly on the EthQuery', () => {
       it('should use sendAsync to call the RPC endpoint and, if it is successful, return a promise that resolves to the result', async () => {
-        class EthQuery {
+        class MockEthQuery extends EthQuery {
           sendAsync({ method, params }: any, cb: any) {
             if (method === 'eth_getBlockByHash') {
               return cb(null, { id: params[0] });
@@ -471,22 +474,24 @@ describe('util', () => {
             throw new Error(`Unsupported method ${method}`);
           }
         }
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        const result = await util.query(new EthQuery(), 'eth_getBlockByHash', [
-          '0x1234',
-        ]);
+        const result = await util.query(
+          new MockEthQuery({} as Provider),
+          'eth_getBlockByHash',
+          ['0x1234'],
+        );
         expect(result).toStrictEqual({ id: '0x1234' });
       });
 
       it('should use sendAsync to call the RPC endpoint and, if it errors, return a promise that is rejected with the error', async () => {
-        class EthQuery {
+        class MockEthQuery extends EthQuery {
           sendAsync(_args: any, cb: any) {
             cb(new Error('uh oh'), null);
           }
         }
         await expect(
-          // @ts-expect-error Mock eth query does not fulfill type requirements
-          util.query(new EthQuery(), 'eth_getBlockByHash', ['0x1234']),
+          util.query(new MockEthQuery({} as Provider), 'eth_getBlockByHash', [
+            '0x1234',
+          ]),
         ).rejects.toThrow('uh oh');
       });
     });

--- a/packages/gas-fee-controller/src/fetchBlockFeeHistory.test.ts
+++ b/packages/gas-fee-controller/src/fetchBlockFeeHistory.test.ts
@@ -1,8 +1,9 @@
 import { query, fromHex, toHex } from '@metamask/controller-utils';
-import EthQuery, { type Provider } from '@metamask/eth-query';
+import EthQuery from '@metamask/eth-query';
 import { BN } from 'ethereumjs-util';
 import { when } from 'jest-when';
 
+import { FakeProvider } from '../../../tests/fake-provider';
 import fetchBlockFeeHistory from './fetchBlockFeeHistory';
 
 jest.mock('@metamask/controller-utils', () => {
@@ -34,7 +35,7 @@ function times<T>(n: number, fn: (n: number) => T): T[] {
 }
 
 describe('fetchBlockFeeHistory', () => {
-  const mockEthQuery = new EthQuery({} as Provider);
+  const mockEthQuery = new EthQuery(new FakeProvider());
   describe('with a minimal set of arguments', () => {
     const latestBlockNumber = 3;
     const numberOfRequestedBlocks = 3;

--- a/packages/gas-fee-controller/src/fetchBlockFeeHistory.test.ts
+++ b/packages/gas-fee-controller/src/fetchBlockFeeHistory.test.ts
@@ -1,4 +1,5 @@
 import { query, fromHex, toHex } from '@metamask/controller-utils';
+import EthQuery, { type Provider } from '@metamask/eth-query';
 import { BN } from 'ethereumjs-util';
 import { when } from 'jest-when';
 
@@ -33,23 +34,20 @@ function times<T>(n: number, fn: (n: number) => T): T[] {
 }
 
 describe('fetchBlockFeeHistory', () => {
-  const ethQuery = { eth: 'query' };
-
+  const mockEthQuery = new EthQuery({} as Provider);
   describe('with a minimal set of arguments', () => {
     const latestBlockNumber = 3;
     const numberOfRequestedBlocks = 3;
 
     beforeEach(() => {
       when(mockedQuery)
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        .calledWith(ethQuery, 'blockNumber')
+        .calledWith(mockEthQuery, 'blockNumber')
         .mockResolvedValue(new BN(latestBlockNumber));
     });
 
     it('should return a representation of fee history from the Ethereum network, organized by block rather than type of data', async () => {
       when(mockedQuery)
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        .calledWith(ethQuery, 'eth_feeHistory', [
+        .calledWith(mockEthQuery, 'eth_feeHistory', [
           toHex(numberOfRequestedBlocks),
           toHex(latestBlockNumber),
           [],
@@ -70,7 +68,7 @@ describe('fetchBlockFeeHistory', () => {
         });
 
       const feeHistory = await fetchBlockFeeHistory({
-        ethQuery,
+        ethQuery: mockEthQuery,
         numberOfBlocks: numberOfRequestedBlocks,
       });
 
@@ -98,8 +96,7 @@ describe('fetchBlockFeeHistory', () => {
 
     it('should be able to handle an "empty" response from eth_feeHistory', async () => {
       when(mockedQuery)
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        .calledWith(ethQuery, 'eth_feeHistory', [
+        .calledWith(mockEthQuery, 'eth_feeHistory', [
           toHex(numberOfRequestedBlocks),
           toHex(latestBlockNumber),
           [],
@@ -111,7 +108,7 @@ describe('fetchBlockFeeHistory', () => {
         });
 
       const feeHistory = await fetchBlockFeeHistory({
-        ethQuery,
+        ethQuery: mockEthQuery,
         numberOfBlocks: numberOfRequestedBlocks,
       });
 
@@ -120,8 +117,7 @@ describe('fetchBlockFeeHistory', () => {
 
     it('should be able to handle an response with undefined baseFeePerGas from eth_feeHistory', async () => {
       when(mockedQuery)
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        .calledWith(ethQuery, 'eth_feeHistory', [
+        .calledWith(mockEthQuery, 'eth_feeHistory', [
           toHex(numberOfRequestedBlocks),
           toHex(latestBlockNumber),
           [],
@@ -132,7 +128,7 @@ describe('fetchBlockFeeHistory', () => {
         });
 
       const feeHistory = await fetchBlockFeeHistory({
-        ethQuery,
+        ethQuery: mockEthQuery,
         numberOfBlocks: numberOfRequestedBlocks,
       });
 
@@ -158,8 +154,7 @@ describe('fetchBlockFeeHistory', () => {
       });
 
       when(mockedQuery)
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        .calledWith(ethQuery, 'blockNumber')
+        .calledWith(mockEthQuery, 'blockNumber')
         .mockResolvedValue(new BN(latestBlockNumber));
 
       expectedChunks.forEach(({ startBlockNumber, endBlockNumber }) => {
@@ -171,8 +166,7 @@ describe('fetchBlockFeeHistory', () => {
           .map((block) => block.gasUsedRatio);
 
         when(mockedQuery)
-          // @ts-expect-error Mock eth query does not fulfill type requirements
-          .calledWith(ethQuery, 'eth_feeHistory', [
+          .calledWith(mockEthQuery, 'eth_feeHistory', [
             toHex(endBlockNumber - startBlockNumber + 1),
             toHex(endBlockNumber),
             [],
@@ -185,7 +179,7 @@ describe('fetchBlockFeeHistory', () => {
       });
 
       const feeHistory = await fetchBlockFeeHistory({
-        ethQuery,
+        ethQuery: mockEthQuery,
         numberOfBlocks: numberOfRequestedBlocks,
       });
 
@@ -208,8 +202,7 @@ describe('fetchBlockFeeHistory', () => {
       const numberOfRequestedBlocks = 3;
       const endBlock = new BN(latestBlockNumber);
       when(mockedQuery)
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        .calledWith(ethQuery, 'eth_feeHistory', [
+        .calledWith(mockEthQuery, 'eth_feeHistory', [
           toHex(numberOfRequestedBlocks),
           toHex(endBlock),
           [],
@@ -221,7 +214,7 @@ describe('fetchBlockFeeHistory', () => {
         });
 
       const feeHistory = await fetchBlockFeeHistory({
-        ethQuery,
+        ethQuery: mockEthQuery,
         numberOfBlocks: numberOfRequestedBlocks,
         endBlock,
       });
@@ -236,15 +229,13 @@ describe('fetchBlockFeeHistory', () => {
 
     beforeEach(() => {
       when(mockedQuery)
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        .calledWith(ethQuery, 'blockNumber')
+        .calledWith(mockEthQuery, 'blockNumber')
         .mockResolvedValue(new BN(latestBlockNumber));
     });
 
     it('should match each item in the "reward" key from the response to its percentile', async () => {
       when(mockedQuery)
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        .calledWith(ethQuery, 'eth_feeHistory', [
+        .calledWith(mockEthQuery, 'eth_feeHistory', [
           toHex(numberOfRequestedBlocks),
           toHex(latestBlockNumber),
           [10, 20, 30],
@@ -278,7 +269,7 @@ describe('fetchBlockFeeHistory', () => {
         });
 
       const feeHistory = await fetchBlockFeeHistory({
-        ethQuery,
+        ethQuery: mockEthQuery,
         numberOfBlocks: numberOfRequestedBlocks,
         percentiles: [10, 20, 30],
       });
@@ -319,8 +310,7 @@ describe('fetchBlockFeeHistory', () => {
 
     it('should be able to handle an "empty" response from eth_feeHistory including an empty "reward" array', async () => {
       when(mockedQuery)
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        .calledWith(ethQuery, 'eth_feeHistory', [
+        .calledWith(mockEthQuery, 'eth_feeHistory', [
           toHex(numberOfRequestedBlocks),
           toHex(latestBlockNumber),
           [10, 20, 30],
@@ -333,7 +323,7 @@ describe('fetchBlockFeeHistory', () => {
         });
 
       const feeHistory = await fetchBlockFeeHistory({
-        ethQuery,
+        ethQuery: mockEthQuery,
         numberOfBlocks: numberOfRequestedBlocks,
         percentiles: [10, 20, 30],
       });
@@ -348,8 +338,7 @@ describe('fetchBlockFeeHistory', () => {
 
     it('includes an extra block with an estimated baseFeePerGas', async () => {
       when(mockedQuery)
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        .calledWith(ethQuery, 'eth_feeHistory', [
+        .calledWith(mockEthQuery, 'eth_feeHistory', [
           toHex(numberOfRequestedBlocks),
           toHex(latestBlockNumber),
           [],
@@ -370,7 +359,7 @@ describe('fetchBlockFeeHistory', () => {
         });
 
       const feeHistory = await fetchBlockFeeHistory({
-        ethQuery,
+        ethQuery: mockEthQuery,
         numberOfBlocks: numberOfRequestedBlocks,
         includeNextBlock: true,
       });
@@ -415,8 +404,7 @@ describe('fetchBlockFeeHistory', () => {
       const endBlock = new BN(latestBlockNumber);
 
       when(mockedQuery)
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        .calledWith(ethQuery, 'eth_feeHistory', [
+        .calledWith(mockEthQuery, 'eth_feeHistory', [
           toHex(latestBlockNumber),
           toHex(latestBlockNumber),
           [],
@@ -429,7 +417,7 @@ describe('fetchBlockFeeHistory', () => {
         });
 
       await fetchBlockFeeHistory({
-        ethQuery,
+        ethQuery: mockEthQuery,
         numberOfBlocks: numberOfRequestedBlocks,
         endBlock,
       });

--- a/packages/gas-fee-controller/src/fetchGasEstimatesViaEthFeeHistory.test.ts
+++ b/packages/gas-fee-controller/src/fetchGasEstimatesViaEthFeeHistory.test.ts
@@ -1,3 +1,4 @@
+import EthQuery from '@metamask/eth-query';
 import { BN } from 'ethereumjs-util';
 import { when } from 'jest-when';
 
@@ -31,7 +32,8 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
     number: new BN(1),
     baseFeePerGas: new BN(100_000_000_000),
   };
-  const ethQuery = {
+  const mockEthQuery = {
+    sendAsync: EthQuery.prototype.sendAsync,
     blockNumber: async () => latestBlock.number,
     getBlockByNumber: async () => latestBlock,
   };
@@ -73,7 +75,7 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
     mockedFetchLatestBlock.mockResolvedValue(latestBlock);
     when(mockedFetchBlockFeeHistory)
       .calledWith({
-        ethQuery,
+        ethQuery: mockEthQuery,
         endBlock: latestBlock.number,
         numberOfBlocks: 5,
         percentiles: [10, 20, 30],
@@ -84,8 +86,9 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
       .calledWith(blocks)
       .mockReturnValue(levelSpecificEstimates);
 
-    // @ts-expect-error Mock eth query does not fulfill type requirements
-    const gasFeeEstimates = await fetchGasEstimatesViaEthFeeHistory(ethQuery);
+    const gasFeeEstimates = await fetchGasEstimatesViaEthFeeHistory(
+      mockEthQuery,
+    );
 
     expect(gasFeeEstimates).toStrictEqual({
       ...levelSpecificEstimates,

--- a/packages/transaction-controller/src/utils/transaction-type.test.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.test.ts
@@ -1,3 +1,5 @@
+import EthQuery, { type Provider } from '@metamask/eth-query';
+
 import { TransactionType } from '../types';
 import { determineTransactionType } from './transaction-type';
 
@@ -10,7 +12,7 @@ describe('determineTransactionType', () => {
   };
 
   it('returns a token transfer type when the recipient is a contract, there is no value passed, and data is for the respective method call', async () => {
-    class EthQuery {
+    class MockEthQuery extends EthQuery {
       getCode(_to: any, cb: any) {
         cb(null, '0xab');
       }
@@ -21,8 +23,7 @@ describe('determineTransactionType', () => {
         data: '0xa9059cbb0000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C970000000000000000000000000000000000000000000000000000000000000000a',
         from: FROM_MOCK,
       },
-      // @ts-expect-error Mock eth query does not fulfill type requirements
-      new EthQuery(),
+      new MockEthQuery({} as Provider),
     );
 
     expect(result).toMatchObject({
@@ -35,15 +36,15 @@ describe('determineTransactionType', () => {
     'does NOT return a token transfer type and instead returns contract interaction' +
       ' when the recipient is a contract, the data matches the respective method call, but there is a value passed',
     async () => {
-      class EthQuery {
+      class MockEthQuery extends EthQuery {
         getCode(_to: any, cb: any) {
           cb(null, '0xab');
         }
       }
       const resultWithEmptyValue = await determineTransactionType(
         txParams,
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        new EthQuery(),
+
+        new MockEthQuery({} as Provider),
       );
       expect(resultWithEmptyValue).toMatchObject({
         type: TransactionType.tokenMethodTransfer,
@@ -55,8 +56,8 @@ describe('determineTransactionType', () => {
           value: '0x0000',
           ...txParams,
         },
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        new EthQuery(),
+
+        new MockEthQuery({} as Provider),
       );
 
       expect(resultWithEmptyValue2).toMatchObject({
@@ -69,8 +70,8 @@ describe('determineTransactionType', () => {
           value: '0x12345',
           ...txParams,
         },
-        // @ts-expect-error Mock eth query does not fulfill type requirements
-        new EthQuery(),
+
+        new MockEthQuery({} as Provider),
       );
       expect(resultWithValue).toMatchObject({
         type: TransactionType.contractInteraction,
@@ -80,15 +81,14 @@ describe('determineTransactionType', () => {
   );
 
   it('does NOT return a token transfer type when the recipient is not a contract but the data matches the respective method call', async () => {
-    class EthQuery {
+    class MockEthQuery extends EthQuery {
       getCode(_to: any, cb: any) {
         cb(null, '0x');
       }
     }
     const result = await determineTransactionType(
       txParams,
-      // @ts-expect-error Mock eth query does not fulfill type requirements
-      new EthQuery(),
+      new MockEthQuery({} as Provider),
     );
     expect(result).toMatchObject({
       type: TransactionType.simpleSend,
@@ -97,7 +97,7 @@ describe('determineTransactionType', () => {
   });
 
   it('returns a token approve type when the recipient is a contract and data is for the respective method call', async () => {
-    class EthQuery {
+    class MockEthQuery extends EthQuery {
       getCode(_to: any, cb: any) {
         cb(null, '0xab');
       }
@@ -107,8 +107,7 @@ describe('determineTransactionType', () => {
         ...txParams,
         data: '0x095ea7b30000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C9700000000000000000000000000000000000000000000000000000000000000005',
       },
-      // @ts-expect-error Mock eth query does not fulfill type requirements
-      new EthQuery(),
+      new MockEthQuery({} as Provider),
     );
     expect(result).toMatchObject({
       type: TransactionType.tokenMethodApprove,
@@ -117,7 +116,7 @@ describe('determineTransactionType', () => {
   });
 
   it('returns a contract deployment type when "to" is falsy and there is data', async () => {
-    class EthQuery {
+    class MockEthQuery extends EthQuery {
       getCode(_to: any, cb: any) {
         cb(null, '');
       }
@@ -128,8 +127,7 @@ describe('determineTransactionType', () => {
         to: '',
         data: '0xabd',
       },
-      // @ts-expect-error Mock eth query does not fulfill type requirements
-      new EthQuery(),
+      new MockEthQuery({} as Provider),
     );
     expect(result).toMatchObject({
       type: TransactionType.deployContract,
@@ -138,7 +136,7 @@ describe('determineTransactionType', () => {
   });
 
   it('returns a simple send type with a 0x getCodeResponse when there is data, but the "to" address is not a contract address', async () => {
-    class EthQuery {
+    class MockEthQuery extends EthQuery {
       getCode(_to: any, cb: any) {
         cb(null, '0x');
       }
@@ -148,8 +146,7 @@ describe('determineTransactionType', () => {
         ...txParams,
         data: '0xabd',
       },
-      // @ts-expect-error Mock eth query does not fulfill type requirements
-      new EthQuery(),
+      new MockEthQuery({} as Provider),
     );
     expect(result).toMatchObject({
       type: TransactionType.simpleSend,
@@ -158,7 +155,7 @@ describe('determineTransactionType', () => {
   });
 
   it('returns a simple send type with a null getCodeResponse when "to" is truthy and there is data, but getCode returns an error', async () => {
-    class EthQuery {
+    class MockEthQuery extends EthQuery {
       getCode(_to: any, cb: any) {
         cb(new Error('Some error'));
       }
@@ -168,8 +165,7 @@ describe('determineTransactionType', () => {
         ...txParams,
         data: '0xabd',
       },
-      // @ts-expect-error Mock eth query does not fulfill type requirements
-      new EthQuery(),
+      new MockEthQuery({} as Provider),
     );
     expect(result).toMatchObject({
       type: TransactionType.simpleSend,
@@ -178,7 +174,7 @@ describe('determineTransactionType', () => {
   });
 
   it('returns a contract interaction type with the correct getCodeResponse when "to" is truthy and there is data, and it is not a token transaction', async () => {
-    class EthQuery {
+    class MockEthQuery extends EthQuery {
       getCode(_to: any, cb: any) {
         cb(null, '0xa');
       }
@@ -188,8 +184,7 @@ describe('determineTransactionType', () => {
         ...txParams,
         data: 'abd',
       },
-      // @ts-expect-error Mock eth query does not fulfill type requirements
-      new EthQuery(),
+      new MockEthQuery({} as Provider),
     );
     expect(result).toMatchObject({
       type: TransactionType.contractInteraction,
@@ -198,7 +193,7 @@ describe('determineTransactionType', () => {
   });
 
   it('returns a contract interaction type with the correct getCodeResponse when "to" is a contract address and data is falsy', async () => {
-    class EthQuery {
+    class MockEthQuery extends EthQuery {
       getCode(_to: any, cb: any) {
         cb(null, '0xa');
       }
@@ -208,8 +203,7 @@ describe('determineTransactionType', () => {
         ...txParams,
         data: '',
       },
-      // @ts-expect-error Mock eth query does not fulfill type requirements
-      new EthQuery(),
+      new MockEthQuery({} as Provider),
     );
     expect(result).toMatchObject({
       type: TransactionType.contractInteraction,
@@ -218,7 +212,7 @@ describe('determineTransactionType', () => {
   });
 
   it('returns contractInteraction for send with approve', async () => {
-    class EthQuery {
+    class MockEthQuery extends EthQuery {
       getCode(_to: any, cb: any) {
         cb(null, '0xa');
       }
@@ -230,8 +224,7 @@ describe('determineTransactionType', () => {
         value: '0x5af3107a4000',
         data: '0x095ea7b30000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C9700000000000000000000000000000000000000000000000000000000000000005',
       },
-      // @ts-expect-error Mock eth query does not fulfill type requirements
-      new EthQuery(),
+      new MockEthQuery({} as Provider),
     );
     expect(result).toMatchObject({
       type: TransactionType.contractInteraction,

--- a/packages/transaction-controller/src/utils/transaction-type.test.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.test.ts
@@ -1,5 +1,6 @@
-import EthQuery, { type Provider } from '@metamask/eth-query';
+import EthQuery from '@metamask/eth-query';
 
+import { FakeProvider } from '../../../../tests/fake-provider';
 import { TransactionType } from '../types';
 import { determineTransactionType } from './transaction-type';
 
@@ -23,7 +24,7 @@ describe('determineTransactionType', () => {
         data: '0xa9059cbb0000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C970000000000000000000000000000000000000000000000000000000000000000a',
         from: FROM_MOCK,
       },
-      new MockEthQuery({} as Provider),
+      new MockEthQuery(new FakeProvider()),
     );
 
     expect(result).toMatchObject({
@@ -44,7 +45,7 @@ describe('determineTransactionType', () => {
       const resultWithEmptyValue = await determineTransactionType(
         txParams,
 
-        new MockEthQuery({} as Provider),
+        new MockEthQuery(new FakeProvider()),
       );
       expect(resultWithEmptyValue).toMatchObject({
         type: TransactionType.tokenMethodTransfer,
@@ -57,7 +58,7 @@ describe('determineTransactionType', () => {
           ...txParams,
         },
 
-        new MockEthQuery({} as Provider),
+        new MockEthQuery(new FakeProvider()),
       );
 
       expect(resultWithEmptyValue2).toMatchObject({
@@ -71,7 +72,7 @@ describe('determineTransactionType', () => {
           ...txParams,
         },
 
-        new MockEthQuery({} as Provider),
+        new MockEthQuery(new FakeProvider()),
       );
       expect(resultWithValue).toMatchObject({
         type: TransactionType.contractInteraction,
@@ -88,7 +89,7 @@ describe('determineTransactionType', () => {
     }
     const result = await determineTransactionType(
       txParams,
-      new MockEthQuery({} as Provider),
+      new MockEthQuery(new FakeProvider()),
     );
     expect(result).toMatchObject({
       type: TransactionType.simpleSend,
@@ -107,7 +108,7 @@ describe('determineTransactionType', () => {
         ...txParams,
         data: '0x095ea7b30000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C9700000000000000000000000000000000000000000000000000000000000000005',
       },
-      new MockEthQuery({} as Provider),
+      new MockEthQuery(new FakeProvider()),
     );
     expect(result).toMatchObject({
       type: TransactionType.tokenMethodApprove,
@@ -127,7 +128,7 @@ describe('determineTransactionType', () => {
         to: '',
         data: '0xabd',
       },
-      new MockEthQuery({} as Provider),
+      new MockEthQuery(new FakeProvider()),
     );
     expect(result).toMatchObject({
       type: TransactionType.deployContract,
@@ -146,7 +147,7 @@ describe('determineTransactionType', () => {
         ...txParams,
         data: '0xabd',
       },
-      new MockEthQuery({} as Provider),
+      new MockEthQuery(new FakeProvider()),
     );
     expect(result).toMatchObject({
       type: TransactionType.simpleSend,
@@ -165,7 +166,7 @@ describe('determineTransactionType', () => {
         ...txParams,
         data: '0xabd',
       },
-      new MockEthQuery({} as Provider),
+      new MockEthQuery(new FakeProvider()),
     );
     expect(result).toMatchObject({
       type: TransactionType.simpleSend,
@@ -184,7 +185,7 @@ describe('determineTransactionType', () => {
         ...txParams,
         data: 'abd',
       },
-      new MockEthQuery({} as Provider),
+      new MockEthQuery(new FakeProvider()),
     );
     expect(result).toMatchObject({
       type: TransactionType.contractInteraction,
@@ -203,7 +204,7 @@ describe('determineTransactionType', () => {
         ...txParams,
         data: '',
       },
-      new MockEthQuery({} as Provider),
+      new MockEthQuery(new FakeProvider()),
     );
     expect(result).toMatchObject({
       type: TransactionType.contractInteraction,
@@ -224,7 +225,7 @@ describe('determineTransactionType', () => {
         value: '0x5af3107a4000',
         data: '0x095ea7b30000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C9700000000000000000000000000000000000000000000000000000000000000005',
       },
-      new MockEthQuery({} as Provider),
+      new MockEthQuery(new FakeProvider()),
     );
     expect(result).toMatchObject({
       type: TransactionType.contractInteraction,


### PR DESCRIPTION
## Explanation

Fixes `// @ts-expect-error Mock eth query does not fulfill type requirements` annotations throughout core repo.

## References

- Builds upon
  - https://github.com/MetaMask/eth-query/pull/21
  - https://github.com/MetaMask/core/pull/2028
- Related https://github.com/MetaMask/core/issues/1823
- Closes https://github.com/MetaMask/core/issues/2036

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
