### PR TITLE
Make `TokenRatesController.fetchAndMapExchangeRates` private

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -363,7 +363,7 @@ export class TokenRatesController extends PollingControllerV1<
       return;
     }
 
-    const newContractExchangeRates = await this.fetchAndMapExchangeRates({
+    const newContractExchangeRates = await this.#fetchAndMapExchangeRates({
       tokenContractAddresses,
       chainId,
       nativeCurrency,
@@ -406,7 +406,7 @@ export class TokenRatesController extends PollingControllerV1<
    * native currency, or an empty map if no exchange rates can be obtained for
    * the chain ID.
    */
-  async fetchAndMapExchangeRates({
+  async #fetchAndMapExchangeRates({
     tokenContractAddresses,
     chainId,
     nativeCurrency,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,19 +1,13 @@
 /**
- * Resolve all pending promises.
- * This method is used for async tests that use fake timers.
- * See https://stackoverflow.com/a/58716087 and https://jestjs.io/docs/timer-mocks.
- */
-const flushPromises = () => {
-  return new Promise(jest.requireActual('timers').setImmediate);
-};
-
-/**
  * Advances the provided fake timer by a specified duration in incremental steps.
- * Between each step, any enqueued promises are processed. Fake timers in testing libraries
- * allow simulation of time without actually waiting. However, they don't always account for
- * promises or other asynchronous operations that may get enqueued during the timer's duration.
- * By advancing time in incremental steps and flushing promises between each step,
- * this function ensures that both timers and promises are comprehensively processed.
+ * Between each step, any enqueued promises are processed. However, any setTimeouts created
+ * by those promises will not have their timers advanced until the next incremental step.
+ *
+ * Fake timers in testing libraries allow simulation of time without actually waiting. However,
+ * they don't always account for promises or other asynchronous operations that may get enqueued
+ * during the timer's duration. By advancing time in incremental steps and flushing promises
+ * between each step, this function ensures that both timers and promises are comprehensively processed.
+ *
  * @param options - The options object.
  * @param options.clock - The Sinon fake timer instance used to manipulate time in tests.
  * @param options.duration - The total amount of time (in milliseconds) to advance the timer by.
@@ -30,7 +24,6 @@ export async function advanceTime({
 }): Promise<void> {
   do {
     await clock.tickAsync(stepSize);
-    await flushPromises();
     duration -= stepSize;
   } while (duration > 0);
 }


### PR DESCRIPTION
## Explanation

Revisting this controller after adding PollingController to reduce it's API surface area.

## References

* Fixes https://github.com/MetaMask/core/issues/2060

## Changelog

### `@metamask/assets-controllers`

- **BREAKING**: `TokenRatesController.fetchAndMapExchangeRates` is no longer exposed publicly

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
