### PR TITLE
Support token detection on Base and zkSync

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -43,6 +43,10 @@ export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID: Record<Hex, string> = {
     '0x151E24A486D7258dd7C33Fb67E4bB01919B7B32c',
   [SupportedTokenDetectionNetworks.optimism]:
     '0xB1c568e9C3E6bdaf755A60c7418C269eb11524FC',
+  [SupportedTokenDetectionNetworks.base]:
+    '0x6aa75276052d96696134252587894ef5ffa520af',
+  [SupportedTokenDetectionNetworks.zksync]:
+    '0x458fEd3144680a5b8bcfaa0F9594aa19B4Ea2D34',
 };
 
 export const MISSING_PROVIDER_ERROR =

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -44,7 +44,7 @@ export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID: Record<Hex, string> = {
   [SupportedTokenDetectionNetworks.optimism]:
     '0xB1c568e9C3E6bdaf755A60c7418C269eb11524FC',
   [SupportedTokenDetectionNetworks.base]:
-    '0x6aa75276052d96696134252587894ef5ffa520af',
+    '0x6AA75276052D96696134252587894ef5FFA520af',
   [SupportedTokenDetectionNetworks.zksync]:
     '0x458fEd3144680a5b8bcfaa0F9594aa19B4Ea2D34',
 };

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -150,6 +150,8 @@ export enum SupportedTokenDetectionNetworks {
   linea_mainnet = '0xe708', // decimal: 59144
   arbitrum = '0xa4b1', // decimal: 42161
   optimism = '0xa', // decimal: 10
+  base = '0x2105', // decimal: 8453
+  zksync = '0x144', // decimal: 324
 }
 
 /**


### PR DESCRIPTION
## Explanation

Adds support for token detection on Base and zkSync.  After these chains, we'll support token detection on MetaMask's top 10 most popular networks.

Token lists are available for both chains:
- https://token-api.metaswap.codefi.network/tokens/8453
- https://token-api.metaswap.codefi.network/tokens/324

I deployed and verified the [ERC20 balance checker](https://github.com/wbobeirne/eth-balance-checker) on both chains, since I didn't find existing ones documented:
- https://basescan.org/address/0x6aa75276052d96696134252587894ef5ffa520af#code
- https://explorer.zksync.io/address/0x458fEd3144680a5b8bcfaa0F9594aa19B4Ea2D34#contract

Related PR to extension (depends on this PR):
https://github.com/MetaMask/metamask-extension/pull/21841

## References

Related issues:
- https://github.com/MetaMask/metamask-extension/issues/17697
- https://github.com/MetaMask/metamask-extension/issues/16496

## Changelog

### `@metamask/assets-controllers`

- **ADDED**: Token detection support for Base and zkSync

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
