### PR TITLE
fix(assets-controllers): Prevent overlapping token rate updates

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -146,7 +146,7 @@ export class TokenRatesController extends PollingControllerV1<
 
   #tokenPricesService: AbstractTokenPricesService;
 
-  #inProcessExchangeRateUpdate: Record<Hex, Promise<void>> = {};
+  #inProcessExchangeRateUpdate: Record<`${Hex}:${string}`, Promise<void>> = {};
 
   /**
    * Name of this controller used during composition
@@ -362,11 +362,12 @@ export class TokenRatesController extends PollingControllerV1<
       return;
     }
 
-    if (chainId in this.#inProcessExchangeRateUpdate) {
+    const updateKey: `${Hex}:${string}` = `${chainId}:${nativeCurrency}`;
+    if (updateKey in this.#inProcessExchangeRateUpdate) {
       // This prevents redundant updates
       // This promise is resolved after the in-progress update has finished,
       // and state has been updated.
-      await this.#inProcessExchangeRateUpdate[chainId];
+      await this.#inProcessExchangeRateUpdate[updateKey];
       return;
     }
 
@@ -375,7 +376,7 @@ export class TokenRatesController extends PollingControllerV1<
       resolve: updateSucceeded,
       reject: updateFailed,
     } = deferredPromise({ suppressUnhandledRejection: true });
-    this.#inProcessExchangeRateUpdate[chainId] = inProgressUpdate;
+    this.#inProcessExchangeRateUpdate[updateKey] = inProgressUpdate;
 
     try {
       const newContractExchangeRates = await this.#fetchAndMapExchangeRates({
@@ -413,7 +414,7 @@ export class TokenRatesController extends PollingControllerV1<
       updateFailed(error);
       throw error;
     } finally {
-      delete this.#inProcessExchangeRateUpdate[chainId];
+      delete this.#inProcessExchangeRateUpdate[updateKey];
     }
   }
 

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -146,7 +146,7 @@ export class TokenRatesController extends PollingControllerV1<
 
   #tokenPricesService: AbstractTokenPricesService;
 
-  #inProcessExchangeRateUpdate: Record<`${Hex}:${string}`, Promise<void>> = {};
+  #inProcessExchangeRateUpdates: Record<`${Hex}:${string}`, Promise<void>> = {};
 
   /**
    * Name of this controller used during composition
@@ -363,11 +363,11 @@ export class TokenRatesController extends PollingControllerV1<
     }
 
     const updateKey: `${Hex}:${string}` = `${chainId}:${nativeCurrency}`;
-    if (updateKey in this.#inProcessExchangeRateUpdate) {
+    if (updateKey in this.#inProcessExchangeRateUpdates) {
       // This prevents redundant updates
       // This promise is resolved after the in-progress update has finished,
       // and state has been updated.
-      await this.#inProcessExchangeRateUpdate[updateKey];
+      await this.#inProcessExchangeRateUpdates[updateKey];
       return;
     }
 
@@ -376,7 +376,7 @@ export class TokenRatesController extends PollingControllerV1<
       resolve: updateSucceeded,
       reject: updateFailed,
     } = deferredPromise({ suppressUnhandledRejection: true });
-    this.#inProcessExchangeRateUpdate[updateKey] = inProgressUpdate;
+    this.#inProcessExchangeRateUpdates[updateKey] = inProgressUpdate;
 
     try {
       const newContractExchangeRates = await this.#fetchAndMapExchangeRates({
@@ -414,7 +414,7 @@ export class TokenRatesController extends PollingControllerV1<
       updateFailed(error);
       throw error;
     } finally {
-      delete this.#inProcessExchangeRateUpdate[updateKey];
+      delete this.#inProcessExchangeRateUpdates[updateKey];
     }
   }
 

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -146,6 +146,8 @@ export class TokenRatesController extends PollingControllerV1<
 
   #tokenPricesService: AbstractTokenPricesService;
 
+  #inProcessExchangeRateUpdate: Record<Hex, Promise<void>> = {};
+
   /**
    * Name of this controller used during composition
    */
@@ -360,36 +362,59 @@ export class TokenRatesController extends PollingControllerV1<
       return;
     }
 
-    const newContractExchangeRates = await this.#fetchAndMapExchangeRates({
-      tokenContractAddresses,
-      chainId,
-      nativeCurrency,
-    });
+    if (chainId in this.#inProcessExchangeRateUpdate) {
+      // This prevents redundant updates
+      // This promise is resolved after the in-progress update has finished,
+      // and state has been updated.
+      await this.#inProcessExchangeRateUpdate[chainId];
+      return;
+    }
 
-    const existingContractExchangeRates = this.state.contractExchangeRates;
-    const updatedContractExchangeRates =
-      chainId === this.config.chainId &&
-      nativeCurrency === this.config.nativeCurrency
-        ? newContractExchangeRates
-        : existingContractExchangeRates;
+    const {
+      promise: inProgressUpdate,
+      resolve: updateSucceeded,
+      reject: updateFailed,
+    } = deferredPromise({ suppressUnhandledRejection: true });
+    this.#inProcessExchangeRateUpdate[chainId] = inProgressUpdate;
 
