### PR TITLE
feat: migrate token balances controller to base controller v2

### DIFF
--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -47,6 +47,7 @@ describe('TokenBalancesController', () => {
       getERC20BalanceOf: sinon.stub(),
       messenger: getMessenger(),
     });
+
     expect(tokenBalances.state).toStrictEqual({ contractBalances: {} });
   });
 
@@ -62,10 +63,12 @@ describe('TokenBalancesController', () => {
       getERC20BalanceOf: sinon.stub(),
       messenger: getMessenger(),
     });
+
     expect(mock.called).toBe(true);
     expect(mock.calledTwice).toBe(false);
 
     await advanceTime({ clock, duration: 15 });
+
     expect(mock.calledTwice).toBe(true);
   });
 
@@ -80,8 +83,10 @@ describe('TokenBalancesController', () => {
       getERC20BalanceOf: sinon.stub().returns(new BN(1)),
       messenger: getMessenger(),
     });
+
     await tokenBalances.updateBalances();
-    expect(Object.keys(tokenBalances.state.contractBalances)).toStrictEqual({});
+
+    expect(tokenBalances.state.contractBalances).toStrictEqual({});
   });
 
   it('should clear previous interval', async () => {
@@ -93,8 +98,10 @@ describe('TokenBalancesController', () => {
       getERC20BalanceOf: sinon.stub(),
       messenger: getMessenger(),
     });
+
     await tokenBalances.poll(1338);
     await advanceTime({ clock, duration: 1339 });
+
     expect(mock.called).toBe(true);
   });
 
@@ -109,18 +116,20 @@ describe('TokenBalancesController', () => {
       getERC20BalanceOf: sinon.stub().returns(new BN(1)),
       messenger: getMessenger(),
     });
+
     expect(tokenBalances.state.contractBalances).toStrictEqual({});
 
     await tokenBalances.updateBalances();
+
     const mytoken = getToken(tokenBalances, address);
+
     expect(mytoken?.balanceError).toBeNull();
     expect(Object.keys(tokenBalances.state.contractBalances)).toContain(
       address,
     );
-
-    expect(
-      tokenBalances.state.contractBalances[address].toString(),
-    ).toBeGreaterThan(0);
+    expect(tokenBalances.state.contractBalances[address].toString()).not.toBe(
+      '0',
+    );
   });
 
   it('should handle `getERC20BalanceOf` error case', async () => {
@@ -139,22 +148,25 @@ describe('TokenBalancesController', () => {
     });
 
     expect(tokenBalances.state.contractBalances).toStrictEqual({});
+
     await tokenBalances.updateBalances();
+
     const mytoken = getToken(tokenBalances, address);
     expect(mytoken?.balanceError).toBeInstanceOf(Error);
     expect(mytoken?.balanceError).toHaveProperty('message', errorMsg);
-    expect(tokenBalances.state.contractBalances[address].toNumber()).toBe(0);
+    expect(tokenBalances.state.contractBalances[address].toString()).toBe('0');
 
     getERC20BalanceOfStub.returns(new BN(1));
+
     await tokenBalances.updateBalances();
+
     expect(mytoken?.balanceError).toBeNull();
     expect(Object.keys(tokenBalances.state.contractBalances)).toContain(
       address,
     );
-
-    expect(
-      tokenBalances.state.contractBalances[address].toNumber(),
-    ).toBeGreaterThan(0);
+    expect(tokenBalances.state.contractBalances[address].toString()).not.toBe(
+      0,
+    );
   });
 
   it('should update balances when tokens change', async () => {
@@ -224,7 +236,7 @@ describe('TokenBalancesController', () => {
     await tokenBalances.updateBalances();
 
     expect(tokenBalances.state.contractBalances).toStrictEqual({
-      '0x02': new BN(1),
+      '0x02': new BN(1).toString(16),
     });
   });
 });

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -1,4 +1,5 @@
 import { ControllerMessenger } from '@metamask/base-controller';
+import { toHex } from '@metamask/controller-utils';
 import { BN } from 'ethereumjs-util';
 
 import { flushPromises } from '../../../tests/helpers';
@@ -81,7 +82,7 @@ describe('TokenBalancesController', () => {
     await controller.updateBalances();
 
     expect(controller.state.contractBalances).toStrictEqual({
-      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': '1',
+      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': toHex(new BN(1)),
     });
   });
 
@@ -122,7 +123,7 @@ describe('TokenBalancesController', () => {
     await controller.updateBalances();
 
     expect(controller.state.contractBalances).toStrictEqual({
-      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': '1',
+      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': toHex(new BN(1)),
     });
   });
 
