### PR TITLE
chore(user-operation-controller): Remove unnecessary `peerDependency`

### DIFF
--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -61,7 +61,6 @@
     "@metamask/approval-controller": "^5.1.1",
     "@metamask/gas-fee-controller": "^12.0.0",
     "@metamask/network-controller": "^17.1.0",
-    "@metamask/polling-controller": "^4.0.0",
     "@metamask/transaction-controller": "^20.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2945,7 +2945,6 @@ __metadata:
     "@metamask/approval-controller": ^5.1.1
     "@metamask/gas-fee-controller": ^12.0.0
     "@metamask/network-controller": ^17.1.0
-    "@metamask/polling-controller": ^4.0.0
     "@metamask/transaction-controller": ^20.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Explanation

The `@metamask/user-operation-controller` package has been updated to remove the peer dependency `@metamask/polling-controller`. Contrary to what the name might suggest, `@metamask/polling-controller` is not itself a controller package, so it's not subject to our policy of making controller dependencies peer dependencies. It's just a regular library.

## References

N/A

## Changelog

### `@metamask/user-operation-controller`
#### Removed
- Remove `@metamask/polling-controller` peer dependency
  - This was mistakenly added as a peer dependency in v1. Now it's a regular dependency.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
