### PR TITLE
Move state update call after networkClient is instantiated and added to registry in `upsertNetworkConfiguration`

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1237,13 +1237,6 @@ export class NetworkController extends BaseController<
       upsertedNetworkConfigurationId,
     );
 
-    this.update((state) => {
-      state.networkConfigurations[upsertedNetworkConfigurationId] = {
-        id: upsertedNetworkConfigurationId,
-        ...sanitizedNetworkConfiguration,
-      };
-    });
-
     const customNetworkClientRegistry =
       autoManagedNetworkClientRegistry[NetworkClientType.Custom];
     const existingAutoManagedNetworkClient =
@@ -1266,6 +1259,13 @@ export class NetworkController extends BaseController<
           ticker,
         });
     }
+
+    this.update((state) => {
+      state.networkConfigurations[upsertedNetworkConfigurationId] = {
+        id: upsertedNetworkConfigurationId,
+        ...sanitizedNetworkConfiguration,
+      };
+    });
 
     if (!existingNetworkConfiguration) {
       this.#trackMetaMetricsEvent({


### PR DESCRIPTION
## @metamask/network-controller
### Changed:
- Moves state update call after networkClient was instantiated so that `NetworkController:stateChange` event can be safely used to identify when new networkClients have been added and are available for use

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
