### PR TITLE
Add method to get transactions

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 88.48,
-      functions: 94,
-      lines: 98.5,
-      statements: 98,
+      branches: 88.6,
+      functions: 93.72,
+      lines: 98.32,
+      statements: 98.28,
     },
   },
 

--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 88.6,
-      functions: 93.72,
-      lines: 98.32,
-      statements: 98.28,
+      branches: 88.78,
+      functions: 94.14,
+      lines: 98.29,
+      statements: 98.25,
     },
   },
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -3931,7 +3931,7 @@ describe('TransactionController', () => {
         ).toStrictEqual([transactions[0], transactions[2]]);
       });
 
-      it('returns limited number of transactions sorted by descending time', () => {
+      it('returns limited number of transactions sorted by ascending time', () => {
         const controller = newController();
 
         const transactions: TransactionMeta[] = [
@@ -3945,17 +3945,23 @@ describe('TransactionController', () => {
           {
             chainId: '0x1',
             id: 'testId2',
-
-            status: TransactionStatus.unapproved,
+            status: TransactionStatus.confirmed,
             time: 2,
-            txParams: { from: '0x2', nonce: '0x2' },
+            txParams: { from: '0x1', nonce: '0x2' },
           },
           {
             chainId: '0x1',
             id: 'testId3',
-            status: TransactionStatus.submitted,
+            status: TransactionStatus.unapproved,
             time: 3,
-            txParams: { from: '0x1', nonce: '0x3' },
+            txParams: { from: '0x2', nonce: '0x3' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId4',
+            status: TransactionStatus.submitted,
+            time: 4,
+            txParams: { from: '0x1', nonce: '0x4' },
           },
         ];
 
@@ -3965,9 +3971,9 @@ describe('TransactionController', () => {
           controller.getTransactions({
             searchCriteria: { from: '0x1' },
             filterToCurrentNetwork: false,
-            limit: 1,
+            limit: 2,
           }),
-        ).toStrictEqual([transactions[2]]);
+        ).toStrictEqual([transactions[1], transactions[3]]);
       });
 
       it('returns limited number of transactions except for duplicate nonces', () => {
@@ -3996,6 +4002,13 @@ describe('TransactionController', () => {
             time: 3,
             txParams: { from: '0x1', nonce: '0x1' },
           },
+          {
+            chainId: '0x1',
+            id: 'testId4',
+            status: TransactionStatus.submitted,
+            time: 4,
+            txParams: { from: '0x1', nonce: '0x3' },
+          },
         ];
 
         controller.state.transactions = transactions;
@@ -4004,9 +4017,9 @@ describe('TransactionController', () => {
           controller.getTransactions({
             searchCriteria: { from: '0x1' },
             filterToCurrentNetwork: false,
-            limit: 1,
+            limit: 2,
           }),
-        ).toStrictEqual([transactions[0], transactions[2]]);
+        ).toStrictEqual([transactions[0], transactions[2], transactions[3]]);
       });
     });
   });

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -625,269 +625,6 @@ describe('TransactionController', () => {
         updateGasFeesMock.mockReset();
       });
 
-      it('creates approvals for all unapproved transaction', async () => {
-        const mockTransactionMeta = {
-          from: ACCOUNT_MOCK,
-          chainId: toHex(5),
-          status: TransactionStatus.unapproved,
-          txParams: {
-            from: ACCOUNT_MOCK,
-            to: ACCOUNT_2_MOCK,
-          },
-        };
-
-        const mockedTransactions = [
-          {
-            id: '123',
-            ...mockTransactionMeta,
-            history: [{ ...mockTransactionMeta, id: '123' }],
-          },
-          {
-            id: '1234',
-            ...mockTransactionMeta,
-            history: [{ ...mockTransactionMeta, id: '1234' }],
-          },
-        ];
-
-        const mockedControllerState = {
-          transactions: mockedTransactions,
-          methodData: {},
-          lastFetchedBlockNumbers: {},
-        };
-
-        newController({
-          state: mockedControllerState as any,
-        });
-
-        expect(delayMessengerMock.call).toHaveBeenCalledTimes(2);
-        expect(delayMessengerMock.call).toHaveBeenCalledWith(
-          'ApprovalController:addRequest',
-          {
-            expectsResult: true,
-            id: '123',
-            origin: 'metamask',
-            requestData: { txId: '123' },
-            type: 'transaction',
-          },
-          false,
-        );
-        expect(delayMessengerMock.call).toHaveBeenCalledWith(
-          'ApprovalController:addRequest',
-          {
-            expectsResult: true,
-            id: '1234',
-            origin: 'metamask',
-            requestData: { txId: '1234' },
-            type: 'transaction',
-          },
-          false,
-        );
-      });
-
-      it('catches error without code property in error object while creating approval', async () => {
-        const mockTransactionMeta = {
-          from: ACCOUNT_MOCK,
-          chainId: toHex(5),
-          status: TransactionStatus.unapproved,
-          txParams: {
-            from: ACCOUNT_MOCK,
-            to: ACCOUNT_2_MOCK,
-          },
-        };
-
-        const mockedTransactions = [
-          {
-            id: '123',
-            ...mockTransactionMeta,
-            history: [{ ...mockTransactionMeta, id: '123' }],
-          },
-          {
-            id: '1234',
-            ...mockTransactionMeta,
-            history: [{ ...mockTransactionMeta, id: '1234' }],
-          },
-        ];
-
-        const mockedControllerState = {
-          transactions: mockedTransactions,
-          methodData: {},
-          lastFetchedBlockNumbers: {},
-        };
-
-        const mockedErrorMessage = 'mocked error';
-
-        // Expect both calls to throw error, one with code property to check if it is handled
-        (delayMessengerMock.call as jest.MockedFunction<any>)
-          .mockImplementationOnce(() => {
-            // eslint-disable-next-line @typescript-eslint/no-throw-literal
-            throw { message: mockedErrorMessage };
-          })
-          .mockImplementationOnce(() => {
-            // eslint-disable-next-line @typescript-eslint/no-throw-literal
-            throw {
-              message: mockedErrorMessage,
-              code: errorCodes.provider.userRejectedRequest,
-            };
-          });
-        const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-
-        newController({
-          state: mockedControllerState as any,
-        });
-
-        await flushPromises();
-
-        expect(consoleSpy).toHaveBeenCalledTimes(1);
-        expect(consoleSpy).toHaveBeenCalledWith(
-          'Error during persisted transaction approval',
-          new Error(mockedErrorMessage),
-        );
-        expect(delayMessengerMock.call).toHaveBeenCalledTimes(2);
-      });
-
-      it('does not create any approval when there is no unapproved transaction', async () => {
-        newController();
-        expect(delayMessengerMock.call).not.toHaveBeenCalled();
-      });
-
-      it('updates gas values of unapproved transactions', async () => {
-        const mockTransactionMeta = {
-          from: ACCOUNT_MOCK,
-          chainId: toHex(5),
-          status: TransactionStatus.unapproved,
-          txParams: {
-            from: ACCOUNT_MOCK,
-            to: ACCOUNT_2_MOCK,
-          },
-        };
-        const mockGasPrice = '0x2';
-        const mockGas = '0x1';
-        const mockedTransactions = [
-          {
-            id: '123',
-            ...mockTransactionMeta,
-            history: [{ ...mockTransactionMeta, id: '123' }],
-          },
-          {
-            id: '1234',
-            ...mockTransactionMeta,
-            history: [{ ...mockTransactionMeta, id: '1234' }],
-          },
-        ];
-
-        const mockedControllerState = {
-          transactions: mockedTransactions,
-          methodData: {},
-          lastFetchedBlockNumbers: {},
-        };
-
-        updateGasFeesMock.mockImplementation(({ txMeta }) => {
-          // Assume this is a sample update
-          txMeta.txParams.gasPrice = mockGasPrice;
-          return Promise.resolve();
-        });
-
-        updateGasMock.mockImplementation(({ txMeta }) => {
-          // Assume this is a sample update
-          txMeta.txParams.gas = mockGas;
-          return Promise.resolve();
-        });
-
-        const controller = newController({
-          state: mockedControllerState as any,
-        });
-
-        await flushPromises();
-
-        [updateGasMock, updateGasFeesMock].forEach((mockedGasFn) => {
-          expect(mockedGasFn).toHaveBeenCalledTimes(2);
-          expect(mockedGasFn.mock.calls[0][0]).toStrictEqual(
-            expect.objectContaining({
-              txMeta: expect.objectContaining({
-                id: '123',
-              }),
-            }),
-          );
-          expect(mockedGasFn.mock.calls[1][0]).toStrictEqual(
-            expect.objectContaining({
-              txMeta: expect.objectContaining({
-                id: '1234',
-              }),
-            }),
-          );
-        });
-
-        const { transactions } = controller.state;
-
-        expect(transactions[0].txParams.gasPrice).toBe(mockGasPrice);
-        expect(transactions[1].txParams.gasPrice).toBe(mockGasPrice);
-      });
-
-      it('updates transaction as failed if failes to update gas fees', async () => {
-        const mockGasPrice = '0x1';
-        const mockGas = '0x1';
-
-        const mockTransactionMeta = {
-          from: ACCOUNT_MOCK,
-          chainId: toHex(5),
-          status: TransactionStatus.unapproved,
-          txParams: {
-            from: ACCOUNT_MOCK,
-            to: ACCOUNT_2_MOCK,
-          },
-        };
-        const mockedTransactions = [
-          {
-            id: '123',
-            ...mockTransactionMeta,
-            history: [{ ...mockTransactionMeta, id: '123' }],
-          },
-          {
-            id: '1234',
-            ...mockTransactionMeta,
-            history: [{ ...mockTransactionMeta, id: '1234' }],
-          },
-        ];
-
-        const mockedControllerState = {
-          transactions: mockedTransactions,
-          methodData: {},
-          lastFetchedBlockNumbers: {},
-        };
-
-        // Let the first update pass and fail the second one
-        // to test the failure case
-        updateGasFeesMock
-          .mockImplementationOnce(({ txMeta }) => {
-            // Assume this is a sample update
-            txMeta.txParams.gasPrice = mockGasPrice;
-            return Promise.resolve();
-          })
-          .mockImplementationOnce(() => {
-            return Promise.reject(new Error('unexpected failure'));
-          });
-
-        updateGasMock.mockImplementation(({ txMeta }) => {
-          // Assume this is a sample update
-          txMeta.txParams.gasPrice = mockGas;
-          return Promise.resolve();
-        });
-
-        // Second gas update will fail, in order to keep the console clean during test mock console.error once
-        jest.spyOn(console, 'error').mockImplementation();
-
-        const controller = newController({
-          state: mockedControllerState as any,
-        });
-
-        await flushPromises();
-
-        const { transactions } = controller.state;
-
-        expect(transactions[0].status).toBe(TransactionStatus.unapproved);
-        expect(transactions[1].status).toBe(TransactionStatus.failed);
-      });
-
       it('submits an approved transaction', async () => {
         const mockTransactionMeta = {
           from: ACCOUNT_MOCK,
@@ -2536,6 +2273,11 @@ describe('TransactionController', () => {
         },
         {
           op: 'add',
+          path: '/txParams/value',
+          value: '0x0',
+        },
+        {
+          op: 'add',
           path: '/txReceipt',
           value: expect.anything(),
         },
@@ -3510,10 +3252,15 @@ describe('TransactionController', () => {
   });
 
   describe('with hooks', () => {
-    const txMeta = {
+    const paramsMock = {
       from: ACCOUNT_MOCK,
       to: ACCOUNT_MOCK,
     };
+
+    const metadataMock = {
+      txParams: paramsMock,
+    };
+
     it('adds a transaction, signs and update status to `approved`', async () => {
       const controller = newController({
         options: {
@@ -3521,14 +3268,14 @@ describe('TransactionController', () => {
             afterSign: () => false,
             beforeApproveOnInit: () => false,
             beforePublish: () => false,
-            getAdditionalSignArguments: () => [txMeta],
+            getAdditionalSignArguments: () => [metadataMock],
           },
         },
       });
       const signSpy = jest.spyOn(controller, 'sign' as any);
       const updateTransactionSpy = jest.spyOn(controller, 'updateTransaction');
 
-      await controller.addTransaction(txMeta, {
+      await controller.addTransaction(paramsMock, {
         origin: 'origin',
         actionId: ACTION_ID_MOCK,
       });
@@ -3537,14 +3284,23 @@ describe('TransactionController', () => {
       await wait(0);
 
       const transactionMeta = controller.state.transactions[0];
+
       expect(signSpy).toHaveBeenCalledTimes(1);
-      expect(updateTransactionSpy).toHaveBeenCalledTimes(1);
+
+      expect(updateTransactionSpy).toHaveBeenCalledTimes(2);
       expect(updateTransactionSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          txParams: expect.objectContaining(txMeta),
+          txParams: expect.objectContaining(paramsMock),
         }),
         'TransactionController#approveTransaction - Transaction approved',
       );
+      expect(updateTransactionSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          txParams: expect.objectContaining(paramsMock),
+        }),
+        'TransactionController#signTransaction - Update after sign',
+      );
+
       expect(transactionMeta.status).toBe(TransactionStatus.approved);
     });
 
@@ -3555,7 +3311,7 @@ describe('TransactionController', () => {
             afterSign: () => false,
             beforeApproveOnInit: () => false,
             beforePublish: () => false,
-            getAdditionalSignArguments: () => [txMeta],
+            getAdditionalSignArguments: () => [metadataMock],
           },
         },
         config: { sign: async () => undefined },
@@ -3563,7 +3319,7 @@ describe('TransactionController', () => {
       const signSpy = jest.spyOn(controller, 'sign' as any);
       const updateTransactionSpy = jest.spyOn(controller, 'updateTransaction');
 
-      await controller.addTransaction(txMeta, {
+      await controller.addTransaction(paramsMock, {
         origin: 'origin',
         actionId: ACTION_ID_MOCK,
       });
@@ -3581,14 +3337,14 @@ describe('TransactionController', () => {
           hooks: {
             beforePublish: undefined,
             afterSign: () => false,
-            getAdditionalSignArguments: () => [txMeta],
+            getAdditionalSignArguments: () => [metadataMock],
           },
         },
       });
       const signSpy = jest.spyOn(controller, 'sign' as any);
       const updateTransactionSpy = jest.spyOn(controller, 'updateTransaction');
 
-      await controller.addTransaction(txMeta, {
+      await controller.addTransaction(paramsMock, {
         origin: 'origin',
         actionId: ACTION_ID_MOCK,
       });
@@ -3597,12 +3353,19 @@ describe('TransactionController', () => {
       await wait(0);
 
       expect(signSpy).toHaveBeenCalledTimes(1);
-      expect(updateTransactionSpy).toHaveBeenCalledTimes(1);
+
+      expect(updateTransactionSpy).toHaveBeenCalledTimes(2);
       expect(updateTransactionSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          txParams: expect.objectContaining(txMeta),
+          txParams: expect.objectContaining(paramsMock),
         }),
         'TransactionController#approveTransaction - Transaction approved',
+      );
+      expect(updateTransactionSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          txParams: expect.objectContaining(paramsMock),
+        }),
+        'TransactionController#signTransaction - Update after sign',
       );
     });
   });
@@ -3704,119 +3467,547 @@ describe('TransactionController', () => {
         'Cannot update security alert response as no transaction metadata found',
       );
     });
-  });
 
-  describe('updateCustodialTransaction', () => {
-    const transactionId = '1';
-    const statusMock = TransactionStatus.unapproved as const;
-    const baseTransaction = {
-      id: transactionId,
-      chainId: toHex(5),
-      status: statusMock,
-      time: 123456789,
-      txParams: {
-        from: ACCOUNT_MOCK,
-        to: ACCOUNT_2_MOCK,
-      },
-    };
-    const transactionMeta: TransactionMeta = {
-      ...baseTransaction,
-      custodyId: '123',
-      history: [{ ...baseTransaction }],
-    };
-    it.each([
-      {
-        newStatus: TransactionStatus.signed,
-      },
-      {
-        newStatus: TransactionStatus.submitted,
-      },
-      {
-        newStatus: TransactionStatus.failed,
-        errorMessage: 'Error mock',
-      },
-    ])(
-      'updates transaction status to $newStatus',
-      async ({ newStatus, errorMessage }) => {
-        const newHash = '1234';
-        const newCustodyStatus = 'submitted';
+    describe('updateCustodialTransaction', () => {
+      const transactionId = '1';
+      const statusMock = TransactionStatus.unapproved as const;
+      const baseTransaction = {
+        id: transactionId,
+        chainId: toHex(5),
+        status: statusMock,
+        time: 123456789,
+        txParams: {
+          from: ACCOUNT_MOCK,
+          to: ACCOUNT_2_MOCK,
+        },
+      };
+      const transactionMeta: TransactionMeta = {
+        ...baseTransaction,
+        custodyId: '123',
+        history: [{ ...baseTransaction }],
+      };
+      it.each([
+        {
+          newStatus: TransactionStatus.signed,
+        },
+        {
+          newStatus: TransactionStatus.submitted,
+        },
+        {
+          newStatus: TransactionStatus.failed,
+          errorMessage: 'Error mock',
+        },
+      ])(
+        'updates transaction status to $newStatus',
+        async ({ newStatus, errorMessage }) => {
+          const newHash = '1234';
+          const controller = newController();
+          controller.state.transactions.push(transactionMeta);
+
+          controller.updateCustodialTransaction(transactionId, {
+            status: newStatus,
+            hash: newHash,
+            errorMessage,
+          });
+
+          const updatedTransaction = controller.state.transactions[0];
+
+          expect(updatedTransaction?.status).toStrictEqual(newStatus);
+          expect(updatedTransaction?.hash).toStrictEqual(newHash);
+        },
+      );
+
+      it('throws if custodial transaction does not exists', async () => {
+        const nonExistentId = 'nonExistentId';
+        const newStatus = TransactionStatus.approved as const;
+        const controller = newController();
+
+        expect(() =>
+          controller.updateCustodialTransaction(nonExistentId, {
+            status: newStatus,
+          }),
+        ).toThrow(
+          'Cannot update custodial transaction as no transaction metadata found',
+        );
+      });
+
+      it('throws if transaction is not a custodial transaction', async () => {
+        const nonCustodialTransaction: TransactionMeta = {
+          ...baseTransaction,
+          history: [{ ...baseTransaction }],
+        };
+        const newStatus = TransactionStatus.approved as const;
+        const controller = newController();
+        controller.state.transactions.push(nonCustodialTransaction);
+
+        expect(() =>
+          controller.updateCustodialTransaction(nonCustodialTransaction.id, {
+            status: newStatus,
+          }),
+        ).toThrow('Transaction must be a custodian transaction');
+      });
+
+      it('throws if status is invalid', async () => {
+        const newStatus = TransactionStatus.approved as const;
         const controller = newController();
         controller.state.transactions.push(transactionMeta);
 
-        controller.updateCustodialTransaction(transactionId, {
-          status: newStatus,
-          hash: newHash,
-          custodyStatus: newCustodyStatus,
-          errorMessage,
-        });
+        expect(() =>
+          controller.updateCustodialTransaction(transactionMeta.id, {
+            status: newStatus,
+          }),
+        ).toThrow(
+          `Cannot update custodial transaction with status: ${newStatus}`,
+        );
+      });
+
+      it('no property was updated', async () => {
+        const controller = newController();
+        controller.state.transactions.push(transactionMeta);
+
+        controller.updateCustodialTransaction(transactionId, {});
 
         const updatedTransaction = controller.state.transactions[0];
 
-        expect(updatedTransaction?.status).toStrictEqual(newStatus);
-        expect(updatedTransaction?.hash).toStrictEqual(newHash);
-        expect(updatedTransaction?.custodyStatus).toStrictEqual(
-          newCustodyStatus,
+        expect(updatedTransaction?.status).toStrictEqual(
+          transactionMeta.status,
         );
-      },
-    );
-
-    it('throws if custodial transaction does not exists', async () => {
-      const nonExistentId = 'nonExistentId';
-      const newStatus = TransactionStatus.approved as const;
-      const controller = newController();
-
-      expect(() =>
-        controller.updateCustodialTransaction(nonExistentId, {
-          status: newStatus,
-        }),
-      ).toThrow(
-        'Cannot update custodial transaction as no transaction metadata found',
-      );
+        expect(updatedTransaction?.hash).toStrictEqual(transactionMeta.hash);
+      });
     });
 
-    it('throws if transaction is not a custodial transaction', async () => {
-      const nonCustodialTransaction: TransactionMeta = {
-        ...baseTransaction,
-        history: [{ ...baseTransaction }],
-      };
-      const newStatus = TransactionStatus.approved as const;
-      const controller = newController();
-      controller.state.transactions.push(nonCustodialTransaction);
+    describe('initApprovals', () => {
+      it('creates approvals for all unapproved transaction', async () => {
+        const mockTransactionMeta = {
+          from: ACCOUNT_MOCK,
+          chainId: toHex(5),
+          status: TransactionStatus.unapproved,
+          txParams: {
+            from: ACCOUNT_MOCK,
+            to: ACCOUNT_2_MOCK,
+          },
+        };
 
-      expect(() =>
-        controller.updateCustodialTransaction(nonCustodialTransaction.id, {
-          status: newStatus,
-        }),
-      ).toThrow('Transaction must be a custodian transaction');
+        const mockedTransactions = [
+          {
+            id: '123',
+            ...mockTransactionMeta,
+            history: [{ ...mockTransactionMeta, id: '123' }],
+          },
+          {
+            id: '1234',
+            ...mockTransactionMeta,
+            history: [{ ...mockTransactionMeta, id: '1234' }],
+          },
+        ];
+
+        const mockedControllerState = {
+          transactions: mockedTransactions,
+          methodData: {},
+          lastFetchedBlockNumbers: {},
+        };
+
+        const controller = newController({
+          state: mockedControllerState as any,
+        });
+
+        controller.initApprovals();
+        await flushPromises();
+
+        expect(delayMessengerMock.call).toHaveBeenCalledTimes(2);
+        expect(delayMessengerMock.call).toHaveBeenCalledWith(
+          'ApprovalController:addRequest',
+          {
+            expectsResult: true,
+            id: '123',
+            origin: 'metamask',
+            requestData: { txId: '123' },
+            type: 'transaction',
+          },
+          false,
+        );
+        expect(delayMessengerMock.call).toHaveBeenCalledWith(
+          'ApprovalController:addRequest',
+          {
+            expectsResult: true,
+            id: '1234',
+            origin: 'metamask',
+            requestData: { txId: '1234' },
+            type: 'transaction',
+          },
+          false,
+        );
+      });
+
+      it('catches error without code property in error object while creating approval', async () => {
+        const mockTransactionMeta = {
+          from: ACCOUNT_MOCK,
+          chainId: toHex(5),
+          status: TransactionStatus.unapproved,
+          txParams: {
+            from: ACCOUNT_MOCK,
+            to: ACCOUNT_2_MOCK,
+          },
+        };
+
+        const mockedTransactions = [
+          {
+            id: '123',
+            ...mockTransactionMeta,
+            history: [{ ...mockTransactionMeta, id: '123' }],
+          },
+          {
+            id: '1234',
+            ...mockTransactionMeta,
+            history: [{ ...mockTransactionMeta, id: '1234' }],
+          },
+        ];
+
+        const mockedControllerState = {
+          transactions: mockedTransactions,
+          methodData: {},
+          lastFetchedBlockNumbers: {},
+        };
+
+        const mockedErrorMessage = 'mocked error';
+
+        // Expect both calls to throw error, one with code property to check if it is handled
+        (delayMessengerMock.call as jest.MockedFunction<any>)
+          .mockImplementationOnce(() => {
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
+            throw { message: mockedErrorMessage };
+          })
+          .mockImplementationOnce(() => {
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
+            throw {
+              message: mockedErrorMessage,
+              code: errorCodes.provider.userRejectedRequest,
+            };
+          });
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+        const controller = newController({
+          state: mockedControllerState as any,
+        });
+
+        controller.initApprovals();
+
+        await flushPromises();
+
+        expect(consoleSpy).toHaveBeenCalledTimes(1);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Error during persisted transaction approval',
+          new Error(mockedErrorMessage),
+        );
+        expect(delayMessengerMock.call).toHaveBeenCalledTimes(2);
+      });
+
+      it('does not create any approval when there is no unapproved transaction', async () => {
+        const controller = newController();
+        controller.initApprovals();
+        await flushPromises();
+        expect(delayMessengerMock.call).not.toHaveBeenCalled();
+      });
     });
 
-    it('throws if status is invalid', async () => {
-      const newStatus = TransactionStatus.approved as const;
-      const controller = newController();
-      controller.state.transactions.push(transactionMeta);
+    describe('getTransactions', () => {
+      it('returns transactions matching values in search criteria', () => {
+        const controller = newController();
 
-      expect(() =>
-        controller.updateCustodialTransaction(transactionMeta.id, {
-          status: newStatus,
-        }),
-      ).toThrow(
-        `Cannot update custodial transaction with status: ${newStatus}`,
-      );
-    });
+        const transactions: TransactionMeta[] = [
+          {
+            chainId: '0x1',
+            id: 'testId1',
+            status: TransactionStatus.confirmed,
+            time: 1,
+            txParams: { from: '0x1' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId2',
+            status: TransactionStatus.unapproved,
+            time: 2,
+            txParams: { from: '0x2' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId3',
+            status: TransactionStatus.submitted,
+            time: 1,
+            txParams: { from: '0x3' },
+          },
+        ];
 
-    it('no property was updated', async () => {
-      const controller = newController();
-      controller.state.transactions.push(transactionMeta);
+        controller.state.transactions = transactions;
 
-      controller.updateCustodialTransaction(transactionId, {});
+        expect(
+          controller.getTransactions({
+            searchCriteria: { time: 1 },
+            filterToCurrentNetwork: false,
+          }),
+        ).toStrictEqual([transactions[0], transactions[2]]);
+      });
 
-      const updatedTransaction = controller.state.transactions[0];
+      it('returns transactions matching param values in search criteria', () => {
+        const controller = newController();
 
-      expect(updatedTransaction?.status).toStrictEqual(transactionMeta.status);
-      expect(updatedTransaction?.custodyStatus).toStrictEqual(
-        transactionMeta.custodyStatus,
-      );
-      expect(updatedTransaction?.hash).toStrictEqual(transactionMeta.hash);
+        const transactions: TransactionMeta[] = [
+          {
+            chainId: '0x1',
+            id: 'testId1',
+            status: TransactionStatus.confirmed,
+            time: 1,
+            txParams: { from: '0x1' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId2',
+            status: TransactionStatus.unapproved,
+            time: 2,
+            txParams: { from: '0x2' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId3',
+            status: TransactionStatus.submitted,
+            time: 3,
+            txParams: { from: '0x1' },
+          },
+        ];
+
+        controller.state.transactions = transactions;
+
+        expect(
+          controller.getTransactions({
+            searchCriteria: { from: '0x1' },
+            filterToCurrentNetwork: false,
+          }),
+        ).toStrictEqual([transactions[0], transactions[2]]);
+      });
+
+      it('returns transactions matching multiple values in search criteria', () => {
+        const controller = newController();
+
+        const transactions: TransactionMeta[] = [
+          {
+            chainId: '0x1',
+            id: 'testId1',
+            status: TransactionStatus.confirmed,
+            time: 1,
+            txParams: { from: '0x1' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId2',
+            status: TransactionStatus.unapproved,
+            time: 2,
+            txParams: { from: '0x2' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId3',
+            status: TransactionStatus.submitted,
+            time: 1,
+            txParams: { from: '0x1' },
+          },
+        ];
+
+        controller.state.transactions = transactions;
+
+        expect(
+          controller.getTransactions({
+            searchCriteria: { from: '0x1', time: 1 },
+            filterToCurrentNetwork: false,
+          }),
+        ).toStrictEqual([transactions[0], transactions[2]]);
+      });
+
+      it('returns transactions matching function in search criteria', () => {
+        const controller = newController();
+
+        const transactions: TransactionMeta[] = [
+          {
+            chainId: '0x1',
+            id: 'testId1',
+            status: TransactionStatus.confirmed,
+            time: 1,
+            txParams: { from: '0x1' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId2',
+            status: TransactionStatus.unapproved,
+            time: 2,
+            txParams: { from: '0x2' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId3',
+            status: TransactionStatus.submitted,
+            time: 1,
+            txParams: { from: '0x3' },
+          },
+        ];
+
+        controller.state.transactions = transactions;
+
+        expect(
+          controller.getTransactions({
+            searchCriteria: { time: (v: any) => v === 1 },
+            filterToCurrentNetwork: false,
+          }),
+        ).toStrictEqual([transactions[0], transactions[2]]);
+      });
+
+      it('returns transactions matching current network', () => {
+        const controller = newController();
+
+        const transactions: TransactionMeta[] = [
+          {
+            chainId: MOCK_NETWORK.state.providerConfig.chainId,
+            id: 'testId1',
+            status: TransactionStatus.confirmed,
+            time: 1,
+            txParams: { from: '0x1' },
+          },
+          {
+            chainId: '0x2',
+            id: 'testId2',
+            status: TransactionStatus.unapproved,
+            time: 2,
+            txParams: { from: '0x2' },
+          },
+          {
+            chainId: MOCK_NETWORK.state.providerConfig.chainId,
+            id: 'testId3',
+            status: TransactionStatus.submitted,
+            time: 1,
+            txParams: { from: '0x3' },
+          },
+        ];
+
+        controller.state.transactions = transactions;
+
+        expect(
+          controller.getTransactions({
+            filterToCurrentNetwork: true,
+          }),
+        ).toStrictEqual([transactions[0], transactions[2]]);
+      });
+
+      it('returns transactions from specified list', () => {
+        const controller = newController();
+
+        const transactions: TransactionMeta[] = [
+          {
+            chainId: '0x1',
+            id: 'testId1',
+            status: TransactionStatus.confirmed,
+            time: 1,
+            txParams: { from: '0x1' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId2',
+            status: TransactionStatus.unapproved,
+            time: 2,
+            txParams: { from: '0x2' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId3',
+            status: TransactionStatus.submitted,
+            time: 1,
+            txParams: { from: '0x3' },
+          },
+        ];
+
+        expect(
+          controller.getTransactions({
+            searchCriteria: { time: 1 },
+            initialList: transactions,
+            filterToCurrentNetwork: false,
+          }),
+        ).toStrictEqual([transactions[0], transactions[2]]);
+      });
+
+      it('returns limited number of transactions sorted by descending time', () => {
+        const controller = newController();
+
+        const transactions: TransactionMeta[] = [
+          {
+            chainId: '0x1',
+            id: 'testId1',
+            status: TransactionStatus.confirmed,
+            time: 1,
+            txParams: { from: '0x1', nonce: '0x1' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId2',
+
+            status: TransactionStatus.unapproved,
+            time: 2,
+            txParams: { from: '0x2', nonce: '0x2' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId3',
+            status: TransactionStatus.submitted,
+            time: 3,
+            txParams: { from: '0x1', nonce: '0x3' },
+          },
+        ];
+
+        controller.state.transactions = transactions;
+
+        expect(
+          controller.getTransactions({
+            searchCriteria: { from: '0x1' },
+            filterToCurrentNetwork: false,
+            limit: 1,
+          }),
+        ).toStrictEqual([transactions[2]]);
+      });
+
+      it('returns limited number of transactions except for duplicate nonces', () => {
+        const controller = newController();
+
+        const transactions: TransactionMeta[] = [
+          {
+            chainId: '0x1',
+            id: 'testId1',
+            status: TransactionStatus.confirmed,
+            time: 1,
+            txParams: { from: '0x1', nonce: '0x1' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId2',
+
+            status: TransactionStatus.unapproved,
+            time: 2,
+            txParams: { from: '0x2', nonce: '0x2' },
+          },
+          {
+            chainId: '0x1',
+            id: 'testId3',
+            status: TransactionStatus.submitted,
+            time: 3,
+            txParams: { from: '0x1', nonce: '0x1' },
+          },
+        ];
+
+        controller.state.transactions = transactions;
+
+        expect(
+          controller.getTransactions({
+            searchCriteria: { from: '0x1' },
+            filterToCurrentNetwork: false,
+            limit: 1,
+          }),
+        ).toStrictEqual([transactions[0], transactions[2]]);
+      });
     });
   });
 });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -33,7 +33,7 @@ import { Mutex } from 'async-mutex';
 import MethodRegistry from 'eth-method-registry';
 import { addHexPrefix, bufferToHex } from 'ethereumjs-util';
 import { EventEmitter } from 'events';
-import { keyBy, mapValues, merge, pickBy, sortBy } from 'lodash';
+import { mapValues, merge, pickBy, sortBy } from 'lodash';
 import { NonceTracker } from 'nonce-tracker';
 import type { NonceLock } from 'nonce-tracker';
 import { v1 as random } from 'uuid';
@@ -786,7 +786,7 @@ export class TransactionController extends BaseController<
             gasLimit: transactionMeta.txParams.gas,
             maxFeePerGas: newMaxFeePerGas,
             maxPriorityFeePerGas: newMaxPriorityFeePerGas,
-            type: '0x2',
+            type: TransactionEnvelopeType.feeMarket,
             nonce: transactionMeta.txParams.nonce,
             to: transactionMeta.txParams.from,
             value: '0x0',
@@ -930,7 +930,7 @@ export class TransactionController extends BaseController<
             gasLimit: transactionMeta.txParams.gas,
             maxFeePerGas: newMaxFeePerGas,
             maxPriorityFeePerGas: newMaxPriorityFeePerGas,
-            type: '0x2',
+            type: TransactionEnvelopeType.feeMarket,
           }
         : {
             ...transactionMeta.txParams,
@@ -1545,7 +1545,7 @@ export class TransactionController extends BaseController<
     initialList?: TransactionMeta[];
     filterToCurrentNetwork?: boolean;
     limit?: number;
-  } = {}) {
+  } = {}): TransactionMeta[] {
     const chainId = this.getChainId();
     // searchCriteria is an object that might have values that aren't predicate
     // methods. When providing any other value type (string, number, etc), we
@@ -1559,13 +1559,7 @@ export class TransactionController extends BaseController<
         : (v: any) => v === predicate;
     });
 
-    // If an initial list is provided we need to change it back into an object
-    // first, so that it matches the shape of our state. This is done by the
-    // lodash keyBy method. This is the edge case for this method, typically
-    // initialList will be undefined.
-    const transactionsToFilter = initialList
-      ? keyBy(initialList, 'id')
-      : this.state.transactions;
+    const transactionsToFilter = initialList ?? this.state.transactions;
 
     // Combine sortBy and pickBy to transform our state object into an array of
     // matching transactions that are sorted by time.
@@ -1901,7 +1895,7 @@ export class TransactionController extends BaseController<
             ...baseTxParams,
             estimatedBaseFee: transactionMeta.txParams.estimatedBaseFee,
             // specify type 2 if maxFeePerGas and maxPriorityFeePerGas are set
-            type: '0x2',
+            type: TransactionEnvelopeType.feeMarket,
           }
         : baseTxParams;
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -33,7 +33,7 @@ import { Mutex } from 'async-mutex';
 import MethodRegistry from 'eth-method-registry';
 import { addHexPrefix, bufferToHex } from 'ethereumjs-util';
 import { EventEmitter } from 'events';
-import { merge, pickBy } from 'lodash';
+import { keyBy, mapValues, merge, pickBy, sortBy } from 'lodash';
 import NonceTracker from 'nonce-tracker';
 import type { NonceLock } from 'nonce-tracker/dist/NonceTracker';
 import { v1 as random } from 'uuid';
@@ -82,6 +82,7 @@ import {
   validateIfTransactionUnapproved,
   validateMinimumIncrease,
   normalizeTxError,
+  normalizeGasFeeValues,
 } from './utils/utils';
 import {
   validateTransactionOrigin,
@@ -720,8 +721,11 @@ export class TransactionController extends BaseController<
     }
 
     if (gasValues) {
+      // Not good practice to reassign a parameter but temporarily avoiding a larger refactor.
+      gasValues = normalizeGasFeeValues(gasValues);
       validateGasValues(gasValues);
     }
+
     const transactionMeta = this.getTransaction(transactionId);
     if (!transactionMeta) {
       return;
@@ -781,7 +785,7 @@ export class TransactionController extends BaseController<
             gasLimit: transactionMeta.txParams.gas,
             maxFeePerGas: newMaxFeePerGas,
             maxPriorityFeePerGas: newMaxPriorityFeePerGas,
-            type: '2',
+            type: '0x2',
             nonce: transactionMeta.txParams.nonce,
             to: transactionMeta.txParams.from,
             value: '0x0',
@@ -857,8 +861,11 @@ export class TransactionController extends BaseController<
     }
 
     if (gasValues) {
+      // Not good practice to reassign a parameter but temporarily avoiding a larger refactor.
+      gasValues = normalizeGasFeeValues(gasValues);
       validateGasValues(gasValues);
     }
+
     const transactionMeta = this.state.transactions.find(
       ({ id }) => id === transactionId,
     );
@@ -922,7 +929,7 @@ export class TransactionController extends BaseController<
             gasLimit: transactionMeta.txParams.gas,
             maxFeePerGas: newMaxFeePerGas,
             maxPriorityFeePerGas: newMaxPriorityFeePerGas,
-            type: '2',
+            type: '0x2',
           }
         : {
             ...transactionMeta.txParams,
@@ -1434,7 +1441,6 @@ export class TransactionController extends BaseController<
    *
    * @param transactionId - The ID of the transaction to update.
    * @param options - The custodial transaction options to update.
-   * @param options.custodyStatus - The new custody status value to be assigned.
    * @param options.errorMessage - The error message to be assigned in case transaction status update to failed.
    * @param options.hash - The new hash value to be assigned.
    * @param options.status - The new status value to be assigned.
@@ -1442,19 +1448,16 @@ export class TransactionController extends BaseController<
   updateCustodialTransaction(
     transactionId: string,
     {
-      custodyStatus,
       errorMessage,
       hash,
       status,
     }: {
-      custodyStatus?: string;
       errorMessage?: string;
       hash?: string;
       status?: TransactionStatus;
     },
   ) {
-    let transactionMeta;
-    transactionMeta = this.getTransaction(transactionId);
+    const transactionMeta = this.getTransaction(transactionId);
 
     if (!transactionMeta) {
       throw new Error(
@@ -1478,35 +1481,148 @@ export class TransactionController extends BaseController<
         `Cannot update custodial transaction with status: ${status}`,
       );
     }
-    if (status === TransactionStatus.signed) {
-      transactionMeta.status = status;
-    }
+
+    const updatedTransactionMeta = merge(
+      transactionMeta,
+      pickBy({ hash, status }),
+    );
 
     if (status === TransactionStatus.submitted) {
-      transactionMeta.submittedTime = new Date().getTime();
-      transactionMeta.status = status;
+      updatedTransactionMeta.submittedTime = new Date().getTime();
     }
 
     if (status === TransactionStatus.failed) {
-      transactionMeta = {
-        ...transactionMeta,
-        error: normalizeTxError(new Error(errorMessage)),
-        status: TransactionStatus.failed,
-      };
-    }
-
-    if (custodyStatus) {
-      transactionMeta.custodyStatus = custodyStatus;
-    }
-
-    if (hash) {
-      transactionMeta.hash = hash;
+      updatedTransactionMeta.error = normalizeTxError(new Error(errorMessage));
     }
 
     this.updateTransaction(
-      transactionMeta,
+      updatedTransactionMeta,
       `TransactionController:updateCustodialTransaction - Custodial transaction updated`,
     );
+  }
+
+  /**
+   * Creates approvals for all unapproved transactions persisted.
+   */
+  initApprovals() {
+    const chainId = this.getChainId();
+    const unapprovedTxs = this.state.transactions.filter(
+      (transaction) =>
+        transaction.status === TransactionStatus.unapproved &&
+        transaction.chainId === chainId,
+    );
+
+    for (const txMeta of unapprovedTxs) {
+      this.processApproval(txMeta, {
+        shouldShowRequest: false,
+      }).catch((error) => {
+        if (error?.code === errorCodes.provider.userRejectedRequest) {
+          return;
+        }
+        console.error('Error during persisted transaction approval', error);
+      });
+    }
+  }
+
+  /**
+   * Search transaction metadata for matching entries.
+   *
+   * @param opts - Options bag.
+   * @param opts.searchCriteria - An object containing values or functions for transaction properties to filter transactions with.
+   * @param opts.initialList - The transactions to search. Defaults to the current state.
+   * @param opts.filterToCurrentNetwork - Whether to filter the results to the current network. Defaults to true.
+   * @param opts.limit - The maximum number of transactions to return. No limit by default.
+   * @returns An array of transactions matching the provided options.
+   */
+  getTransactions({
+    searchCriteria = {},
+    initialList,
+    filterToCurrentNetwork = true,
+    limit,
+  }: {
+    searchCriteria?: any;
+    initialList?: TransactionMeta[];
+    filterToCurrentNetwork?: boolean;
+    limit?: number;
+  } = {}) {
+    const chainId = this.getChainId();
+    // searchCriteria is an object that might have values that aren't predicate
+    // methods. When providing any other value type (string, number, etc), we
+    // consider this shorthand for "check the value at key for strict equality
+    // with the provided value". To conform this object to be only methods, we
+    // mapValues (lodash) such that every value on the object is a method that
+    // returns a boolean.
+    const predicateMethods = mapValues(searchCriteria, (predicate) => {
+      return typeof predicate === 'function'
+        ? predicate
+        : (v: any) => v === predicate;
+    });
+
+    // If an initial list is provided we need to change it back into an object
+    // first, so that it matches the shape of our state. This is done by the
+    // lodash keyBy method. This is the edge case for this method, typically
+    // initialList will be undefined.
+    const transactionsToFilter = initialList
+      ? keyBy(initialList, 'id')
+      : this.state.transactions;
+
+    // Combine sortBy and pickBy to transform our state object into an array of
+    // matching transactions that are sorted by time.
+    const filteredTransactions = sortBy(
+      pickBy(transactionsToFilter, (transaction) => {
+        if (filterToCurrentNetwork && transaction.chainId !== chainId) {
+          return false;
+        }
+        // iterate over the predicateMethods keys to check if the transaction
+        // matches the searchCriteria
+        for (const [key, predicate] of Object.entries(predicateMethods)) {
+          // We return false early as soon as we know that one of the specified
+          // search criteria do not match the transaction. This prevents
+          // needlessly checking all criteria when we already know the criteria
+          // are not fully satisfied. We check both txParams and the base
+          // object as predicate keys can be either.
+          if (key in transaction.txParams) {
+            if (predicate((transaction.txParams as any)[key]) === false) {
+              return false;
+            }
+          } else if (predicate((transaction as any)[key]) === false) {
+            return false;
+          }
+        }
+
+        return true;
+      }),
+      'time',
+    );
+    if (limit !== undefined) {
+      // We need to have all transactions of a given nonce in order to display
+      // necessary details in the UI. We use the size of this set to determine
+      // whether we have reached the limit provided, thus ensuring that all
+      // transactions of nonces we include will be sent to the UI.
+      const nonces = new Set();
+      const txs = [];
+      // By default, the transaction list we filter from is sorted by time ASC.
+      // To ensure that filtered results prefers the newest transactions we
+      // iterate from right to left, inserting transactions into front of a new
+      // array. The original order is preserved, but we ensure that newest txs
+      // are preferred.
+      for (let i = filteredTransactions.length - 1; i > -1; i--) {
+        const txMeta = filteredTransactions[i];
+        const { nonce } = txMeta.txParams;
+        if (!nonces.has(nonce)) {
+          if (nonces.size < limit) {
+            nonces.add(nonce);
+          } else {
+            continue;
+          }
+        }
+        // Push transaction into the beginning of our array to ensure the
+        // original order is preserved.
+        txs.unshift(txMeta);
+      }
+      return txs;
+    }
+    return filteredTransactions;
   }
 
   private async signExternalTransaction(
@@ -1584,8 +1700,6 @@ export class TransactionController extends BaseController<
   }
 
   private onBootCleanup() {
-    this.createApprovalsForUnapprovedTransactions();
-    this.loadGasValuesForUnapprovedTransactions();
     this.submitApprovedTransactions();
   }
 
@@ -1607,38 +1721,6 @@ export class TransactionController extends BaseController<
         /* istanbul ignore next */
         console.error('Error during persisted transaction approval', error);
       });
-    }
-  }
-
-  /**
-   * Update the gas values of all unapproved transactions on current chain.
-   */
-  private async loadGasValuesForUnapprovedTransactions() {
-    const unapprovedTransactions = this.getCurrentChainTransactionsByStatus(
-      TransactionStatus.unapproved,
-    );
-
-    const results = await Promise.allSettled(
-      unapprovedTransactions.map(async (transactionMeta) => {
-        await this.updateGasProperties(transactionMeta);
-        this.updateTransaction(
-          transactionMeta,
-          'TransactionController:loadGasValuesForUnapprovedTransactions - Gas values updated',
-        );
-      }),
-    );
-
-    for (const [index, result] of results.entries()) {
-      if (result.status === 'rejected') {
-        const transactionMeta = unapprovedTransactions[index];
-        this.failTransaction(transactionMeta, result.reason);
-        /* istanbul ignore next */
-        console.error(
-          'Error while loading gas values for persisted transaction id: ',
-          transactionMeta.id,
-          result.reason,
-        );
-      }
     }
   }
 
@@ -1686,7 +1768,17 @@ export class TransactionController extends BaseController<
           const acceptResult = await this.requestApproval(transactionMeta, {
             shouldShowRequest,
           });
+
           resultCallbacks = acceptResult.resultCallbacks;
+
+          if (resultCallbacks) {
+            this.hub.once(`${transactionId}:publish-skip`, () => {
+              resultCallbacks?.success();
+
+              // Remove the reference to prevent additional reports once submitted.
+              resultCallbacks = undefined;
+            });
+          }
         }
 
         const { isCompleted: isTxCompleted } =
@@ -1806,23 +1898,17 @@ export class TransactionController extends BaseController<
       const txParams: TransactionParams = isEIP1559
         ? {
             ...baseTxParams,
-            maxFeePerGas: transactionMeta.txParams.maxFeePerGas,
-            maxPriorityFeePerGas: transactionMeta.txParams.maxPriorityFeePerGas,
             estimatedBaseFee: transactionMeta.txParams.estimatedBaseFee,
             // specify type 2 if maxFeePerGas and maxPriorityFeePerGas are set
-            type: '2',
+            type: '0x2',
           }
         : baseTxParams;
 
-      // delete gasPrice if maxFeePerGas and maxPriorityFeePerGas are set
-      if (isEIP1559) {
-        delete txParams.gasPrice;
-      }
-
-      const rawTx = await this.signTransaction(transactionMeta);
+      const rawTx = await this.signTransaction(transactionMeta, txParams);
 
       if (!this.beforePublish(transactionMeta)) {
         log('Skipping publishing transaction based on hook');
+        this.hub.emit(`${transactionMeta.id}:publish-skip`, transactionMeta);
         return;
       }
 
@@ -2301,9 +2387,8 @@ export class TransactionController extends BaseController<
 
   private async signTransaction(
     transactionMeta: TransactionMeta,
+    txParams: TransactionParams,
   ): Promise<string | undefined> {
-    const { txParams } = transactionMeta;
-
     const unsignedEthTx = this.prepareUnsignedEthTx(txParams);
     this.inProcessOfSigning.add(transactionMeta.id);
     const signedTx = await this.sign?.(
@@ -2318,7 +2403,13 @@ export class TransactionController extends BaseController<
     }
 
     if (!this.afterSign(transactionMeta, signedTx)) {
+      this.updateTransaction(
+        transactionMeta,
+        'TransactionController#signTransaction - Update after sign',
+      );
+
       log('Skipping signed status based on hook');
+
       return undefined;
     }
 

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -32,8 +32,9 @@ export type Events = {
     { transactionMeta: TransactionMeta; actionId?: string },
   ];
   ['unapprovedTransaction']: [transactionMeta: TransactionMeta];
-  [key: `${string}:finished`]: [transactionMeta: TransactionMeta];
   [key: `${string}:confirmed`]: [transactionMeta: TransactionMeta];
+  [key: `${string}:finished`]: [transactionMeta: TransactionMeta];
+  [key: `${string}:publish-skip`]: [tansactionMeta: TransactionMeta];
   [key: `${string}:speedup`]: [transactionMeta: TransactionMeta];
 };
 

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -321,7 +321,7 @@ type TransactionMetaBase = {
   /**
    * The metadata of the swap transaction.
    */
-  swapMetaData?: Record<string, unknown>;
+  swapMetaData?: Record<string, any>;
 
   /**
    * The value of the token being swapped.
@@ -689,9 +689,9 @@ export interface TransactionReceipt {
   status?: string;
 
   /**
-   * The index of this transaction in the list of transactions included in the block this transaction was mined in.
+   * The hexadecimal index of this transaction in the list of transactions included in the block this transaction was mined in.
    */
-  transactionIndex?: number;
+  transactionIndex?: string;
 }
 
 /**

--- a/packages/transaction-controller/src/utils/utils.test.ts
+++ b/packages/transaction-controller/src/utils/utils.test.ts
@@ -185,7 +185,7 @@ describe('utils', () => {
   });
 
   describe('getAndFormatTransactionsForNonceTracker', () => {
-    it('should return an array of formatted NonceTrackerTransaction objects filtered by fromAddress and transactionStatus', () => {
+    it('returns formatted transactions filtered by chain, from, isTransfer, and status', () => {
       const fromAddress = '0x123';
       const inputTransactions: TransactionMeta[] = [
         {
@@ -224,6 +224,31 @@ describe('utils', () => {
           },
           status: TransactionStatus.approved,
         },
+        {
+          id: '4',
+          chainId: '0x2',
+          time: 123459,
+          txParams: {
+            from: fromAddress,
+            gas: '0x103',
+            value: '0x203',
+            nonce: '0x4',
+          },
+          status: TransactionStatus.confirmed,
+        },
+        {
+          id: '5',
+          chainId: '0x2',
+          isTransfer: true,
+          time: 123460,
+          txParams: {
+            from: fromAddress,
+            gas: '0x104',
+            value: '0x204',
+            nonce: '0x5',
+          },
+          status: TransactionStatus.confirmed,
+        },
       ];
 
       const expectedResult: NonceTrackerTransaction[] = [
@@ -232,18 +257,20 @@ describe('utils', () => {
           history: [{}],
           txParams: {
             from: fromAddress,
-            gas: '0x100',
-            value: '0x200',
-            nonce: '0x1',
+            gas: '0x103',
+            value: '0x203',
+            nonce: '0x4',
           },
         },
       ];
 
       const result = util.getAndFormatTransactionsForNonceTracker(
+        '0x2',
         fromAddress,
         TransactionStatus.confirmed,
         inputTransactions,
       );
+
       expect(result).toStrictEqual(expectedResult);
     });
   });

--- a/packages/transaction-controller/src/utils/utils.test.ts
+++ b/packages/transaction-controller/src/utils/utils.test.ts
@@ -50,6 +50,7 @@ describe('utils', () => {
         estimatedBaseFee: '0xestimatedBaseFee',
       });
     });
+
     it('normalizeTransaction if type is zero', () => {
       const normalized = util.normalizeTxParams({
         ...commonInput,
@@ -67,6 +68,13 @@ describe('utils', () => {
         maxPriorityFeePerGas: '0xmaxPriorityFeePerGas',
         estimatedBaseFee: '0xestimatedBaseFee',
         type: '0x0',
+      });
+    });
+
+    it('sets value if not specified', () => {
+      expect(util.normalizeTxParams({ from: '0xfrom' })).toStrictEqual({
+        from: '0xfrom',
+        value: '0x0',
       });
     });
   });
@@ -269,6 +277,35 @@ describe('utils', () => {
         ...errorBase,
         code: 'ERROR_CODE',
         rpc: { code: 'rpc data' },
+      });
+    });
+  });
+
+  describe('normalizeGasFeeValues', () => {
+    it('returns normalized object if legacy gas fees', () => {
+      expect(
+        util.normalizeGasFeeValues({ gasPrice: '1A', test: 'value' } as any),
+      ).toStrictEqual({ gasPrice: '0x1A' });
+    });
+
+    it('returns normalized object if 1559 gas fees', () => {
+      expect(
+        util.normalizeGasFeeValues({
+          maxFeePerGas: '1A',
+          maxPriorityFeePerGas: '2B3C',
+          test: 'value',
+        } as any),
+      ).toStrictEqual({ maxFeePerGas: '0x1A', maxPriorityFeePerGas: '0x2B3C' });
+    });
+
+    it('returns empty 1559 object if missing gas fees', () => {
+      expect(
+        util.normalizeGasFeeValues({
+          test: 'value',
+        } as any),
+      ).toStrictEqual({
+        maxFeePerGas: undefined,
+        maxPriorityFeePerGas: undefined,
       });
     });
   });

--- a/packages/transaction-controller/src/utils/utils.ts
+++ b/packages/transaction-controller/src/utils/utils.ts
@@ -41,11 +41,17 @@ const NORMALIZERS: { [param in keyof TransactionParams]: any } = {
  */
 export function normalizeTxParams(txParams: TransactionParams) {
   const normalizedTxParams: TransactionParams = { from: '' };
+
   for (const key of getKnownPropertyNames(NORMALIZERS)) {
     if (txParams[key]) {
       normalizedTxParams[key] = NORMALIZERS[key](txParams[key]);
     }
   }
+
+  if (!normalizedTxParams.value) {
+    normalizedTxParams.value = '0x0';
+  }
+
   return normalizedTxParams;
 }
 
@@ -187,5 +193,29 @@ export function normalizeTxError(
     stack: error.stack,
     code: error?.code,
     rpc: error?.value,
+  };
+}
+
+/**
+ * Normalize an object containing gas fee values.
+ *
+ * @param gasFeeValues - An object containing gas fee values.
+ * @returns An object containing normalized gas fee values.
+ */
+export function normalizeGasFeeValues(
+  gasFeeValues: GasPriceValue | FeeMarketEIP1559Values,
+): GasPriceValue | FeeMarketEIP1559Values {
+  const normalize = (value: any) =>
+    typeof value === 'string' ? addHexPrefix(value) : value;
+
+  if ('gasPrice' in gasFeeValues) {
+    return {
+      gasPrice: normalize(gasFeeValues.gasPrice),
+    };
+  }
+
+  return {
+    maxFeePerGas: normalize(gasFeeValues.maxFeePerGas),
+    maxPriorityFeePerGas: normalize(gasFeeValues.maxPriorityFeePerGas),
   };
 }

--- a/packages/transaction-controller/src/utils/utils.ts
+++ b/packages/transaction-controller/src/utils/utils.ts
@@ -126,19 +126,23 @@ export function validateMinimumIncrease(proposed: string, min: string) {
 /**
  * Helper function to filter and format transactions for the nonce tracker.
  *
+ * @param currentChainId - Chain ID of the current network.
  * @param fromAddress - Address of the account from which the transactions to filter from are sent.
  * @param transactionStatus - Status of the transactions for which to filter.
  * @param transactions - Array of transactionMeta objects that have been prefiltered.
  * @returns Array of transactions formatted for the nonce tracker.
  */
 export function getAndFormatTransactionsForNonceTracker(
+  currentChainId: string,
   fromAddress: string,
   transactionStatus: TransactionStatus,
   transactions: TransactionMeta[],
 ): NonceTrackerTransaction[] {
   return transactions
     .filter(
-      ({ status, txParams: { from } }) =>
+      ({ chainId, isTransfer, status, txParams: { from } }) =>
+        !isTransfer &&
+        chainId === currentChainId &&
         status === transactionStatus &&
         from.toLowerCase() === fromAddress.toLowerCase(),
     )


### PR DESCRIPTION
## Explanation

Add multiple fixes to support usage by the extension, including:

- Add `getTransactions` method to search transactions using the specified criteria and options.
- Re-add `initApprovals` method to allow client to finish initialisation before creating approvals.
- Remove unnecessary gas property update during initialisation since transactions are not added to the state until gas properties are updated.
- Normalise the gas fee values provided to `speedUpTransaction` and `stopTransaction` to support the extension arguments.
- Update the transaction after the `afterSign` hook to persist any updated properties.
- Report success to the result callback after publish is skipped to unblock the UI during the MMI flows.
- Set the `value` parameter to `0x0` if not specified.
- Limit properties updated by `updateCustodianTransaction` so it can initially be used for `hash` and `status` updates only, with more general MMI updates continuing to use `updateTransaction`.
- Align nonce logic with mobile.
- Update post transaction balance of swaps transactions after internal transactions.

## Changelog

### `@metamask/transaction-controller`

- **BREAKING**: Update types of `TransactionReceipt.transactionIndex` and `TransactionMeta.swapMetaData`.
- **ADDED**: Add `initApprovals` method to trigger the approval flow for any pending transactions during initialisation.
- **ADDED**: Add `getTransactions` method to search transactions used the given criteria and options.
- **CHANGED**: Normalize the gas values provided to the `speedUpTransaction` and `stopTransaction` methods.
- **CHANGED**: Persist any property changes performed by the `afterSign` hook.
- **CHANGED**: Report success to the approver if publishing is skipped by the `beforePublish` hook.
- **CHANGED**: Update `postTxBalance` after all swap transactions.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
