### PR TITLE
Deprecate `BaseControllerV1` and use `BaseControllerV2` as default

### DIFF
--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -3,7 +3,7 @@ import type {
   ControllerStateChangeEvent,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import { SnapKeyring } from '@metamask/eth-snap-keyring';
 import type { InternalAccount } from '@metamask/keyring-api';
 import { EthAccountType } from '@metamask/keyring-api';
@@ -133,7 +133,7 @@ const defaultState: AccountsControllerState = {
  * The accounts controller also listens for snap state changes and updates the internal accounts accordingly.
  *
  */
-export class AccountsController extends BaseControllerV2<
+export class AccountsController extends BaseController<
   typeof controllerName,
   AccountsControllerState,
   AccountsControllerMessenger

--- a/packages/address-book-controller/src/AddressBookController.ts
+++ b/packages/address-book-controller/src/AddressBookController.ts
@@ -1,5 +1,5 @@
 import type { BaseConfig, BaseState } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import { BaseControllerV1 } from '@metamask/base-controller';
 import {
   normalizeEnsName,
   isValidHexAddress,
@@ -70,7 +70,7 @@ export interface AddressBookState extends BaseState {
 /**
  * Controller that manages a list of recipient addresses associated with nicknames.
  */
-export class AddressBookController extends BaseController<
+export class AddressBookController extends BaseControllerV1<
   BaseConfig,
   AddressBookState
 > {

--- a/packages/announcement-controller/src/AnnouncementController.ts
+++ b/packages/announcement-controller/src/AnnouncementController.ts
@@ -3,7 +3,7 @@ import type {
   ControllerStateChangeEvent,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 
 type ViewedAnnouncement = {
   [id: number]: boolean;
@@ -77,7 +77,7 @@ export type AnnouncementControllerMessenger = RestrictedControllerMessenger<
 /**
  * Controller for managing in-app announcements.
  */
-export class AnnouncementController extends BaseControllerV2<
+export class AnnouncementController extends BaseController<
   typeof controllerName,
   AnnouncementControllerState,
   AnnouncementControllerMessenger

--- a/packages/approval-controller/src/ApprovalController.ts
+++ b/packages/approval-controller/src/ApprovalController.ts
@@ -1,6 +1,6 @@
 import type { ControllerGetStateAction } from '@metamask/base-controller';
 import {
-  BaseControllerV2,
+  BaseController,
   type ControllerStateChangeEvent,
   type RestrictedControllerMessenger,
 } from '@metamask/base-controller';
@@ -338,7 +338,7 @@ export type ApprovalControllerActions =
  * Adding a request returns a promise that resolves or rejects when the request
  * is approved or denied, respectively.
  */
-export class ApprovalController extends BaseControllerV2<
+export class ApprovalController extends BaseController<
   typeof controllerName,
   ApprovalControllerState,
   ApprovalControllerMessenger

--- a/packages/assets-controllers/src/AccountTrackerController.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.ts
@@ -1,5 +1,5 @@
 import type { BaseConfig, BaseState } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import { BaseControllerV1 } from '@metamask/base-controller';
 import {
   BNToHex,
   query,
@@ -54,7 +54,7 @@ export interface AccountTrackerState extends BaseState {
 /**
  * Controller that tracks the network balances for all user accounts.
  */
-export class AccountTrackerController extends BaseController<
+export class AccountTrackerController extends BaseControllerV1<
   AccountTrackerConfig,
   AccountTrackerState
 > {

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -1,7 +1,7 @@
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
 import type { BaseConfig, BaseState } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import { BaseControllerV1 } from '@metamask/base-controller';
 import { IPFS_DEFAULT_GATEWAY_URL } from '@metamask/controller-utils';
 import type {
   NetworkClientId,
@@ -75,7 +75,7 @@ export interface BalanceMap {
 /**
  * Controller that interacts with contracts on mainnet through web3
  */
-export class AssetsContractController extends BaseController<
+export class AssetsContractController extends BaseControllerV1<
   AssetsContractConfig,
   BaseState
 > {

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -5,7 +5,7 @@ import type {
   BaseState,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import { BaseControllerV1 } from '@metamask/base-controller';
 import {
   safelyExecute,
   handleFetch,
@@ -226,7 +226,7 @@ export type NftControllerMessenger = RestrictedControllerMessenger<
 /**
  * Controller that stores assets and exposes convenience methods
  */
-export class NftController extends BaseController<NftConfig, NftState> {
+export class NftController extends BaseControllerV1<NftConfig, NftState> {
   private readonly mutex = new Mutex();
 
   private readonly messagingSystem: NftControllerMessenger;

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -1,5 +1,5 @@
 import type { BaseConfig, BaseState } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import { BaseControllerV1 } from '@metamask/base-controller';
 import { safelyExecute } from '@metamask/controller-utils';
 import type { PreferencesState } from '@metamask/preferences-controller';
 import { BN } from 'ethereumjs-util';
@@ -43,7 +43,7 @@ export interface TokenBalancesState extends BaseState {
  * Controller that passively polls on a set interval token balances
  * for tokens stored in the TokensController
  */
-export class TokenBalancesController extends BaseController<
+export class TokenBalancesController extends BaseControllerV1<
   TokenBalancesConfig,
   TokenBalancesState
 > {

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -6,7 +6,7 @@ import type {
   BaseState,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import { BaseControllerV1 } from '@metamask/base-controller';
 import contractsMap from '@metamask/contract-metadata';
 import {
   toChecksumHexAddress,
@@ -124,7 +124,7 @@ export type TokensControllerMessenger = RestrictedControllerMessenger<
 /**
  * Controller that stores assets and exposes convenience methods
  */
-export class TokensController extends BaseController<
+export class TokensController extends BaseControllerV1<
   TokensConfig,
   TokensState
 > {

--- a/packages/base-controller/src/BaseControllerV1.test.ts
+++ b/packages/base-controller/src/BaseControllerV1.test.ts
@@ -1,7 +1,7 @@
 import * as sinon from 'sinon';
 
-import type { BaseConfig, BaseState } from './BaseController';
-import { BaseController } from './BaseController';
+import type { BaseConfig, BaseState } from './BaseControllerV1';
+import { BaseController } from './BaseControllerV1';
 
 const STATE = { name: 'foo' };
 const CONFIG = { disabled: true };

--- a/packages/base-controller/src/BaseControllerV1.test.ts
+++ b/packages/base-controller/src/BaseControllerV1.test.ts
@@ -1,7 +1,7 @@
 import * as sinon from 'sinon';
 
 import type { BaseConfig, BaseState } from './BaseControllerV1';
-import { BaseController } from './BaseControllerV1';
+import { BaseControllerV1 as BaseController } from './BaseControllerV1';
 
 const STATE = { name: 'foo' };
 const CONFIG = { disabled: true };

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -30,7 +30,7 @@ export interface BaseState {
 }
 
 /**
- * @deprecated in favor of controller-messenger pattern implemented in BaseControllerV2
+ * @deprecated This class has been renamed to BaseControllerV1 and is no longer recommended for use for controllers. Please use BaseController (formerly BaseControllerV2) instead.
  *
  * Controller class that provides configuration, state management, and subscriptions.
  *

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -192,4 +192,4 @@ export class BaseController<C extends BaseConfig, S extends BaseState> {
   }
 }
 
-export default BaseControllerV1;
+export default BaseController;

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -30,6 +30,8 @@ export interface BaseState {
 }
 
 /**
+ * @deprecated in favor of controller-messenger pattern implemented in BaseControllerV2
+ *
  * Controller class that provides configuration, state management, and subscriptions.
  *
  * The core purpose of every controller is to maintain an internal data object
@@ -68,7 +70,7 @@ export class BaseController<C extends BaseConfig, S extends BaseState> {
   private readonly internalListeners: Listener<S>[] = [];
 
   /**
-   * Creates a BaseController instance. Both initial state and initial
+   * Creates a BaseControllerV1 instance. Both initial state and initial
    * configuration options are merged with defaults upon initialization.
    *
    * @param config - Initial options used to configure this controller.
@@ -190,4 +192,4 @@ export class BaseController<C extends BaseConfig, S extends BaseState> {
   }
 }
 
-export default BaseController;
+export default BaseControllerV1;

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -38,7 +38,7 @@ export interface BaseState {
  * called "state". Each controller is responsible for its own state, and all global wallet state
  * is tracked in a controller as state.
  */
-export class BaseController<C extends BaseConfig, S extends BaseState> {
+export class BaseControllerV1<C extends BaseConfig, S extends BaseState> {
   /**
    * Default options used to configure this controller
    */
@@ -192,4 +192,4 @@ export class BaseController<C extends BaseConfig, S extends BaseState> {
   }
 }
 
-export default BaseController;
+export default BaseControllerV1;

--- a/packages/base-controller/src/index.ts
+++ b/packages/base-controller/src/index.ts
@@ -5,13 +5,13 @@ export type {
   StateDeriver,
   StateMetadata,
   StatePropertyMetadata,
+  ControllerGetStateAction,
+  ControllerStateChangeEvent,
 } from './BaseControllerV2';
 export {
-  BaseController as BaseControllerV2,
+  BaseController,
   getAnonymizedState,
   getPersistentState,
-  type ControllerGetStateAction,
-  type ControllerStateChangeEvent,
 } from './BaseControllerV2';
 export * from './ControllerMessenger';
 export * from './RestrictedControllerMessenger';

--- a/packages/base-controller/src/index.ts
+++ b/packages/base-controller/src/index.ts
@@ -1,5 +1,5 @@
 export type { BaseConfig, BaseState, Listener } from './BaseControllerV1';
-export { BaseController as BaseControllerV1 } from './BaseControllerV1';
+export { BaseControllerV1 } from './BaseControllerV1';
 export type {
   Listener as ListenerV2,
   StateDeriver,

--- a/packages/base-controller/src/index.ts
+++ b/packages/base-controller/src/index.ts
@@ -1,5 +1,5 @@
-export type { BaseConfig, BaseState, Listener } from './BaseController';
-export { BaseController } from './BaseController';
+export type { BaseConfig, BaseState, Listener } from './BaseControllerV1';
+export { BaseController as BaseControllerV1 } from './BaseControllerV1';
 export type {
   Listener as ListenerV2,
   StateDeriver,

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -12,7 +12,7 @@ import * as sinon from 'sinon';
 
 import { ComposableController } from './ComposableController';
 
-// Mock BaseControllerV2 classes
+// Mock BaseController classes
 
 type FooControllerState = {
   foo: string;
@@ -37,7 +37,7 @@ const fooControllerStateMetadata = {
   },
 };
 
-class FooController extends BaseControllerV2<
+class FooController extends BaseController<
   'FooController',
   FooControllerState,
   FooMessenger
@@ -58,13 +58,13 @@ class FooController extends BaseControllerV2<
   }
 }
 
-// Mock BaseController classes
+// Mock BaseControllerV1 classes
 
 type BarControllerState = BaseState & {
   bar: string;
 };
 
-class BarController extends BaseController<never, BarControllerState> {
+class BarController extends BaseControllerV1<never, BarControllerState> {
   defaultState = {
     bar: 'bar',
   };
@@ -163,7 +163,7 @@ describe('ComposableController', () => {
     });
   });
 
-  describe('BaseControllerV2', () => {
+  describe('BaseController', () => {
     it('should compose controller state', () => {
       const controllerMessenger = new ControllerMessenger<
         never,
@@ -264,7 +264,7 @@ describe('ComposableController', () => {
     });
   });
 
-  describe('Mixed BaseController and BaseControllerV2', () => {
+  describe('Mixed BaseControllerV1 and BaseController', () => {
     it('should compose controller state', () => {
       const barController = new BarController();
       const controllerMessenger = new ControllerMessenger<
@@ -329,7 +329,7 @@ describe('ComposableController', () => {
       });
     });
 
-    it('should notify listeners of BaseController state change', () => {
+    it('should notify listeners of BaseControllerV1 state change', () => {
       const barController = new BarController();
       const controllerMessenger = new ControllerMessenger<
         never,
@@ -371,7 +371,7 @@ describe('ComposableController', () => {
       });
     });
 
-    it('should notify listeners of BaseControllerV2 state change', () => {
+    it('should notify listeners of BaseController state change', () => {
       const barController = new BarController();
       const controllerMessenger = new ControllerMessenger<
         never,
@@ -430,7 +430,7 @@ describe('ComposableController', () => {
       expect(
         () => new ComposableController([barController, fooController]),
       ).toThrow(
-        'Messaging system required if any BaseControllerV2 controllers are used',
+        'Messaging system required if any BaseController controllers are used',
       );
     });
   });

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -103,7 +103,7 @@ describe('ComposableController', () => {
     sinon.restore();
   });
 
-  describe('BaseController', () => {
+  describe('BaseControllerV1', () => {
     it('should compose controller state', () => {
       const composableMessenger = new ControllerMessenger().getRestricted<
         'ComposableController',
@@ -163,7 +163,7 @@ describe('ComposableController', () => {
     });
   });
 
-  describe('BaseController', () => {
+  describe('BaseControllerV2', () => {
     it('should compose controller state', () => {
       const controllerMessenger = new ControllerMessenger<
         never,
@@ -264,7 +264,7 @@ describe('ComposableController', () => {
     });
   });
 
-  describe('Mixed BaseControllerV1 and BaseController', () => {
+  describe('Mixed BaseControllerV1 and BaseControllerV2', () => {
     it('should compose controller state', () => {
       const barController = new BarController();
       const controllerMessenger = new ControllerMessenger<
@@ -371,7 +371,7 @@ describe('ComposableController', () => {
       });
     });
 
-    it('should notify listeners of BaseController state change', () => {
+    it('should notify listeners of BaseControllerV2 state change', () => {
       const barController = new BarController();
       const controllerMessenger = new ControllerMessenger<
         never,
@@ -430,7 +430,7 @@ describe('ComposableController', () => {
       expect(
         () => new ComposableController([barController, fooController]),
       ).toThrow(
-        'Messaging system required if any BaseController controllers are used',
+        'Messaging system required if any BaseControllerV2 controllers are used',
       );
     });
   });

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -4,7 +4,7 @@ import type {
 } from '@metamask/base-controller';
 import {
   BaseController,
-  BaseControllerV2,
+  BaseControllerV1,
   ControllerMessenger,
 } from '@metamask/base-controller';
 import type { Patch } from 'immer';
@@ -85,7 +85,7 @@ type BazControllerState = BaseState & {
   baz: string;
 };
 
-class BazController extends BaseController<never, BazControllerState> {
+class BazController extends BaseControllerV1<never, BazControllerState> {
   defaultState = {
     baz: 'baz',
   };

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -430,7 +430,7 @@ describe('ComposableController', () => {
       expect(
         () => new ComposableController([barController, fooController]),
       ).toThrow(
-        'Messaging system required if any BaseControllerV2 controllers are used',
+        'Messaging system required if any BaseController controllers are used',
       );
     });
   });

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -1,17 +1,17 @@
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import { BaseControllerV1 } from '@metamask/base-controller';
 
 /**
  * List of child controller instances
  *
- * This type encompasses controllers based up either BaseController or
- * BaseControllerV2. The BaseControllerV2 type can't be included directly
+ * This type encompasses controllers based up either BaseControllerV1 or
+ * BaseController. The BaseController type can't be included directly
  * because the generic parameters it expects require knowing the exact state
- * shape, so instead we look for an object with the BaseControllerV2 properties
+ * shape, so instead we look for an object with the BaseController properties
  * that we use in the ComposableController (name and state).
  */
 export type ControllerList = (
-  | BaseController<any, any>
+  | BaseControllerV1<any, any>
   | { name: string; state: Record<string, unknown> }
 )[];
 
@@ -21,7 +21,7 @@ export type ComposableControllerRestrictedMessenger =
 /**
  * Controller that can be used to compose multiple controllers together.
  */
-export class ComposableController extends BaseController<never, any> {
+export class ComposableController extends BaseControllerV1<never, any> {
   private readonly controllers: ControllerList = [];
 
   private readonly messagingSystem?: ComposableControllerRestrictedMessenger;
@@ -35,7 +35,7 @@ export class ComposableController extends BaseController<never, any> {
    * Creates a ComposableController instance.
    *
    * @param controllers - Map of names to controller instances.
-   * @param messenger - The controller messaging system, used for communicating with BaseControllerV2 controllers.
+   * @param messenger - The controller messaging system, used for communicating with BaseController controllers.
    */
   constructor(
     controllers: ControllerList,
@@ -53,8 +53,8 @@ export class ComposableController extends BaseController<never, any> {
     this.messagingSystem = messenger;
     this.controllers.forEach((controller) => {
       const { name } = controller;
-      if ((controller as BaseController<any, any>).subscribe !== undefined) {
-        (controller as BaseController<any, any>).subscribe((state) => {
+      if ((controller as BaseControllerV1<any, any>).subscribe !== undefined) {
+        (controller as BaseControllerV1<any, any>).subscribe((state) => {
           this.update({ [name]: state });
         });
       } else if (this.messagingSystem) {
@@ -66,7 +66,7 @@ export class ComposableController extends BaseController<never, any> {
         );
       } else {
         throw new Error(
-          `Messaging system required if any BaseControllerV2 controllers are used`,
+          `Messaging system required if any BaseController controllers are used`,
         );
       }
     });

--- a/packages/ens-controller/src/EnsController.ts
+++ b/packages/ens-controller/src/EnsController.ts
@@ -4,7 +4,7 @@ import type {
 } from '@ethersproject/providers';
 import { Web3Provider } from '@ethersproject/providers';
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import type { ChainId } from '@metamask/controller-utils';
 import {
   normalizeEnsName,
@@ -77,7 +77,7 @@ const ZERO_X_ERROR_ADDRESS = '0x';
  * Controller that manages a list ENS names and their resolved addresses
  * by chainId. A null address indicates an unresolved ENS name.
  */
-export class EnsController extends BaseControllerV2<
+export class EnsController extends BaseController<
   typeof name,
   EnsControllerState,
   EnsControllerMessenger

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -4,7 +4,7 @@ import type {
   IKeyringState as IQRKeyringState,
 } from '@keystonehq/metamask-airgapped-keyring';
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import { KeyringController as EthKeyringController } from '@metamask/eth-keyring-controller';
 import type {
   ExportableKeyEncryptor,
@@ -254,7 +254,7 @@ function assertHasUint8ArrayMnemonic(
  * with the internal keyring controller and handling certain complex operations that involve the
  * keyrings.
  */
-export class KeyringController extends BaseControllerV2<
+export class KeyringController extends BaseController<
   typeof name,
   KeyringControllerState,
   KeyringControllerMessenger

--- a/packages/logging-controller/src/LoggingController.ts
+++ b/packages/logging-controller/src/LoggingController.ts
@@ -1,5 +1,5 @@
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import { v1 as random } from 'uuid';
 
 import type { Log } from './logTypes';
@@ -61,7 +61,7 @@ const defaultState = {
 /**
  * Controller that manages a list of logs for signature requests.
  */
-export class LoggingController extends BaseControllerV2<
+export class LoggingController extends BaseController<
   typeof name,
   LoggingControllerState,
   LoggingControllerMessenger

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -1,5 +1,5 @@
 import type { BaseConfig, BaseState } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import { BaseControllerV1 } from '@metamask/base-controller';
 import type { Hex, Json } from '@metamask/utils';
 import { EventEmitter } from 'events';
 
@@ -109,7 +109,7 @@ export abstract class AbstractMessageManager<
   M extends AbstractMessage,
   P extends AbstractMessageParams,
   PM extends AbstractMessageParamsMetamask,
-> extends BaseController<BaseConfig, MessageManagerState<M>> {
+> extends BaseControllerV1<BaseConfig, MessageManagerState<M>> {
   protected messages: M[];
 
   protected getCurrentChainId: getCurrentChainId | undefined;

--- a/packages/name-controller/src/NameController.ts
+++ b/packages/name-controller/src/NameController.ts
@@ -3,7 +3,7 @@ import type {
   ControllerStateChangeEvent,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 
 import type {
   NameProvider,
@@ -104,7 +104,7 @@ export type SetNameRequest = {
 /**
  * Controller for storing and deriving names for values such as Ethereum addresses.
  */
-export class NameController extends BaseControllerV2<
+export class NameController extends BaseController<
   typeof controllerName,
   NameControllerState,
   NameControllerMessenger

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -3,7 +3,7 @@ import type {
   ControllerStateChangeEvent,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import {
   BUILT_IN_NETWORKS,
   NetworksTicker,
@@ -532,7 +532,7 @@ type AutoManagedNetworkClientRegistry = {
 /**
  * Controller that creates and manages an Ethereum network provider.
  */
-export class NetworkController extends BaseControllerV2<
+export class NetworkController extends BaseController<
   typeof name,
   NetworkState,
   NetworkControllerMessenger

--- a/packages/notification-controller/src/NotificationController.ts
+++ b/packages/notification-controller/src/NotificationController.ts
@@ -3,7 +3,7 @@ import type {
   ControllerStateChangeEvent,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import { hasProperty } from '@metamask/utils';
 import { nanoid } from 'nanoid';
 
@@ -89,7 +89,7 @@ const defaultState = {
 /**
  * Controller that handles storing notifications and showing them to the user
  */
-export class NotificationController extends BaseControllerV2<
+export class NotificationController extends BaseController<
   typeof name,
   NotificationControllerState,
   NotificationControllerMessenger

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -13,7 +13,7 @@ import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import type { NonEmptyArray } from '@metamask/controller-utils';
 import {
   isNonEmptyArray,
@@ -511,7 +511,7 @@ export type PermissionControllerOptions<
 export class PermissionController<
   ControllerPermissionSpecification extends PermissionSpecificationConstraint,
   ControllerCaveatSpecification extends CaveatSpecificationConstraint,
-> extends BaseControllerV2<
+> extends BaseController<
   typeof controllerName,
   PermissionControllerState<
     ExtractPermission<
@@ -565,7 +565,7 @@ export class PermissionController<
    * @param options.unrestrictedMethods - The callable names of all JSON-RPC
    * methods ignored by the new controller.
    * @param options.messenger - The controller messenger. See
-   * {@link BaseControllerV2} for more information.
+   * {@link BaseController} for more information.
    * @param options.state - Existing state to hydrate the controller with at
    * initialization.
    */

--- a/packages/permission-controller/src/SubjectMetadataController.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.ts
@@ -3,7 +3,7 @@ import type {
   ControllerStateChangeEvent,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import type { Json } from '@metamask/utils';
 
 import type {
@@ -97,7 +97,7 @@ type SubjectMetadataControllerOptions = {
  * A controller for storing metadata associated with permission subjects. More
  * or less, a cache.
  */
-export class SubjectMetadataController extends BaseControllerV2<
+export class SubjectMetadataController extends BaseController<
   typeof controllerName,
   SubjectMetadataControllerState,
   SubjectMetadataControllerMessenger

--- a/packages/permission-log-controller/src/PermissionLogController.ts
+++ b/packages/permission-log-controller/src/PermissionLogController.ts
@@ -1,5 +1,5 @@
 import {
-  BaseControllerV2,
+  BaseController,
   type RestrictedControllerMessenger,
 } from '@metamask/base-controller';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
@@ -93,7 +93,7 @@ const name = 'PermissionLogController';
  * Controller with middleware for logging requests and responses to restricted
  * and permissions-related methods.
  */
-export class PermissionLogController extends BaseControllerV2<
+export class PermissionLogController extends BaseController<
   typeof name,
   PermissionLogControllerState,
   PermissionLogControllerMessenger

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -1,5 +1,5 @@
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseControllerV2 as BaseController } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import { safelyExecute } from '@metamask/controller-utils';
 import PhishingDetector from 'eth-phishing-detect/src/detector';
 import { toASCII } from 'punycode/';

--- a/packages/polling-controller/src/PollingController.ts
+++ b/packages/polling-controller/src/PollingController.ts
@@ -190,5 +190,5 @@ function PollingControllerMixin<TBase extends Constructor>(Base: TBase) {
 class Empty {}
 
 export const PollingControllerOnly = PollingControllerMixin(Empty);
-export const PollingController = PollingControllerMixin(BaseControllerV2);
+export const PollingController = PollingControllerMixin(BaseController);
 export const PollingControllerV1 = PollingControllerMixin(BaseControllerV1);

--- a/packages/polling-controller/src/PollingController.ts
+++ b/packages/polling-controller/src/PollingController.ts
@@ -1,4 +1,4 @@
-import { BaseController, BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController, BaseControllerV1 } from '@metamask/base-controller';
 import type { NetworkClientId } from '@metamask/network-controller';
 import type { Json } from '@metamask/utils';
 import stringify from 'fast-json-stable-stringify';
@@ -191,4 +191,4 @@ class Empty {}
 
 export const PollingControllerOnly = PollingControllerMixin(Empty);
 export const PollingController = PollingControllerMixin(BaseControllerV2);
-export const PollingControllerV1 = PollingControllerMixin(BaseController);
+export const PollingControllerV1 = PollingControllerMixin(BaseControllerV1);

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -1,5 +1,5 @@
 import type { BaseConfig, BaseState } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import { BaseControllerV1 } from '@metamask/base-controller';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 
 import { ETHERSCAN_SUPPORTED_CHAIN_IDS } from './constants';
@@ -62,7 +62,7 @@ export interface PreferencesState extends BaseState {
 /**
  * Controller that stores shared settings and exposes convenience methods
  */
-export class PreferencesController extends BaseController<
+export class PreferencesController extends BaseControllerV1<
   BaseConfig,
   PreferencesState
 > {

--- a/packages/queued-request-controller/src/QueuedRequestController.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.ts
@@ -1,5 +1,5 @@
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 
 const controllerName = 'QueuedRequestController';
 
@@ -53,7 +53,7 @@ export type QueuedRequestControllerOptions = {
  * an `enqueueRequest` method for adding requests to the queue. The controller initializes with a count of zero and
  * registers message handlers for request enqueuing. It also publishes count changes to inform external observers.
  */
-export class QueuedRequestController extends BaseControllerV2<
+export class QueuedRequestController extends BaseController<
   typeof controllerName,
   QueuedRequestControllerState,
   QueuedRequestControllerMessenger

--- a/packages/rate-limit-controller/src/RateLimitController.ts
+++ b/packages/rate-limit-controller/src/RateLimitController.ts
@@ -4,7 +4,7 @@ import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
-import { BaseControllerV2 as BaseController } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
 
 /**

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -1,5 +1,5 @@
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import type {
   BlockTrackerProxy,
   NetworkClientId,
@@ -97,7 +97,7 @@ export type NetworkProxy = {
 /**
  * Controller for getting and setting the network for a particular domain.
  */
-export class SelectedNetworkController extends BaseControllerV2<
+export class SelectedNetworkController extends BaseController<
   typeof controllerName,
   SelectedNetworkControllerState,
   SelectedNetworkControllerMessenger

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -8,7 +8,7 @@ import type {
   ControllerStateChangeEvent,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import { ApprovalType, ORIGIN_METAMASK } from '@metamask/controller-utils';
 import type {
   KeyringControllerSignMessageAction,
@@ -134,7 +134,7 @@ export type SignatureControllerOptions = {
 /**
  * Controller for creating signing requests requiring user approval.
  */
-export class SignatureController extends BaseControllerV2<
+export class SignatureController extends BaseController<
   typeof controllerName,
   SignatureControllerState,
   SignatureControllerMessenger

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -11,7 +11,7 @@ import type {
   BaseState,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import { BaseControllerV1 } from '@metamask/base-controller';
 import {
   query,
   NetworkType,
@@ -210,7 +210,7 @@ export interface TransactionControllerEventEmitter extends EventEmitter {
 /**
  * Controller responsible for submitting and managing transactions.
  */
-export class TransactionController extends BaseController<
+export class TransactionController extends BaseControllerV1<
   TransactionConfig,
   TransactionState
 > {
@@ -1967,7 +1967,7 @@ export class TransactionController extends BaseController<
    * representation, this function will not break apart transactions with the
    * same nonce, created on the same day, per network. Not accounting for transactions of the same
    * nonce, same day and network combo can result in confusing or broken experiences
-   * in the UI. The transactions are then updated using the BaseController update.
+   * in the UI. The transactions are then updated using the BaseControllerV1 update.
    *
    * @param transactions - The transactions to be applied to the state.
    * @returns The trimmed list of transactions.


### PR DESCRIPTION
## Motivation

The controller-messenger pattern implemented by `BaseControllerV2` is intended to be used by all of our controllers. Currently, the default `BaseController` name points to the older base controller implementation, which needs to be deprecated and only used for temporary backwards compatibility while all controllers are brought up-to-date. 

## Explanation

In this commit, we export `BaseControllerV2` as the default `BaseController`, and add a `@deprecated` tsdoc tag to the old `BaseController` class as well as export it under the new name `BaseControllerV1` to discourage future usage. 

This aligns with the `PollingController` naming scheme, where the up-to-date version is the default, and outdated mixins are named with qualifiers (`PollingControllerOnly`, `PollingControllerV1`). 

## Impact

Existing controller classes in core that extend from the old base controller are not affected — they now simply extend from `BaseControllerV1` instead of `BaseController`. 

External packages will need to update any instances of `extends BaseController` to `extends BaseControllerV1` and `extends BaseControllerV2` to `extends BaseController`, along with accompanying changes to import statements.

## References

- Closes https://github.com/MetaMask/core/issues/2072
- Follow-up TODO: https://github.com/MetaMask/core/issues/2080

## Changelog

### `@metamask/base-controller`

#### Changed
- **BREAKING:** The default `BaseController` export now points to the up-to-date implementation that was formerly named `BaseControllerV2`. 
- **BREAKING:** The old `BaseController` class is marked as deprecated with the `@deprecated` tsdoc tag and exported under the name `BaseControllerV1`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
