### PR TITLE
Fix Linea Goerli Etherscan subdomain

### DIFF
--- a/packages/transaction-controller/src/constants.ts
+++ b/packages/transaction-controller/src/constants.ts
@@ -40,7 +40,7 @@ export const ETHERSCAN_SUPPORTED_NETWORKS = {
   },
   [CHAIN_IDS.LINEA_GOERLI]: {
     domain: 'lineascan.build',
-    subdomain: 'goerli',
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-goerli`,
   },
   [CHAIN_IDS.LINEA_MAINNET]: {
     domain: 'lineascan.build',


### PR DESCRIPTION
## Explanation

Incoming transactions are not working in Firefox with Linea Goerli as the configured Etherscan subdomain generates the correct API response but does not include the CORS headers required by Firefox.

This updates the subdomain to the correct value with the standard `api-` prefix.

## Changelog

### `@metamask/transaction-controller`

- **FIXED**: Update Etherscan subdomain for Linea Goerli to support incoming transactions in Firefox.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
