### PR TITLE
fix(signature-controller): Add missing dependency on keyring controller

### DIFF
--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -33,6 +33,7 @@
     "@metamask/approval-controller": "^4.1.0",
     "@metamask/base-controller": "^3.2.3",
     "@metamask/controller-utils": "^5.0.2",
+    "@metamask/keyring-controller": "^8.1.0",
     "@metamask/logging-controller": "^1.0.4",
     "@metamask/message-manager": "^7.3.5",
     "@metamask/rpc-errors": "^6.1.0",
@@ -42,7 +43,6 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.3",
-    "@metamask/keyring-controller": "^8.1.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
@@ -53,6 +53,7 @@
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^4.1.0",
+    "@metamask/keyring-controller": "^8.1.0",
     "@metamask/logging-controller": "^1.0.4"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2422,6 +2422,7 @@ __metadata:
     typescript: ~4.8.4
   peerDependencies:
     "@metamask/approval-controller": ^4.1.0
+    "@metamask/keyring-controller": ^8.1.0
     "@metamask/logging-controller": ^1.0.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Explanation

The signature controller has been updated to include `@metamask/keyring-controller` as a dependency and as a peer dependency. The keyring controller types are relied upon by the signature controller, and are referenced by the `.d.ts` files included in the signature controller package.
## References

## Changelog

### `@metamask/signature-controller`

- **BREAKING**: Add `@metamask/keyring-controller` as a dependency and peer dependency
  - This was relied upon by past versions, but this was not reflected in the package manifest until now

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
