### PR TITLE
Fix main branch CI failure by increasing jest `testTimeout` option

### DIFF
--- a/jest.config.packages.js
+++ b/jest.config.packages.js
@@ -176,6 +176,9 @@ module.exports = {
   // This option allows use of a custom test runner
   // testRunner: "jest-circus/runner",
 
+  // Default timeout of a test in milliseconds.
+  testTimeout: 30000,
+
   // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
   // testURL: "http://localhost",
 


### PR DESCRIPTION
## Explanation

- Fixes main branch CI failure: https://github.com/MetaMask/core/actions/runs/6944013982/job/18901645361
- Increases jest `testTimeout` option from default of 5000 to 30000.

## References

- Closes https://github.com/MetaMask/core/issues/2075

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
