### PR TITLE
Add `NetworkState` payload to `NetworkController:networkWillChange` and `NetworkController:networkDidChange`

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -363,7 +363,7 @@ export type NetworkControllerStateChangeEvent = ControllerStateChangeEvent<
  */
 export type NetworkControllerNetworkWillChangeEvent = {
   type: 'NetworkController:networkWillChange';
-  payload: [];
+  payload: [NetworkState];
 };
 
 /**
@@ -372,7 +372,7 @@ export type NetworkControllerNetworkWillChangeEvent = {
  */
 export type NetworkControllerNetworkDidChangeEvent = {
   type: 'NetworkController:networkDidChange';
-  payload: [];
+  payload: [NetworkState];
 };
 
 /**
@@ -732,9 +732,15 @@ export class NetworkController extends BaseController<
    * 3. Notifies subscribers that the network has changed.
    */
   async #refreshNetwork() {
-    this.messagingSystem.publish('NetworkController:networkWillChange');
+    this.messagingSystem.publish(
+      'NetworkController:networkWillChange',
+      this.state,
+    );
     this.#applyNetworkSelection();
-    this.messagingSystem.publish('NetworkController:networkDidChange');
+    this.messagingSystem.publish(
+      'NetworkController:networkDidChange',
+      this.state,
+    );
     await this.lookupNetwork();
   }
 

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -4990,7 +4990,7 @@ describe('NetworkController', () => {
     describe('if a provider has been set', () => {
       for (const { networkType } of INFURA_NETWORKS) {
         describe(`if the previous provider configuration had a type of "${networkType}"`, () => {
-          it('emits networkWillChange', async () => {
+          it('emits networkWillChange with state payload', async () => {
             await withController(
               {
                 state: {
@@ -5020,6 +5020,7 @@ describe('NetworkController', () => {
                 const networkWillChange = waitForPublishedEvents({
                   messenger,
                   eventType: 'NetworkController:networkWillChange',
+                  filter: ([networkState]) => networkState === controller.state,
                   operation: () => {
                     // Intentionally not awaited because we're capturing an event
                     // emitted partway through the operation
@@ -5032,7 +5033,7 @@ describe('NetworkController', () => {
             );
           });
 
-          it('emits networkDidChange', async () => {
+          it('emits networkDidChange with state payload', async () => {
             await withController(
               {
                 state: {
@@ -5062,6 +5063,7 @@ describe('NetworkController', () => {
                 const networkDidChange = waitForPublishedEvents({
                   messenger,
                   eventType: 'NetworkController:networkDidChange',
+                  filter: ([networkState]) => networkState === controller.state,
                   operation: () => {
                     // Intentionally not awaited because we're capturing an event
                     // emitted partway through the operation
@@ -5592,7 +5594,7 @@ describe('NetworkController', () => {
       }
 
       describe(`if the previous provider configuration had a type of "rpc"`, () => {
-        it('emits networkWillChange', async () => {
+        it('emits networkWillChange with state payload', async () => {
           await withController(
             {
               state: {
@@ -5610,6 +5612,7 @@ describe('NetworkController', () => {
               const networkWillChange = waitForPublishedEvents({
                 messenger,
                 eventType: 'NetworkController:networkWillChange',
+                filter: ([networkState]) => networkState === controller.state,
                 operation: () => {
                   // Intentionally not awaited because we're capturing an event
                   // emitted partway through the operation
@@ -5622,7 +5625,7 @@ describe('NetworkController', () => {
           );
         });
 
-        it('emits networkDidChange', async () => {
+        it('emits networkDidChange with state payload', async () => {
           await withController(
             {
               state: {
@@ -5640,6 +5643,7 @@ describe('NetworkController', () => {
               const networkDidChange = waitForPublishedEvents({
                 messenger,
                 eventType: 'NetworkController:networkDidChange',
+                filter: ([networkState]) => networkState === controller.state,
                 operation: () => {
                   // Intentionally not awaited because we're capturing an event
                   // emitted partway through the operation
@@ -6237,7 +6241,7 @@ function refreshNetworkTests({
   initialState?: Partial<NetworkState>;
   operation: (controller: NetworkController) => Promise<void>;
 }) {
-  it('emits networkWillChange', async () => {
+  it('emits networkWillChange with state payload', async () => {
     await withController(
       {
         state: initialState,
@@ -6250,6 +6254,7 @@ function refreshNetworkTests({
         const networkWillChange = waitForPublishedEvents({
           messenger,
           eventType: 'NetworkController:networkWillChange',
+          filter: ([networkState]) => networkState === controller.state,
           operation: () => {
             // Intentionally not awaited because we're capturing an event
             // emitted partway through the operation
@@ -6262,7 +6267,7 @@ function refreshNetworkTests({
     );
   });
 
-  it('emits networkDidChange', async () => {
+  it('emits networkDidChange with state payload', async () => {
     await withController(
       {
         state: initialState,
@@ -6275,6 +6280,7 @@ function refreshNetworkTests({
         const networkDidChange = waitForPublishedEvents({
           messenger,
           eventType: 'NetworkController:networkDidChange',
+          filter: ([networkState]) => networkState === controller.state,
           operation: () => {
             // Intentionally not awaited because we're capturing an event
             // emitted partway through the operation


### PR DESCRIPTION
## Explanation

While debugging an issue with SwapsController's provider instance being updated too soon due to the remove networkId refactor, I noticed many of our controllers listen to `NetworkController:stateChange` which fires numerous times each time the network switches. Some of these controllers keep track of the `chainId` it's last seen between these events to ensure it only fires off any necessary side effects once. Some controllers don't keep track of if it's seen the `chainId` at all and will fire off the side effects for each and every `stateChange` event. Using `chainId` as a guard isn't even necessarily correct in some cases as the provider may have changed despite the chainId remaining the same.

It seems more appropriate/accurate for these controllers to be listening to `NetworkController:networkDidChange` instead which only fires once for each network switch, and after the provider proxy has been updated to point at the right RPC endpoint.

Currently the `NetworkController:networkDidChange` event is a little bit inconvenient to consume because generally any listeners to this event would want to know what the network changed to / what the current state of things are to determine next steps. This PR adds `NetworkState` to the `NetworkController:networkWillChange` and `NetworkController:networkDidChange` event payloads

## References

* See: https://github.com/MetaMask/MetaMask-planning/issues/1713


## Changelog

### `@metamask/network-controller`

- **CHANGED**: `NetworkController:networkWillChange` includes `NetworkState` as the first and only item in the payload
- **CHANGED**: `NetworkController:networkDidChange` includes `NetworkState` as the first and only item in the payload


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
