### PR TITLE
Transaction multichain init tracking map

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -4737,9 +4737,9 @@ describe('TransactionController', () => {
       });
       expect(controller).toBeDefined();
     });
+    // eslint-disable-next-line jest/no-done-callback
     it('should handle removals in the networkController registry', (done) => {
       const hub = new EventEmitter() as TransactionControllerEventEmitter;
-      let stateChangeFn: (state: any) => void;
       const mockGetNetworkClientRegistry = jest.fn();
       mockGetNetworkClientRegistry.mockImplementationOnce(() => ({
         sepolia: {
@@ -4779,9 +4779,6 @@ describe('TransactionController', () => {
       const controller = newController({
         options: {
           getNetworkClientRegistry: mockGetNetworkClientRegistry,
-          onNetworkStateChange: (fn: (state: any) => void) => {
-            stateChangeFn = fn;
-          },
           hub,
         },
       });
@@ -4791,7 +4788,6 @@ describe('TransactionController', () => {
   // eslint-disable-next-line jest/no-done-callback
   it('should handle removals in the networkController registry', (done) => {
     const hub = new EventEmitter() as TransactionControllerEventEmitter;
-    let stateChangeFn: (state: any) => void;
     const mockGetNetworkClientRegistry = jest.fn();
     mockGetNetworkClientRegistry.mockImplementationOnce(() => ({
       sepolia: {
@@ -4838,9 +4834,6 @@ describe('TransactionController', () => {
       options: {
         messenger: mockMessenger.messenger,
         getNetworkClientRegistry: mockGetNetworkClientRegistry,
-        onNetworkStateChange: (fn: (state: any) => void) => {
-          stateChangeFn = fn;
-        },
         hub,
       },
     });

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -4719,7 +4719,12 @@ describe('TransactionController', () => {
     // eslint-disable-next-line jest/no-done-callback
     it('should initialize the tracking map on construction', (done) => {
       const hub = new EventEmitter() as TransactionControllerEventEmitter;
-      hub.on('tracking-map-init', () => {
+      hub.on('tracking-map-init', (networkClientIds) => {
+        expect(networkClientIds).toStrictEqual([
+          'sepolia',
+          'goerli',
+          'customNetworkClientId-1',
+        ]);
         done();
       });
       const controller = newController({
@@ -4765,7 +4770,8 @@ describe('TransactionController', () => {
           },
         }));
       });
-      hub.on('tracking-map-remove', () => {
+      hub.on('tracking-map-remove', (networkClientIds) => {
+        expect(networkClientIds).toStrictEqual(['customNetworkClientId-1']);
         done();
       });
       const controller = newController({
@@ -4803,8 +4809,8 @@ describe('TransactionController', () => {
         },
       }));
     });
-    hub.on('tracking-map-add', ([trackedNetworkClientId]) => {
-      expect(trackedNetworkClientId).toBe('goerli');
+    hub.on('tracking-map-add', (networkClientIds) => {
+      expect(networkClientIds).toStrictEqual(['goerli']);
       done();
     });
     const mockMessenger = buildMockMessenger({});

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -20,6 +20,7 @@ import type {
 } from '@metamask/network-controller';
 import { NetworkClientType, NetworkStatus } from '@metamask/network-controller';
 import { errorCodes, providerErrors, rpcErrors } from '@metamask/rpc-errors';
+import { EventEmitter } from 'events';
 import * as NonceTrackerPackage from 'nonce-tracker';
 
 import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
@@ -30,6 +31,7 @@ import type {
   TransactionControllerMessenger,
   TransactionConfig,
   TransactionState,
+  TransactionControllerEventEmitter,
 } from './TransactionController';
 import { TransactionController } from './TransactionController';
 import type {
@@ -4717,8 +4719,17 @@ describe('TransactionController', () => {
     });
   });
   describe('initTrackingMap', () => {
-    it('should initialize the tracking map on construction', () => {
-      const controller = newController();
+    // eslint-disable-next-line jest/no-done-callback
+    it('should initialize the tracking map on construction', (done) => {
+      const hub = new EventEmitter() as TransactionControllerEventEmitter;
+      hub.on('tracking-map-init', () => {
+        done();
+      });
+      const controller = newController({
+        options: {
+          hub,
+        },
+      });
       expect(controller).toBeDefined();
     });
     it('should handle changes in networkController registry', () => {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -578,8 +578,32 @@ describe('TransactionController', () => {
               blockTracker: finalNetwork.blockTracker,
               provider: finalNetwork.provider,
             };
+          case 'sepolia':
+            return {
+              configuration: {
+                chainId: SEPOLIA.chainId,
+              },
+              blockTracker: buildMockBlockTracker('0x1'),
+              provider: MAINNET_PROVIDER,
+            };
+          case 'goerli':
+            return {
+              configuration: {
+                chainId: GOERLI.chainId,
+              },
+              blockTracker: buildMockBlockTracker('0x1'),
+              provider: MAINNET_PROVIDER,
+            };
+          case 'customNetworkClientId-1':
+            return {
+              configuration: {
+                chainId: '0xa',
+              },
+              blockTracker: buildMockBlockTracker('0x1'),
+              provider: MAINNET_PROVIDER,
+            };
           default:
-            throw new Error('Invalid network client id');
+            throw new Error(`Invalid network client id ${networkClientId}`);
         }
       });
 
@@ -593,30 +617,6 @@ describe('TransactionController', () => {
         getGasFeeEstimates: () => Promise.resolve({}),
         getPermittedAccounts: () => [ACCOUNT_MOCK],
         getSelectedAddress: () => ACCOUNT_MOCK,
-        getNetworkClientById: (networkClientId) => {
-          switch (networkClientId) {
-            case 'sepolia':
-              return {
-                configuration: {
-                  chainId: SEPOLIA.chainId,
-                },
-              };
-            case 'goerli':
-              return {
-                configuration: {
-                  chainId: GOERLI.chainId,
-                },
-              };
-            case 'customNetworkClientId-1':
-              return {
-                configuration: {
-                  chainId: '0xa',
-                },
-              };
-            default:
-              throw new Error('Invalid network client id');
-          }
-        },
         getNetworkClientRegistry: () => ({
           sepolia: {
             configuration: {
@@ -776,7 +776,8 @@ describe('TransactionController', () => {
             ACCOUNT_MOCK,
           );
 
-        expect(nonceTrackerMock).toHaveBeenCalledTimes(1);
+        // gets called in constructor now
+        expect(nonceTrackerMock).toHaveBeenCalledTimes(4);
         expect(pendingTransactions).toStrictEqual([
           expect.any(Object),
           ...externalPendingTransactions,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -69,6 +69,17 @@ const mockFlags: { [key: string]: any } = {
   getBlockByNumberValue: null,
 };
 
+const SEPOLIA = {
+  chainId: toHex(11155111),
+  type: NetworkType.sepolia,
+  ticker: NetworksTicker.sepolia,
+};
+const GOERLI = {
+  chainId: toHex(5),
+  type: NetworkType.goerli,
+  ticker: NetworksTicker.goerli,
+};
+
 const ethQueryMockResults = {
   sendRawTransaction: 'mockSendRawTransactionResult',
 };
@@ -512,6 +523,8 @@ describe('TransactionController', () => {
       typeof PendingTransactionTracker
     >;
 
+
+
   /**
    * Create a new instance of the TransactionController.
    *
@@ -580,6 +593,47 @@ describe('TransactionController', () => {
         getGasFeeEstimates: () => Promise.resolve({}),
         getPermittedAccounts: () => [ACCOUNT_MOCK],
         getSelectedAddress: () => ACCOUNT_MOCK,
+        getNetworkClientById: (networkClientId) => {
+          switch (networkClientId) {
+            case 'sepolia':
+              return {
+                configuration: {
+                  chainId: SEPOLIA.chainId,
+                },
+              };
+            case 'goerli':
+              return {
+                configuration: {
+                  chainId: GOERLI.chainId,
+                },
+              };
+            case 'customNetworkClientId-1':
+              return {
+                configuration: {
+                  chainId: '0xa',
+                },
+              };
+            default:
+              throw new Error('Invalid network client id');
+          }
+        },
+        getNetworkClientRegistry: () => ({
+          sepolia: {
+            configuration: {
+              chainId: SEPOLIA.chainId,
+            },
+          },
+          goerli: {
+            configuration: {
+              chainId: GOERLI.chainId,
+            },
+          },
+          'customNetworkClientId-1': {
+            configuration: {
+              chainId: '0xa',
+            },
+          },
+        }),
         messenger,
         onNetworkStateChange: finalNetwork.subscribe,
         provider: finalNetwork.provider,
@@ -4636,7 +4690,7 @@ describe('TransactionController', () => {
       Current tx status: ${TransactionStatus.submitted}`);
     });
   });
-  describe('startTrackinbByNetworkClientId', () => {
+  describe('startTrackingByNetworkClientId', () => {
     it('should start tracking in a tracking map', () => {
       const controller = newController();
       const trackingMap = controller.startTrackingByNetworkClientId('mainnet');
@@ -4659,6 +4713,16 @@ describe('TransactionController', () => {
       const stopSpy = jest.spyOn(incomingTransactionHelper, 'stop');
       controller.stopTrackingByNetworkClientId('mainnet');
       expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe('initTrackingMap', () => {
+    it('should initialize the tracking map on construction', () => {
+      const controller = newController();
+      expect(controller).toBeDefined();
+    });
+    it('should handle changes in networkController registry', () => {
+      const controller = newController();
+      expect(controller).toBeDefined();
     });
   });
 });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -615,7 +615,6 @@ export class TransactionController extends BaseControllerV1<
     this.messagingSystem.subscribe(
       'NetworkController:stateChange',
       (_, patches) => {
-        // TODO(SJ): Needs to check the patch for registry changes
         const refresh = patches.find((patch) => {
           const correctOp = patch.op === 'add' || patch.op === 'remove';
           const correctPath = patch.path[0] === 'networkConfigurations';

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -29,6 +29,7 @@ import type {
   NetworkState,
   Provider,
   NetworkClientConfiguration,
+  ProviderConfig,
 } from '@metamask/network-controller';
 import { NetworkClientType } from '@metamask/network-controller';
 import type { AutoManagedNetworkClient } from '@metamask/network-controller/src/create-auto-managed-network-client';
@@ -100,7 +101,6 @@ import {
   validateTransactionOrigin,
   validateTxParams,
 } from './utils/validation';
-import { CustomNetworkClientConfiguration } from '@metamask/network-controller/src/types';
 
 export const HARDFORK = Hardfork.London;
 
@@ -412,10 +412,9 @@ export class TransactionController extends BaseControllerV1<
    * @param options.hooks.getAdditionalSignArguments - Returns additional arguments required to sign a transaction.
    * @param options.getNetworkClientIdForDomain - Gets the network client id for the given domain.
    * @param options.hub - Use a different event emitter for the hub.
+   * @param options.getNetworkClientRegistry - Gets the network client registry.
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
-   * @param options.getNetworkClientIdForDomain
-   * @param options.getNetworkClientRegistry - Gets the network client registry.
    */
   constructor(
     {
@@ -615,7 +614,7 @@ export class TransactionController extends BaseControllerV1<
 
     this.messagingSystem.subscribe(
       'NetworkController:stateChange',
-      (state, patches) => {
+      (_, patches) => {
         // TODO(SJ): Needs to check the patch for registry changes
         const refresh = patches.find((patch) => {
           const correctOp = patch.op === 'add' || patch.op === 'remove';
@@ -1331,7 +1330,7 @@ export class TransactionController extends BaseControllerV1<
           selectedNetworkClientId: 'mainnet',
           networkConfigurations: {},
           networksMetadata: {},
-          providerConfig: {} as any,
+          providerConfig: {} as ProviderConfig,
         };
       },
       isEnabled: () => true,

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -615,12 +615,12 @@ export class TransactionController extends BaseControllerV1<
     this.messagingSystem.subscribe(
       'NetworkController:stateChange',
       (_, patches) => {
-        const refresh = patches.find((patch) => {
+        const shouldRefresh = patches.some((patch) => {
           const correctOp = patch.op === 'add' || patch.op === 'remove';
           const correctPath = patch.path[0] === 'networkConfigurations';
           return correctOp && correctPath;
         });
-        if (refresh) {
+        if (shouldRefresh) {
           this.#refreshTrackingMap();
         }
       },

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1323,10 +1323,11 @@ export class TransactionController extends BaseControllerV1<
       blockTracker: networkClient.blockTracker,
       getCurrentAccount: this.getSelectedAddress,
       getLastFetchedBlockNumbers: () => this.state.lastFetchedBlockNumbers,
+      // TODO(JL): Fix this type
       getNetworkState: () => {
         return {
           providerConfig: { chainId } as ProviderConfig,
-        };
+        } as NetworkState;
       },
       isEnabled: () => true,
       queryEntireHistory: true,

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -672,9 +672,7 @@ export class TransactionController extends BaseControllerV1<
   #initTrackingMap = () => {
     const networkClients = this.getNetworkClientRegistry();
     const networkClientIds = Object.keys(networkClients);
-    networkClientIds.map((id) =>
-      this.startTrackingByNetworkClientId(id),
-    );
+    networkClientIds.map((id) => this.startTrackingByNetworkClientId(id));
     this.hub.emit('tracking-map-init', networkClientIds);
   };
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1327,10 +1327,7 @@ export class TransactionController extends BaseControllerV1<
       getLastFetchedBlockNumbers: () => this.state.lastFetchedBlockNumbers,
       getNetworkState: () => {
         return {
-          selectedNetworkClientId: 'mainnet',
-          networkConfigurations: {},
-          networksMetadata: {},
-          providerConfig: {} as ProviderConfig,
+          providerConfig: { chainId } as ProviderConfig,
         };
       },
       isEnabled: () => true,

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -672,10 +672,11 @@ export class TransactionController extends BaseControllerV1<
 
   #initTrackingMap = () => {
     const networkClients = this.getNetworkClientRegistry();
-    Object.keys(networkClients).map((id) =>
+    const networkClientIds = Object.keys(networkClients);
+    networkClientIds.map((id) =>
       this.startTrackingByNetworkClientId(id),
     );
-    this.hub.emit('tracking-map-init', Object.keys(networkClients));
+    this.hub.emit('tracking-map-init', networkClientIds);
   };
 
   #onStateChange = () => {

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -4,6 +4,9 @@ import type { Hex } from '@metamask/utils';
 import type { Operation } from 'fast-json-patch';
 
 export type Events = {
+  ['tracking-map-init']: [networkClientIds: NetworkClientId[]];
+  ['tracking-map-add']: [networkClientIds: NetworkClientId[]];
+  ['tracking-map-remove']: [networkClientIds: NetworkClientId[]];
   ['incomingTransactionBlock']: [blockNumber: number];
   ['post-transaction-balance-updated']: [
     {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
