### PR TITLE
Make getEthQuery private

### DIFF
--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -643,7 +643,7 @@ export class TransactionController extends BaseControllerV1<
     }
   }
 
-  getEthQuery({
+  #getEthQuery({
     networkClientId,
     chainId,
   }: {
@@ -761,7 +761,7 @@ export class TransactionController extends BaseControllerV1<
     );
 
     const chainId = this.getChainId(networkClientId);
-    const ethQuery = this.getEthQuery({ networkClientId, chainId });
+    const ethQuery = this.#getEthQuery({ networkClientId, chainId });
 
     const transactionType =
       type ?? (await determineTransactionType(txParams, ethQuery)).type;
@@ -970,7 +970,7 @@ export class TransactionController extends BaseControllerV1<
       txParams: newTxParams,
     });
 
-    const ethQuery = this.getEthQuery({
+    const ethQuery = this.#getEthQuery({
       networkClientId: transactionMeta.networkClientId,
       chainId: transactionMeta.chainId,
     });
@@ -1130,7 +1130,7 @@ export class TransactionController extends BaseControllerV1<
 
     log('Submitting speed up transaction', { oldFee, newFee, txParams });
 
-    const ethQuery = this.getEthQuery({
+    const ethQuery = this.#getEthQuery({
       networkClientId: transactionMeta.networkClientId,
       chainId: transactionMeta.chainId,
     });
@@ -1282,7 +1282,7 @@ export class TransactionController extends BaseControllerV1<
     transaction: TransactionParams,
     networkClientId?: NetworkClientId,
   ) {
-    const ethQuery = this.getEthQuery({ networkClientId });
+    const ethQuery = this.#getEthQuery({ networkClientId });
     const { estimatedGas, simulationFails } = await estimateGas(
       transaction,
       ethQuery,
@@ -1304,7 +1304,7 @@ export class TransactionController extends BaseControllerV1<
     multiplier: number,
     networkClientId?: NetworkClientId,
   ) {
-    const ethQuery = this.getEthQuery({ networkClientId });
+    const ethQuery = this.#getEthQuery({ networkClientId });
     const { blockGasLimit, estimatedGas, simulationFails } = await estimateGas(
       transaction,
       ethQuery,
@@ -1758,7 +1758,7 @@ export class TransactionController extends BaseControllerV1<
     const updatedTransaction = merge(transactionMeta, editableParams);
     const { type } = await determineTransactionType(
       updatedTransaction.txParams,
-      this.getEthQuery({
+      this.#getEthQuery({
         networkClientId: transactionMeta.networkClientId,
         chainId: transactionMeta.chainId,
       }),
@@ -2088,7 +2088,7 @@ export class TransactionController extends BaseControllerV1<
     }
 
     await updateGas({
-      ethQuery: this.getEthQuery({ networkClientId, chainId }),
+      ethQuery: this.#getEthQuery({ networkClientId, chainId }),
       chainId,
       isCustomNetwork,
       txMeta: transactionMeta,
@@ -2096,7 +2096,7 @@ export class TransactionController extends BaseControllerV1<
 
     await updateGasFees({
       eip1559: isEIP1559Compatible,
-      ethQuery: this.getEthQuery({ networkClientId, chainId }),
+      ethQuery: this.#getEthQuery({ networkClientId, chainId }),
       getSavedGasFees: this.getSavedGasFees.bind(this),
       getGasFeeEstimates: this.getGasFeeEstimates.bind(this),
       txMeta: transactionMeta,
@@ -2324,7 +2324,7 @@ export class TransactionController extends BaseControllerV1<
         return;
       }
 
-      const ethQuery = this.getEthQuery({
+      const ethQuery = this.#getEthQuery({
         networkClientId: transactionMeta.networkClientId,
         chainId: transactionMeta.chainId,
       });
@@ -2943,7 +2943,7 @@ export class TransactionController extends BaseControllerV1<
         return;
       }
 
-      const ethQuery = this.getEthQuery({
+      const ethQuery = this.#getEthQuery({
         networkClientId: transactionMeta.networkClientId,
         chainId: transactionMeta.chainId,
       });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1401,16 +1401,6 @@ export class TransactionController extends BaseControllerV1<
     });
   }
 
-  // NOTE(JL): Where is this called?
-  startIncomingTransactionProcessing() {
-    this.incomingTransactionHelper.start();
-  }
-
-  // NOTE(JL): Where is this called?
-  stopIncomingTransactionProcessing() {
-    this.incomingTransactionHelper.stop();
-  }
-
   /**
    * Adds external provided transaction to state as confirmed transaction.
    *

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1182,6 +1182,7 @@ export class TransactionController extends BaseControllerV1<
     this.hub.emit(`${transactionMeta.id}:speedup`, newTransactionMeta);
   }
 
+  // NOTE(JL): Should this be private?
   stopTrackingByNetworkClientId(networkClientId: NetworkClientId) {
     const trackers = this.trackingMap.get(networkClientId);
     if (trackers) {
@@ -1200,6 +1201,7 @@ export class TransactionController extends BaseControllerV1<
     this.trackingMap.delete(networkClientId);
   }
 
+  // NOTE(JL): Should this be private?
   startTrackingByNetworkClientId(networkClientId: NetworkClientId) {
     const networkClient = this.getNetworkClientById(networkClientId);
     const { chainId } = networkClient.configuration;
@@ -1399,10 +1401,12 @@ export class TransactionController extends BaseControllerV1<
     });
   }
 
+  // NOTE(JL): Where is this called?
   startIncomingTransactionProcessing() {
     this.incomingTransactionHelper.start();
   }
 
+  // NOTE(JL): Where is this called?
   stopIncomingTransactionProcessing() {
     this.incomingTransactionHelper.stop();
   }
@@ -1665,6 +1669,7 @@ export class TransactionController extends BaseControllerV1<
     address: string,
     networkClientId?: NetworkClientId,
   ): Promise<NonceLock> {
+    // TODO(JL): SmartTransactionController reaches into TransactionController.nonceTracker directly. Should probably change this.
     // TODO(JL): Revisit this method. It's a bit complicated and not obvious what it achieves.
     let nonceMutexForChainId: Mutex | undefined;
     let { nonceTracker } = this;


### PR DESCRIPTION
## Explanation

* Makes `getEthQuery` #private
  * Leaves existing ts private keywords in place

## References

Related https://github.com/MetaMask/MetaMask-planning/issues/1892

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
