### PR TITLE
chore(network-controller): Remove unused internal variable

### DIFF
--- a/packages/network-controller/jest.config.js
+++ b/packages/network-controller/jest.config.js
@@ -19,8 +19,8 @@ module.exports = merge(baseConfig, {
     global: {
       branches: 76.53,
       functions: 95,
-      lines: 92.03,
-      statements: 91.62,
+      lines: 92,
+      statements: 91.58,
     },
   },
 

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -552,8 +552,6 @@ export class NetworkController extends BaseController<
 
   #providerProxy: ProviderProxy | undefined;
 
-  #provider: ProxyWithAccessibleTarget<Provider> | undefined;
-
   #blockTrackerProxy: BlockTrackerProxy | undefined;
 
   #autoManagedNetworkClientRegistry?: AutoManagedNetworkClientRegistry;
@@ -1636,7 +1634,6 @@ export class NetworkController extends BaseController<
     } else {
       this.#providerProxy = createEventEmitterProxy(provider);
     }
-    this.#provider = provider;
 
     if (this.#blockTrackerProxy) {
       this.#blockTrackerProxy.setTarget(blockTracker);


### PR DESCRIPTION
## Explanation

The internal variable `#provider` has been removed. It was not used.

## References

N/A

## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
