### PR TITLE
Revert "feat: add externalLinkClicked to TransactionMetaBase type"

### DIFF
--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -164,11 +164,6 @@ type TransactionMetaBase = {
   estimateUsed?: string;
 
   /**
-   * Description of the link clicked associated with the transaction
-   */
-  externalLinkClicked?: string;
-
-  /**
    * The chosen amount which will be the same as the originally proposed token
    * amount if the user does not edit the  amount or will be a custom token
    * amount set by the user.


### PR DESCRIPTION
Reverts MetaMask/core#3828

no longer needed after discovering we can update the event fragment ad-hoc using the useTransactionEventFragment hook

Related to https://github.com/MetaMask/metamask-extension/pull/22631