### PR TITLE
Add `SubjectMetadataController:addSubjectMetadata` action

### DIFF
--- a/packages/permission-controller/src/SubjectMetadataController.test.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.test.ts
@@ -282,7 +282,7 @@ describe('SubjectMetadataController', () => {
   });
 
   describe('controller actions', () => {
-    it('SubjectMetadataController:getSubjectMetadata returns the subject metadata', () => {
+    it(':getSubjectMetadata returns the subject metadata', () => {
       const [messenger, hasPermissionsSpy] =
         getSubjectMetadataControllerMessenger();
       const controller = new SubjectMetadataController({
@@ -314,7 +314,7 @@ describe('SubjectMetadataController', () => {
       ).toStrictEqual(getSubjectMetadata('bar.io', 'bar', SubjectType.Website));
     });
 
-    it('SubjectMetadataController:addSubjectMetadata adds passed subject metadata', () => {
+    it(':addSubjectMetadata adds passed subject metadata', () => {
       const [messenger, hasPermissionsSpy] =
         getSubjectMetadataControllerMessenger();
       const controller = new SubjectMetadataController({

--- a/packages/permission-controller/src/SubjectMetadataController.test.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.test.ts
@@ -282,7 +282,7 @@ describe('SubjectMetadataController', () => {
   });
 
   describe('controller actions', () => {
-    it('subjectMetadataController:getSubjectMetadata returns the subject metadata', () => {
+    it('SubjectMetadataController:getSubjectMetadata returns the subject metadata', () => {
       const [messenger, hasPermissionsSpy] =
         getSubjectMetadataControllerMessenger();
       const controller = new SubjectMetadataController({
@@ -314,7 +314,7 @@ describe('SubjectMetadataController', () => {
       ).toStrictEqual(getSubjectMetadata('bar.io', 'bar', SubjectType.Website));
     });
 
-    it('subjectMetadataController:addSubjectMetadata adds subject metadata', () => {
+    it('SubjectMetadataController:addSubjectMetadata adds passed subject metadata', () => {
       const [messenger, hasPermissionsSpy] =
         getSubjectMetadataControllerMessenger();
       const controller = new SubjectMetadataController({

--- a/packages/permission-controller/src/SubjectMetadataController.test.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.test.ts
@@ -280,4 +280,66 @@ describe('SubjectMetadataController', () => {
       });
     });
   });
+
+  describe('controller actions', () => {
+    it('subjectMetadataController:getSubjectMetadata returns the subject metadata', () => {
+      const [messenger, hasPermissionsSpy] =
+        getSubjectMetadataControllerMessenger();
+      const controller = new SubjectMetadataController({
+        messenger,
+        subjectCacheLimit: 100,
+      });
+      hasPermissionsSpy.mockImplementationOnce(() => true);
+
+      controller.addSubjectMetadata(
+        getSubjectMetadata('foo.com', 'foo', SubjectType.Snap),
+      );
+
+      controller.addSubjectMetadata(
+        getSubjectMetadata('bar.io', 'bar', SubjectType.Website),
+      );
+
+      expect(
+        messenger.call(
+          'SubjectMetadataController:getSubjectMetadata',
+          'foo.com',
+        ),
+      ).toStrictEqual(getSubjectMetadata('foo.com', 'foo', SubjectType.Snap));
+
+      expect(
+        messenger.call(
+          'SubjectMetadataController:getSubjectMetadata',
+          'bar.io',
+        ),
+      ).toStrictEqual(getSubjectMetadata('bar.io', 'bar', SubjectType.Website));
+    });
+
+    it('subjectMetadataController:addSubjectMetadata adds subject metadata', () => {
+      const [messenger, hasPermissionsSpy] =
+        getSubjectMetadataControllerMessenger();
+      const controller = new SubjectMetadataController({
+        messenger,
+        subjectCacheLimit: 100,
+      });
+      hasPermissionsSpy.mockImplementationOnce(() => true);
+
+      messenger.call(
+        'SubjectMetadataController:addSubjectMetadata',
+        getSubjectMetadata('foo.com', 'foo', SubjectType.Snap),
+      );
+
+      messenger.call(
+        'SubjectMetadataController:addSubjectMetadata',
+        getSubjectMetadata('bar.io', 'bar', SubjectType.Website),
+      );
+
+      expect(controller.getSubjectMetadata('foo.com')).toStrictEqual(
+        getSubjectMetadata('foo.com', 'foo', SubjectType.Snap),
+      );
+
+      expect(controller.getSubjectMetadata('bar.io')).toStrictEqual(
+        getSubjectMetadata('bar.io', 'bar', SubjectType.Website),
+      );
+    });
+  });
 });

--- a/packages/permission-controller/src/SubjectMetadataController.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.ts
@@ -66,9 +66,15 @@ export type GetSubjectMetadata = {
   handler: (origin: SubjectOrigin) => SubjectMetadata | undefined;
 };
 
+export type AddSubjectMetadata = {
+  type: `${typeof controllerName}:addSubjectMetadata`;
+  handler: (metadata: SubjectMetadataToAdd) => void;
+};
+
 export type SubjectMetadataControllerActions =
   | GetSubjectMetadataState
-  | GetSubjectMetadata;
+  | GetSubjectMetadata
+  | AddSubjectMetadata;
 
 export type SubjectMetadataStateChange = ControllerStateChangeEvent<
   typeof controllerName,
@@ -139,6 +145,11 @@ export class SubjectMetadataController extends BaseController<
     this.messagingSystem.registerActionHandler(
       `${this.name}:getSubjectMetadata`,
       this.getSubjectMetadata.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${this.name}:addSubjectMetadata`,
+      this.addSubjectMetadata.bind(this),
     );
   }
 


### PR DESCRIPTION
## Explanation

The `SubjectMetadataController` is currently being called with a direct reference to the controller in the extension client: https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/metamask-controller.js#L2367-L2373

To simplify this and make it easier for the SnapController to handle the population of metadata, this PR adds an exposed action for `addSubjectMetadata`.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/permission-controller`

- **Added**:  Add `SubjectMetadataController:addSubjectMetadata` action

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
