### PR TITLE
[assets-controllers] Upgrade `TokensController` to fully utilize controller-messenger pattern

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Adds `@metamask/accounts-controller` ^8.0.0 and `@metamask/keyring-controller` ^12.0.0 as dependencies and peer dependencies. ([#3775](https://github.com/MetaMask/core/pull/3775/)).
 - **BREAKING:** `TokenDetectionController` newly subscribes to the `PreferencesController:stateChange`, `AccountsController:selectedAccountChange`, `KeyringController:lock`, `KeyringController:unlock` events, and allows the `PreferencesController:getState` messenger action. ([#3775](https://github.com/MetaMask/core/pull/3775/))
+- `TokensController` now exports `TokensControllerActions`, `TokensControllerGetStateAction`, `TokensControllerAddDetectedTokensAction`, `TokensControllerEvents`, `TokensControllerStateChangeEvent`. ([#3690](https://github.com/MetaMask/core/pull/3690/))
 
 ### Changed
 
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **BREAKING:** `TokenDetectionController` constructor no longer accepts options `onPreferencesStateChange`, `getPreferencesState`. ([#3775](https://github.com/MetaMask/core/pull/3775/))
+- **BREAKING:** `TokenDetectionController` constructor no longer accepts options `onPreferencesStateChange`, `getPreferencesState`, `getTokensState`, `addDetectedTokens`. ([#3690](https://github.com/MetaMask/core/pull/3690/), [#3775](https://github.com/MetaMask/core/pull/3775/))
 - **BREAKING:** `TokenDetectionController` no longer allows the `NetworkController:stateChange` event. The `NetworkController:networkDidChange` event can be used instead. ([#3775](https://github.com/MetaMask/core/pull/3775/))
 - **BREAKING:** `TokensController` constructor no longer accepts options `onPreferencesStateChange`, `onNetworkDidChange`, `onTokenListStateChange`, `getNetworkClientById`. ([#3690](https://github.com/MetaMask/core/pull/3690/))
 - **BREAKING:** `TokenBalancesController` constructor no longer accepts options `onTokensStateChange`, `getSelectedAddress`. ([#3690](https://github.com/MetaMask/core/pull/3690/))

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **BREAKING:** The `detectTokens` method now excludes tokens that are already included in the `TokensController`'s `detectedTokens` list from the batch of incoming tokens it sends to the `TokensController` `addDetectedTokens` method.
   - **BREAKING:** The constructor for `TokenDetectionController` expects a new required proprerty `trackMetaMetricsEvent`, which defines the callback that is called in the `detectTokens` method.
   - **BREAKING:** In Mainnet, even if the `PreferenceController`'s `useTokenDetection` option is set to false, automatic token detection is performed on the legacy token list (token data from the contract-metadata repo).
+  - **BREAKING:** The `TokensState` type is now defined as a type alias rather than an interface. ([#3690](https://github.com/MetaMask/core/pull/3690/))
+    - This is breaking because it could affect how this type is used with other types, such as `Json`, which does not support TypeScript interfaces.
 
 ### Removed
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** `TokenDetectionController` constructor no longer accepts options `onPreferencesStateChange`, `getPreferencesState`. ([#3775](https://github.com/MetaMask/core/pull/3775/))
 - **BREAKING:** `TokenDetectionController` no longer allows the `NetworkController:stateChange` event. The `NetworkController:networkDidChange` event can be used instead. ([#3775](https://github.com/MetaMask/core/pull/3775/))
+- **BREAKING:** `TokensController` constructor no longer accepts options `onPreferencesStateChange`, `onNetworkDidChange`, `onTokenListStateChange`, `getNetworkClientById`. ([#3690](https://github.com/MetaMask/core/pull/3690/))
+- **BREAKING:** `TokenBalancesController` constructor no longer accepts options `onTokensStateChange`, `getSelectedAddress`. ([#3690](https://github.com/MetaMask/core/pull/3690/))
 
 ## [25.0.0]
 
@@ -136,8 +138,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - These are needed for the new "polling by `networkClientId`" feature
 - **BREAKING:** `AccountTrackerController` has a new required state property, `accountByChainId`([#3586](https://github.com/MetaMask/core/pull/3586))
   - This is needed to track balances accross chains. It was introduced for the "polling by `networkClientId`" feature, but is useful on its own as well.
-- **BREAKING**: `AccountTrackerController` adds a mutex to `refresh` making it only possible for one call to be executed at time ([#3586](https://github.com/MetaMask/core/pull/3586))
-- **BREAKING**: `TokensController.watchAsset` now performs on-chain validation of the asset's symbol and decimals, if they're defined in the contract ([#1745](https://github.com/MetaMask/core/pull/1745))
+- **BREAKING:** `AccountTrackerController` adds a mutex to `refresh` making it only possible for one call to be executed at time ([#3586](https://github.com/MetaMask/core/pull/3586))
+- **BREAKING:** `TokensController.watchAsset` now performs on-chain validation of the asset's symbol and decimals, if they're defined in the contract ([#1745](https://github.com/MetaMask/core/pull/1745))
   - The `TokensController` constructor no longer accepts a `getERC20TokenName` option. It was no longer needed due to this change.
   - Add new method `_getProvider`, though this is intended for internal use and should not be called externally.
   - Additionally, if the symbol and decimals are defined in the contract, they are no longer required to be passed to `watchAsset`
@@ -168,10 +170,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This method was previously used in TokenRatesController to access the CoinGecko API. There is no equivalent.
 - **BREAKING:** Remove `CoinGeckoResponse` and `CoinGeckoPlatform` types ([#3600](https://github.com/MetaMask/core/pull/3600))
   - These types were previously used in TokenRatesController to represent data returned from the CoinGecko API. There is no equivalent.
-- **BREAKING**: The TokenRatesController now only supports updating and polling rates for tokens tracked by the TokensController ([#3639](https://github.com/MetaMask/core/pull/3639))
+- **BREAKING:** The TokenRatesController now only supports updating and polling rates for tokens tracked by the TokensController ([#3639](https://github.com/MetaMask/core/pull/3639))
   - The `tokenAddresses` option has been removed from `startPollingByNetworkClientId`
   - The `tokenContractAddresses` option has been removed from `updateExchangeRatesByChainId`
-- **BREAKING**: `TokenRatesController.fetchAndMapExchangeRates` is no longer exposed publicly ([#3621](https://github.com/MetaMask/core/pull/3621))
+- **BREAKING:** `TokenRatesController.fetchAndMapExchangeRates` is no longer exposed publicly ([#3621](https://github.com/MetaMask/core/pull/3621))
 
 ### Fixed
 
@@ -255,7 +257,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ```
 - **BREAKING**: `CurrencyRateController` now extends `PollingController` ([#1805](https://github.com/MetaMask/core/pull/1805))
   - `start()` and `stop()` methods replaced with `startPollingByNetworkClientId()`, `stopPollingByPollingToken()`, and `stopAllPolling()`
-- **BREAKING**: `CurrencyRateController` now sends the `NetworkController:getNetworkClientById` action via messaging controller ([#1805](https://github.com/MetaMask/core/pull/1805))
+- **BREAKING:** `CurrencyRateController` now sends the `NetworkController:getNetworkClientById` action via messaging controller ([#1805](https://github.com/MetaMask/core/pull/1805))
 
 ### Fixed
 
@@ -360,7 +362,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       networkClientId?: NetworkClientId;
     }
   ```
-- **BREAKING**: Bump peer dependency on `@metamask/network-controller` to ^13.0.0 ([#1633](https://github.com/MetaMask/core/pull/1633))
+- **BREAKING:** Bump peer dependency on `@metamask/network-controller` to ^13.0.0 ([#1633](https://github.com/MetaMask/core/pull/1633))
 - **CHANGED**: `TokensController.addToken` will use the chain ID value derived from state for `networkClientId` if provided ([#1676](https://github.com/MetaMask/core/pull/1676))
 - **CHANGED**: `TokensController.addTokens` now accepts an optional `networkClientId` as the last parameter ([#1676](https://github.com/MetaMask/core/pull/1676))
 - **CHANGED**: `TokensController.addTokens` will use the chain ID value derived from state for `networkClientId` if provided ([#1676](https://github.com/MetaMask/core/pull/1676))
@@ -425,13 +427,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING**: New required constructor parameters for the `TokenRatesController` ([#1497](https://github.com/MetaMask/core/pull/1497), [#1511](https://github.com/MetaMask/core/pull/1511))
   - The new required parameters are `ticker`, `onSelectedAddress`, and `onPreferencesStateChange`
-- **BREAKING**: Remove `onCurrencyRateStateChange` constructor parameter from `TokenRatesController` ([#1496](https://github.com/MetaMask/core/pull/1496))
-- **BREAKING**: Disable `TokenRatesController` automatic polling ([#1501](https://github.com/MetaMask/core/pull/1501))
+- **BREAKING:** Remove `onCurrencyRateStateChange` constructor parameter from `TokenRatesController` ([#1496](https://github.com/MetaMask/core/pull/1496))
+- **BREAKING:** Disable `TokenRatesController` automatic polling ([#1501](https://github.com/MetaMask/core/pull/1501))
   - Polling must be started explicitly by calling the `start` method
   - The token rates are not updated upon state changes when polling is disabled.
-- **BREAKING**: Replace the `poll` method with `start` ([#1501](https://github.com/MetaMask/core/pull/1501))
+- **BREAKING:** Replace the `poll` method with `start` ([#1501](https://github.com/MetaMask/core/pull/1501))
   - The `start` method does not offer a way to change the interval. That must be done by calling `.configure` instead
-- **BREAKING**: Remove `TokenRatecontroller` setter for `chainId` and `tokens` properties ([#1505](https://github.com/MetaMask/core/pull/1505))
+- **BREAKING:** Remove `TokenRatecontroller` setter for `chainId` and `tokens` properties ([#1505](https://github.com/MetaMask/core/pull/1505))
 - Bump @metamask/abi-utils from 1.2.0 to 2.0.1 ([#1525](https://github.com/MetaMask/core/pull/1525))
 - Update `@metamask/utils` to `^6.2.0` ([#1514](https://github.com/MetaMask/core/pull/1514))
 - Remove unnecessary `babel-runtime` dependency ([#1504](https://github.com/MetaMask/core/pull/1504))
@@ -520,7 +522,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The tokens controller `addDetectedTokens` method now accepts the `chainId` property of the `detectionDetails` parameter to be of type `Hex` rather than decimal `string`.
   - The tokens controller state properties `allTokens`, `allIgnoredTokens`, and `allDetectedTokens` are now keyed by chain ID in `Hex` format rather than decimal `string`.
     - This requires a state migration
-- **BREAKING**: Use approval controller for suggested assets ([#1261](https://github.com/MetaMask/core/pull/1261), [#1268](https://github.com/MetaMask/core/pull/1268))
+- **BREAKING:** Use approval controller for suggested assets ([#1261](https://github.com/MetaMask/core/pull/1261), [#1268](https://github.com/MetaMask/core/pull/1268))
   - The actions `ApprovalController:acceptRequest` and `ApprovalController:rejectRequest` are no longer required by the token controller messenger.
   - The `suggestedAssets` state has been removed, which means that suggested assets are no longer persisted in state
   - The return type for `watchAsset` has changed. It now returns a Promise that settles after the request has been confirmed or rejected.

--- a/packages/assets-controllers/jest.config.js
+++ b/packages/assets-controllers/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 88.3,
+      branches: 88.22,
       functions: 95.32,
-      lines: 96.69,
-      statements: 96.7,
+      lines: 96.68,
+      statements: 96.68,
     },
   },
 

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -1,9 +1,15 @@
 import { ControllerMessenger } from '@metamask/base-controller';
 import { toHex } from '@metamask/controller-utils';
+import type {
+  NetworkControllerActions,
+  NetworkControllerEvents,
+} from '@metamask/network-controller';
+import {} from '@metamask/network-controller';
 import { BN } from 'ethereumjs-util';
 
 import { flushPromises } from '../../../tests/helpers';
 import { TokenBalancesController } from './TokenBalancesController';
+import type { TokenListStateChange } from './TokenListController';
 import type { Token } from './TokenRatesController';
 import { getDefaultTokensState, type TokensState } from './TokensController';
 
@@ -25,12 +31,21 @@ function getMessenger() {
 }
 
 describe('TokenBalancesController', () => {
+  let controllerMessenger: ControllerMessenger<
+    NetworkControllerActions,
+    NetworkControllerEvents | TokenListStateChange
+  >;
+
   beforeEach(() => {
     jest.useFakeTimers();
+    controllerMessenger = new ControllerMessenger();
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:networkDidChange',
+    );
   });
 
   it('should set default state', () => {

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -1,15 +1,14 @@
 import { ControllerMessenger } from '@metamask/base-controller';
 import { toHex } from '@metamask/controller-utils';
-import type {
-  NetworkControllerActions,
-  NetworkControllerEvents,
-} from '@metamask/network-controller';
-import {} from '@metamask/network-controller';
 import { BN } from 'ethereumjs-util';
 
 import { flushPromises } from '../../../tests/helpers';
+import type {
+  AllowedActions,
+  AllowedEvents,
+  TokenBalancesControllerMessenger,
+} from './TokenBalancesController';
 import { TokenBalancesController } from './TokenBalancesController';
-import type { TokenListStateChange } from './TokenListController';
 import type { Token } from './TokenRatesController';
 import { getDefaultTokensState, type TokensState } from './TokensController';
 
@@ -18,48 +17,54 @@ const controllerName = 'TokenBalancesController';
 /**
  * Constructs a restricted controller messenger.
  *
+ * @param controllerMessenger - The controller messenger to restrict.
  * @returns A restricted controller messenger.
  */
-function getMessenger() {
-  return new ControllerMessenger().getRestricted<
-    typeof controllerName,
-    never,
-    never
-  >({
+function getMessenger(
+  controllerMessenger = new ControllerMessenger<
+    AllowedActions,
+    AllowedEvents
+  >(),
+): TokenBalancesControllerMessenger {
+  return controllerMessenger.getRestricted({
     name: controllerName,
+    allowedActions: ['PreferencesController:getState'],
+    allowedEvents: ['TokensController:stateChange'],
   });
 }
 
 describe('TokenBalancesController', () => {
-  let controllerMessenger: ControllerMessenger<
-    NetworkControllerActions,
-    NetworkControllerEvents | TokenListStateChange
-  >;
+  let controllerMessenger: ControllerMessenger<AllowedActions, AllowedEvents>;
+  let messenger: TokenBalancesControllerMessenger;
 
   beforeEach(() => {
     jest.useFakeTimers();
     controllerMessenger = new ControllerMessenger();
+    messenger = getMessenger(controllerMessenger);
   });
 
   afterEach(() => {
     jest.useRealTimers();
-    controllerMessenger.clearEventSubscriptions(
-      'NetworkController:networkDidChange',
-    );
   });
 
   it('should set default state', () => {
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress: '0x1234' }),
+    );
     const controller = new TokenBalancesController({
-      onTokensStateChange: jest.fn(),
-      getSelectedAddress: () => '0x1234',
       getERC20BalanceOf: jest.fn(),
-      messenger: getMessenger(),
+      messenger,
     });
 
     expect(controller.state).toStrictEqual({ contractBalances: {} });
   });
 
   it('should poll and update balances in the right interval', async () => {
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress: '0x1234' }),
+    );
     const updateBalancesSpy = jest.spyOn(
       TokenBalancesController.prototype,
       'updateBalances',
@@ -67,10 +72,8 @@ describe('TokenBalancesController', () => {
 
     new TokenBalancesController({
       interval: 10,
-      onTokensStateChange: jest.fn(),
-      getSelectedAddress: () => '0x1234',
       getERC20BalanceOf: jest.fn(),
-      messenger: getMessenger(),
+      messenger,
     });
     await flushPromises();
 
@@ -84,14 +87,16 @@ describe('TokenBalancesController', () => {
 
   it('should update balances if enabled', async () => {
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress: '0x1234' }),
+    );
     const controller = new TokenBalancesController({
       disabled: false,
       tokens: [{ address, decimals: 18, symbol: 'EOS', aggregators: [] }],
       interval: 10,
-      onTokensStateChange: jest.fn(),
-      getSelectedAddress: () => '0x1234',
       getERC20BalanceOf: jest.fn().mockReturnValue(new BN(1)),
-      messenger: getMessenger(),
+      messenger,
     });
 
     await controller.updateBalances();
@@ -103,14 +108,16 @@ describe('TokenBalancesController', () => {
 
   it('should not update balances if disabled', async () => {
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress: '0x1234' }),
+    );
     const controller = new TokenBalancesController({
       disabled: true,
       tokens: [{ address, decimals: 18, symbol: 'EOS', aggregators: [] }],
       interval: 10,
-      onTokensStateChange: jest.fn(),
-      getSelectedAddress: () => '0x1234',
       getERC20BalanceOf: jest.fn().mockReturnValue(new BN(1)),
-      messenger: getMessenger(),
+      messenger,
     });
 
     await controller.updateBalances();
@@ -120,14 +127,16 @@ describe('TokenBalancesController', () => {
 
   it('should update balances if controller is manually enabled', async () => {
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress: '0x1234' }),
+    );
     const controller = new TokenBalancesController({
       disabled: true,
       tokens: [{ address, decimals: 18, symbol: 'EOS', aggregators: [] }],
       interval: 10,
-      onTokensStateChange: jest.fn(),
-      getSelectedAddress: () => '0x1234',
       getERC20BalanceOf: jest.fn().mockReturnValue(new BN(1)),
-      messenger: getMessenger(),
+      messenger,
     });
 
     await controller.updateBalances();
@@ -144,14 +153,16 @@ describe('TokenBalancesController', () => {
 
   it('should not update balances if controller is manually disabled', async () => {
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress: '0x1234' }),
+    );
     const controller = new TokenBalancesController({
       disabled: false,
       tokens: [{ address, decimals: 18, symbol: 'EOS', aggregators: [] }],
       interval: 10,
-      onTokensStateChange: jest.fn(),
-      getSelectedAddress: () => '0x1234',
       getERC20BalanceOf: jest.fn().mockReturnValue(new BN(1)),
-      messenger: getMessenger(),
+      messenger,
     });
 
     await controller.updateBalances();
@@ -169,23 +180,20 @@ describe('TokenBalancesController', () => {
   });
 
   it('should update balances if tokens change and controller is manually enabled', async () => {
-    const tokensStateChangeListeners: ((state: TokensState) => void)[] = [];
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress: '0x1234' }),
+    );
     const controller = new TokenBalancesController({
       disabled: true,
       tokens: [{ address, decimals: 18, symbol: 'EOS', aggregators: [] }],
       interval: 10,
-      getSelectedAddress: () => '0x1234',
       getERC20BalanceOf: jest.fn().mockReturnValue(new BN(1)),
-      onTokensStateChange: (listener) => {
-        tokensStateChangeListeners.push(listener);
-      },
-      messenger: getMessenger(),
+      messenger,
     });
     const triggerTokensStateChange = async (state: TokensState) => {
-      for (const listener of tokensStateChangeListeners) {
-        listener(state);
-      }
+      controllerMessenger.publish('TokensController:stateChange', state, []);
     };
 
     await controller.updateBalances();
@@ -210,23 +218,20 @@ describe('TokenBalancesController', () => {
   });
 
   it('should not update balances if tokens change and controller is manually disabled', async () => {
-    const tokensStateChangeListeners: ((state: TokensState) => void)[] = [];
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress: '0x1234' }),
+    );
     const controller = new TokenBalancesController({
       disabled: false,
       tokens: [{ address, decimals: 18, symbol: 'EOS', aggregators: [] }],
       interval: 10,
-      getSelectedAddress: () => '0x1234',
       getERC20BalanceOf: jest.fn().mockReturnValue(new BN(1)),
-      onTokensStateChange: (listener) => {
-        tokensStateChangeListeners.push(listener);
-      },
-      messenger: getMessenger(),
+      messenger,
     });
     const triggerTokensStateChange = async (state: TokensState) => {
-      for (const listener of tokensStateChangeListeners) {
-        listener(state);
-      }
+      controllerMessenger.publish('TokensController:stateChange', state, []);
     };
 
     await controller.updateBalances();
@@ -253,12 +258,14 @@ describe('TokenBalancesController', () => {
   });
 
   it('should clear previous interval', async () => {
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress: '0x1234' }),
+    );
     const controller = new TokenBalancesController({
       interval: 1337,
-      onTokensStateChange: jest.fn(),
-      getSelectedAddress: () => '0x1234',
       getERC20BalanceOf: jest.fn(),
-      messenger: getMessenger(),
+      messenger,
     });
 
     const mockClearTimeout = jest.spyOn(global, 'clearTimeout');
@@ -281,13 +288,15 @@ describe('TokenBalancesController', () => {
         aggregators: [],
       },
     ];
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress }),
+    );
     const controller = new TokenBalancesController({
       interval: 1337,
       tokens,
-      onTokensStateChange: jest.fn(),
-      getSelectedAddress: () => selectedAddress,
       getERC20BalanceOf: jest.fn().mockReturnValue(new BN(1)),
-      messenger: getMessenger(),
+      messenger,
     });
 
     expect(controller.state.contractBalances).toStrictEqual({});
@@ -313,13 +322,16 @@ describe('TokenBalancesController', () => {
         aggregators: [],
       },
     ];
+
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({}),
+    );
     const controller = new TokenBalancesController({
       interval: 1337,
       tokens,
-      onTokensStateChange: jest.fn(),
-      getSelectedAddress: jest.fn(),
       getERC20BalanceOf: getERC20BalanceOfStub,
-      messenger: getMessenger(),
+      messenger,
     });
 
     expect(controller.state.contractBalances).toStrictEqual({});
@@ -340,20 +352,17 @@ describe('TokenBalancesController', () => {
   });
 
   it('should update balances when tokens change', async () => {
-    const tokensStateChangeListeners: ((state: TokensState) => void)[] = [];
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress: '0x1234' }),
+    );
     const controller = new TokenBalancesController({
-      onTokensStateChange: (listener) => {
-        tokensStateChangeListeners.push(listener);
-      },
-      getSelectedAddress: jest.fn(),
       getERC20BalanceOf: jest.fn(),
       interval: 1337,
-      messenger: getMessenger(),
+      messenger,
     });
     const triggerTokensStateChange = async (state: TokensState) => {
-      for (const listener of tokensStateChangeListeners) {
-        listener(state);
-      }
+      controllerMessenger.publish('TokensController:stateChange', state, []);
     };
     const updateBalancesSpy = jest.spyOn(controller, 'updateBalances');
 
@@ -372,20 +381,17 @@ describe('TokenBalancesController', () => {
   });
 
   it('should update token balances when detected tokens are added', async () => {
-    const tokensStateChangeListeners: ((state: TokensState) => void)[] = [];
+    controllerMessenger.registerActionHandler(
+      'PreferencesController:getState',
+      jest.fn().mockReturnValue({ selectedAddress: '0x1234' }),
+    );
     const controller = new TokenBalancesController({
       interval: 1337,
-      onTokensStateChange: (listener) => {
-        tokensStateChangeListeners.push(listener);
-      },
-      getSelectedAddress: () => '0x1234',
       getERC20BalanceOf: jest.fn().mockReturnValue(new BN(1)),
-      messenger: getMessenger(),
+      messenger,
     });
     const triggerTokensStateChange = async (state: TokensState) => {
-      for (const listener of tokensStateChangeListeners) {
-        listener(state);
-      }
+      controllerMessenger.publish('TokensController:stateChange', state, []);
     };
     expect(controller.state.contractBalances).toStrictEqual({});
 

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -82,7 +82,7 @@ export type TokenBalancesControllerMessenger = RestrictedControllerMessenger<
  *
  * @returns The default TokenBalancesController state.
  */
-function getDefaultState(): TokenBalancesControllerState {
+export function getDefaultTokenBalancesState(): TokenBalancesControllerState {
   return {
     contractBalances: {},
   };
@@ -137,7 +137,7 @@ export class TokenBalancesController extends BaseController<
       metadata,
       messenger,
       state: {
-        ...getDefaultState(),
+        ...getDefaultTokenBalancesState(),
         ...state,
       },
     });

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -1359,7 +1359,7 @@ async function withController<ReturnValue>(
     'KeyringController:getState',
     mockKeyringState.mockReturnValue({
       isUnlocked: true,
-    } as unknown as KeyringControllerState),
+    } as KeyringControllerState),
   );
   const mockGetNetworkConfigurationByNetworkClientId = jest.fn<
     ReturnType<NetworkController['getNetworkConfigurationByNetworkClientId']>,

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -1390,7 +1390,6 @@ async function withController<ReturnValue>(
       ...getDefaultPreferencesState(),
     }),
   );
-
   const mockAddDetectedTokens = jest.spyOn(controllerMessenger, 'call');
 
   const controller = new TokenDetectionController({
@@ -1406,17 +1405,11 @@ async function withController<ReturnValue>(
       mockKeyringGetState: (state: KeyringControllerState) => {
         mockKeyringState.mockReturnValue(state);
       },
+      mockTokensGetState: (state: TokensState) => {
+        mockTokensState.mockReturnValue(state);
+      },
       mockPreferencesGetState: (state: PreferencesState) => {
         mockPreferencesState.mockReturnValue(state);
-      },
-      mockTokensGetState: (state: TokensState) => {
-        controllerMessenger.unregisterActionHandler(
-          'TokensController:getState',
-        );
-        controllerMessenger.registerActionHandler(
-          'TokensController:getState',
-          mockTokensState.mockReturnValue(state),
-        );
       },
       mockTokenListGetState: (state: TokenListState) => {
         mockTokenListState.mockReturnValue(state);

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -40,6 +40,7 @@ import {
   type TokenListState,
   type TokenListToken,
 } from './TokenListController';
+import type { TokensState } from './TokensController';
 import { getDefaultTokensState } from './TokensController';
 
 const DEFAULT_INTERVAL = 180000;
@@ -138,6 +139,8 @@ function buildTokenDetectionControllerMessenger(
     allowedActions: [
       'KeyringController:getState',
       'NetworkController:getNetworkConfigurationByNetworkClientId',
+      'TokensController:getState',
+      'TokensController:addDetectedTokens',
       'TokenListController:getState',
       'PreferencesController:getState',
     ],
@@ -222,18 +225,20 @@ describe('TokenDetectionController', () => {
       const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
         [sampleTokenA.address]: new BN(1),
       });
-      const mockAddDetectedTokens = jest.fn();
       const selectedAddress = '0x0000000000000000000000000000000000000001';
       await withController(
         {
           options: {
-            addDetectedTokens: mockAddDetectedTokens,
             getBalancesInSingleCall: mockGetBalancesInSingleCall,
             networkClientId: NetworkType.mainnet,
             selectedAddress,
           },
         },
-        async ({ controller, mockTokenListGetState }) => {
+        async ({
+          controller,
+          mockTokenListGetState,
+          mockAddDetectedTokens,
+        }) => {
           mockTokenListGetState({
             ...getDefaultTokenListState(),
             tokenList: {
@@ -251,10 +256,14 @@ describe('TokenDetectionController', () => {
 
           await controller.start();
 
-          expect(mockAddDetectedTokens).toHaveBeenCalledWith([sampleTokenA], {
-            chainId: ChainId.mainnet,
-            selectedAddress,
-          });
+          expect(mockAddDetectedTokens).toHaveBeenCalledWith(
+            'TokensController:addDetectedTokens',
+            [sampleTokenA],
+            {
+              chainId: ChainId.mainnet,
+              selectedAddress,
+            },
+          );
         },
       );
     });
@@ -263,18 +272,20 @@ describe('TokenDetectionController', () => {
       const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
         [sampleTokenA.address]: new BN(1),
       });
-      const mockAddDetectedTokens = jest.fn();
       const selectedAddress = '0x0000000000000000000000000000000000000001';
       await withController(
         {
           options: {
-            addDetectedTokens: mockAddDetectedTokens,
             getBalancesInSingleCall: mockGetBalancesInSingleCall,
             networkClientId: 'polygon',
             selectedAddress,
           },
         },
-        async ({ controller, mockTokenListGetState }) => {
+        async ({
+          controller,
+          mockTokenListGetState,
+          mockAddDetectedTokens,
+        }) => {
           mockTokenListGetState({
             ...getDefaultTokenListState(),
             tokenList: {
@@ -292,10 +303,14 @@ describe('TokenDetectionController', () => {
 
           await controller.start();
 
-          expect(mockAddDetectedTokens).toHaveBeenCalledWith([sampleTokenA], {
-            chainId: '0x89',
-            selectedAddress,
-          });
+          expect(mockAddDetectedTokens).toHaveBeenCalledWith(
+            'TokensController:addDetectedTokens',
+            [sampleTokenA],
+            {
+              chainId: '0x89',
+              selectedAddress,
+            },
+          );
         },
       );
     });
@@ -305,20 +320,22 @@ describe('TokenDetectionController', () => {
         [sampleTokenA.address]: new BN(1),
         [sampleTokenB.address]: new BN(1),
       });
-      const mockAddDetectedTokens = jest.fn();
       const selectedAddress = '0x0000000000000000000000000000000000000001';
       const interval = 100;
       await withController(
         {
           options: {
-            addDetectedTokens: mockAddDetectedTokens,
             getBalancesInSingleCall: mockGetBalancesInSingleCall,
             interval,
             networkClientId: NetworkType.mainnet,
             selectedAddress,
           },
         },
-        async ({ controller, mockTokenListGetState }) => {
+        async ({
+          controller,
+          mockTokenListGetState,
+          mockAddDetectedTokens,
+        }) => {
           const tokenListState = {
             ...getDefaultTokenListState(),
             tokenList: {
@@ -335,7 +352,6 @@ describe('TokenDetectionController', () => {
           };
           mockTokenListGetState(tokenListState);
           await controller.start();
-          mockAddDetectedTokens.mockReset();
 
           tokenListState.tokenList[sampleTokenB.address] = {
             name: sampleTokenB.name as string,
@@ -350,6 +366,7 @@ describe('TokenDetectionController', () => {
           await advanceTime({ clock, duration: interval });
 
           expect(mockAddDetectedTokens).toHaveBeenCalledWith(
+            'TokensController:addDetectedTokens',
             [sampleTokenA, sampleTokenB],
             {
               chainId: ChainId.mainnet,
@@ -364,23 +381,25 @@ describe('TokenDetectionController', () => {
       const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
         [sampleTokenA.address]: new BN(1),
       });
-      const mockAddDetectedTokens = jest.fn();
-      const mockGetTokensState = jest.fn().mockReturnValue({
-        ...getDefaultTokensState(),
-        ignoredTokens: [sampleTokenA.address],
-      });
       const selectedAddress = '0x0000000000000000000000000000000000000001';
       await withController(
         {
           options: {
-            addDetectedTokens: mockAddDetectedTokens,
             getBalancesInSingleCall: mockGetBalancesInSingleCall,
-            getTokensState: mockGetTokensState,
             networkClientId: NetworkType.mainnet,
             selectedAddress,
           },
         },
-        async ({ controller, mockTokenListGetState }) => {
+        async ({
+          controller,
+          mockTokensGetState,
+          mockTokenListGetState,
+          mockAddDetectedTokens,
+        }) => {
+          mockTokensGetState({
+            ...getDefaultTokensState(),
+            ignoredTokens: [sampleTokenA.address],
+          });
           mockTokenListGetState({
             ...getDefaultTokenListState(),
             tokenList: {
@@ -398,7 +417,9 @@ describe('TokenDetectionController', () => {
 
           await controller.start();
 
-          expect(mockAddDetectedTokens).not.toHaveBeenCalled();
+          expect(mockAddDetectedTokens).not.toHaveBeenCalledWith(
+            'TokensController:addDetectedTokens',
+          );
         },
       );
     });
@@ -407,17 +428,19 @@ describe('TokenDetectionController', () => {
       const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
         [sampleTokenA.address]: new BN(1),
       });
-      const mockAddDetectedTokens = jest.fn();
       await withController(
         {
           options: {
-            addDetectedTokens: mockAddDetectedTokens,
             getBalancesInSingleCall: mockGetBalancesInSingleCall,
             networkClientId: NetworkType.mainnet,
             selectedAddress: '',
           },
         },
-        async ({ controller, mockTokenListGetState }) => {
+        async ({
+          controller,
+          mockTokenListGetState,
+          mockAddDetectedTokens,
+        }) => {
           mockTokenListGetState({
             ...getDefaultTokenListState(),
             tokenList: {
@@ -435,7 +458,9 @@ describe('TokenDetectionController', () => {
 
           await controller.start();
 
-          expect(mockAddDetectedTokens).not.toHaveBeenCalled();
+          expect(mockAddDetectedTokens).not.toHaveBeenCalledWith(
+            'TokensController:addDetectedTokens',
+          );
         },
       );
     });
@@ -456,7 +481,6 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const firstSelectedAddress =
           '0x0000000000000000000000000000000000000001';
         const secondSelectedAddress =
@@ -464,14 +488,17 @@ describe('TokenDetectionController', () => {
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: false,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress: firstSelectedAddress,
             },
           },
-          async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
+          async ({
+            mockTokenListGetState,
+            triggerPreferencesStateChange,
+            mockAddDetectedTokens,
+          }) => {
             mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
@@ -494,10 +521,14 @@ describe('TokenDetectionController', () => {
             });
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).toHaveBeenCalledWith([sampleTokenA], {
-              chainId: ChainId.mainnet,
-              selectedAddress: secondSelectedAddress,
-            });
+            expect(mockAddDetectedTokens).toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+              [sampleTokenA],
+              {
+                chainId: ChainId.mainnet,
+                selectedAddress: secondSelectedAddress,
+              },
+            );
           },
         );
       });
@@ -506,19 +537,21 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const selectedAddress = '0x0000000000000000000000000000000000000001';
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: false,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
           },
-          async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
+          async ({
+            mockTokenListGetState,
+            triggerPreferencesStateChange,
+            mockAddDetectedTokens,
+          }) => {
             mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
@@ -548,10 +581,14 @@ describe('TokenDetectionController', () => {
             });
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).toHaveBeenCalledWith([sampleTokenA], {
-              chainId: ChainId.mainnet,
-              selectedAddress,
-            });
+            expect(mockAddDetectedTokens).toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+              [sampleTokenA],
+              {
+                chainId: ChainId.mainnet,
+                selectedAddress,
+              },
+            );
           },
         );
       });
@@ -560,7 +597,6 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const firstSelectedAddress =
           '0x0000000000000000000000000000000000000001';
         const secondSelectedAddress =
@@ -568,14 +604,17 @@ describe('TokenDetectionController', () => {
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: false,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress: firstSelectedAddress,
             },
           },
-          async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
+          async ({
+            mockTokenListGetState,
+            triggerPreferencesStateChange,
+            mockAddDetectedTokens,
+          }) => {
             mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
@@ -598,7 +637,9 @@ describe('TokenDetectionController', () => {
             });
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).not.toHaveBeenCalled();
+            expect(mockAddDetectedTokens).not.toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+            );
           },
         );
       });
@@ -607,19 +648,21 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const selectedAddress = '0x0000000000000000000000000000000000000001';
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: false,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
           },
-          async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
+          async ({
+            mockTokenListGetState,
+            triggerPreferencesStateChange,
+            mockAddDetectedTokens,
+          }) => {
             mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
@@ -642,7 +685,9 @@ describe('TokenDetectionController', () => {
             });
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).not.toHaveBeenCalled();
+            expect(mockAddDetectedTokens).not.toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+            );
           },
         );
       });
@@ -653,7 +698,6 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const firstSelectedAddress =
           '0x0000000000000000000000000000000000000001';
         const secondSelectedAddress =
@@ -661,14 +705,17 @@ describe('TokenDetectionController', () => {
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: true,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress: firstSelectedAddress,
             },
           },
-          async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
+          async ({
+            mockTokenListGetState,
+            triggerPreferencesStateChange,
+            mockAddDetectedTokens,
+          }) => {
             mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
@@ -691,7 +738,9 @@ describe('TokenDetectionController', () => {
             });
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).not.toHaveBeenCalled();
+            expect(mockAddDetectedTokens).not.toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+            );
           },
         );
       });
@@ -700,19 +749,21 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const selectedAddress = '0x0000000000000000000000000000000000000001';
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: true,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
           },
-          async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
+          async ({
+            mockTokenListGetState,
+            triggerPreferencesStateChange,
+            mockAddDetectedTokens,
+          }) => {
             mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
@@ -742,7 +793,9 @@ describe('TokenDetectionController', () => {
             });
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).not.toHaveBeenCalled();
+            expect(mockAddDetectedTokens).not.toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+            );
           },
         );
       });
@@ -764,24 +817,21 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const selectedAddress = '0x0000000000000000000000000000000000000001';
-        const messenger = new ControllerMessenger<
-          AllowedActions,
-          AllowedEvents
-        >();
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: false,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
-            messenger,
           },
-          async ({ mockTokenListGetState }) => {
+          async ({
+            mockTokenListGetState,
+            mockAddDetectedTokens,
+            triggerNetworkDidChange,
+          }) => {
             mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
@@ -797,16 +847,20 @@ describe('TokenDetectionController', () => {
               },
             });
 
-            messenger.publish('NetworkController:networkDidChange', {
+            triggerNetworkDidChange({
               ...defaultNetworkState,
               selectedNetworkClientId: 'polygon',
             });
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).toHaveBeenCalledWith([sampleTokenA], {
-              chainId: '0x89',
-              selectedAddress,
-            });
+            expect(mockAddDetectedTokens).toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+              [sampleTokenA],
+              {
+                chainId: '0x89',
+                selectedAddress,
+              },
+            );
           },
         );
       });
@@ -815,24 +869,21 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const selectedAddress = '0x0000000000000000000000000000000000000001';
-        const messenger = new ControllerMessenger<
-          AllowedActions,
-          AllowedEvents
-        >();
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: false,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
-            messenger,
           },
-          async ({ mockTokenListGetState }) => {
+          async ({
+            mockTokenListGetState,
+            mockAddDetectedTokens,
+            triggerNetworkDidChange,
+          }) => {
             mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
@@ -848,13 +899,15 @@ describe('TokenDetectionController', () => {
               },
             });
 
-            messenger.publish('NetworkController:networkDidChange', {
+            triggerNetworkDidChange({
               ...defaultNetworkState,
               selectedNetworkClientId: 'goerli',
             });
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).not.toHaveBeenCalled();
+            expect(mockAddDetectedTokens).not.toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+            );
           },
         );
       });
@@ -863,24 +916,21 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const selectedAddress = '0x0000000000000000000000000000000000000001';
-        const messenger = new ControllerMessenger<
-          AllowedActions,
-          AllowedEvents
-        >();
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: false,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
-            messenger,
           },
-          async ({ mockTokenListGetState }) => {
+          async ({
+            mockTokenListGetState,
+            mockAddDetectedTokens,
+            triggerNetworkDidChange,
+          }) => {
             mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
@@ -896,13 +946,15 @@ describe('TokenDetectionController', () => {
               },
             });
 
-            messenger.publish('NetworkController:networkDidChange', {
+            triggerNetworkDidChange({
               ...defaultNetworkState,
               selectedNetworkClientId: 'mainnet',
             });
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).not.toHaveBeenCalled();
+            expect(mockAddDetectedTokens).not.toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+            );
           },
         );
       });
@@ -913,24 +965,21 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const selectedAddress = '0x0000000000000000000000000000000000000001';
-        const messenger = new ControllerMessenger<
-          AllowedActions,
-          AllowedEvents
-        >();
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: true,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
-            messenger,
           },
-          async ({ mockTokenListGetState }) => {
+          async ({
+            mockTokenListGetState,
+            mockAddDetectedTokens,
+            triggerNetworkDidChange,
+          }) => {
             mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
@@ -946,13 +995,15 @@ describe('TokenDetectionController', () => {
               },
             });
 
-            messenger.publish('NetworkController:networkDidChange', {
+            triggerNetworkDidChange({
               ...defaultNetworkState,
               selectedNetworkClientId: 'polygon',
             });
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).not.toHaveBeenCalled();
+            expect(mockAddDetectedTokens).not.toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+            );
           },
         );
       });
@@ -974,24 +1025,21 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const selectedAddress = '0x0000000000000000000000000000000000000001';
-        const messenger = new ControllerMessenger<
-          AllowedActions,
-          AllowedEvents
-        >();
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: false,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
-            messenger,
           },
-          async ({ mockTokenListGetState }) => {
+          async ({
+            mockTokenListGetState,
+            mockAddDetectedTokens,
+            triggerTokenListStateChange,
+          }) => {
             const tokenListState = {
               ...getDefaultTokenListState(),
               tokenList: {
@@ -1008,17 +1056,17 @@ describe('TokenDetectionController', () => {
             };
             mockTokenListGetState(tokenListState);
 
-            messenger.publish(
-              'TokenListController:stateChange',
-              tokenListState,
-              [],
-            );
+            triggerTokenListStateChange(tokenListState);
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).toHaveBeenCalledWith([sampleTokenA], {
-              chainId: ChainId.mainnet,
-              selectedAddress,
-            });
+            expect(mockAddDetectedTokens).toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+              [sampleTokenA],
+              {
+                chainId: ChainId.mainnet,
+                selectedAddress,
+              },
+            );
           },
         );
       });
@@ -1027,38 +1075,33 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const selectedAddress = '0x0000000000000000000000000000000000000001';
-        const messenger = new ControllerMessenger<
-          AllowedActions,
-          AllowedEvents
-        >();
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: false,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
-            messenger,
           },
-          async ({ mockTokenListGetState }) => {
+          async ({
+            mockTokenListGetState,
+            mockAddDetectedTokens,
+            triggerTokenListStateChange,
+          }) => {
             const tokenListState = {
               ...getDefaultTokenListState(),
               tokenList: {},
             };
             mockTokenListGetState(tokenListState);
 
-            messenger.publish(
-              'TokenListController:stateChange',
-              tokenListState,
-              [],
-            );
+            triggerTokenListStateChange(tokenListState);
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).not.toHaveBeenCalled();
+            expect(mockAddDetectedTokens).not.toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+            );
           },
         );
       });
@@ -1069,24 +1112,21 @@ describe('TokenDetectionController', () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
-        const mockAddDetectedTokens = jest.fn();
         const selectedAddress = '0x0000000000000000000000000000000000000001';
-        const messenger = new ControllerMessenger<
-          AllowedActions,
-          AllowedEvents
-        >();
         await withController(
           {
             options: {
-              addDetectedTokens: mockAddDetectedTokens,
               disabled: true,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
-            messenger,
           },
-          async ({ mockTokenListGetState }) => {
+          async ({
+            mockTokenListGetState,
+            mockAddDetectedTokens,
+            triggerTokenListStateChange,
+          }) => {
             const tokenListState = {
               ...getDefaultTokenListState(),
               tokenList: {
@@ -1103,14 +1143,12 @@ describe('TokenDetectionController', () => {
             };
             mockTokenListGetState(tokenListState);
 
-            messenger.publish(
-              'TokenListController:stateChange',
-              tokenListState,
-              [],
-            );
+            triggerTokenListStateChange(tokenListState);
             await advanceTime({ clock, duration: 1 });
 
-            expect(mockAddDetectedTokens).not.toHaveBeenCalled();
+            expect(mockAddDetectedTokens).not.toHaveBeenCalledWith(
+              'TokensController:addDetectedTokens',
+            );
           },
         );
       });
@@ -1131,22 +1169,15 @@ describe('TokenDetectionController', () => {
       const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
         [sampleTokenA.address]: new BN(1),
       });
-      const mockAddDetectedTokens = jest.fn();
       const selectedAddress = '0x0000000000000000000000000000000000000001';
-      const messenger = new ControllerMessenger<
-        AllowedActions,
-        AllowedEvents
-      >();
       await withController(
         {
           options: {
-            addDetectedTokens: mockAddDetectedTokens,
             disabled: false,
             getBalancesInSingleCall: mockGetBalancesInSingleCall,
             networkClientId: NetworkType.mainnet,
             selectedAddress,
           },
-          messenger,
         },
         async ({ controller, mockTokenListGetState }) => {
           mockTokenListGetState({
@@ -1205,24 +1236,21 @@ describe('TokenDetectionController', () => {
       const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
         [sampleTokenA.address]: new BN(1),
       });
-      const mockAddDetectedTokens = jest.fn();
       const selectedAddress = '0x0000000000000000000000000000000000000001';
-      const messenger = new ControllerMessenger<
-        AllowedActions,
-        AllowedEvents
-      >();
       await withController(
         {
           options: {
-            addDetectedTokens: mockAddDetectedTokens,
             disabled: false,
             getBalancesInSingleCall: mockGetBalancesInSingleCall,
             networkClientId: NetworkType.mainnet,
             selectedAddress,
           },
-          messenger,
         },
-        async ({ controller, mockTokenListGetState }) => {
+        async ({
+          controller,
+          mockTokenListGetState,
+          mockAddDetectedTokens,
+        }) => {
           mockTokenListGetState({
             ...getDefaultTokenListState(),
             tokenList: {
@@ -1243,10 +1271,14 @@ describe('TokenDetectionController', () => {
             accountAddress: selectedAddress,
           });
 
-          expect(mockAddDetectedTokens).toHaveBeenCalledWith([sampleTokenA], {
-            chainId: ChainId.mainnet,
-            selectedAddress,
-          });
+          expect(mockAddDetectedTokens).toHaveBeenCalledWith(
+            'TokensController:addDetectedTokens',
+            [sampleTokenA],
+            {
+              chainId: ChainId.mainnet,
+              selectedAddress,
+            },
+          );
         },
       );
     });
@@ -1268,8 +1300,10 @@ function getTokensPath(chainId: Hex) {
 type WithControllerCallback<ReturnValue> = ({
   controller,
   mockKeyringGetState,
+  mockTokensGetState,
   mockTokenListGetState,
   mockPreferencesGetState,
+  mockAddDetectedTokens,
   triggerKeyringUnlock,
   triggerKeyringLock,
   triggerTokenListStateChange,
@@ -1279,11 +1313,13 @@ type WithControllerCallback<ReturnValue> = ({
 }: {
   controller: TokenDetectionController;
   mockKeyringGetState: (state: KeyringControllerState) => void;
+  mockTokensGetState: (state: TokensState) => void;
   mockTokenListGetState: (state: TokenListState) => void;
   mockPreferencesGetState: (state: PreferencesState) => void;
   mockGetNetworkConfigurationByNetworkClientId: (
     handler: (networkClientId: string) => NetworkConfiguration,
   ) => void;
+  mockAddDetectedTokens: jest.SpyInstance;
   triggerKeyringUnlock: () => void;
   triggerKeyringLock: () => void;
   triggerTokenListStateChange: (state: TokenListState) => void;
@@ -1337,6 +1373,11 @@ async function withController<ReturnValue>(
       },
     ),
   );
+  const mockTokensState = jest.fn<TokensState, []>();
+  controllerMessenger.registerActionHandler(
+    'TokensController:getState',
+    mockTokensState.mockReturnValue({ ...getDefaultTokensState() }),
+  );
   const mockTokenListState = jest.fn<TokenListState, []>();
   controllerMessenger.registerActionHandler(
     'TokenListController:getState',
@@ -1350,11 +1391,11 @@ async function withController<ReturnValue>(
     }),
   );
 
+  const mockAddDetectedTokens = jest.spyOn(controllerMessenger, 'call');
+
   const controller = new TokenDetectionController({
     networkClientId: NetworkType.mainnet,
     getBalancesInSingleCall: jest.fn(),
-    addDetectedTokens: jest.fn(),
-    getTokensState: jest.fn().mockReturnValue(getDefaultTokensState()),
     trackMetaMetricsEvent: jest.fn(),
     messenger: buildTokenDetectionControllerMessenger(controllerMessenger),
     ...options,
@@ -1368,6 +1409,15 @@ async function withController<ReturnValue>(
       mockPreferencesGetState: (state: PreferencesState) => {
         mockPreferencesState.mockReturnValue(state);
       },
+      mockTokensGetState: (state: TokensState) => {
+        controllerMessenger.unregisterActionHandler(
+          'TokensController:getState',
+        );
+        controllerMessenger.registerActionHandler(
+          'TokensController:getState',
+          mockTokensState.mockReturnValue(state),
+        );
+      },
       mockTokenListGetState: (state: TokenListState) => {
         mockTokenListState.mockReturnValue(state);
       },
@@ -1378,6 +1428,7 @@ async function withController<ReturnValue>(
           handler,
         );
       },
+      mockAddDetectedTokens,
       triggerKeyringUnlock: () => {
         controllerMessenger.publish('KeyringController:unlock');
       },

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -35,7 +35,10 @@ import type {
   TokenListToken,
 } from './TokenListController';
 import type { Token } from './TokenRatesController';
-import type { TokensController, TokensState } from './TokensController';
+import type {
+  TokensControllerAddDetectedTokensAction,
+  TokensControllerGetStateAction,
+} from './TokensController';
 
 const DEFAULT_INTERVAL = 180000;
 
@@ -90,7 +93,9 @@ export type AllowedActions =
   | NetworkControllerGetNetworkConfigurationByNetworkClientId
   | GetTokenListState
   | KeyringControllerGetStateAction
-  | PreferencesControllerGetStateAction;
+  | PreferencesControllerGetStateAction
+  | TokensControllerGetStateAction
+  | TokensControllerAddDetectedTokensAction;
 
 export type TokenDetectionControllerStateChangeEvent =
   ControllerStateChangeEvent<typeof controllerName, TokenDetectionState>;
@@ -146,11 +151,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
   #isDetectionEnabledForNetwork: boolean;
 
-  readonly #addDetectedTokens: TokensController['addDetectedTokens'];
-
   readonly #getBalancesInSingleCall: AssetsContractController['getBalancesInSingleCall'];
-
-  readonly #getTokensState: () => TokensState;
 
   readonly #trackMetaMetricsEvent: (options: {
     event: string;
@@ -171,9 +172,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
    * @param options.interval - Polling interval used to fetch new token rates
    * @param options.networkClientId - The selected network client ID of the current network
    * @param options.selectedAddress - Vault selected address
-   * @param options.addDetectedTokens - Add a list of detected tokens.
    * @param options.getBalancesInSingleCall - Gets the balances of a list of tokens for the given address.
-   * @param options.getTokensState - Gets the current state of the Tokens controller.
    * @param options.trackMetaMetricsEvent - Sets options for MetaMetrics event tracking.
    */
   constructor({
@@ -182,8 +181,6 @@ export class TokenDetectionController extends StaticIntervalPollingController<
     interval = DEFAULT_INTERVAL,
     disabled = true,
     getBalancesInSingleCall,
-    addDetectedTokens,
-    getTokensState,
     trackMetaMetricsEvent,
     messenger,
   }: {
@@ -191,9 +188,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
     selectedAddress?: string;
     interval?: number;
     disabled?: boolean;
-    addDetectedTokens: TokensController['addDetectedTokens'];
     getBalancesInSingleCall: AssetsContractController['getBalancesInSingleCall'];
-    getTokensState: () => TokensState;
     trackMetaMetricsEvent: (options: {
       event: string;
       category: string;
@@ -226,9 +221,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
       this.#chainId,
     );
 
-    this.#addDetectedTokens = addDetectedTokens;
     this.#getBalancesInSingleCall = getBalancesInSingleCall;
-    this.#getTokensState = getTokensState;
 
     this.#trackMetaMetricsEvent = trackMetaMetricsEvent;
 
@@ -460,7 +453,9 @@ export class TokenDetectionController extends StaticIntervalPollingController<
       ? STATIC_MAINNET_TOKEN_LIST
       : tokenList;
 
-    const { tokens, detectedTokens } = this.#getTokensState();
+    const { tokens, detectedTokens } = this.messagingSystem.call(
+      'TokensController:getState',
+    );
     const tokensToDetect: string[] = [];
 
     for (const tokenAddress of Object.keys(tokenListUsed)) {
@@ -504,7 +499,9 @@ export class TokenDetectionController extends StaticIntervalPollingController<
         for (const tokenAddress of Object.keys(balances)) {
           let ignored;
           /* istanbul ignore else */
-          const { ignoredTokens } = this.#getTokensState();
+          const { ignoredTokens } = this.messagingSystem.call(
+            'TokensController:getState',
+          );
           if (ignoredTokens.length) {
             ignored = ignoredTokens.find(
               (ignoredTokenAddress) =>
@@ -543,10 +540,14 @@ export class TokenDetectionController extends StaticIntervalPollingController<
               asset_type: 'TOKEN',
             },
           });
-          await this.#addDetectedTokens(tokensToAdd, {
-            selectedAddress,
-            chainId,
-          });
+          await this.messagingSystem.call(
+            'TokensController:addDetectedTokens',
+            tokensToAdd,
+            {
+              selectedAddress,
+              chainId,
+            },
+          );
         }
       });
     }

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -462,7 +462,6 @@ export class TokenDetectionController extends StaticIntervalPollingController<
       'TokensController:getState',
     );
     const tokensToDetect: string[] = [];
-
     for (const tokenAddress of Object.keys(tokenListUsed)) {
       if (
         !findCaseInsensitiveMatch(

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -453,7 +453,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
       ? STATIC_MAINNET_TOKEN_LIST
       : tokenList;
 
-    const { tokens, detectedTokens } = this.messagingSystem.call(
+    const { tokens, detectedTokens, ignoredTokens } = this.messagingSystem.call(
       'TokensController:getState',
     );
     const tokensToDetect: string[] = [];
@@ -495,13 +495,9 @@ export class TokenDetectionController extends StaticIntervalPollingController<
           tokensSlice,
         );
         const tokensToAdd: Token[] = [];
-        const eventTokensDetails = [];
+        const eventTokensDetails: string[] = [];
+        let ignored;
         for (const tokenAddress of Object.keys(balances)) {
-          let ignored;
-          /* istanbul ignore else */
-          const { ignoredTokens } = this.messagingSystem.call(
-            'TokensController:getState',
-          );
           if (ignoredTokens.length) {
             ignored = ignoredTokens.find(
               (ignoredTokenAddress) =>
@@ -516,7 +512,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
           if (ignored === undefined) {
             const { decimals, symbol, aggregators, iconUrl, name } =
-              tokenList[caseInsensitiveTokenKey];
+              tokenListUsed[caseInsensitiveTokenKey];
             eventTokensDetails.push(`${symbol} - ${tokenAddress}`);
             tokensToAdd.push({
               address: tokenAddress,

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -64,7 +64,12 @@ type LegacyToken = Omit<
 
 export const STATIC_MAINNET_TOKEN_LIST = Object.entries<LegacyToken>(
   contractMap,
-).reduce<Record<string, Partial<TokenListToken>>>((acc, [base, contract]) => {
+).reduce<
+  Record<
+    string,
+    Partial<TokenListToken> & Pick<Token, 'address' | 'symbol' | 'decimals'>
+  >
+>((acc, [base, contract]) => {
   const { logo, ...tokenMetadata } = contract;
   return {
     ...acc,

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -17,6 +17,7 @@ import {
 } from '@metamask/controller-utils';
 import type {
   BlockTrackerProxy,
+  NetworkController,
   ProviderConfig,
   ProviderProxy,
 } from '@metamask/network-controller';
@@ -32,6 +33,7 @@ import {
 import nock from 'nock';
 import * as sinon from 'sinon';
 
+import { FakeProvider } from '../../../tests/fake-provider';
 import { ERC20Standard } from './Standards/ERC20Standard';
 import { ERC1155Standard } from './Standards/NftStandards/ERC1155/ERC1155Standard';
 import { TOKEN_END_POINT_API } from './token-service';
@@ -130,7 +132,10 @@ describe('TokensController', () => {
     });
   };
 
-  const getNetworkClientByIdHandler = jest.fn();
+  const getNetworkClientByIdHandler = jest.fn<
+    ReturnType<NetworkController['getNetworkClientById']>,
+    Parameters<NetworkController['getNetworkClientById']>
+  >();
   beforeEach(async () => {
     const defaultSelectedAddress = '0x1';
     const preferencesStateChangeListeners: ((
@@ -155,7 +160,9 @@ describe('TokensController', () => {
 
     messenger.registerActionHandler(
       `NetworkController:getNetworkClientById`,
-      getNetworkClientByIdHandler.mockReturnValue(mockMainnetClient),
+      getNetworkClientByIdHandler.mockReturnValue(
+        mockMainnetClient as unknown as AutoManagedNetworkClient<CustomNetworkClientConfiguration>,
+      ),
     );
   });
 
@@ -426,7 +433,7 @@ describe('TokensController', () => {
       `NetworkController:getNetworkClientById`,
       getNetworkClientByIdHandler.mockReturnValue({
         configuration: { chainId: '0x5' },
-      }),
+      } as unknown as AutoManagedNetworkClient<CustomNetworkClientConfiguration>),
     );
     await tokensController.addToken({
       address: '0x01',
@@ -1117,7 +1124,7 @@ describe('TokensController', () => {
         `NetworkController:getNetworkClientById`,
         getNetworkClientByIdHandler.mockReturnValue({
           configuration: { chainId: '0x5' },
-        }),
+        } as unknown as AutoManagedNetworkClient<CustomNetworkClientConfiguration>),
       );
       const dummyTokens: Token[] = [
         {
@@ -1578,8 +1585,8 @@ describe('TokensController', () => {
         `NetworkController:getNetworkClientById`,
         getNetworkClientByIdHandler.mockReturnValue({
           configuration: { chainId: '0x5' },
-          provider: sinon.stub(),
-        }),
+          provider: new FakeProvider({ stubs: [] }),
+        } as unknown as AutoManagedNetworkClient<CustomNetworkClientConfiguration>),
       );
 
       const generateRandomIdStub = jest

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -1236,8 +1236,6 @@ describe('TokensController', () => {
           .spyOn(ERC20Standard.prototype as any, 'getTokenDecimals')
           .mockImplementationOnce(() => a.decimals?.toString());
       });
-
-    let addRequestHandler: jest.Mock;
     let createEthersStub: sinon.SinonStub;
     beforeEach(function () {
       type = ERC20;
@@ -1248,7 +1246,6 @@ describe('TokensController', () => {
         image: 'image',
         name: undefined,
       };
-      addRequestHandler = jest.fn();
 
       isERC721 = false;
       isERC1155 = false;
@@ -1592,6 +1589,7 @@ describe('TokensController', () => {
         }),
       );
 
+      const addRequestHandler = jest.fn();
       messenger.unregisterActionHandler(`ApprovalController:addRequest`);
       messenger.registerActionHandler(
         `ApprovalController:addRequest`,

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -95,6 +95,10 @@ describe('TokensController', () => {
   >;
   let tokensControllerMessenger;
   let approvalControllerMessenger;
+  let getNetworkClientByIdHandler: jest.Mock<
+    ReturnType<NetworkController['getNetworkClientById']>,
+    Parameters<NetworkController['getNetworkClientById']>
+  >;
 
   const changeNetwork = (providerConfig: ProviderConfig) => {
     messenger.publish(`NetworkController:networkDidChange`, {
@@ -106,11 +110,6 @@ describe('TokensController', () => {
   const triggerPreferencesStateChange = (state: PreferencesState) => {
     messenger.publish('PreferencesController:stateChange', state, []);
   };
-
-  const getNetworkClientByIdHandler = jest.fn<
-    ReturnType<NetworkController['getNetworkClientById']>,
-    Parameters<NetworkController['getNetworkClientById']>
-  >();
 
   beforeEach(async () => {
     const defaultSelectedAddress = '0x1';
@@ -151,6 +150,7 @@ describe('TokensController', () => {
       typesExcludedFromRateLimiting: [ApprovalType.WatchAsset],
     });
 
+    getNetworkClientByIdHandler = jest.fn();
     messenger.registerActionHandler(
       `NetworkController:getNetworkClientById`,
       getNetworkClientByIdHandler.mockReturnValue(
@@ -163,7 +163,6 @@ describe('TokensController', () => {
 
   afterEach(() => {
     sinon.restore();
-    messenger.unregisterActionHandler(`NetworkController:getNetworkClientById`);
   });
 
   it('should set default state', () => {

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -422,13 +422,9 @@ describe('TokensController', () => {
 
   it('should add token to the correct chainId when passed a networkClientId', async () => {
     const stub = stubCreateEthers(tokensController, () => false);
-    messenger.unregisterActionHandler(`NetworkController:getNetworkClientById`);
-    messenger.registerActionHandler(
-      `NetworkController:getNetworkClientById`,
-      getNetworkClientByIdHandler.mockReturnValue({
-        configuration: { chainId: '0x5' },
-      } as unknown as ReturnType<NetworkController['getNetworkClientById']>),
-    );
+    getNetworkClientByIdHandler.mockReturnValue({
+      configuration: { chainId: '0x5' },
+    } as unknown as ReturnType<NetworkController['getNetworkClientById']>);
     await tokensController.addToken({
       address: '0x01',
       symbol: 'bar',
@@ -1111,15 +1107,9 @@ describe('TokensController', () => {
     });
 
     it('should add tokens to the correct chainId when passed a networkClientId', async () => {
-      messenger.unregisterActionHandler(
-        `NetworkController:getNetworkClientById`,
-      );
-      messenger.registerActionHandler(
-        `NetworkController:getNetworkClientById`,
-        getNetworkClientByIdHandler.mockReturnValue({
-          configuration: { chainId: '0x5' },
-        } as unknown as ReturnType<NetworkController['getNetworkClientById']>),
-      );
+      getNetworkClientByIdHandler.mockReturnValue({
+        configuration: { chainId: '0x5' },
+      } as unknown as ReturnType<NetworkController['getNetworkClientById']>);
       const dummyTokens: Token[] = [
         {
           address: '0x01',
@@ -1571,23 +1561,17 @@ describe('TokensController', () => {
     });
 
     it('stores token correctly when passed a networkClientId', async function () {
-      messenger.unregisterActionHandler(
-        `NetworkController:getNetworkClientById`,
-      );
-      messenger.registerActionHandler(
-        `NetworkController:getNetworkClientById`,
-        getNetworkClientByIdHandler.mockImplementation((networkClientId) => {
-          expect(networkClientId).toBe('networkClientId1');
-          return {
-            configuration: { chainId: '0x5' },
-            provider: new FakeProvider({
-              stubs: [],
-            }),
-            blockTracker: new FakeBlockTracker(),
-            destroy: jest.fn(),
-          } as unknown as ReturnType<NetworkController['getNetworkClientById']>;
-        }),
-      );
+      getNetworkClientByIdHandler.mockImplementation((networkClientId) => {
+        expect(networkClientId).toBe('networkClientId1');
+        return {
+          configuration: { chainId: '0x5' },
+          provider: new FakeProvider({
+            stubs: [],
+          }),
+          blockTracker: new FakeBlockTracker(),
+          destroy: jest.fn(),
+        } as unknown as ReturnType<NetworkController['getNetworkClientById']>;
+      });
 
       const addRequestHandler = jest.fn();
       messenger.unregisterActionHandler(`ApprovalController:addRequest`);

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -1700,7 +1700,7 @@ describe('TokensController', () => {
 
       mockContract([asset, anotherAsset]);
 
-      const registerListeners = new Promise<void>((resolve) => {
+      const promiseForApprovals = new Promise<void>((resolve) => {
         const listener = (state: ApprovalControllerState) => {
           if (state.pendingApprovalCount === 2) {
             messenger.unsubscribe('ApprovalController:stateChange', listener);
@@ -1720,7 +1720,7 @@ describe('TokensController', () => {
         interactingAddress,
       });
 
-      await registerListeners;
+      await promiseForApprovals;
 
       await approvalController.accept(requestId);
       await approvalController.accept('67890');

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -1957,8 +1957,13 @@ describe('TokensController', () => {
           aggregators: ['Aave'],
         },
       };
-
-      await tokenListStateChangeListener({ tokenList: sampleMainnetTokenList });
+      messenger.publish(
+        'TokenListController:stateChange',
+        {
+          tokenList: sampleMainnetTokenList,
+        } as unknown as TokenListState,
+        [],
+      );
 
       expect(tokensController.state.tokens[0]).toStrictEqual({
         address: '0x01',

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -5,6 +5,8 @@ import type {
   BaseConfig,
   BaseState,
   RestrictedControllerMessenger,
+  ControllerGetStateAction,
+  ControllerStateChangeEvent,
 } from '@metamask/base-controller';
 import { BaseControllerV1 } from '@metamask/base-controller';
 import contractsMap from '@metamask/contract-metadata';
@@ -106,6 +108,13 @@ export type TokensState = BaseState &
  * The name of the {@link TokensController}.
  */
 const controllerName = 'TokensController';
+
+export type TokensControllerActions = TokensControllerGetStateAction;
+
+export type TokensControllerGetStateAction = ControllerGetStateAction<
+  typeof controllerName,
+  TokensState
+>;
 
 /**
  * The external actions available to the {@link TokensController}.

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -94,15 +94,14 @@ type SuggestedAssetMeta = {
  * @property allIgnoredTokens - Object containing hidden/ignored tokens by network and account
  * @property allDetectedTokens - Object containing tokens detected with non-zero balances
  */
-export type TokensState = BaseState &
-  Record<string, unknown> & {
-    tokens: Token[];
-    ignoredTokens: string[];
-    detectedTokens: Token[];
-    allTokens: { [chainId: Hex]: { [key: string]: Token[] } };
-    allIgnoredTokens: { [chainId: Hex]: { [key: string]: string[] } };
-    allDetectedTokens: { [chainId: Hex]: { [key: string]: Token[] } };
-  };
+export type TokensState = {
+  tokens: Token[];
+  ignoredTokens: string[];
+  detectedTokens: Token[];
+  allTokens: { [chainId: Hex]: { [key: string]: Token[] } };
+  allIgnoredTokens: { [chainId: Hex]: { [key: string]: string[] } };
+  allDetectedTokens: { [chainId: Hex]: { [key: string]: Token[] } };
+};
 
 /**
  * The name of the {@link TokensController}.
@@ -169,7 +168,7 @@ export const getDefaultTokensState = (): TokensState => {
  */
 export class TokensController extends BaseControllerV1<
   TokensConfig,
-  TokensState
+  TokensState & BaseState
 > {
   private readonly mutex = new Mutex();
 

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -92,17 +92,15 @@ type SuggestedAssetMeta = {
  * @property allIgnoredTokens - Object containing hidden/ignored tokens by network and account
  * @property allDetectedTokens - Object containing tokens detected with non-zero balances
  */
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export interface TokensState extends BaseState {
-  tokens: Token[];
-  ignoredTokens: string[];
-  detectedTokens: Token[];
-  allTokens: { [chainId: Hex]: { [key: string]: Token[] } };
-  allIgnoredTokens: { [chainId: Hex]: { [key: string]: string[] } };
-  allDetectedTokens: { [chainId: Hex]: { [key: string]: Token[] } };
-}
+export type TokensState = BaseState &
+  Record<string, unknown> & {
+    tokens: Token[];
+    ignoredTokens: string[];
+    detectedTokens: Token[];
+    allTokens: { [chainId: Hex]: { [key: string]: Token[] } };
+    allIgnoredTokens: { [chainId: Hex]: { [key: string]: string[] } };
+    allDetectedTokens: { [chainId: Hex]: { [key: string]: Token[] } };
+  };
 
 /**
  * The name of the {@link TokensController}.

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -109,12 +109,19 @@ export type TokensState = BaseState &
  */
 const controllerName = 'TokensController';
 
-export type TokensControllerActions = TokensControllerGetStateAction;
+export type TokensControllerActions =
+  | TokensControllerGetStateAction
+  | TokensControllerAddDetectedTokensAction;
 
 export type TokensControllerGetStateAction = ControllerGetStateAction<
   typeof controllerName,
   TokensState
 >;
+
+export type TokensControllerAddDetectedTokensAction = {
+  type: `${typeof controllerName}:addDetectedTokens`;
+  handler: TokensController['addDetectedTokens'];
+};
 
 /**
  * The external actions available to the {@link TokensController}.
@@ -245,6 +252,11 @@ export class TokensController extends BaseControllerV1<
     this.abortController = new AbortController();
 
     this.messagingSystem = messenger;
+
+    this.messagingSystem.registerActionHandler(
+      `${controllerName}:addDetectedTokens` as const,
+      this.addDetectedTokens.bind(this),
+    );
 
     this.messagingSystem.subscribe(
       'PreferencesController:stateChange',

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -706,7 +706,7 @@ export class TokensController extends BaseControllerV1<
             'NetworkController:getNetworkClientById',
             networkClientId,
           ).provider
-        : this.config?.provider,
+        : this.config.provider,
     );
   }
 

--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -19,8 +19,24 @@ export type {
   TokenDetectionControllerStateChangeEvent,
 } from './TokenDetectionController';
 export { TokenDetectionController } from './TokenDetectionController';
-export * from './TokenListController';
-export * from './TokenRatesController';
+export type {
+  TokenListState,
+  TokenListToken,
+  TokenListMap,
+  TokenListStateChange,
+  TokenListControllerEvents,
+  GetTokenListState,
+  TokenListControllerActions,
+  TokenListControllerMessenger,
+} from './TokenListController';
+export { TokenListController } from './TokenListController';
+export type {
+  Token,
+  TokenRatesConfig,
+  ContractExchangeRates,
+  TokenRatesState,
+} from './TokenRatesController';
+export { TokenRatesController } from './TokenRatesController';
 export type {
   TokensConfig,
   TokensState,

--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -21,7 +21,17 @@ export type {
 export { TokenDetectionController } from './TokenDetectionController';
 export * from './TokenListController';
 export * from './TokenRatesController';
-export * from './TokensController';
+export type {
+  TokensConfig,
+  TokensState,
+  TokensControllerActions,
+  TokensControllerGetStateAction,
+  TokensControllerAddDetectedTokensAction,
+  TokensControllerEvents,
+  TokensControllerStateChangeEvent,
+  TokensControllerMessenger,
+} from './TokensController';
+export { TokensController } from './TokensController';
 export {
   isTokenDetectionSupportedForNetwork,
   formatIconUrlWithProxy,


### PR DESCRIPTION
## Motivation

Remove `TokenDetectionController` constructor callbacks for `TokensController`.
- `TokensController` features should be exposed as messenger actions/events so that consumers don't need to import the entire class.
- `TokensController` should use messenger action/events to consume external controller features instead of callbacks.

## Explanation

- Replaces constructor options callbacks `onPreferencesStateChange`, `onNetworkDidChange`, `onTokenListStateChange`, `getNetworkClientById` with messenger actions (`NetworkController:getNetworkClientById`) and events (`PreferencesController:stateChange`, `NetworkController:networkDidChange`, `TokenListController:stateChange`).
- Replaces tokens-controller callbacks in token-detection-controller and token-balances-controller with `TokensController:getState`, `TokensController:addDetectedTokens` actions and `TokensController:stateChange` event.

## References

- Extracted from https://github.com/MetaMask/core/pull/3775
- Contributes to #3626 

## Changelog

### [`@metamask/assets-controllers`](https://github.com/MetaMask/core/pull/3690/files#diff-ee47d03d53776b8dd530799a8047f5e32e36e35765620aeb50b294adc3339fab)

### Added

- `TokensController` now exports `TokensControllerActions`, `TokensControllerGetStateAction`, `TokensControllerAddDetectedTokensAction`, `TokensControllerEvents`, `TokensControllerStateChangeEvent`. ([#3690](https://github.com/MetaMask/core/pull/3690/))

### Changed

- **BREAKING:** The `TokensState` type is now defined as a type alias rather than an interface. ([#3690](https://github.com/MetaMask/core/pull/3690/))
  - This is breaking because it could affect how this type is used with other types, such as `Json`, which does not support TypeScript interfaces.

### Removed

- **BREAKING:** `TokenDetectionController` constructor no longer accepts options `onPreferencesStateChange`, `getPreferencesState`, `getTokensState`, `addDetectedTokens`. ([#3690](https://github.com/MetaMask/core/pull/3690/), [#3775](https://github.com/MetaMask/core/pull/3775/))
- **BREAKING:** `TokensController` constructor no longer accepts options `onPreferencesStateChange`, `onNetworkDidChange`, `onTokenListStateChange`, `getNetworkClientById`. ([#3690](https://github.com/MetaMask/core/pull/3690/))
- **BREAKING:** `TokenBalancesController` constructor no longer accepts options `onTokensStateChange`, `getSelectedAddress`. ([#3690](https://github.com/MetaMask/core/pull/3690/))

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
