### PR TITLE
fix: Make `updateExchangeRatesByChainId` respect `disabled`

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -952,30 +952,33 @@ describe('TokenRatesController', () => {
 
   describe('updateExchangeRates', () => {
     it('should not update exchange rates if legacy polling is disabled', async () => {
-      const controller = new TokenRatesController({
-        chainId: '0x1',
-        ticker: NetworksTicker.mainnet,
-        selectedAddress: defaultSelectedAddress,
-        onPreferencesStateChange: jest.fn(),
-        onTokensStateChange: jest.fn(),
-        onNetworkStateChange: jest.fn(),
-        getNetworkClientById: jest.fn(),
-      }, {
-        allTokens: {
-          '0x1': {
-            [defaultSelectedAddress]: [
-              {
-                address: '0x123',
-                decimals: 18,
-                symbol: 'DAI',
-                aggregators: [],
-              },
-              { address: ADDRESS, decimals: 0, symbol: '', aggregators: [] },
-            ],
-          },
+      const controller = new TokenRatesController(
+        {
+          chainId: '0x1',
+          ticker: NetworksTicker.mainnet,
+          selectedAddress: defaultSelectedAddress,
+          onPreferencesStateChange: jest.fn(),
+          onTokensStateChange: jest.fn(),
+          onNetworkStateChange: jest.fn(),
+          getNetworkClientById: jest.fn(),
         },
-        disabled: true,
-      });
+        {
+          allTokens: {
+            '0x1': {
+              [defaultSelectedAddress]: [
+                {
+                  address: '0x123',
+                  decimals: 18,
+                  symbol: 'DAI',
+                  aggregators: [],
+                },
+                { address: ADDRESS, decimals: 0, symbol: '', aggregators: [] },
+              ],
+            },
+          },
+          disabled: true,
+        },
+      );
       expect(controller.state.contractExchangeRates).toStrictEqual({});
       expect(controller.state.contractExchangeRatesByChainId).toStrictEqual({});
 
@@ -1066,16 +1069,19 @@ describe('TokenRatesController', () => {
 
     it('should not update state when disabled', async () => {
       const tokenAddress = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359';
-      const controller = new TokenRatesController({
-        interval: 100,
-        chainId: '0x2',
-        ticker: 'ticker',
-        selectedAddress: '0xdeadbeef',
-        onPreferencesStateChange: jest.fn(),
-        onTokensStateChange: jest.fn(),
-        onNetworkStateChange: jest.fn(),
-        getNetworkClientById: jest.fn(),
-      }, { disabled: true });
+      const controller = new TokenRatesController(
+        {
+          interval: 100,
+          chainId: '0x2',
+          ticker: 'ticker',
+          selectedAddress: '0xdeadbeef',
+          onPreferencesStateChange: jest.fn(),
+          onTokensStateChange: jest.fn(),
+          onNetworkStateChange: jest.fn(),
+          getNetworkClientById: jest.fn(),
+        },
+        { disabled: true },
+      );
       expect(controller.state.contractExchangeRatesByChainId).toStrictEqual({});
 
       await controller.updateExchangeRatesByChainId({

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -960,15 +960,29 @@ describe('TokenRatesController', () => {
         onTokensStateChange: jest.fn(),
         onNetworkStateChange: jest.fn(),
         getNetworkClientById: jest.fn(),
+      }, {
+        allTokens: {
+          '0x1': {
+            [defaultSelectedAddress]: [
+              {
+                address: '0x123',
+                decimals: 18,
+                symbol: 'DAI',
+                aggregators: [],
+              },
+              { address: ADDRESS, decimals: 0, symbol: '', aggregators: [] },
+            ],
+          },
+        },
+        disabled: true,
       });
-      controller.disabled = true;
-
-      const updateExchangeRatesByChainIdSpy = jest
-        .spyOn(controller, 'updateExchangeRatesByChainId')
-        .mockResolvedValue();
+      expect(controller.state.contractExchangeRates).toStrictEqual({});
+      expect(controller.state.contractExchangeRatesByChainId).toStrictEqual({});
 
       await controller.updateExchangeRates();
-      expect(updateExchangeRatesByChainIdSpy).not.toHaveBeenCalled();
+
+      expect(controller.state.contractExchangeRates).toStrictEqual({});
+      expect(controller.state.contractExchangeRatesByChainId).toStrictEqual({});
     });
 
     it('should update legacy state after updateExchangeRatesByChainId', async () => {
@@ -1047,6 +1061,29 @@ describe('TokenRatesController', () => {
         nativeCurrency: 'ETH',
         tokenAddresses: [],
       });
+      expect(controller.state.contractExchangeRatesByChainId).toStrictEqual({});
+    });
+
+    it('should not update state when disabled', async () => {
+      const tokenAddress = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359';
+      const controller = new TokenRatesController({
+        interval: 100,
+        chainId: '0x2',
+        ticker: 'ticker',
+        selectedAddress: '0xdeadbeef',
+        onPreferencesStateChange: jest.fn(),
+        onTokensStateChange: jest.fn(),
+        onNetworkStateChange: jest.fn(),
+        getNetworkClientById: jest.fn(),
+      }, { disabled: true });
+      expect(controller.state.contractExchangeRatesByChainId).toStrictEqual({});
+
+      await controller.updateExchangeRatesByChainId({
+        chainId: '0x1',
+        nativeCurrency: 'ETH',
+        tokenAddresses: [tokenAddress],
+      });
+
       expect(controller.state.contractExchangeRatesByChainId).toStrictEqual({});
     });
 

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -952,40 +952,23 @@ describe('TokenRatesController', () => {
 
   describe('updateExchangeRates', () => {
     it('should not update exchange rates if legacy polling is disabled', async () => {
-      const controller = new TokenRatesController(
-        {
-          chainId: '0x1',
-          ticker: NetworksTicker.mainnet,
-          selectedAddress: defaultSelectedAddress,
-          onPreferencesStateChange: jest.fn(),
-          onTokensStateChange: jest.fn(),
-          onNetworkStateChange: jest.fn(),
-          getNetworkClientById: jest.fn(),
-        },
-        {
-          allTokens: {
-            '0x1': {
-              [defaultSelectedAddress]: [
-                {
-                  address: '0x123',
-                  decimals: 18,
-                  symbol: 'DAI',
-                  aggregators: [],
-                },
-                { address: ADDRESS, decimals: 0, symbol: '', aggregators: [] },
-              ],
-            },
-          },
-          disabled: true,
-        },
-      );
-      expect(controller.state.contractExchangeRates).toStrictEqual({});
-      expect(controller.state.contractExchangeRatesByChainId).toStrictEqual({});
+      const controller = new TokenRatesController({
+        chainId: '0x1',
+        ticker: NetworksTicker.mainnet,
+        selectedAddress: defaultSelectedAddress,
+        onPreferencesStateChange: jest.fn(),
+        onTokensStateChange: jest.fn(),
+        onNetworkStateChange: jest.fn(),
+        getNetworkClientById: jest.fn(),
+      });
+      controller.disabled = true;
+
+      const updateExchangeRatesByChainIdSpy = jest
+        .spyOn(controller, 'updateExchangeRatesByChainId')
+        .mockResolvedValue();
 
       await controller.updateExchangeRates();
-
-      expect(controller.state.contractExchangeRates).toStrictEqual({});
-      expect(controller.state.contractExchangeRatesByChainId).toStrictEqual({});
+      expect(updateExchangeRatesByChainIdSpy).not.toHaveBeenCalled();
     });
 
     it('should update legacy state after updateExchangeRatesByChainId', async () => {

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -444,6 +444,7 @@ export class TokenRatesController extends PollingControllerV1<
     if (this.tokenList.length === 0 || this.disabled) {
       return;
     }
+
     const { chainId, nativeCurrency } = this.config;
     const tokenAddresses = this.tokenList.map((token) => token.address);
     await this.updateExchangeRatesByChainId({

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -444,7 +444,6 @@ export class TokenRatesController extends PollingControllerV1<
     if (this.tokenList.length === 0 || this.disabled) {
       return;
     }
-
     const { chainId, nativeCurrency } = this.config;
     const tokenAddresses = this.tokenList.map((token) => token.address);
     await this.updateExchangeRatesByChainId({
@@ -476,7 +475,7 @@ export class TokenRatesController extends PollingControllerV1<
     nativeCurrency: string;
     tokenAddresses: string[];
   }) {
-    if (!tokenAddresses.length) {
+    if (tokenAddresses.length === 0 || this.disabled) {
       return;
     }
     const chainSlug = await this.getChainSlug(chainId);


### PR DESCRIPTION
## Explanation

The `updateExchangeRatesByChainId` method has been updated to no longer perform any updates if the controller is disabled.

Likely the `disabled` configuration is something we'll at least consider removing soon, as I don't think we use it. But as long as it's here, we should use it consistently.

## References

Fixes #3595

## Changelog

### `@metamask/assets-controllers`

#### Fixed
- The `TokenRatesController` method `updateExchangeRatesByChainId` now respects the `disabled` configuration

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
