### PR TITLE
refactor(assets-controllers): Simplify `TokenDetectionController` tests

### DIFF
--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -443,7 +443,7 @@ describe('TokenDetectionController', () => {
       clock.restore();
     });
 
-    describe('enabled', () => {
+    describe('when "disabled" is "false"', () => {
       it('should detect new tokens after switching between accounts', async () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
@@ -638,7 +638,7 @@ describe('TokenDetectionController', () => {
       });
     });
 
-    describe('disabled', () => {
+    describe('when "disabled" is "true"', () => {
       it('should not detect new tokens after switching between accounts', async () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
@@ -747,7 +747,7 @@ describe('TokenDetectionController', () => {
       clock.restore();
     });
 
-    describe('enabled', () => {
+    describe('when "disabled" is "false"', () => {
       it('should detect new tokens after switching chains', async () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
@@ -896,7 +896,7 @@ describe('TokenDetectionController', () => {
       });
     });
 
-    describe('disabled', () => {
+    describe('when "disabled" is "true"', () => {
       it('should not detect new tokens after switching chains', async () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
@@ -957,7 +957,7 @@ describe('TokenDetectionController', () => {
       clock.restore();
     });
 
-    describe('enabled', () => {
+    describe('when "disabled" is "false"', () => {
       it('should detect tokens if the token list is non-empty', async () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
@@ -1052,7 +1052,7 @@ describe('TokenDetectionController', () => {
       });
     });
 
-    describe('disabled', () => {
+    describe('when "disabled" is "true"', () => {
       it('should not detect tokens', async () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -84,10 +84,12 @@ const metadata = {
   preventPollingOnNetworkRestart: { persist: true, anonymous: true },
 };
 
-const defaultState: TokenListState = {
-  tokenList: {},
-  tokensChainsCache: {},
-  preventPollingOnNetworkRestart: false,
+export const getDefaultTokenListState = (): TokenListState => {
+  return {
+    tokenList: {},
+    tokensChainsCache: {},
+    preventPollingOnNetworkRestart: false,
+  };
 };
 
 /**
@@ -145,7 +147,7 @@ export class TokenListController extends StaticIntervalPollingController<
       name,
       metadata,
       messenger,
-      state: { ...defaultState, ...state },
+      state: { ...getDefaultTokenListState(), ...state },
     });
     this.intervalDelay = interval;
     this.cacheRefreshThreshold = cacheRefreshThreshold;

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -448,6 +448,20 @@ describe('TokensController', () => {
     stub.restore();
   });
 
+  it('should remove detected token', async () => {
+    const stub = stubCreateEthers(tokensController, () => false);
+    await tokensController.addDetectedTokens([
+      {
+        address: '0x01',
+        symbol: 'bar',
+        decimals: 2,
+      },
+    ]);
+    tokensController.ignoreTokens(['0x01']);
+    expect(tokensController.state.detectedTokens).toHaveLength(0);
+    stub.restore();
+  });
+
   it('should remove token by selected address', async () => {
     const stub = stubCreateEthers(tokensController, () => false);
     const firstAddress = '0x123';


### PR DESCRIPTION
## Explanation

The `TokenDetectionController` tests have been refactored to use mocks instead of real controller instances, and to use the `withController` pattern to simplify controller setup and ensure that polling has stopped after each test.

A `getDefaultTokenListState` function has been added to the `TokenListController` to enable us to use that default state in tests.

One test was added to the `TokensController` tests to prevent a coverage drop (it was previously being tested indirectly via the `TokenDetectionController` tests).

## References

Relates to #3708

## Changelog

### `@metamask/assets-controllers`

#### Added
- Add `getDefaultTokenListState` function to `TokenListController

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
