### PR TITLE
PollingController: add option to poll by blockTracker

### DIFF
--- a/packages/polling-controller/src/PollingController.test.ts
+++ b/packages/polling-controller/src/PollingController.test.ts
@@ -276,243 +276,238 @@ describe('PollingController', () => {
         expect(c.stopPollingByPollingToken).toBeDefined();
       });
     });
-    describe('startPollingByNetworkClientId after setPollWithBlockTracker', () => {
-      class TestBlockTracker extends EventEmitter {
-        private latestBlockNumber: number;
+  });
 
-        public interval: number;
+  describe('Polling on block times', () => {
+    class TestBlockTracker extends EventEmitter {
+      private latestBlockNumber: number;
 
-        constructor({ interval } = { interval: 1000 }) {
-          super();
-          this.latestBlockNumber = 0;
-          this.interval = interval;
-          this.start(interval);
-        }
+      public interval: number;
 
-        private start(interval: number) {
-          setInterval(() => {
-            this.latestBlockNumber += 1;
-            this.emit('latest', this.latestBlockNumber);
-          }, interval);
-        }
+      constructor({ interval } = { interval: 1000 }) {
+        super();
+        this.latestBlockNumber = 0;
+        this.interval = interval;
+        this.start(interval);
       }
 
-      let getNetworkClientById: jest.Mock;
-      let mainnetBlockTracker: TestBlockTracker;
-      let goerliBlockTracker: TestBlockTracker;
-      let sepoliaBlockTracker: TestBlockTracker;
-      beforeEach(() => {
-        mainnetBlockTracker = new TestBlockTracker({ interval: 5 });
-        goerliBlockTracker = new TestBlockTracker({ interval: 10 });
-        sepoliaBlockTracker = new TestBlockTracker({ interval: 15 });
+      private start(interval: number) {
+        setInterval(() => {
+          this.latestBlockNumber += 1;
+          this.emit('latest', this.latestBlockNumber);
+        }, interval);
+      }
+    }
 
-        getNetworkClientById = jest
-          .fn()
-          .mockImplementation((networkClientId) => {
-            switch (networkClientId) {
-              case 'mainnet':
-                return {
-                  blockTracker: mainnetBlockTracker,
-                };
-              case 'goerli':
-                return {
-                  blockTracker: goerliBlockTracker,
-                };
-              case 'sepolia':
-                return {
-                  blockTracker: sepoliaBlockTracker,
-                };
-              default:
-                throw new Error(`Unknown networkClientId: ${networkClientId}`);
-            }
-          });
+    let getNetworkClientById: jest.Mock;
+    let mainnetBlockTracker: TestBlockTracker;
+    let goerliBlockTracker: TestBlockTracker;
+    let sepoliaBlockTracker: TestBlockTracker;
+    beforeEach(() => {
+      mainnetBlockTracker = new TestBlockTracker({ interval: 5 });
+      goerliBlockTracker = new TestBlockTracker({ interval: 10 });
+      sepoliaBlockTracker = new TestBlockTracker({ interval: 15 });
+
+      getNetworkClientById = jest.fn().mockImplementation((networkClientId) => {
+        switch (networkClientId) {
+          case 'mainnet':
+            return {
+              blockTracker: mainnetBlockTracker,
+            };
+          case 'goerli':
+            return {
+              blockTracker: goerliBlockTracker,
+            };
+          case 'sepolia':
+            return {
+              blockTracker: sepoliaBlockTracker,
+            };
+          default:
+            throw new Error(`Unknown networkClientId: ${networkClientId}`);
+        }
       });
+    });
 
-      it('should set the interval length to undefined', () => {
-        controller.setPollWithBlockTracker(getNetworkClientById);
+    it('should set the interval length to undefined', () => {
+      controller.setPollWithBlockTracker(getNetworkClientById);
 
-        expect(controller.getIntervalLength()).toBeUndefined();
-      });
+      expect(controller.getIntervalLength()).toBeUndefined();
+    });
 
-      it('should start polling for the specified networkClientId', async () => {
-        controller.setPollWithBlockTracker(getNetworkClientById);
+    it('should start polling for the specified networkClientId', async () => {
+      controller.setPollWithBlockTracker(getNetworkClientById);
 
-        controller.startPollingByNetworkClientId('mainnet');
+      controller.startPollingByNetworkClientId('mainnet');
 
-        expect(getNetworkClientById).toHaveBeenCalledWith('mainnet');
+      expect(getNetworkClientById).toHaveBeenCalledWith('mainnet');
 
-        await advanceTime({ clock, duration: 5 });
+      await advanceTime({ clock, duration: 5 });
 
-        expect(controller._executePoll).toHaveBeenCalledTimes(1);
+      expect(controller._executePoll).toHaveBeenCalledTimes(1);
 
-        await advanceTime({ clock, duration: 1 });
+      await advanceTime({ clock, duration: 1 });
 
-        expect(controller._executePoll).toHaveBeenCalledTimes(1);
+      expect(controller._executePoll).toHaveBeenCalledTimes(1);
 
-        await advanceTime({ clock, duration: 4 });
+      await advanceTime({ clock, duration: 4 });
 
-        expect(controller._executePoll.mock.calls).toMatchObject([
-          expect.arrayContaining(['mainnet', {}]),
-          expect.arrayContaining(['mainnet', {}]),
-        ]);
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        expect.arrayContaining(['mainnet', {}]),
+        expect.arrayContaining(['mainnet', {}]),
+      ]);
 
-        controller.stopAllPolling();
-      });
+      controller.stopAllPolling();
+    });
 
-      it('should poll on new block intervals for each networkClientId', async () => {
-        controller.setPollWithBlockTracker(getNetworkClientById);
+    it('should poll on new block intervals for each networkClientId', async () => {
+      controller.setPollWithBlockTracker(getNetworkClientById);
 
-        controller.startPollingByNetworkClientId('mainnet');
-        controller.startPollingByNetworkClientId('goerli');
-        await advanceTime({ clock, duration: 5 });
+      controller.startPollingByNetworkClientId('mainnet');
+      controller.startPollingByNetworkClientId('goerli');
+      await advanceTime({ clock, duration: 5 });
 
-        expect(controller._executePoll).toHaveBeenCalledTimes(1);
-        expect(controller._executePoll).toHaveBeenCalledWith('mainnet', {}, 1);
+      expect(controller._executePoll).toHaveBeenCalledTimes(1);
+      expect(controller._executePoll).toHaveBeenCalledWith('mainnet', {}, 1);
 
-        await advanceTime({ clock, duration: 5 });
+      await advanceTime({ clock, duration: 5 });
 
-        expect(controller._executePoll.mock.calls).toMatchObject([
-          ['mainnet', {}, 1],
-          ['mainnet', {}, 2],
-          ['goerli', {}, 1],
-        ]);
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['goerli', {}, 1],
+      ]);
 
-        await advanceTime({ clock, duration: 5 });
+      await advanceTime({ clock, duration: 5 });
 
-        expect(controller._executePoll.mock.calls).toMatchObject([
-          ['mainnet', {}, 1],
-          ['mainnet', {}, 2],
-          ['goerli', {}, 1],
-          ['mainnet', {}, 3],
-        ]);
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['goerli', {}, 1],
+        ['mainnet', {}, 3],
+      ]);
 
-        // 15ms have passed
-        // Start polling for sepolia, 15ms interval
-        controller.startPollingByNetworkClientId('sepolia');
+      // 15ms have passed
+      // Start polling for sepolia, 15ms interval
+      controller.startPollingByNetworkClientId('sepolia');
 
-        await advanceTime({ clock, duration: 15 });
+      await advanceTime({ clock, duration: 15 });
 
-        // at 30ms, 6 blocks have passed for mainnet (every 5ms), 3 for goerli (every 10ms), and 2 for sepolia (every 15ms)
-        // Didn't start listening to sepolia until 15ms had passed, so we only call executePoll on the 2nd block
-        expect(controller._executePoll.mock.calls).toMatchObject([
-          ['mainnet', {}, 1],
-          ['mainnet', {}, 2],
-          ['goerli', {}, 1],
-          ['mainnet', {}, 3],
-          ['mainnet', {}, 4],
-          ['goerli', {}, 2],
-          ['mainnet', {}, 5],
-          ['mainnet', {}, 6],
-          ['goerli', {}, 3],
-          ['sepolia', {}, 2],
-        ]);
+      // at 30ms, 6 blocks have passed for mainnet (every 5ms), 3 for goerli (every 10ms), and 2 for sepolia (every 15ms)
+      // Didn't start listening to sepolia until 15ms had passed, so we only call executePoll on the 2nd block
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['goerli', {}, 1],
+        ['mainnet', {}, 3],
+        ['mainnet', {}, 4],
+        ['goerli', {}, 2],
+        ['mainnet', {}, 5],
+        ['mainnet', {}, 6],
+        ['goerli', {}, 3],
+        ['sepolia', {}, 2],
+      ]);
 
-        controller.stopAllPolling();
-      });
+      controller.stopAllPolling();
+    });
 
