### PR TITLE
[`base-controller`] Add `RestrictedControllerMessenger` tests for runtime error handling

### DIFF
--- a/packages/base-controller/jest.config.js
+++ b/packages/base-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 98,
+      branches: 85.71,
       functions: 100,
-      lines: 100,
-      statements: 100,
+      lines: 95.54,
+      statements: 95.56,
     },
   },
 });

--- a/packages/base-controller/jest.config.js
+++ b/packages/base-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 85.71,
+      branches: 100,
       functions: 100,
-      lines: 95.54,
-      statements: 95.56,
+      lines: 100,
+      statements: 100,
     },
   },
 });

--- a/packages/base-controller/src/RestrictedControllerMessenger.test.ts
+++ b/packages/base-controller/src/RestrictedControllerMessenger.test.ts
@@ -300,9 +300,10 @@ describe('RestrictedControllerMessenger', () => {
     });
 
     expect(() => {
-      // @ts-expect-error suppressing to test runtime error handling
       restrictedControllerMessenger.registerActionHandler(
+        // @ts-expect-error suppressing to test runtime error handling
         'CountController:count',
+        () => undefined,
       );
     }).toThrow(
       `Only allowed registering action handlers prefixed by 'PingController:'`,

--- a/packages/base-controller/src/RestrictedControllerMessenger.ts
+++ b/packages/base-controller/src/RestrictedControllerMessenger.ts
@@ -154,7 +154,6 @@ export class RestrictedControllerMessenger<
     actionType: ActionType,
     ...params: ExtractActionParameters<Action, ActionType>
   ): ExtractActionResponse<Action, ActionType> {
-    /* istanbul ignore next */ // Branches unreachable with valid types
     if (!this.#isAllowedAction(actionType)) {
       throw new Error(`Action missing from allow list: ${actionType}`);
     }
@@ -257,7 +256,6 @@ export class RestrictedControllerMessenger<
       SelectorReturnValue
     >,
   ) {
-    /* istanbul ignore next */ // Branches unreachable with valid types
     if (!this.#isAllowedEvent(event)) {
       throw new Error(`Event missing from allow list: ${event}`);
     }
@@ -285,7 +283,6 @@ export class RestrictedControllerMessenger<
       | AllowedEvent
       | (Event['type'] & NamespacedName<Namespace>),
   >(event: EventType, handler: ExtractEventHandler<Event, EventType>) {
-    /* istanbul ignore next */ // Branches unreachable with valid types
     if (!this.#isAllowedEvent(event)) {
       throw new Error(`Event missing from allow list: ${event}`);
     }
@@ -306,7 +303,6 @@ export class RestrictedControllerMessenger<
   clearEventSubscriptions<
     EventType extends Event['type'] & NamespacedName<Namespace>,
   >(event: EventType) {
-    /* istanbul ignore if */ // Branch unreachable with valid types
     if (!this.#isInCurrentNamespace(event)) {
       throw new Error(
         `Only allowed clearing events prefixed by '${this.#controllerName}:'`,


### PR DESCRIPTION
## Explanation

- Previously, error handling branches for `RestrictedControllerMessenger` methods were not being tested on the basis of compile-time checks: "Branches unreachable with valid types".
- However, given that these methods are being called by our JavaScript clients, we also need assurances on runtime error-handling behavior.
- This PR adds jest tests for the previously ignored error handling branches: coverage is brought up to 100%.
- `@ts-expect-error` is used to suppress the compile-time type errors to simulate a JavaScript environment. 

## References

- Closes https://github.com/MetaMask/core/issues/2059
- See https://github.com/MetaMask/core/pull/2051#discussion_r1396339975

## Changelog

### `@metamask/base-controller`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
