### PR TITLE
refactor: Remove duplicated code in `setProviderType`

### DIFF
--- a/packages/network-controller/jest.config.js
+++ b/packages/network-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 76.53,
-      functions: 95,
-      lines: 92,
-      statements: 91.58,
+      branches: 76.57,
+      functions: 94.93,
+      lines: 91.78,
+      statements: 91.36,
     },
   },
 

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -965,26 +965,7 @@ export class NetworkController extends BaseController<
       `Unknown Infura provider type "${type}".`,
     );
 
-    this.#previousProviderConfig = this.state.providerConfig;
-
-    // If testnet the ticker symbol should use a testnet prefix
-    const ticker =
-      type in NetworksTicker && NetworksTicker[type].length > 0
-        ? NetworksTicker[type]
-        : 'ETH';
-
-    this.#ensureAutoManagedNetworkClientRegistryPopulated();
-
-    this.update((state) => {
-      state.providerConfig.type = type;
-      state.providerConfig.ticker = ticker;
-      state.providerConfig.chainId = ChainId[type];
-      state.providerConfig.rpcPrefs = BUILT_IN_NETWORKS[type].rpcPrefs;
-      state.providerConfig.rpcUrl = undefined;
-      state.providerConfig.nickname = undefined;
-      state.providerConfig.id = undefined;
-    });
-    await this.#refreshNetwork();
+    await this.setActiveNetwork(type);
   }
 
   /**


### PR DESCRIPTION
## Explanation

The method `setProviderType` has been updated to use `setActiveNetwork` internally, allowing us to remove a bunch of code that was duplicated between both methods.

## References

N/A

## Changelog

None

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
