### PR TITLE
Move `eth-query` back from devDeps to deps

### DIFF
--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -30,6 +30,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@metamask/eth-query": "^4.0.0",
     "@metamask/ethjs-unit": "^0.2.1",
     "@metamask/utils": "^8.2.0",
     "@spruceid/siwe-parser": "1.1.3",
@@ -39,7 +40,6 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.3",
-    "@metamask/eth-query": "^4.0.0",
     "@types/jest": "^27.4.1",
     "bn.js": "^5.2.1",
     "deepmerge": "^4.2.2",


### PR DESCRIPTION
## Explanation

In #1815, `@metamask/eth-query` was moved from deps to devDeps under the assumption that this would be safe because the dependency is only used for types. This assumption is false as the type import is shipped in `utils.d.ts` and will be attempted to be resolved in packages that consume the library. This in turn causes build errors like: `Error: node_modules/@metamask/controller-utils/dist/util.d.ts(2,27): error TS2307: Cannot find module '@metamask/eth-query' or its corresponding type declarations.` 

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/controller-utils`

- **Fixed**: Move `@metamask/eth-query` from devDependencies to dependencies

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
