### PR TITLE
deps(transactions-controller): eth-method-registry@^1.1.0->^3.0.0

### DIFF
--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -44,7 +44,7 @@
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/utils": "^8.2.0",
     "async-mutex": "^0.2.6",
-    "eth-method-registry": "1.1.0",
+    "eth-method-registry": "^3.0.0",
     "ethereumjs-util": "^7.0.10",
     "fast-json-patch": "^3.1.1",
     "lodash": "^4.17.21",

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -30,7 +30,7 @@ import type {
 import { errorCodes, rpcErrors, providerErrors } from '@metamask/rpc-errors';
 import type { Hex } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
-import MethodRegistry from 'eth-method-registry';
+import { MethodRegistry } from 'eth-method-registry';
 import { addHexPrefix, bufferToHex } from 'ethereumjs-util';
 import { EventEmitter } from 'events';
 import { mapValues, merge, pickBy, sortBy } from 'lodash';
@@ -470,6 +470,7 @@ export class TransactionController extends BaseControllerV1<
     this.isSendFlowHistoryDisabled = disableSendFlowHistory ?? false;
     this.isHistoryDisabled = disableHistory ?? false;
     this.isSwapsDisabled = disableSwaps ?? false;
+    // @ts-expect-error the type in eth-method-registry is inappropriate and should be changed
     this.registry = new MethodRegistry({ provider });
     this.getSavedGasFees = getSavedGasFees ?? ((_chainId) => undefined);
     this.getCurrentAccountEIP1559Compatibility =

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,12 +2055,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/ethjs-contract@npm:^0.3.3":
+  version: 0.3.4
+  resolution: "@metamask/ethjs-contract@npm:0.3.4"
+  dependencies:
+    "@metamask/ethjs-filter": ^0.2.0
+    "@metamask/ethjs-util": ^0.2.0
+    babel-runtime: ^6.26.0
+    ethjs-abi: ^0.2.0
+    js-sha3: ^0.9.2
+    promise-to-callback: ^1.0.0
+  checksum: 790903283fafa4bf4bc9430caf7931f9c796f382c64e86f6e2cac38a9b721f3c017e9c95638849d5145e28cbb50b2b3061d3b2e22faf86c7f5f1b8b5788e3c7c
+  languageName: node
+  linkType: hard
+
+"@metamask/ethjs-filter@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@metamask/ethjs-filter@npm:0.2.0"
+  checksum: d6a987797e396a6d942c9d53bde70ca3f9d486c9062ca309ea606ee2393e91083bc69a8632aac6a1310766d2f9ae12ddb9d833fe3ab04e46ff273279bce5e1f2
+  languageName: node
+  linkType: hard
+
+"@metamask/ethjs-format@npm:^0.2.9":
+  version: 0.2.9
+  resolution: "@metamask/ethjs-format@npm:0.2.9"
+  dependencies:
+    "@metamask/ethjs-util": ^0.2.0
+    bn.js: 4.11.6
+    ethjs-schema: 0.2.1
+    is-hex-prefixed: 1.0.0
+    number-to-bn: 1.7.0
+    strip-hex-prefix: 1.0.0
+  checksum: 3036f9e6628cb281c0e59d9798fb178e254879871b56299313aa7f5ed9e466105afd65f1c7f23a6ca58bfd19e3bdfd11c0791c23048e5641425b15031b2582e7
+  languageName: node
+  linkType: hard
+
 "@metamask/ethjs-provider-http@npm:^0.2.0":
   version: 0.2.0
   resolution: "@metamask/ethjs-provider-http@npm:0.2.0"
   dependencies:
     xhr2: 0.2.1
   checksum: 97a9e168b9ad4bf26a9ed7b1c2f785c42d7a3829dea32ef47445a9035163f6632d32895b1f231dcf9641197626a4c54385c6a9de199bfe83fd316498d1e4b456
+  languageName: node
+  linkType: hard
+
+"@metamask/ethjs-query@npm:^0.5.2":
+  version: 0.5.3
+  resolution: "@metamask/ethjs-query@npm:0.5.3"
+  dependencies:
+    "@metamask/ethjs-format": ^0.2.9
+    "@metamask/ethjs-rpc": 0.3.0 || ^0.3.2
+    babel-runtime: ^6.26.0
+    promise-to-callback: ^1.0.0
+  checksum: 1362dd371e1767647f6b1fa4f216fa17fc8ebd5ccaf5a5072ce84a58f8de67483efdc0c37245080ee81f9cd6e35a5a3676bcf28c12de740682aef57308df1206
+  languageName: node
+  linkType: hard
+
+"@metamask/ethjs-rpc@npm:0.3.0 || ^0.3.2":
+  version: 0.3.2
+  resolution: "@metamask/ethjs-rpc@npm:0.3.2"
+  dependencies:
+    promise-to-callback: ^1.0.0
+  checksum: ef331056ca8e0ada1f8e7bd62e314675854781097bfa5d151d258b671bef22b3a5c0c9c47d77b14c61d057d869555eb03f5232e7fba8977c55c0450eac120b17
   languageName: node
   linkType: hard
 
@@ -2071,6 +2127,34 @@ __metadata:
     bn.js: 4.11.6
     number-to-bn: 1.7.0
   checksum: 0c8bbbe06000f647b46701fcf976e29b67c7362b3ae252d8d4fe2feb74f3988c1203eb03cc34bb899101f01812c8c300158d75bc721d649124c048e8b149b557
+  languageName: node
+  linkType: hard
+
+"@metamask/ethjs-util@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@metamask/ethjs-util@npm:0.2.0"
+  dependencies:
+    is-hex-prefixed: 1.0.0
+    strip-hex-prefix: 1.0.0
+  checksum: 15929757c7848634d56580018b128877f616f89ddcba3cdb5de303e9bd2b346ba63c03adaee0336339cf2edcc6bb094d46c39daa77c2cd8ca83de5bdd74c56b4
+  languageName: node
+  linkType: hard
+
+"@metamask/ethjs@npm:^0.5.0":
+  version: 0.5.1
+  resolution: "@metamask/ethjs@npm:0.5.1"
+  dependencies:
+    "@metamask/ethjs-contract": ^0.3.3
+    "@metamask/ethjs-filter": ^0.2.0
+    "@metamask/ethjs-provider-http": ^0.2.0
+    "@metamask/ethjs-query": ^0.5.2
+    "@metamask/ethjs-unit": ^0.2.1
+    "@metamask/ethjs-util": ^0.2.0
+    bn.js: 4.11.6
+    ethjs-abi: 0.2.1
+    js-sha3: ^0.9.2
+    number-to-bn: 1.7.0
+  checksum: 11850a7f9295efd51f6c8d774b0bc316921e835e86fea9b17eb1f12cc2ab0b332271c096f90e9b910ec49627dea43ac163a42ff672b88d99d0ab59cee2c9bf58
   languageName: node
   linkType: hard
 
@@ -2807,7 +2891,7 @@ __metadata:
     async-mutex: ^0.2.6
     babel-runtime: ^6.26.0
     deepmerge: ^4.2.2
-    eth-method-registry: 1.1.0
+    eth-method-registry: ^3.0.0
     ethereumjs-util: ^7.0.10
     fast-json-patch: ^3.1.1
     jest: ^27.5.1
@@ -5886,12 +5970,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eth-method-registry@npm:1.1.0":
-  version: 1.1.0
-  resolution: "eth-method-registry@npm:1.1.0"
+"eth-method-registry@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "eth-method-registry@npm:3.0.0"
   dependencies:
-    ethjs: ^0.3.0
-  checksum: 3529e06e67740572d5771761d425faf5197695df06035e3c085213e45492eb1fad71f26df36c733769f4ceaa3d0f3d7e91065d42806f800e8ddc4b44b232c614
+    "@metamask/ethjs": ^0.5.0
+  checksum: 8d28fcf48d07c4d7370160ce5188a86e4bd3d829b3d2948a06afb7278443b4f215924a356814815c49ce61dcd9033c61ffe72c1a5033824fbc810346c206e3fa
   languageName: node
   linkType: hard
 
@@ -5975,18 +6059,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethjs-abi@npm:0.2.0":
-  version: 0.2.0
-  resolution: "ethjs-abi@npm:0.2.0"
-  dependencies:
-    bn.js: 4.11.6
-    js-sha3: 0.5.5
-    number-to-bn: 1.7.0
-  checksum: ce66790b312874a8b96122308fe33c05a758127518bda0407b33f8f9ef4641fd75f7c79df850256cc68449442fe4eea74a116a7e26672e72bd326831bdf81570
-  languageName: node
-  linkType: hard
-
-"ethjs-abi@npm:0.2.1":
+"ethjs-abi@npm:0.2.1, ethjs-abi@npm:^0.2.0":
   version: 0.2.1
   resolution: "ethjs-abi@npm:0.2.1"
   dependencies:
@@ -5997,68 +6070,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethjs-contract@npm:0.2.2":
-  version: 0.2.2
-  resolution: "ethjs-contract@npm:0.2.2"
-  dependencies:
-    ethjs-abi: 0.2.0
-    ethjs-filter: 0.1.8
-    ethjs-util: 0.1.3
-    js-sha3: 0.5.5
-  checksum: b340749cf51705ac1e67e7c9b3ae1ceba6631dddffa2b9c62447c348aeba0a56685da956b7193d537c51b9fa2b7bdd2de147e834d4e66214cfa1abdde3d82781
-  languageName: node
-  linkType: hard
-
-"ethjs-filter@npm:0.1.8":
-  version: 0.1.8
-  resolution: "ethjs-filter@npm:0.1.8"
-  checksum: c8cfab8416aae0cf94f670fb09b4adb418447693a749760fea6f9ed5dda293b56b035070236c7cd79622f3e4558de7f790fa6494a1770f7f3f4b8ee9d3aa75a5
-  languageName: node
-  linkType: hard
-
-"ethjs-format@npm:0.2.7":
-  version: 0.2.7
-  resolution: "ethjs-format@npm:0.2.7"
-  dependencies:
-    bn.js: 4.11.6
-    ethjs-schema: 0.2.1
-    ethjs-util: 0.1.3
-    is-hex-prefixed: 1.0.0
-    number-to-bn: 1.7.0
-    strip-hex-prefix: 1.0.0
-  checksum: b27ea907e03ffcecd94baf8fa58afcc345af0af6ceb4ebe45e2f2aea3e3d14cf70a80c18ceb302f4b6cc439018fc05060f6bbf98751ab2fdc7f4af19b3b578b7
-  languageName: node
-  linkType: hard
-
-"ethjs-provider-http@npm:0.1.6":
-  version: 0.1.6
-  resolution: "ethjs-provider-http@npm:0.1.6"
-  dependencies:
-    xhr2: 0.1.3
-  checksum: 0eb8f45d362e5a12f9852da3346cf80bd150562eb0abcbb95892502a6d8f7de77da4aff24341f925f2766e57bb17414c53dafd08bf695b8208d6f50abe7c7716
-  languageName: node
-  linkType: hard
-
-"ethjs-query@npm:0.3.7":
-  version: 0.3.7
-  resolution: "ethjs-query@npm:0.3.7"
-  dependencies:
-    ethjs-format: 0.2.7
-    ethjs-rpc: 0.2.0
-    promise-to-callback: ^1.0.0
-  checksum: 08e8fcced0f7af2828da3f67df94a8a384430d988e43e5d5266aa161ac8f7b4bfc143897e613ba79dd158c0596a9422c0a6efdfe1308530e5b24cd4789ffd694
-  languageName: node
-  linkType: hard
-
-"ethjs-rpc@npm:0.2.0":
-  version: 0.2.0
-  resolution: "ethjs-rpc@npm:0.2.0"
-  dependencies:
-    promise-to-callback: ^1.0.0
-  checksum: b6f4f021ba2b613d453fc02a7d33ec198d64d29af3da137bf728175360281323ab1525b22079d9b0689db0683d76cf265b68774412bff7281d0d26898f4875da
-  languageName: node
-  linkType: hard
-
 "ethjs-schema@npm:0.2.1":
   version: 0.2.1
   resolution: "ethjs-schema@npm:0.2.1"
@@ -6066,41 +6077,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethjs-unit@npm:0.1.6, ethjs-unit@npm:^0.1.6":
+"ethjs-unit@npm:^0.1.6":
   version: 0.1.6
   resolution: "ethjs-unit@npm:0.1.6"
   dependencies:
     bn.js: 4.11.6
     number-to-bn: 1.7.0
   checksum: df6b4752ff7461a59a20219f4b1684c631ea601241c39660e3f6c6bd63c950189723841c22b3c6c0ebeb3c9fc99e0e803e3c613101206132603705fcbcf4def5
-  languageName: node
-  linkType: hard
-
-"ethjs-util@npm:0.1.3":
-  version: 0.1.3
-  resolution: "ethjs-util@npm:0.1.3"
-  dependencies:
-    is-hex-prefixed: 1.0.0
-    strip-hex-prefix: 1.0.0
-  checksum: 1e2c0f94a806986f0db84604e5ecbad93937f34e6cf589de4db2f2870a8278b366482a2d116b392bfa87910f29300c114daace8fa876d3d6b8b886ca0c023b57
-  languageName: node
-  linkType: hard
-
-"ethjs@npm:^0.3.0":
-  version: 0.3.9
-  resolution: "ethjs@npm:0.3.9"
-  dependencies:
-    bn.js: 4.11.6
-    ethjs-abi: 0.2.1
-    ethjs-contract: 0.2.2
-    ethjs-filter: 0.1.8
-    ethjs-provider-http: 0.1.6
-    ethjs-query: 0.3.7
-    ethjs-unit: 0.1.6
-    ethjs-util: 0.1.3
-    js-sha3: 0.5.5
-    number-to-bn: 1.7.0
-  checksum: aa4e69ce4b5db75f8869850ba97199fbee086d0e1a228002a599bdf5617ff1fc914f7552ed25d7c916cf0457d3cbc5d4385f6ea20890b67762eed93a0ef74851
   languageName: node
   linkType: hard
 
@@ -8168,6 +8151,13 @@ __metadata:
   version: 0.5.7
   resolution: "js-sha3@npm:0.5.7"
   checksum: 973a28ea4b26cc7f12d2ab24f796e24ee4a71eef45a6634a052f6eb38cf8b2333db798e896e6e094ea6fa4dfe8e42a2a7942b425cf40da3f866623fd05bb91ea
+  languageName: node
+  linkType: hard
+
+"js-sha3@npm:^0.9.2":
+  version: 0.9.3
+  resolution: "js-sha3@npm:0.9.3"
+  checksum: cfab12cdb3aa9c0c8e8466761d89cb9770653880910b920682fa676dd102868a827709c857cb089bdc0d6120542137f92a7c1699ab428c0f4057c823aef24601
   languageName: node
   linkType: hard
 
@@ -11459,13 +11449,6 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: c3c100a181b731f40b7f2fddf004aa023f79d64f489706a28bc23ff88e87f6a64b3c6651fbec3a84a53960b75159574d7a7385709847a62ddb7ad6af76f49138
-  languageName: node
-  linkType: hard
-
-"xhr2@npm:0.1.3":
-  version: 0.1.3
-  resolution: "xhr2@npm:0.1.3"
-  checksum: 4a3bdcf5f39b4bddc99fd3de1de2f88ce3f23430483bfe6a50628b2c999af3073a781c95f42e161d332de209101fbd313501ba38a7a883dec566c60914042aa2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

- Removes dependency on legacy `ethjs` packages and deprecated version of `xhr2`
  - Prepare for removing dependency on `babel-runtime` 


## References

- https://github.com/MetaMask/metamask-extension/pull/22351

#### Breaking changes in the updated package part of this update
- https://github.com/MetaMask/eth-method-registry/pull/31
- [`provider` is now required](https://github.com/MetaMask/eth-method-registry/pull/15)
  - [we good](https://github.com/MetaMask/core/blob/da6a302d0fb708401a0a423590530873c67045f2/packages/transaction-controller/src/TransactionController.ts#L473) 


## Changelog


### `@metamask/transactions-controller`

- **CHANGED**: Update `@metamask/eth-method-registry` from `^1.1.0` to `^3.0.0`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
