### PR TITLE
[composable-controller] Remove `flatState` getter

### DIFF
--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -120,21 +120,6 @@ describe('ComposableController', () => {
       });
     });
 
-    it('should compose flat controller state', () => {
-      const composableMessenger = new ControllerMessenger().getRestricted({
-        name: 'ComposableController',
-      });
-      const controller = new ComposableController({
-        controllers: [new BarController(), new BazController()],
-        messenger: composableMessenger,
-      });
-
-      expect(controller.flatState).toStrictEqual({
-        bar: 'bar',
-        baz: 'baz',
-      });
-    });
-
     it('should notify listeners of nested state change', () => {
       const controllerMessenger = new ControllerMessenger<
         never,
@@ -185,28 +170,6 @@ describe('ComposableController', () => {
       });
       expect(composableController.state).toStrictEqual({
         FooController: { foo: 'foo' },
-      });
-    });
-
-    it('should compose flat controller state', () => {
-      const controllerMessenger = new ControllerMessenger<
-        never,
-        FooControllerEvent
-      >();
-      const fooControllerMessenger = controllerMessenger.getRestricted({
-        name: 'FooController',
-      });
-      const fooController = new FooController(fooControllerMessenger);
-      const composableControllerMessenger = controllerMessenger.getRestricted({
-        name: 'ComposableController',
-        allowedEvents: ['FooController:stateChange'],
-      });
-      const composableController = new ComposableController({
-        controllers: [fooController],
-        messenger: composableControllerMessenger,
-      });
-      expect(composableController.flatState).toStrictEqual({
-        foo: 'foo',
       });
     });
 
@@ -270,30 +233,6 @@ describe('ComposableController', () => {
       expect(composableController.state).toStrictEqual({
         BarController: { bar: 'bar' },
         FooController: { foo: 'foo' },
-      });
-    });
-
-    it('should compose flat controller state', () => {
-      const barController = new BarController();
-      const controllerMessenger = new ControllerMessenger<
-        never,
-        FooControllerEvent
-      >();
-      const fooControllerMessenger = controllerMessenger.getRestricted({
-        name: 'FooController',
-      });
-      const fooController = new FooController(fooControllerMessenger);
-      const composableControllerMessenger = controllerMessenger.getRestricted({
-        name: 'ComposableController',
-        allowedEvents: ['FooController:stateChange'],
-      });
-      const composableController = new ComposableController({
-        controllers: [barController, fooController],
-        messenger: composableControllerMessenger,
-      });
-      expect(composableController.flatState).toStrictEqual({
-        bar: 'bar',
-        foo: 'foo',
       });
     });
 

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -100,21 +100,6 @@ export class ComposableController extends BaseController<
   }
 
   /**
-   * Flat state representation, one that isn't keyed
-   * of controller name. Instead, all child controller state is merged
-   * together into a single, flat object.
-   *
-   * @returns Merged state representation of all child controllers.
-   */
-  get flatState() {
-    let flatState = {};
-    for (const controller of this.#controllers) {
-      flatState = { ...flatState, ...controller.state };
-    }
-    return flatState;
-  }
-
-  /**
    * Adds a child controller instance to composable controller state,
    * or updates the state of a child controller.
    * @param controller - Controller instance to update


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR removes the `flatState` getter from `@metamask/composable-controller`

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes #3812 

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/composable-controller`

- **BREAKING**: Remove `flatState` getter
  - This method was confusing to use in practice. Consumers should use the ComposableController state directly.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
