### PR TITLE
Move keyring-controller dep to devdep in Accounts Controller

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -34,7 +34,6 @@
     "@metamask/base-controller": "^4.1.0",
     "@metamask/eth-snap-keyring": "^2.1.1",
     "@metamask/keyring-api": "^3.0.0",
-    "@metamask/keyring-controller": "^12.0.0",
     "@metamask/snaps-sdk": "^1.3.2",
     "@metamask/snaps-utils": "^5.1.2",
     "@metamask/utils": "^8.3.0",
@@ -45,6 +44,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/keyring-controller": "^12.0.0",
     "@metamask/snaps-controllers": "^4.0.0",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",


### PR DESCRIPTION
## Explanation

Move the keyring-controller from a dependency to to dev dependency in Accounts Controller. This was accidentally recategorized in #3747, this PR undoes that change.

## References

## Changelog

### `@metamask/accounts-controller`

- **Changed**: Move keyring-controller from a dependency to devDependency in the AccountsController

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
