### PR TITLE
fix(base-controller): Fix `stateChange` subscriptions with selectors

### DIFF
--- a/packages/base-controller/src/BaseControllerV2.test.ts
+++ b/packages/base-controller/src/BaseControllerV2.test.ts
@@ -296,6 +296,64 @@ describe('BaseController', () => {
     ]);
   });
 
+  it('should notify a subscriber with a selector of state changes', () => {
+    const controllerMessenger = new ControllerMessenger<
+      never,
+      CountControllerEvent
+    >();
+    const controller = new CountController({
+      messenger: getCountMessenger(controllerMessenger),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    const listener = sinon.stub();
+    controllerMessenger.subscribe(
+      'CountController:stateChange',
+      listener,
+      ({ count }) => {
+        // Selector rounds down to nearest multiple of 10
+        return Math.floor(count / 10);
+      },
+    );
+
+    controller.update(() => {
+      return { count: 10 };
+    });
+
+    expect(listener.callCount).toBe(1);
+    expect(listener.firstCall.args).toStrictEqual([1, 0]);
+  });
+
+  it('should not inform a subscriber of state changes if the selected value is unchanged', () => {
+    const controllerMessenger = new ControllerMessenger<
+      never,
+      CountControllerEvent
+    >();
+    const controller = new CountController({
+      messenger: getCountMessenger(controllerMessenger),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    const listener = sinon.stub();
+    controllerMessenger.subscribe(
+      'CountController:stateChange',
+      listener,
+      ({ count }) => {
+        // Selector rounds down to nearest multiple of 10
+        return Math.floor(count / 10);
+      },
+    );
+
+    controller.update(() => {
+      // Note that this rounds down to zero, so the selected value is still zero
+      return { count: 1 };
+    });
+
+    expect(listener.callCount).toBe(0);
+  });
+
   it('should inform a subscriber of each state change once even after multiple subscriptions', () => {
     const controllerMessenger = new ControllerMessenger<
       never,

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -154,6 +154,11 @@ export class BaseController<
       `${name}:getState`,
       () => this.state,
     );
+
+    this.messagingSystem.registerInitialEventPayload({
+      eventType: `${name}:stateChange`,
+      getPayload: () => [this.state, []],
+    });
   }
 
   /**

--- a/packages/name-controller/src/NameController.test.ts
+++ b/packages/name-controller/src/NameController.test.ts
@@ -13,6 +13,7 @@ const TIME_MOCK = 123;
 
 const MESSENGER_MOCK = {
   registerActionHandler: jest.fn(),
+  registerInitialEventPayload: jest.fn(),
   publish: jest.fn(),
   // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -92,6 +92,7 @@ const requestMock = {
 const createMessengerMock = () =>
   ({
     registerActionHandler: jest.fn(),
+    registerInitialEventPayload: jest.fn(),
     publish: jest.fn(),
     call: jest.fn(),
     // TODO: Replace `any` with type

--- a/packages/user-operation-controller/src/UserOperationController.test.ts
+++ b/packages/user-operation-controller/src/UserOperationController.test.ts
@@ -99,6 +99,7 @@ function createMessengerMock() {
     call: jest.fn(),
     publish: jest.fn(),
     registerActionHandler: jest.fn(),
+    registerInitialEventPayload: jest.fn(),
   } as unknown as jest.Mocked<UserOperationControllerMessenger>;
 }
 

--- a/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.test.ts
+++ b/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.test.ts
@@ -49,6 +49,7 @@ jest.mock('@metamask/controller-utils', () => ({
 function createMessengerMock() {
   return {
     call: jest.fn(),
+    registerInitialEventPayload: jest.fn(),
   } as unknown as jest.Mocked<UserOperationControllerMessenger>;
 }
 


### PR DESCRIPTION
## Explanation

Subscribers to the `stateChange` event of any `BaseControllerV2`-based controllers will now correctly handle the initial state change event.

Previously the initial state change would always result in this event firing, even for subscriptions with selectors where the selected value has not changed. Additionally, the `previousValue` returned was always set to `undefined` the first time.

`BaseControllerV2` has been updated to correctly compare with the previous value even for the first state change. The returned `previousValue` is also now guaranteed to be correct even for the initial state change.

## References

Fixes #3701

## Changelog

### `@metamask/base-controller`

- Fixed: Subscribers to the `stateChange` event of any `BaseControllerV2`-based controllers will now correctly handle the initial state change event
  - Previously the initial state change would always result in this event firing, even for subscriptions with selectors where the selected value has not changed. Additionally, the `previousValue` returned was always set to `undefined` the first time.
  - `BaseControllerV2` has been updated to correctly compare with the previous value even for the first state change. The returned `previousValue` is also now guaranteed to be correct even for the initial state change.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
