### PR TITLE
refactor: Update `@metamask/utils` and use `createDeferredPromise` from utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/eth-json-rpc-provider": "^2.3.1",
     "@metamask/json-rpc-engine": "^7.3.1",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.18.54",
     "@typescript-eslint/eslint-plugin": "^5.62.0",

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -36,7 +36,7 @@
     "@metamask/keyring-api": "^1.1.0",
     "@metamask/snaps-sdk": "^1.3.1",
     "@metamask/snaps-utils": "^5.1.1",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "deepmerge": "^4.2.2",
     "ethereumjs-util": "^7.0.10",
     "immer": "^9.0.6",

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@metamask/base-controller": "^4.1.0",
     "@metamask/controller-utils": "^8.0.1",
-    "@metamask/utils": "^8.2.0"
+    "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@metamask/base-controller": "^4.1.0",
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "nanoid": "^3.1.31"
   },
   "devDependencies": {

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -46,7 +46,7 @@
     "@metamask/polling-controller": "^4.0.0",
     "@metamask/preferences-controller": "^6.0.0",
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "@types/uuid": "^8.3.0",
     "async-mutex": "^0.2.6",
     "cockatiel": "^3.1.2",

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -12,7 +12,7 @@ import type {
 } from '@metamask/network-controller';
 import { StaticIntervalPollingControllerV1 } from '@metamask/polling-controller';
 import type { PreferencesState } from '@metamask/preferences-controller';
-import type { Hex } from '@metamask/utils';
+import { createDeferredPromise, type Hex } from '@metamask/utils';
 import { isEqual } from 'lodash';
 
 import { reduceInBatchesSerially, TOKEN_PRICES_BATCH_SIZE } from './assetsUtil';
@@ -589,62 +589,6 @@ export class TokenRatesController extends StaticIntervalPollingControllerV1<
       {},
     );
   }
-}
-
-/**
- * A deferred Promise.
- *
- * A deferred Promise is one that can be resolved or rejected independently of
- * the Promise construction.
- */
-type DeferredPromise = {
-  /**
-   * The Promise that has been deferred.
-   */
-  promise: Promise<void>;
-  /**
-   * A function that resolves the Promise.
-   */
-  resolve: () => void;
-  /**
-   * A function that rejects the Promise.
-   */
-  reject: (error: unknown) => void;
-};
-
-/**
- * Create a defered Promise.
- *
- * TODO: Migrate this to utils
- *
- * @param args - The arguments.
- * @param args.suppressUnhandledRejection - This option adds an empty error handler
- * to the Promise to suppress the UnhandledPromiseRejection error. This can be
- * useful if the deferred Promise is sometimes intentionally not used.
- * @returns A deferred Promise.
- */
-function createDeferredPromise({
-  suppressUnhandledRejection = false,
-}: {
-  suppressUnhandledRejection: boolean;
-}): DeferredPromise {
-  let resolve: DeferredPromise['resolve'];
-  let reject: DeferredPromise['reject'];
-  const promise = new Promise<void>(
-    (innerResolve: () => void, innerReject: () => void) => {
-      resolve = innerResolve;
-      reject = innerReject;
-    },
-  );
-
-  if (suppressUnhandledRejection) {
-    promise.catch((_error) => {
-      // This handler is used to suppress the UnhandledPromiseRejection error
-    });
-  }
-
-  // @ts-expect-error We know that these are assigned, but TypeScript doesn't
-  return { promise, resolve, reject };
 }
 
 export default TokenRatesController;

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -31,7 +31,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "immer": "^9.0.6"
   },
   "devDependencies": {

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -31,7 +31,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "@types/eslint": "^8.44.7"
   },
   "devDependencies": {

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@metamask/eth-query": "^4.0.0",
     "@metamask/ethjs-unit": "^0.2.1",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "@spruceid/siwe-parser": "1.1.3",
     "eth-ens-namehash": "^2.0.8",
     "ethereumjs-util": "^7.0.10",

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -34,7 +34,7 @@
     "@ethersproject/providers": "^5.7.0",
     "@metamask/base-controller": "^4.1.0",
     "@metamask/controller-utils": "^8.0.1",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "ethereum-ens-network-map": "^1.0.2",
     "punycode": "^2.1.1"
   },

