### PR TITLE
refactor(assets-controllers): Simplify `TokenBalancesController` tests

### DIFF
--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -125,6 +125,17 @@ export type TokensControllerMessenger = RestrictedControllerMessenger<
   never
 >;
 
+export const getDefaultTokensState = (): TokensState => {
+  return {
+    tokens: [],
+    ignoredTokens: [],
+    detectedTokens: [],
+    allTokens: {},
+    allIgnoredTokens: {},
+    allDetectedTokens: {},
+  };
+};
+
 /**
  * Controller that stores assets and exposes convenience methods
  */
@@ -225,12 +236,7 @@ export class TokensController extends BaseControllerV1<
     };
 
     this.defaultState = {
-      tokens: [],
-      ignoredTokens: [],
-      detectedTokens: [],
-      allTokens: {},
-      allIgnoredTokens: {},
-      allDetectedTokens: {},
+      ...getDefaultTokensState(),
       ...state,
     };
 


### PR DESCRIPTION
## Explanation

The `TokenBalancesController` tests have been refactored to use mocks instead of `NetworkController` and `PreferencesController` instances. This should make the tests easier to read, and it decouples the tests further from the other controllers.

## References

Relates to #3708

## Changelog

### `@metamask/assets-controllers`

#### Added
- Add `getDefaultTokensState` function to the `TokensController`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
