### PR TITLE
docs: fix typos

### DIFF
--- a/docs/migrate-tags.md
+++ b/docs/migrate-tags.md
@@ -24,9 +24,9 @@ The `./scripts/migrate-tags.sh` script automates the process of enumerating the 
 - `-t`, `--tag-prefix-before-package-rename` (optional)
   - Default if omitted: `<package-name>` supplied in the first argument.
 - `-d`, `--tmp-dir` (optional)
-  - Default if ommited: `/tmp`
+  - Default if omitted: `/tmp`
   - Specifies the temporary directory where `git-filter-repo` was applied to a clone of the original repo.
-- `-p`, `--sed-pattern` (optional): sed pattern for extracting verson numbers from the original repo's tag names.
+- `-p`, `--sed-pattern` (optional): sed pattern for extracting version numbers from the original repo's tag names.
   - Default if omitted: `'s/^v//'`
   - If the original tag names follow a different naming scheme than `v[major].[minor].[patch]`, adjust this setting.
 - `--no-dry-run` (optional):

--- a/docs/package-migration-process-guide.md
+++ b/docs/package-migration-process-guide.md
@@ -80,7 +80,7 @@ This document outlines the process for migrating a MetaMask library into the cor
 - Make updates to the CHANGELOG tag diff links so that they follow this naming scheme:
   1. Navigate to `merged-packages/<package-name>`
   2. Run this command: `../../scripts/validate-changelog.sh @metamask/<package-name>`
-  3. Apply the diffs outputed by the script.
+  3. Apply the diffs outputted by the script.
 - If the package has been renamed or needs to be renamed with the `@metamask/` namespace, supply two arguments to the script: `--version-before-package-rename`, `--tag-prefix-before-package-rename`.
 - For further instructions on using the script, see: https://github.com/MetaMask/auto-changelog#validate.
 


### PR DESCRIPTION
fix typos:
    docs/migrate-tags.md
    docs/package-migration-process-guide.md