-    const existingContractExchangeRatesForChainId =
-      this.state.contractExchangeRatesByChainId[chainId] ?? {};
-    const updatedContractExchangeRatesForChainId = {
-      ...this.state.contractExchangeRatesByChainId,
-      [chainId]: {
-        ...existingContractExchangeRatesForChainId,
-        [nativeCurrency]: {
-          ...existingContractExchangeRatesForChainId[nativeCurrency],
-          ...newContractExchangeRates,
+    try {
+      const newContractExchangeRates = await this.#fetchAndMapExchangeRates({
+        tokenContractAddresses,
+        chainId,
+        nativeCurrency,
+      });
+
+      const existingContractExchangeRates = this.state.contractExchangeRates;
+      const updatedContractExchangeRates =
+        chainId === this.config.chainId &&
+        nativeCurrency === this.config.nativeCurrency
+          ? newContractExchangeRates
+          : existingContractExchangeRates;
+
+      const existingContractExchangeRatesForChainId =
+        this.state.contractExchangeRatesByChainId[chainId] ?? {};
+      const updatedContractExchangeRatesForChainId = {
+        ...this.state.contractExchangeRatesByChainId,
+        [chainId]: {
+          ...existingContractExchangeRatesForChainId,
+          [nativeCurrency]: {
+            ...existingContractExchangeRatesForChainId[nativeCurrency],
+            ...newContractExchangeRates,
+          },
         },
-      },
-    };
+      };
 
-    this.update({
-      contractExchangeRates: updatedContractExchangeRates,
-      contractExchangeRatesByChainId: updatedContractExchangeRatesForChainId,
-    });
+      this.update({
+        contractExchangeRates: updatedContractExchangeRates,
+        contractExchangeRatesByChainId: updatedContractExchangeRatesForChainId,
+      });
+      updateSucceeded();
+    } catch (error: unknown) {
+      updateFailed(error);
+      throw error;
+    } finally {
+      delete this.#inProcessExchangeRateUpdate[chainId];
+    }
   }
 
   /**
@@ -546,6 +571,62 @@ export class TokenRatesController extends PollingControllerV1<
       {},
     );
   }
+}
+
+/**
+ * A deferred Promise.
+ *
+ * A deferred Promise is one that can be resolved or rejected independently of
+ * the Promise construction.
+ */
+type DeferredPromise = {
+  /**
+   * The Promise that has been deferred.
+   */
+  promise: Promise<void>;
+  /**
+   * A function that resolves the Promise.
+   */
+  resolve: () => void;
+  /**
+   * A function that rejects the Promise.
+   */
+  reject: (error: unknown) => void;
+};
+
+/**
+ * Create a defered Promise.
+ *
+ * TODO: Migrate this to utils
+ *
+ * @param args - The arguments.
+ * @param args.suppressUnhandledRejection - This option adds an empty error handler
+ * to the Promise to suppress the UnhandledPromiseRejection error. This can be
+ * useful if the deferred Promise is sometimes intentionally not used.
+ * @returns A deferred Promise.
+ */
+function deferredPromise({
+  suppressUnhandledRejection = false,
+}: {
+  suppressUnhandledRejection: boolean;
+}): DeferredPromise {
+  let resolve: DeferredPromise['resolve'];
+  let reject: DeferredPromise['reject'];
+  const promise = new Promise<void>(
+    (innerResolve: () => void, innerReject: () => void) => {
+      resolve = innerResolve;
+      reject = innerReject;
+    },
+  );
+
+  if (suppressUnhandledRejection) {
+    promise.catch((_error) => {
+      // This handler is used to suppress the UnhandledPromiseRejection error
+    });
+  }
+
+  // @ts-expect-error We know that these are assigned, but TypeScript doesn't
+  return { promise, resolve, reject };
 }
 
 export default TokenRatesController;

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -375,7 +375,7 @@ export class TokenRatesController extends PollingControllerV1<
       promise: inProgressUpdate,
       resolve: updateSucceeded,
       reject: updateFailed,
-    } = deferredPromise({ suppressUnhandledRejection: true });
+    } = createDeferredPromise({ suppressUnhandledRejection: true });
     this.#inProcessExchangeRateUpdates[updateKey] = inProgressUpdate;
 
     try {
@@ -606,7 +606,7 @@ type DeferredPromise = {
  * useful if the deferred Promise is sometimes intentionally not used.
  * @returns A deferred Promise.
  */
-function deferredPromise({
+function createDeferredPromise({
   suppressUnhandledRejection = false,
 }: {
   suppressUnhandledRejection: boolean;


### PR DESCRIPTION
## Explanation

Previously it was possible for two redundant token rate updates to be ongoing at the same time. This is non-optimal for performance reasons, and because the answer might change between the two requests and get persisted in the wrong order.

We now guard against this by storing in-progress updates as a private instance variable. Any redundant calls will wait on the in-progress call to finish, then return as a no-op.

## References

Fixes #3606

## Changelog

### `@metamask/assets-controllers`

-Fixed: Prevent overlapping token rate updates
  - This should have no impact to the API at all, it just reduces network traffic

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