@@ -141,14 +142,14 @@ describe('TokenBalancesController', () => {
     await controller.updateBalances();
 
     expect(controller.state.contractBalances).toStrictEqual({
-      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': '1',
+      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': toHex(new BN(1)),
     });
 
     controller.disable();
     await controller.updateBalances();
 
     expect(controller.state.contractBalances).toStrictEqual({
-      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': '1',
+      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': toHex(new BN(1)),
     });
   });
 
@@ -189,7 +190,7 @@ describe('TokenBalancesController', () => {
     });
 
     expect(controller.state.contractBalances).toStrictEqual({
-      '0x00': '1',
+      '0x00': toHex(new BN(1)),
     });
   });
 
@@ -216,7 +217,7 @@ describe('TokenBalancesController', () => {
     await controller.updateBalances();
 
     expect(controller.state.contractBalances).toStrictEqual({
-      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': '1',
+      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': toHex(new BN(1)),
     });
 
     controller.disable();
@@ -232,7 +233,7 @@ describe('TokenBalancesController', () => {
     });
 
     expect(controller.state.contractBalances).toStrictEqual({
-      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': '1',
+      '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': toHex(new BN(1)),
     });
   });
 
@@ -280,7 +281,7 @@ describe('TokenBalancesController', () => {
 
     expect(tokens[0].balanceError).toBeNull();
     expect(Object.keys(controller.state.contractBalances)).toContain(address);
-    expect(controller.state.contractBalances[address]).not.toBe('0');
+    expect(controller.state.contractBalances[address]).not.toBe(toHex(0));
   });
 
   it('should handle `getERC20BalanceOf` error case', async () => {
@@ -312,7 +313,7 @@ describe('TokenBalancesController', () => {
 
     expect(tokens[0].balanceError).toBeInstanceOf(Error);
     expect(tokens[0].balanceError).toHaveProperty('message', errorMsg);
-    expect(controller.state.contractBalances[address]).toBe('0');
+    expect(controller.state.contractBalances[address]).toBe(toHex(0));
 
     getERC20BalanceOfStub.mockReturnValue(new BN(1));
 
@@ -388,7 +389,7 @@ describe('TokenBalancesController', () => {
     });
 
     expect(controller.state.contractBalances).toStrictEqual({
-      '0x02': new BN(1).toString(16),
+      '0x02': toHex(new BN(1)),
     });
   });
 });

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -6,7 +6,6 @@ import {
 } from '@metamask/base-controller';
 import { safelyExecute } from '@metamask/controller-utils';
 import type { PreferencesState } from '@metamask/preferences-controller';
-import { BN } from 'ethereumjs-util';
 
 import type { AssetsContractController } from './AssetsContractController';
 import type { Token } from './TokenRatesController';
@@ -21,8 +20,6 @@ const metadata = {
 };
 
 /**
- * @type TokenBalancesControllerOptions
- *
  * Token balances controller options
  * @property interval - Polling interval used to fetch new token balances.
  * @property tokens - List of tokens to track balances for.
@@ -31,7 +28,7 @@ const metadata = {
  * @property getSelectedAddress - Gets the current selected address.
  * @property getERC20BalanceOf - Gets the balance of the given account at the given contract address.
  */
