### PR TITLE
Move etherscan mocks

### DIFF
--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -20,7 +20,7 @@ import {
   ETHERSCAN_TRANSACTION_RESPONSE_MOCK,
   ETHERSCAN_TOKEN_TRANSACTION_MOCK,
   ETHERSCAN_TRANSACTION_SUCCESS_MOCK,
-} from './helpers/EtherscanMocks';
+} from '../test/EtherscanMocks';
 import { TransactionController } from './TransactionController';
 import type { TransactionMeta } from './types';
 import { TransactionStatus, TransactionType } from './types';

--- a/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.test.ts
+++ b/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.test.ts
@@ -16,7 +16,7 @@ import {
   EXPECTED_NORMALISED_TOKEN_TRANSACTION,
   ETHERSCAN_TOKEN_TRANSACTION_RESPONSE_ERROR_MOCK,
   ETHERSCAN_TRANSACTION_RESPONSE_ERROR_MOCK,
-} from './EtherscanMocks';
+} from '../../test/EtherscanMocks';
 import { EtherscanRemoteTransactionSource } from './EtherscanRemoteTransactionSource';
 
 jest.mock('../utils/etherscan', () => ({

--- a/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.test.ts
+++ b/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.test.ts
@@ -1,10 +1,5 @@
 import { v1 as random } from 'uuid';
 
-import { CHAIN_IDS } from '../constants';
-import {
-  fetchEtherscanTokenTransactions,
-  fetchEtherscanTransactions,
-} from '../utils/etherscan';
 import {
   ID_MOCK,
   ETHERSCAN_TRANSACTION_RESPONSE_EMPTY_MOCK,
@@ -17,6 +12,11 @@ import {
   ETHERSCAN_TOKEN_TRANSACTION_RESPONSE_ERROR_MOCK,
   ETHERSCAN_TRANSACTION_RESPONSE_ERROR_MOCK,
 } from '../../test/EtherscanMocks';
+import { CHAIN_IDS } from '../constants';
+import {
+  fetchEtherscanTokenTransactions,
+  fetchEtherscanTransactions,
+} from '../utils/etherscan';
 import { EtherscanRemoteTransactionSource } from './EtherscanRemoteTransactionSource';
 
 jest.mock('../utils/etherscan', () => ({

--- a/packages/transaction-controller/test/EtherscanMocks.ts
+++ b/packages/transaction-controller/test/EtherscanMocks.ts
@@ -1,10 +1,10 @@
-import { TransactionStatus, TransactionType } from '../types';
+import { TransactionStatus, TransactionType } from '../src/types';
 import type {
   EtherscanTokenTransactionMeta,
   EtherscanTransactionMeta,
   EtherscanTransactionMetaBase,
   EtherscanTransactionResponse,
-} from '../utils/etherscan';
+} from '../src/utils/etherscan';
 
 export const ID_MOCK = '6843ba00-f4bf-11e8-a715-5f2fff84549d';
 


### PR DESCRIPTION
## Explanation

* Moves etherscan mocks into `test` folder outside of the `src` folder which also means it won't be included in builds

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
