### PR TITLE
Release 98.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "97.0.0",
+  "version": "98.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/build-utils/CHANGELOG.md
+++ b/packages/build-utils/CHANGELOG.md
@@ -10,5 +10,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/controllers/compare/@metamask/build-utils@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/controllers/releases/tag/@metamask/build-utils@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/build-utils@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/build-utils@1.0.0

--- a/packages/build-utils/CHANGELOG.md
+++ b/packages/build-utils/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.0.0]
-### Uncategorized
-- `@metamask/build-utils`: Convert @types/eslint to production dependency ([#3588](https://github.com/MetaMask/controllers/pull/3588))
+### Added
+- Initial release
 
 [Unreleased]: https://github.com/MetaMask/controllers/compare/@metamask/build-utils@1.0.0...HEAD
 [1.0.0]: https://github.com/MetaMask/controllers/releases/tag/@metamask/build-utils@1.0.0

--- a/packages/build-utils/CHANGELOG.md
+++ b/packages/build-utils/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0]
 ### Added
-- Initial release
+- Initial release ([#3577](https://github.com/MetaMask/core/pull/3577) [#3588](https://github.com/MetaMask/core/pull/3588))
 
 [Unreleased]: https://github.com/MetaMask/core/compare/@metamask/build-utils@1.0.0...HEAD
 [1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/build-utils@1.0.0

--- a/packages/build-utils/CHANGELOG.md
+++ b/packages/build-utils/CHANGELOG.md
@@ -6,4 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/MetaMask/core/
+## [1.0.0]
+### Uncategorized
+- `@metamask/build-utils`: Convert @types/eslint to production dependency ([#3588](https://github.com/MetaMask/controllers/pull/3588))
+
+[Unreleased]: https://github.com/MetaMask/controllers/compare/@metamask/build-utils@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/controllers/releases/tag/@metamask/build-utils@1.0.0

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/build-utils",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Utilities for building MetaMask applications",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
`@metamask/build-utils@1.0.0`, the first release of this new package.