-      it('should should stop polling when all polling tokens for a networkClientId are deleted', async () => {
-        controller.setPollWithBlockTracker(getNetworkClientById);
+    it('should should stop polling when all polling tokens for a networkClientId are deleted', async () => {
+      controller.setPollWithBlockTracker(getNetworkClientById);
 
-        const pollingToken1 =
-          controller.startPollingByNetworkClientId('mainnet');
+      const pollingToken1 = controller.startPollingByNetworkClientId('mainnet');
 
-        await advanceTime({ clock, duration: 5 });
+      await advanceTime({ clock, duration: 5 });
 
-        expect(controller._executePoll).toHaveBeenCalledTimes(1);
-        expect(controller._executePoll).toHaveBeenCalledWith('mainnet', {}, 1);
+      expect(controller._executePoll).toHaveBeenCalledTimes(1);
+      expect(controller._executePoll).toHaveBeenCalledWith('mainnet', {}, 1);
 
-        const pollingToken2 =
-          controller.startPollingByNetworkClientId('mainnet');
-        await advanceTime({ clock, duration: 5 });
+      const pollingToken2 = controller.startPollingByNetworkClientId('mainnet');
+      await advanceTime({ clock, duration: 5 });
 
-        expect(controller._executePoll.mock.calls).toMatchObject([
-          ['mainnet', {}, 1],
-          ['mainnet', {}, 2],
-        ]);
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+      ]);
 
-        controller.stopPollingByPollingToken(pollingToken1);
+      controller.stopPollingByPollingToken(pollingToken1);
 
-        await advanceTime({ clock, duration: 5 });
+      await advanceTime({ clock, duration: 5 });
 
-        expect(controller._executePoll.mock.calls).toMatchObject([
-          ['mainnet', {}, 1],
-          ['mainnet', {}, 2],
-          ['mainnet', {}, 3],
-        ]);
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['mainnet', {}, 3],
+      ]);
 
