### PR TITLE
Remove Aurora support

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -33,8 +33,6 @@ export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID: Record<Hex, string> = {
     '0x2352c63A83f9Fd126af8676146721Fa00924d7e4',
   [SupportedTokenDetectionNetworks.avax]:
     '0xD023D153a0DFa485130ECFdE2FAA7e612EF94818',
-  [SupportedTokenDetectionNetworks.aurora]:
-    '0x1286415D333855237f89Df27D388127181448538',
   [SupportedTokenDetectionNetworks.linea_goerli]:
     '0x10dAd7Ca3921471f616db788D9300DC97Db01783',
   [SupportedTokenDetectionNetworks.linea_mainnet]:

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -299,22 +299,6 @@ describe('TokenDetectionController', () => {
     expect(tokensController.state.detectedTokens).toStrictEqual([sampleTokenA]);
   });
 
-  it('should detect tokens correctly on the Aurora network', async () => {
-    const auroraMainnet = {
-      chainId: ChainId.aurora,
-      type: NetworkType.mainnet,
-      ticker: 'Aurora ETH',
-    };
-    preferences.update({ selectedAddress: '0x1' });
-    changeNetwork(auroraMainnet);
-
-    getBalancesInSingleCall.resolves({
-      [sampleTokenA.address]: new BN(1),
-    });
-    await tokenDetection.start();
-    expect(tokensController.state.detectedTokens).toStrictEqual([sampleTokenA]);
-  });
-
   it('should update detectedTokens when new tokens are detected', async () => {
     preferences.update({ selectedAddress: '0x1' });
     changeNetwork(mainnet);

--- a/packages/assets-controllers/src/assetsUtil.test.ts
+++ b/packages/assets-controllers/src/assetsUtil.test.ts
@@ -262,14 +262,6 @@ describe('assetsUtil', () => {
       ).toBe(true);
     });
 
-    it('returns true for the Aurora network', () => {
-      expect(
-        assetsUtil.isTokenDetectionSupportedForNetwork(
-          assetsUtil.SupportedTokenDetectionNetworks.aurora,
-        ),
-      ).toBe(true);
-    });
-
     it('returns false for testnets such as Goerli', () => {
       expect(assetsUtil.isTokenDetectionSupportedForNetwork(toHex(5))).toBe(
         false,

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -145,7 +145,6 @@ export enum SupportedTokenDetectionNetworks {
   bsc = '0x38', // decimal: 56
   polygon = '0x89', // decimal: 137
   avax = '0xa86a', // decimal: 43114
-  aurora = '0x4e454152', // decimal: 1313161554
   linea_goerli = '0xe704', // decimal: 59140
   linea_mainnet = '0xe708', // decimal: 59144
   arbitrum = '0xa4b1', // decimal: 42161

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -220,8 +220,6 @@ export const SUPPORTED_CHAIN_IDS = [
   '0xa86a',
   // Polis Mainnet
   '0x518af',
-  // Aurora Mainnet
-  '0x4e454152',
   // Harmony Mainnet Shard 0
   '0x63564c40',
 ] as const;

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -57,7 +57,6 @@ export enum BuiltInNetworkName {
   Sepolia = 'sepolia',
   LineaGoerli = 'linea-goerli',
   LineaMainnet = 'linea-mainnet',
-  Aurora = 'aurora',
 }
 
 /**
@@ -69,7 +68,6 @@ export const ChainId = {
   [BuiltInNetworkName.Mainnet]: '0x1', // toHex(1)
   [BuiltInNetworkName.Goerli]: '0x5', // toHex(5)
   [BuiltInNetworkName.Sepolia]: '0xaa36a7', // toHex(11155111)
-  [BuiltInNetworkName.Aurora]: '0x4e454152', // toHex(1313161554)
   [BuiltInNetworkName.LineaGoerli]: '0xe704', // toHex(59140)
   [BuiltInNetworkName.LineaMainnet]: '0xe708', // toHex(59144)
 } as const;


### PR DESCRIPTION
## Explanation

The Aurora network is being deprecated by Infura and thus MetaMask is discontinuing support.  This PR reflects that deprecation

## References

* Related to https://github.com/MetaMask/MetaMask-planning/issues/1609

## Changelog

### `@metamask/assets-controller`

- **BREAKING**: Remove support for the aurora network

### `@metamask/token-detection-controller`

- **BREAKING**: Remove support for the aurora network

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
