### PR TITLE
refactor(assets-controllers): Simplify `AccountTrackerController` tests and add `getDefaultPreferencesState`

### DIFF
--- a/packages/assets-controllers/src/AccountTrackerController.test.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.test.ts
@@ -1,7 +1,10 @@
 import { query } from '@metamask/controller-utils';
 import HttpProvider from '@metamask/ethjs-provider-http';
-import type { Identity } from '@metamask/preferences-controller';
-import { PreferencesController } from '@metamask/preferences-controller';
+import {
+  PreferencesController,
+  type Identity,
+  type PreferencesState,
+} from '@metamask/preferences-controller';
 import * as sinon from 'sinon';
 
 import { advanceTime } from '../../../tests/helpers';
@@ -70,11 +73,15 @@ describe('AccountTrackerController', () => {
     );
   });
 
-  it('should subscribe to new sibling preference controllers', async () => {
-    const preferences = new PreferencesController();
+  it('should refresh when preferences state changes', async () => {
+    const preferencesStateChangeListeners: ((
+      state: PreferencesState,
+    ) => void)[] = [];
     const controller = new AccountTrackerController(
       {
-        onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+        onPreferencesStateChange: (listener) => {
+          preferencesStateChangeListeners.push(listener);
+        },
         getIdentities: () => ({}),
         getSelectedAddress: () => '0x0',
         getMultiAccountBalancesEnabled: () => true,
@@ -83,9 +90,15 @@ describe('AccountTrackerController', () => {
       },
       { provider },
     );
+    const triggerPreferencesStateChange = (state: PreferencesState) => {
+      for (const listener of preferencesStateChangeListeners) {
+        listener(state);
+      }
+    };
     controller.refresh = sinon.stub();
 
-    preferences.setFeatureFlag('foo', true);
+    triggerPreferencesStateChange(PreferencesController.getDefaultState());
+
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((controller.refresh as any).called).toBe(true);
@@ -485,11 +498,10 @@ describe('AccountTrackerController', () => {
   });
 
   it('should call refresh every interval on legacy polling', async () => {
-    const preferences = new PreferencesController();
     const poll = sinon.spy(AccountTrackerController.prototype, 'poll');
     const controller = new AccountTrackerController(
       {
-        onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+        onPreferencesStateChange: jest.fn(),
         getIdentities: () => ({}),
         getSelectedAddress: () => '',
         getMultiAccountBalancesEnabled: () => true,
@@ -508,11 +520,10 @@ describe('AccountTrackerController', () => {
   });
 
   it('should call refresh every interval for each networkClientId being polled', async () => {
-    const preferences = new PreferencesController();
     sinon.stub(AccountTrackerController.prototype, 'poll');
     const controller = new AccountTrackerController(
       {
-        onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+        onPreferencesStateChange: jest.fn(),
         getIdentities: () => ({}),
         getSelectedAddress: () => '',
         getMultiAccountBalancesEnabled: () => true,

--- a/packages/assets-controllers/src/AccountTrackerController.test.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.test.ts
@@ -1,7 +1,7 @@
 import { query } from '@metamask/controller-utils';
 import HttpProvider from '@metamask/ethjs-provider-http';
 import {
-  PreferencesController,
+  getDefaultPreferencesState,
   type Identity,
   type PreferencesState,
 } from '@metamask/preferences-controller';
@@ -97,7 +97,7 @@ describe('AccountTrackerController', () => {
     };
     controller.refresh = sinon.stub();
 
-    triggerPreferencesStateChange(PreferencesController.getDefaultState());
+    triggerPreferencesStateChange(getDefaultPreferencesState());
 
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -109,6 +109,52 @@ export type PreferencesState = {
 };
 
 /**
+ * Get the default PreferencesController state.
+ *
+ * @returns The default PreferencesController state.
+ */
+export function getDefaultPreferencesState() {
+  return {
+    disabledRpcMethodPreferences: {
+      eth_sign: false,
+    },
+    featureFlags: {},
+    identities: {},
+    ipfsGateway: 'https://ipfs.io/ipfs/',
+    isIpfsGatewayEnabled: true,
+    isMultiAccountBalancesEnabled: true,
+    lostIdentities: {},
+    openSeaEnabled: false,
+    securityAlertsEnabled: false,
+    selectedAddress: '',
+    showIncomingTransactions: {
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.MAINNET]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.GOERLI]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.BSC]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.BSC_TESTNET]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.OPTIMISM]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.OPTIMISM_TESTNET]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.POLYGON]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.POLYGON_TESTNET]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.AVALANCHE]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.AVALANCHE_TESTNET]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.FANTOM]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.FANTOM_TESTNET]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.SEPOLIA]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.LINEA_GOERLI]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.LINEA_MAINNET]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.MOONBEAM]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.MOONBEAM_TESTNET]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.MOONRIVER]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.GNOSIS]: true,
+    },
+    showTestNetworks: false,
+    useNftDetection: false,
+    useTokenDetection: true,
+  };
+}
+
+/**
  * Controller that stores shared settings and exposes convenience methods
  */
 export class PreferencesController extends BaseControllerV1<
