### PR TITLE
fix: add tokenURI to compare nft data

### DIFF
--- a/packages/assets-controllers/src/assetsUtil.test.ts
+++ b/packages/assets-controllers/src/assetsUtil.test.ts
@@ -57,6 +57,30 @@ describe('assetsUtil', () => {
       expect(different).toBe(true);
     });
 
+    it('should resolve true if only tokenURI is different', () => {
+      const nftMetadata: NftMetadata = {
+        description: null,
+        favorite: false,
+        image: 'test',
+        name: null,
+        standard: 'ERC1155',
+        tokenURI: 'foo',
+      };
+      const nft: Nft = {
+        address: '0x1D03117e63c3A476a236a897147a1358579F2c45',
+        description: null,
+        favorite: false,
+        image: 'test',
+        name: null,
+        standard: 'ERC1155',
+        tokenId: '1',
+        tokenURI: 'bar',
+      };
+
+      const different = assetsUtil.compareNftMetadata(nftMetadata, nft);
+      expect(different).toBe(true);
+    });
+
     it('should resolve true if any key is different as always as metadata is not undefined', () => {
       const nftMetadata: NftMetadata = {
         name: 'name',

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -45,6 +45,7 @@ export function compareNftMetadata(newNftMetadata: NftMetadata, nft: Nft) {
     'animation',
     'animationOriginal',
     'externalLink',
+    'tokenURI',
   ];
   const differentValues = keys.reduce((value, key) => {
     if (newNftMetadata[key] && newNftMetadata[key] !== nft[key]) {


### PR DESCRIPTION
## Explanation

While i was testing NFT refreshing mechanism on Mobile with an Opensea collection, noticed that the tokenURI returned was the old URI,  that was because the compareNftMetadata fct was returning false while it should have returned true.
I added the TokenURI as a key to compare with.

## References


## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **FIXED**: Added tokenURI key to compareNftMetadata fct


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
