### PR TITLE
feat: Keep `PreferencesController` in sync with keyring state

### DIFF
--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -47,7 +47,6 @@
     "@keystonehq/bc-ur-registry-eth": "^0.9.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/eth-sig-util": "^7.0.1",
-    "@metamask/preferences-controller": "^6.0.0",
     "@metamask/scure-bip39": "^2.1.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
@@ -59,9 +58,6 @@
     "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "~4.8.4",
     "uuid": "^8.3.2"
-  },
-  "peerDependencies": {
-    "@metamask/preferences-controller": "^6.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -36,7 +36,6 @@
     "@metamask/eth-keyring-controller": "^17.0.1",
     "@metamask/keyring-api": "^3.0.0",
     "@metamask/message-manager": "^7.3.7",
-    "@metamask/preferences-controller": "^6.0.0",
     "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6",
     "ethereumjs-util": "^7.0.10",

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -14,7 +14,6 @@ import type {
   PersonalMessageParams,
   TypedMessageParams,
 } from '@metamask/message-manager';
-import type { PreferencesController } from '@metamask/preferences-controller';
 import type { Eip1024EncryptedData, Hex, Keyring, Json } from '@metamask/utils';
 import { assertIsStrictHexString, hasProperty } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
@@ -172,10 +171,10 @@ export type KeyringControllerMessenger = RestrictedControllerMessenger<
 >;
 
 export type KeyringControllerOptions = {
-  syncIdentities: PreferencesController['syncIdentities'];
-  updateIdentities: PreferencesController['updateIdentities'];
-  setSelectedAddress: PreferencesController['setSelectedAddress'];
-  setAccountLabel?: PreferencesController['setAccountLabel'];
+  syncIdentities: (addresses: string[]) => string;
+  updateIdentities: (addresses: string[]) => void;
+  setSelectedAddress: (selectedAddress: string) => void;
+  setAccountLabel?: (address: string, label: string) => void;
   keyringBuilders?: { (): Keyring<Json>; type: string }[];
   messenger: KeyringControllerMessenger;
   state?: { vault?: string };
@@ -221,9 +220,11 @@ export enum SignTypedDataVersion {
   V4 = 'V4',
 }
 
-const defaultState: KeyringControllerState = {
-  isUnlocked: false,
-  keyrings: [],
+export const getDefaultKeyringState = (): KeyringControllerState => {
+  return {
+    isUnlocked: false,
+    keyrings: [],
+  };
 };
 
 /**
@@ -261,13 +262,13 @@ export class KeyringController extends BaseController<
 > {
   private readonly mutex = new Mutex();
 
-  private readonly syncIdentities: PreferencesController['syncIdentities'];
+  private readonly syncIdentities: (addresses: string[]) => string;
 
-  private readonly updateIdentities: PreferencesController['updateIdentities'];
+  private readonly updateIdentities: (addresses: string[]) => void;
 
-  private readonly setSelectedAddress: PreferencesController['setSelectedAddress'];
+  private readonly setSelectedAddress: (selectedAddress: string) => void;
 
-  private readonly setAccountLabel?: PreferencesController['setAccountLabel'];
+  private readonly setAccountLabel?: (address: string, label: string) => void;
 
   #keyring: EthKeyringController;
 
@@ -311,7 +312,7 @@ export class KeyringController extends BaseController<
       },
       messenger,
       state: {
-        ...defaultState,
+        ...getDefaultKeyringState(),
         ...state,
       },
     });

--- a/packages/keyring-controller/tsconfig.build.json
+++ b/packages/keyring-controller/tsconfig.build.json
@@ -11,9 +11,6 @@
     },
     {
       "path": "../message-manager/tsconfig.build.json"
-    },
-    {
-      "path": "../preferences-controller/tsconfig.build.json"
     }
   ],
   "include": ["../../types", "./src"]

--- a/packages/keyring-controller/tsconfig.json
+++ b/packages/keyring-controller/tsconfig.json
@@ -9,9 +9,6 @@
     },
     {
       "path": "../message-manager"
-    },
-    {
-      "path": "../preferences-controller"
     }
   ],
   "include": ["../../types", "./src", "./tests"]

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-controller": "^12.0.0",
+    "@metamask/keyring-controller": "^12.1.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
@@ -47,7 +47,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/keyring-controller": "^12.0.0"
+    "@metamask/keyring-controller": "^12.1.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -36,13 +36,18 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/keyring-controller": "^12.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
+    "lodash": "^4.17.21",
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "~4.8.4"
+  },
+  "peerDependencies": {
+    "@metamask/keyring-controller": "^12.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -202,21 +202,31 @@ describe('PreferencesController', () => {
       expect(controller.state.identities).toStrictEqual(identitiesState);
     });
 
-    it('should not update selected address if it is still among identities', () => {
+    it('should not update selected address on account removal if it is still among identities', () => {
+      const identitiesState = {
+        '0x00': { address: '0x00', importTime: 1, name: 'Account 1' },
+        '0x01': { address: '0x01', importTime: 2, name: 'Account 2' },
+        '0x02': { address: '0x02', importTime: 3, name: 'Account 3' },
+      };
+      const messenger = getControllerMessenger();
       const controller = setupPreferencesController({
         options: {
           state: {
-            identities: {
-              '0x00': { address: '0x00', name: 'Account 1' },
-              '0x01': { address: '0x01', name: 'Account 2' },
-              '0x02': { address: '0x02', importTime: 3, name: 'Account 3' },
-            },
+            identities: cloneDeep(identitiesState),
             selectedAddress: '0x01',
           },
         },
+        messenger,
       });
 
-      controller.updateIdentities(['0x00', '0x01']);
+      messenger.publish(
+        'KeyringController:stateChange',
+        {
+          ...getDefaultKeyringState(),
+          keyrings: [{ accounts: ['0x00', '0x01'], type: 'CustomKeyring' }],
+        },
+        [],
+      );
 
       expect(controller.state.selectedAddress).toBe('0x01');
     });

--- a/packages/preferences-controller/tsconfig.build.json
+++ b/packages/preferences-controller/tsconfig.build.json
@@ -7,7 +7,8 @@
   },
   "references": [
     { "path": "../base-controller/tsconfig.build.json" },
-    { "path": "../controller-utils/tsconfig.build.json" }
+    { "path": "../controller-utils/tsconfig.build.json" },
+    { "path": "../keyring-controller/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/preferences-controller/tsconfig.json
+++ b/packages/preferences-controller/tsconfig.json
@@ -5,7 +5,8 @@
   },
   "references": [
     { "path": "../base-controller" },
-    { "path": "../controller-utils" }
+    { "path": "../controller-utils" },
+    { "path": "../keyring-controller" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2275,7 +2275,6 @@ __metadata:
     "@metamask/eth-keyring-controller": ^15.1.0
     "@metamask/eth-sig-util": ^7.0.1
     "@metamask/message-manager": ^7.3.7
-    "@metamask/preferences-controller": ^6.0.0
     "@metamask/scure-bip39": ^2.1.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2292,8 +2291,6 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
     uuid: ^8.3.2
-  peerDependencies:
-    "@metamask/preferences-controller": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -2590,13 +2587,17 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^4.1.0
     "@metamask/controller-utils": ^8.0.1
+    "@metamask/keyring-controller": ^12.0.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
+    lodash: ^4.17.21
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
+  peerDependencies:
+    "@metamask/keyring-controller": ^12.0.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,7 +2245,6 @@ __metadata:
     "@metamask/eth-sig-util": ^7.0.1
     "@metamask/keyring-api": ^3.0.0
     "@metamask/message-manager": ^7.3.7
-    "@metamask/preferences-controller": ^6.0.0
     "@metamask/scure-bip39": ^2.1.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,7 +2526,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^4.1.0
     "@metamask/controller-utils": ^8.0.1
-    "@metamask/keyring-controller": ^12.0.0
+    "@metamask/keyring-controller": ^12.1.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -2536,7 +2536,7 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
   peerDependencies:
-    "@metamask/keyring-controller": ^12.0.0
+    "@metamask/keyring-controller": ^12.1.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Explanation

The `PreferencesController` now listens for `KeyringController` state changes, and updates its own state in response to account removals or additions. New accounts are added to the `identities` state and given default labels. Removed accounts are removed from the `identities` state, and the `selectedAddress` is updated if it was removed.

The dependency between these two packages has been flipped; the `@metamask/preferences-controller` package now depends upon `@metamask/keyring-controller` rather than the other away around, so that the `KeyringController` state type and state change event can be accessed. The dependency the other way was just to get the types for the four `PreferencesController` methods that are passed into the `KeyringController` constructor. These types were easily inlined, and these methods will soon be removed anyway.

A `getDefaultKeyringState` export was added to the `@metamask/keyring-controller` package to make it easier to write the necessary `PreferencesController` tests.

## References

Closes #3794

## Changelog

### `@metamask/keyring-controller`

#### Added
- Add `getDefaultKeyringState` function

#### Removed
- Remove `peerDependency` and `devDependency` upon `@metamask/preferences-controller`
  - This dependency was just used to access the types of four methods. Those types are now inlined instead.

### `@metamask/preferences-controller`

#### Changed
- **BREAKING:** Keep `PreferencesController` state synchronized with `KeyringController` state
  - The `KeyringController:stateChange` event is now required by the `PreferencesController` messenger, which is a breaking change.
  - The package `@metamask/keyring-controller` has been added as a `peerDependency` and as a `devDependency`, which is a breaking change.
  - Previously the state was synchronized manually by calling `syncIdentities` or  `updateIdentities`. Calling these methods is no longer required.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
