### PR TITLE
fix: quick succession of submit password causing Accounts Controller state to be cleared

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -364,7 +364,30 @@ describe('AccountsController', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
-    it('should only update if the keyring is unlocked', async () => {
+    it('should not update state when only keyring is unlocked without any keyrings', async () => {
+      const messenger = buildMessenger();
+      const accountsController = setupAccountsController({
+        initialState: {
+          internalAccounts: {
+            accounts: {},
+            selectedAccount: '',
+          },
+        },
+        messenger,
+      });
+
+      messenger.publish(
+        'KeyringController:stateChange',
+        { isUnlocked: true, keyrings: [] },
+        [],
+      );
+
+      const accounts = accountsController.listAccounts();
+
+      expect(accounts).toStrictEqual([]);
+    });
+
+    it('should only update if the keyring is unlocked and when there are keyrings', async () => {
       const messenger = buildMessenger();
 
       const mockNewKeyringState = {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -494,6 +494,9 @@ export class AccountsController extends BaseController<
     // check if there are any new accounts added
     // TODO: change when accountAdded event is added to the keyring controller
 
+    // We check for keyrings length to be greater than 0 because the extension client may try execute
+    // submit password twice and clear the keyring state.
+    // https://github.com/MetaMask/KeyringController/blob/2d73a4deed8d013913f6ef0c9f5c0bb7c614f7d3/src/KeyringController.ts#L910
     if (keyringState.isUnlocked && keyringState.keyrings.length > 0) {
       const updatedNormalKeyringAddresses: AddressAndKeyringTypeObject[] = [];
       const updatedSnapKeyringAddresses: AddressAndKeyringTypeObject[] = [];

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -487,7 +487,7 @@ export class AccountsController extends BaseController<
     // check if there are any new accounts added
     // TODO: change when accountAdded event is added to the keyring controller
 
-    if (keyringState.isUnlocked) {
+    if (keyringState.isUnlocked && keyringState.keyrings.length > 0) {
       const updatedNormalKeyringAddresses: AddressAndKeyringTypeObject[] = [];
       const updatedSnapKeyringAddresses: AddressAndKeyringTypeObject[] = [];
 


### PR DESCRIPTION
## Explanation

This PR fixes the edge case that leads to the reset of the Accounts Controller state. The accounts controller listens to the keyring controller state change, when the extension client executes two submit passwords in succession, there is a race condition where the [keyring controller would empty its keyring state ](https://github.com/MetaMask/KeyringController/blob/2d73a4deed8d013913f6ef0c9f5c0bb7c614f7d3/src/KeyringController.ts#L910)causing the accounts controller to clear its state.

## References

For example:

* [Fixes #215](https://github.com/MetaMask/accounts-planning/issues/215)


## Changelog

### `@metamask/accounts-controller`

- **CHANGED**: onKeyringState only triggers when the keyring controller is unlocked and has keyrings.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [] I've highlighted breaking changes using the "BREAKING" category above as appropriate
