### PR TITLE
Fix broken URL in `build-utils/README.md`

### DIFF
--- a/packages/build-utils/README.md
+++ b/packages/build-utils/README.md
@@ -14,7 +14,7 @@ or
 
 ### `/transforms`
 
-See [the transforms readme](https://github.com/MetaMask/core/packages/build-utils/src/transforms/README.md).
+See [the transforms readme](https://github.com/MetaMask/core/blob/main/packages/build-utils/src/transforms/README.md).
 
 ## Contributing
 


### PR DESCRIPTION
## Explanation

Fixes a broken URL in the `build-utils` README.

## References

N/A

## Changelog

N/A