### PR TITLE
Selected network controller should update all domains when feature flag is off

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -142,6 +142,14 @@ export class SelectedNetworkController extends BaseController<
 
   setNetworkClientIdForMetamask(networkClientId: NetworkClientId) {
     this.setNetworkClientIdForDomain(METAMASK_DOMAIN, networkClientId);
+
+    if (!this.state.perDomainNetwork) {
+      Object.entries(this.state.domains).filter(([domain]) => domain !== 'metamask').map(([domain, networkClientIdForDomain]) => {
+        if (networkClientIdForDomain !== networkClientId) {
+          this.setNetworkClientIdForDomain(domain, networkClientId);
+        }
+      });
+    }
   }
 
   setNetworkClientIdForDomain(

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -148,7 +148,6 @@ export class SelectedNetworkController extends BaseController<
     domain: Domain,
     networkClientId: NetworkClientId,
   ) {
-    console.log('WHAT THE FUCK');
     const networkClient = this.messagingSystem.call(
       'NetworkController:getNetworkClientById',
       networkClientId,

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -144,10 +144,11 @@ export class SelectedNetworkController extends BaseController<
     this.setNetworkClientIdForDomain(METAMASK_DOMAIN, networkClientId);
   }
 
-  setNetworkClientIdForDomain(
+  #setNetworkClientIdForDomain(
     domain: Domain,
     networkClientId: NetworkClientId,
   ) {
+    console.log('WHAT THE FUCK');
     const networkClient = this.messagingSystem.call(
       'NetworkController:getNetworkClientById',
       networkClientId,
@@ -171,19 +172,25 @@ export class SelectedNetworkController extends BaseController<
         state.domains[METAMASK_DOMAIN] = networkClientId;
       }
     });
+  }
 
-    if (!this.state.perDomainNetwork && domain === METAMASK_DOMAIN) {
+  setNetworkClientIdForDomain(
+    domain: Domain,
+    networkClientId: NetworkClientId,
+  ) {
+    if (!this.state.perDomainNetwork) {
       Object.entries(this.state.domains).forEach(
         ([entryDomain, networkClientIdForDomain]) => {
-          if (entryDomain !== 'metamask') {
-            return;
-          }
-          if (networkClientIdForDomain !== networkClientId) {
-            this.setNetworkClientIdForDomain(entryDomain, networkClientId);
+          if (
+            networkClientIdForDomain !== networkClientId &&
+            entryDomain !== domain
+          ) {
+            this.#setNetworkClientIdForDomain(entryDomain, networkClientId);
           }
         },
       );
     }
+    this.#setNetworkClientIdForDomain(domain, networkClientId);
   }
 
   getNetworkClientIdForDomain(domain: Domain) {

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -142,14 +142,6 @@ export class SelectedNetworkController extends BaseController<
 
   setNetworkClientIdForMetamask(networkClientId: NetworkClientId) {
     this.setNetworkClientIdForDomain(METAMASK_DOMAIN, networkClientId);
-
-    if (!this.state.perDomainNetwork) {
-      Object.entries(this.state.domains).filter(([domain]) => domain !== 'metamask').map(([domain, networkClientIdForDomain]) => {
-        if (networkClientIdForDomain !== networkClientId) {
-          this.setNetworkClientIdForDomain(domain, networkClientId);
-        }
-      });
-    }
   }
 
   setNetworkClientIdForDomain(
@@ -179,6 +171,19 @@ export class SelectedNetworkController extends BaseController<
         state.domains[METAMASK_DOMAIN] = networkClientId;
       }
     });
+
+    if (!this.state.perDomainNetwork && domain === METAMASK_DOMAIN) {
+      Object.entries(this.state.domains).forEach(
+        ([entryDomain, networkClientIdForDomain]) => {
+          if (entryDomain !== 'metamask') {
+            return;
+          }
+          if (networkClientIdForDomain !== networkClientId) {
+            this.setNetworkClientIdForDomain(entryDomain, networkClientId);
+          }
+        },
+      );
+    }
   }
 
   getNetworkClientIdForDomain(domain: Domain) {

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -83,6 +83,40 @@ describe('SelectedNetworkController', () => {
       expect(controller.state.domains[domain]).toBe(networkClientId);
     });
 
+    it('when the perDomainNetwork option is false, it updates the networkClientId for all domains in state', () => {
+      const options: SelectedNetworkControllerOptions = {
+        messenger: buildSelectedNetworkControllerMessenger(),
+      };
+      const controller = new SelectedNetworkController(options);
+      const domains = ['1.com', '2.com', '3.com'];
+      const networkClientIds = ['1', '2', '3'];
+      const mockProviderProxy = {
+        setTarget: jest.fn(),
+        eventNames: jest.fn(),
+        rawListeners: jest.fn(),
+        removeAllListeners: jest.fn(),
+        on: jest.fn(),
+        prependListener: jest.fn(),
+        addListener: jest.fn(),
+        off: jest.fn(),
+        once: jest.fn(),
+      };
+      createEventEmitterProxyMock.mockReturnValue(mockProviderProxy);
+      domains.forEach((domain, i) =>
+        controller.setNetworkClientIdForDomain(domain, networkClientIds[i]),
+      );
+
+      controller.setNetworkClientIdForMetamask('foo');
+      domains.forEach((domain) =>
+        expect(controller.state.domains[domain]).toBe('foo'),
+      );
+
+      controller.setNetworkClientIdForMetamask('bar');
+      domains.forEach((domain) =>
+        expect(controller.state.domains[domain]).toBe('bar'),
+      );
+    });
+
     it('creates a new provider and block tracker proxy when they dont exist yet for the domain', () => {
       const options: SelectedNetworkControllerOptions = {
         messenger: buildSelectedNetworkControllerMessenger(),

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -88,6 +88,7 @@ describe('SelectedNetworkController', () => {
         messenger: buildSelectedNetworkControllerMessenger(),
       };
       const controller = new SelectedNetworkController(options);
+      controller.state.perDomainNetwork = false;
       const domains = ['1.com', '2.com', '3.com'];
       const networkClientIds = ['1', '2', '3'];
       const mockProviderProxy = {
@@ -102,6 +103,7 @@ describe('SelectedNetworkController', () => {
         once: jest.fn(),
       };
       createEventEmitterProxyMock.mockReturnValue(mockProviderProxy);
+      controller.setNetworkClientIdForMetamask('abc');
       domains.forEach((domain, i) =>
         controller.setNetworkClientIdForDomain(domain, networkClientIds[i]),
       );
@@ -111,9 +113,9 @@ describe('SelectedNetworkController', () => {
         expect(controller.state.domains[domain]).toBe('foo'),
       );
 
-      controller.setNetworkClientIdForMetamask('bar');
+      controller.setNetworkClientIdForMetamask('abc');
       domains.forEach((domain) =>
-        expect(controller.state.domains[domain]).toBe('bar'),
+        expect(controller.state.domains[domain]).toBe('abc'),
       );
     });
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

When the feature flag for per dapp network is turned off, we should keep all the proxies for all the domains in sync. To do that, we add some code to the end of the function used to set network client id for a given domain. When the user is setting the domain for 'metamask', and when the feature flag is off, we do the update to all the domains, not just metamask.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/selected-network-controller`

- **CHANGED**: NetworkClientId for each domain will be the same as metamask when the feature flag is off

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
