### PR TITLE
chore(assets-controllers): Update `cockatiel` and widen range

### DIFF
--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -48,7 +48,7 @@
     "@metamask/utils": "^8.2.0",
     "@types/uuid": "^8.3.0",
     "async-mutex": "^0.2.6",
-    "cockatiel": "3.1.1",
+    "cockatiel": "^3.1.2",
     "ethereumjs-util": "^7.0.10",
     "lodash": "^4.17.21",
     "multiformats": "^9.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,7 +1601,7 @@ __metadata:
     "@types/node": ^16.18.54
     "@types/uuid": ^8.3.0
     async-mutex: ^0.2.6
-    cockatiel: 3.1.1
+    cockatiel: ^3.1.2
     deepmerge: ^4.2.2
     ethereumjs-util: ^7.0.10
     jest: ^27.5.1
@@ -4698,10 +4698,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cockatiel@npm:3.1.1":
-  version: 3.1.1
-  resolution: "cockatiel@npm:3.1.1"
-  checksum: c394fa5dc5a0f21a9ff9f007f16320a162000191c570fa277b527a72505a954aae5f2e93b0de0a558f5e3340fed37c014c9fe72d43adfee4aa09d976bdefe745
+"cockatiel@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "cockatiel@npm:3.1.2"
+  checksum: 5ba2d9ffd738d38c5f1af66f4c36f302485f4ebf25b96e47aa9c9ea3fecd47ed770bfc9da52ac58bef3dfb330efd7e9be557691b4e620a1479d79009bff2b74e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

The package `cockatiel` was mistakenly pinned when it was introduced. It has been updated to use a caret range, and the minimum has been bumped to v3.1.2. v3.1.2 removes test files from the package, which reduces the package size and resolves a false positive security warning from Socket.

## References

N/A

## Changelog

### `@metamask/assets-controllers`

- Changed: Update `cockatiel` to `^3.1.2`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