--- a/packages/eth-json-rpc-provider/package.json
+++ b/packages/eth-json-rpc-provider/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@metamask/json-rpc-engine": "^7.3.1",
     "@metamask/safe-event-emitter": "^3.0.0",
-    "@metamask/utils": "^8.2.0"
+    "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -37,7 +37,7 @@
     "@metamask/ethjs-unit": "^0.2.1",
     "@metamask/network-controller": "^17.1.0",
     "@metamask/polling-controller": "^4.0.0",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "@types/uuid": "^8.3.0",
     "ethereumjs-util": "^7.0.10",
     "uuid": "^8.3.2"

--- a/packages/json-rpc-engine/package.json
+++ b/packages/json-rpc-engine/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/safe-event-emitter": "^3.0.0",
-    "@metamask/utils": "^8.2.0"
+    "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",

--- a/packages/json-rpc-middleware-stream/package.json
+++ b/packages/json-rpc-middleware-stream/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@metamask/json-rpc-engine": "^7.3.1",
     "@metamask/safe-event-emitter": "^3.0.0",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "readable-stream": "^3.6.2"
   },
   "devDependencies": {

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -35,7 +35,7 @@
     "@metamask/base-controller": "^4.1.0",
     "@metamask/eth-keyring-controller": "^15.1.0",
     "@metamask/message-manager": "^7.3.7",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6",
     "ethereumjs-util": "^7.0.10",
     "ethereumjs-wallet": "^1.0.1",

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -34,7 +34,7 @@
     "@metamask/base-controller": "^4.1.0",
     "@metamask/controller-utils": "^8.0.1",
     "@metamask/eth-sig-util": "^7.0.1",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "@types/uuid": "^8.3.0",
     "ethereumjs-util": "^7.0.10",
     "jsonschema": "^1.2.4",

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^4.1.0",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6"
   },
   "devDependencies": {

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -40,7 +40,7 @@
     "@metamask/json-rpc-engine": "^7.3.1",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/swappable-obj-proxy": "^2.1.0",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6",
     "eth-block-tracker": "^8.0.0",
     "immer": "^9.0.6",

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^4.1.0",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "nanoid": "^3.1.31"
   },
   "devDependencies": {

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -35,7 +35,7 @@
     "@metamask/controller-utils": "^8.0.1",
     "@metamask/json-rpc-engine": "^7.3.1",
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "@types/deep-freeze-strict": "^1.1.0",
     "deep-freeze-strict": "^1.1.1",
     "immer": "^9.0.6",

--- a/packages/permission-log-controller/package.json
+++ b/packages/permission-log-controller/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@metamask/base-controller": "^4.1.0",
     "@metamask/json-rpc-engine": "^7.3.1",
-    "@metamask/utils": "^8.2.0"
+    "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -34,7 +34,7 @@
     "@metamask/base-controller": "^4.1.0",
     "@metamask/controller-utils": "^8.0.1",
     "@metamask/network-controller": "^17.1.0",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "@types/uuid": "^8.3.0",
     "fast-json-stable-stringify": "^2.1.0",
     "uuid": "^8.3.2"

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -36,7 +36,7 @@
     "@metamask/json-rpc-engine": "^7.3.1",
     "@metamask/rpc-errors": "^6.1.0",
     "@metamask/swappable-obj-proxy": "^2.1.0",
-    "@metamask/utils": "^8.2.0"
+    "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {
     "@metamask/approval-controller": "^5.1.1",

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -35,7 +35,7 @@
     "@metamask/json-rpc-engine": "^7.3.1",
     "@metamask/network-controller": "^17.1.0",
     "@metamask/swappable-obj-proxy": "^2.1.0",
-    "@metamask/utils": "^8.2.0"
+    "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -38,7 +38,7 @@
     "@metamask/logging-controller": "^2.0.1",
     "@metamask/message-manager": "^7.3.7",
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "ethereumjs-util": "^7.0.10",
     "lodash": "^4.17.21"
   },

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -42,7 +42,7 @@
     "@metamask/metamask-eth-abis": "^3.0.0",
     "@metamask/network-controller": "^17.1.0",
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6",
     "eth-method-registry": "^3.0.0",
     "ethereumjs-util": "^7.0.10",

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -40,7 +40,7 @@
     "@metamask/network-controller": "^17.1.0",
     "@metamask/polling-controller": "^4.0.0",
     "@metamask/transaction-controller": "^19.0.1",