-        controller.stopPollingByPollingToken(pollingToken2);
+      controller.stopPollingByPollingToken(pollingToken2);
 
-        await advanceTime({ clock, duration: 15 });
+      await advanceTime({ clock, duration: 15 });
 
-        // no further polling should occur
-        expect(controller._executePoll.mock.calls).toMatchObject([
-          ['mainnet', {}, 1],
-          ['mainnet', {}, 2],
-          ['mainnet', {}, 3],
-        ]);
-      });
+      // no further polling should occur
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['mainnet', {}, 3],
+      ]);
+    });
 
-      it('should should stop polling for one networkClientId when all polling tokens for that networkClientId are deleted, without stopping polling for networkClientIds with active pollingTokens', async () => {
-        controller.setPollWithBlockTracker(getNetworkClientById);
+    it('should should stop polling for one networkClientId when all polling tokens for that networkClientId are deleted, without stopping polling for networkClientIds with active pollingTokens', async () => {
+      controller.setPollWithBlockTracker(getNetworkClientById);
 
-        const pollingToken1 =
-          controller.startPollingByNetworkClientId('mainnet');
+      const pollingToken1 = controller.startPollingByNetworkClientId('mainnet');
 
-        await advanceTime({ clock, duration: 5 });
+      await advanceTime({ clock, duration: 5 });
 
-        expect(controller._executePoll).toHaveBeenCalledWith('mainnet', {}, 1);
+      expect(controller._executePoll).toHaveBeenCalledWith('mainnet', {}, 1);
 
-        const pollingToken2 =
-          controller.startPollingByNetworkClientId('mainnet');
+      const pollingToken2 = controller.startPollingByNetworkClientId('mainnet');
 
-        await advanceTime({ clock, duration: 5 });
+      await advanceTime({ clock, duration: 5 });
 
-        expect(controller._executePoll.mock.calls).toMatchObject([
-          ['mainnet', {}, 1],
-          ['mainnet', {}, 2],
-        ]);
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+      ]);
 
-        controller.startPollingByNetworkClientId('goerli');
-        await advanceTime({ clock, duration: 5 });
+      controller.startPollingByNetworkClientId('goerli');
+      await advanceTime({ clock, duration: 5 });
 
-        // 3 blocks have passed for mainnet, 1 for goerli but we only started listening to goerli after 5ms
-        // so the next block will come at 20ms and be the 2nd block for goerli
-        expect(controller._executePoll.mock.calls).toMatchObject([
-          ['mainnet', {}, 1],
-          ['mainnet', {}, 2],
-          ['mainnet', {}, 3],
-        ]);
+      // 3 blocks have passed for mainnet, 1 for goerli but we only started listening to goerli after 5ms
+      // so the next block will come at 20ms and be the 2nd block for goerli
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['mainnet', {}, 3],
+      ]);
 
-        controller.stopPollingByPollingToken(pollingToken1);
+      controller.stopPollingByPollingToken(pollingToken1);
 
-        await advanceTime({ clock, duration: 5 });
+      await advanceTime({ clock, duration: 5 });
 
-        // 20ms have passed, 4 blocks for mainnet, 2 for goerli
-        expect(controller._executePoll.mock.calls).toMatchObject([
-          ['mainnet', {}, 1],
-          ['mainnet', {}, 2],
-          ['mainnet', {}, 3],
-          ['mainnet', {}, 4],
-          ['goerli', {}, 2],
-        ]);
+      // 20ms have passed, 4 blocks for mainnet, 2 for goerli
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['mainnet', {}, 3],
+        ['mainnet', {}, 4],
+        ['goerli', {}, 2],
+      ]);
 
-        controller.stopPollingByPollingToken(pollingToken2);
+      controller.stopPollingByPollingToken(pollingToken2);
 
