### PR TITLE
feat(assets-controllers): Drop support for updating arbitary token rates

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -17,6 +17,7 @@ import type { TokenRatesConfig } from './TokenRatesController';
 import type { TokensState } from './TokensController';
 
 const defaultSelectedAddress = '0x0000000000000000000000000000000000000001';
+const mockTokenAddress = '0x0000000000000000000000000000000000000010';
 
 describe('TokenRatesController', () => {
   afterEach(() => {
@@ -127,7 +128,12 @@ describe('TokenRatesController', () => {
             allTokens: {
               '0x1': {
                 [defaultSelectedAddress]: [
-                  { address: 'bar', decimals: 0, symbol: '', aggregators: [] },
+                  {
+                    address: mockTokenAddress,
+                    decimals: 0,
+                    symbol: '',
+                    aggregators: [],
+                  },
                 ],
               },
             },
@@ -144,7 +150,12 @@ describe('TokenRatesController', () => {
           allTokens: {
             '0x1': {
               [defaultSelectedAddress]: [
-                { address: 'foo', decimals: 0, symbol: '', aggregators: [] },
+                {
+                  address: mockTokenAddress,
+                  decimals: 0,
+                  symbol: '',
+                  aggregators: [],
+                },
               ],
             },
           },
@@ -162,7 +173,12 @@ describe('TokenRatesController', () => {
         const allTokens = {
           '0x1': {
             [defaultSelectedAddress]: [
-              { address: 'foo', decimals: 0, symbol: '', aggregators: [] },
+              {
+                address: mockTokenAddress,
+                decimals: 0,
+                symbol: '',
+                aggregators: [],
+              },
             ],
           },
         };
@@ -196,7 +212,12 @@ describe('TokenRatesController', () => {
           allDetectedTokens,
           allTokens,
           tokens: [
-            { address: 'bar', decimals: 0, symbol: '', aggregators: [] },
+            {
+              address: mockTokenAddress,
+              decimals: 0,
+              symbol: '',
+              aggregators: [],
+            },
           ],
         });
 
@@ -226,7 +247,12 @@ describe('TokenRatesController', () => {
             allTokens: {
               '0x1': {
                 [defaultSelectedAddress]: [
-                  { address: 'bar', decimals: 0, symbol: '', aggregators: [] },
+                  {
+                    address: mockTokenAddress,
+                    decimals: 0,
+                    symbol: '',
+                    aggregators: [],
+                  },
                 ],
               },
             },
@@ -242,7 +268,12 @@ describe('TokenRatesController', () => {
           allTokens: {
             '0x1': {
               [defaultSelectedAddress]: [
-                { address: 'foo', decimals: 0, symbol: '', aggregators: [] },
+                {
+                  address: mockTokenAddress,
+                  decimals: 0,
+                  symbol: '',
+                  aggregators: [],
+                },
               ],
             },
           },
@@ -256,6 +287,10 @@ describe('TokenRatesController', () => {
         const onTokensStateChange = jest.fn().mockImplementation((listener) => {
           tokenStateChangeListener = listener;
         });
+        const tokenAddresses = [
+          '0x0000000000000000000000000000000000000010',
+          '0x0000000000000000000000000000000000000020',
+        ];
         const controller = new TokenRatesController(
           {
             interval: 100,
@@ -272,7 +307,12 @@ describe('TokenRatesController', () => {
             allDetectedTokens: {
               [toHex(1)]: {
                 [defaultSelectedAddress]: [
-                  { address: 'bar', decimals: 0, symbol: '', aggregators: [] },
+                  {
+                    address: tokenAddresses[0],
+                    decimals: 0,
+                    symbol: '',
+                    aggregators: [],
+                  },
                 ],
               },
             },
@@ -288,7 +328,12 @@ describe('TokenRatesController', () => {
           allDetectedTokens: {
             [toHex(1)]: {
               [defaultSelectedAddress]: [
-                { address: 'foo', decimals: 0, symbol: '', aggregators: [] },
+                {
+                  address: tokenAddresses[1],
+                  decimals: 0,
+                  symbol: '',
+                  aggregators: [],
+                },
               ],
             },
           },
@@ -764,7 +809,12 @@ describe('TokenRatesController', () => {
             allTokens: {
               '0x1': {
                 [defaultSelectedAddress]: [
-                  { address: 'bar', decimals: 0, symbol: '', aggregators: [] },
+                  {
+                    address: mockTokenAddress,
+                    decimals: 0,
+                    symbol: '',
+                    aggregators: [],
+                  },
                 ],
               },
             },
@@ -803,7 +853,12 @@ describe('TokenRatesController', () => {
             allTokens: {
               '0x1': {
                 [defaultSelectedAddress]: [
-                  { address: 'bar', decimals: 0, symbol: '', aggregators: [] },
+                  {
+                    address: mockTokenAddress,
+                    decimals: 0,
+                    symbol: '',
+                    aggregators: [],
+                  },
                 ],
               },
             },
@@ -836,26 +891,40 @@ describe('TokenRatesController', () => {
       const interval = 100;
       const tokenPricesService = buildMockTokenPricesService();
       jest.spyOn(tokenPricesService, 'fetchTokenPrices');
-      const controller = new TokenRatesController({
-        interval,
-        chainId: '0x2',
-        ticker: 'ticker',
-        selectedAddress: '0xdeadbeef',
-        onPreferencesStateChange: jest.fn(),
-        onTokensStateChange: jest.fn(),
-        onNetworkStateChange: jest.fn(),
-        getNetworkClientById: jest.fn().mockReturnValue({
-          configuration: {
-            chainId: '0x1',
-            ticker: NetworksTicker.mainnet,
+      const controller = new TokenRatesController(
+        {
+          interval,
+          chainId: '0x2',
+          ticker: 'ticker',
+          selectedAddress: defaultSelectedAddress,
+          onPreferencesStateChange: jest.fn(),
+          onTokensStateChange: jest.fn(),
+          onNetworkStateChange: jest.fn(),
+          getNetworkClientById: jest.fn().mockReturnValue({
+            configuration: {
+              chainId: '0x1',
+              ticker: NetworksTicker.mainnet,
+            },
+          }),
+          tokenPricesService,
+        },
+        {
+          allTokens: {
+            '0x1': {
+              [defaultSelectedAddress]: [
+                {
+                  address: mockTokenAddress,
+                  decimals: 0,
+                  symbol: '',
+                  aggregators: [],
+                },
+              ],
+            },
           },
-        }),
-        tokenPricesService,
-      });
+        },
+      );
 
-      controller.startPollingByNetworkClientId('mainnet', {
-        tokenAddresses: ['0x0'],
-      });
+      controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
       expect(tokenPricesService.fetchTokenPrices).toHaveBeenCalledTimes(1);
 
@@ -875,25 +944,45 @@ describe('TokenRatesController', () => {
               return currency === 'ETH';
             },
           });
-          const controller = new TokenRatesController({
-            chainId: '0x2',
-            ticker: 'ticker',
-            selectedAddress: '0xdeadbeef',
-            onPreferencesStateChange: jest.fn(),
-            onTokensStateChange: jest.fn(),
-            onNetworkStateChange: jest.fn(),
-            getNetworkClientById: jest.fn().mockReturnValue({
-              configuration: {
-                chainId: '0x1',
-                ticker: NetworksTicker.mainnet,
+          const controller = new TokenRatesController(
+            {
+              chainId: '0x2',
+              ticker: 'ticker',
+              selectedAddress: defaultSelectedAddress,
+              onPreferencesStateChange: jest.fn(),
+              onTokensStateChange: jest.fn(),
+              onNetworkStateChange: jest.fn(),
+              getNetworkClientById: jest.fn().mockReturnValue({
+                configuration: {
+                  chainId: '0x1',
+                  ticker: NetworksTicker.mainnet,
+                },
+              }),
+              tokenPricesService,
+            },
+            {
+              allTokens: {
+                '0x1': {
+                  [defaultSelectedAddress]: [
+                    {
+                      address: '0x02',
+                      decimals: 0,
+                      symbol: '',
+                      aggregators: [],
+                    },
+                    {
+                      address: '0x03',
+                      decimals: 0,
+                      symbol: '',
+                      aggregators: [],
+                    },
+                  ],
+                },
               },
-            }),
-            tokenPricesService,
-          });
+            },
+          );
 
-          controller.startPollingByNetworkClientId('mainnet', {
-            tokenAddresses: ['0x02', '0x03'],
-          });
+          controller.startPollingByNetworkClientId('mainnet');
           await advanceTime({ clock, duration: 0 });
 
           expect(controller.state.contractExchangeRatesByChainId).toStrictEqual(
@@ -921,25 +1010,45 @@ describe('TokenRatesController', () => {
               return currency !== 'LOL';
             },
           });
-          const controller = new TokenRatesController({
-            chainId: '0x2',
-            ticker: 'ticker',
-            selectedAddress: '0xdeadbeef',
-            onPreferencesStateChange: jest.fn(),
-            onTokensStateChange: jest.fn(),
-            onNetworkStateChange: jest.fn(),
-            getNetworkClientById: jest.fn().mockReturnValue({
-              configuration: {
-                chainId: '0x1',
-                ticker: 'LOL',
+          const controller = new TokenRatesController(
+            {
+              chainId: '0x2',
+              ticker: 'ticker',
+              selectedAddress: defaultSelectedAddress,
+              onPreferencesStateChange: jest.fn(),
+              onTokensStateChange: jest.fn(),
+              onNetworkStateChange: jest.fn(),
+              getNetworkClientById: jest.fn().mockReturnValue({
+                configuration: {
+                  chainId: '0x1',
+                  ticker: 'LOL',
+                },
+              }),
+              tokenPricesService,
+            },
+            {
+              allTokens: {
+                '0x1': {
+                  [defaultSelectedAddress]: [
+                    {
+                      address: '0x02',
+                      decimals: 0,
+                      symbol: '',
+                      aggregators: [],
+                    },
+                    {
+                      address: '0x03',
+                      decimals: 0,
+                      symbol: '',
+                      aggregators: [],
+                    },
+                  ],
+                },
               },
-            }),
-            tokenPricesService,
-          });
+            },
+          );
 
-          controller.startPollingByNetworkClientId('mainnet', {
-            tokenAddresses: ['0x02', '0x03'],
-          });
+          controller.startPollingByNetworkClientId('mainnet');
           // flush promises and advance setTimeouts they enqueue 3 times
           // needed because fetch() doesn't resolve immediately, so any
           // downstream promises aren't flushed until the next advanceTime loop
@@ -967,25 +1076,45 @@ describe('TokenRatesController', () => {
             );
 
           const tokenPricesService = buildMockTokenPricesService();
-          const controller = new TokenRatesController({
-            chainId: '0x2',
-            ticker: 'ETH',
-            selectedAddress: '0xdeadbeef',
-            onPreferencesStateChange: jest.fn(),
-            onTokensStateChange: jest.fn(),
-            onNetworkStateChange: jest.fn(),
-            getNetworkClientById: jest.fn().mockReturnValue({
-              configuration: {
-                chainId: '0x1',
-                ticker: 'LOL',
+          const controller = new TokenRatesController(
+            {
+              chainId: '0x2',
+              ticker: 'ETH',
+              selectedAddress: defaultSelectedAddress,
+              onPreferencesStateChange: jest.fn(),
+              onTokensStateChange: jest.fn(),
+              onNetworkStateChange: jest.fn(),
+              getNetworkClientById: jest.fn().mockReturnValue({
+                configuration: {
+                  chainId: '0x1',
+                  ticker: 'LOL',
+                },
+              }),
+              tokenPricesService,
+            },
+            {
+              allTokens: {
+                '0x1': {
+                  [defaultSelectedAddress]: [
+                    {
+                      address: '0x02',
+                      decimals: 0,
+                      symbol: '',
+                      aggregators: [],
+                    },
+                    {
+                      address: '0x03',
+                      decimals: 0,
+                      symbol: '',
+                      aggregators: [],
+                    },
+                  ],
+                },
               },
-            }),
-            tokenPricesService,
-          });
+            },
+          );
 
-          controller.startPollingByNetworkClientId('mainnet', {
-            tokenAddresses: ['0x02', '0x03'],
-          });
+          controller.startPollingByNetworkClientId('mainnet');
           // flush promises and advance setTimeouts they enqueue 3 times
           // needed because fetch() doesn't resolve immediately, so any
           // downstream promises aren't flushed until the next advanceTime loop
@@ -1007,26 +1136,40 @@ describe('TokenRatesController', () => {
       const interval = 100;
       const tokenPricesService = buildMockTokenPricesService();
       jest.spyOn(tokenPricesService, 'fetchTokenPrices');
-      const controller = new TokenRatesController({
-        interval,
-        chainId: '0x2',
-        ticker: 'ticker',
-        selectedAddress: '0xdeadbeef',
-        onPreferencesStateChange: jest.fn(),
-        onTokensStateChange: jest.fn(),
-        onNetworkStateChange: jest.fn(),
-        getNetworkClientById: jest.fn().mockReturnValue({
-          configuration: {
-            chainId: '0x1',
-            ticker: NetworksTicker.mainnet,
+      const controller = new TokenRatesController(
+        {
+          interval,
+          chainId: '0x2',
+          ticker: 'ticker',
+          selectedAddress: defaultSelectedAddress,
+          onPreferencesStateChange: jest.fn(),
+          onTokensStateChange: jest.fn(),
+          onNetworkStateChange: jest.fn(),
+          getNetworkClientById: jest.fn().mockReturnValue({
+            configuration: {
+              chainId: '0x1',
+              ticker: NetworksTicker.mainnet,
+            },
+          }),
+          tokenPricesService,
+        },
+        {
+          allTokens: {
+            '0x1': {
+              [defaultSelectedAddress]: [
+                {
+                  address: mockTokenAddress,
+                  decimals: 0,
+                  symbol: '',
+                  aggregators: [],
+                },
+              ],
+            },
           },
-        }),
-        tokenPricesService,
-      });
+        },
+      );
 
-      const pollingToken = controller.startPollingByNetworkClientId('mainnet', {
-        tokenAddresses: ['0x0'],
-      });
+      const pollingToken = controller.startPollingByNetworkClientId('mainnet');
       await advanceTime({ clock, duration: 0 });
       expect(tokenPricesService.fetchTokenPrices).toHaveBeenCalledTimes(1);
 
@@ -1596,6 +1739,12 @@ async function callUpdateExchangeRatesMethod({
       'The "setChainAsCurrent" flag cannot be enabled when calling the "updateExchangeRates" method',
     );
   }
+  // Note that the state given here is intentionally incomplete because the
+  // controller only uses these two properties, and the tests are written to
+  // only consider these two. We want this to break if we start relying on
+  // more, as we'd need to update the tests accordingly.
+  // @ts-expect-error Intentionally incomplete state
+  controllerEvents.tokensStateChange({ allDetectedTokens: {}, allTokens });
 
   if (setChainAsCurrent) {
     // We're using controller events here instead of calling `configure`
@@ -1610,24 +1759,14 @@ async function callUpdateExchangeRatesMethod({
       // @ts-expect-error Intentionally incomplete state
       providerConfig: { chainId, ticker: nativeCurrency },
     });
-    // Note that the state given here is intentionally incomplete because the
-    // controller only uses these two properties, and the tests are written to
-    // only consider these two. We want this to break if we start relying on
-    // more, as we'd need to update the tests accordingly.
-    // @ts-expect-error Intentionally incomplete state
-    controllerEvents.tokensStateChange({ allDetectedTokens: {}, allTokens });
   }
 
   if (method === 'updateExchangeRates') {
     await controller.updateExchangeRates();
   } else {
-    const { selectedAddress } = controller.config;
-    const tokens = allTokens[chainId]?.[selectedAddress] || [];
-    const tokenContractAddresses = tokens.map((token) => toHex(token.address));
     await controller.updateExchangeRatesByChainId({
       chainId,
       nativeCurrency,
-      tokenContractAddresses,
     });
   }
 }

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -3,6 +3,7 @@ import {
   safelyExecute,
   toChecksumHexAddress,
   FALL_BACK_VS_CURRENCY,
+  toHex,
 } from '@metamask/controller-utils';
 import type {
   NetworkClientId,
@@ -140,8 +141,6 @@ export class TokenRatesController extends PollingControllerV1<
 > {
   private handle?: ReturnType<typeof setTimeout>;
 
-  private tokenList: Token[] = [];
-
   #pollState = PollState.Inactive;
 
   #tokenPricesService: AbstractTokenPricesService;
@@ -227,12 +226,10 @@ export class TokenRatesController extends PollingControllerV1<
     if (config?.disabled) {
       this.configure({ disabled: true }, false, false);
     }
-    this.#updateTokenList();
 
     onPreferencesStateChange(async ({ selectedAddress }) => {
       if (this.config.selectedAddress !== selectedAddress) {
         this.configure({ selectedAddress });
-        this.#updateTokenList();
         if (this.#pollState === PollState.Active) {
           await this.updateExchangeRates();
         }
@@ -246,7 +243,6 @@ export class TokenRatesController extends PollingControllerV1<
         this.config.allDetectedTokens !== allDetectedTokens
       ) {
         this.configure({ allTokens, allDetectedTokens });
-        this.#updateTokenList();
         if (this.#pollState === PollState.Active) {
           await this.updateExchangeRates();
         }
@@ -261,7 +257,6 @@ export class TokenRatesController extends PollingControllerV1<
       ) {
         this.update({ contractExchangeRates: {} });
         this.configure({ chainId, nativeCurrency: ticker });
-        this.#updateTokenList();
         if (this.#pollState === PollState.Active) {
           await this.updateExchangeRates();
         }
@@ -269,14 +264,19 @@ export class TokenRatesController extends PollingControllerV1<
     });
   }
 
-  #updateTokenList() {
+  /**
+   * Get the user's tokens for the given chain.
+   *
+   * @param chainId - The chain ID.
+   * @returns The list of tokens addresses for the current chain
+   */
+  #getTokenAddresses(chainId: Hex): Hex[] {
     const { allTokens, allDetectedTokens } = this.config;
-    const tokens =
-      allTokens[this.config.chainId]?.[this.config.selectedAddress] || [];
+    const tokens = allTokens[chainId]?.[this.config.selectedAddress] || [];
     const detectedTokens =
-      allDetectedTokens[this.config.chainId]?.[this.config.selectedAddress] ||
-      [];
-    this.tokenList = [...tokens, ...detectedTokens];
+      allDetectedTokens[chainId]?.[this.config.selectedAddress] || [];
+
+    return [...tokens, ...detectedTokens].map((token) => toHex(token.address));
   }
 
   /**
@@ -322,18 +322,10 @@ export class TokenRatesController extends PollingControllerV1<
    * Updates exchange rates for all tokens.
    */
   async updateExchangeRates() {
-    if (this.tokenList.length === 0 || this.disabled) {
-      return;
-    }
-
     const { chainId, nativeCurrency } = this.config;
-    const tokenContractAddresses = this.tokenList.map(
-      (token) => token.address,
-    ) as Hex[];
     await this.updateExchangeRatesByChainId({
       chainId,
       nativeCurrency,
-      tokenContractAddresses,
     });
   }
 
@@ -343,18 +335,20 @@ export class TokenRatesController extends PollingControllerV1<
    * @param options - The options to fetch exchange rates.
    * @param options.chainId - The chain ID.
    * @param options.nativeCurrency - The ticker for the chain.
-   * @param options.tokenContractAddresses - The addresses for the token contracts.
    */
   async updateExchangeRatesByChainId({
     chainId,
     nativeCurrency,
-    tokenContractAddresses,
   }: {
     chainId: Hex;
     nativeCurrency: string;
-    tokenContractAddresses: Hex[];
   }) {
-    if (tokenContractAddresses.length === 0 || this.disabled) {
+    if (this.disabled) {
+      return;
+    }
+
+    const tokenContractAddresses = this.#getTokenAddresses(chainId);
+    if (tokenContractAddresses.length === 0) {
       return;
     }
 
@@ -443,22 +437,16 @@ export class TokenRatesController extends PollingControllerV1<
   }
 
   /**
-   * Updates token rates for the given networkClientId and contract addresses
+   * Updates token rates for the given networkClientId
    *
    * @param networkClientId - The network client ID used to get a ticker value.
-   * @param options - The polling options.
-   * @param options.tokenAddresses - The addresses for the token contracts.
    * @returns The controller state.
    */
-  async _executePoll(
-    networkClientId: NetworkClientId,
-    options: { tokenAddresses: Hex[] },
-  ): Promise<void> {
+  async _executePoll(networkClientId: NetworkClientId): Promise<void> {
     const networkClient = this.getNetworkClientById(networkClientId);
     await this.updateExchangeRatesByChainId({
       chainId: networkClient.configuration.chainId,
       nativeCurrency: networkClient.configuration.ticker,
-      tokenContractAddresses: options.tokenAddresses,
     });
   }
 


### PR DESCRIPTION
## Explanation

Updating and polling for token rates for arbitrary tokens is no longer supported. Instead the user's token list (from the `TokensController`) always dictates which tokens will be tracked by the `TokenRatesController`. See #3637 for more details.

This simplifies the API, dramatically simplifies the complexity of testing this controller thoroughly, and it resolves a recently introduced bug (#3638).

Rates from non-tracked tokens can still be retrieved by calling the price service directly, using the `token-prices-service` module.

## References

Resolves #3637
Fixes #3638

## Changelog

### `@metamask/assets-controllers`

- **BREAKING**: The TokenRatesController now only supports updating and polling rates for tokens tracked by the TokensController
  - The `tokenAddresses` option has been removed from `startPollingByNetworkClientId`
  - The `tokenContractAddresses` option has been removed from `updateExchangeRatesByChainId`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
