### PR TITLE
Support custom nonce value

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 88.78,
-      functions: 94.16,
-      lines: 98.07,
-      statements: 98.03,
+      branches: 89.18,
+      functions: 94.18,
+      lines: 98.09,
+      statements: 98.05,
     },
   },
 

--- a/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.test.ts
+++ b/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.test.ts
@@ -1,7 +1,7 @@
 import { v1 as random } from 'uuid';
 
 import { CHAIN_IDS } from '../constants';
-import { TransactionStatus } from '../types';
+import { TransactionStatus, TransactionType } from '../types';
 import type {
   EtherscanTokenTransactionMeta,
   EtherscanTransactionMeta,
@@ -116,6 +116,7 @@ const EXPECTED_NORMALISED_TRANSACTION_BASE = {
     to: ETHERSCAN_TRANSACTION_SUCCESS_MOCK.to,
     value: '0xb1a2bc2ec50000',
   },
+  type: TransactionType.incoming,
   verifiedOnBlockchain: false,
 };
 

--- a/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.ts
@@ -10,7 +10,7 @@ import type {
   RemoteTransactionSourceRequest,
   TransactionMeta,
 } from '../types';
-import { TransactionStatus } from '../types';
+import { TransactionStatus, TransactionType } from '../types';
 import {
   fetchEtherscanTokenTransactions,
   fetchEtherscanTransactions,
@@ -177,6 +177,7 @@ export class EtherscanRemoteTransactionSource
         to: txMeta.to,
         value: BNToHex(new BN(txMeta.value)),
       },