-        await advanceTime({ clock, duration: 20 });
+      await advanceTime({ clock, duration: 20 });
 
-        // no further polling for mainnet should occur
-        expect(controller._executePoll.mock.calls).toMatchObject([
-          ['mainnet', {}, 1],
-          ['mainnet', {}, 2],
-          ['mainnet', {}, 3],
-          ['mainnet', {}, 4],
-          ['goerli', {}, 2],
-          ['goerli', {}, 3],
-          ['goerli', {}, 4],
-        ]);
+      // no further polling for mainnet should occur
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['mainnet', {}, 3],
+        ['mainnet', {}, 4],
+        ['goerli', {}, 2],
+        ['goerli', {}, 3],
+        ['goerli', {}, 4],
+      ]);
 
-        controller.stopAllPolling();
-      });
+      controller.stopAllPolling();
     });
   });
 });

--- a/packages/polling-controller/src/PollingController.test.ts
+++ b/packages/polling-controller/src/PollingController.test.ts
@@ -1,4 +1,5 @@
 import { ControllerMessenger } from '@metamask/base-controller';
+import EventEmitter from 'events';
 import { useFakeTimers } from 'sinon';
 
 import { advanceTime } from '../../../tests/helpers';
@@ -13,6 +14,10 @@ const createExecutePollMock = () => {
   return executePollMock;
 };
 
