### PR TITLE
Addition of "fallback" Variation to the NameController for Petnames

### DIFF
--- a/packages/name-controller/src/NameController.test.ts
+++ b/packages/name-controller/src/NameController.test.ts
@@ -1,4 +1,4 @@
-import { NameController } from './NameController';
+import { FALLBACK_VARIATION, NameController } from './NameController';
 import type { NameProvider } from './types';
 import { NameType } from './types';
 
@@ -357,6 +357,19 @@ describe('NameController', () => {
       });
     });
 
+    it('does not throw if variation is fallback and type is Ethereum address', () => {
+      const controller = new NameController(CONTROLLER_ARGS_MOCK);
+
+      expect(() => {
+        controller.setName({
+          value: VALUE_MOCK,
+          type: NameType.ETHEREUM_ADDRESS,
+          name: NAME_MOCK,
+          variation: FALLBACK_VARIATION,
+        });
+      }).not.toThrow();
+    });
+
     describe('throws if', () => {
       it.each([
         ['missing', undefined],
@@ -457,7 +470,7 @@ describe('NameController', () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } as any),
         ).toThrow(
-          `Must specify a chain ID in hexidecimal format for variation when using '${NameType.ETHEREUM_ADDRESS}' type.`,
+          `Must specify a chain ID in hexidecimal format or the fallback, "*", for variation when using 'ethereumAddress' type.`,
         );
       });
 
@@ -1767,7 +1780,7 @@ describe('NameController', () => {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } as any),
           ).rejects.toThrow(
-            `Must specify a chain ID in hexidecimal format for variation when using '${NameType.ETHEREUM_ADDRESS}' type.`,
+            `Must specify a chain ID in hexidecimal format or the fallback, "*", for variation when using 'ethereumAddress' type.`,
           );
         },
       );

--- a/packages/name-controller/src/NameController.ts
+++ b/packages/name-controller/src/NameController.ts
@@ -13,6 +13,7 @@ import type {
 } from './types';
 import { NameType } from './types';
 
+export const FALLBACK_VARIATION = '*';
 const DEFAULT_UPDATE_DELAY = 60 * 2; // 2 Minutes
 const DEFAULT_VARIATION = '';
 
@@ -571,10 +572,11 @@ export class NameController extends BaseController<
     if (
       !variation?.length ||
       typeof variation !== 'string' ||
-      !variation.match(/^0x[0-9A-Fa-f]+$/u)
+      (!variation.match(/^0x[0-9A-Fa-f]+$/u) &&
+        variation !== FALLBACK_VARIATION)
     ) {
       errorMessages.push(
-        `Must specify a chain ID in hexidecimal format for variation when using '${type}' type.`,
+        `Must specify a chain ID in hexidecimal format or the fallback, "${FALLBACK_VARIATION}", for variation when using '${type}' type.`,
       );
     }
   }


### PR DESCRIPTION
## Explanation

In this PR, we introduced a "fallback" variation (denoted as "*") in the ﻿NameController specifically for the handling of petnames. In the case of ethereum addresses, variations typically are the hexadecimal chainID, implicitly defining petnames for a specific address within a particular chain.

The rationale behind adding a fallback variation is to accommodate scenarios where the petnames are not strictly tied to a particular chain. Instead of enforcing a chain-specific petname, the fallback variation operates on a more flexible rule: Given an Ethereum address, if a chain-specific petname does not exist, the fallback variation is automatically inspected to determine if a petname exists for this general scenario.

## References

* Related to https://github.com/MetaMask/MetaMask-planning/issues/1624

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/name-controller`

- **ADDED**: Fallback variation for petnames

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
