### PR TITLE
[WIP]: fetch token fiat balance before import

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -296,7 +296,7 @@ export class TokenRatesController extends PollingControllerV1<
           this.config.allDetectedTokens !== allDetectedTokens ||
           this.config.allTemporaryTokens !== allTemporaryTokens
         ) {
-          this.configure({ allTokens, allDetectedTokens });
+          this.configure({ allTokens, allDetectedTokens, allTemporaryTokens });
           this.#updateTokenList();
           if (this.#pollState === PollState.Active) {
             await this.updateExchangeRates();

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -948,14 +948,14 @@ export class TokensController extends BaseControllerV1<
         allTemporaryTokens[chainIdToAddTokens] &&
         allTemporaryTokens[chainIdToAddTokens][userAddressToAddTokens])
     ) {
-      const networkDetectedTokens = allTemporaryTokens[chainIdToAddTokens];
-      const newDetectedNetworkTokens = {
-        ...networkDetectedTokens,
+      const networkTemporaryTokens = allTemporaryTokens[chainIdToAddTokens];
+      const newTemporaryNetworkTokens = {
+        ...networkTemporaryTokens,
         ...{ [userAddressToAddTokens]: newTemporaryTokens },
       };
       newAllTemporaryTokens = {
         ...allTemporaryTokens,
-        ...{ [chainIdToAddTokens]: newDetectedNetworkTokens },
+        ...{ [chainIdToAddTokens]: newTemporaryNetworkTokens },
       };
     }
 


### PR DESCRIPTION
## Explanation

On the extension side; we want to be able to fetch user token balances in, fiat before he clicks on "import" button.

Displaying the fiat balance would require having `contractExchangeRates`.

These values today are added to the state once the user clicks on the "import" button which submits a background action
calling `addTokens `function on  the `TokensController.ts`. Once the tokens state is updated it triggers `onTokensStateChange  `on the T`okenRatesController` which does the fetching of exchange rates.

So basically we wanted access to these values before the user clicks on the import. 

We thought about using the already existing "addTokens" function; but then the we would have to remove them if the user just closes the modal and does not import the token. And if the removal fails, he will see a token on the home page that he did not import.

Eventually we created that new state variable temporaryTokens, that adds the tokens to the state when the user clicks "Next" button on the import modal. Then he should be able to see the fiat token balance.

Another related PR on extension exists for this: https://github.com/MetaMask/metamask-extension/pull/22176


## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
