### PR TITLE
feat: private destroy variable of Network Controller

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -556,6 +556,8 @@ export class NetworkController extends BaseController<
 
   #autoManagedNetworkClientRegistry?: AutoManagedNetworkClientRegistry;
 
+  #destroyed: boolean;
+
   constructor({
     messenger,
     state,
@@ -635,6 +637,7 @@ export class NetworkController extends BaseController<
     );
 
     this.#previousProviderConfig = this.state.providerConfig;
+    this.#destroyed = false;
   }
 
   /**
@@ -913,7 +916,7 @@ export class NetworkController extends BaseController<
       }
     }
 
-    if (networkChanged) {
+    if (networkChanged || this.#destroyed) {
       // If the network has changed, then `lookupNetwork` either has been or is
       // in the process of being called, so we don't need to go further.
       return;
@@ -1345,6 +1348,7 @@ export class NetworkController extends BaseController<
    * In-progress requests will not be aborted.
    */
   async destroy() {
+    this.#destroyed = true;
     await this.#blockTrackerProxy?.destroy();
   }
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
The network controller needed a internal destroy variable, to be able to stop `lookupNetwork` function being processed if the Network Controller was destroyed by the client. 

* What is the solution your changes offer and how does it work?
The solution is on the `lookupNetwork`, verify if the controller was destroyed (we only assign that new internal variable to true if the `destroy` function was called), if it was destroyed we stop the on going lookupNetwork function.

-->

## References

Relates to the upgrade on mobile to controllers v53: https://github.com/MetaMask/metamask-mobile/pull/7999

## Changelog



### `@metamask/network-controller`

- **<ADDED>**: Add internal destroyed variable to stop on going lookupNetwork function.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
