### PR TITLE
Release 91.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "90.0.0",
+  "version": "91.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [18.0.1]
+### Uncategorized
+- Add optional `networkClientId` and `userAddress` args to remaining `NftController` public methods ([#2006](https://github.com/MetaMask/core/pull/2006))
+- fix: add name and symbol to getDetails ([#1727](https://github.com/MetaMask/core/pull/1727))
+- Re-enable @typescript-eslint/consistent-type-definitions ([#1933](https://github.com/MetaMask/core/pull/1933))
+- Release 88.0.0 ([#1996](https://github.com/MetaMask/core/pull/1996))
+- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
+- Advance time utility function ([#1973](https://github.com/MetaMask/core/pull/1973))
+- Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
+- Change `test` build scripts to only show output for failed tests by default ([#1949](https://github.com/MetaMask/core/pull/1949))
+
 ### Changed
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 
@@ -367,7 +379,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use Ethers for AssetsContractController ([#845](https://github.com/MetaMask/core/pull/845))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@18.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@18.0.1...HEAD
+[18.0.1]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@18.0.0...@metamask/assets-controllers@18.0.1
 [18.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@17.0.0...@metamask/assets-controllers@18.0.0
 [17.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@16.0.0...@metamask/assets-controllers@17.0.0
 [16.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@15.0.0...@metamask/assets-controllers@16.0.0

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [19.0.0]
 ### Changed
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
-- **BREAKING:** Add optional `networkClientId` and `userAddress` args to remaining `NftController` public methods ([#2006](https://github.com/MetaMask/core/pull/2006))
+- Add optional `networkClientId` and `userAddress` args to remaining `NftController` public methods ([#2006](https://github.com/MetaMask/core/pull/2006))
   - `watchNft`, `removeNft`, `removeAndIgnoreNft`, `removeNftContract`, `updateNftFavoriteStatus`, and `checkAndUpdateAllNftsOwnershipStatus` methods on `NftController` all now accept an optional options object argument containing `networkClientId` and `userAddress` to identify where in state to mutate.
   - **BREAKING**: `addNft` no longer accepts a `chainId` property in its options argument since this value can be retrieved by the `networkClientId` property and is therefore redundant.
   - **BREAKING**: The third and fourth arguments on NftController's `addNftVerifyOwnership` method, have been replaced with an options object containing optional properties `networkClientId`, `userAddress` and `source`. This method signature is more aligned with the options pattern for passing `networkClientId` and `userAddress` on this controller and elsewhere.

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [19.0.0]
-### Added
-- Add name and symbol to `ERC1155Standard` class `getDetails` method ([#1727](https://github.com/MetaMask/core/pull/1727))
-
 ### Changed
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
 - **BREAKING:** Add optional `networkClientId` and `userAddress` args to remaining `NftController` public methods ([#2006](https://github.com/MetaMask/core/pull/2006))
@@ -23,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/auto-changelog` from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 - Bump `@metamask/utils` from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
+
+### Fixed
+- Add name and symbol to the payload returned by the `ERC1155Standard` class `getDetails` method for `ERC1155` contracts ([#1727](https://github.com/MetaMask/core/pull/1727))
 
 ## [18.0.0]
 ### Changed

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -6,13 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [18.1.0]
+## [19.0.0]
 ### Added
-- Add optional `networkClientId` and `userAddress` args to remaining `NftController` public methods ([#2006](https://github.com/MetaMask/core/pull/2006))
 - Add name and symbol to `ERC1155Standard` class `getDetails` method ([#1727](https://github.com/MetaMask/core/pull/1727))
 
 ### Changed
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
+- **BREAKING:** Add optional `networkClientId` and `userAddress` args to remaining `NftController` public methods ([#2006](https://github.com/MetaMask/core/pull/2006))
+  - `watchNft`, `removeNft`, `removeAndIgnoreNft`, `removeNftContract`, `updateNftFavoriteStatus`, and `checkAndUpdateAllNftsOwnershipStatus` methods on `NftController` all now accept an optional options object argument containing `networkClientId` and `userAddress` to identify where in state to mutate.
+  - **BREAKING**: `addNft` no longer accepts a `chainId` property in its options argument since this value can be retrieved by the `networkClientId` property and is therefore redundant.
+  - **BREAKING**: The third and fourth arguments on NftController's `addNftVerifyOwnership` method, have been replaced with an options object containing optional properties `networkClientId`, `userAddress` and `source`. This method signature is more aligned with the options pattern for passing `networkClientId` and `userAddress` on this controller and elsewhere.
+  - **BREAKING**: `checkAndUpdateSingleNftOwnershipStatus` on NftController no longer accepts a `chainId` in its options argument. This is replaced with an optional `networkClientId` property which can be used to fetch chainId.
+   ***BREAKING**: The fourth argument of the `isNftOwner` method on `NftController` is now an options object with an optional `networkClientId` property. This method signature is more aligned with the options pattern for passing `networkClientId` on this controller and elsewhere.
+  - **BREAKING**: `validateWatchNft` method on `NftController` is now private.
+  - **BREAKING**: `detectNfts` on `NftDetectionController` now accepts a single object argument with optional properties `networkClientId` and `userAddress`, rather than taking these as two sequential arguments.
 - Bump `@metamask/auto-changelog` from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 - Bump `@metamask/utils` from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
@@ -376,8 +383,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use Ethers for AssetsContractController ([#845](https://github.com/MetaMask/core/pull/845))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@18.1.0...HEAD
-[18.1.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@18.0.0...@metamask/assets-controllers@18.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@19.0.0...HEAD
+[19.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@18.0.0...@metamask/assets-controllers@19.0.0
 [18.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@17.0.0...@metamask/assets-controllers@18.0.0
 [17.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@16.0.0...@metamask/assets-controllers@17.0.0
 [16.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@15.0.0...@metamask/assets-controllers@16.0.0

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    ***BREAKING**: The fourth argument of the `isNftOwner` method on `NftController` is now an options object with an optional `networkClientId` property. This method signature is more aligned with the options pattern for passing `networkClientId` on this controller and elsewhere.
   - **BREAKING**: `validateWatchNft` method on `NftController` is now private.
   - **BREAKING**: `detectNfts` on `NftDetectionController` now accepts a single object argument with optional properties `networkClientId` and `userAddress`, rather than taking these as two sequential arguments.
-- Bump `@metamask/auto-changelog` from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 - Bump `@metamask/utils` from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -6,19 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [18.0.1]
-### Uncategorized
+## [18.1.0]
+### Added
 - Add optional `networkClientId` and `userAddress` args to remaining `NftController` public methods ([#2006](https://github.com/MetaMask/core/pull/2006))
-- fix: add name and symbol to getDetails ([#1727](https://github.com/MetaMask/core/pull/1727))
-- Re-enable @typescript-eslint/consistent-type-definitions ([#1933](https://github.com/MetaMask/core/pull/1933))
-- Release 88.0.0 ([#1996](https://github.com/MetaMask/core/pull/1996))
-- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
-- Advance time utility function ([#1973](https://github.com/MetaMask/core/pull/1973))
-- Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
-- Change `test` build scripts to only show output for failed tests by default ([#1949](https://github.com/MetaMask/core/pull/1949))
+- Add name and symbol to `ERC1155Standard` class `getDetails` method ([#1727](https://github.com/MetaMask/core/pull/1727))
 
 ### Changed
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
+- Bump `@metamask/auto-changelog` from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
+- Bump `@metamask/utils` from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
 
 ## [18.0.0]
 ### Changed
@@ -379,8 +376,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use Ethers for AssetsContractController ([#845](https://github.com/MetaMask/core/pull/845))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@18.0.1...HEAD
-[18.0.1]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@18.0.0...@metamask/assets-controllers@18.0.1
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@18.1.0...HEAD
+[18.1.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@18.0.0...@metamask/assets-controllers@18.1.0
 [18.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@17.0.0...@metamask/assets-controllers@18.0.0
 [17.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@16.0.0...@metamask/assets-controllers@17.0.0
 [16.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@15.0.0...@metamask/assets-controllers@16.0.0

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **BREAKING**: `validateWatchNft` method on `NftController` is now private.
   - **BREAKING**: `detectNfts` on `NftDetectionController` now accepts a single object argument with optional properties `networkClientId` and `userAddress`, rather than taking these as two sequential arguments.
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
+- Bump dependency on `@metamask/polling-controller` to ^1.0.2
 - Bump `@metamask/utils` from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
 
 ### Fixed

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/assets-controllers",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "Controllers which manage interactions involving ERC-20, ERC-721, and ERC-1155 tokens (including NFTs)",
   "keywords": [
     "MetaMask",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/assets-controllers",
-  "version": "18.1.0",
+  "version": "19.0.0",
   "description": "Controllers which manage interactions involving ERC-20, ERC-721, and ERC-1155 tokens (including NFTs)",
   "keywords": [
     "MetaMask",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/assets-controllers",
-  "version": "18.0.1",
+  "version": "18.1.0",
   "description": "Controllers which manage interactions involving ERC-20, ERC-721, and ERC-1155 tokens (including NFTs)",
   "keywords": [
     "MetaMask",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -41,8 +41,8 @@
     "@metamask/controller-utils": "^5.0.2",
     "@metamask/eth-query": "^4.0.0",
     "@metamask/metamask-eth-abis": "3.0.0",
-    "@metamask/network-controller": "^15.2.0",
-    "@metamask/polling-controller": "^1.0.1",
+    "@metamask/network-controller": "^16.0.0",
+    "@metamask/polling-controller": "^1.0.2",
     "@metamask/preferences-controller": "^4.4.3",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/utils": "^8.2.0",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^4.1.0",
-    "@metamask/network-controller": "^15.2.0",
+    "@metamask/network-controller": "^16.0.0",
     "@metamask/preferences-controller": "^4.4.3"
   },
   "engines": {

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.0.1]
 ### Changed
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
-- Bump @metamask/auto-changelog from 3.2.0 to 3.4.3 ([#1870](https://github.com/MetaMask/core/pull/1870), [#1905](https://github.com/MetaMask/core/pull/1905), [#1997](https://github.com/MetaMask/core/pull/1997))
 - Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
 
 ## [6.0.0]

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -7,14 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [6.0.1]
-### Uncategorized
-- Release 88.0.0 ([#1996](https://github.com/MetaMask/core/pull/1996))
-- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
+### Changed
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
+- Bump @metamask/auto-changelog from 3.2.0 to 3.4.3 ([#1870](https://github.com/MetaMask/core/pull/1870), [#1905](https://github.com/MetaMask/core/pull/1905), [#1997](https://github.com/MetaMask/core/pull/1997))
 - Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
-- Change `test` build scripts to only show output for failed tests by default ([#1949](https://github.com/MetaMask/core/pull/1949))
-- Release/84.0.0 ([#1904](https://github.com/MetaMask/core/pull/1904))
-- bump `@metamask/auto-changelog` to `^3.4.2` ([#1905](https://github.com/MetaMask/core/pull/1905))
-- Bump @metamask/auto-changelog from 3.2.0 to 3.4.0 ([#1870](https://github.com/MetaMask/core/pull/1870))
 
 ## [6.0.0]
 ### Changed

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.1]
+### Uncategorized
+- Release 88.0.0 ([#1996](https://github.com/MetaMask/core/pull/1996))
+- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
+- Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
+- Change `test` build scripts to only show output for failed tests by default ([#1949](https://github.com/MetaMask/core/pull/1949))
+- Release/84.0.0 ([#1904](https://github.com/MetaMask/core/pull/1904))
+- bump `@metamask/auto-changelog` to `^3.4.2` ([#1905](https://github.com/MetaMask/core/pull/1905))
+- Bump @metamask/auto-changelog from 3.2.0 to 3.4.0 ([#1870](https://github.com/MetaMask/core/pull/1870))
+
 ## [6.0.0]
 ### Changed
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^15.0.0
@@ -81,7 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@6.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@6.0.1...HEAD
+[6.0.1]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@6.0.0...@metamask/ens-controller@6.0.1
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@5.0.2...@metamask/ens-controller@6.0.0
 [5.0.2]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@5.0.1...@metamask/ens-controller@5.0.2
 [5.0.1]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@5.0.0...@metamask/ens-controller@5.0.1

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -33,7 +33,7 @@
     "@ethersproject/providers": "^5.7.0",
     "@metamask/base-controller": "^3.2.3",
     "@metamask/controller-utils": "^5.0.2",
-    "@metamask/network-controller": "^15.2.0",
+    "@metamask/network-controller": "^16.0.0",
     "@metamask/utils": "^8.2.0",
     "ethereum-ens-network-map": "^1.0.2",
     "punycode": "^2.1.1"
@@ -49,7 +49,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^15.2.0"
+    "@metamask/network-controller": "^16.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ens-controller",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Maps ENS names to their resolved addresses by chain id",
   "keywords": [
     "MetaMask",

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [10.0.1]
+### Uncategorized
+- Fix misaligned mock eth query types in controller tests ([#2037](https://github.com/MetaMask/core/pull/2037))
+- Release 88.0.0 ([#1996](https://github.com/MetaMask/core/pull/1996))
+- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
+- Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
+- Change `test` build scripts to only show output for failed tests by default ([#1949](https://github.com/MetaMask/core/pull/1949))
+- Re-enable @typescript-eslint/no-loss-of-precision ([#1939](https://github.com/MetaMask/core/pull/1939))
+- Release/86.0.0 ([#1956](https://github.com/MetaMask/core/pull/1956))
+
 ### Changed
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 
@@ -120,7 +131,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@10.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@10.0.1...HEAD
+[10.0.1]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@10.0.0...@metamask/gas-fee-controller@10.0.1
 [10.0.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@9.0.0...@metamask/gas-fee-controller@10.0.0
 [9.0.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@8.0.0...@metamask/gas-fee-controller@9.0.0
 [8.0.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@7.0.1...@metamask/gas-fee-controller@8.0.0

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [10.0.1]
 ### Changed
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
-- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 - Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
 

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
+- Bump dependency on `@metamask/polling-controller` to ^1.0.2
 - Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
 
 ## [10.0.0]

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -7,17 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [10.0.1]
-### Uncategorized
-- Fix misaligned mock eth query types in controller tests ([#2037](https://github.com/MetaMask/core/pull/2037))
-- Release 88.0.0 ([#1996](https://github.com/MetaMask/core/pull/1996))
-- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
-- Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
-- Change `test` build scripts to only show output for failed tests by default ([#1949](https://github.com/MetaMask/core/pull/1949))
-- Re-enable @typescript-eslint/no-loss-of-precision ([#1939](https://github.com/MetaMask/core/pull/1939))
-- Release/86.0.0 ([#1956](https://github.com/MetaMask/core/pull/1956))
-
 ### Changed
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
+- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
+- Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
 
 ## [10.0.0]
 ### Added

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -33,8 +33,8 @@
     "@metamask/base-controller": "^3.2.3",
     "@metamask/controller-utils": "^5.0.2",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/network-controller": "^15.2.0",
-    "@metamask/polling-controller": "^1.0.1",
+    "@metamask/network-controller": "^16.0.0",
+    "@metamask/polling-controller": "^1.0.2",
     "@metamask/utils": "^8.2.0",
     "@types/uuid": "^8.3.0",
     "ethereumjs-util": "^7.0.10",
@@ -57,7 +57,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^15.2.0"
+    "@metamask/network-controller": "^16.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/gas-fee-controller",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Periodically calculates gas fee estimates based on various gas limits as well as other data displayed on transaction confirm screens",
   "keywords": [
     "MetaMask",

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [16.0.0]
+### Uncategorized
+- Extract/fix FakeProvider for use among packages ([#2039](https://github.com/MetaMask/core/pull/2039))
+- Release 90.0.0 ([#2014](https://github.com/MetaMask/core/pull/2014))
+- Revert "Release 90.0.0" ([#2012](https://github.com/MetaMask/core/pull/2012))
+- Release 90.0.0 ([#2011](https://github.com/MetaMask/core/pull/2011))
+- Re-enable @typescript-eslint/consistent-type-definitions ([#1933](https://github.com/MetaMask/core/pull/1933))
+
 ### Changed
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 
@@ -306,7 +315,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@15.2.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@16.0.0...HEAD
+[16.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@15.2.0...@metamask/network-controller@16.0.0
 [15.2.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@15.1.0...@metamask/network-controller@15.2.0
 [15.1.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@15.0.0...@metamask/network-controller@15.1.0
 [15.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@14.0.0...@metamask/network-controller@15.0.0

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,15 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [16.0.0]
-### Uncategorized
-- Extract/fix FakeProvider for use among packages ([#2039](https://github.com/MetaMask/core/pull/2039))
-- Release 90.0.0 ([#2014](https://github.com/MetaMask/core/pull/2014))
-- Revert "Release 90.0.0" ([#2012](https://github.com/MetaMask/core/pull/2012))
-- Release 90.0.0 ([#2011](https://github.com/MetaMask/core/pull/2011))
-- Re-enable @typescript-eslint/consistent-type-definitions ([#1933](https://github.com/MetaMask/core/pull/1933))
-
 ### Changed
-- Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
+- **BREAKING:** Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
+  - This is breaking because it changes the type of the EthQuery instance this controller creates internally and exports under the `getEthQuery` action. Please consult the [changelog for `@metamask/eth-query` 4.0.0](https://github.com/MetaMask/eth-query/blob/main/CHANGELOG.md#400) for more.
 
 ## [15.2.0]
 ### Changed

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-controller",
-  "version": "15.2.0",
+  "version": "16.0.0",
   "description": "Provides an interface to the currently selected network via a MetaMask-compatible provider object",
   "keywords": [
     "MetaMask",

--- a/packages/polling-controller/CHANGELOG.md
+++ b/packages/polling-controller/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2]
 ### Changed
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
-- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
 - Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
 
 ## [1.0.1]

--- a/packages/polling-controller/CHANGELOG.md
+++ b/packages/polling-controller/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2]
+### Uncategorized
+- Release 88.0.0 ([#1996](https://github.com/MetaMask/core/pull/1996))
+- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
+- Advance time utility function ([#1973](https://github.com/MetaMask/core/pull/1973))
+- Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
+- Change `test` build scripts to only show output for failed tests by default ([#1949](https://github.com/MetaMask/core/pull/1949))
+
 ## [1.0.1]
 ### Fixed
 - Export `PollingControllerOnly` ([#1921](https://github.com/MetaMask/core/pull/1921))
@@ -34,7 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@1.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@1.0.2...HEAD
+[1.0.2]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@1.0.1...@metamask/polling-controller@1.0.2
 [1.0.1]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@1.0.0...@metamask/polling-controller@1.0.1
 [1.0.0]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@0.2.0...@metamask/polling-controller@1.0.0
 [0.2.0]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@0.1.0...@metamask/polling-controller@0.2.0

--- a/packages/polling-controller/CHANGELOG.md
+++ b/packages/polling-controller/CHANGELOG.md
@@ -7,12 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.2]
-### Uncategorized
-- Release 88.0.0 ([#1996](https://github.com/MetaMask/core/pull/1996))
+### Changed
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
 - Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
-- Advance time utility function ([#1973](https://github.com/MetaMask/core/pull/1973))
 - Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
-- Change `test` build scripts to only show output for failed tests by default ([#1949](https://github.com/MetaMask/core/pull/1949))
 
 ## [1.0.1]
 ### Fixed

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/polling-controller",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Polling Controller is the base for controllers that polling by networkClientId",
   "keywords": [
     "MetaMask",

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@metamask/base-controller": "^3.2.3",
     "@metamask/controller-utils": "^5.0.2",
-    "@metamask/network-controller": "^15.2.0",
+    "@metamask/network-controller": "^16.0.0",
     "@metamask/utils": "^8.2.0",
     "@types/uuid": "^8.3.0",
     "fast-json-stable-stringify": "^2.1.0",
@@ -50,7 +50,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^15.2.0"
+    "@metamask/network-controller": "^16.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -7,10 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.1.4]
-### Uncategorized
-- Release 90.0.0 ([#2014](https://github.com/MetaMask/core/pull/2014))
-- Revert "Release 90.0.0" ([#2012](https://github.com/MetaMask/core/pull/2012))
-- Release 90.0.0 ([#2011](https://github.com/MetaMask/core/pull/2011))
+### Changed
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
 
 ## [0.1.3]
 ### Changed

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4]
+### Uncategorized
+- Release 90.0.0 ([#2014](https://github.com/MetaMask/core/pull/2014))
+- Revert "Release 90.0.0" ([#2012](https://github.com/MetaMask/core/pull/2012))
+- Release 90.0.0 ([#2011](https://github.com/MetaMask/core/pull/2011))
+
 ## [0.1.3]
 ### Changed
 - Bump dependency on @metamask/json-rpc-engine to ^7.2.0 ([#1895](https://github.com/MetaMask/core/pull/1895))
@@ -27,7 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.1.3...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.1.4...HEAD
+[0.1.4]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.1.3...@metamask/queued-request-controller@0.1.4
 [0.1.3]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.1.2...@metamask/queued-request-controller@0.1.3
 [0.1.2]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.1.1...@metamask/queued-request-controller@0.1.2
 [0.1.1]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.1.0...@metamask/queued-request-controller@0.1.1

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.4]
 ### Changed
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
+- Bump dependency and peer dependency on `@metamask/selected-network-controller` to ^3.1.2
 
 ## [0.1.3]
 ### Changed

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -33,9 +33,9 @@
     "@metamask/base-controller": "^3.2.3",
     "@metamask/controller-utils": "^5.0.2",
     "@metamask/json-rpc-engine": "^7.3.0",
-    "@metamask/network-controller": "^15.2.0",
+    "@metamask/network-controller": "^16.0.0",
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/selected-network-controller": "^3.1.1",
+    "@metamask/selected-network-controller": "^3.1.2",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/utils": "^8.2.0"
   },
@@ -55,8 +55,8 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^15.2.0",
-    "@metamask/selected-network-controller": "^3.1.1"
+    "@metamask/network-controller": "^16.0.0",
+    "@metamask/selected-network-controller": "^3.1.2"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/queued-request-controller",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Includes a controller and middleware that implements a request queue",
   "keywords": [
     "MetaMask",

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.2]
+
 ## [3.1.1]
 ### Changed
 - Bump `@metamask/json-rpc-engine` from `^7.1.0` to `^7.2.0` ([#1895](https://github.com/MetaMask/core/pull/1895))
@@ -40,7 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial Release ([#1643](https://github.com/MetaMask/core/pull/1643))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@3.1.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@3.1.2...HEAD
+[3.1.2]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@3.1.1...@metamask/selected-network-controller@3.1.2
 [3.1.1]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@3.1.0...@metamask/selected-network-controller@3.1.1
 [3.1.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@3.0.0...@metamask/selected-network-controller@3.1.0
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@2.0.1...@metamask/selected-network-controller@3.0.0

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [3.1.2]
+### Changed
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
 
 ## [3.1.1]
 ### Changed

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/selected-network-controller",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Provides an interface to the currently selected networkClientId for a given domain",
   "keywords": [
     "MetaMask",

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@metamask/base-controller": "^3.2.3",
     "@metamask/json-rpc-engine": "^7.3.0",
-    "@metamask/network-controller": "^15.2.0",
+    "@metamask/network-controller": "^16.0.0",
     "@metamask/swappable-obj-proxy": "^2.1.0"
   },
   "devDependencies": {
@@ -50,7 +50,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^15.2.0"
+    "@metamask/network-controller": "^16.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -5,6 +5,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [16.0.1]
+### Uncategorized
+- Fix misaligned mock eth query types in controller tests ([#2037](https://github.com/MetaMask/core/pull/2037))
+- Add `updateCustodialTransaction` method ([#2018](https://github.com/MetaMask/core/pull/2018))
+- Align core transaction metadata properties with extension metrics ([#1999](https://github.com/MetaMask/core/pull/1999))
+- Add `accessList` to txParam types ([#2016](https://github.com/MetaMask/core/pull/2016))
+- Adds `estimateGasBuffered` public method ([#2021](https://github.com/MetaMask/core/pull/2021))
+- Create additional `cancel` transaction for `stopTransaction` ([#1998](https://github.com/MetaMask/core/pull/1998))
+- Add method for adding params to transaction meta ([#1985](https://github.com/MetaMask/core/pull/1985))
+- Re-enable @typescript-eslint/consistent-type-definitions ([#1933](https://github.com/MetaMask/core/pull/1933))
+- Release 88.0.0 ([#1996](https://github.com/MetaMask/core/pull/1996))
+- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
+- Add gas values validation to transaction params ([#1978](https://github.com/MetaMask/core/pull/1978))
+- Mock console.error in particular `TransactionController` tests ([#1995](https://github.com/MetaMask/core/pull/1995))
+- Persist specific error properties in core transaction metadata ([#1915](https://github.com/MetaMask/core/pull/1915))
+- Align core transaction error messages with extension ([#1980](https://github.com/MetaMask/core/pull/1980))
+- Add swaps logic into `TransactionController` ([#1877](https://github.com/MetaMask/core/pull/1877))
+- Add hooks to support mmi logic ([#1787](https://github.com/MetaMask/core/pull/1787))
+- Add `approveTransactionsWithSameNonce` method to core transaction controller ([#1961](https://github.com/MetaMask/core/pull/1961))
+- Support advanced gas fees in `TransactionController` ([#1966](https://github.com/MetaMask/core/pull/1966))
+- Adds `clearUnapprovedTxs` function to `TransactionController` ([#1979](https://github.com/MetaMask/core/pull/1979))
+- Add `onBootCleanup` functionality to constructor and `onNetworkChange` ([#1916](https://github.com/MetaMask/core/pull/1916))
+- Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
+- Change `test` build scripts to only show output for failed tests by default ([#1949](https://github.com/MetaMask/core/pull/1949))
+- Refactor pending transaction tracker ([#1896](https://github.com/MetaMask/core/pull/1896))
+- Add `updatePreviousGasParams` to `TransactionController` ([#1943](https://github.com/MetaMask/core/pull/1943))
+- Add TransactionEvents to `TransactionController` ([#1894](https://github.com/MetaMask/core/pull/1894))
+- Typing fixes for `TransactionController.test.ts` ([#1954](https://github.com/MetaMask/core/pull/1954))
+- Change initApprovals method based on the extension ([#1867](https://github.com/MetaMask/core/pull/1867))
+
 ### Changed
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 
@@ -250,7 +281,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@16.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@16.0.1...HEAD
+[16.0.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@16.0.0...@metamask/transaction-controller@16.0.1
 [16.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@15.0.0...@metamask/transaction-controller@16.0.0
 [15.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@14.0.0...@metamask/transaction-controller@15.0.0
 [14.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@13.0.0...@metamask/transaction-controller@14.0.0

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -8,32 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [17.0.0]
 ### Added
-- **BREAKING:** Add swaps logic into `TransactionController` ([#1877](https://github.com/MetaMask/core/pull/1877))
+- **BREAKING:** Add additional support swaps support ([#1877](https://github.com/MetaMask/core/pull/1877))
   - Swap transaction updates can be prevented by setting `disableSwaps` as `true`. If not set it will default to `false`.
-  - This value MUST be set to true in mobile, since mobile doesn't use any swap logic.
   - If `disableSwaps` is `false` or not set, then the `createSwapsTransaction` callback MUST be defined.
-- Add hooks to support mmi logic ([#1787](https://github.com/MetaMask/core/pull/1787))
-  - Add the option in the construction `hooks` giving the possibility to pass callback functions additional logic to execute.
-  - Add the optional callback in hooks `getAdditionalSignArguments` returns additional arguments required to sign a transaction.
-  - Add the optional callback in hooks `beforeApproveOnInit` additional logic to execute before starting an approval flow for a transaction during initialization. Return false to skip the transaction.
-  - Add the optional callback in hooks `afterSign` additional logic to execute after signing a transaction. Return false to not change the status to signed.
-  - Add the optional callback in hooks `beforePublish` additional logic to execute before publishing a transaction. Return false to prevent the broadcast of the transaction.
-- Add `onBootCleanup` functionality to constructor and `onNetworkChange` ([#1916](https://github.com/MetaMask/core/pull/1916))
-  - Initialises approvals of `TransactionStatus.unapproved` transactions on active network
-  - Refreshes the gas values for `TransactionStatus.unapproved` transactions on active network
-  - Submits the `TransactionStatus.approved` transactions on active network
-- Support advanced gas fees in `TransactionController` ([#1966](https://github.com/MetaMask/core/pull/1966))
-  - `getSavedGasFees` callback added as an optional parameter in constructor.
-  - Setting `getSavedGasFees` callback will make saved gas fees (`advancedGasFees` in the `PreferencesController` state) be taken into account when updating gas fees.
-- Add updateCustodialTransaction to update the custodial transactions associated with a specific transaction ID. ([#2018](https://github.com/MetaMask/core/pull/2018))
+- Add optional hooks to support alternate flows ([#1787](https://github.com/MetaMask/core/pull/1787))
+  - Add the `getAdditionalSignArguments` hook to provide additional arguments when signing.
+  - Add the `beforeApproveOnInit` hook to execute additional logic before starting an approval flow for a transaction during initialization. Return `false` to skip the transaction.
+  - Add the `afterSign` hook to execute additional logic after signing a transaction. Return `false` to not change the `status` to `signed`.
+  - Add the `beforePublish` hook to execute additional logic before publishing a transaction. Return `false` to prevent the transaction being submitted.
+- Add additional persisted transaction support during initialization and on network change ([#1916](https://github.com/MetaMask/core/pull/1916))
+  - Initialise approvals for unapproved transactions on the current network.
+  - Add missing gas values for unapproved transactions on the current network.
+  - Submit any approved transactions on the current network.
+- Support saved gas fees ([#1966](https://github.com/MetaMask/core/pull/1966))
+  - Add optional `getSavedGasFees` callback to constructor.
+- Add `updateCustodialTransaction` method to update custodial transactions ([#2018](https://github.com/MetaMask/core/pull/2018))
 - Add `accessList` to txParam types ([#2016](https://github.com/MetaMask/core/pull/2016))
-- Adds `estimateGasBuffered` public method ([#2021](https://github.com/MetaMask/core/pull/2021))
-- Add method for adding params to transaction meta ([#1985](https://github.com/MetaMask/core/pull/1985))
-- Add gas values validation to transaction params ([#1978](https://github.com/MetaMask/core/pull/1978))
-- Add `approveTransactionsWithSameNonce` public method to core transaction controller ([#1961](https://github.com/MetaMask/core/pull/1961))
-- Add `clearUnapprovedTxs` public method to `TransactionController` ([#1979](https://github.com/MetaMask/core/pull/1979))
-- Add `updatePreviousGasParams` public method to `TransactionController` ([#1943](https://github.com/MetaMask/core/pull/1943))
-- Add `TransactionEvents` to be emitted from `TransactionController` ([#1894](https://github.com/MetaMask/core/pull/1894))
+- Add `estimateGasBuffered` method to estimate gas and apply a specific buffer multiplier ([#2021](https://github.com/MetaMask/core/pull/2021))
+- Add `updateSecurityAlertResponse` method ([#1985](https://github.com/MetaMask/core/pull/1985))
+- Add gas values validation ([#1978](https://github.com/MetaMask/core/pull/1978))
+- Add `approveTransactionsWithSameNonce` method ([#1961](https://github.com/MetaMask/core/pull/1961))
+- Add `clearUnapprovedTransactions` method ([#1979](https://github.com/MetaMask/core/pull/1979))
+- Add `updatePreviousGasParams` method ([#1943](https://github.com/MetaMask/core/pull/1943))
+- Emit additional events to support metrics in the clients ([#1894](https://github.com/MetaMask/core/pull/1894))
 - Populate the `firstRetryBlockNumber`, `retryCount`, and `warning` properties in the transaction metadata. ([#1896](https://github.com/MetaMask/core/pull/1896))
 
 ### Changed
@@ -41,16 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This can be disabled by setting the new `pendingTransactions.isResubmitEnabled` constructor option to `false`.
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
 - Persist specific error properties in core transaction metadata ([#1915](https://github.com/MetaMask/core/pull/1915))
-  - create `TxError` type with specific properties to support both clients.
-  - Updated `failTransaction` to use the new type.
+  - Create `TransactionError` type with explicit properties.
 - Align core transaction error messages with extension ([#1980](https://github.com/MetaMask/core/pull/1980))
-  - `processApproval` when the user rejects the request: MetaMask Tx Signature: User denied transaction signature.`
-  - `validateParamRecipient` to use `@metamask/rpc-errors`: `Invalid "to" address.`
-  - `validateParamFrom` to use `@metamask/rpc-errors`: `Invalid "from" address.`
-  - `validateIfTransactionUnapproved`: ``TransactionsController: Can only call ${fnName} on an unapproved transaction.`
-- Change `initApprovals` method based on the extension ([#1867](https://github.com/MetaMask/core/pull/1867))
   - Catch of the `initApprovals` method to skip logging when the error is `userRejectedRequest`.
-- `stopTransaction` now creates a cancel transaction with same nonce instead of changing type to cancel ([#1998](https://github.com/MetaMask/core/pull/1998))
+- Create an additional transaction metadata entry when calling `stopTransaction` ([#1998](https://github.com/MetaMask/core/pull/1998))
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 - Bump dependency and peer dependency on `@metamask/gas-fee-controller` to ^10.0.1
 - Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Catch of the `initApprovals` method to skip logging when the error is `userRejectedRequest`.
 - `stopTransaction` now creates a cancel transaction with same nonce instead of changing type to cancel ([#1998](https://github.com/MetaMask/core/pull/1998))
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
+- Bump dependency and peer dependency on `@metamask/gas-fee-controller` to ^10.0.1
 - Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
 
 ## [16.0.0]

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -6,38 +6,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [16.0.1]
-### Uncategorized
-- Fix misaligned mock eth query types in controller tests ([#2037](https://github.com/MetaMask/core/pull/2037))
-- Add `updateCustodialTransaction` method ([#2018](https://github.com/MetaMask/core/pull/2018))
-- Align core transaction metadata properties with extension metrics ([#1999](https://github.com/MetaMask/core/pull/1999))
+## [17.0.0]
+### Added
+- **BREAKING:** Add swaps logic into `TransactionController` ([#1877](https://github.com/MetaMask/core/pull/1877))
+  - Swap transaction updates can be prevented by setting `disableSwaps` as `true`. If not set it will default to `false`.
+  - This value MUST be set to true in mobile, since mobile doesn't use any swap logic.
+  - If `disableSwaps` is `false` or not set, then the `createSwapsTransaction` callback MUST be defined.
+- Add hooks to support mmi logic ([#1787](https://github.com/MetaMask/core/pull/1787))
+  - Add the option in the construction `hooks` giving the possibility to pass callback functions additional logic to execute.
+  - Add the optional callback in hooks `getAdditionalSignArguments` returns additional arguments required to sign a transaction.
+  - Add the optional callback in hooks `beforeApproveOnInit` additional logic to execute before starting an approval flow for a transaction during initialization. Return false to skip the transaction.
+  - Add the optional callback in hooks `afterSign` additional logic to execute after signing a transaction. Return false to not change the status to signed.
+  - Add the optional callback in hooks `beforePublish` additional logic to execute before publishing a transaction. Return false to prevent the broadcast of the transaction.
+- Add `onBootCleanup` functionality to constructor and `onNetworkChange` ([#1916](https://github.com/MetaMask/core/pull/1916))
+  - Initialises approvals of `TransactionStatus.unapproved` transactions on active network
+  - Refreshes the gas values for `TransactionStatus.unapproved` transactions on active network
+  - Submits the `TransactionStatus.approved` transactions on active network
+- Support advanced gas fees in `TransactionController` ([#1966](https://github.com/MetaMask/core/pull/1966))
+  - `getSavedGasFees` callback added as an optional parameter in constructor.
+  - Setting `getSavedGasFees` callback will make saved gas fees (`advancedGasFees` in the `PreferencesController` state) be taken into account when updating gas fees.
+- Add updateCustodialTransaction to update the custodial transactions associated with a specific transaction ID. ([#2018](https://github.com/MetaMask/core/pull/2018))
 - Add `accessList` to txParam types ([#2016](https://github.com/MetaMask/core/pull/2016))
 - Adds `estimateGasBuffered` public method ([#2021](https://github.com/MetaMask/core/pull/2021))
-- Create additional `cancel` transaction for `stopTransaction` ([#1998](https://github.com/MetaMask/core/pull/1998))
 - Add method for adding params to transaction meta ([#1985](https://github.com/MetaMask/core/pull/1985))
-- Re-enable @typescript-eslint/consistent-type-definitions ([#1933](https://github.com/MetaMask/core/pull/1933))
-- Release 88.0.0 ([#1996](https://github.com/MetaMask/core/pull/1996))
-- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
 - Add gas values validation to transaction params ([#1978](https://github.com/MetaMask/core/pull/1978))
-- Mock console.error in particular `TransactionController` tests ([#1995](https://github.com/MetaMask/core/pull/1995))
-- Persist specific error properties in core transaction metadata ([#1915](https://github.com/MetaMask/core/pull/1915))
-- Align core transaction error messages with extension ([#1980](https://github.com/MetaMask/core/pull/1980))
-- Add swaps logic into `TransactionController` ([#1877](https://github.com/MetaMask/core/pull/1877))
-- Add hooks to support mmi logic ([#1787](https://github.com/MetaMask/core/pull/1787))
-- Add `approveTransactionsWithSameNonce` method to core transaction controller ([#1961](https://github.com/MetaMask/core/pull/1961))
-- Support advanced gas fees in `TransactionController` ([#1966](https://github.com/MetaMask/core/pull/1966))
-- Adds `clearUnapprovedTxs` function to `TransactionController` ([#1979](https://github.com/MetaMask/core/pull/1979))
-- Add `onBootCleanup` functionality to constructor and `onNetworkChange` ([#1916](https://github.com/MetaMask/core/pull/1916))
-- Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
-- Change `test` build scripts to only show output for failed tests by default ([#1949](https://github.com/MetaMask/core/pull/1949))
-- Refactor pending transaction tracker ([#1896](https://github.com/MetaMask/core/pull/1896))
-- Add `updatePreviousGasParams` to `TransactionController` ([#1943](https://github.com/MetaMask/core/pull/1943))
-- Add TransactionEvents to `TransactionController` ([#1894](https://github.com/MetaMask/core/pull/1894))
-- Typing fixes for `TransactionController.test.ts` ([#1954](https://github.com/MetaMask/core/pull/1954))
-- Change initApprovals method based on the extension ([#1867](https://github.com/MetaMask/core/pull/1867))
+- Add `approveTransactionsWithSameNonce` public method to core transaction controller ([#1961](https://github.com/MetaMask/core/pull/1961))
+- Add `clearUnapprovedTxs` public method to `TransactionController` ([#1979](https://github.com/MetaMask/core/pull/1979))
+- Add `updatePreviousGasParams` public method to `TransactionController` ([#1943](https://github.com/MetaMask/core/pull/1943))
+- Add `TransactionEvents` to be emitted from `TransactionController` ([#1894](https://github.com/MetaMask/core/pull/1894))
+- Populate the `firstRetryBlockNumber`, `retryCount`, and `warning` properties in the transaction metadata. ([#1896](https://github.com/MetaMask/core/pull/1896))
 
 ### Changed
+- **BREAKING:** Pending transactions are now automatically resubmitted. ([#1896](https://github.com/MetaMask/core/pull/1896))
+  - This can be disabled by setting the new `pendingTransactions.isResubmitEnabled` constructor option to `false`.
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to ^16.0.0
+- Persist specific error properties in core transaction metadata ([#1915](https://github.com/MetaMask/core/pull/1915))
+  - create `TxError` type with specific properties to support both clients.
+  - Updated `failTransaction` to use the new type.
+- Align core transaction error messages with extension ([#1980](https://github.com/MetaMask/core/pull/1980))
+  - `processApproval` when the user rejects the request: MetaMask Tx Signature: User denied transaction signature.`
+  - `validateParamRecipient` to use `@metamask/rpc-errors`: `Invalid "to" address.`
+  - `validateParamFrom` to use `@metamask/rpc-errors`: `Invalid "from" address.`
+  - `validateIfTransactionUnapproved`: ``TransactionsController: Can only call ${fnName} on an unapproved transaction.`
+- Change `initApprovals` method based on the extension ([#1867](https://github.com/MetaMask/core/pull/1867))
+  - Catch of the `initApprovals` method to skip logging when the error is `userRejectedRequest`.
+- `stopTransaction` now creates a cancel transaction with same nonce instead of changing type to cancel ([#1998](https://github.com/MetaMask/core/pull/1998))
+- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
+- Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
 
 ## [16.0.0]
 ### Changed
@@ -281,8 +297,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@16.0.1...HEAD
-[16.0.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@16.0.0...@metamask/transaction-controller@16.0.1
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@17.0.0...HEAD
+[17.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@16.0.0...@metamask/transaction-controller@17.0.0
 [16.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@15.0.0...@metamask/transaction-controller@16.0.0
 [15.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@14.0.0...@metamask/transaction-controller@15.0.0
 [14.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@13.0.0...@metamask/transaction-controller@14.0.0

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -51,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `initApprovals` method based on the extension ([#1867](https://github.com/MetaMask/core/pull/1867))
   - Catch of the `initApprovals` method to skip logging when the error is `userRejectedRequest`.
 - `stopTransaction` now creates a cancel transaction with same nonce instead of changing type to cancel ([#1998](https://github.com/MetaMask/core/pull/1998))
-- Bump @metamask/auto-changelog from 3.4.2 to 3.4.3 ([#1997](https://github.com/MetaMask/core/pull/1997))
 - Bump dependency `@metamask/eth-query` from ^3.0.1 to ^4.0.0 ([#2028](https://github.com/MetaMask/core/pull/2028))
 - Bump @metamask/utils from 8.1.0 to 8.2.0 ([#1957](https://github.com/MetaMask/core/pull/1957))
 

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "16.0.1",
+  "version": "17.0.0",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -37,9 +37,9 @@
     "@metamask/base-controller": "^3.2.3",
     "@metamask/controller-utils": "^5.0.2",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/gas-fee-controller": "^10.0.0",
+    "@metamask/gas-fee-controller": "^10.0.1",
     "@metamask/metamask-eth-abis": "^3.0.0",
-    "@metamask/network-controller": "^15.2.0",
+    "@metamask/network-controller": "^16.0.0",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/utils": "^8.2.0",
     "async-mutex": "^0.2.6",
@@ -66,8 +66,8 @@
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^4.1.0",
-    "@metamask/gas-fee-controller": "^10.0.0",
-    "@metamask/network-controller": "^15.2.0",
+    "@metamask/gas-fee-controller": "^10.0.1",
+    "@metamask/network-controller": "^16.0.0",
     "babel-runtime": "^6.26.0"
   },
   "engines": {

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,8 +1476,8 @@ __metadata:
     "@metamask/controller-utils": ^5.0.2
     "@metamask/eth-query": ^4.0.0
     "@metamask/metamask-eth-abis": 3.0.0
-    "@metamask/network-controller": ^15.2.0
-    "@metamask/polling-controller": ^1.0.1
+    "@metamask/network-controller": ^16.0.0
+    "@metamask/polling-controller": ^1.0.2
     "@metamask/preferences-controller": ^4.4.3
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/utils": ^8.2.0
@@ -1502,7 +1502,7 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/network-controller": ^15.2.0
+    "@metamask/network-controller": ^16.0.0
     "@metamask/preferences-controller": ^4.4.3
   languageName: unknown
   linkType: soft
@@ -1665,7 +1665,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.3
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
-    "@metamask/network-controller": ^15.2.0
+    "@metamask/network-controller": ^16.0.0
     "@metamask/utils": ^8.2.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1677,7 +1677,7 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
   peerDependencies:
-    "@metamask/network-controller": ^15.2.0
+    "@metamask/network-controller": ^16.0.0
   languageName: unknown
   linkType: soft
 
@@ -1862,7 +1862,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gas-fee-controller@^10.0.0, @metamask/gas-fee-controller@workspace:packages/gas-fee-controller":
+"@metamask/gas-fee-controller@^10.0.1, @metamask/gas-fee-controller@workspace:packages/gas-fee-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/gas-fee-controller@workspace:packages/gas-fee-controller"
   dependencies:
@@ -1870,8 +1870,8 @@ __metadata:
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/eth-query": ^4.0.0
-    "@metamask/network-controller": ^15.2.0
-    "@metamask/polling-controller": ^1.0.1
+    "@metamask/network-controller": ^16.0.0
+    "@metamask/polling-controller": ^1.0.2
     "@metamask/utils": ^8.2.0
     "@types/jest": ^27.4.1
     "@types/jest-when": ^2.7.3
@@ -1890,7 +1890,7 @@ __metadata:
     typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/network-controller": ^15.2.0
+    "@metamask/network-controller": ^16.0.0
   languageName: unknown
   linkType: soft
 
@@ -2069,7 +2069,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/network-controller@^15.2.0, @metamask/network-controller@workspace:packages/network-controller":
+"@metamask/network-controller@^16.0.0, @metamask/network-controller@workspace:packages/network-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/network-controller@workspace:packages/network-controller"
   dependencies:
@@ -2226,14 +2226,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/polling-controller@^1.0.1, @metamask/polling-controller@workspace:packages/polling-controller":
+"@metamask/polling-controller@^1.0.2, @metamask/polling-controller@workspace:packages/polling-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/polling-controller@workspace:packages/polling-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.3
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
-    "@metamask/network-controller": ^15.2.0
+    "@metamask/network-controller": ^16.0.0
     "@metamask/utils": ^8.2.0
     "@types/jest": ^27.4.1
     "@types/uuid": ^8.3.0
@@ -2247,7 +2247,7 @@ __metadata:
     typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/network-controller": ^15.2.0
+    "@metamask/network-controller": ^16.0.0
   languageName: unknown
   linkType: soft
 
@@ -2306,9 +2306,9 @@ __metadata:
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/json-rpc-engine": ^7.3.0
-    "@metamask/network-controller": ^15.2.0
+    "@metamask/network-controller": ^16.0.0
     "@metamask/rpc-errors": ^6.1.0
-    "@metamask/selected-network-controller": ^3.1.1
+    "@metamask/selected-network-controller": ^3.1.2
     "@metamask/swappable-obj-proxy": ^2.1.0
     "@metamask/utils": ^8.2.0
     "@types/jest": ^27.4.1
@@ -2323,8 +2323,8 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
   peerDependencies:
-    "@metamask/network-controller": ^15.2.0
-    "@metamask/selected-network-controller": ^3.1.1
+    "@metamask/network-controller": ^16.0.0
+    "@metamask/selected-network-controller": ^3.1.2
   languageName: unknown
   linkType: soft
 
@@ -2380,14 +2380,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/selected-network-controller@^3.1.1, @metamask/selected-network-controller@workspace:packages/selected-network-controller":
+"@metamask/selected-network-controller@^3.1.2, @metamask/selected-network-controller@workspace:packages/selected-network-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/selected-network-controller@workspace:packages/selected-network-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.3
     "@metamask/base-controller": ^3.2.3
     "@metamask/json-rpc-engine": ^7.3.0
-    "@metamask/network-controller": ^15.2.0
+    "@metamask/network-controller": ^16.0.0
     "@metamask/swappable-obj-proxy": ^2.1.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -2401,7 +2401,7 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
   peerDependencies:
-    "@metamask/network-controller": ^15.2.0
+    "@metamask/network-controller": ^16.0.0
   languageName: unknown
   linkType: soft
 
@@ -2633,9 +2633,9 @@ __metadata:
     "@metamask/base-controller": ^3.2.3
     "@metamask/controller-utils": ^5.0.2
     "@metamask/eth-query": ^4.0.0
-    "@metamask/gas-fee-controller": ^10.0.0
+    "@metamask/gas-fee-controller": ^10.0.1
     "@metamask/metamask-eth-abis": ^3.0.0
-    "@metamask/network-controller": ^15.2.0
+    "@metamask/network-controller": ^16.0.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/utils": ^8.2.0
     "@types/jest": ^27.4.1
@@ -2658,8 +2658,8 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/approval-controller": ^4.1.0
-    "@metamask/gas-fee-controller": ^10.0.0
-    "@metamask/network-controller": ^15.2.0
+    "@metamask/gas-fee-controller": ^10.0.1
+    "@metamask/network-controller": ^16.0.0
     babel-runtime: ^6.26.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Explanation

- Releases major version of `network-controller`, which enables usage of updated `Provider` type and `getEthQuery` messenger action.
- Releases major version of `transaction-controller`, which includes [a large number of significant changes](https://github.com/MetaMask/core/pull/2044/files#diff-d2a0ba2c61bc1c4862fd8cf52c56eeecf51037b90a3e9eb832b68ad9706195bc).
- Releases major version of `assets-controllers`, which includes [breaking changes in `NfTController`](https://github.com/MetaMask/core/pull/2044/files#diff-ee47d03d53776b8dd530799a8047f5e32e36e35765620aeb50b294adc3339fab).
- Releases patch versions of `{ens,gas-fee,polling,queued-request,selected-network}-controller`, which are downstream of `network-controller`.

## References

## Changelog

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
