### PR TITLE
Support external pending transactions in nonce calculation

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 89.18,
-      functions: 94.18,
-      lines: 98.09,
-      statements: 98.05,
+      branches: 89.23,
+      functions: 94.23,
+      lines: 98.16,
+      statements: 98.12,
     },
   },
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -35,7 +35,10 @@ import { addHexPrefix, bufferToHex } from 'ethereumjs-util';
 import { EventEmitter } from 'events';
 import { mapValues, merge, pickBy, sortBy } from 'lodash';
 import { NonceTracker } from 'nonce-tracker';
-import type { NonceLock } from 'nonce-tracker';
+import type {
+  NonceLock,
+  Transaction as NonceTrackerTransaction,
+} from 'nonce-tracker';
 import { v1 as random } from 'uuid';
 
 import { EtherscanRemoteTransactionSource } from './helpers/EtherscanRemoteTransactionSource';
@@ -250,6 +253,10 @@ export class TransactionController extends BaseControllerV1<
 
   private readonly getSelectedAddress: () => string;
 
+  private readonly getExternalPendingTransactions: (
+    address: string,
+  ) => NonceTrackerTransaction[];
+
   private readonly messagingSystem: TransactionControllerMessenger;
 
   private readonly incomingTransactionHelper: IncomingTransactionHelper;
@@ -338,12 +345,13 @@ export class TransactionController extends BaseControllerV1<
    * @param options.disableHistory - Whether to disable storing history in transaction metadata.
    * @param options.disableSendFlowHistory - Explicitly disable transaction metadata history.
    * @param options.disableSwaps - Whether to disable additional processing on swaps transactions.
-   * @param options.getSavedGasFees - Gets the saved gas fee config.
    * @param options.getCurrentAccountEIP1559Compatibility - Whether or not the account supports EIP-1559.
    * @param options.getCurrentNetworkEIP1559Compatibility - Whether or not the network supports EIP-1559.
+   * @param options.getExternalPendingTransactions - Callback to retrieve pending transactions from external sources.
    * @param options.getGasFeeEstimates - Callback to retrieve gas fee estimates.
    * @param options.getNetworkState - Gets the state of the network controller.
    * @param options.getPermittedAccounts - Get accounts that a given origin has permissions for.
+   * @param options.getSavedGasFees - Gets the saved gas fee config.
    * @param options.getSelectedAddress - Gets the address of the currently selected account.
    * @param options.incomingTransactions - Configuration options for incoming transaction support.
    * @param options.incomingTransactions.includeTokenTransfers - Whether or not to include ERC20 token transfers.
@@ -373,12 +381,13 @@ export class TransactionController extends BaseControllerV1<
       disableHistory,
       disableSendFlowHistory,
       disableSwaps,
-      getSavedGasFees,
       getCurrentAccountEIP1559Compatibility,
       getCurrentNetworkEIP1559Compatibility,
+      getExternalPendingTransactions,
       getGasFeeEstimates,
       getNetworkState,
       getPermittedAccounts,
+      getSavedGasFees,
       getSelectedAddress,
       incomingTransactions = {},
       messenger,
@@ -394,12 +403,15 @@ export class TransactionController extends BaseControllerV1<
       disableHistory: boolean;
       disableSendFlowHistory: boolean;
       disableSwaps: boolean;
-      getSavedGasFees?: (chainId: Hex) => SavedGasFees | undefined;
       getCurrentAccountEIP1559Compatibility?: () => Promise<boolean>;
       getCurrentNetworkEIP1559Compatibility: () => Promise<boolean>;
+      getExternalPendingTransactions?: (
+        address: string,
+      ) => NonceTrackerTransaction[];
       getGasFeeEstimates?: () => Promise<GasFeeState>;
       getNetworkState: () => NetworkState;
       getPermittedAccounts: (origin?: string) => Promise<string[]>;
+      getSavedGasFees?: (chainId: Hex) => SavedGasFees | undefined;
       getSelectedAddress: () => string;
       incomingTransactions?: {
         includeTokenTransfers?: boolean;
@@ -464,6 +476,8 @@ export class TransactionController extends BaseControllerV1<
       getGasFeeEstimates || (() => Promise.resolve({} as GasFeeState));
     this.getPermittedAccounts = getPermittedAccounts;
     this.getSelectedAddress = getSelectedAddress;
+    this.getExternalPendingTransactions =
+      getExternalPendingTransactions ?? (() => []);
     this.securityProviderRequest = securityProviderRequest;
     this.cancelMultiplier = cancelMultiplier ?? CANCEL_RATE;
     this.speedUpMultiplier = speedUpMultiplier ?? SPEED_UP_RATE;
@@ -482,10 +496,8 @@ export class TransactionController extends BaseControllerV1<
       // @ts-expect-error provider types misaligned: SafeEventEmitterProvider vs Record<string,string>
       provider,
       blockTracker,
-      getPendingTransactions: this.getNonceTrackerTransactions.bind(
-        this,
-        TransactionStatus.submitted,
-      ),
+      getPendingTransactions:
+        this.getNonceTrackerPendingTransactions.bind(this),
       getConfirmedTransactions: this.getNonceTrackerTransactions.bind(
         this,
         TransactionStatus.confirmed,
@@ -1499,6 +1511,10 @@ export class TransactionController extends BaseControllerV1<
   async approveTransactionsWithSameNonce(
     listOfTxParams: TransactionParams[] = [],
   ): Promise<string | string[]> {
+    log('Approving transactions with same nonce', {
+      transactions: listOfTxParams,
+    });
+
     if (listOfTxParams.length === 0) {
       return '';
     }
@@ -1524,6 +1540,8 @@ export class TransactionController extends BaseControllerV1<
       const fromAddress = initialTx.from;
       nonceLock = await this.nonceTracker.getNonceLock(fromAddress);
       const nonce = nonceLock.nextNonce;
+
+      log('Using nonce from nonce tracker', nonce, nonceLock.nonceDetails);
 
       rawTransactions = await Promise.all(
         listOfTxParams.map((txParams) => {
@@ -2589,6 +2607,18 @@ export class TransactionController extends BaseControllerV1<
 
   private onTransactionStatusChange(transactionMeta: TransactionMeta) {
     this.hub.emit('transaction-status-update', { transactionMeta });
+  }
+
+  private getNonceTrackerPendingTransactions(address: string) {
+    const standardPendingTransactions = this.getNonceTrackerTransactions(
+      TransactionStatus.submitted,
+      address,
+    );
+
+    const externalPendingTransactions =
+      this.getExternalPendingTransactions(address);
+
+    return [...standardPendingTransactions, ...externalPendingTransactions];
   }
 
   private getNonceTrackerTransactions(


### PR DESCRIPTION
## Explanation

Add an optional constructor callback to provide external pending transactions that will be checked when generating nonces.

Required to fully support smart transactions in the extension since their pending state is known only to the `SmartTransactionController` and scenarios such as swaps requiring approval need to generate multiple sequential nonces for pending transactions.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **ADDED**: Add optional `getExternalPendingTransactions` callback argument to constructor.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
