### PR TITLE
add getNonceLock tests

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2520,7 +2520,7 @@ describe('TransactionController', () => {
   });
 
   describe('getNonceLock', () => {
-    it('gets the next nonce according to the nonce-tracker', async () => {
+    it('gets the next nonce from the globally selected nonceTracker when no networkClientId is provided', async () => {
       const controller = newController({
         network: MOCK_LINEA_MAINNET_NETWORK,
       });
@@ -2529,6 +2529,31 @@ describe('TransactionController', () => {
 
       expect(getNonceLockSpy).toHaveBeenCalledTimes(1);
       expect(getNonceLockSpy).toHaveBeenCalledWith(ACCOUNT_MOCK);
+      expect(nextNonce).toBe(NONCE_MOCK);
+    });
+
+    it('gets the next nonce from the nonceTracker for the provided networkClientId', async () => {
+      const controller = newController({
+        network: MOCK_LINEA_MAINNET_NETWORK,
+      });
+
+      const trackingMap = controller.startTrackingByNetworkClientId(
+        'customNetworkClientId-1',
+      );
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const { nonceTracker } = trackingMap.get('customNetworkClientId-1')!;
+      const nonceTrackerGetNonceLockSpy = jest.spyOn(
+        nonceTracker,
+        'getNonceLock',
+      );
+
+      const { nextNonce } = await controller.getNonceLock(
+        ACCOUNT_MOCK,
+        'customNetworkClientId-1',
+      );
+
+      expect(nonceTrackerGetNonceLockSpy).toHaveBeenCalledTimes(1);
+      expect(nonceTrackerGetNonceLockSpy).toHaveBeenCalledWith(ACCOUNT_MOCK);
       expect(nextNonce).toBe(NONCE_MOCK);
     });
   });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -190,6 +190,15 @@ export const CANCEL_RATE = 1.5;
  */
 export const SPEED_UP_RATE = 1.1;
 
+/**
+ * @type IncomingTransactionOptions
+ *
+ * Configuration options for incoming transaction support
+ * @property includeTokenTransfers - Whether or not to include ERC20 token transfers.
+ * @property isEnabled - Whether or not incoming transaction retrieval is enabled.
+ * @property queryEntireHistory - Whether to initially query the entire transaction history or only recent blocks.
+ * @property updateTransactions - Whether to update local transactions using remote transaction data.
+ */
 type IncomingTransactionOptions = {
   includeTokenTransfers?: boolean;
   isEnabled?: () => boolean;
@@ -398,10 +407,6 @@ export class TransactionController extends BaseControllerV1<
    * @param options.getSavedGasFees - Gets the saved gas fee config.
    * @param options.getSelectedAddress - Gets the address of the currently selected account.
    * @param options.incomingTransactions - Configuration options for incoming transaction support.
-   * @param options.incomingTransactions.includeTokenTransfers - Whether or not to include ERC20 token transfers.
-   * @param options.incomingTransactions.isEnabled - Whether or not incoming transaction retrieval is enabled.
-   * @param options.incomingTransactions.queryEntireHistory - Whether to initially query the entire transaction history or only recent blocks.
-   * @param options.incomingTransactions.updateTransactions - Whether to update local transactions using remote transaction data.
    * @param options.messenger - The controller messenger.
    * @param options.onNetworkStateChange - Allows subscribing to network controller state changes.
    * @param options.pendingTransactions - Configuration options for pending transaction support.


### PR DESCRIPTION
## Explanation

* Add scenario to `getNonceLock` to checks if the right nonceTracker is used when a networkClientId is provided
* Add integration tests for `getNonceLock` that test result and that an acquired lock blocks subsequent attempts to acquire
* Lint IncomingTxOptions jsdoc 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