-export type TokenBalancesControllerOptions = {
+type TokenBalancesControllerOptions = {
   interval?: number;
   tokens?: Token[];
   disabled?: boolean;
@@ -48,8 +45,6 @@ export type TokenBalancesControllerOptions = {
 type ContractBalances = Record<string, string>;
 
 /**
- * @type TokenBalancesControllerState
- *
  * Token balances controller state
  * @property contractBalances - Hash of token contract addresses to balances
  */
@@ -82,11 +77,16 @@ export type TokenBalancesControllerMessenger = RestrictedControllerMessenger<
   never
 >;
 
-const getDefaultState = (): TokenBalancesControllerState => {
+/**
+ * Get the default TokenBalancesController state.
+ *
+ * @returns The default TokenBalancesController state.
+ */
+function getDefaultState(): TokenBalancesControllerState {
   return {
     contractBalances: {},
   };
-};
+}
 
 /**
  * Controller that passively polls on a set interval token balances
@@ -176,13 +176,6 @@ export class TokenBalancesController extends BaseController<
     this.#disabled = true;
   }
 
-  /*
-   * Lists all tracked tokens.
-   */
-  getTokens() {
-    return this.#tokens;
-  }
-
   /**
    * Starts a new polling interval.
    *
@@ -221,7 +214,7 @@ export class TokenBalancesController extends BaseController<
         ).toString(16);
         token.balanceError = null;
       } catch (error) {
-        newContractBalances[address] = new BN(0).toString(16);
+        newContractBalances[address] = '0';
         token.balanceError = error;
       }
     }

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -1,5 +1,7 @@
 import {
   type RestrictedControllerMessenger,
+  type ControllerGetStateAction,
+  type ControllerStateChangeEvent,
   BaseController,
 } from '@metamask/base-controller';
 import { safelyExecute } from '@metamask/controller-utils';
@@ -55,19 +57,36 @@ export type TokenBalancesControllerState = {
   contractBalances: ContractBalances;
 };
 
+export type TokenBalancesControllerGetStateAction = ControllerGetStateAction<
+  typeof controllerName,
+  TokenBalancesControllerState
+>;
+
+export type TokenBalancesControllerActions =
+  TokenBalancesControllerGetStateAction;
+
+export type TokenBalancesControllerStateChangeEvent =
+  ControllerStateChangeEvent<
+    typeof controllerName,
+    TokenBalancesControllerState
+  >;
+
+export type TokenBalancesControllerEvents =
+  TokenBalancesControllerStateChangeEvent;
+
+export type TokenBalancesControllerMessenger = RestrictedControllerMessenger<
+  typeof controllerName,
+  TokenBalancesControllerActions,
+  TokenBalancesControllerEvents,
+  never,
+  never
+>;
+
 const getDefaultState = (): TokenBalancesControllerState => {
   return {
     contractBalances: {},
   };
 };
-
-export type TokenBalancesControllerMessenger = RestrictedControllerMessenger<
-  typeof controllerName,
-  never,
-  never,
-  never,
-  never
->;
 
 /**
  * Controller that passively polls on a set interval token balances

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -43,7 +43,7 @@ export type TokenBalancesControllerOptions = {
 /**
  * Represents a mapping of hash token contract addresses to their balances.
  */
-type ContractBalances = Record<string, BN>;
+type ContractBalances = Record<string, string>;
 
 /**
  * @type TokenBalancesControllerState
@@ -197,13 +197,12 @@ export class TokenBalancesController extends BaseController<
     for (const token of this.#tokens) {
       const { address } = token;
       try {
-        newContractBalances[address] = await this.#getERC20BalanceOf(
-          address,
-          this.#getSelectedAddress(),
-        );
+        newContractBalances[address] = (
+          await this.#getERC20BalanceOf(address, this.#getSelectedAddress())
+        ).toString(16);
         token.balanceError = null;
       } catch (error) {
-        newContractBalances[address] = new BN(0);
+        newContractBalances[address] = new BN(0).toString(16);
         token.balanceError = error;
       }
     }

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -4,7 +4,7 @@ import {
   type ControllerStateChangeEvent,
   BaseController,
 } from '@metamask/base-controller';
-import { safelyExecute } from '@metamask/controller-utils';
+import { safelyExecute, toHex } from '@metamask/controller-utils';
 import type { PreferencesState } from '@metamask/preferences-controller';
 
 import type { AssetsContractController } from './AssetsContractController';
@@ -209,12 +209,12 @@ export class TokenBalancesController extends BaseController<
     for (const token of this.#tokens) {
       const { address } = token;
       try {
-        newContractBalances[address] = (
-          await this.#getERC20BalanceOf(address, this.#getSelectedAddress())
-        ).toString(16);
+        newContractBalances[address] = toHex(
+          await this.#getERC20BalanceOf(address, this.#getSelectedAddress()),
+        );
         token.balanceError = null;
       } catch (error) {
-        newContractBalances[address] = '0';
+        newContractBalances[address] = toHex(0);
         token.balanceError = error;
       }
     }

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -10,7 +10,7 @@ import { add0x } from '@metamask/utils';
 import nock from 'nock';
 import { useFakeTimers } from 'sinon';
 
-import { advanceTime } from '../../../tests/helpers';
+import { advanceTime, flushPromises } from '../../../tests/helpers';
 import { TOKEN_PRICES_BATCH_SIZE } from './assetsUtil';
 import type {
   AbstractTokenPricesService,
@@ -2289,18 +2289,6 @@ async function withController<ReturnValue>(
     controller.stop();
     await flushPromises();
   }
-}
-
-/**
- * Resolve all pending promises.
- *
- * This method is used for async tests that use fake timers.
- * See https://stackoverflow.com/a/58716087 and https://jestjs.io/docs/timer-mocks.
- *
- * TODO: migrate this to @metamask/utils
- */
-async function flushPromises(): Promise<void> {
-  await new Promise(jest.requireActual('timers').setImmediate);
 }
 
 /**

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -17,7 +17,7 @@ import type {
   TokenPrice,
   TokenPricesByTokenAddress,
 } from './token-prices-service/abstract-token-prices-service';
-import type { TokenBalancesState } from './TokenBalancesController';
+import type { TokenBalancesControllerState } from './TokenBalancesController';
 import { TokenRatesController } from './TokenRatesController';
 import type { TokenRatesConfig, Token } from './TokenRatesController';
 import type { TokensState } from './TokensController';
@@ -2228,7 +2228,7 @@ type WithControllerCallback<ReturnValue> = ({
 type PartialConstructorParameters = {
   options?: Partial<ConstructorParameters<typeof TokenRatesController>[0]>;
   config?: Partial<TokenRatesConfig>;
-  state?: Partial<TokenBalancesState>;
+  state?: Partial<TokenBalancesControllerState>;
 };
 
 type WithControllerArgs<ReturnValue> =

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -17,9 +17,12 @@ import type {
   TokenPrice,
   TokenPricesByTokenAddress,
 } from './token-prices-service/abstract-token-prices-service';
-import type { TokenBalancesControllerState } from './TokenBalancesController';
 import { TokenRatesController } from './TokenRatesController';
-import type { TokenRatesConfig, Token } from './TokenRatesController';
+import type {
+  TokenRatesConfig,
+  Token,
+  TokenRatesState,
+} from './TokenRatesController';
 import type { TokensState } from './TokensController';
 
 const defaultSelectedAddress = '0x0000000000000000000000000000000000000001';
@@ -2228,7 +2231,7 @@ type WithControllerCallback<ReturnValue> = ({
 type PartialConstructorParameters = {
   options?: Partial<ConstructorParameters<typeof TokenRatesController>[0]>;
   config?: Partial<TokenRatesConfig>;
-  state?: Partial<TokenBalancesControllerState>;
+  state?: Partial<TokenRatesState>;
 };
 
 type WithControllerArgs<ReturnValue> =

--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -4,7 +4,6 @@ export * from './CurrencyRateController';
 export * from './NftController';
 export * from './NftDetectionController';
 export type {
-  TokenBalancesControllerOptions,
   TokenBalancesControllerMessenger,
   TokenBalancesControllerActions,
   TokenBalancesControllerGetStateAction,

--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -3,7 +3,15 @@ export * from './AssetsContractController';
 export * from './CurrencyRateController';
 export * from './NftController';
 export * from './NftDetectionController';
-export * from './TokenBalancesController';
+export type {
+  TokenBalancesControllerOptions,
+  TokenBalancesControllerMessenger,
+  TokenBalancesControllerActions,
+  TokenBalancesControllerGetStateAction,
+  TokenBalancesControllerEvents,
+  TokenBalancesControllerStateChangeEvent,
+} from './TokenBalancesController';
+export { TokenBalancesController } from './TokenBalancesController';
 export type {
   TokenDetectionControllerMessenger,
   TokenDetectionControllerActions,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -23,6 +23,7 @@ import { errorCodes, providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import * as NonceTrackerPackage from 'nonce-tracker';
 
 import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
+import { flushPromises } from '../../../tests/helpers';
 import { mockNetwork } from '../../../tests/mock-network';
 import { IncomingTransactionHelper } from './helpers/IncomingTransactionHelper';
 import { PendingTransactionTracker } from './helpers/PendingTransactionTracker';
@@ -304,15 +305,6 @@ function waitForTransactionFinished(
       },
     );
   });
-}
-
-/**
- * Resolve all pending promises.
- * This method is used for async tests that use fake timers.
- * See https://stackoverflow.com/a/58716087 and https://jestjs.io/docs/timer-mocks.
- */
-function flushPromises(): Promise<unknown> {
-  return new Promise(jest.requireActual('timers').setImmediate);
 }
 
 const MOCK_PREFERENCES = { state: { selectedAddress: 'foo' } };
@@ -2640,7 +2632,7 @@ describe('TransactionController', () => {
         externalBaseFeePerGas,
       );
 
-      await new Promise(jest.requireActual('timers').setImmediate);
+      await flushPromises();
 
       expect(mockPostTransactionBalanceUpdatedListener).toHaveBeenCalledTimes(
         1,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -27,3 +27,15 @@ export async function advanceTime({
     duration -= stepSize;
   } while (duration > 0);
 }
+
+/**
+ * Resolve all pending promises.
+ *
+ * This method is used for async tests that use fake timers.
+ * See https://stackoverflow.com/a/58716087 and https://jestjs.io/docs/timer-mocks.
+ *
+ * TODO: migrate this to @metamask/utils
+ */
+export async function flushPromises(): Promise<void> {
+  await new Promise(jest.requireActual('timers').setImmediate);
+}


### PR DESCRIPTION
## Explanation

The `TokenBalancesController` has been migrated to `BaseControllerV2`.

## References

Closes #1808

## Changelog

### `@metamask/token-balances-controller`

#### Changed
- **BREAKING:** Convert to `BaseControllerV2`
  - The constructor parameters have changed; rather than accepting a "config" parameter for interval and tokens we now pass both values as controller options, and a "state" parameter, there is now just a single object for all constructor arguments. This object has a mandatory `messenger` and an optional `state`, `tokens`, `interval`  properties a disabled property has also been added.
  - State now saves tokens  balances as strings and not as a BNs.
  - Additional BN export has been removed as it was intended to be removed in the next major release.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
