### PR TITLE
wallet revoke permissions

### DIFF
--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -64,6 +64,67 @@ describe('revokePermissions RPC method', () => {
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
   });
 
+  it('returns an error if the permissionKeys is a plain object', async () => {
+    const { implementation } = revokePermissionsHandler;
+    const mockRevokePermissionsForOrigin = jest.fn();
+
+    const engine = new JsonRpcEngine();
+    engine.push((req, res, next, end) =>
+      implementation(req as any, res as any, next, end, {
+        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+      }),
+    );
+
+    const req = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'wallet_revokePermissions',
+      params: [{}],
+    };
+
+    const expectedError = rpcErrors
+      .invalidParams({
+        data: { request: { ...req } },
+      })
+      .serialize();
+    delete expectedError.stack;
+
+    const response: any = await engine.handle(req as any);
+    delete response.error.stack;
+    expect(response.error).toStrictEqual(expectedError);
+    expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
+  });
+
+  it('returns an error if the params are not set', async () => {
+    const { implementation } = revokePermissionsHandler;
+    const mockRevokePermissionsForOrigin = jest.fn();
+
+    const engine = new JsonRpcEngine();
+    engine.push((req, res, next, end) =>
+      implementation(req as any, res as any, next, end, {
+        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+      }),
+    );
+
+    const req = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'wallet_revokePermissions',
+    };
+
+    const expectedError = rpcErrors
+      .invalidParams({
+        data: { request: { ...req } },
+      })
+      .serialize();
+    delete expectedError.stack;
+
+    const response: any = await engine.handle(req as any);
+    delete response.error.stack;
+    expect(response.error).toStrictEqual(expectedError);
+    expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
+  });
+
   it('returns an error if the request params is an empty array', async () => {
     const { implementation } = revokePermissionsHandler;
     const mockRevokePermissionsForOrigin = jest.fn();

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -19,7 +19,11 @@ describe('revokePermissions RPC method', () => {
       jsonrpc: '2.0',
       id: 1,
       method: 'wallet_revokePermissions',
-      params: { snap_dialog: { caveats: [{ type: 'foo', value: 'bar' }] } },
+      params: [
+        {
+          snap_dialog: {},
+        },
+      ],
     });
 
     expect(response.result).toBeNull();
@@ -29,38 +33,7 @@ describe('revokePermissions RPC method', () => {
     ]);
   });
 
-  it('returns an error if the request params is not a plain object', async () => {
-    const { implementation } = revokePermissionsHandler;
-    const mockRevokePermissionsForOrigin = jest.fn();
-
-    const engine = new JsonRpcEngine();
-    engine.push((req, res, next, end) =>
-      implementation(req as any, res as any, next, end, {
-        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
-      }),
-    );
-
-    const req = {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'wallet_revokePermissions',
-      params: [],
-    };
-
-    const expectedError = rpcErrors
-      .invalidParams({
-        data: { request: { ...req } },
-      })
-      .serialize();
-    delete expectedError.stack;
-
-    const response: any = await engine.handle(req as any);
-    delete response.error.stack;
-    expect(response.error).toStrictEqual(expectedError);
-    expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
-  });
-
-  it('returns an error if the request params is an empty object', async () => {
+  it('returns an error if the request params is a plain object', async () => {
     const { implementation } = revokePermissionsHandler;
     const mockRevokePermissionsForOrigin = jest.fn();
 
@@ -76,6 +49,37 @@ describe('revokePermissions RPC method', () => {
       id: 1,
       method: 'wallet_revokePermissions',
       params: {},
+    };
+
+    const expectedError = rpcErrors
+      .invalidParams({
+        data: { request: { ...req } },
+      })
+      .serialize();
+    delete expectedError.stack;
+
+    const response: any = await engine.handle(req as any);
+    delete response.error.stack;
+    expect(response.error).toStrictEqual(expectedError);
+    expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
+  });
+
+  it('returns an error if the request params is an empty array', async () => {
+    const { implementation } = revokePermissionsHandler;
+    const mockRevokePermissionsForOrigin = jest.fn();
+
+    const engine = new JsonRpcEngine();
+    engine.push((req, res, next, end) =>
+      implementation(req as any, res as any, next, end, {
+        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+      }),
+    );
+
+    const req = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'wallet_revokePermissions',
+      params: [],
     };
 
     const expectedError = rpcErrors

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.ts
@@ -1,4 +1,3 @@
-import { isPlainObject } from '@metamask/controller-utils';
 import type { JsonRpcEngineEndCallback } from '@metamask/json-rpc-engine';
 import type {
   Json,
@@ -57,13 +56,15 @@ async function revokePermissionsImplementation(
 ): Promise<void> {
   const { params } = req;
 
-  if (!isPlainObject(params)) {
+  const param = params?.[0];
+
+  if (!param) {
     return end(invalidParams({ data: { request: req } }));
   }
 
   // For now, this API revokes the entire permission key
   // even if caveats are specified.
-  const permissionKeys = Object.keys(params);
+  const permissionKeys = Object.keys(param);
 
   if (permissionKeys.length === 0) {
     return end(invalidParams({ data: { request: req } }));


### PR DESCRIPTION
This changes the `revokePermissions` rpc method params to be by-position similar to `requestPermissions`