### PR TITLE
Bind `getNonceTrackerPendingTransactions` with chainId when passing to NonceTracker constructor

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -717,6 +717,7 @@ describe('TransactionController', () => {
           },
         ];
 
+        // this feels like a weird thing to test here
         const pendingTransactions =
           nonceTrackerMock.mock.calls[0][0].getPendingTransactions(
             ACCOUNT_MOCK,
@@ -730,8 +731,8 @@ describe('TransactionController', () => {
         expect(getExternalPendingTransactions).toHaveBeenCalledTimes(1);
         expect(getExternalPendingTransactions).toHaveBeenCalledWith(
           ACCOUNT_MOCK,
-          // TODO(JL): This shouldn't be undefined. NonceTracker needs
-          // to be updated to call this method with the chainId.
+          // This is undefined for the base nonceTracker
+          // TODO (AD) add tests for using external pending transactions with a networkClientId once we have trackingMaps instantiated
           undefined,
         );
       });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -533,8 +533,10 @@ export class TransactionController extends BaseControllerV1<
       // @ts-expect-error provider types misaligned: SafeEventEmitterProvider vs Record<string,string>
       provider,
       blockTracker,
-      getPendingTransactions:
-        this.getNonceTrackerPendingTransactions.bind(this),
+      getPendingTransactions: this.getNonceTrackerPendingTransactions.bind(
+        this,
+        undefined,
+      ),
       getConfirmedTransactions: this.getNonceTrackerTransactions.bind(
         this,
         TransactionStatus.confirmed,
@@ -1169,8 +1171,10 @@ export class TransactionController extends BaseControllerV1<
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       provider: networkClient.provider as any,
       blockTracker: networkClient.blockTracker,
-      getPendingTransactions:
-        this.getNonceTrackerPendingTransactions.bind(this),
+      getPendingTransactions: this.getNonceTrackerPendingTransactions.bind(
+        this,
+        chainId,
+      ),
       getConfirmedTransactions: this.getNonceTrackerTransactions.bind(
         this,
         TransactionStatus.confirmed,
@@ -2846,8 +2850,8 @@ export class TransactionController extends BaseControllerV1<
   }
 
   private getNonceTrackerPendingTransactions(
+    chainId: string | undefined,
     address: string,
-    chainId?: string,
   ) {
     const standardPendingTransactions = this.getNonceTrackerTransactions(
       TransactionStatus.submitted,


### PR DESCRIPTION
Rather than modify NonceTracker to accept a static chainId arg in its constructor we can bind the `getNonceTrackerPendingTransaction` callback with the chainId for the networkClient it is concerned with.