### PR TITLE
feat: Add `onBreak` handler to token price service

### DIFF
--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -269,16 +269,20 @@ export class CodefiTokenPricesServiceV2
    * @param options.retries - Number of retry attempts for each token price update.
    * @param options.maximumConsecutiveFailures - The maximum number of consecutive failures
    * allowed before breaking the circuit and pausing further updates.
+   * @param options.onBreak - An event handler for when the circuit breaks, useful for capturing
+   * metrics about network failures.
    * @param options.circuitBreakDuration - The amount of time to wait when the circuit breaks
    * from too many consecutive failures.
    */
   constructor({
     retries = DEFAULT_TOKEN_PRICE_RETRIES,
     maximumConsecutiveFailures = DEFAULT_TOKEN_PRICE_MAX_CONSECUTIVE_FAILURES,
+    onBreak,
     circuitBreakDuration = 30 * 60 * 1000,
   }: {
     retries?: number;
     maximumConsecutiveFailures?: number;
+    onBreak?: () => void;
     circuitBreakDuration?: number;
   } = {}) {
     // Construct a policy that will retry each update, and halt further updates
@@ -291,6 +295,9 @@ export class CodefiTokenPricesServiceV2
       halfOpenAfter: circuitBreakDuration,
       breaker: new ConsecutiveBreaker(maximumConsecutiveFailures),
     });
+    if (onBreak) {
+      circuitBreakerPolicy.onBreak(onBreak);
+    }
     this.#tokenPricePolicy = wrap(retryPolicy, circuitBreakerPolicy);
   }
 


### PR DESCRIPTION
## Explanation

The `CodefiTokenPricesServiceV2` service now accepts an `onBreak` event handler. This handler is called upon each circuit break. This allows us to collect metrics on circuit breaks, which would help is detect widespread failures of this service.

## References

N/A

## Changelog

### `@metamask/assets-controllers`

- Added: Add `onBreak` option to `CodefiTokenPricesServiceV2`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
