### PR TITLE
Add Linea to price api supported chains

### DIFF
--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -234,7 +234,7 @@ export const SUPPORTED_CHAIN_IDS = [
   // Harmony Mainnet Shard 0
   '0x63564c40',
   // Linea Mainnet
-  '0xe708'
+  '0xe708',
 ] as const;
 
 /**

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -233,6 +233,8 @@ export const SUPPORTED_CHAIN_IDS = [
   '0x4e454152',
   // Harmony Mainnet Shard 0
   '0x63564c40',
+  // Linea Mainnet
+  '0xe708'
 ] as const;
 
 /**


### PR DESCRIPTION
## Explanation

Adds Linea to the list of chains the price API supports.  To enable pricing ERC20 tokens.

Before:

<img width="345" alt="Screenshot 2024-01-18 at 12 03 53 PM" src="https://github.com/MetaMask/core/assets/3500406/95267449-607a-42d6-8ff4-19cb01b0a555">


After:

<img width="349" alt="Screenshot 2024-01-18 at 3 50 05 PM" src="https://github.com/MetaMask/core/assets/3500406/0af6a27d-b179-4fec-b673-7b9e77ee8031">


## References

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **ADDED**: Add Linea to the price api supported chains

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
