### PR TITLE
add method to reset proxies when flag toggled

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -166,11 +166,10 @@ export class SelectedNetworkController extends BaseController<
     }
 
     this.update((state) => {
-      if (state.perDomainNetwork) {
-        state.domains[domain] = networkClientId;
-        return;
+      state.domains[domain] = networkClientId;
+      if (!state.perDomainNetwork) {
+        state.domains[METAMASK_DOMAIN] = networkClientId;
       }
-      state.domains[METAMASK_DOMAIN] = networkClientId;
     });
   }
 
@@ -204,5 +203,15 @@ export class SelectedNetworkController extends BaseController<
     }
 
     return networkProxy;
+  }
+
+  setPerDomainNetwork(enabled: boolean) {
+    this.update((state) => {
+      state.perDomainNetwork = enabled;
+      return state;
+    });
+    Object.entries(this.state.domains).forEach(([domain, networkClientId]) => {
+      this.setNetworkClientIdForDomain(domain, networkClientId);
+    });
   }
 }

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -210,8 +210,12 @@ export class SelectedNetworkController extends BaseController<
       state.perDomainNetwork = enabled;
       return state;
     });
-    Object.entries(this.state.domains).forEach(([domain, networkClientId]) => {
-      this.setNetworkClientIdForDomain(domain, networkClientId);
+    Object.keys(this.state.domains).forEach((domain) => {
+      // when perDomainNetwork is false, getNetworkClientIdForDomain always returns the networkClientId for the domain 'metamask'
+      this.setNetworkClientIdForDomain(
+        domain,
+        this.getNetworkClientIdForDomain(domain),
+      );
     });
   }
 }

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -184,4 +184,25 @@ describe('SelectedNetworkController', () => {
       expect(result).toBeDefined();
     });
   });
+
+  describe('setPerDomainNetwork', () => {
+    it('toggles the feature flag & updates the proxies for each domain', () => {
+      const options: SelectedNetworkControllerOptions = {
+        messenger: buildSelectedNetworkControllerMessenger(),
+        state: { domains: {}, perDomainNetwork: false },
+      };
+      const controller = new SelectedNetworkController(options);
+      const mockProviderProxy = {
+        setTarget: jest.fn(),
+        eventNames: jest.fn(),
+        rawListeners: jest.fn(),
+        removeAllListeners: jest.fn(),
+      };
+      createEventEmitterProxyMock.mockReturnValue(mockProviderProxy);
+      controller.setNetworkClientIdForDomain('example.com', 'network7');
+      expect(mockProviderProxy.setTarget).toHaveBeenCalledTimes(0);
+      controller.setPerDomainNetwork(true);
+      expect(mockProviderProxy.setTarget).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Fixes a bug where turning on / off the request queue feature flag requires dapps to be manually refreshed in order for the changes to take effect.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/selected-network-controller`

- **ADDED**: A method on selected-network-controller that can be called when changing the feature flag. This will update the proxies accordingly.
- **FIXED**: Fixed a bug where when the feature flag was off, we were not savng network selections for domains.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