-    "@metamask/utils": "^8.2.0",
+    "@metamask/utils": "^8.3.0",
     "ethereumjs-util": "^7.0.10",
     "immer": "^9.0.6",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,7 +1480,7 @@ __metadata:
     "@metamask/snaps-controllers": ^3.6.0
     "@metamask/snaps-sdk": ^1.3.1
     "@metamask/snaps-utils": ^5.1.1
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/readable-stream": ^2.3.0
     deepmerge: ^4.2.2
@@ -1516,7 +1516,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^4.1.0
     "@metamask/controller-utils": ^8.0.1
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -1550,7 +1550,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^4.1.0
     "@metamask/rpc-errors": ^6.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -1597,7 +1597,7 @@ __metadata:
     "@metamask/polling-controller": ^4.0.0
     "@metamask/preferences-controller": ^6.0.0
     "@metamask/rpc-errors": ^6.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/lodash": ^4.14.191
     "@types/node": ^16.18.54
@@ -1660,7 +1660,7 @@ __metadata:
   resolution: "@metamask/base-controller@workspace:packages/base-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/sinon": ^9.0.10
     deepmerge: ^4.2.2
@@ -1698,7 +1698,7 @@ __metadata:
   resolution: "@metamask/build-utils@workspace:packages/build-utils"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/eslint": ^8.44.7
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1743,7 +1743,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-unit": ^0.2.1
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@spruceid/siwe-parser": 1.1.3
     "@types/jest": ^27.4.1
     bn.js: ^5.2.1
@@ -1790,7 +1790,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/eth-json-rpc-provider": ^2.3.1
     "@metamask/json-rpc-engine": ^7.3.1
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/node": ^16.18.54
     "@typescript-eslint/eslint-plugin": ^5.62.0
@@ -1852,7 +1852,7 @@ __metadata:
     "@metamask/base-controller": ^4.1.0
     "@metamask/controller-utils": ^8.0.1
     "@metamask/network-controller": ^17.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     ethereum-ens-network-map: ^1.0.2
@@ -1967,7 +1967,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/json-rpc-engine": ^7.3.1
     "@metamask/safe-event-emitter": ^3.0.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -2170,7 +2170,7 @@ __metadata:
     "@metamask/ethjs-unit": ^0.2.1
     "@metamask/network-controller": ^17.1.0
     "@metamask/polling-controller": ^4.0.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/jest-when": ^2.7.3
     "@types/uuid": ^8.3.0
@@ -2198,7 +2198,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/safe-event-emitter": ^3.0.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -2216,7 +2216,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/json-rpc-engine": ^7.3.1
     "@metamask/safe-event-emitter": ^3.0.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/readable-stream": ^2.3.0
     deepmerge: ^4.2.2
@@ -2277,7 +2277,7 @@ __metadata:
     "@metamask/message-manager": ^7.3.7
     "@metamask/preferences-controller": ^6.0.0
     "@metamask/scure-bip39": ^2.1.1
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     async-mutex: ^0.2.6
     deepmerge: ^4.2.2
@@ -2323,7 +2323,7 @@ __metadata:
     "@metamask/base-controller": ^4.1.0
     "@metamask/controller-utils": ^8.0.1
     "@metamask/eth-sig-util": ^7.0.1
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/uuid": ^8.3.0
     deepmerge: ^4.2.2
@@ -2351,7 +2351,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^4.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     async-mutex: ^0.2.6
     deepmerge: ^4.2.2