+class MyGasFeeController extends PollingController<any, any, any> {
+  _executePoll = createExecutePollMock();
+}
+
 describe('PollingController', () => {
   let clock: sinon.SinonFakeTimers;
   beforeEach(() => {
@@ -23,9 +28,6 @@ describe('PollingController', () => {
   });
   describe('start', () => {
     it('should start polling if not polling', async () => {
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
       const mockMessenger = new ControllerMessenger<any, any>();
 
       const controller = new MyGasFeeController({
@@ -44,9 +46,6 @@ describe('PollingController', () => {
   });
   describe('stop', () => {
     it('should stop polling when called with a valid polling that was the only active pollingToken for a given networkClient', async () => {
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
       const mockMessenger = new ControllerMessenger<any, any>();
 
       const controller = new MyGasFeeController({
@@ -65,9 +64,6 @@ describe('PollingController', () => {
       controller.stopAllPolling();
     });
     it('should not stop polling if called with one of multiple active polling tokens for a given networkClient', async () => {
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
       const mockMessenger = new ControllerMessenger<any, any>();
 
       const controller = new MyGasFeeController({
@@ -88,9 +84,6 @@ describe('PollingController', () => {
       controller.stopAllPolling();
     });
     it('should error if no pollingToken is passed', () => {
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
       const mockMessenger = new ControllerMessenger<any, any>();
 
       const controller = new MyGasFeeController({
@@ -106,9 +99,6 @@ describe('PollingController', () => {
       controller.stopAllPolling();
     });
     it('should error if no matching pollingToken is found', () => {
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
       const mockMessenger = new ControllerMessenger<any, any>();
 
       const controller = new MyGasFeeController({
@@ -126,9 +116,6 @@ describe('PollingController', () => {
   });
   describe('startPollingByNetworkClientId', () => {
     it('should call _executePoll immediately and on interval if polling', async () => {
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
       const mockMessenger = new ControllerMessenger<any, any>();
 
       const controller = new MyGasFeeController({
@@ -144,9 +131,6 @@ describe('PollingController', () => {
       expect(controller._executePoll).toHaveBeenCalledTimes(3);
     });
     it('should call _executePoll immediately once and continue calling _executePoll on interval when start is called again with the same networkClientId', async () => {
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
       const mockMessenger = new ControllerMessenger<any, any>();
 
       const controller = new MyGasFeeController({
@@ -169,9 +153,7 @@ describe('PollingController', () => {
     });
     it('should publish "pollingComplete" when stop is called', async () => {
       const pollingComplete: any = jest.fn();
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
+
       const name = 'PollingController';
 
       const mockMessenger = new ControllerMessenger<any, any>();
@@ -188,9 +170,6 @@ describe('PollingController', () => {
       expect(pollingComplete).toHaveBeenCalledTimes(1);
     });
     it('should poll at the interval length when set via setIntervalLength', async () => {
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
       const mockMessenger = new ControllerMessenger<any, any>();
 
       const controller = new MyGasFeeController({
@@ -211,9 +190,6 @@ describe('PollingController', () => {
       expect(controller._executePoll).toHaveBeenCalledTimes(2);
     });
     it('should start and stop polling sessions for different networkClientIds with the same options', async () => {
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
       const mockMessenger = new ControllerMessenger<any, any>();
 
       const controller = new MyGasFeeController({
@@ -263,9 +239,6 @@ describe('PollingController', () => {
   });
   describe('multiple networkClientIds', () => {
     it('should poll for each networkClientId', async () => {
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
       const mockMessenger = new ControllerMessenger<any, any>();
 
       const controller = new MyGasFeeController({
@@ -277,38 +250,35 @@ describe('PollingController', () => {
       controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
 
-      controller.startPollingByNetworkClientId('rinkeby');
+      controller.startPollingByNetworkClientId('goerli');
       await advanceTime({ clock, duration: 0 });
 
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
-        ['rinkeby', {}],
+        ['goerli', {}],
       ]);
       await advanceTime({ clock, duration: TICK_TIME });
 
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
-        ['rinkeby', {}],
+        ['goerli', {}],
         ['mainnet', {}],
-        ['rinkeby', {}],
+        ['goerli', {}],
       ]);
       await advanceTime({ clock, duration: TICK_TIME });
 
       expect(controller._executePoll.mock.calls).toMatchObject([
         ['mainnet', {}],
-        ['rinkeby', {}],
+        ['goerli', {}],
         ['mainnet', {}],
-        ['rinkeby', {}],
+        ['goerli', {}],
         ['mainnet', {}],
-        ['rinkeby', {}],
+        ['goerli', {}],
       ]);
       controller.stopAllPolling();
     });
 
     it('should poll multiple networkClientIds when setting interval length', async () => {
-      class MyGasFeeController extends PollingController<any, any, any> {
-        _executePoll = createExecutePollMock();
-      }
       const mockMessenger = new ControllerMessenger<any, any>();
 
       const controller = new MyGasFeeController({
@@ -381,6 +351,273 @@ describe('PollingController', () => {
       expect(c.stopAllPolling).toBeDefined();
       expect(c.startPollingByNetworkClientId).toBeDefined();
       expect(c.stopPollingByPollingToken).toBeDefined();
+    });
+  });
+  describe('startPollingByNetworkClientId after setPollOnNewBlocks', () => {
+    class TestBlockTracker extends EventEmitter {
+      private latestBlockNumber: number;
+
+      public interval: number;
+
+      constructor({ interval } = { interval: 1000 }) {
+        super();
+        this.latestBlockNumber = 0;
+        this.interval = interval;
+        this.start(interval);
+      }
+
+      private start(interval: number) {
+        setInterval(() => {
+          this.latestBlockNumber += 1;
+          this.emit('latest', this.latestBlockNumber);
+        }, interval);
+      }
+    }
+
+    let getNetworkClientById: jest.Mock;
+    let mainnetBlockTracker: TestBlockTracker;
+    let goerliBlockTracker: TestBlockTracker;
+    let sepoliaBlockTracker: TestBlockTracker;
+    beforeEach(() => {
+      mainnetBlockTracker = new TestBlockTracker({ interval: 5 });
+      goerliBlockTracker = new TestBlockTracker({ interval: 10 });
+      sepoliaBlockTracker = new TestBlockTracker({ interval: 15 });
+
+      getNetworkClientById = jest.fn().mockImplementation((networkClientId) => {
+        switch (networkClientId) {
+          case 'mainnet':
+            return {
+              blockTracker: mainnetBlockTracker,
+            };
+          case 'goerli':
+            return {
+              blockTracker: goerliBlockTracker,
+            };
+          case 'sepolia':
+            return {
+              blockTracker: sepoliaBlockTracker,
+            };
+          default:
+            throw new Error(`Unknown networkClientId: ${networkClientId}`);
+        }
+      });
+    });
+
+    it('should start polling for the specified networkClientId', async () => {
+      const mockMessenger = new ControllerMessenger<any, any>();
+
+      const controller = new MyGasFeeController({
+        messenger: mockMessenger,
+        metadata: {},
+        name: 'PollingController',
+        state: { foo: 'bar' },
+      });
+
+      // const getNetworkClientById = jest.fn().mockReturnValue({
+      //   blockTracker: new TestBlockTracker({ interval: 5 }),
+      // });
+
+      controller.setPollOnNewBlocks(getNetworkClientById);
+
+      controller.startPollingByNetworkClientId('mainnet');
+
+      expect(getNetworkClientById).toHaveBeenCalledWith('mainnet');
+
+      await advanceTime({ clock, duration: 5 });
+
+      expect(controller._executePoll).toHaveBeenCalledTimes(1);
+
+      await advanceTime({ clock, duration: 1 });
+
+      expect(controller._executePoll).toHaveBeenCalledTimes(1);
+
+      await advanceTime({ clock, duration: 4 });
+
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        expect.arrayContaining(['mainnet', {}]),
+        expect.arrayContaining(['mainnet', {}]),
+      ]);
+
+      // Stop all polling
+      controller.stopAllPolling();
+    });
+
+    it('should poll on new block intervals for each networkClientId', async () => {
+      const mockMessenger = new ControllerMessenger<any, any>();
+
+      const controller = new MyGasFeeController({
+        messenger: mockMessenger,
+        metadata: {},
+        name: 'PollingController',
+        state: { foo: 'bar' },
+      });
+
+      controller.setPollOnNewBlocks(getNetworkClientById);
+
+      controller.startPollingByNetworkClientId('mainnet');
+      controller.startPollingByNetworkClientId('goerli');
+      await advanceTime({ clock, duration: 5 });
+
+      expect(controller._executePoll).toHaveBeenCalledTimes(1);
+      expect(controller._executePoll).toHaveBeenCalledWith('mainnet', {}, 1);
+
+      // Start polling for goerli, 10ms interval
+      await advanceTime({ clock, duration: 5 });
+
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['goerli', {}, 1],
+      ]);
+
+      await advanceTime({ clock, duration: 5 });
+
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['goerli', {}, 1],
+        ['mainnet', {}, 3],
+      ]);
+
+      // 15ms have passed
+      // Start polling for sepolia, 15ms interval
+      controller.startPollingByNetworkClientId('sepolia');
+
+      await advanceTime({ clock, duration: 15 });
+
+      // at 30ms, 6 blocks have passed for mainnet (every 5ms), 3 for goerli (every 10ms), and 2 for sepolia (every 15ms)
+      // Didn't start listening to sepolia until 15ms had passed, so we only call executePoll on the 2nd block
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['goerli', {}, 1],
+        ['mainnet', {}, 3],
+        ['mainnet', {}, 4],
+        ['goerli', {}, 2],
+        ['mainnet', {}, 5],
+        ['mainnet', {}, 6],
+        ['goerli', {}, 3],
+        ['sepolia', {}, 2],
+      ]);
+
+      // Stop all polling
+      controller.stopAllPolling();
+    });
+
+    it('should should stop polling when all polling tokens for a networkClientId are deleted', async () => {
+      const mockMessenger = new ControllerMessenger<any, any>();
+
+      const controller = new MyGasFeeController({
+        messenger: mockMessenger,
+        metadata: {},
+        name: 'PollingController',
+        state: { foo: 'bar' },
+      });
+
+      controller.setPollOnNewBlocks(getNetworkClientById);
+
+      const pollingToken1 = controller.startPollingByNetworkClientId('mainnet');
+
+      await advanceTime({ clock, duration: 5 });
+
+      expect(controller._executePoll).toHaveBeenCalledTimes(1);
+      expect(controller._executePoll).toHaveBeenCalledWith('mainnet', {}, 1);
+
+      const pollingToken2 = controller.startPollingByNetworkClientId('mainnet');
+      await advanceTime({ clock, duration: 5 });
+
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+      ]);
+
+      controller.stopPollingByPollingToken(pollingToken1);
+
+      await advanceTime({ clock, duration: 5 });
+
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['mainnet', {}, 3],
+      ]);
+
+      controller.stopPollingByPollingToken(pollingToken2);
+
+      await advanceTime({ clock, duration: 15 });
+
+      // no further polling should occur
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['mainnet', {}, 3],
+      ]);
+    });
+
+    it('should should stop polling when all polling tokens for a networkClientId are deleted, even if other networkClientIds are still polling', async () => {
+      const mockMessenger = new ControllerMessenger<any, any>();
+
+      const controller = new MyGasFeeController({
+        messenger: mockMessenger,
+        metadata: {},
+        name: 'PollingController',
+        state: { foo: 'bar' },
+      });
+
+      controller.setPollOnNewBlocks(getNetworkClientById);
+
+      const pollingToken1 = controller.startPollingByNetworkClientId('mainnet');
+
+      await advanceTime({ clock, duration: 5 });
+
+      expect(controller._executePoll).toHaveBeenCalledWith('mainnet', {}, 1);
+
+      const pollingToken2 = controller.startPollingByNetworkClientId('mainnet');
+
+      await advanceTime({ clock, duration: 5 });
+
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+      ]);
+
+      controller.startPollingByNetworkClientId('goerli');
+      await advanceTime({ clock, duration: 5 });
+
+      // 3 blocks have passed for mainnet, 1 for goerli but we only started listening to goerli after 5ms
+      // so the next block will come at 20ms and be the 2nd block for goerli
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['mainnet', {}, 3],
+      ]);
+
+      controller.stopPollingByPollingToken(pollingToken1);
+
+      await advanceTime({ clock, duration: 5 });
+
+      // 20ms have passed, 4 blocks for mainnet, 2 for goerli
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['mainnet', {}, 3],
+        ['mainnet', {}, 4],
+        ['goerli', {}, 2],
+      ]);
+
+      controller.stopPollingByPollingToken(pollingToken2);
+
+      await advanceTime({ clock, duration: 20 });
+
+      // no further polling for mainnet should occur
+      expect(controller._executePoll.mock.calls).toMatchObject([
+        ['mainnet', {}, 1],
+        ['mainnet', {}, 2],
+        ['mainnet', {}, 3],
+        ['mainnet', {}, 4],
+        ['goerli', {}, 2],
+        ['goerli', {}, 3],
+        ['goerli', {}, 4],
+      ]);
     });
   });
 });

--- a/packages/polling-controller/src/PollingController.test.ts
+++ b/packages/polling-controller/src/PollingController.test.ts
@@ -20,7 +20,16 @@ class MyGasFeeController extends PollingController<any, any, any> {
 
 describe('PollingController', () => {
   let clock: sinon.SinonFakeTimers;
+  let mockMessenger: any;
+  let controller: any;
   beforeEach(() => {
+    mockMessenger = new ControllerMessenger<any, any>();
+    controller = new MyGasFeeController({
+      messenger: mockMessenger,
+      metadata: {},
+      name: 'PollingController',
+      state: { foo: 'bar' },
+    });
     clock = useFakeTimers();
   });
   afterEach(() => {
@@ -28,14 +37,6 @@ describe('PollingController', () => {
   });
   describe('start', () => {
     it('should start polling if not polling', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
       controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
       expect(controller._executePoll).toHaveBeenCalledTimes(1);
@@ -46,14 +47,6 @@ describe('PollingController', () => {
   });
   describe('stop', () => {
     it('should stop polling when called with a valid polling that was the only active pollingToken for a given networkClient', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
       const pollingToken = controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
       expect(controller._executePoll).toHaveBeenCalledTimes(1);
@@ -64,14 +57,6 @@ describe('PollingController', () => {
       controller.stopAllPolling();
     });
     it('should not stop polling if called with one of multiple active polling tokens for a given networkClient', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
       const pollingToken1 = controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
 
@@ -84,14 +69,6 @@ describe('PollingController', () => {
       controller.stopAllPolling();
     });
     it('should error if no pollingToken is passed', () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
       controller.startPollingByNetworkClientId('mainnet');
       expect(() => {
         controller.stopPollingByPollingToken(undefined as unknown as any);
@@ -99,14 +76,6 @@ describe('PollingController', () => {
       controller.stopAllPolling();
     });
     it('should error if no matching pollingToken is found', () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
       controller.startPollingByNetworkClientId('mainnet');
       expect(() => {
         controller.stopPollingByPollingToken('potato');
@@ -116,14 +85,6 @@ describe('PollingController', () => {
   });
   describe('startPollingByNetworkClientId', () => {
     it('should call _executePoll immediately and on interval if polling', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
       controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
       expect(controller._executePoll).toHaveBeenCalledTimes(1);
@@ -131,14 +92,6 @@ describe('PollingController', () => {
       expect(controller._executePoll).toHaveBeenCalledTimes(3);
     });
     it('should call _executePoll immediately once and continue calling _executePoll on interval when start is called again with the same networkClientId', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
       controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
 
@@ -153,31 +106,12 @@ describe('PollingController', () => {
     });
     it('should publish "pollingComplete" when stop is called', async () => {
       const pollingComplete: any = jest.fn();
-
-      const name = 'PollingController';
-
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name,
-        state: { foo: 'bar' },
-      });
       controller.onPollingCompleteByNetworkClientId('mainnet', pollingComplete);
       const pollingToken = controller.startPollingByNetworkClientId('mainnet');
       controller.stopPollingByPollingToken(pollingToken);
       expect(pollingComplete).toHaveBeenCalledTimes(1);
     });
     it('should poll at the interval length when set via setIntervalLength', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
       controller.setIntervalLength(TICK_TIME);
       controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
@@ -190,14 +124,6 @@ describe('PollingController', () => {
       expect(controller._executePoll).toHaveBeenCalledTimes(2);
     });
     it('should start and stop polling sessions for different networkClientIds with the same options', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
       const pollToken1 = controller.startPollingByNetworkClientId('mainnet', {
         address: '0x1',
       });
@@ -239,14 +165,6 @@ describe('PollingController', () => {
   });
   describe('multiple networkClientIds', () => {
     it('should poll for each networkClientId', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
       controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
 
@@ -279,14 +197,6 @@ describe('PollingController', () => {
     });
 
     it('should poll multiple networkClientIds when setting interval length', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
       controller.setIntervalLength(TICK_TIME * 2);
       controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
@@ -404,19 +314,6 @@ describe('PollingController', () => {
     });
 
     it('should start polling for the specified networkClientId', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
-
-      // const getNetworkClientById = jest.fn().mockReturnValue({
-      //   blockTracker: new TestBlockTracker({ interval: 5 }),
-      // });
-
       controller.setPollOnNewBlocks(getNetworkClientById);
 
       controller.startPollingByNetworkClientId('mainnet');
@@ -438,20 +335,10 @@ describe('PollingController', () => {
         expect.arrayContaining(['mainnet', {}]),
       ]);
 
-      // Stop all polling
       controller.stopAllPolling();
     });
 
     it('should poll on new block intervals for each networkClientId', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
-
       controller.setPollOnNewBlocks(getNetworkClientById);
 
       controller.startPollingByNetworkClientId('mainnet');
@@ -500,20 +387,10 @@ describe('PollingController', () => {
         ['sepolia', {}, 2],
       ]);
 
-      // Stop all polling
       controller.stopAllPolling();
     });
 
     it('should should stop polling when all polling tokens for a networkClientId are deleted', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
-
       controller.setPollOnNewBlocks(getNetworkClientById);
 
       const pollingToken1 = controller.startPollingByNetworkClientId('mainnet');
@@ -551,18 +428,11 @@ describe('PollingController', () => {
         ['mainnet', {}, 2],
         ['mainnet', {}, 3],
       ]);
+
+      controller.stopAllPolling();
     });
 
     it('should should stop polling when all polling tokens for a networkClientId are deleted, even if other networkClientIds are still polling', async () => {
-      const mockMessenger = new ControllerMessenger<any, any>();
-
-      const controller = new MyGasFeeController({
-        messenger: mockMessenger,
-        metadata: {},
-        name: 'PollingController',
-        state: { foo: 'bar' },
-      });
-
       controller.setPollOnNewBlocks(getNetworkClientById);
 
       const pollingToken1 = controller.startPollingByNetworkClientId('mainnet');
@@ -618,6 +488,8 @@ describe('PollingController', () => {
         ['goerli', {}, 3],
         ['goerli', {}, 4],
       ]);
+
+      controller.stopAllPolling();
     });
   });
 });

--- a/packages/polling-controller/src/PollingController.ts
+++ b/packages/polling-controller/src/PollingController.ts
@@ -143,8 +143,10 @@ function PollingControllerMixin<TBase extends Constructor>(Base: TBase) {
           found = true;
           tokenSet.delete(pollingToken);
           if (tokenSet.size === 0) {
-            clearTimeout(this.#intervalIds[key]);
-            delete this.#intervalIds[key];
+            if (this.#intervalIds[key]) {
+              clearTimeout(this.#intervalIds[key]);
+              delete this.#intervalIds[key];
+            }
 
             // if applicable stop listening for new blocks
             if (this.#getNetworkClientById !== undefined) {

--- a/packages/polling-controller/src/PollingController.ts
+++ b/packages/polling-controller/src/PollingController.ts
@@ -1,8 +1,9 @@
-import { BaseController, BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController, BaseControllerV1 } from '@metamask/base-controller';
 import type {
   NetworkClientId,
   NetworkClient,
 } from '@metamask/network-controller';
+import type { Json } from '@metamask/utils';
 import stringify from 'fast-json-stable-stringify';
 import { v4 as random } from 'uuid';
 
@@ -188,6 +189,7 @@ function PollingControllerMixin<TBase extends Constructor>(Base: TBase) {
 
         if (blockTracker) {
           const updateOnNewBlock = this._executePoll.bind(
+            this,
             networkClientId,
             options,
           );
@@ -252,5 +254,5 @@ function PollingControllerMixin<TBase extends Constructor>(Base: TBase) {
 class Empty {}
 
 export const PollingControllerOnly = PollingControllerMixin(Empty);
-export const PollingController = PollingControllerMixin(BaseControllerV2);
-export const PollingControllerV1 = PollingControllerMixin(BaseController);
+export const PollingController = PollingControllerMixin(BaseController);
+export const PollingControllerV1 = PollingControllerMixin(BaseControllerV1);

--- a/packages/polling-controller/src/PollingController.ts
+++ b/packages/polling-controller/src/PollingController.ts
@@ -61,6 +61,10 @@ function PollingControllerMixin<TBase extends Constructor>(Base: TBase) {
       return this.#intervalLength;
     }
 
+    getPollingWithBlockTracker() {
+      return this.#getNetworkClientById !== undefined;
+    }
+
     /**
      * Sets the length of the polling interval
      *
@@ -68,17 +72,22 @@ function PollingControllerMixin<TBase extends Constructor>(Base: TBase) {
      */
     setIntervalLength(length: number) {
       this.#intervalLength = length;
+
+      // setting and using an interval is mutually exclusive with polling on new blocks
+      this.#getNetworkClientById = undefined;
     }
 
-    setPollOnNewBlocks(
+    setPollWithBlockTracker(
       getNetworkClientById: (networkClientId: NetworkClientId) => NetworkClient,
     ) {
       if (!getNetworkClientById) {
         throw new Error('getNetworkClientById callback required');
       }
 
-      this.#intervalLength = 0;
       this.#getNetworkClientById = getNetworkClientById;
+
+      // using block times is mutually exclusive with polling on a static interval
+      this.#intervalLength = 0;
     }
 
     /**


### PR DESCRIPTION
Addresses: https://github.com/MetaMask/MetaMask-planning/issues/1788

[@matthewwalsh0](https://github.com/matthewwalsh0) and the Confirmation Systems Team is hoping to use the `PollingController` for a new `UserOperationController` but are needing to tie polling intervals to block times rather than a static interval length. This is achievable using the vanilla blockTracker and adding callbacks to its listeners but we will want to multiplex it for multichain and it so it makes sense to do so using the `PollingController` abstraction since they are basically doing the same thing but just using a different source for the interval of execution.