### PR TITLE
refactor(network-controller): Consolidate `setActiveNetwork` and `setProviderType`

### DIFF
--- a/packages/network-controller/jest.config.js
+++ b/packages/network-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 76.27,
+      branches: 76.53,
       functions: 95,
-      lines: 92.09,
-      statements: 91.68,
+      lines: 92.03,
+      statements: 91.62,
     },
   },
 


### PR DESCRIPTION
## Explanation

The `setActiveNetwork` method (and action) has been updated to support both network client IDs and built-in network types, letting us use it for switching to any type of network.

Note that the coverage has been updated, increasing coverage for branches but reducing it for lines and statements. The reductions were due to lines being removed; there are no lines or statements that have become uncovered in this PR.

## References

This was done to assist with #3763

Closes #2020

## Changelog

### `@metamask/network-controller`

#### Changed
- The `setActiveNetwork` method and action now supports built-in network types.
  - Previously this would only accept a network configuration ID. Now it will accept the type of a built-in network as well, using it like an ID. This lets you switch to a built-in or custom network with a single method/action.
- Deprecate the `setProviderType` method and action
  - Use `setActiveNetwork` instead

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
