### PR TITLE
fix: fix fetch price

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -538,7 +538,7 @@ export class TokenRatesController extends StaticIntervalPollingControllerV1<
       (obj, [tokenAddress, tokenPrice]) => {
         return {
           ...obj,
-          [tokenAddress]: tokenPrice.value,
+          [tokenAddress]: tokenPrice?.value,
         };
       },
       {},

--- a/packages/assets-controllers/src/token-prices-service/abstract-token-prices-service.ts
+++ b/packages/assets-controllers/src/token-prices-service/abstract-token-prices-service.ts
@@ -5,7 +5,7 @@ import type { Hex } from '@metamask/utils';
  */
 export type TokenPrice<TokenAddress extends Hex, Currency extends string> = {
   tokenAddress: TokenAddress;
-  value: number | undefined;
+  value: number;
   currency: Currency;
 };
 

--- a/packages/assets-controllers/src/token-prices-service/abstract-token-prices-service.ts
+++ b/packages/assets-controllers/src/token-prices-service/abstract-token-prices-service.ts
@@ -5,7 +5,7 @@ import type { Hex } from '@metamask/utils';
  */
 export type TokenPrice<TokenAddress extends Hex, Currency extends string> = {
   tokenAddress: TokenAddress;
-  value: number;
+  value: number | undefined;
   currency: Currency;
 };
 
@@ -55,7 +55,7 @@ export type AbstractTokenPricesService<
     chainId: ChainId;
     tokenAddresses: TokenAddress[];
     currency: Currency;
