### PR TITLE
Prevent redundant token rate updates

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -13,6 +13,7 @@ import type {
 import { PollingControllerV1 } from '@metamask/polling-controller';
 import type { PreferencesState } from '@metamask/preferences-controller';
 import type { Hex } from '@metamask/utils';
+import { isDeepStrictEqual } from 'util';
 
 import { fetchExchangeRate as fetchNativeCurrencyExchangeRate } from './crypto-compare';
 import type { AbstractTokenPricesService } from './token-prices-service/abstract-token-prices-service';
@@ -237,15 +238,16 @@ export class TokenRatesController extends PollingControllerV1<
     });
 
     onTokensStateChange(async ({ allTokens, allDetectedTokens }) => {
-      // These two state properties are assumed to be immutable
+      const previousTokenAddresses = this.#getTokenAddresses(
+        this.config.chainId,
+      );
+      this.configure({ allTokens, allDetectedTokens });
+      const newTokenAddresses = this.#getTokenAddresses(this.config.chainId);
       if (
-        this.config.allTokens !== allTokens ||
-        this.config.allDetectedTokens !== allDetectedTokens
+        !isDeepStrictEqual(previousTokenAddresses, newTokenAddresses) &&
+        this.#pollState === PollState.Active
       ) {
-        this.configure({ allTokens, allDetectedTokens });
-        if (this.#pollState === PollState.Active) {
-          await this.updateExchangeRates();
-        }
+        await this.updateExchangeRates();
       }
     });
 
@@ -276,7 +278,13 @@ export class TokenRatesController extends PollingControllerV1<
     const detectedTokens =
       allDetectedTokens[chainId]?.[this.config.selectedAddress] || [];
 
-    return [...tokens, ...detectedTokens].map((token) => toHex(token.address));
+    return [
+      ...new Set(
+        [...tokens, ...detectedTokens].map((token) =>
+          toHex(toChecksumHexAddress(token.address)),
+        ),
+      ),
+    ].sort();
   }
 
   /**
@@ -482,7 +490,7 @@ export class TokenRatesController extends PollingControllerV1<
       (obj, [tokenContractAddress, tokenPrice]) => {
         return {
           ...obj,
-          [toChecksumHexAddress(tokenContractAddress)]: tokenPrice.value,
+          [tokenContractAddress]: tokenPrice.value,
         };
       },
       {},
@@ -531,7 +539,7 @@ export class TokenRatesController extends PollingControllerV1<
       (obj, [tokenContractAddress, tokenPrice]) => {
         return {
           ...obj,
-          [toChecksumHexAddress(tokenContractAddress)]:
+          [tokenContractAddress]:
             tokenPrice.value * fallbackCurrencyToNativeCurrencyConversionRate,
         };
       },


### PR DESCRIPTION


## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

The token rates controller fetches rates for certain collections of tokens obtained via the tokens controller. If any of these collections change, then new rates need to be fetched.

Unfortunately, because the check to determine whether these collections have changed is simplistic, new rates are fetched every single time the tokens controller state is changed.

To address this, we can consider two things:

- The token rates controller only uses the addresses of tokens in these collections to fetch rates, and it also normalizes those addresses when updating state.
- These collections of tokens may contain duplicates.

So to reduce the number of times rates are fetched and to optimize each request, this commit updates the tokens state callback to assemble the aforementioned token collections into a deduplicated, normalized list of token addresses, and then it checks to see if this list has any changes to know whether or not to re-fetch rates.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes #3605.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **FIXED**: Fix TokenRatesController to prevent redundant token rate updates when tokens change
  - Previously, token rates would be re-fetched for the globally selected network on all TokensController state changes, but now token rates are always performed for a deduplicated and normalized set of addresses, and changes to this set determine whether rates should be re-fetched.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