@@ -121,52 +167,6 @@ export class PreferencesController extends BaseControllerV1<
   override name = 'PreferencesController';
 
   /**
-   * Get the default PreferencesController state.
-   *
-   * @returns The default PreferencesController state.
-   */
-  static getDefaultState() {
-    return {
-      disabledRpcMethodPreferences: {
-        eth_sign: false,
-      },
-      featureFlags: {},
-      identities: {},
-      ipfsGateway: 'https://ipfs.io/ipfs/',
-      isIpfsGatewayEnabled: true,
-      isMultiAccountBalancesEnabled: true,
-      lostIdentities: {},
-      openSeaEnabled: false,
-      securityAlertsEnabled: false,
-      selectedAddress: '',
-      showIncomingTransactions: {
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.MAINNET]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.GOERLI]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.BSC]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.BSC_TESTNET]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.OPTIMISM]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.OPTIMISM_TESTNET]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.POLYGON]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.POLYGON_TESTNET]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.AVALANCHE]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.AVALANCHE_TESTNET]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.FANTOM]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.FANTOM_TESTNET]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.SEPOLIA]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.LINEA_GOERLI]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.LINEA_MAINNET]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.MOONBEAM]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.MOONBEAM_TESTNET]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.MOONRIVER]: true,
-        [ETHERSCAN_SUPPORTED_CHAIN_IDS.GNOSIS]: true,
-      },
-      showTestNetworks: false,
-      useNftDetection: false,
-      useTokenDetection: true,
-    };
-  }
-
-  /**
    * Creates a PreferencesController instance.
    *
    * @param config - Initial options used to configure this controller.
@@ -174,7 +174,7 @@ export class PreferencesController extends BaseControllerV1<
    */
   constructor(config?: Partial<BaseConfig>, state?: Partial<PreferencesState>) {
     super(config, state);
-    this.defaultState = PreferencesController.getDefaultState();
+    this.defaultState = getDefaultPreferencesState();
     this.initialize();
   }
 

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -121,14 +121,12 @@ export class PreferencesController extends BaseControllerV1<
   override name = 'PreferencesController';
 
   /**
-   * Creates a PreferencesController instance.
+   * Get the default PreferencesController state.
    *
-   * @param config - Initial options used to configure this controller.
-   * @param state - Initial state to set on this controller.
+   * @returns The default PreferencesController state.
    */
-  constructor(config?: Partial<BaseConfig>, state?: Partial<PreferencesState>) {
-    super(config, state);
-    this.defaultState = {
+  static getDefaultState() {
+    return {
       disabledRpcMethodPreferences: {
         eth_sign: false,
       },
@@ -166,6 +164,17 @@ export class PreferencesController extends BaseControllerV1<
       useNftDetection: false,
       useTokenDetection: true,
     };
+  }
+
+  /**
+   * Creates a PreferencesController instance.
+   *
+   * @param config - Initial options used to configure this controller.
+   * @param state - Initial state to set on this controller.
+   */
+  constructor(config?: Partial<BaseConfig>, state?: Partial<PreferencesState>) {
+    super(config, state);
+    this.defaultState = PreferencesController.getDefaultState();
     this.initialize();
   }
 


### PR DESCRIPTION
## Explanation

The `AccountTrackerController` tests have been updated to remove instances of the `PreferencesController`. Mocks are now used instead of the real controller.

It was useful to have a reference in tests to the default `PreferencesController` state, so I added a `getDefaultPreferencesState` function. This was added as a function to protect against accidental mutations.

## References

Relates to #3708

## Changelog

### `@metamask/preferences-controller`

#### Added
- Add `getDefaultPreferencesState` function

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
