### PR TITLE
fix: refetch metadata from URI for original URI with id

### DIFF
--- a/packages/assets-controllers/src/assetsUtil.test.ts
+++ b/packages/assets-controllers/src/assetsUtil.test.ts
@@ -585,6 +585,23 @@ describe('assetsUtil', () => {
       }
     });
   });
+
+  describe('getFetchableURI', () => {
+    it('should return the input tokenURI if no match found', () => {
+      const testURI = 'test';
+      const result = assetsUtil.getFetchableURI(testURI);
+      expect(result).toBe('test');
+    });
+
+    it('should return original tokenId when a match is found', () => {
+      const testURI =
+        'https://cloudflare-ipfs.com/ipfs/bafybeidojhsf6aqfewgvvvb7tefeuv5p7nnf7gqthlpcybqulmmz5whcjm/0000000000000000000000000000000000000000000000000000000048d9a18e';
+      const result = assetsUtil.getFetchableURI(testURI);
+      expect(result).toBe(
+        'https://cloudflare-ipfs.com/ipfs/bafybeidojhsf6aqfewgvvvb7tefeuv5p7nnf7gqthlpcybqulmmz5whcjm/1222222222',
+      );
+    });
+  });
 });
 
 /**

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -460,3 +460,29 @@ export async function fetchTokenContractExchangeRates({
     {},
   );
 }
+
+// Regex to match any last strings in URI starting from the last "/"
+// Example given a string: https://something.something/something/tokenID0001, it will return tokenID0001
+export const extractedTokenIdRegex = /\/([^/]+)$/u;
+
+/**
+ * Retrieve the tokenId from URI, converts it from hex to original tokenID
+ * @param tokenUri - string URI value
+ * @returns URI that can be used to fetch metadata object
+ */
+export const getFetchableURI = (tokenUri: string) => {
+  // tokenUri must be a match
+  const match = tokenUri.match(extractedTokenIdRegex);
+  // Extract the numeric string from the match
+  if (match) {
+    // Extract the substring from the match
+    const extractedHexTokenId = match[1];
+    // Convert extracted Hex tokenId to original id
+    const originalId = parseInt(extractedHexTokenId, 16);
+
+    // Replace the original uri string in the converted tokenId string
+    const result = tokenUri.replace(extractedTokenIdRegex, `/${originalId}`);
+    return result;
+  }
+  return tokenUri;
+};


### PR DESCRIPTION
## Explanation

This PR adds a check if the original tokenId includes "/{id}", in those cases, we will convert the tokenId value to hex format, hence,  the tokenURI value will have a hex format of the tokenId.
In those cases the handleFetch will fail causing the image to be null.
However, even though this fetch would fail, the getNftInformationFromApi will succeed and populate
the imgUrl. The issue here is when the tokenURI is updated on the contract, and we fetch the data from opensea again, the imgUrl will not be updated. Opensea made a fix recently for this, however, you would have to call the refresh metadata API to get the updated image.

To avoid calling another opensea API, and because the getNftInformationFromApi would always return the not updated imgUrl, i am recreating a fetchable URI to get the imgURL. This will make the pull down experience on mobile display the updated img when metadata is updated.

## References

For example:
* Related to [#67890](https://github.com/MetaMask/metamask-mobile/pull/8348)


## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- FIXED: Added a utility fct getFetchableURI in assetsUtils.ts to convert the tokenId hex format to original format. This fct is only called in case the originalTokenURI includes {id}.
- FIXED: Added a check in fct getNftInformationFromTokenURI in nftController.ts to check if original URI includes {id} if it is the case we convert it to original tokenId so its possible to fetch metadata.
- FIXED: Made the fct getNftURIAndStandard return also the original tokenURI.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
