### PR TITLE
Remove superfluous typescript reference paths

### DIFF
--- a/packages/approval-controller/tsconfig.build.json
+++ b/packages/approval-controller/tsconfig.build.json
@@ -8,7 +8,7 @@
   "references": [
     {
       "path": "../base-controller/tsconfig.build.json"
-    },
+    }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/approval-controller/tsconfig.build.json
+++ b/packages/approval-controller/tsconfig.build.json
@@ -9,9 +9,6 @@
     {
       "path": "../base-controller/tsconfig.build.json"
     },
-    {
-      "path": "../controller-utils/tsconfig.build.json"
-    }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/approval-controller/tsconfig.json
+++ b/packages/approval-controller/tsconfig.json
@@ -6,7 +6,7 @@
   "references": [
     {
       "path": "../base-controller"
-    },
+    }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/approval-controller/tsconfig.json
+++ b/packages/approval-controller/tsconfig.json
@@ -7,9 +7,6 @@
     {
       "path": "../base-controller"
     },
-    {
-      "path": "../controller-utils"
-    }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/composable-controller/tsconfig.build.json
+++ b/packages/composable-controller/tsconfig.build.json
@@ -8,7 +8,7 @@
   "references": [
     {
       "path": "../base-controller/tsconfig.build.json"
-    },
+    }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/composable-controller/tsconfig.build.json
+++ b/packages/composable-controller/tsconfig.build.json
@@ -7,23 +7,8 @@
   },
   "references": [
     {
-      "path": "../address-book-controller/tsconfig.build.json"
-    },
-    {
-      "path": "../assets-controllers/tsconfig.build.json"
-    },
-    {
       "path": "../base-controller/tsconfig.build.json"
     },
-    {
-      "path": "../ens-controller/tsconfig.build.json"
-    },
-    {
-      "path": "../network-controller/tsconfig.build.json"
-    },
-    {
-      "path": "../preferences-controller/tsconfig.build.json"
-    }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/composable-controller/tsconfig.json
+++ b/packages/composable-controller/tsconfig.json
@@ -6,7 +6,7 @@
   "references": [
     {
       "path": "../base-controller"
-    },
+    }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/composable-controller/tsconfig.json
+++ b/packages/composable-controller/tsconfig.json
@@ -5,23 +5,8 @@
   },
   "references": [
     {
-      "path": "../address-book-controller"
-    },
-    {
-      "path": "../assets-controllers"
-    },
-    {
       "path": "../base-controller"
     },
-    {
-      "path": "../ens-controller"
-    },
-    {
-      "path": "../network-controller"
-    },
-    {
-      "path": "../preferences-controller"
-    }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/keyring-controller/tsconfig.build.json
+++ b/packages/keyring-controller/tsconfig.build.json
@@ -10,9 +10,6 @@
       "path": "../base-controller/tsconfig.build.json"
     },
     {
-      "path": "../controller-utils/tsconfig.build.json"
-    },
-    {
       "path": "../message-manager/tsconfig.build.json"
     },
     {

--- a/packages/keyring-controller/tsconfig.json
+++ b/packages/keyring-controller/tsconfig.json
@@ -8,9 +8,6 @@
       "path": "../base-controller"
     },
     {
-      "path": "../controller-utils"
-    },
-    {
       "path": "../message-manager"
     },
     {

--- a/packages/logging-controller/tsconfig.build.json
+++ b/packages/logging-controller/tsconfig.build.json
@@ -7,7 +7,7 @@
   },
   "references": [
     { "path": "../base-controller/tsconfig.build.json" },
-    { "path": "../controller-utils/tsconfig.build.json" },
+    { "path": "../controller-utils/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/logging-controller/tsconfig.build.json
+++ b/packages/logging-controller/tsconfig.build.json
@@ -8,7 +8,6 @@
   "references": [
     { "path": "../base-controller/tsconfig.build.json" },
     { "path": "../controller-utils/tsconfig.build.json" },
-    { "path": "../network-controller/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/logging-controller/tsconfig.json
+++ b/packages/logging-controller/tsconfig.json
@@ -5,7 +5,7 @@
   },
   "references": [
     { "path": "../base-controller" },
-    { "path": "../controller-utils" },
+    { "path": "../controller-utils" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/logging-controller/tsconfig.json
+++ b/packages/logging-controller/tsconfig.json
@@ -6,7 +6,6 @@
   "references": [
     { "path": "../base-controller" },
     { "path": "../controller-utils" },
-    { "path": "../network-controller" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/notification-controller/tsconfig.build.json
+++ b/packages/notification-controller/tsconfig.build.json
@@ -6,8 +6,7 @@
     "rootDir": "./src"
   },
   "references": [
-    { "path": "../base-controller/tsconfig.build.json" },
-    { "path": "../controller-utils/tsconfig.build.json" }
+    { "path": "../base-controller/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/notification-controller/tsconfig.build.json
+++ b/packages/notification-controller/tsconfig.build.json
@@ -5,8 +5,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "references": [
-    { "path": "../base-controller/tsconfig.build.json" }
-  ],
+  "references": [{ "path": "../base-controller/tsconfig.build.json" }],
   "include": ["../../types", "./src"]
 }

--- a/packages/notification-controller/tsconfig.json
+++ b/packages/notification-controller/tsconfig.json
@@ -5,7 +5,6 @@
   },
   "references": [
     { "path": "../base-controller" },
-    { "path": "../controller-utils" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/notification-controller/tsconfig.json
+++ b/packages/notification-controller/tsconfig.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-  ],
+  "references": [{ "path": "../base-controller" }],
   "include": ["../../types", "./src"]
 }

--- a/packages/permission-log-controller/tsconfig.build.json
+++ b/packages/permission-log-controller/tsconfig.build.json
@@ -7,7 +7,6 @@
   },
   "references": [
     { "path": "../base-controller/tsconfig.build.json" },
-    { "path": "../controller-utils/tsconfig.build.json" },
     { "path": "../json-rpc-engine/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]

--- a/packages/permission-log-controller/tsconfig.json
+++ b/packages/permission-log-controller/tsconfig.json
@@ -5,7 +5,6 @@
   },
   "references": [
     { "path": "../base-controller" },
-    { "path": "../controller-utils" },
     { "path": "../json-rpc-engine" }
   ],
   "include": ["../../types", "./src", "./tests"]


### PR DESCRIPTION
## Explanation

- Removes superfluous TypeScript reference paths to non-dependencies.
- TODO: We should have `yarn constraints` rules to enforce this.

## References

## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
