### PR TITLE
fix(test/selected-network-controller): add missing mock functions on mock provider proxy

### DIFF
--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -95,6 +95,11 @@ describe('SelectedNetworkController', () => {
         eventNames: jest.fn(),
         rawListeners: jest.fn(),
         removeAllListeners: jest.fn(),
+        on: jest.fn(),
+        prependListener: jest.fn(),
+        addListener: jest.fn(),
+        off: jest.fn(),
+        once: jest.fn(),
       };
       createEventEmitterProxyMock.mockReturnValue(mockProviderProxy);
       controller.setNetworkClientIdForDomain(
@@ -116,6 +121,11 @@ describe('SelectedNetworkController', () => {
         eventNames: jest.fn(),
         rawListeners: jest.fn(),
         removeAllListeners: jest.fn(),
+        on: jest.fn(),
+        prependListener: jest.fn(),
+        addListener: jest.fn(),
+        off: jest.fn(),
+        once: jest.fn(),
       };
       createEventEmitterProxyMock.mockReturnValue(mockProviderProxy);
       controller.setNetworkClientIdForDomain(
@@ -197,6 +207,11 @@ describe('SelectedNetworkController', () => {
         eventNames: jest.fn(),
         rawListeners: jest.fn(),
         removeAllListeners: jest.fn(),
+        on: jest.fn(),
+        prependListener: jest.fn(),
+        addListener: jest.fn(),
+        off: jest.fn(),
+        once: jest.fn(),
       };
       createEventEmitterProxyMock.mockReturnValue(mockProviderProxy);
       controller.setNetworkClientIdForDomain('example.com', 'network7');


### PR DESCRIPTION
- Targeting #3784 


- Context: https://github.com/MetaMask/core/pull/3784#issuecomment-1894424306