### PR TITLE
fix: resolve tx custodian promise when set transaction to submitted or failed

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -3821,6 +3821,7 @@ describe('TransactionController', () => {
         custodyId: '123',
         history: [{ ...baseTransaction }],
       };
+
       it.each([
         {
           newStatus: TransactionStatus.signed,

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1630,18 +1630,22 @@ export class TransactionController extends BaseControllerV1<
 
     if (status === TransactionStatus.submitted) {
       updatedTransactionMeta.submittedTime = new Date().getTime();
-      this.hub.emit(`${transactionMeta.id}:finished`, updatedTransactionMeta);
     }
 
     if (status === TransactionStatus.failed) {
       updatedTransactionMeta.error = normalizeTxError(new Error(errorMessage));
-      this.hub.emit(`${transactionMeta.id}:finished`, updatedTransactionMeta);
     }
 
     this.updateTransaction(
       updatedTransactionMeta,
       `TransactionController:updateCustodialTransaction - Custodial transaction updated`,
     );
+    if (
+      status &&
+      [TransactionStatus.submitted, TransactionStatus.failed].includes(status)
+    ) {
+      this.hub.emit(`${transactionMeta.id}:finished`, updatedTransactionMeta);
+    }
   }
 
   /**

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1640,9 +1640,11 @@ export class TransactionController extends BaseControllerV1<
       updatedTransactionMeta,
       `TransactionController:updateCustodialTransaction - Custodial transaction updated`,
     );
+
     if (
-      status &&
-      [TransactionStatus.submitted, TransactionStatus.failed].includes(status)
+      [TransactionStatus.submitted, TransactionStatus.failed].includes(
+        status as TransactionStatus,
+      )
     ) {
       this.hub.emit(`${transactionMeta.id}:finished`, updatedTransactionMeta);
     }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1630,10 +1630,12 @@ export class TransactionController extends BaseControllerV1<
 
     if (status === TransactionStatus.submitted) {
       updatedTransactionMeta.submittedTime = new Date().getTime();
+      this.hub.emit(`${transactionMeta.id}:finished`, updatedTransactionMeta);
     }
 
     if (status === TransactionStatus.failed) {
       updatedTransactionMeta.error = normalizeTxError(new Error(errorMessage));
+      this.hub.emit(`${transactionMeta.id}:finished`, updatedTransactionMeta);
     }
 
     this.updateTransaction(


### PR DESCRIPTION
## Explanation
This PR aims to fix an issue with the custodian transaction where the promise is not resolved.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **FIXED**: Emit `txId:finished` when custodian transaction status is updated to `submitted` or `failed`


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
