### PR TITLE
Improve rate limiting logic in `etherscanRemoteTransactionSource`

### DIFF
--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -3095,7 +3095,7 @@ describe('TransactionController Integration', () => {
       );
 
       // we have to wait for the mutex to be released after the 5 second API rate limit timer
-      await advanceTime({ clock, duration: 5000 });
+      await advanceTime({ clock, duration: 1 });
 
       expect(transactionController.state.transactions).toHaveLength(
         2 * networkClientIds.length,


### PR DESCRIPTION
Addresses [feedback](https://github.com/MetaMask/core/pull/3643#discussion_r1470225885) given on the feature branch.

We no longer wait til the rate limit time is up to return the fetchedTransaction. We only wait the full time to unlock the mutex to prevent another request until 5 seconds have elapsed.