@@ -2378,7 +2378,7 @@ __metadata:
     "@metamask/json-rpc-engine": ^7.3.1
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/swappable-obj-proxy": ^2.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/jest-when": ^2.7.3
     "@types/lodash": ^4.14.191
@@ -2405,7 +2405,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^4.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -2468,7 +2468,7 @@ __metadata:
     "@metamask/controller-utils": ^8.0.1
     "@metamask/json-rpc-engine": ^7.3.1
     "@metamask/rpc-errors": ^6.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/deep-freeze-strict": ^1.1.0
     "@types/jest": ^27.4.1
     deep-freeze-strict: ^1.1.1
@@ -2512,7 +2512,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^4.1.0
     "@metamask/json-rpc-engine": ^7.3.1
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/deep-freeze-strict": ^1.1.0
     "@types/jest": ^27.4.1
     deep-freeze-strict: ^1.1.1
@@ -2556,7 +2556,7 @@ __metadata:
     "@metamask/base-controller": ^4.1.0
     "@metamask/controller-utils": ^8.0.1
     "@metamask/network-controller": ^17.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/uuid": ^8.3.0
     deepmerge: ^4.2.2
@@ -2652,7 +2652,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/selected-network-controller": ^6.0.0
     "@metamask/swappable-obj-proxy": ^2.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     immer: ^9.0.6
@@ -2731,7 +2731,7 @@ __metadata:
     "@metamask/json-rpc-engine": ^7.3.1
     "@metamask/network-controller": ^17.1.0
     "@metamask/swappable-obj-proxy": ^2.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     immer: ^9.0.6
@@ -2760,7 +2760,7 @@ __metadata:
     "@metamask/logging-controller": ^2.0.1
     "@metamask/message-manager": ^7.3.7
     "@metamask/rpc-errors": ^6.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     ethereumjs-util: ^7.0.10
@@ -2983,7 +2983,7 @@ __metadata:
     "@metamask/metamask-eth-abis": ^3.0.0
     "@metamask/network-controller": ^17.1.0
     "@metamask/rpc-errors": ^6.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/node": ^16.18.54
     async-mutex: ^0.2.6
@@ -3022,7 +3022,7 @@ __metadata:
     "@metamask/network-controller": ^17.1.0
     "@metamask/polling-controller": ^4.0.0
     "@metamask/transaction-controller": ^19.0.1
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     ethereumjs-util: ^7.0.10
@@ -3071,9 +3071,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0, @metamask/utils@npm:^8.2.1":
-  version: 8.2.1
-  resolution: "@metamask/utils@npm:8.2.1"
+"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0, @metamask/utils@npm:^8.2.1, @metamask/utils@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "@metamask/utils@npm:8.3.0"
   dependencies:
     "@ethereumjs/tx": ^4.2.0
     "@noble/hashes": ^1.3.1
@@ -3083,7 +3083,7 @@ __metadata:
     pony-cause: ^2.1.10
     semver: ^7.5.4
     superstruct: ^1.0.3
-  checksum: 36a714a17e4949d2040bedb28d4373a22e7e86bb797aa2d59223f9799fd76e662443bcede113719c4e200f5e9d90a9d62feafad5028fff8b9a7a85fface097ca
+  checksum: cd60c49b4c0397fb31e6b38937a0d9346cbb8337cb8add59db8db0e0e2156fb063ff4df93a26410157f0cc02aa9a9b785fc1b53cfc4ab73204462893ed11cacb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

The `createDeferredPromise` function that had been defined in the `TokenRatesController` has been replaced by the function with the same name from the `@metamask/utils` package. It behaves identically.

The `@metamask/utils` package has been updated from `^8.2.0` to `^8.3.0` in all packages because the `createDeferredPromise` function was added in `v8.3.0`.

## References

This is a follow-up to #3635. The function was temporarily inlined in that PR, but the plan was always to ship it as part of utils.

This was done now because it helps somewhat with #3763, but it's not a complete blocker.

## Changelog

This change entry applies to all packages in the diff for this PR.

#### Changed
- Bump `@metamask/utils` to `^8.3.0`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
