### PR TITLE
refactor: Remove usage of deprecated `setProviderType`

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -917,7 +917,7 @@ describe('AssetsContractController', () => {
     );
     expect(balances[ERC20_SAI_ADDRESS]).toBeDefined();
 
-    await network.setProviderType(NetworkType.sepolia);
+    await network.setActiveNetwork(NetworkType.sepolia);
 
     const noBalances = await assetsContract.getBalancesInSingleCall(
       ERC20_SAI_ADDRESS,

--- a/packages/queued-request-controller/src/QueuedRequestMiddleware.test.ts
+++ b/packages/queued-request-controller/src/QueuedRequestMiddleware.test.ts
@@ -85,12 +85,6 @@ const buildMocks = (
     mockAddRequest,
   );
 
-  const mockSetProviderType = jest.fn().mockResolvedValue(true);
-  messenger.registerActionHandler(
-    'NetworkController:setProviderType',
-    mockSetProviderType,
-  );
-
   const mockSetActiveNetwork = jest.fn().mockResolvedValue(true);
   messenger.registerActionHandler(
     'NetworkController:setActiveNetwork',
@@ -111,7 +105,6 @@ const buildMocks = (
     enqueueRequest: mockEnqueueRequest,
     addRequest: mockAddRequest,
     setActiveNetwork: mockSetActiveNetwork,
-    setProviderType: mockSetProviderType,
     setNetworkClientIdForDomain: mockSetNetworkClientIdForDomain,
   };
 };
@@ -379,37 +372,7 @@ describe('createQueuedRequestMiddleware', () => {
         expect(res.error).toStrictEqual(serializeError(rejected));
       });
 
-      it('uses setProviderType when the network is an infura one', async () => {
-        const messenger = buildMessenger();
-        const middleware = createQueuedRequestMiddleware({
-          messenger,
-          useRequestQueue: () => true,
-        });
-        const mocks = buildMocks(messenger, {
-          getProviderConfig: jest.fn().mockReturnValue({
-            chainId: '0x5',
-          }),
-        });
-
-        const req = {
-          ...requestDefaults,
-          method: 'eth_sendTransaction',
-        };
-
-        await new Promise((resolve, reject) =>
-          middleware(
-            req,
-            {} as PendingJsonRpcResponse<typeof req>,
-            resolve,
-            reject,
-          ),
-        );
-
-        expect(mocks.setProviderType).toHaveBeenCalled();
-        expect(mocks.setActiveNetwork).not.toHaveBeenCalled();
-      });
-
-      it('uses setActiveNetwork when the network is a custom one', async () => {
+      it('switches the current active network', async () => {
         const messenger = buildMessenger();
         const middleware = createQueuedRequestMiddleware({
           messenger,
@@ -451,7 +414,6 @@ describe('createQueuedRequestMiddleware', () => {
           ),
         );
 
-        expect(mocks.setProviderType).not.toHaveBeenCalled();
         expect(mocks.setActiveNetwork).toHaveBeenCalled();
       });
     });

--- a/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
+++ b/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
@@ -9,7 +9,6 @@ import type {
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetStateAction,
   NetworkControllerSetActiveNetworkAction,
-  NetworkControllerSetProviderTypeAction,
 } from '@metamask/network-controller';
 import { serializeError } from '@metamask/rpc-errors';
 import type { SelectedNetworkControllerSetNetworkClientIdForDomainAction } from '@metamask/selected-network-controller';
@@ -22,7 +21,6 @@ import { QueuedRequestControllerActionTypes } from './QueuedRequestController';
 export type MiddlewareAllowedActions =
   | NetworkControllerGetStateAction
   | NetworkControllerSetActiveNetworkAction
-  | NetworkControllerSetProviderTypeAction
   | NetworkControllerGetNetworkClientByIdAction
   | NetworkControllerFindNetworkClientIdByChainIdAction
   | SelectedNetworkControllerSetNetworkClientIdForDomainAction
@@ -155,10 +153,8 @@ export const createQueuedRequestMiddleware = ({
               true,
             );
 
-            const method = isBuiltIn ? 'setProviderType' : 'setActiveNetwork';
-
             await messenger.call(
-              `NetworkController:${method}`,
+              `NetworkController:setActiveNetwork`,
               networkClientIdForRequest,
             );
 


### PR DESCRIPTION
## Explanation

All uages of the deprecated `NetworkController` method `setProviderType` have been removed from this repository. They have been replaced by calls to `setActiveNetwork`, which now also supports being given network types, just like `setProviderType` did.

## References

N/A

## Changelog

### `@metamask/queued-request-controller`

#### Changed
- The action `NetworkController:setProviderType` is no longer used, so it's no longer required by the `QueuedRequestController` messenger.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
