### PR TITLE
OpenSea supply -> total_supply

### DIFF
--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -272,7 +272,7 @@ describe('NftController', () => {
         collection: 'FOO',
         contract_standard: 'erc721',
         name: 'Name',
-        supply: 0,
+        total_supply: 0,
       })
       .get(`/collections/FOO`)
       .reply(200, {
@@ -286,7 +286,7 @@ describe('NftController', () => {
         collection: 'FOU',
         contract_standard: 'erc721',
         name: 'FOU',
-        supply: 0,
+        total_supply: 0,
       })
       .get(`/collections/FOO`)
       .reply(200, {
@@ -1288,7 +1288,7 @@ describe('NftController', () => {
           collection: 'Kudos',
           contract_standard: 'erc721',
           name: 'Name',
-          supply: 10,
+          total_supply: 10,
         });
 
       nock('https://ipfs.gitcoin.co:443')
@@ -1845,7 +1845,7 @@ describe('NftController', () => {
           collection: 'KDO',
           contract_standard: 'erc721',
           name: 'Kudos',
-          supply: 10,
+          total_supply: 10,
         })
         .get(`/collections/KDO`)
         .reply(200, {

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -105,7 +105,7 @@ export type OpenSeaV2Contract = {
   collection: string;
   contract_standard: string;
   name: string;
-  supply: number;
+  total_supply?: number;
 };
 
 export type OpenSeaV2Collection = {
@@ -125,6 +125,7 @@ export type OpenSeaV2Collection = {
   telegram_url?: string;
   twitter_username?: string;
   instagram_username?: string;
+  total_supply?: number;
 };
 
 /**

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -166,7 +166,7 @@ describe('NftDetectionController', () => {
         collection: 'Name',
         contract_standard: 'erc721',
         name: 'Name',
-        supply: 0,
+        total_supply: 0,
       })
       .get(
         `/chain/ethereum/contract/0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD`,
@@ -177,7 +177,7 @@ describe('NftDetectionController', () => {
         collection: 'Name HH',
         contract_standard: 'erc721',
         name: 'Name HH',
-        supply: 10,
+        total_supply: 10,
       })
       .get(`/collections/Name%20HH`)
       .reply(200, {
@@ -694,7 +694,7 @@ describe('NftDetectionController', () => {
         collection: 'Name GG',
         contract_standard: 'erc721',
         name: 'Name GG',
-        supply: 10,
+        total_supply: 10,
       })
       .get(`/collections/Name%20GG`)
       .reply(200, {
@@ -710,7 +710,7 @@ describe('NftDetectionController', () => {
         collection: 'Name II',
         contract_standard: 'erc721',
         name: 'Name II',
-        supply: 10,
+        total_supply: 10,
       })
       .get(`/collections/Name%20II`)
       .reply(200, {
@@ -878,7 +878,7 @@ describe('NftDetectionController', () => {
         collection: 'mycollection',
         contract_standard: 'erc721',
         name: 'myname',
-        supply: 0,
+        total_supply: 0,
       })
       .get(`/collections/mycollection`)
       .reply(200, {});

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -376,7 +376,10 @@ export function mapOpenSeaContractV2ToV1(
     created_date: null,
     schema_name: contract.contract_standard.toUpperCase(),
     symbol: null,
-    total_supply: contract.supply.toString(),
+    total_supply:
+      collection?.total_supply?.toString() ??
+      contract.total_supply?.toString() ??
+      null,
     description: collection?.description ?? null,
     external_link: collection?.project_url ?? null,
     collection: {


### PR DESCRIPTION
## Explanation

OpenSea renamed the field `supply`, which used to be required, to `total_supply`.  Fixes the error:

`undefined is not an object (evaluating 'contract.supply.toString')`

A more accurate `total_supply` was also added to the collection object, which is now preferred to the one on the contract.

## References



## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **FIXED**: OpenSea response from `supply` to `total_supply`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
