### PR TITLE
Price API perf improvements

### DIFF
--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -24,7 +24,7 @@ import { type ContractExchangeRates } from './TokenRatesController';
  * The maximum number of token addresses that should be sent to the Price API in
  * a single request.
  */
-export const TOKEN_PRICES_BATCH_SIZE = 100;
+export const TOKEN_PRICES_BATCH_SIZE = 30;
 
 /**
  * Compares nft metadata entries to any nft entry.
@@ -432,7 +432,7 @@ export async function fetchTokenContractExchangeRates({
     Hex,
     Awaited<ReturnType<AbstractTokenPricesService['fetchTokenPrices']>>
   >({
-    values: tokenAddresses,
+    values: [...tokenAddresses].sort(),
     batchSize: TOKEN_PRICES_BATCH_SIZE,
     eachBatch: async (allTokenPricesByTokenAddress, batch) => {
       const tokenPricesByTokenAddressForBatch =


### PR DESCRIPTION
## Explanation

Makes 2 perf improvements to price API calls:

- Batch size of 30 instead of 100
- Sort token addresses in query params for more cache hits

## References

- https://github.com/MetaMask/MetaMask-planning/issues/1891
- https://github.com/MetaMask/mobile-planning/issues/1458

## Changelog

### `@metamask/assets-controllers`

- **CHANGED**: Price API batch size reduced from 100 to 30

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
