### PR TITLE
feat: export exchange rates fct

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -15,7 +15,7 @@ import type { PreferencesState } from '@metamask/preferences-controller';
 import type { Hex } from '@metamask/utils';
 import { isEqual } from 'lodash';
 
-import { reduceInBatchesSerially } from './assetsUtil';
+import { reduceInBatchesSerially, TOKEN_PRICES_BATCH_SIZE } from './assetsUtil';
 import { fetchExchangeRate as fetchNativeCurrencyExchangeRate } from './crypto-compare';
 import type { AbstractTokenPricesService } from './token-prices-service/abstract-token-prices-service';
 import type { TokensState } from './TokensController';
@@ -69,7 +69,7 @@ export interface TokenRatesConfig extends BaseConfig {
 // This interface was created before this ESLint rule was added.
 // Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-interface ContractExchangeRates {
+export interface ContractExchangeRates {
   [address: string]: number | undefined;
 }
 
@@ -95,12 +95,6 @@ export interface TokenRatesState extends BaseState {
     Record<string, ContractExchangeRates>
   >;
 }
-
-/**
- * The maximum number of token addresses that should be sent to the Price API in
- * a single request.
- */
-const TOKEN_PRICES_BATCH_SIZE = 100;
 
 /**
  * Uses the CryptoCompare API to fetch the exchange rate between one currency

--- a/packages/assets-controllers/src/assetsUtil.test.ts
+++ b/packages/assets-controllers/src/assetsUtil.test.ts
@@ -441,27 +441,16 @@ describe('assetsUtil', () => {
   });
 
   describe('fetchAndMapExchangeRates', () => {
-    const mockedPricesService: AbstractTokenPricesService = {
-      validateChainIdSupported(_chainId: unknown): _chainId is Hex {
-        return true;
-      },
-      validateCurrencySupported(_currency: unknown): _currency is string {
-        return true;
-      },
-      async fetchTokenPrices() {
-        return {};
-      },
-    };
-
     it('should return empty object when chainId not supported', async () => {
       const testTokenAddress = '0x7BEF710a5759d197EC0Bf621c3Df802C2D60D848';
+      const mockPriceService = createMockPriceService();
 
       jest
-        .spyOn(mockedPricesService, 'validateChainIdSupported')
+        .spyOn(mockPriceService, 'validateChainIdSupported')
         .mockReturnValue(false);
 
       const result = await assetsUtil.fetchTokenContractExchangeRates({
-        tokenPricesService: mockedPricesService,
+        tokenPricesService: mockPriceService,
         nativeCurrency: 'ETH',
         tokenAddresses: [testTokenAddress],
         chainId: '0x0',
@@ -472,12 +461,13 @@ describe('assetsUtil', () => {
 
     it('should return empty object when nativeCurrency not supported', async () => {
       const testTokenAddress = '0x7BEF710a5759d197EC0Bf621c3Df802C2D60D848';
+      const mockPriceService = createMockPriceService();
       jest
-        .spyOn(mockedPricesService, 'validateCurrencySupported')
+        .spyOn(mockPriceService, 'validateCurrencySupported')
         .mockReturnValue(false);
 
       const result = await assetsUtil.fetchTokenContractExchangeRates({
-        tokenPricesService: mockedPricesService,
+        tokenPricesService: mockPriceService,
         nativeCurrency: 'X',
         tokenAddresses: [testTokenAddress],
         chainId: '0x1',
@@ -490,15 +480,16 @@ describe('assetsUtil', () => {
       const testTokenAddress = '0x7BEF710a5759d197EC0Bf621c3Df802C2D60D848';
       const testNativeCurrency = 'ETH';
       const testChainId = '0x1';
+      const mockPriceService = createMockPriceService();
       jest
-        .spyOn(mockedPricesService, 'validateCurrencySupported')
+        .spyOn(mockPriceService, 'validateCurrencySupported')
         .mockReturnValue(true);
 
       jest
-        .spyOn(mockedPricesService, 'validateChainIdSupported')
+        .spyOn(mockPriceService, 'validateChainIdSupported')
         .mockReturnValue(true);
 
-      jest.spyOn(mockedPricesService, 'fetchTokenPrices').mockResolvedValue({
+      jest.spyOn(mockPriceService, 'fetchTokenPrices').mockResolvedValue({
         [testTokenAddress]: {
           tokenAddress: testTokenAddress,
           value: 0.0004588648479937523,
@@ -507,7 +498,7 @@ describe('assetsUtil', () => {
       });
 
       const result = await assetsUtil.fetchTokenContractExchangeRates({
-        tokenPricesService: mockedPricesService,
+        tokenPricesService: mockPriceService,
         nativeCurrency: testNativeCurrency,
         tokenAddresses: [testTokenAddress],
         chainId: testChainId,
@@ -519,6 +510,7 @@ describe('assetsUtil', () => {
     });
 
     it('should fetch successfully in batches of 100', async () => {
+      const mockPriceService = createMockPriceService();
       const tokenAddresses = [...new Array(200).keys()]
         .map(buildAddress)
         .sort();
@@ -526,20 +518,20 @@ describe('assetsUtil', () => {
       const testNativeCurrency = 'ETH';
       const testChainId = '0x1';
       jest
-        .spyOn(mockedPricesService, 'validateCurrencySupported')
+        .spyOn(mockPriceService, 'validateCurrencySupported')
         .mockReturnValue(true);
 
       jest
-        .spyOn(mockedPricesService, 'validateChainIdSupported')
+        .spyOn(mockPriceService, 'validateChainIdSupported')
         .mockReturnValue(true);
 
       const fetchTokenPricesSpy = jest.spyOn(
-        mockedPricesService,
+        mockPriceService,
         'fetchTokenPrices',
       );
 
       await assetsUtil.fetchTokenContractExchangeRates({
-        tokenPricesService: mockedPricesService,
+        tokenPricesService: mockPriceService,
         nativeCurrency: testNativeCurrency,
         tokenAddresses: tokenAddresses as Hex[],
         chainId: testChainId,
@@ -569,4 +561,23 @@ describe('assetsUtil', () => {
  */
 function buildAddress(number: number) {
   return toChecksumHexAddress(add0x(number.toString(16).padStart(40, '0')));
+}
+
+/**
+ * Creates a mock for token prices service.
+ *
+ * @returns The mocked functions of token prices service.
+ */
+function createMockPriceService(): AbstractTokenPricesService {
+  return {
+    validateChainIdSupported(_chainId: unknown): _chainId is Hex {
+      return true;
+    },
+    validateCurrencySupported(_currency: unknown): _currency is string {
+      return true;
+    },
+    async fetchTokenPrices() {
+      return {};
+    },
+  };
 }

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -2,6 +2,7 @@ import type { BigNumber } from '@ethersproject/bignumber';
 import {
   convertHexToDecimal,
   GANACHE_CHAIN_ID,
+  toChecksumHexAddress,
 } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 import { BN, stripHexPrefix } from 'ethereumjs-util';
@@ -16,6 +17,14 @@ import type {
   OpenSeaV2Nft,
 } from './NftController';
 import type { ApiNft, ApiNftContract } from './NftDetectionController';
+import type { AbstractTokenPricesService } from './token-prices-service';
+import { type ContractExchangeRates } from './TokenRatesController';
+
+/**
+ * The maximum number of token addresses that should be sent to the Price API in
+ * a single request.
+ */
+export const TOKEN_PRICES_BATCH_SIZE = 100;
 
 /**
  * Compares nft metadata entries to any nft entry.
@@ -387,4 +396,67 @@ export function mapOpenSeaContractV2ToV1(
       image_url: collection?.image_url,
     },
   };
+}
+
+/**
+ * Retrieves token prices for a set of contract addresses in a specific currency and chainId.
+ *
+ * @param args - The arguments to function.
+ * @param args.tokenPricesService - An object in charge of retrieving token prices.
+ * @param args.nativeCurrency - The native currency to request price in.
+ * @param args.tokenAddresses - The list of contract addresses.
+ * @param args.chainId - The chainId of the tokens.
+ * @returns The prices for the requested tokens.
+ */
+export async function fetchTokenContractExchangeRates({
+  tokenPricesService,
+  nativeCurrency,
+  tokenAddresses,
+  chainId,
+}: {
+  tokenPricesService: AbstractTokenPricesService;
+  nativeCurrency: string;
+  tokenAddresses: Hex[];
+  chainId: Hex;
+}): Promise<ContractExchangeRates> {
+  const isChainIdSupported =
+    tokenPricesService.validateChainIdSupported(chainId);
+  const isCurrencySupported =
+    tokenPricesService.validateCurrencySupported(nativeCurrency);
+
+  if (!isChainIdSupported || !isCurrencySupported) {
+    return {};
+  }
+
+  const tokenPricesByTokenAddress = await reduceInBatchesSerially<
+    Hex,
+    Awaited<ReturnType<AbstractTokenPricesService['fetchTokenPrices']>>
+  >({
+    values: tokenAddresses,
+    batchSize: TOKEN_PRICES_BATCH_SIZE,
+    eachBatch: async (allTokenPricesByTokenAddress, batch) => {
+      const tokenPricesByTokenAddressForBatch =
+        await tokenPricesService.fetchTokenPrices({
+          tokenAddresses: batch,
+          chainId,
+          currency: nativeCurrency,
+        });
+
+      return {
+        ...allTokenPricesByTokenAddress,
+        ...tokenPricesByTokenAddressForBatch,
+      };
+    },
+    initialResult: {},
+  });
+
+  return Object.entries(tokenPricesByTokenAddress).reduce(
+    (obj, [tokenAddress, tokenPrice]) => {
+      return {
+        ...obj,
+        [toChecksumHexAddress(tokenAddress)]: tokenPrice.value,
+      };
+    },
+    {},
+  );
 }

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -454,7 +454,7 @@ export async function fetchTokenContractExchangeRates({
     (obj, [tokenAddress, tokenPrice]) => {
       return {
         ...obj,
-        [toChecksumHexAddress(tokenAddress)]: tokenPrice.value,
+        [toChecksumHexAddress(tokenAddress)]: tokenPrice?.value,
       };
     },
     {},

--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -12,5 +12,6 @@ export {
   isTokenDetectionSupportedForNetwork,
   formatIconUrlWithProxy,
   getFormattedIpfsUrl,
+  fetchTokenContractExchangeRates,
 } from './assetsUtil';
 export { CodefiTokenPricesServiceV2 } from './token-prices-service';


### PR DESCRIPTION
## Explanation

Export a function from assets controller to fetch token exchange rates.

This function will be used by extension to compute user token fiat amount and display it on the import token modal confirmation page.

## References

* Fixes [#12345](https://consensyssoftware.atlassian.net/browse/MMASSETS-88)
* Related to [#67890](https://github.com/MetaMask/metamask-extension/pull/22263)

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->


### `@metamask/assets-controllers`

- **<CATEGORY>**: Updated `assetsUtil `file to export `fetchAndMapExchangeRates `function

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
