### PR TITLE
allow initial state to be passed into the constructor

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -110,13 +110,17 @@ export class SelectedNetworkController extends BaseController<
    *
    * @param options - The controller options.
    * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
+   * @param options.state - The controllers initial state.
    */
-  constructor({ messenger, state = getDefaultState() }: SelectedNetworkControllerOptions) {
+  constructor({
+    messenger,
+    state = getDefaultState(),
+  }: SelectedNetworkControllerOptions) {
     super({
       name: controllerName,
       metadata: stateMetadata,
       messenger,
-      state
+      state,
     });
     this.#registerMessageHandlers();
   }

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -86,6 +86,7 @@ export type SelectedNetworkControllerMessenger = RestrictedControllerMessenger<
 >;
 
 export type SelectedNetworkControllerOptions = {
+  state?: SelectedNetworkControllerState;
   messenger: SelectedNetworkControllerMessenger;
 };
 
@@ -110,12 +111,12 @@ export class SelectedNetworkController extends BaseController<
    * @param options - The controller options.
    * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
    */
-  constructor({ messenger }: SelectedNetworkControllerOptions) {
+  constructor({ messenger, state = getDefaultState() }: SelectedNetworkControllerOptions) {
     super({
       name: controllerName,
       metadata: stateMetadata,
       messenger,
-      state: getDefaultState(),
+      state
     });
     this.#registerMessageHandlers();
   }


### PR DESCRIPTION
## Explanation

We were not able to use persisted values because the initial state could not be passed in. This fixes the issue.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/selected-network-controller`

- **Added**: Ability to pass in initial state.


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
