### PR TITLE
Fix TokenRatesController write to legacy contractExchangeRates

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -335,11 +335,6 @@ export class TokenRatesController extends PollingControllerV1<
       nativeCurrency,
       tokenContractAddresses,
     });
-
-    this.update({
-      contractExchangeRates:
-        this.state.contractExchangeRatesByChainId[chainId][nativeCurrency],
-    });
   }
 
   /**
@@ -373,6 +368,9 @@ export class TokenRatesController extends PollingControllerV1<
       this.state.contractExchangeRatesByChainId[chainId] ?? {};
 
     this.update({
+      ...(chainId === this.config.chainId && {
+        contractExchangeRates: newContractExchangeRates
+      }),
       contractExchangeRatesByChainId: {
         ...this.state.contractExchangeRatesByChainId,
         [chainId]: {

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -366,19 +366,20 @@ export class TokenRatesController extends PollingControllerV1<
 
     const existingContractExchangeRatesForChainId =
       this.state.contractExchangeRatesByChainId[chainId] ?? {};
+    const contractExchangeRatesForNativeCurrency = {
+      ...existingContractExchangeRatesForChainId[nativeCurrency],
+      ...newContractExchangeRates,
+    };
 
     this.update({
       ...(chainId === this.config.chainId && {
-        contractExchangeRates: newContractExchangeRates
+        contractExchangeRates: contractExchangeRatesForNativeCurrency,
       }),
       contractExchangeRatesByChainId: {
         ...this.state.contractExchangeRatesByChainId,
         [chainId]: {
           ...existingContractExchangeRatesForChainId,
-          [nativeCurrency]: {
-            ...existingContractExchangeRatesForChainId[nativeCurrency],
-            ...newContractExchangeRates,
-          },
+          [nativeCurrency]: contractExchangeRatesForNativeCurrency,
         },
       },
     });


### PR DESCRIPTION
## Explanation

Currently in `TokenRatesController` it is possible for the wrong chainId's `contractExchangeRates` to populate `state. contractExchangeRates` if the network changed in the middle of a `updateExchangeRates` execution. This PR fixes this issue by adding a guard to check if the chainId is still matching rather than assuming it still does.

## References

* Fixes https://github.com/MetaMask/MetaMask-planning/issues/1122

## Changelog

### `@metamask/assets-controllers`

- **FIXED**: No longer possible for `TokenRatesController` to update `contractExchangeRates` with stale data if the network changes in the middle of a call to `updateExchangeRates`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