-  }): Promise<TokenPricesByTokenAddress<TokenAddress, Currency>>;
+  }): Promise<Partial<TokenPricesByTokenAddress<TokenAddress, Currency>>>;
 
   /**
    * Type guard for whether the API can return token prices for the given chain

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.test.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.test.ts
@@ -58,7 +58,7 @@ describe('CodefiTokenPricesServiceV2', () => {
       });
     });
 
-    it('should include an empty object for token address when token price in not included the response data', async () => {
+    it('should not include token price object for token address when token price in not included the response data', async () => {
       nock('https://price-api.metafi.codefi.network')
         .get('/v2/chains/1/spot-prices')
         .query({
@@ -80,7 +80,6 @@ describe('CodefiTokenPricesServiceV2', () => {
         currency: 'ETH',
       });
       expect(result).toStrictEqual({
-        '0xAAA': {},
         '0xBBB': {
           tokenAddress: '0xBBB',
           value: 33689.98134554716,
@@ -94,7 +93,7 @@ describe('CodefiTokenPricesServiceV2', () => {
       });
     });
 
-    it('should include empty object for token address when price is undefined for token response data', async () => {
+    it('should not include token price object for token address when price is undefined for token response data', async () => {
       nock('https://price-api.metafi.codefi.network')
         .get('/v2/chains/1/spot-prices')
         .query({
@@ -118,7 +117,6 @@ describe('CodefiTokenPricesServiceV2', () => {
       });
 
       expect(result).toStrictEqual({
-        '0xAAA': {},
         '0xBBB': {
           tokenAddress: '0xBBB',
           value: 33689.98134554716,

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.test.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.test.ts
@@ -58,7 +58,7 @@ describe('CodefiTokenPricesServiceV2', () => {
       });
     });
 
-    it('should not throw if one of the token addresses cannot be found in the response data', async () => {
+    it('should include an empty object for token address when token price in not included the response data', async () => {
       nock('https://price-api.metafi.codefi.network')
         .get('/v2/chains/1/spot-prices')
         .query({
@@ -80,11 +80,7 @@ describe('CodefiTokenPricesServiceV2', () => {
         currency: 'ETH',
       });
       expect(result).toStrictEqual({
-        '0xAAA': {
-          tokenAddress: '0xAAA',
-          value: undefined,
-          currency: 'ETH',
-        },
+        '0xAAA': {},
         '0xBBB': {
           tokenAddress: '0xBBB',
           value: 33689.98134554716,
@@ -98,7 +94,7 @@ describe('CodefiTokenPricesServiceV2', () => {
       });
     });
 
-    it('throws if the currency cannot be found in the response data', async () => {
+    it('should include empty object for token address when price is undefined for token response data', async () => {
       nock('https://price-api.metafi.codefi.network')
         .get('/v2/chains/1/spot-prices')
         .query({
@@ -122,11 +118,7 @@ describe('CodefiTokenPricesServiceV2', () => {
       });
 
       expect(result).toStrictEqual({
-        '0xAAA': {
-          tokenAddress: '0xAAA',
-          value: undefined,
-          currency: 'ETH',
-        },
+        '0xAAA': {},
         '0xBBB': {
           tokenAddress: '0xBBB',
           value: 33689.98134554716,

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.test.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.test.ts
@@ -58,7 +58,7 @@ describe('CodefiTokenPricesServiceV2', () => {
       });
     });
 
-    it('throws if one of the token addresses cannot be found in the response data', async () => {
+    it('should not throw if one of the token addresses cannot be found in the response data', async () => {
       nock('https://price-api.metafi.codefi.network')
         .get('/v2/chains/1/spot-prices')
         .query({
@@ -74,13 +74,28 @@ describe('CodefiTokenPricesServiceV2', () => {
           },
         });
 
-      await expect(
-        new CodefiTokenPricesServiceV2().fetchTokenPrices({
-          chainId: '0x1',
-          tokenAddresses: ['0xAAA', '0xBBB', '0xCCC'],
+      const result = await new CodefiTokenPricesServiceV2().fetchTokenPrices({
+        chainId: '0x1',
+        tokenAddresses: ['0xAAA', '0xBBB', '0xCCC'],
+        currency: 'ETH',
+      });
+      expect(result).toStrictEqual({
+        '0xAAA': {
+          tokenAddress: '0xAAA',
+          value: undefined,
           currency: 'ETH',
-        }),
-      ).rejects.toThrow('Could not find price for "0xAAA" in "ETH"');
+        },
+        '0xBBB': {
+          tokenAddress: '0xBBB',
+          value: 33689.98134554716,
+          currency: 'ETH',
+        },
+        '0xCCC': {
+          tokenAddress: '0xCCC',
+          value: 148.1344197578456,
+          currency: 'ETH',
+        },
+      });
     });
 
     it('throws if the currency cannot be found in the response data', async () => {
@@ -100,13 +115,29 @@ describe('CodefiTokenPricesServiceV2', () => {
           },
         });
 
-      await expect(
-        new CodefiTokenPricesServiceV2().fetchTokenPrices({
-          chainId: '0x1',
-          tokenAddresses: ['0xAAA', '0xBBB', '0xCCC'],
+      const result = await new CodefiTokenPricesServiceV2().fetchTokenPrices({
+        chainId: '0x1',
+        tokenAddresses: ['0xAAA', '0xBBB', '0xCCC'],
+        currency: 'ETH',
+      });
+
+      expect(result).toStrictEqual({
+        '0xAAA': {
+          tokenAddress: '0xAAA',
+          value: undefined,
           currency: 'ETH',
-        }),
-      ).rejects.toThrow('Could not find price for "0xAAA" in "ETH"');
+        },
+        '0xBBB': {
+          tokenAddress: '0xBBB',
+          value: 33689.98134554716,
+          currency: 'ETH',
+        },
+        '0xCCC': {
+          tokenAddress: '0xCCC',
+          value: 148.1344197578456,
+          currency: 'ETH',
+        },
+      });
     });
 
     it('throws if the request fails consistently', async () => {

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -359,9 +359,12 @@ export class CodefiTokenPricesServiceV2
           value: price,
           currency,
         };
+
         return {
           ...obj,
-          [tokenAddress]: tokenPrice.value ? tokenPrice : {},
+          ...(tokenPrice.value !== undefined
+            ? { [tokenAddress]: tokenPrice }
+            : {}),
         };
       },
       {},

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -318,7 +318,7 @@ export class CodefiTokenPricesServiceV2
     chainId: SupportedChainId;
     tokenAddresses: Hex[];
     currency: SupportedCurrency;
-  }): Promise<TokenPricesByTokenAddress<Hex, SupportedCurrency>> {
+  }): Promise<Partial<TokenPricesByTokenAddress<Hex, SupportedCurrency>>> {
     const chainIdAsNumber = hexToNumber(chainId);
 
     const url = new URL(`${BASE_URL}/chains/${chainIdAsNumber}/spot-prices`);
@@ -361,11 +361,11 @@ export class CodefiTokenPricesServiceV2
         };
         return {
           ...obj,
-          [tokenAddress]: tokenPrice,
+          [tokenAddress]: tokenPrice.value ? tokenPrice : {},
         };
       },
       {},
-    ) as TokenPricesByTokenAddress<Hex, SupportedCurrency>;
+    ) as Partial<TokenPricesByTokenAddress<Hex, SupportedCurrency>>;
   }
 
   /**

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -348,7 +348,8 @@ export class CodefiTokenPricesServiceV2
           ];
 
         if (!price) {
-          throw new Error(
+          // console error instead of throwing to not interrupt the fetching of other tokens in case just one fails
+          console.error(
             `Could not find price for "${tokenAddress}" in "${currency}"`,
           );
         }


### PR DESCRIPTION
## Explanation

This used to throw an error;
Noticed that on the import flow, if you try to import two tokens exp (USDC and STEELO) where it should succeed to fetch prices for USDC and not for STEELO. It will throw for STEELO preventing fetching for USDC; hence you end up on the home page where you do not see the user token amount for USDC.

Steps to REPRODUCE:
1- Go to home page on extension (IDEALLY remove the extension and import again so u don't have cached rate values)
2- search for STEELO and select it
3- search for USDC and select it
4- Click next and click import
5- go to home page and notice you do not see the USDC token amount in fiat

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- Fixed: removed the throw error in codefi-v2.ts file and changed it to just console the error

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
