### PR TITLE
Add @metamask/transaction-controller@20.0.0 resolution for SES

### DIFF
--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -30,6 +30,9 @@
     "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"
   },
+  "resolutions": {
+    "babel-runtime/regenerator-runtime": "^0.13.8"
+  },
   "dependencies": {
     "@ethereumjs/common": "^3.2.0",
     "@ethereumjs/tx": "^4.2.0",


### PR DESCRIPTION
## Explanation

Spotted a dependency of `@metamask/transaction-controller` is incompatible with SES

```
@metamask/core-monorepo@109.0.0
└─┬ @metamask/transaction-controller@20.0.0 -> ./packages/transaction-controller
  └─┬ babel-runtime@6.26.0
    └── regenerator-runtime@0.11.1
```

`regenerator-runtime@0.13.8` contains the [fix](https://github.com/facebook/regenerator/commit/903a50726da73d0ffd5b57a7617bbcc2fd4bbc99)
if a resolution is a viable option for now (cc @Gudahtt if not i'll close this pr)
but noticed we have no other package.json "resolutions" in this repo

nb: this is more an early preventative measure for when metamask-mobile eventually gets updated to `@metamask/transaction-controller@20.0.0` cc @tommasini

## References

Spotted in https://github.com/MetaMask/metamask-mobile/pull/8033#issuecomment-1903864012

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
