### PR TITLE
Add optional chainId to getTransactions

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -4576,7 +4576,7 @@ describe('TransactionController', () => {
         ).toStrictEqual([transactions[0], transactions[2]]);
       });
 
-      it('returns transactions matching current network', () => {
+      it('returns transactions matching current network if chainId is not provided', () => {
         const controller = newController();
 
         const transactions: TransactionMeta[] = [
@@ -4610,6 +4610,43 @@ describe('TransactionController', () => {
             filterToCurrentNetwork: true,
           }),
         ).toStrictEqual([transactions[0], transactions[2]]);
+      });
+
+      it('returns transactions matching chainId if provided', () => {
+        const controller = newController();
+
+        const transactions: TransactionMeta[] = [
+          {
+            chainId: MOCK_NETWORK.state.providerConfig.chainId,
+            id: 'testId1',
+            status: TransactionStatus.confirmed,
+            time: 1,
+            txParams: { from: '0x1' },
+          },
+          {
+            chainId: '0x2',
+            id: 'testId2',
+            status: TransactionStatus.unapproved,
+            time: 2,
+            txParams: { from: '0x2' },
+          },
+          {
+            chainId: MOCK_NETWORK.state.providerConfig.chainId,
+            id: 'testId3',
+            status: TransactionStatus.submitted,
+            time: 1,
+            txParams: { from: '0x3' },
+          },
+        ];
+
+        controller.state.transactions = transactions;
+
+        expect(
+          controller.getTransactions({
+            filterToCurrentNetwork: true,
+            chainId: '0x2'
+          }),
+        ).toStrictEqual([transactions[1]]);
       });
 
       it('returns transactions from specified list', () => {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -2100,6 +2100,7 @@ export class TransactionController extends BaseControllerV1<
    * @param opts.initialList - The transactions to search. Defaults to the current state.
    * @param opts.filterToCurrentNetwork - Whether to filter the results to the current network. Defaults to true.
    * @param opts.limit - The maximum number of transactions to return. No limit by default.
+   * @param opts.chainId - Optional chainId to filter transactions by. Defaults to the current chainId.
    * @returns An array of transactions matching the provided options.
    */
   getTransactions({
@@ -2107,6 +2108,7 @@ export class TransactionController extends BaseControllerV1<
     initialList,
     filterToCurrentNetwork = true,
     limit,
+    chainId = this.getChainId(),
   }: {
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2114,8 +2116,8 @@ export class TransactionController extends BaseControllerV1<
     initialList?: TransactionMeta[];
     filterToCurrentNetwork?: boolean;
     limit?: number;
+    chainId?: Hex;
   } = {}): TransactionMeta[] {
-    const chainId = this.getChainId(); // TODO(JL): This should be made into an optional param
     // searchCriteria is an object that might have values that aren't predicate
     // methods. When providing any other value type (string, number, etc), we
     // consider this shorthand for "check the value at key for strict equality


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
