### PR TITLE
update swappable-obj-proxy to 2.2.0

### DIFF
--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -39,7 +39,7 @@
     "@metamask/eth-query": "^4.0.0",
     "@metamask/json-rpc-engine": "^7.3.1",
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/swappable-obj-proxy": "^2.1.0",
+    "@metamask/swappable-obj-proxy": "^2.2.0",
     "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6",
     "eth-block-tracker": "^8.0.0",

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -35,7 +35,7 @@
     "@metamask/controller-utils": "^8.0.1",
     "@metamask/json-rpc-engine": "^7.3.1",
     "@metamask/rpc-errors": "^6.1.0",
-    "@metamask/swappable-obj-proxy": "^2.1.0",
+    "@metamask/swappable-obj-proxy": "^2.2.0",
     "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -34,7 +34,7 @@
     "@metamask/base-controller": "^4.1.0",
     "@metamask/json-rpc-engine": "^7.3.1",
     "@metamask/network-controller": "^17.1.0",
-    "@metamask/swappable-obj-proxy": "^2.1.0",
+    "@metamask/swappable-obj-proxy": "^2.2.0",
     "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -95,6 +95,11 @@ describe('SelectedNetworkController', () => {
         eventNames: jest.fn(),
         rawListeners: jest.fn(),
         removeAllListeners: jest.fn(),
+        on: jest.fn(),
+        prependListener: jest.fn(),
+        addListener: jest.fn(),
+        off: jest.fn(),
+        once: jest.fn(),
       };
       createEventEmitterProxyMock.mockReturnValue(mockProviderProxy);
       controller.setNetworkClientIdForDomain(
@@ -116,6 +121,11 @@ describe('SelectedNetworkController', () => {
         eventNames: jest.fn(),
         rawListeners: jest.fn(),
         removeAllListeners: jest.fn(),
+        on: jest.fn(),
+        prependListener: jest.fn(),
+        addListener: jest.fn(),
+        off: jest.fn(),
+        once: jest.fn(),
       };
       createEventEmitterProxyMock.mockReturnValue(mockProviderProxy);
       controller.setNetworkClientIdForDomain(
@@ -197,6 +207,11 @@ describe('SelectedNetworkController', () => {
         eventNames: jest.fn(),
         rawListeners: jest.fn(),
         removeAllListeners: jest.fn(),
+        on: jest.fn(),
+        prependListener: jest.fn(),
+        addListener: jest.fn(),
+        off: jest.fn(),
+        once: jest.fn(),
       };
       createEventEmitterProxyMock.mockReturnValue(mockProviderProxy);
       controller.setNetworkClientIdForDomain('example.com', 'network7');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,14 +2959,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/swappable-obj-proxy@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@metamask/swappable-obj-proxy@npm:2.1.0"
-  checksum: b15cebee7fb189d1143d3a755a38a7d88f56f91e1277425a51f63c50c432dfb4e6e22650ef67474ae4ef2a97344231af00be6780f126c47d401a23c8a8fb3c9c
-  languageName: node
-  linkType: hard
-
-"@metamask/swappable-obj-proxy@npm:^2.2.0":
+"@metamask/swappable-obj-proxy@npm:^2.1.0, @metamask/swappable-obj-proxy@npm:^2.2.0":
   version: 2.2.0
   resolution: "@metamask/swappable-obj-proxy@npm:2.2.0"
   checksum: 343c95f72c96776980ef3e70600f7fa312be9a75683c132404a66ddd3c507abadee9c4deba1385246f73bded1938a7958e5a89fc407c19dfc352dd9b398e216f

--- a/yarn.lock
+++ b/yarn.lock
@@ -2377,7 +2377,7 @@ __metadata:
     "@metamask/eth-query": ^4.0.0
     "@metamask/json-rpc-engine": ^7.3.1
     "@metamask/rpc-errors": ^6.1.0
-    "@metamask/swappable-obj-proxy": ^2.1.0
+    "@metamask/swappable-obj-proxy": ^2.2.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/jest-when": ^2.7.3
@@ -2730,7 +2730,7 @@ __metadata:
     "@metamask/base-controller": ^4.1.0
     "@metamask/json-rpc-engine": ^7.3.1
     "@metamask/network-controller": ^17.1.0
-    "@metamask/swappable-obj-proxy": ^2.1.0
+    "@metamask/swappable-obj-proxy": ^2.2.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -2963,6 +2963,13 @@ __metadata:
   version: 2.1.0
   resolution: "@metamask/swappable-obj-proxy@npm:2.1.0"
   checksum: b15cebee7fb189d1143d3a755a38a7d88f56f91e1277425a51f63c50c432dfb4e6e22650ef67474ae4ef2a97344231af00be6780f126c47d401a23c8a8fb3c9c
+  languageName: node
+  linkType: hard
+
+"@metamask/swappable-obj-proxy@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@metamask/swappable-obj-proxy@npm:2.2.0"
+  checksum: 343c95f72c96776980ef3e70600f7fa312be9a75683c132404a66ddd3c507abadee9c4deba1385246f73bded1938a7958e5a89fc407c19dfc352dd9b398e216f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2651,7 +2651,7 @@ __metadata:
     "@metamask/network-controller": ^17.1.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/selected-network-controller": ^6.0.0
-    "@metamask/swappable-obj-proxy": ^2.1.0
+    "@metamask/swappable-obj-proxy": ^2.2.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -2959,7 +2959,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/swappable-obj-proxy@npm:^2.1.0, @metamask/swappable-obj-proxy@npm:^2.2.0":
+"@metamask/swappable-obj-proxy@npm:^2.2.0":
   version: 2.2.0
   resolution: "@metamask/swappable-obj-proxy@npm:2.2.0"
   checksum: 343c95f72c96776980ef3e70600f7fa312be9a75683c132404a66ddd3c507abadee9c4deba1385246f73bded1938a7958e5a89fc407c19dfc352dd9b398e216f


### PR DESCRIPTION
Network controller and selected network controller are the two places updated by this PR.

[See here for more details](https://github.com/MetaMask/swappable-obj-proxy/pull/53)

not required for https://github.com/MetaMask/metamask-extension/pull/22202 but updating this here is a matter of good package hygene. 

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/selected-network-controller`

- **FIXED**: Event listeners added to the blockTracker via a different proxy are migrated undesireably.

### `@metamask/package-b`

- **FIXED**: Event listeners added to the blockTracker via a different proxy (or directly on the blockTracker) are migrated undesireably.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
