### PR TITLE
Sort token addresses before batching calls to price API

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -510,7 +510,7 @@ export class TokenRatesController extends StaticIntervalPollingControllerV1<
       Hex,
       Awaited<ReturnType<AbstractTokenPricesService['fetchTokenPrices']>>
     >({
-      values: tokenAddresses,
+      values: [...tokenAddresses].sort(),
       batchSize: TOKEN_PRICES_BATCH_SIZE,
       eachBatch: async (allTokenPricesByTokenAddress, batch) => {
         const tokenPricesByTokenAddressForBatch =


### PR DESCRIPTION
## Explanation

Sort token addresses before batching calls to price API for more cache hits.

## References

- https://github.com/MetaMask/MetaMask-planning/issues/1891
- https://github.com/MetaMask/mobile-planning/issues/1458

## Changelog

### `@metamask/assets-controllers`

- **CHANGED**: Sort token addresses before batching calls to price API

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
