### PR TITLE
feat(base-controller): Allow using internal events/actions

### DIFF
--- a/packages/base-controller/src/RestrictedControllerMessenger.test.ts
+++ b/packages/base-controller/src/RestrictedControllerMessenger.test.ts
@@ -11,7 +11,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: ['CountController:count'],
     });
 
     let count = 0;
@@ -36,7 +35,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<MessageAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: ['MessageController:reset', 'MessageController:concat'],
     });
 
     let message = '';
@@ -71,7 +69,6 @@ describe('RestrictedControllerMessenger', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: ['CountController:increment'],
     });
 
     let count = 0;
@@ -94,7 +91,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<MessageAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: ['MessageController:message'],
     });
 
     const messages: Record<string, string> = {};
@@ -122,7 +118,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<AddAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MathController',
-      allowedActions: ['MathController:add'],
     });
 
     restrictedControllerMessenger.registerActionHandler(
@@ -145,7 +140,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
-      allowedActions: ['PingController:ping'],
     });
 
     restrictedControllerMessenger.registerActionHandler(
@@ -166,7 +160,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
-      allowedActions: ['PingController:ping'],
     });
 
     expect(() => {
@@ -179,7 +172,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<PingAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
-      allowedActions: ['PingController:ping'],
     });
 
     expect(() => {
@@ -212,7 +204,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:message'],
     });
 
     const handler = sinon.stub();
@@ -234,7 +225,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:complexMessage'],
     });
 
     const handler = sinon.stub();
@@ -263,7 +253,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:message', 'MessageController:ping'],
     });
 
     const messageHandler = sinon.stub();
@@ -292,7 +281,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, PingEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
-      allowedEvents: ['PingController:ping'],
     });
 
     const handler = sinon.stub();
@@ -311,7 +299,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:message'],
     });
 
     const handler = sinon.stub();
@@ -338,7 +325,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:message'],
     });
 
     const handler = sinon.stub();
@@ -365,7 +351,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:message'],
     });
 
     const handler1 = sinon.stub();
@@ -395,7 +380,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:message'],
     });
 
     const handler = sinon.stub();
@@ -421,7 +405,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:message'],
     });
 
     const handler = sinon.stub();
@@ -441,7 +424,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:message'],
     });
 
     const handler1 = sinon.stub();
@@ -467,7 +449,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:message'],
     });
 
     const handler = sinon.stub();
@@ -492,7 +473,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:message'],
     });
 
     expect(() =>
@@ -510,7 +490,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: ['CountController:count'],
     });
 
     let count = 0;
@@ -560,7 +539,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedEvents: ['MessageController:message'],
     });
 
     const handler = sinon.stub();

--- a/packages/base-controller/src/RestrictedControllerMessenger.ts
+++ b/packages/base-controller/src/RestrictedControllerMessenger.ts
@@ -92,10 +92,9 @@ export class RestrictedControllerMessenger<
    * @throws Will throw if an action handler that is not in the current namespace is being registered.
    * @template ActionType - A type union of Action type strings that are namespaced by Namespace.
    */
