### PR TITLE
refactor(base-controller): Replace `private` keyword

### DIFF
--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -100,7 +100,7 @@ export class BaseController<
     string
   >,
 > {
-  private internalState: ControllerState;
+  #internalState: ControllerState;
 
   protected messagingSystem: messenger;
 
@@ -143,7 +143,7 @@ export class BaseController<
   }) {
     this.messagingSystem = messenger;
     this.name = name;
-    this.internalState = state;
+    this.#internalState = state;
     this.metadata = metadata;
 
     this.messagingSystem.registerActionHandler(
@@ -158,7 +158,7 @@ export class BaseController<
    * @returns The current state.
    */
   get state() {
-    return this.internalState;
+    return this.#internalState;
   }
 
   set state(_) {
@@ -192,9 +192,9 @@ export class BaseController<
         state: ControllerState,
         cb: typeof callback,
       ) => [ControllerState, Patch[], Patch[]]
-    )(this.internalState, callback);
+    )(this.#internalState, callback);
 
-    this.internalState = nextState;
+    this.#internalState = nextState;
     this.messagingSystem.publish(
       `${this.name}:stateChange`,
       nextState,
@@ -212,8 +212,8 @@ export class BaseController<
    * or undo changes.
    */
   protected applyPatches(patches: Patch[]) {
-    const nextState = applyPatches(this.internalState, patches);
-    this.internalState = nextState;
+    const nextState = applyPatches(this.#internalState, patches);
+    this.#internalState = nextState;
     this.messagingSystem.publish(
       `${this.name}:stateChange`,
       nextState,

--- a/packages/base-controller/src/RestrictedControllerMessenger.ts
+++ b/packages/base-controller/src/RestrictedControllerMessenger.ts
@@ -33,16 +33,16 @@ export class RestrictedControllerMessenger<
   AllowedAction extends string,
   AllowedEvent extends string,
 > {
-  private readonly controllerMessenger: ControllerMessenger<
+  readonly #controllerMessenger: ControllerMessenger<
     ActionConstraint,
     EventConstraint
   >;
 
-  private readonly controllerName: Namespace;
+  readonly #controllerName: Namespace;
 
-  private readonly allowedActions: AllowedAction[] | null;
+  readonly #allowedActions: AllowedAction[] | null;
 
-  private readonly allowedEvents: AllowedEvent[] | null;
+  readonly #allowedEvents: AllowedEvent[] | null;
 
   /**
    * Constructs a restricted controller messenger
@@ -73,10 +73,10 @@ export class RestrictedControllerMessenger<
     allowedActions?: AllowedAction[];
     allowedEvents?: AllowedEvent[];
   }) {
-    this.controllerMessenger = controllerMessenger;
-    this.controllerName = name;
-    this.allowedActions = allowedActions || null;
-    this.allowedEvents = allowedEvents || null;
+    this.#controllerMessenger = controllerMessenger;
+    this.#controllerName = name;
+    this.#allowedActions = allowedActions || null;
+    this.#allowedEvents = allowedEvents || null;
   }
 
   /**
@@ -97,12 +97,14 @@ export class RestrictedControllerMessenger<
     handler: ActionHandler<Action, ActionType>,
   ) {
     /* istanbul ignore if */ // Branch unreachable with valid types
-    if (!action.startsWith(`${this.controllerName}:`)) {
+    if (!action.startsWith(`${this.#controllerName}:`)) {
       throw new Error(
-        `Only allowed registering action handlers prefixed by '${this.controllerName}:'`,
+        `Only allowed registering action handlers prefixed by '${
+          this.#controllerName
+        }:'`,
       );
     }
-    this.controllerMessenger.registerActionHandler(action, handler);
+    this.#controllerMessenger.registerActionHandler(action, handler);
   }
 
   /**
@@ -119,12 +121,14 @@ export class RestrictedControllerMessenger<
     action: ActionType,
   ) {
     /* istanbul ignore if */ // Branch unreachable with valid types
-    if (!action.startsWith(`${this.controllerName}:`)) {
+    if (!action.startsWith(`${this.#controllerName}:`)) {
       throw new Error(
-        `Only allowed unregistering action handlers prefixed by '${this.controllerName}:'`,
+        `Only allowed unregistering action handlers prefixed by '${
+          this.#controllerName
+        }:'`,
       );
     }
-    this.controllerMessenger.unregisterActionHandler(action);
+    this.#controllerMessenger.unregisterActionHandler(action);
   }
 
   /**
@@ -147,12 +151,12 @@ export class RestrictedControllerMessenger<
     ...params: ExtractActionParameters<Action, ActionType>
   ): ExtractActionResponse<Action, ActionType> {
     /* istanbul ignore next */ // Branches unreachable with valid types
-    if (this.allowedActions === null) {
+    if (this.#allowedActions === null) {
       throw new Error('No actions allowed');
-    } else if (!this.allowedActions.includes(action)) {
+    } else if (!this.#allowedActions.includes(action)) {
       throw new Error(`Action missing from allow list: ${action}`);
     }
-    return this.controllerMessenger.call(action, ...params);
+    return this.#controllerMessenger.call(action, ...params);
   }
 
   /**
@@ -172,12 +176,12 @@ export class RestrictedControllerMessenger<
     ...payload: ExtractEventPayload<Event, EventType>
   ) {
     /* istanbul ignore if */ // Branch unreachable with valid types
-    if (!event.startsWith(`${this.controllerName}:`)) {
+    if (!event.startsWith(`${this.#controllerName}:`)) {
       throw new Error(
-        `Only allowed publishing events prefixed by '${this.controllerName}:'`,
+        `Only allowed publishing events prefixed by '${this.#controllerName}:'`,
       );
     }
-    this.controllerMessenger.publish(event, ...payload);
+    this.#controllerMessenger.publish(event, ...payload);
   }
 
   /**
@@ -240,16 +244,16 @@ export class RestrictedControllerMessenger<
     >,
   ) {
     /* istanbul ignore next */ // Branches unreachable with valid types
-    if (this.allowedEvents === null) {
+    if (this.#allowedEvents === null) {
       throw new Error('No events allowed');
-    } else if (!this.allowedEvents.includes(event)) {
+    } else if (!this.#allowedEvents.includes(event)) {
       throw new Error(`Event missing from allow list: ${event}`);
     }
 
     if (selector) {
-      return this.controllerMessenger.subscribe(event, handler, selector);
+      return this.#controllerMessenger.subscribe(event, handler, selector);
     }
-    return this.controllerMessenger.subscribe(event, handler);
+    return this.#controllerMessenger.subscribe(event, handler);
   }
 
   /**
@@ -269,12 +273,12 @@ export class RestrictedControllerMessenger<
     handler: ExtractEventHandler<Event, EventType>,
   ) {
     /* istanbul ignore next */ // Branches unreachable with valid types
-    if (this.allowedEvents === null) {
+    if (this.#allowedEvents === null) {
       throw new Error('No events allowed');
-    } else if (!this.allowedEvents.includes(event)) {
+    } else if (!this.#allowedEvents.includes(event)) {
       throw new Error(`Event missing from allow list: ${event}`);
     }
-    this.controllerMessenger.unsubscribe(event, handler);
+    this.#controllerMessenger.unsubscribe(event, handler);
   }
 
   /**
@@ -291,11 +295,11 @@ export class RestrictedControllerMessenger<
     event: EventType,
   ) {
     /* istanbul ignore if */ // Branch unreachable with valid types
-    if (!event.startsWith(`${this.controllerName}:`)) {
+    if (!event.startsWith(`${this.#controllerName}:`)) {
       throw new Error(
-        `Only allowed clearing events prefixed by '${this.controllerName}:'`,
+        `Only allowed clearing events prefixed by '${this.#controllerName}:'`,
       );
     }
-    this.controllerMessenger.clearEventSubscriptions(event);
+    this.#controllerMessenger.clearEventSubscriptions(event);
   }
 }


### PR DESCRIPTION
## Explanation

All uses of the `private` keyword have been replaced with a `#` prefix (except those in the deprecated `BaseController`). The use of `private` is discouraged in our repositories, as `#`-prefixed properties are truly private and are easier to work with.

Technically this could be considered a breaking change because there are ways to work around `private`, but I would consider this non- breaking because these properties were clearly intended to be private.

## References

Tangentially related to #2047 (not strictly required, but when I was investigating that issue, I ended up doing this as well because our lint rules were forcing me to destructure `this` in order to access properties, which was very awkward for one line where I needed to upcast something)

## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
