### PR TITLE
[token-detection-controller] Consolidate with `DetectTokensController` from extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
   "simple-git-hooks": {
     "pre-push": "yarn lint"
   },
-  "resolutions": {
-    "@metamask/providers": "^14.0.2"
-  },
   "devDependencies": {
     "@babel/core": "^7.23.5",
     "@babel/plugin-transform-modules-commonjs": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
   "simple-git-hooks": {
     "pre-push": "yarn lint"
   },
+  "resolutions": {
+    "@metamask/providers": "^14.0.2"
+  },
   "devDependencies": {
     "@babel/core": "^7.23.5",
     "@babel/plugin-transform-modules-commonjs": "^7.23.3",

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - **BREAKING:** Adds `@metamask/accounts-controller` ^8.0.0 and `@metamask/keyring-controller` ^12.0.0 as dependencies and peer dependencies. ([#3775](https://github.com/MetaMask/core/pull/3775/)).
-  - Adds `@metamask/keyring-api` as a devDependency.
-  - Fixes `@metamask/providers` version to ^14.0.2 in the `resolutions` field in the root package.json file.
+- Adds `@metamask/keyring-api` ^3.0.0 as a devDependency. ([#3775](https://github.com/MetaMask/core/pull/3775/))
 
 ### Changed
 - **BREAKING:** `TokenDetectionController` is merged with `DetectTokensController` from the `metamask-extension` repo. ([#3775](https://github.com/MetaMask/core/pull/3775/))

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **BREAKING:** Adds `@metamask/accounts-controller` ^8.0.0 and `@metamask/keyring-controller` ^12.0.0 as dependencies and peer dependencies. ([#3775](https://github.com/MetaMask/core/pull/3775/)).
+  - Adds `@metamask/keyring-api` as a devDependency.
+  - Fixes `@metamask/providers` version to ^14.0.2 in the `resolutions` field in the root package.json file.
+
+### Changed
+- **BREAKING:** `TokenDetectionController` is merged with `DetectTokensController` from the `metamask-extension` repo. ([#3775](https://github.com/MetaMask/core/pull/3775/))
+  - **BREAKING:** `TokenDetectionController` now resets its polling interval to the default value of 3 minutes when token detection is triggered by external controller events.
+  - **BREAKING:** `TokenDetectionController` cannot initiate polling or token detection if `KeyringController` state is locked. It also subscribes to the `KeyringController:lock` and `KeyringController:unlock` events.
+  - **BREAKING:** The `detectTokens` method now excludes tokens that are already included in the `TokensController`'s `detectedTokens` list from the batch of incoming tokens it sends to the `TokensController` `addDetectedTokens` method.
+  - **BREAKING:** The constructor for `TokenDetectionController` expects a new required proprerty `trackMetaMetricsEvent`, which defines the callback that is called in the `detectTokens` method.
+  - **BREAKING:** In Mainnet, even if the `PreferenceController`'s `useTokenDetection` option is set to false, automatic token detection is performed on the legacy token list (token data from the contract-metadata repo).
+  - `TokenDetectionController` newly subscribes to the `PreferencesController:stateChange`, `AccountsController:selectedAccountChange` events and allows the `PreferencesController:getState` messenger action.
+
+## Removed
+- **BREAKING:** `TokenDetectionController` constructor no longer accepts options `onPreferencesStateChange`, `getPreferencesState`. ([#3775](https://github.com/MetaMask/core/pull/3775/))
+- **BREAKING:** `TokenDetectionController` no longer allows the `NetworkController:stateChange` event. The `NetworkController:networkDidChange` event can be used instead. ([#3775](https://github.com/MetaMask/core/pull/3775/))
 
 ## [25.0.0]
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** `TokenDetectionController` is merged with `DetectTokensController` from the `metamask-extension` repo. ([#3775](https://github.com/MetaMask/core/pull/3775/))
-  - **BREAKING:** `TokenDetectionController` now resets its polling interval to the default value of 3 minutes when token detection is triggered by external controller events.
+  - **BREAKING:** `TokenDetectionController` now resets its polling interval to the default value of 3 minutes when token detection is triggered by external controller events `KeyringController:unlock`, `TokenListController:stateChange`, `PreferencesController:stateChange`, `AccountsController:selectedAccountChange`.
+  - **BREAKING:** `TokenDetectionController` now responds to `NetworkController:networkDidChange` event only if the `networkClientId` is changed, and does not reset the polling interval in this case.
   - **BREAKING:** `TokenDetectionController` cannot initiate polling or token detection if `KeyringController` state is locked. It also subscribes to the `KeyringController:lock` and `KeyringController:unlock` events.
   - **BREAKING:** The `detectTokens` method now excludes tokens that are already included in the `TokensController`'s `detectedTokens` list from the batch of incoming tokens it sends to the `TokensController` `addDetectedTokens` method.
   - **BREAKING:** The constructor for `TokenDetectionController` expects a new required proprerty `trackMetaMetricsEvent`, which defines the callback that is called in the `detectTokens` method.

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -10,14 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **BREAKING:** Adds `@metamask/accounts-controller` ^8.0.0 and `@metamask/keyring-controller` ^12.0.0 as dependencies and peer dependencies. ([#3775](https://github.com/MetaMask/core/pull/3775/)).
-- Adds `@metamask/keyring-api` ^3.0.0 as a devDependency. ([#3775](https://github.com/MetaMask/core/pull/3775/))
-- `TokenDetectionController` newly subscribes to the `PreferencesController:stateChange`, `AccountsController:selectedAccountChange`, `KeyringController:lock`, `KeyringController:unlock` events, and allows the `PreferencesController:getState` messenger action. ([#3775](https://github.com/MetaMask/core/pull/3775/))
+- **BREAKING:** `TokenDetectionController` newly subscribes to the `PreferencesController:stateChange`, `AccountsController:selectedAccountChange`, `KeyringController:lock`, `KeyringController:unlock` events, and allows the `PreferencesController:getState` messenger action. ([#3775](https://github.com/MetaMask/core/pull/3775/))
 
 ### Changed
 
 - **BREAKING:** `TokenDetectionController` is merged with `DetectTokensController` from the `metamask-extension` repo. ([#3775](https://github.com/MetaMask/core/pull/3775/))
   - **BREAKING:** `TokenDetectionController` now resets its polling interval to the default value of 3 minutes when token detection is triggered by external controller events `KeyringController:unlock`, `TokenListController:stateChange`, `PreferencesController:stateChange`, `AccountsController:selectedAccountChange`.
-  - **BREAKING:** `TokenDetectionController` now responds to `NetworkController:networkDidChange` event only if the `networkClientId` is changed, and does not reset the polling interval in this case.
+  - **BREAKING:** `TokenDetectionController` now refetches tokens on `NetworkController:networkDidChange` if the `networkClientId` is changed instead of `chainId`.
   - **BREAKING:** `TokenDetectionController` cannot initiate polling or token detection if `KeyringController` state is locked.
   - **BREAKING:** The `detectTokens` method now excludes tokens that are already included in the `TokensController`'s `detectedTokens` list from the batch of incoming tokens it sends to the `TokensController` `addDetectedTokens` method.
   - **BREAKING:** The constructor for `TokenDetectionController` expects a new required proprerty `trackMetaMetricsEvent`, which defines the callback that is called in the `detectTokens` method.

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -11,17 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Adds `@metamask/accounts-controller` ^8.0.0 and `@metamask/keyring-controller` ^12.0.0 as dependencies and peer dependencies. ([#3775](https://github.com/MetaMask/core/pull/3775/)).
 - Adds `@metamask/keyring-api` ^3.0.0 as a devDependency. ([#3775](https://github.com/MetaMask/core/pull/3775/))
+- `TokenDetectionController` newly subscribes to the `PreferencesController:stateChange`, `AccountsController:selectedAccountChange`, `KeyringController:lock`, `KeyringController:unlock` events, and allows the `PreferencesController:getState` messenger action. ([#3775](https://github.com/MetaMask/core/pull/3775/))
 
 ### Changed
 
 - **BREAKING:** `TokenDetectionController` is merged with `DetectTokensController` from the `metamask-extension` repo. ([#3775](https://github.com/MetaMask/core/pull/3775/))
   - **BREAKING:** `TokenDetectionController` now resets its polling interval to the default value of 3 minutes when token detection is triggered by external controller events `KeyringController:unlock`, `TokenListController:stateChange`, `PreferencesController:stateChange`, `AccountsController:selectedAccountChange`.
   - **BREAKING:** `TokenDetectionController` now responds to `NetworkController:networkDidChange` event only if the `networkClientId` is changed, and does not reset the polling interval in this case.
-  - **BREAKING:** `TokenDetectionController` cannot initiate polling or token detection if `KeyringController` state is locked. It also subscribes to the `KeyringController:lock` and `KeyringController:unlock` events.
+  - **BREAKING:** `TokenDetectionController` cannot initiate polling or token detection if `KeyringController` state is locked.
   - **BREAKING:** The `detectTokens` method now excludes tokens that are already included in the `TokensController`'s `detectedTokens` list from the batch of incoming tokens it sends to the `TokensController` `addDetectedTokens` method.
   - **BREAKING:** The constructor for `TokenDetectionController` expects a new required proprerty `trackMetaMetricsEvent`, which defines the callback that is called in the `detectTokens` method.
   - **BREAKING:** In Mainnet, even if the `PreferenceController`'s `useTokenDetection` option is set to false, automatic token detection is performed on the legacy token list (token data from the contract-metadata repo).
-  - `TokenDetectionController` newly subscribes to the `PreferencesController:stateChange`, `AccountsController:selectedAccountChange` events and allows the `PreferencesController:getState` messenger action.
 
 ### Removed
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -6,11 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
+
 - **BREAKING:** Adds `@metamask/accounts-controller` ^8.0.0 and `@metamask/keyring-controller` ^12.0.0 as dependencies and peer dependencies. ([#3775](https://github.com/MetaMask/core/pull/3775/)).
 - Adds `@metamask/keyring-api` ^3.0.0 as a devDependency. ([#3775](https://github.com/MetaMask/core/pull/3775/))
 
 ### Changed
+
 - **BREAKING:** `TokenDetectionController` is merged with `DetectTokensController` from the `metamask-extension` repo. ([#3775](https://github.com/MetaMask/core/pull/3775/))
   - **BREAKING:** `TokenDetectionController` now resets its polling interval to the default value of 3 minutes when token detection is triggered by external controller events.
   - **BREAKING:** `TokenDetectionController` cannot initiate polling or token detection if `KeyringController` state is locked. It also subscribes to the `KeyringController:lock` and `KeyringController:unlock` events.
@@ -19,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **BREAKING:** In Mainnet, even if the `PreferenceController`'s `useTokenDetection` option is set to false, automatic token detection is performed on the legacy token list (token data from the contract-metadata repo).
   - `TokenDetectionController` newly subscribes to the `PreferencesController:stateChange`, `AccountsController:selectedAccountChange` events and allows the `PreferencesController:getState` messenger action.
 
-## Removed
+### Removed
+
 - **BREAKING:** `TokenDetectionController` constructor no longer accepts options `onPreferencesStateChange`, `getPreferencesState`. ([#3775](https://github.com/MetaMask/core/pull/3775/))
 - **BREAKING:** `TokenDetectionController` no longer allows the `NetworkController:stateChange` event. The `NetworkController:networkDidChange` event can be used instead. ([#3775](https://github.com/MetaMask/core/pull/3775/))
 

--- a/packages/assets-controllers/jest.config.js
+++ b/packages/assets-controllers/jest.config.js
@@ -17,7 +17,7 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 88.5,
+      branches: 88.3,
       functions: 95.32,
       lines: 96.76,
       statements: 96.76,

--- a/packages/assets-controllers/jest.config.js
+++ b/packages/assets-controllers/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 88.36,
+      branches: 88.5,
       functions: 95.32,
-      lines: 96.82,
-      statements: 96.83,
+      lines: 96.76,
+      statements: 96.76,
     },
   },
 

--- a/packages/assets-controllers/jest.config.js
+++ b/packages/assets-controllers/jest.config.js
@@ -18,9 +18,9 @@ module.exports = merge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 88.36,
-      functions: 97.08,
-      lines: 97.23,
-      statements: 97.28,
+      functions: 95.32,
+      lines: 96.82,
+      statements: 96.83,
     },
   },
 

--- a/packages/assets-controllers/jest.config.js
+++ b/packages/assets-controllers/jest.config.js
@@ -19,8 +19,8 @@ module.exports = merge(baseConfig, {
     global: {
       branches: 88.3,
       functions: 95.32,
-      lines: 96.76,
-      statements: 96.76,
+      lines: 96.69,
+      statements: 96.7,
     },
   },
 

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/ethjs-provider-http": "^0.2.0",
-    "@metamask/keyring-api": "^1.1.0",
+    "@metamask/keyring-api": "^3.0.0",
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.191",
     "@types/node": "^16.18.54",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -36,11 +36,13 @@
     "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@metamask/abi-utils": "^2.0.2",
+    "@metamask/accounts-controller": "^10.0.0",
     "@metamask/approval-controller": "^5.1.2",
     "@metamask/base-controller": "^4.1.1",
     "@metamask/contract-metadata": "^2.4.0",
     "@metamask/controller-utils": "^8.0.2",
     "@metamask/eth-query": "^4.0.0",
+    "@metamask/keyring-controller": "^12.2.0",
     "@metamask/metamask-eth-abis": "3.0.0",
     "@metamask/network-controller": "^17.2.0",
     "@metamask/polling-controller": "^5.0.0",
@@ -73,7 +75,9 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
+    "@metamask/accounts-controller": "^10.0.0",
     "@metamask/approval-controller": "^5.1.2",
+    "@metamask/keyring-controller": "^12.2.0",
     "@metamask/network-controller": "^17.2.0",
     "@metamask/preferences-controller": "^7.0.0"
   },

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/ethjs-provider-http": "^0.2.0",
+    "@metamask/keyring-api": "^1.1.0",
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.191",
     "@types/node": "^16.18.54",

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -6,6 +6,7 @@ import {
   convertHexToDecimal,
   BUILT_IN_NETWORKS,
 } from '@metamask/controller-utils';
+import type { KeyringControllerState } from '@metamask/keyring-controller';
 import {
   defaultState as defaultNetworkState,
   type NetworkConfiguration,
@@ -1303,9 +1304,9 @@ async function withController<ReturnValue>(
     });
   controllerMessenger.registerActionHandler(
     'KeyringController:getState',
-    jest.fn().mockReturnValue({
-      isActive: true,
-    }),
+    jest.fn<KeyringControllerState, []>().mockReturnValue({
+      isUnlocked: true,
+    } as unknown as KeyringControllerState),
   );
   controllerMessenger.registerActionHandler(
     'NetworkController:getNetworkConfigurationByNetworkClientId',

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -760,7 +760,7 @@ describe('TokenDetectionController', () => {
     });
 
     describe('when "disabled" is "false"', () => {
-      it('should detect new tokens after switching chains', async () => {
+      it('should detect new tokens after switching network client id', async () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
@@ -859,7 +859,7 @@ describe('TokenDetectionController', () => {
         );
       });
 
-      it('should not detect new tokens if the chain has not changed', async () => {
+      it('should not detect new tokens if the network client id has not changed', async () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });
@@ -898,7 +898,7 @@ describe('TokenDetectionController', () => {
 
             messenger.publish('NetworkController:networkDidChange', {
               ...defaultNetworkState,
-              selectedNetworkClientId: 'mainnnet',
+              selectedNetworkClientId: 'mainnet',
             });
             await advanceTime({ clock, duration: 1 });
 
@@ -909,7 +909,7 @@ describe('TokenDetectionController', () => {
     });
 
     describe('when "disabled" is "true"', () => {
-      it('should not detect new tokens after switching chains', async () => {
+      it('should not detect new tokens after switching network client id', async () => {
         const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
           [sampleTokenA.address]: new BN(1),
         });

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -514,11 +514,6 @@ describe('TokenDetectionController', () => {
               addDetectedTokens: mockAddDetectedTokens,
               disabled: false,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
-              getPreferencesState: jest.fn().mockReturnValue({
-                ...getDefaultPreferencesState(),
-                selectedAddress,
-                useTokenDetection: false,
-              }),
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
@@ -538,6 +533,13 @@ describe('TokenDetectionController', () => {
                 },
               },
             });
+
+            triggerPreferencesStateChange({
+              ...getDefaultPreferencesState(),
+              selectedAddress,
+              useTokenDetection: false,
+            });
+            await advanceTime({ clock, duration: 1 });
 
             triggerPreferencesStateChange({
               ...getDefaultPreferencesState(),
@@ -706,11 +708,6 @@ describe('TokenDetectionController', () => {
               addDetectedTokens: mockAddDetectedTokens,
               disabled: true,
               getBalancesInSingleCall: mockGetBalancesInSingleCall,
-              getPreferencesState: jest.fn().mockReturnValue({
-                ...getDefaultPreferencesState(),
-                selectedAddress,
-                useTokenDetection: false,
-              }),
               networkClientId: NetworkType.mainnet,
               selectedAddress,
             },
@@ -730,6 +727,13 @@ describe('TokenDetectionController', () => {
                 },
               },
             });
+
+            triggerPreferencesStateChange({
+              ...getDefaultPreferencesState(),
+              selectedAddress,
+              useTokenDetection: false,
+            });
+            await advanceTime({ clock, duration: 1 });
 
             triggerPreferencesStateChange({
               ...getDefaultPreferencesState(),

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -137,14 +137,15 @@ function buildTokenDetectionControllerMessenger(
       'KeyringController:getState',
       'NetworkController:getNetworkConfigurationByNetworkClientId',
       'TokenListController:getState',
+      'PreferencesController:getState',
     ],
     allowedEvents: [
       'AccountsController:selectedAccountChange',
       'KeyringController:lock',
       'KeyringController:unlock',
-      'NetworkController:stateChange',
       'NetworkController:networkDidChange',
       'TokenListController:stateChange',
+      'PreferencesController:stateChange',
     ],
   });
 }

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -6,9 +6,11 @@ import {
   convertHexToDecimal,
   BUILT_IN_NETWORKS,
 } from '@metamask/controller-utils';
+import type { InternalAccount } from '@metamask/keyring-api';
 import type { KeyringControllerState } from '@metamask/keyring-controller';
 import {
   defaultState as defaultNetworkState,
+  type NetworkState,
   type NetworkConfiguration,
   type NetworkController,
 } from '@metamask/network-controller';
@@ -232,7 +234,7 @@ describe('TokenDetectionController', () => {
           },
         },
         async ({ controller, mockTokenListGetState }) => {
-          mockTokenListGetState.mockReturnValue({
+          mockTokenListGetState({
             ...getDefaultTokenListState(),
             tokenList: {
               [sampleTokenA.address]: {
@@ -273,7 +275,7 @@ describe('TokenDetectionController', () => {
           },
         },
         async ({ controller, mockTokenListGetState }) => {
-          mockTokenListGetState.mockReturnValue({
+          mockTokenListGetState({
             ...getDefaultTokenListState(),
             tokenList: {
               [sampleTokenA.address]: {
@@ -331,7 +333,7 @@ describe('TokenDetectionController', () => {
               },
             },
           };
-          mockTokenListGetState.mockReturnValue(tokenListState);
+          mockTokenListGetState(tokenListState);
           await controller.start();
           mockAddDetectedTokens.mockReset();
 
@@ -344,7 +346,7 @@ describe('TokenDetectionController', () => {
             aggregators: sampleTokenB.aggregators,
             iconUrl: sampleTokenB.image,
           };
-          mockTokenListGetState.mockReturnValue(tokenListState);
+          mockTokenListGetState(tokenListState);
           await advanceTime({ clock, duration: interval });
 
           expect(mockAddDetectedTokens).toHaveBeenCalledWith(
@@ -379,7 +381,7 @@ describe('TokenDetectionController', () => {
           },
         },
         async ({ controller, mockTokenListGetState }) => {
-          mockTokenListGetState.mockReturnValue({
+          mockTokenListGetState({
             ...getDefaultTokenListState(),
             tokenList: {
               [sampleTokenA.address]: {
@@ -416,7 +418,7 @@ describe('TokenDetectionController', () => {
           },
         },
         async ({ controller, mockTokenListGetState }) => {
-          mockTokenListGetState.mockReturnValue({
+          mockTokenListGetState({
             ...getDefaultTokenListState(),
             tokenList: {
               [sampleTokenA.address]: {
@@ -470,7 +472,7 @@ describe('TokenDetectionController', () => {
             },
           },
           async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
-            mockTokenListGetState.mockReturnValue({
+            mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
                 [sampleTokenA.address]: {
@@ -522,7 +524,7 @@ describe('TokenDetectionController', () => {
             },
           },
           async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
-            mockTokenListGetState.mockReturnValue({
+            mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
                 [sampleTokenA.address]: {
@@ -572,7 +574,7 @@ describe('TokenDetectionController', () => {
             },
           },
           async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
-            mockTokenListGetState.mockReturnValue({
+            mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
                 [sampleTokenA.address]: {
@@ -616,7 +618,7 @@ describe('TokenDetectionController', () => {
             },
           },
           async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
-            mockTokenListGetState.mockReturnValue({
+            mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
                 [sampleTokenA.address]: {
@@ -665,7 +667,7 @@ describe('TokenDetectionController', () => {
             },
           },
           async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
-            mockTokenListGetState.mockReturnValue({
+            mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
                 [sampleTokenA.address]: {
@@ -714,7 +716,7 @@ describe('TokenDetectionController', () => {
             },
           },
           async ({ mockTokenListGetState, triggerPreferencesStateChange }) => {
-            mockTokenListGetState.mockReturnValue({
+            mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
                 [sampleTokenA.address]: {
@@ -776,7 +778,7 @@ describe('TokenDetectionController', () => {
             messenger,
           },
           async ({ mockTokenListGetState }) => {
-            mockTokenListGetState.mockReturnValue({
+            mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
                 [sampleTokenA.address]: {
@@ -827,7 +829,7 @@ describe('TokenDetectionController', () => {
             messenger,
           },
           async ({ mockTokenListGetState }) => {
-            mockTokenListGetState.mockReturnValue({
+            mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
                 [sampleTokenA.address]: {
@@ -875,7 +877,7 @@ describe('TokenDetectionController', () => {
             messenger,
           },
           async ({ mockTokenListGetState }) => {
-            mockTokenListGetState.mockReturnValue({
+            mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
                 [sampleTokenA.address]: {
@@ -925,7 +927,7 @@ describe('TokenDetectionController', () => {
             messenger,
           },
           async ({ mockTokenListGetState }) => {
-            mockTokenListGetState.mockReturnValue({
+            mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokenList: {
                 [sampleTokenA.address]: {
@@ -1000,7 +1002,7 @@ describe('TokenDetectionController', () => {
                 },
               },
             };
-            mockTokenListGetState.mockReturnValue(tokenListState);
+            mockTokenListGetState(tokenListState);
 
             messenger.publish(
               'TokenListController:stateChange',
@@ -1043,7 +1045,7 @@ describe('TokenDetectionController', () => {
               ...getDefaultTokenListState(),
               tokenList: {},
             };
-            mockTokenListGetState.mockReturnValue(tokenListState);
+            mockTokenListGetState(tokenListState);
 
             messenger.publish(
               'TokenListController:stateChange',
@@ -1095,7 +1097,7 @@ describe('TokenDetectionController', () => {
                 },
               },
             };
-            mockTokenListGetState.mockReturnValue(tokenListState);
+            mockTokenListGetState(tokenListState);
 
             messenger.publish(
               'TokenListController:stateChange',
@@ -1143,7 +1145,7 @@ describe('TokenDetectionController', () => {
           messenger,
         },
         async ({ controller, mockTokenListGetState }) => {
-          mockTokenListGetState.mockReturnValue({
+          mockTokenListGetState({
             ...getDefaultTokenListState(),
             tokenList: {
               [sampleTokenA.address]: {
@@ -1217,7 +1219,7 @@ describe('TokenDetectionController', () => {
           messenger,
         },
         async ({ controller, mockTokenListGetState }) => {
-          mockTokenListGetState.mockReturnValue({
+          mockTokenListGetState({
             ...getDefaultTokenListState(),
             tokenList: {
               [sampleTokenA.address]: {
@@ -1261,12 +1263,29 @@ function getTokensPath(chainId: Hex) {
 
 type WithControllerCallback<ReturnValue> = ({
   controller,
+  mockKeyringGetState,
   mockTokenListGetState,
+  mockPreferencesGetState,
+  triggerKeyringUnlock,
+  triggerKeyringLock,
+  triggerTokenListStateChange,
   triggerPreferencesStateChange,
+  triggerSelectedAccountChange,
+  triggerNetworkDidChange,
 }: {
   controller: TokenDetectionController;
-  mockTokenListGetState: jest.Mock<TokenListState, []>;
+  mockKeyringGetState: (state: KeyringControllerState) => void;
+  mockTokenListGetState: (state: TokenListState) => void;
+  mockPreferencesGetState: (state: PreferencesState) => void;
+  mockGetNetworkConfigurationByNetworkClientId: (
+    handler: (networkClientId: string) => NetworkConfiguration,
+  ) => void;
+  triggerKeyringUnlock: () => void;
+  triggerKeyringLock: () => void;
+  triggerTokenListStateChange: (state: TokenListState) => void;
   triggerPreferencesStateChange: (state: PreferencesState) => void;
+  triggerSelectedAccountChange: (account: InternalAccount) => void;
+  triggerNetworkDidChange: (state: NetworkState) => void;
 }) => Promise<ReturnValue> | ReturnValue;
 
 type WithControllerOptions = {
@@ -1295,46 +1314,43 @@ async function withController<ReturnValue>(
   const controllerMessenger =
     messenger ?? new ControllerMessenger<AllowedActions, AllowedEvents>();
 
-  const mockGetNetworkConfigurationByNetworkClientId = jest
-    .fn<
-      ReturnType<NetworkController['getNetworkConfigurationByNetworkClientId']>,
-      Parameters<NetworkController['getNetworkConfigurationByNetworkClientId']>
-    >()
-    .mockImplementation((networkClientId: string) => {
-      return mockNetworkConfigurations[networkClientId];
-    });
+  const mockKeyringState = jest.fn<KeyringControllerState, []>();
   controllerMessenger.registerActionHandler(
     'KeyringController:getState',
-    jest.fn<KeyringControllerState, []>().mockReturnValue({
+    mockKeyringState.mockReturnValue({
       isUnlocked: true,
     } as unknown as KeyringControllerState),
   );
+  const mockGetNetworkConfigurationByNetworkClientId = jest.fn<
+    ReturnType<NetworkController['getNetworkConfigurationByNetworkClientId']>,
+    Parameters<NetworkController['getNetworkConfigurationByNetworkClientId']>
+  >();
   controllerMessenger.registerActionHandler(
     'NetworkController:getNetworkConfigurationByNetworkClientId',
-    mockGetNetworkConfigurationByNetworkClientId,
+    mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
+      (networkClientId: string) => {
+        return mockNetworkConfigurations[networkClientId];
+      },
+    ),
   );
-  const mockTokenListGetState = jest
-    .fn<TokenListState, []>()
-    .mockReturnValue({ ...getDefaultTokenListState() });
+  const mockTokenListState = jest.fn<TokenListState, []>();
   controllerMessenger.registerActionHandler(
     'TokenListController:getState',
-    mockTokenListGetState,
+    mockTokenListState.mockReturnValue({ ...getDefaultTokenListState() }),
+  );
+  const mockPreferencesState = jest.fn<PreferencesState, []>();
+  controllerMessenger.registerActionHandler(
+    'PreferencesController:getState',
+    mockPreferencesState.mockReturnValue({
+      ...getDefaultPreferencesState(),
+    }),
   );
 
-  const preferencesStateChangeListeners: ((state: PreferencesState) => void)[] =
-    [];
   const controller = new TokenDetectionController({
     networkClientId: NetworkType.mainnet,
-    onPreferencesStateChange: (listener) => {
-      preferencesStateChangeListeners.push(listener);
-    },
     getBalancesInSingleCall: jest.fn(),
     addDetectedTokens: jest.fn(),
     getTokensState: jest.fn().mockReturnValue(getDefaultTokensState()),
-    getPreferencesState: jest.fn().mockReturnValue({
-      ...getDefaultPreferencesState(),
-      useTokenDetection: true,
-    }),
     trackMetaMetricsEvent: jest.fn(),
     messenger: buildTokenDetectionControllerMessenger(controllerMessenger),
     ...options,
@@ -1342,11 +1358,77 @@ async function withController<ReturnValue>(
   try {
     return await fn({
       controller,
-      mockTokenListGetState,
+      mockKeyringGetState: (state: KeyringControllerState) => {
+        controllerMessenger.unregisterActionHandler(
+          'KeyringController:getState',
+        );
+        controllerMessenger.registerActionHandler(
+          'KeyringController:getState',
+          mockKeyringState.mockReturnValue(state),
+        );
+      },
+      mockPreferencesGetState: (state: PreferencesState) => {
+        controllerMessenger.unregisterActionHandler(
+          'PreferencesController:getState',
+        );
+        controllerMessenger.registerActionHandler(
+          'PreferencesController:getState',
+          mockPreferencesState.mockReturnValue(state),
+        );
+      },
+      mockTokenListGetState: (state: TokenListState) => {
+        controllerMessenger.unregisterActionHandler(
+          'TokenListController:getState',
+        );
+        controllerMessenger.registerActionHandler(
+          'TokenListController:getState',
+          mockTokenListState.mockReturnValue(state),
+        );
+      },
+      mockGetNetworkConfigurationByNetworkClientId: (
+        handler: (networkClientId: string) => NetworkConfiguration,
+      ) => {
+        controllerMessenger.unregisterActionHandler(
+          'NetworkController:getNetworkConfigurationByNetworkClientId',
+        );
+        controllerMessenger.registerActionHandler(
+          'NetworkController:getNetworkConfigurationByNetworkClientId',
+          mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
+            handler,
+          ),
+        );
+      },
+      triggerKeyringUnlock: () => {
+        controllerMessenger.publish('KeyringController:unlock');
+      },
+      triggerKeyringLock: () => {
+        controllerMessenger.publish('KeyringController:lock');
+      },
+      triggerTokenListStateChange: (state: TokenListState) => {
+        controllerMessenger.publish(
+          'TokenListController:stateChange',
+          state,
+          [],
+        );
+      },
       triggerPreferencesStateChange: (state: PreferencesState) => {
-        for (const listener of preferencesStateChangeListeners) {
-          listener(state);
-        }
+        controllerMessenger.publish(
+          'PreferencesController:stateChange',
+          state,
+          [],
+        );
+      },
+      triggerSelectedAccountChange: (account: InternalAccount) => {
+        controllerMessenger.publish(
+          'AccountsController:selectedAccountChange',
+          account,
+        );
+      },
+      triggerNetworkDidChange: (state: NetworkState) => {
+        controllerMessenger.publish(
+          'NetworkController:networkDidChange',
+          state,
+        );
       },
     });
   } finally {

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -133,10 +133,14 @@ function buildTokenDetectionControllerMessenger(
   return controllerMessenger.getRestricted({
     name: controllerName,
     allowedActions: [
+      'KeyringController:getState',
       'NetworkController:getNetworkConfigurationByNetworkClientId',
       'TokenListController:getState',
     ],
     allowedEvents: [
+      'AccountsController:selectedAccountChange',
+      'KeyringController:lock',
+      'KeyringController:unlock',
       'NetworkController:stateChange',
       'NetworkController:networkDidChange',
       'TokenListController:stateChange',
@@ -1298,6 +1302,12 @@ async function withController<ReturnValue>(
       return mockNetworkConfigurations[networkClientId];
     });
   controllerMessenger.registerActionHandler(
+    'KeyringController:getState',
+    jest.fn().mockReturnValue({
+      isActive: true,
+    }),
+  );
+  controllerMessenger.registerActionHandler(
     'NetworkController:getNetworkConfigurationByNetworkClientId',
     mockGetNetworkConfigurationByNetworkClientId,
   );
@@ -1323,6 +1333,7 @@ async function withController<ReturnValue>(
       ...getDefaultPreferencesState(),
       useTokenDetection: true,
     }),
+    trackMetaMetricsEvent: jest.fn(),
     messenger: buildTokenDetectionControllerMessenger(controllerMessenger),
     ...options,
   });

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -1363,43 +1363,19 @@ async function withController<ReturnValue>(
     return await fn({
       controller,
       mockKeyringGetState: (state: KeyringControllerState) => {
-        controllerMessenger.unregisterActionHandler(
-          'KeyringController:getState',
-        );
-        controllerMessenger.registerActionHandler(
-          'KeyringController:getState',
-          mockKeyringState.mockReturnValue(state),
-        );
+        mockKeyringState.mockReturnValue(state);
       },
       mockPreferencesGetState: (state: PreferencesState) => {
-        controllerMessenger.unregisterActionHandler(
-          'PreferencesController:getState',
-        );
-        controllerMessenger.registerActionHandler(
-          'PreferencesController:getState',
-          mockPreferencesState.mockReturnValue(state),
-        );
+        mockPreferencesState.mockReturnValue(state);
       },
       mockTokenListGetState: (state: TokenListState) => {
-        controllerMessenger.unregisterActionHandler(
-          'TokenListController:getState',
-        );
-        controllerMessenger.registerActionHandler(
-          'TokenListController:getState',
-          mockTokenListState.mockReturnValue(state),
-        );
+        mockTokenListState.mockReturnValue(state);
       },
       mockGetNetworkConfigurationByNetworkClientId: (
         handler: (networkClientId: string) => NetworkConfiguration,
       ) => {
-        controllerMessenger.unregisterActionHandler(
-          'NetworkController:getNetworkConfigurationByNetworkClientId',
-        );
-        controllerMessenger.registerActionHandler(
-          'NetworkController:getNetworkConfigurationByNetworkClientId',
-          mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
-            handler,
-          ),
+        mockGetNetworkConfigurationByNetworkClientId.mockImplementation(
+          handler,
         );
       },
       triggerKeyringUnlock: () => {

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -316,7 +316,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
         if (isNetworkClientIdChanged && this.#isDetectionEnabledForNetwork) {
           this.#networkClientId = selectedNetworkClientId;
-          await this.detectTokens({
+          await this.#restartTokenDetection({
             networkClientId: this.#networkClientId,
           });
         }

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -306,16 +306,16 @@ export class TokenDetectionController extends StaticIntervalPollingController<
     this.messagingSystem.subscribe(
       'NetworkController:networkDidChange',
       async ({ selectedNetworkClientId }) => {
-        this.#networkClientId = selectedNetworkClientId;
-        const newChainId = this.#getCorrectChainId(selectedNetworkClientId);
-        const isChainIdChanged = this.#chainId !== newChainId;
+        const isNetworkClientIdChanged =
+          this.#networkClientId !== selectedNetworkClientId;
 
+        const newChainId = this.#getCorrectChainId(selectedNetworkClientId);
         this.#isDetectionEnabledForNetwork =
           isTokenDetectionSupportedForNetwork(newChainId);
 
-        if (isChainIdChanged && this.#isDetectionEnabledForNetwork) {
-          this.#chainId = newChainId;
-          await this.#restartTokenDetection({
+        if (isNetworkClientIdChanged && this.#isDetectionEnabledForNetwork) {
+          this.#networkClientId = selectedNetworkClientId;
+          await this.detectTokens({
             networkClientId: this.#networkClientId,
           });
         }

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -18,7 +18,6 @@ import type {
 import type {
   NetworkClientId,
   NetworkControllerNetworkDidChangeEvent,
-  NetworkControllerStateChangeEvent,
   NetworkControllerGetNetworkConfigurationByNetworkClientId,
 } from '@metamask/network-controller';
 import { StaticIntervalPollingController } from '@metamask/polling-controller';
@@ -87,7 +86,6 @@ export type TokenDetectionControllerEvents =
 
 export type AllowedEvents =
   | AccountsControllerSelectedAccountChangeEvent
-  | NetworkControllerStateChangeEvent
   | NetworkControllerNetworkDidChangeEvent
   | TokenListStateChange
   | KeyringControllerLockEvent

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -127,7 +127,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
   #disabled: boolean;
 
-  #isUnlocked?: boolean;
+  #isUnlocked: boolean;
 
   #isDetectionEnabledFromPreferences: boolean;
 
@@ -228,6 +228,11 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
     this.#trackMetaMetricsEvent = trackMetaMetricsEvent;
 
+    const { isUnlocked } = this.messagingSystem.call(
+      'KeyringController:getState',
+    );
+    this.#isUnlocked = isUnlocked;
+
     this.messagingSystem.subscribe(
       'TokenListController:stateChange',
       async ({ tokenList }) => {
@@ -325,11 +330,6 @@ export class TokenDetectionController extends StaticIntervalPollingController<
    * to the keyring locked state changes
    */
   async #registerKeyringListeners() {
-    const { isUnlocked } = this.messagingSystem.call(
-      'KeyringController:getState',
-    );
-    this.#isUnlocked = isUnlocked;
-
     this.messagingSystem.subscribe('KeyringController:unlock', async () => {
       this.#isUnlocked = true;
       await this.#restartTokenDetection();

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -1,3 +1,4 @@
+import type { AccountsControllerSelectedAccountChangeEvent } from '@metamask/accounts-controller';
 import type {
   RestrictedControllerMessenger,
   ControllerGetStateAction,
@@ -51,6 +52,7 @@ export type TokenDetectionControllerEvents =
   TokenDetectionControllerStateChangeEvent;
 
 export type AllowedEvents =
+  | AccountsControllerSelectedAccountChangeEvent
   | NetworkControllerStateChangeEvent
   | NetworkControllerNetworkDidChangeEvent
   | TokenListStateChange;
@@ -195,6 +197,18 @@ export class TokenDetectionController extends StaticIntervalPollingController<
         }
       },
     );
+
+    this.messagingSystem.subscribe(
+      'AccountsController:selectedAccountChange',
+      async (account) => {
+        if (
+          this.#selectedAddress !== account.address &&
+          this.#isDetectionEnabledFromPreferences
+        ) {
+          this.#selectedAddress = account.address;
+          await this.#restartTokenDetection({
+            selectedAddress: this.#selectedAddress,
+          });
         }
       },
     );

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -39,6 +39,16 @@ import type { TokensController, TokensState } from './TokensController';
 
 const DEFAULT_INTERVAL = 180000;
 
+/**
+ * Finds a case insensitive match in an array of strings
+ * @param source - An array of strings to search.
+ * @param target - The target string to search for.
+ * @returns The first match that is found.
+ */
+function findCaseInsensitiveMatch(source: string[], target: string) {
+  return source.find((e: string) => e.toLowerCase() === target.toLowerCase());
+}
+
 type LegacyToken = Omit<
   Token,
   'aggregators' | 'image' | 'balanceError' | 'isERC721'
@@ -451,9 +461,6 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
     const { tokens, detectedTokens } = this.#getTokensState();
     const tokensToDetect: string[] = [];
-
-    const findCaseInsensitiveMatch = (source: string[], target: string) =>
-      source.find((e: string) => e.toLowerCase() === target.toLowerCase());
 
     for (const tokenAddress of Object.keys(tokenListUsed)) {
       if (

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -316,7 +316,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
         if (isChainIdChanged && this.#isDetectionEnabledForNetwork) {
           this.#chainId = newChainId;
           await this.#restartTokenDetection({
-            chainId: this.#chainId,
+            networkClientId: this.#networkClientId,
           });
         }
       },
@@ -410,15 +410,15 @@ export class TokenDetectionController extends StaticIntervalPollingController<
    *
    * @param options - Options for restart token detection.
    * @param options.selectedAddress - the selectedAddress against which to detect for token balances
-   * @param options.chainId - the chainId against which to detect for token balances
+   * @param options.networkClientId - The ID of the network client to use.
    */
   async #restartTokenDetection({
     selectedAddress,
-    chainId,
-  }: Partial<{ selectedAddress: string; chainId: Hex }> = {}) {
+    networkClientId,
+  }: { selectedAddress?: string; networkClientId?: string } = {}) {
     await this.detectTokens({
+      networkClientId,
       accountAddress: selectedAddress,
-      networkClientId: chainId,
     });
     this.setIntervalLength(DEFAULT_INTERVAL);
   }

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -278,12 +278,14 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
     this.messagingSystem.subscribe(
       'AccountsController:selectedAccountChange',
-      async (account) => {
+      async ({ address: newSelectedAddress }) => {
+        const isSelectedAddressChanged =
+          this.#selectedAddress !== newSelectedAddress;
         if (
-          this.#selectedAddress !== account.address &&
+          isSelectedAddressChanged &&
           this.#isDetectionEnabledFromPreferences
         ) {
-          this.#selectedAddress = account.address;
+          this.#selectedAddress = newSelectedAddress;
           await this.#restartTokenDetection({
             selectedAddress: this.#selectedAddress,
           });
@@ -297,12 +299,12 @@ export class TokenDetectionController extends StaticIntervalPollingController<
         this.#networkClientId = selectedNetworkClientId;
         const newChainId = this.#getCorrectChainId(selectedNetworkClientId);
         const isChainIdChanged = this.#chainId !== newChainId;
-        this.#chainId = newChainId;
 
         this.#isDetectionEnabledForNetwork =
           isTokenDetectionSupportedForNetwork(newChainId);
 
-        if (this.#isDetectionEnabledForNetwork && isChainIdChanged) {
+        if (isChainIdChanged && this.#isDetectionEnabledForNetwork) {
+          this.#chainId = newChainId;
           await this.#restartTokenDetection({
             chainId: this.#chainId,
           });

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -251,6 +251,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
     this.messagingSystem.subscribe('KeyringController:lock', () => {
       this.#isUnlocked = false;
+      this.#stopPolling();
     });
 
     this.messagingSystem.subscribe(

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -452,10 +452,25 @@ export class TokenDetectionController extends StaticIntervalPollingController<
     const tokenListUsed = isTokenDetectionInactiveInMainnet
       ? STATIC_MAINNET_TOKEN_LIST
       : tokenList;
+
+    const { tokens, detectedTokens } = this.#getTokensState();
     const tokensToDetect: string[] = [];
-    for (const address of Object.keys(tokenListUsed)) {
-      if (!tokensAddresses.includes(address)) {
-        tokensToDetect.push(address);
+
+    const findCaseInsensitiveMatch = (source: string[], target: string) =>
+      source.find((e: string) => e.toLowerCase() === target.toLowerCase());
+
+    for (const tokenAddress of Object.keys(tokenListUsed)) {
+      if (
+        !findCaseInsensitiveMatch(
+          tokens.map(({ address }) => address),
+          tokenAddress,
+        ) &&
+        !findCaseInsensitiveMatch(
+          detectedTokens.map(({ address }) => address),
+          tokenAddress,
+        )
+      ) {
+        tokensToDetect.push(tokenAddress);
       }
     }
     const sliceOfTokensToDetect = [];
@@ -493,8 +508,9 @@ export class TokenDetectionController extends StaticIntervalPollingController<
             );
           }
           const caseInsensitiveTokenKey =
-            Object.keys(tokenListUsed).find(
-              (i) => i.toLowerCase() === tokenAddress.toLowerCase(),
+            findCaseInsensitiveMatch(
+              Object.keys(tokenListUsed),
+              tokenAddress,
             ) ?? '';
 
           if (ignored === undefined) {

--- a/packages/assets-controllers/tsconfig.build.json
+++ b/packages/assets-controllers/tsconfig.build.json
@@ -6,9 +6,11 @@
     "rootDir": "./src"
   },
   "references": [
+    { "path": "../accounts-controller/tsconfig.build.json" },
     { "path": "../approval-controller/tsconfig.build.json" },
     { "path": "../base-controller/tsconfig.build.json" },
     { "path": "../controller-utils/tsconfig.build.json" },
+    { "path": "../keyring-controller/tsconfig.build.json" },
     { "path": "../network-controller/tsconfig.build.json" },
     { "path": "../preferences-controller/tsconfig.build.json" },
     { "path": "../polling-controller/tsconfig.build.json" }

--- a/packages/assets-controllers/tsconfig.json
+++ b/packages/assets-controllers/tsconfig.json
@@ -5,9 +5,11 @@
     "rootDir": "../.."
   },
   "references": [
+    { "path": "../accounts-controller" },
     { "path": "../approval-controller" },
     { "path": "../base-controller" },
     { "path": "../controller-utils" },
+    { "path": "../keyring-controller" },
     { "path": "../network-controller" },
     { "path": "../preferences-controller" },
     { "path": "../polling-controller" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,13 +550,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@endo/env-options@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "@endo/env-options@npm:0.1.4"
-  checksum: 6099f0a6b700a60bee7b226aa2a39bb5748e22f25e9606d70e5a66a8e62cbd8c972b0fe578735a658f80bf2ebece62e28c20aa3f16417cbfe6c19a8689966dd3
-  languageName: node
-  linkType: hard
-
 "@endo/env-options@npm:^1.1.0":
   version: 1.1.0
   resolution: "@endo/env-options@npm:1.1.0"
@@ -1570,19 +1563,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/approval-controller@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@metamask/approval-controller@npm:4.1.0"
-  dependencies:
-    "@metamask/base-controller": ^3.2.3
-    "@metamask/rpc-errors": ^6.1.0
-    "@metamask/utils": ^8.1.0
-    immer: ^9.0.6
-    nanoid: ^3.1.31
-  checksum: b75c900fc656cfc141f8954ccb48346970d561ba83852ec1d27cecddb6606033e03ea560d7253847bd09dfb8317548c9be9cb92c50d906e55134d892d3785806
-  languageName: node
-  linkType: hard
-
 "@metamask/assets-controllers@workspace:packages/assets-controllers":
   version: 0.0.0-use.local
   resolution: "@metamask/assets-controllers@workspace:packages/assets-controllers"
@@ -1600,7 +1580,7 @@ __metadata:
     "@metamask/controller-utils": ^8.0.2
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.2.0
-    "@metamask/keyring-api": ^1.1.0
+    "@metamask/keyring-api": ^3.0.0
     "@metamask/keyring-controller": ^12.2.0
     "@metamask/metamask-eth-abis": 3.0.0
     "@metamask/network-controller": ^17.2.0
@@ -1686,16 +1666,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/base-controller@npm:^3.2.0, @metamask/base-controller@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "@metamask/base-controller@npm:3.2.3"
-  dependencies:
-    "@metamask/utils": ^8.1.0
-    immer: ^9.0.6
-  checksum: f49fcf2bf892ec25657c2d72a50b3c4f3cad59acb1b74d9fdcdf564107b8f38f73647c696aaa9699d94828b5797d8f1479dab44a2dbcda987c268b0088bb3b76
-  languageName: node
-  linkType: hard
-
 "@metamask/browser-passworder@npm:^4.3.0":
   version: 4.3.0
   resolution: "@metamask/browser-passworder@npm:4.3.0"
@@ -1771,21 +1741,6 @@ __metadata:
     typescript: ~4.8.4
   languageName: unknown
   linkType: soft
-
-"@metamask/controller-utils@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "@metamask/controller-utils@npm:5.0.2"
-  dependencies:
-    "@metamask/eth-query": ^3.0.1
-    "@metamask/utils": ^8.1.0
-    "@spruceid/siwe-parser": 1.1.3
-    eth-ens-namehash: ^2.0.8
-    ethereumjs-util: ^7.0.10
-    ethjs-unit: ^0.1.6
-    fast-deep-equal: ^3.1.3
-  checksum: 2345ab9ee0ba900fe2249d80009acfcf458bc60b30418234d00f5f04247b1182a585050572237f8ab09aa23032a24b99ad96399fc0798a0e9a114a29c3bf90d6
-  languageName: node
-  linkType: hard
 
 "@metamask/core-monorepo@workspace:.":
   version: 0.0.0-use.local
@@ -1992,16 +1947,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/eth-query@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@metamask/eth-query@npm:3.0.1"
-  dependencies:
-    json-rpc-random-id: ^1.0.0
-    xtend: ^4.0.1
-  checksum: b9a323dff67328eace7d54fc8b0bc4dd763bf15760870656cbd5aad5380d1ee4489fb5c59506290d5f77cf55e74e530ee97b52702a329f1090ec03a6158434b7
-  languageName: node
-  linkType: hard
-
 "@metamask/eth-query@npm:^4.0.0":
   version: 4.0.0
   resolution: "@metamask/eth-query@npm:4.0.0"
@@ -2190,7 +2135,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/json-rpc-engine@^7.1.1, @metamask/json-rpc-engine@^7.3.0, @metamask/json-rpc-engine@^7.3.1, @metamask/json-rpc-engine@^7.3.2, @metamask/json-rpc-engine@workspace:packages/json-rpc-engine":
+"@metamask/json-rpc-engine@^7.1.1, @metamask/json-rpc-engine@^7.3.1, @metamask/json-rpc-engine@^7.3.2, @metamask/json-rpc-engine@workspace:packages/json-rpc-engine":
   version: 0.0.0-use.local
   resolution: "@metamask/json-rpc-engine@workspace:packages/json-rpc-engine"
   dependencies:
@@ -2243,22 +2188,6 @@ __metadata:
     "@noble/secp256k1": ^1.5.5
     "@scure/base": ^1.0.0
   checksum: 5c81f07351ca59b37570d52edcc80d60424630b2a8403ed7149c3343c264878ac5d3fc0584a61635ea7ddda4a789295ded1247846606dc529d8e2fd42f6fc61a
-  languageName: node
-  linkType: hard
-
-"@metamask/keyring-api@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@metamask/keyring-api@npm:1.1.0"
-  dependencies:
-    "@metamask/providers": ^13.0.0
-    "@metamask/snaps-controllers": ^3.1.0
-    "@metamask/snaps-rpc-methods": ^3.1.0
-    "@metamask/snaps-utils": ^3.0.0
-    "@metamask/utils": ^8.1.0
-    "@types/uuid": ^9.0.1
-    superstruct: ^1.0.3
-    uuid: ^9.0.0
-  checksum: dd07db768861a4c4b9b5168dedac104c7e9a8fdd1de5520f81bf276f9923ea55f649d57e8eee1aa5dda06b6b82f163ec5447e32c614e920063baea06e130ecea
   languageName: node
   linkType: hard
 
@@ -2468,26 +2397,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "@metamask/permission-controller@npm:5.0.1"
-  dependencies:
-    "@metamask/approval-controller": ^4.1.0
-    "@metamask/base-controller": ^3.2.3
-    "@metamask/controller-utils": ^5.0.2
-    "@metamask/json-rpc-engine": ^7.3.0
-    "@metamask/rpc-errors": ^6.1.0
-    "@metamask/utils": ^8.2.0
-    "@types/deep-freeze-strict": ^1.1.0
-    deep-freeze-strict: ^1.1.1
-    immer: ^9.0.6
-    nanoid: ^3.1.31
-  peerDependencies:
-    "@metamask/approval-controller": ^4.1.0
-  checksum: fc61df3f5532b35b9ec26ca712848d680d616103e3d06470691412ee8b5a4b70e27d530065f601b64e0a5c2022aa129b8e6ddcc7c3e8325720aa0f639e3e10ba
-  languageName: node
-  linkType: hard
-
 "@metamask/permission-controller@npm:^7.0.0, @metamask/permission-controller@npm:^7.1.0":
   version: 7.1.0
   resolution: "@metamask/permission-controller@npm:7.1.0"
@@ -2633,7 +2542,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/providers@npm:^14.0.2":
+"@metamask/providers@npm:^14.0.1, @metamask/providers@npm:^14.0.2":
   version: 14.0.2
   resolution: "@metamask/providers@npm:14.0.2"
   dependencies:
@@ -2798,7 +2707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^3.1.0, @metamask/snaps-controllers@npm:^3.4.1":
+"@metamask/snaps-controllers@npm:^3.4.1":
   version: 3.6.0
   resolution: "@metamask/snaps-controllers@npm:3.6.0"
   dependencies:
@@ -2870,17 +2779,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-registry@npm:^2.1.0":
-  version: 2.1.1
-  resolution: "@metamask/snaps-registry@npm:2.1.1"
-  dependencies:
-    "@metamask/utils": ^8.1.0
-    "@noble/secp256k1": ^1.7.1
-    superstruct: ^1.0.3
-  checksum: 274002c44f0fe028740c19d1014f844aa4b534862abc530f872baaad8b7b3b2445ffaefbd0a5a957b5102a5b04fe51e6f03a03b1236c8818abc4c748076d6475
-  languageName: node
-  linkType: hard
-
 "@metamask/snaps-registry@npm:^3.0.0":
   version: 3.0.0
   resolution: "@metamask/snaps-registry@npm:3.0.0"
@@ -2890,22 +2788,6 @@ __metadata:
     "@noble/hashes": ^1.3.2
     superstruct: ^1.0.3
   checksum: d816190ee4f345f04b1dcdbbee48fc7153c12192e2deca16f7947c9f3ee437dddc286fd66c21cdf02d18798c4df799bbc377bc839c11a419226aa00b95b645b0
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-rpc-methods@npm:^3.1.0":
-  version: 3.3.0
-  resolution: "@metamask/snaps-rpc-methods@npm:3.3.0"
-  dependencies:
-    "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^5.0.0
-    "@metamask/rpc-errors": ^6.1.0
-    "@metamask/snaps-ui": ^3.1.0
-    "@metamask/snaps-utils": ^3.3.0
-    "@metamask/utils": ^8.1.0
-    "@noble/hashes": ^1.3.1
-    superstruct: ^1.0.3
-  checksum: 5f830b22db427b4109411632fdd5108ff9c151a819bba35b9bfd0ac6cc70ff581407c91b2ffb34ee0f624869d65054bfde88396e2df13d3052262e29dabbaa05
   languageName: node
   linkType: hard
 
@@ -2952,46 +2834,6 @@ __metadata:
     is-svg: ^4.4.0
     superstruct: ^1.0.3
   checksum: faf3505add1d719bd9640beb5e67a84ed858198b06330d67d675a06e8b1e66250afc097b1a4c3af23bc8fc01bbc899af963bc056a4aafd09780ca59e1bb51917
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-ui@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@metamask/snaps-ui@npm:3.1.0"
-  dependencies:
-    "@metamask/utils": ^8.1.0
-    is-svg: ^4.4.0
-    superstruct: ^1.0.3
-  checksum: a234217e961a103b89708d46732481e82c0778b3ebbecddabc9351eee48d082cdc231102442c3ae5c76aa33b24c24aad70e84fee9d7b492641f290a10c3211c1
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-utils@npm:^3.0.0, @metamask/snaps-utils@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "@metamask/snaps-utils@npm:3.3.0"
-  dependencies:
-    "@babel/core": ^7.23.2
-    "@babel/types": ^7.23.0
-    "@metamask/base-controller": ^3.2.0
-    "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^5.0.0
-    "@metamask/rpc-errors": ^6.1.0
-    "@metamask/snaps-registry": ^2.1.0
-    "@metamask/snaps-ui": ^3.1.0
-    "@metamask/utils": ^8.1.0
-    "@noble/hashes": ^1.3.1
-    "@scure/base": ^1.1.1
-    chalk: ^4.1.2
-    cron-parser: ^4.5.0
-    fast-deep-equal: ^3.1.3
-    fast-json-stable-stringify: ^2.1.0
-    is-svg: ^4.4.0
-    rfdc: ^1.3.0
-    semver: ^7.5.4
-    ses: ^0.18.8
-    superstruct: ^1.0.3
-    validate-npm-package-name: ^5.0.0
-  checksum: 3f106d8e290bc260ec0b7f8bcaff5077bd0505f586d3961ad953bae53bc12bc1dc3c4c666c15b58135489ff0b1b47d9630848842e0deee754527652a7ab77bbb
   languageName: node
   linkType: hard
 
@@ -3209,7 +3051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:^1.5.5, @noble/secp256k1@npm:^1.7.1":
+"@noble/secp256k1@npm:^1.5.5":
   version: 1.7.1
   resolution: "@noble/secp256k1@npm:1.7.1"
   checksum: d2301f1f7690368d8409a3152450458f27e54df47e3f917292de3de82c298770890c2de7c967d237eff9c95b70af485389a9695f73eb05a43e2bd562d18b18cb
@@ -6240,16 +6082,6 @@ __metadata:
   version: 0.2.1
   resolution: "ethjs-schema@npm:0.2.1"
   checksum: 7d8b1225bcf9616bfe94a24c2f4a48dae5ec30180a61d509efd7335eec68431abee638fbd02c2088e0ee59010396284e4b8364af8afdb229ac67e29ae38a3230
-  languageName: node
-  linkType: hard
-
-"ethjs-unit@npm:^0.1.6":
-  version: 0.1.6
-  resolution: "ethjs-unit@npm:0.1.6"
-  dependencies:
-    bn.js: 4.11.6
-    number-to-bn: 1.7.0
-  checksum: df6b4752ff7461a59a20219f4b1684c631ea601241c39660e3f6c6bd63c950189723841c22b3c6c0ebeb3c9fc99e0e803e3c613101206132603705fcbcf4def5
   languageName: node
   linkType: hard
 
@@ -10193,15 +10025,6 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: ae47d06de28836adb9d3e25f22a92943477371292d9b665fb023fae278d345d508ca1958232af086d85e0155aee22e313e100971898bbb8d5d89b8b1d4054ca2
-  languageName: node
-  linkType: hard
-
-"ses@npm:^0.18.8":
-  version: 0.18.8
-  resolution: "ses@npm:0.18.8"
-  dependencies:
-    "@endo/env-options": ^0.1.4
-  checksum: d7976d2ee218baec021c5cfdfb193d63b52bf2b6cbdbbb90c19d835915a1872b6924910f7fd42bc849eb2de78fc7bdd6e7b4667e1df3c79244cc92d4ede48aa6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,6 +550,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@endo/env-options@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "@endo/env-options@npm:0.1.4"
+  checksum: 6099f0a6b700a60bee7b226aa2a39bb5748e22f25e9606d70e5a66a8e62cbd8c972b0fe578735a658f80bf2ebece62e28c20aa3f16417cbfe6c19a8689966dd3
+  languageName: node
+  linkType: hard
+
 "@endo/env-options@npm:^1.1.0":
   version: 1.1.0
   resolution: "@endo/env-options@npm:1.1.0"
@@ -1563,6 +1570,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/approval-controller@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@metamask/approval-controller@npm:4.1.0"
+  dependencies:
+    "@metamask/base-controller": ^3.2.3
+    "@metamask/rpc-errors": ^6.1.0
+    "@metamask/utils": ^8.1.0
+    immer: ^9.0.6
+    nanoid: ^3.1.31
+  checksum: b75c900fc656cfc141f8954ccb48346970d561ba83852ec1d27cecddb6606033e03ea560d7253847bd09dfb8317548c9be9cb92c50d906e55134d892d3785806
+  languageName: node
+  linkType: hard
+
 "@metamask/assets-controllers@workspace:packages/assets-controllers":
   version: 0.0.0-use.local
   resolution: "@metamask/assets-controllers@workspace:packages/assets-controllers"
@@ -1580,6 +1600,7 @@ __metadata:
     "@metamask/controller-utils": ^8.0.2
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.2.0
+    "@metamask/keyring-api": ^1.1.0
     "@metamask/keyring-controller": ^12.2.0
     "@metamask/metamask-eth-abis": 3.0.0
     "@metamask/network-controller": ^17.2.0
@@ -1665,6 +1686,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/base-controller@npm:^3.2.0, @metamask/base-controller@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "@metamask/base-controller@npm:3.2.3"
+  dependencies:
+    "@metamask/utils": ^8.1.0
+    immer: ^9.0.6
+  checksum: f49fcf2bf892ec25657c2d72a50b3c4f3cad59acb1b74d9fdcdf564107b8f38f73647c696aaa9699d94828b5797d8f1479dab44a2dbcda987c268b0088bb3b76
+  languageName: node
+  linkType: hard
+
 "@metamask/browser-passworder@npm:^4.3.0":
   version: 4.3.0
   resolution: "@metamask/browser-passworder@npm:4.3.0"
@@ -1740,6 +1771,21 @@ __metadata:
     typescript: ~4.8.4
   languageName: unknown
   linkType: soft
+
+"@metamask/controller-utils@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@metamask/controller-utils@npm:5.0.2"
+  dependencies:
+    "@metamask/eth-query": ^3.0.1
+    "@metamask/utils": ^8.1.0
+    "@spruceid/siwe-parser": 1.1.3
+    eth-ens-namehash: ^2.0.8
+    ethereumjs-util: ^7.0.10
+    ethjs-unit: ^0.1.6
+    fast-deep-equal: ^3.1.3
+  checksum: 2345ab9ee0ba900fe2249d80009acfcf458bc60b30418234d00f5f04247b1182a585050572237f8ab09aa23032a24b99ad96399fc0798a0e9a114a29c3bf90d6
+  languageName: node
+  linkType: hard
 
 "@metamask/core-monorepo@workspace:.":
   version: 0.0.0-use.local
@@ -1946,6 +1992,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/eth-query@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@metamask/eth-query@npm:3.0.1"
+  dependencies:
+    json-rpc-random-id: ^1.0.0
+    xtend: ^4.0.1
+  checksum: b9a323dff67328eace7d54fc8b0bc4dd763bf15760870656cbd5aad5380d1ee4489fb5c59506290d5f77cf55e74e530ee97b52702a329f1090ec03a6158434b7
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-query@npm:^4.0.0":
   version: 4.0.0
   resolution: "@metamask/eth-query@npm:4.0.0"
@@ -2134,7 +2190,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/json-rpc-engine@^7.1.1, @metamask/json-rpc-engine@^7.3.1, @metamask/json-rpc-engine@^7.3.2, @metamask/json-rpc-engine@workspace:packages/json-rpc-engine":
+"@metamask/json-rpc-engine@^7.1.1, @metamask/json-rpc-engine@^7.3.0, @metamask/json-rpc-engine@^7.3.1, @metamask/json-rpc-engine@^7.3.2, @metamask/json-rpc-engine@workspace:packages/json-rpc-engine":
   version: 0.0.0-use.local
   resolution: "@metamask/json-rpc-engine@workspace:packages/json-rpc-engine"
   dependencies:
@@ -2187,6 +2243,22 @@ __metadata:
     "@noble/secp256k1": ^1.5.5
     "@scure/base": ^1.0.0
   checksum: 5c81f07351ca59b37570d52edcc80d60424630b2a8403ed7149c3343c264878ac5d3fc0584a61635ea7ddda4a789295ded1247846606dc529d8e2fd42f6fc61a
+  languageName: node
+  linkType: hard
+
+"@metamask/keyring-api@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@metamask/keyring-api@npm:1.1.0"
+  dependencies:
+    "@metamask/providers": ^13.0.0
+    "@metamask/snaps-controllers": ^3.1.0
+    "@metamask/snaps-rpc-methods": ^3.1.0
+    "@metamask/snaps-utils": ^3.0.0
+    "@metamask/utils": ^8.1.0
+    "@types/uuid": ^9.0.1
+    superstruct: ^1.0.3
+    uuid: ^9.0.0
+  checksum: dd07db768861a4c4b9b5168dedac104c7e9a8fdd1de5520f81bf276f9923ea55f649d57e8eee1aa5dda06b6b82f163ec5447e32c614e920063baea06e130ecea
   languageName: node
   linkType: hard
 
@@ -2393,6 +2465,26 @@ __metadata:
     "@metamask/safe-event-emitter": ^2.0.0
     through2: ^2.0.3
   checksum: e1497140384de0ac689adbe7286df43e843c5d73fd8ba7080af2faab3de73e823b46b8214be1c839d9e9e5f86fb40df50a26e93bae936329daeaedae5e523323
+  languageName: node
+  linkType: hard
+
+"@metamask/permission-controller@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "@metamask/permission-controller@npm:5.0.1"
+  dependencies:
+    "@metamask/approval-controller": ^4.1.0
+    "@metamask/base-controller": ^3.2.3
+    "@metamask/controller-utils": ^5.0.2
+    "@metamask/json-rpc-engine": ^7.3.0
+    "@metamask/rpc-errors": ^6.1.0
+    "@metamask/utils": ^8.2.0
+    "@types/deep-freeze-strict": ^1.1.0
+    deep-freeze-strict: ^1.1.1
+    immer: ^9.0.6
+    nanoid: ^3.1.31
+  peerDependencies:
+    "@metamask/approval-controller": ^4.1.0
+  checksum: fc61df3f5532b35b9ec26ca712848d680d616103e3d06470691412ee8b5a4b70e27d530065f601b64e0a5c2022aa129b8e6ddcc7c3e8325720aa0f639e3e10ba
   languageName: node
   linkType: hard
 
@@ -2706,7 +2798,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^3.4.1":
+"@metamask/snaps-controllers@npm:^3.1.0, @metamask/snaps-controllers@npm:^3.4.1":
   version: 3.6.0
   resolution: "@metamask/snaps-controllers@npm:3.6.0"
   dependencies:
@@ -2778,6 +2870,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/snaps-registry@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "@metamask/snaps-registry@npm:2.1.1"
+  dependencies:
+    "@metamask/utils": ^8.1.0
+    "@noble/secp256k1": ^1.7.1
+    superstruct: ^1.0.3
+  checksum: 274002c44f0fe028740c19d1014f844aa4b534862abc530f872baaad8b7b3b2445ffaefbd0a5a957b5102a5b04fe51e6f03a03b1236c8818abc4c748076d6475
+  languageName: node
+  linkType: hard
+
 "@metamask/snaps-registry@npm:^3.0.0":
   version: 3.0.0
   resolution: "@metamask/snaps-registry@npm:3.0.0"
@@ -2787,6 +2890,22 @@ __metadata:
     "@noble/hashes": ^1.3.2
     superstruct: ^1.0.3
   checksum: d816190ee4f345f04b1dcdbbee48fc7153c12192e2deca16f7947c9f3ee437dddc286fd66c21cdf02d18798c4df799bbc377bc839c11a419226aa00b95b645b0
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-rpc-methods@npm:^3.1.0":
+  version: 3.3.0
+  resolution: "@metamask/snaps-rpc-methods@npm:3.3.0"
+  dependencies:
+    "@metamask/key-tree": ^9.0.0
+    "@metamask/permission-controller": ^5.0.0
+    "@metamask/rpc-errors": ^6.1.0
+    "@metamask/snaps-ui": ^3.1.0
+    "@metamask/snaps-utils": ^3.3.0
+    "@metamask/utils": ^8.1.0
+    "@noble/hashes": ^1.3.1
+    superstruct: ^1.0.3
+  checksum: 5f830b22db427b4109411632fdd5108ff9c151a819bba35b9bfd0ac6cc70ff581407c91b2ffb34ee0f624869d65054bfde88396e2df13d3052262e29dabbaa05
   languageName: node
   linkType: hard
 
@@ -2833,6 +2952,46 @@ __metadata:
     is-svg: ^4.4.0
     superstruct: ^1.0.3
   checksum: faf3505add1d719bd9640beb5e67a84ed858198b06330d67d675a06e8b1e66250afc097b1a4c3af23bc8fc01bbc899af963bc056a4aafd09780ca59e1bb51917
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-ui@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/snaps-ui@npm:3.1.0"
+  dependencies:
+    "@metamask/utils": ^8.1.0
+    is-svg: ^4.4.0
+    superstruct: ^1.0.3
+  checksum: a234217e961a103b89708d46732481e82c0778b3ebbecddabc9351eee48d082cdc231102442c3ae5c76aa33b24c24aad70e84fee9d7b492641f290a10c3211c1
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-utils@npm:^3.0.0, @metamask/snaps-utils@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "@metamask/snaps-utils@npm:3.3.0"
+  dependencies:
+    "@babel/core": ^7.23.2
+    "@babel/types": ^7.23.0
+    "@metamask/base-controller": ^3.2.0
+    "@metamask/key-tree": ^9.0.0
+    "@metamask/permission-controller": ^5.0.0
+    "@metamask/rpc-errors": ^6.1.0
+    "@metamask/snaps-registry": ^2.1.0
+    "@metamask/snaps-ui": ^3.1.0
+    "@metamask/utils": ^8.1.0
+    "@noble/hashes": ^1.3.1
+    "@scure/base": ^1.1.1
+    chalk: ^4.1.2
+    cron-parser: ^4.5.0
+    fast-deep-equal: ^3.1.3
+    fast-json-stable-stringify: ^2.1.0
+    is-svg: ^4.4.0
+    rfdc: ^1.3.0
+    semver: ^7.5.4
+    ses: ^0.18.8
+    superstruct: ^1.0.3
+    validate-npm-package-name: ^5.0.0
+  checksum: 3f106d8e290bc260ec0b7f8bcaff5077bd0505f586d3961ad953bae53bc12bc1dc3c4c666c15b58135489ff0b1b47d9630848842e0deee754527652a7ab77bbb
   languageName: node
   linkType: hard
 
@@ -3050,7 +3209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:^1.5.5":
+"@noble/secp256k1@npm:^1.5.5, @noble/secp256k1@npm:^1.7.1":
   version: 1.7.1
   resolution: "@noble/secp256k1@npm:1.7.1"
   checksum: d2301f1f7690368d8409a3152450458f27e54df47e3f917292de3de82c298770890c2de7c967d237eff9c95b70af485389a9695f73eb05a43e2bd562d18b18cb
@@ -6081,6 +6240,16 @@ __metadata:
   version: 0.2.1
   resolution: "ethjs-schema@npm:0.2.1"
   checksum: 7d8b1225bcf9616bfe94a24c2f4a48dae5ec30180a61d509efd7335eec68431abee638fbd02c2088e0ee59010396284e4b8364af8afdb229ac67e29ae38a3230
+  languageName: node
+  linkType: hard
+
+"ethjs-unit@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "ethjs-unit@npm:0.1.6"
+  dependencies:
+    bn.js: 4.11.6
+    number-to-bn: 1.7.0
+  checksum: df6b4752ff7461a59a20219f4b1684c631ea601241c39660e3f6c6bd63c950189723841c22b3c6c0ebeb3c9fc99e0e803e3c613101206132603705fcbcf4def5
   languageName: node
   linkType: hard
 
@@ -10024,6 +10193,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: ae47d06de28836adb9d3e25f22a92943477371292d9b665fb023fae278d345d508ca1958232af086d85e0155aee22e313e100971898bbb8d5d89b8b1d4054ca2
+  languageName: node
+  linkType: hard
+
+"ses@npm:^0.18.8":
+  version: 0.18.8
+  resolution: "ses@npm:0.18.8"
+  dependencies:
+    "@endo/env-options": ^0.1.4
+  checksum: d7976d2ee218baec021c5cfdfb193d63b52bf2b6cbdbbb90c19d835915a1872b6924910f7fd42bc849eb2de78fc7bdd6e7b4667e1df3c79244cc92d4ede48aa6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1468,7 +1468,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/accounts-controller@workspace:packages/accounts-controller":
+"@metamask/accounts-controller@^10.0.0, @metamask/accounts-controller@workspace:packages/accounts-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/accounts-controller@workspace:packages/accounts-controller"
   dependencies:
@@ -1572,6 +1572,7 @@ __metadata:
     "@ethersproject/contracts": ^5.7.0
     "@ethersproject/providers": ^5.7.0
     "@metamask/abi-utils": ^2.0.2
+    "@metamask/accounts-controller": ^10.0.0
     "@metamask/approval-controller": ^5.1.2
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^4.1.1
@@ -1579,6 +1580,7 @@ __metadata:
     "@metamask/controller-utils": ^8.0.2
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.2.0
+    "@metamask/keyring-controller": ^12.2.0
     "@metamask/metamask-eth-abis": 3.0.0
     "@metamask/network-controller": ^17.2.0
     "@metamask/polling-controller": ^5.0.0
@@ -1606,7 +1608,9 @@ __metadata:
     typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
+    "@metamask/accounts-controller": ^10.0.0
     "@metamask/approval-controller": ^5.1.2
+    "@metamask/keyring-controller": ^12.2.0
     "@metamask/network-controller": ^17.2.0
     "@metamask/preferences-controller": ^7.0.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2541,7 +2541,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/providers@npm:^14.0.1, @metamask/providers@npm:^14.0.2":
+"@metamask/providers@npm:^14.0.2":
   version: 14.0.2
   resolution: "@metamask/providers@npm:14.0.2"
   dependencies:
@@ -3805,6 +3805,15 @@ __metadata:
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
   checksum: a4a97ec07d7ea112c517036882b2ac22f3109b7b19077dc656316d07d308438aac28e4d9746dc4d84bf6b1e75b4a7b0a5f3cb30592419f128ca9a8cee3bcfa17
+  languageName: node
+  linkType: hard
+
+"abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "abort-controller@npm:3.0.0"
+  dependencies:
+    event-target-shim: ^5.0.0
+  checksum: 170bdba9b47b7e65906a28c8ce4f38a7a369d78e2271706f020849c1bfe0ee2067d4261df8bbb66eb84f79208fd5b710df759d64191db58cfba7ce8ef9c54b75
   languageName: node
   linkType: hard
 
@@ -6072,6 +6081,20 @@ __metadata:
   version: 0.2.1
   resolution: "ethjs-schema@npm:0.2.1"
   checksum: 7d8b1225bcf9616bfe94a24c2f4a48dae5ec30180a61d509efd7335eec68431abee638fbd02c2088e0ee59010396284e4b8364af8afdb229ac67e29ae38a3230
+  languageName: node
+  linkType: hard
+
+"event-target-shim@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "event-target-shim@npm:5.0.1"
+  checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
+  languageName: node
+  linkType: hard
+
+"events@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
   languageName: node
   linkType: hard
 
@@ -9499,6 +9522,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"process@npm:^0.11.10":
+  version: 0.11.10
+  resolution: "process@npm:0.11.10"
+  checksum: bfcce49814f7d172a6e6a14d5fa3ac92cc3d0c3b9feb1279774708a719e19acd673995226351a082a9ae99978254e320ccda4240ddc474ba31a76c79491ca7c3
+  languageName: node
+  linkType: hard
+
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
@@ -9618,7 +9648,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:3.6.2, readable-stream@npm:^3.0.2, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0, readable-stream@npm:^3.6.2, readable-stream@npm:^3.6.2 || ^4.4.2":
+"readable-stream@npm:3.6.2, readable-stream@npm:^3.0.2, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0, readable-stream@npm:^3.6.2":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -9626,6 +9656,19 @@ __metadata:
     string_decoder: ^1.1.1
     util-deprecate: ^1.0.1
   checksum: bdcbe6c22e846b6af075e32cf8f4751c2576238c5043169a1c221c92ee2878458a816a4ea33f4c67623c0b6827c8a400409bfb3cf0bf3381392d0b1dfb52ac8d
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^3.6.2 || ^4.4.2":
+  version: 4.5.2
+  resolution: "readable-stream@npm:4.5.2"
+  dependencies:
+    abort-controller: ^3.0.0
+    buffer: ^6.0.3
+    events: ^3.3.0
+    process: ^0.11.10
+    string_decoder: ^1.3.0
+  checksum: c4030ccff010b83e4f33289c535f7830190773e274b3fcb6e2541475070bdfd69c98001c3b0cb78763fc00c8b62f514d96c2b10a8bd35d5ce45203a25fa1d33a
   languageName: node
   linkType: hard
 
@@ -10368,7 +10411,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1":
+"string_decoder@npm:^1.1.1, string_decoder@npm:^1.3.0":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:


### PR DESCRIPTION
## Explanation

Merges the core `TokenDetectionController` with `DetectTokensController` from the extension   and patches for this controller from mobile. 

- Aims to replace the extension and mobile versions of this controller and implement a unified interface that consolidates the functionality of all three iterations.
- Generally assumes `DetectTokensController` to be more up-to-date, and prioritizes preserving extension and mobile behavior to minimize disruption.

Significant API changes: see [Changelog](https://github.com/MetaMask/core/pull/3775/files#diff-ee47d03d53776b8dd530799a8047f5e32e36e35765620aeb50b294adc3339fab) for details.

## References

- Closes #3626
- See #1813 

## Changelog

### [`@metamask/assets-controllers`](https://github.com/MetaMask/core/pull/3775/files#diff-ee47d03d53776b8dd530799a8047f5e32e36e35765620aeb50b294adc3339fab)
### Added

- **BREAKING:** Adds `@metamask/accounts-controller` ^8.0.0 and `@metamask/keyring-controller` ^12.0.0 as dependencies and peer dependencies. ([#3775](https://github.com/MetaMask/core/pull/3775/)).
- **BREAKING:** `TokenDetectionController` newly subscribes to the `PreferencesController:stateChange`, `AccountsController:selectedAccountChange`, `KeyringController:lock`, `KeyringController:unlock` events, and allows the `PreferencesController:getState` messenger action. ([#3775](https://github.com/MetaMask/core/pull/3775/))

### Changed

- **BREAKING:** `TokenDetectionController` is merged with `DetectTokensController` from the `metamask-extension` repo. ([#3775](https://github.com/MetaMask/core/pull/3775/))
  - **BREAKING:** `TokenDetectionController` now resets its polling interval to the default value of 3 minutes when token detection is triggered by external controller events `KeyringController:unlock`, `TokenListController:stateChange`, `PreferencesController:stateChange`, `AccountsController:selectedAccountChange`.
  - **BREAKING:** `TokenDetectionController` now refetches tokens on `NetworkController:networkDidChange` if the `networkClientId` is changed instead of `chainId`.
  - **BREAKING:** `TokenDetectionController` cannot initiate polling or token detection if `KeyringController` state is locked.
  - **BREAKING:** The `detectTokens` method now excludes tokens that are already included in the `TokensController`'s `detectedTokens` list from the batch of incoming tokens it sends to the `TokensController` `addDetectedTokens` method.
  - **BREAKING:** The constructor for `TokenDetectionController` expects a new required proprerty `trackMetaMetricsEvent`, which defines the callback that is called in the `detectTokens` method.
  - **BREAKING:** In Mainnet, even if the `PreferenceController`'s `useTokenDetection` option is set to false, automatic token detection is performed on the legacy token list (token data from the contract-metadata repo).

### Removed

- **BREAKING:** `TokenDetectionController` constructor no longer accepts options `onPreferencesStateChange`, `getPreferencesState`. ([#3775](https://github.com/MetaMask/core/pull/3775/))
- **BREAKING:** `TokenDetectionController` no longer allows the `NetworkController:stateChange` event. The `NetworkController:networkDidChange` event can be used instead. ([#3775](https://github.com/MetaMask/core/pull/3775/))

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
