### PR TITLE
Release 96.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "95.0.0",
+  "version": "96.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [18.2.0]
+### Uncategorized
+- Support custom nonce value ([#3579](https://github.com/MetaMask/core/pull/3579))
+- Release 95.0.0 ([#3580](https://github.com/MetaMask/core/pull/3580))
+
 ## [18.1.0]
 ### Added
 - Add `cancelMultiplier` and `speedUpMultiplier` constructor arguments to optionally override the default multipliers of `1.5` and `1.1` respectively ([#2678](https://github.com/MetaMask/core/pull/2678))
@@ -319,7 +324,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@18.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@18.2.0...HEAD
+[18.2.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@18.1.0...@metamask/transaction-controller@18.2.0
 [18.1.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@18.0.0...@metamask/transaction-controller@18.1.0
 [18.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@17.0.0...@metamask/transaction-controller@18.0.0
 [17.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@16.0.0...@metamask/transaction-controller@17.0.0

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [18.2.0]
-### Uncategorized
-- Support custom nonce value ([#3579](https://github.com/MetaMask/core/pull/3579))
-- Release 95.0.0 ([#3580](https://github.com/MetaMask/core/pull/3580))
+### Added
+- Add the `customNonceValue` property to the transaction metadata ([#3579](https://github.com/MetaMask/core/pull/3579))
+
+### Changed
+- Update transaction metadata after approval if the approval result includes the `value.txMeta` property  ([#3579](https://github.com/MetaMask/core/pull/3579))
+- Add `type` property to all incoming transactions ([#3579](https://github.com/MetaMask/core/pull/3579))
 
 ## [18.1.0]
 ### Added

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "18.1.0",
+  "version": "18.2.0",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
Minor release of `@metamask/transaction-controller` only to fix issues in the extension.

No breaking changes, and have verified no changes are required from other unreleased packages.