+      type: TransactionType.incoming,
       verifiedOnBlockchain: false,
     };
   }

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -100,13 +100,13 @@ type TransactionMetaBase = {
    */
   custodyId?: string;
 
-  /** The optional custom nonce override as a decimal string. */
-  customNonceValue?: string;
-
   /**
    * Custodian transaction status.
    */
   custodyStatus?: string;
+
+  /** The optional custom nonce override as a decimal string. */
+  customNonceValue?: string;
 
   /**
    * The custom token amount is the amount set by the user.

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -100,6 +100,9 @@ type TransactionMetaBase = {
    */
   custodyId?: string;
 
+  /** The optional custom nonce override as a decimal string. */
+  customNonceValue?: string;
+
   /**
    * Custodian transaction status.
    */

--- a/packages/transaction-controller/src/utils/nonce.test.ts
+++ b/packages/transaction-controller/src/utils/nonce.test.ts
@@ -1,0 +1,186 @@
+import type {
+  NonceTracker,
+  Transaction as NonceTrackerTransaction,
+} from 'nonce-tracker';
+
+import type { TransactionMeta } from '../types';
+import { TransactionStatus } from '../types';
+import { getAndFormatTransactionsForNonceTracker, getNextNonce } from './nonce';
+
+const TRANSACTION_META_MOCK: TransactionMeta = {
+  chainId: '0x1',
+  id: 'testId1',
+  status: TransactionStatus.unapproved,
+  time: 1,
+  txParams: {
+    from: '0x1',
+  },
+};
+
+/**
+ * Creates a mock instance of a nonce tracker.
+ * @returns The mock instance.
+ */
+function createNonceTrackerMock(): jest.Mocked<NonceTracker> {
+  return { getNonceLock: jest.fn() } as any;
+}
+
+describe('nonce', () => {
+  describe('getNextNonce', () => {
+    it('returns custom nonce if provided', async () => {
+      const transactionMeta = {
+        ...TRANSACTION_META_MOCK,
+        customNonceValue: '123',
+      };
+
+      const nonceTracker = createNonceTrackerMock();
+
+      const [nonce, releaseLock] = await getNextNonce(
+        transactionMeta,
+        nonceTracker,
+      );
+
+      expect(nonce).toBe('0x7b');
+      expect(releaseLock).toBeUndefined();
+    });
+
+    it('returns existing nonce if provided and no custom nonce', async () => {
+      const transactionMeta = {
+        ...TRANSACTION_META_MOCK,
+        txParams: {
+          ...TRANSACTION_META_MOCK.txParams,
+          nonce: '0x123',
+        },
+      };
+
+      const nonceTracker = createNonceTrackerMock();
+
+      const [nonce, releaseLock] = await getNextNonce(
+        transactionMeta,
+        nonceTracker,
+      );
+
+      expect(nonce).toBe('0x123');
+      expect(releaseLock).toBeUndefined();
+    });
+
+    it('returns next nonce from tracker if no custom nonce and no existing nonce', async () => {
+      const transactionMeta = {
+        ...TRANSACTION_META_MOCK,
+        txParams: {
+          ...TRANSACTION_META_MOCK.txParams,
+        },
+      };
+
+      const nonceTracker = createNonceTrackerMock();
+      const releaseLock = jest.fn();
+
+      nonceTracker.getNonceLock.mockResolvedValueOnce({
+        nextNonce: 456,
+        releaseLock,
+      } as any);
+
+      const [nonce, resultReleaseLock] = await getNextNonce(
+        transactionMeta,
+        nonceTracker,
+      );
+
+      expect(nonce).toBe('0x1c8');
+
+      resultReleaseLock?.();
+
+      expect(releaseLock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getAndFormatTransactionsForNonceTracker', () => {
+    it('returns formatted transactions filtered by chain, from, isTransfer, and status', () => {
+      const fromAddress = '0x123';
+      const inputTransactions: TransactionMeta[] = [
+        {
+          id: '1',
+          chainId: '0x1',
+          time: 123456,
+          txParams: {
+            from: fromAddress,
+            gas: '0x100',
+            value: '0x200',
+            nonce: '0x1',
+          },
+          status: TransactionStatus.confirmed,
+        },
+        {
+          id: '2',
+          chainId: '0x1',
+          time: 123457,
+          txParams: {
+            from: '0x124',
+            gas: '0x101',
+            value: '0x201',
+            nonce: '0x2',
+          },
+          status: TransactionStatus.submitted,
+        },
+        {
+          id: '3',
+          chainId: '0x1',
+          time: 123458,
+          txParams: {
+            from: fromAddress,
+            gas: '0x102',
+            value: '0x202',
+            nonce: '0x3',
+          },
+          status: TransactionStatus.approved,
+        },
+        {
+          id: '4',
+          chainId: '0x2',
+          time: 123459,
+          txParams: {
+            from: fromAddress,
+            gas: '0x103',
+            value: '0x203',
+            nonce: '0x4',
+          },
+          status: TransactionStatus.confirmed,
+        },
+        {
+          id: '5',
+          chainId: '0x2',
+          isTransfer: true,
+          time: 123460,
+          txParams: {
+            from: fromAddress,
+            gas: '0x104',
+            value: '0x204',
+            nonce: '0x5',
+          },
+          status: TransactionStatus.confirmed,
+        },
+      ];
+
+      const expectedResult: NonceTrackerTransaction[] = [
+        {
+          status: TransactionStatus.confirmed,
+          history: [{}],
+          txParams: {
+            from: fromAddress,
+            gas: '0x103',
+            value: '0x203',
+            nonce: '0x4',
+          },
+        },
+      ];
+
+      const result = getAndFormatTransactionsForNonceTracker(
+        '0x2',
+        fromAddress,
+        TransactionStatus.confirmed,
+        inputTransactions,
+      );
+
+      expect(result).toStrictEqual(expectedResult);
+    });
+  });
+});

--- a/packages/transaction-controller/src/utils/nonce.ts
+++ b/packages/transaction-controller/src/utils/nonce.ts
@@ -1,0 +1,88 @@
+import { toHex } from '@metamask/controller-utils';
+import type {
+  NonceTracker,
+  Transaction as NonceTrackerTransaction,
+} from 'nonce-tracker';
+
+import { createModuleLogger, projectLogger } from '../logger';
+import type { TransactionMeta, TransactionStatus } from '../types';
+
+const log = createModuleLogger(projectLogger, 'nonce');
+
+/**
+ * Determine the next nonce to be used for a transaction.
+ *
+ * @param txMeta - The transaction metadata.
+ * @param nonceTracker - An instance of a nonce tracker.
+ * @returns The next hexadecimal nonce to be used for the given transaction, and optionally a function to release the nonce lock.
+ */
+export async function getNextNonce(
+  txMeta: TransactionMeta,
+  nonceTracker: NonceTracker,
+): Promise<[string, (() => void) | undefined]> {
+  const {
+    customNonceValue,
+    txParams: { from, nonce: existingNonce },
+  } = txMeta;
+
+  const customNonce = customNonceValue ? toHex(customNonceValue) : undefined;
+
+  if (customNonce) {
+    log('Using custom nonce', customNonce);
+    return [customNonce, undefined];
+  }
+
+  if (existingNonce) {
+    log('Using existing nonce', existingNonce);
+    return [existingNonce, undefined];
+  }
+
+  const nonceLock = await nonceTracker.getNonceLock(from);
+  const nonce = toHex(nonceLock.nextNonce);
+  const releaseLock = nonceLock.releaseLock.bind(nonceLock);
+
+  log('Using nonce from nonce tracker', nonce, nonceLock.nonceDetails);
+
+  return [nonce, releaseLock];
+}
+
+/**
+ * Filter and format transactions for the nonce tracker.
+ *
+ * @param currentChainId - Chain ID of the current network.
+ * @param fromAddress - Address of the account from which the transactions to filter from are sent.
+ * @param transactionStatus - Status of the transactions for which to filter.
+ * @param transactions - Array of transactionMeta objects that have been prefiltered.
+ * @returns Array of transactions formatted for the nonce tracker.
+ */
+export function getAndFormatTransactionsForNonceTracker(
+  currentChainId: string,
+  fromAddress: string,
+  transactionStatus: TransactionStatus,
+  transactions: TransactionMeta[],
+): NonceTrackerTransaction[] {
+  return transactions
+    .filter(
+      ({ chainId, isTransfer, status, txParams: { from } }) =>
+        !isTransfer &&
+        chainId === currentChainId &&
+        status === transactionStatus &&
+        from.toLowerCase() === fromAddress.toLowerCase(),
+    )
+    .map(({ status, txParams: { from, gas, value, nonce } }) => {
+      // the only value we care about is the nonce
+      // but we need to return the other values to satisfy the type
+      // TODO: refactor nonceTracker to not require this
+      /* istanbul ignore next */
+      return {
+        status,
+        history: [{}],
+        txParams: {
+          from: from ?? '',
+          gas: gas ?? '',
+          value: value ?? '',
+          nonce: nonce ?? '',
+        },
+      };
+    });
+}

--- a/packages/transaction-controller/src/utils/utils.test.ts
+++ b/packages/transaction-controller/src/utils/utils.test.ts
@@ -1,11 +1,8 @@
-import type { Transaction as NonceTrackerTransaction } from 'nonce-tracker';
-
 import type {
   GasPriceValue,
   FeeMarketEIP1559Values,
 } from '../TransactionController';
-import type { TransactionParams, TransactionMeta } from '../types';
-import { TransactionStatus } from '../types';
+import type { TransactionParams } from '../types';
 import * as util from './utils';
 
 const MAX_FEE_PER_GAS = 'maxFeePerGas';
@@ -181,97 +178,6 @@ describe('utils', () => {
       expect(() =>
         util.validateMinimumIncrease('0x7162a5ca', '0x5916a6d6'),
       ).not.toThrow(Error);
-    });
-  });
-
-  describe('getAndFormatTransactionsForNonceTracker', () => {
-    it('returns formatted transactions filtered by chain, from, isTransfer, and status', () => {
-      const fromAddress = '0x123';
-      const inputTransactions: TransactionMeta[] = [
-        {
-          id: '1',
-          chainId: '0x1',
-          time: 123456,
-          txParams: {
-            from: fromAddress,
-            gas: '0x100',
-            value: '0x200',
-            nonce: '0x1',
-          },
-          status: TransactionStatus.confirmed,
-        },
-        {
-          id: '2',
-          chainId: '0x1',
-          time: 123457,
-          txParams: {
-            from: '0x124',
-            gas: '0x101',
-            value: '0x201',
-            nonce: '0x2',
-          },
-          status: TransactionStatus.submitted,
-        },
-        {
-          id: '3',
-          chainId: '0x1',
-          time: 123458,
-          txParams: {
-            from: fromAddress,
-            gas: '0x102',
-            value: '0x202',
-            nonce: '0x3',
-          },
-          status: TransactionStatus.approved,
-        },
-        {
-          id: '4',
-          chainId: '0x2',
-          time: 123459,
-          txParams: {
-            from: fromAddress,
-            gas: '0x103',
-            value: '0x203',
-            nonce: '0x4',
-          },
-          status: TransactionStatus.confirmed,
-        },
-        {
-          id: '5',
-          chainId: '0x2',
-          isTransfer: true,
-          time: 123460,
-          txParams: {
-            from: fromAddress,
-            gas: '0x104',
-            value: '0x204',
-            nonce: '0x5',
-          },
-          status: TransactionStatus.confirmed,
-        },
-      ];
-
-      const expectedResult: NonceTrackerTransaction[] = [
-        {
-          status: TransactionStatus.confirmed,
-          history: [{}],
-          txParams: {
-            from: fromAddress,
-            gas: '0x103',
-            value: '0x203',
-            nonce: '0x4',
-          },
-        },
-      ];
-
-      const result = util.getAndFormatTransactionsForNonceTracker(
-        '0x2',
-        fromAddress,
-        TransactionStatus.confirmed,
-        inputTransactions,
-      );
-
-      expect(result).toStrictEqual(expectedResult);
     });
   });
 

--- a/packages/transaction-controller/src/utils/utils.ts
+++ b/packages/transaction-controller/src/utils/utils.ts
@@ -1,7 +1,6 @@
 import { convertHexToDecimal } from '@metamask/controller-utils';
 import { getKnownPropertyNames } from '@metamask/utils';
 import { addHexPrefix, isHexString } from 'ethereumjs-util';
-import type { Transaction as NonceTrackerTransaction } from 'nonce-tracker';
 
 import type {
   GasPriceValue,
@@ -121,46 +120,6 @@ export function validateMinimumIncrease(proposed: string, min: string) {
   }
   const errorMsg = `The proposed value: ${proposedDecimal} should meet or exceed the minimum value: ${minDecimal}`;
   throw new Error(errorMsg);
-}
-
-/**
- * Helper function to filter and format transactions for the nonce tracker.
- *
- * @param currentChainId - Chain ID of the current network.
- * @param fromAddress - Address of the account from which the transactions to filter from are sent.
- * @param transactionStatus - Status of the transactions for which to filter.
- * @param transactions - Array of transactionMeta objects that have been prefiltered.
- * @returns Array of transactions formatted for the nonce tracker.
- */
-export function getAndFormatTransactionsForNonceTracker(
-  currentChainId: string,
-  fromAddress: string,
-  transactionStatus: TransactionStatus,
-  transactions: TransactionMeta[],
-): NonceTrackerTransaction[] {
-  return transactions
-    .filter(
-      ({ chainId, isTransfer, status, txParams: { from } }) =>
-        !isTransfer &&
-        chainId === currentChainId &&
-        status === transactionStatus &&
-        from.toLowerCase() === fromAddress.toLowerCase(),
-    )
-    .map(({ status, txParams: { from, gas, value, nonce } }) => {
-      // the only value we care about is the nonce
-      // but we need to return the other values to satisfy the type
-      // TODO: refactor nonceTracker to not require this
-      return {
-        status,
-        history: [{}],
-        txParams: {
-          from: from ?? '',
-          gas: gas ?? '',
-          value: value ?? '',
-          nonce: nonce ?? '',
-        },
-      };
-    });
 }
 
 /**


### PR DESCRIPTION
## Explanation

Support the use of custom nonces through the `customNonceValue` property used by the extension, in addition to the standard `txParams.nonce` field.

In addition:

- Encapsulate all nonce logic in a new `nonce.ts` file with additional logging.
- Add `type` to incoming transactions.

## Changelog

### `@metamask/transaction-controller`

- **ADDED**: Add the `customNonceValue` property to the transaction metadata.
- **CHANGED**: Update transaction metadata after approval if the approval result includes the `value.txMeta` property.
- **CHANGED**: Add `type` property to all incoming transactions.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
