### PR TITLE
chore(base-controller): Restore `subscrbe` property

### DIFF
--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -114,6 +114,17 @@ export class BaseController<
   public readonly metadata: StateMetadata<ControllerState>;
 
   /**
+   * The existence of the `subscribe` property is how the ComposableController used to detect
+   * whether a controller extends the old BaseController or the new one. We set it to `undefined` here to
+   * ensure the ComposableController never mistakes them for an older style controller.
+   *
+   * This property is no longer used, and will be removed in a future release.
+   *
+   * @deprecated This will be removed in a future release
+   */
+  public readonly subscribe: undefined;
+
+  /**
    * Creates a BaseController instance.
    *
    * @param options - Controller options.


### PR DESCRIPTION
## Explanation

The `subscribe` property was removed in #3590 because it is no longer used. It has been restored here so that we can release the `@metamask/base-controller` without any breaking changes.

This property's description has been updated to clarify that it's no longer used, and it's now marked as deprecated.

## References

Discussed in the v104 release candidate PR: https://github.com/MetaMask/core/pull/3695#discussion_r1435225330

## Changelog

### `@metamask/base-controller`

- Changed: Deprecate the `subscribe` property of `BaseControllerV2`
  - This property was used to differentiate between `BaseControllerV1` and `BaseControllerV2` controllers. It is no longer used, so it has been marked as deprecated.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