-  registerActionHandler<ActionType extends Action['type']>(
-    action: ActionType,
-    handler: ActionHandler<Action, ActionType>,
-  ) {
+  registerActionHandler<
+    ActionType extends Action['type'] & NamespacedName<Namespace>,
+  >(action: ActionType, handler: ActionHandler<Action, ActionType>) {
     /* istanbul ignore if */ // Branch unreachable with valid types
     if (!action.startsWith(`${this.#controllerName}:`)) {
       throw new Error(
@@ -117,9 +116,9 @@ export class RestrictedControllerMessenger<
    * @param action - The action type. This is a unqiue identifier for this action.
    * @template ActionType - A type union of Action type strings that are namespaced by Namespace.
    */
-  unregisterActionHandler<ActionType extends NamespacedName<Namespace>>(
-    action: ActionType,
-  ) {
+  unregisterActionHandler<
+    ActionType extends Action['type'] & NamespacedName<Namespace>,
+  >(action: ActionType) {
     /* istanbul ignore if */ // Branch unreachable with valid types
     if (!action.startsWith(`${this.#controllerName}:`)) {
       throw new Error(
@@ -139,24 +138,31 @@ export class RestrictedControllerMessenger<
    *
    * The action type being called must be on the action allowlist.
    *
-   * @param action - The action type. This is a unqiue identifier for this action.
+   * @param actionType - The action type. This is a unqiue identifier for this action.
    * @param params - The action parameters. These must match the type of the parameters of the
    * registered action handler.
    * @throws Will throw when no handler has been registered for the given type.
    * @template ActionType - A type union of allowed Action type strings.
    * @returns The action return value.
    */
-  call<ActionType extends AllowedAction & NamespacedName>(
-    action: ActionType,
+  call<
+    ActionType extends
+      | AllowedAction
+      | (Action['type'] & NamespacedName<Namespace>),
+  >(
+    actionType: ActionType,
     ...params: ExtractActionParameters<Action, ActionType>
   ): ExtractActionResponse<Action, ActionType> {
     /* istanbul ignore next */ // Branches unreachable with valid types
-    if (this.#allowedActions === null) {
-      throw new Error('No actions allowed');
-    } else if (!this.#allowedActions.includes(action)) {
-      throw new Error(`Action missing from allow list: ${action}`);
+    if (!this.#isAllowedAction(actionType)) {
+      throw new Error(`Action missing from allow list: ${actionType}`);
     }
-    return this.#controllerMessenger.call(action, ...params);
+    const response = this.#controllerMessenger.call<ActionType>(
+      actionType,
+      ...params,
+    );
+
+    return response;
   }
 
   /**
@@ -171,7 +177,7 @@ export class RestrictedControllerMessenger<
    * match the type of this payload.
    * @template EventType - A type union of Event type strings that are namespaced by Namespace.
    */
-  publish<EventType extends NamespacedName<Namespace>>(
+  publish<EventType extends Event['type'] & NamespacedName<Namespace>>(
     event: EventType,
     ...payload: ExtractEventPayload<Event, EventType>
   ) {
@@ -196,10 +202,11 @@ export class RestrictedControllerMessenger<
    * match the type of the payload for this event type.
    * @template EventType - A type union of Event type strings.
    */
-  subscribe<EventType extends AllowedEvent & NamespacedName>(
-    eventType: EventType,
-    handler: ExtractEventHandler<Event, EventType>,
-  ): void;
+  subscribe<
+    EventType extends
+      | AllowedEvent
+      | (Event['type'] & NamespacedName<Namespace>),
+  >(eventType: EventType, handler: ExtractEventHandler<Event, EventType>): void;
 
   /**
    * Subscribe to an event, with a selector.
@@ -221,7 +228,9 @@ export class RestrictedControllerMessenger<
    * @template SelectorReturnValue - The selector return value.
    */
   subscribe<
-    EventType extends AllowedEvent & NamespacedName,
+    EventType extends
+      | AllowedEvent
+      | (Event['type'] & NamespacedName<Namespace>),
     SelectorReturnValue,
   >(
     eventType: EventType,
@@ -233,7 +242,9 @@ export class RestrictedControllerMessenger<
   ): void;
 
   subscribe<
-    EventType extends AllowedEvent & NamespacedName,
+    EventType extends
+      | AllowedEvent
+      | (Event['type'] & NamespacedName<Namespace>),
     SelectorReturnValue,
   >(
     event: EventType,
@@ -244,9 +255,7 @@ export class RestrictedControllerMessenger<
     >,
   ) {
     /* istanbul ignore next */ // Branches unreachable with valid types
-    if (this.#allowedEvents === null) {
-      throw new Error('No events allowed');
-    } else if (!this.#allowedEvents.includes(event)) {
+    if (!this.#isAllowedEvent(event)) {
       throw new Error(`Event missing from allow list: ${event}`);
     }
 
@@ -268,14 +277,13 @@ export class RestrictedControllerMessenger<
    * @throws Will throw when the given event handler is not registered for this event.
    * @template EventType - A type union of allowed Event type strings.
    */
-  unsubscribe<EventType extends AllowedEvent & NamespacedName>(
-    event: EventType,
-    handler: ExtractEventHandler<Event, EventType>,
-  ) {
+  unsubscribe<
+    EventType extends
+      | AllowedEvent
+      | (Event['type'] & NamespacedName<Namespace>),
+  >(event: EventType, handler: ExtractEventHandler<Event, EventType>) {
     /* istanbul ignore next */ // Branches unreachable with valid types
-    if (this.#allowedEvents === null) {
-      throw new Error('No events allowed');
-    } else if (!this.#allowedEvents.includes(event)) {
+    if (!this.#isAllowedEvent(event)) {
       throw new Error(`Event missing from allow list: ${event}`);
     }
     this.#controllerMessenger.unsubscribe(event, handler);
@@ -291,15 +299,59 @@ export class RestrictedControllerMessenger<
    * @param event - The event type. This is a unique identifier for this event.
    * @template EventType - A type union of Event type strings that are namespaced by Namespace.
    */
-  clearEventSubscriptions<EventType extends NamespacedName<Namespace>>(
-    event: EventType,
-  ) {
+  clearEventSubscriptions<
+    EventType extends Event['type'] & NamespacedName<Namespace>,
+  >(event: EventType) {
     /* istanbul ignore if */ // Branch unreachable with valid types
-    if (!event.startsWith(`${this.#controllerName}:`)) {
+    if (!this.#isInCurrentNamespace(event)) {
       throw new Error(
         `Only allowed clearing events prefixed by '${this.#controllerName}:'`,
       );
     }
     this.#controllerMessenger.clearEventSubscriptions(event);
+  }
+
+  /**
+   * Determine whether the given event type is allowed. Event types are
+   * allowed if they are in the current namespace or on the list of
+   * allowed events.
+   *
+   * @param eventType - The event type to check.
+   * @returns Whether the event type is allowed.
+   */
+  #isAllowedEvent(eventType: Event['type']): eventType is AllowedEvent {
+    // Safely upcast to allow runtime check
+    const allowedEvents: string[] | null = this.#allowedEvents;
+    return (
+      this.#isInCurrentNamespace(eventType) ||
+      (allowedEvents !== null && allowedEvents.includes(eventType))
+    );
+  }
+
+  /**
+   * Determine whether the given action type is allowed. Action types
+   * are allowed if they are in the current namespace or on the list of
+   * allowed actions.
+   *
+   * @param actionType - The action type to check.
+   * @returns Whether the action type is allowed.
+   */
+  #isAllowedAction(actionType: Action['type']): actionType is AllowedAction {
+    // Safely upcast to allow runtime check
+    const allowedActions: string[] | null = this.#allowedActions;
+    return (
+      this.#isInCurrentNamespace(actionType) ||
+      (allowedActions !== null && allowedActions.includes(actionType))
+    );
+  }
+
+  /**
+   * Determine whether the given name is within the current namespace.
+   *
+   * @param name - The name to check
+   * @returns Whether the name is within the current namespace
+   */
+  #isInCurrentNamespace(name: string): name is NamespacedName<Namespace> {
+    return name.startsWith(`${this.#controllerName}:`);
   }
 }

--- a/packages/base-controller/src/RestrictedControllerMessenger.ts
+++ b/packages/base-controller/src/RestrictedControllerMessenger.ts
@@ -113,7 +113,8 @@ export class RestrictedControllerMessenger<
    *
    * The action type being unregistered *must* be in the current namespace.
    *
-   * @param action - The action type. This is a unqiue identifier for this action.
+   * @param action - The action type. This is a unique identifier for this action.
+   * @throws Will throw if an action handler that is not in the current namespace is being unregistered.
    * @template ActionType - A type union of Action type strings that are namespaced by Namespace.
    */
   unregisterActionHandler<
@@ -175,6 +176,7 @@ export class RestrictedControllerMessenger<
    * @param event - The event type. This is a unique identifier for this event.
    * @param payload - The event payload. The type of the parameters for each event handler must
    * match the type of this payload.
+   * @throws Will throw if an event that is not in the current namespace is being published.
    * @template EventType - A type union of Event type strings that are namespaced by Namespace.
    */
   publish<EventType extends Event['type'] & NamespacedName<Namespace>>(
@@ -200,6 +202,7 @@ export class RestrictedControllerMessenger<
    * @param eventType - The event type. This is a unique identifier for this event.
    * @param handler - The event handler. The type of the parameters for this event handler must
    * match the type of the payload for this event type.
+   * @throws Will throw if the given event is not an allowed event for this controller messenger.
    * @template EventType - A type union of Event type strings.
    */
   subscribe<
@@ -274,7 +277,7 @@ export class RestrictedControllerMessenger<
    *
    * @param event - The event type. This is a unique identifier for this event.
    * @param handler - The event handler to unregister.
-   * @throws Will throw when the given event handler is not registered for this event.
+   * @throws Will throw when the given event is not an allowed event for this controller messenger.
    * @template EventType - A type union of allowed Event type strings.
    */
   unsubscribe<
@@ -297,6 +300,7 @@ export class RestrictedControllerMessenger<
    * The event type being cleared *must* be in the current namespace.
    *
    * @param event - The event type. This is a unique identifier for this event.
+   * @throws Will throw if a subscription for an event that is not in the current namespace is being cleared.
    * @template EventType - A type union of Event type strings that are namespaced by Namespace.
    */
   clearEventSubscriptions<

--- a/packages/base-controller/src/RestrictedControllerMessenger.ts
+++ b/packages/base-controller/src/RestrictedControllerMessenger.ts
@@ -96,7 +96,7 @@ export class RestrictedControllerMessenger<
     ActionType extends Action['type'] & NamespacedName<Namespace>,
   >(action: ActionType, handler: ActionHandler<Action, ActionType>) {
     /* istanbul ignore if */ // Branch unreachable with valid types
-    if (!action.startsWith(`${this.#controllerName}:`)) {
+    if (!this.#isInCurrentNamespace(action)) {
       throw new Error(
         `Only allowed registering action handlers prefixed by '${
           this.#controllerName
@@ -120,7 +120,7 @@ export class RestrictedControllerMessenger<
     ActionType extends Action['type'] & NamespacedName<Namespace>,
   >(action: ActionType) {
     /* istanbul ignore if */ // Branch unreachable with valid types
-    if (!action.startsWith(`${this.#controllerName}:`)) {
+    if (!this.#isInCurrentNamespace(action)) {
       throw new Error(
         `Only allowed unregistering action handlers prefixed by '${
           this.#controllerName
@@ -182,7 +182,7 @@ export class RestrictedControllerMessenger<
     ...payload: ExtractEventPayload<Event, EventType>
   ) {
     /* istanbul ignore if */ // Branch unreachable with valid types
-    if (!event.startsWith(`${this.#controllerName}:`)) {
+    if (!this.#isInCurrentNamespace(event)) {
       throw new Error(
         `Only allowed publishing events prefixed by '${this.#controllerName}:'`,
       );


### PR DESCRIPTION
## Explanation

The restricted controller messenger now allows using all internal events and actions. Previously internal events were treated the same as external events, they had to be explicitly allowed.

This is a non-breaking change; internal actions/events are still permitted to be list as "allowed", it's just no longer necessary.

## References

Resolves #2047

## Changelog

### `@metamask/base-controller`

- CHANGED: The restricted controller messenger now allows calling all internal events and actions
  - Previously internal events and actions were only usable if they were listed as "allowed". They are still permitted to be listed as "allowed" now, but it is no longer necessary.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
