### PR TITLE
Ensure selectedNetworkController always returns a networkClientId whe…

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -194,11 +194,7 @@ export class SelectedNetworkController extends BaseController<
 
   getNetworkClientIdForDomain(domain: Domain): NetworkClientId {
     if (this.state.perDomainNetwork) {
-      const id = this.state.domains[domain];
-      if (id === undefined) {
-        return this.state.domains[METAMASK_DOMAIN];
-      }
-      return id;
+      return this.state.domains[domain] ?? this.state.domains[METAMASK_DOMAIN];
     }
     return this.state.domains[METAMASK_DOMAIN];
   }

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -192,9 +192,13 @@ export class SelectedNetworkController extends BaseController<
     this.#setNetworkClientIdForDomain(domain, networkClientId);
   }
 
-  getNetworkClientIdForDomain(domain: Domain) {
+  getNetworkClientIdForDomain(domain: Domain): NetworkClientId {
     if (this.state.perDomainNetwork) {
-      return this.state.domains[domain];
+      const id = this.state.domains[domain];
+      if (id === undefined) {
+        return this.state.domains[METAMASK_DOMAIN];
+      }
+      return id;
     }
     return this.state.domains[METAMASK_DOMAIN];
   }

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -205,6 +205,18 @@ describe('SelectedNetworkController', () => {
       expect(result1).toBe(networkClientId1);
       expect(result2).toBe(networkClientId2);
     });
+
+    it('returns the networkClientId for the metamask domain, when the perDomainNetwork option is true, but no networkClientId has been set for the domain requested', () => {
+      const options: SelectedNetworkControllerOptions = {
+        messenger: buildSelectedNetworkControllerMessenger(),
+      };
+      const controller = new SelectedNetworkController(options);
+      controller.state.perDomainNetwork = true;
+      const networkClientId = 'network7';
+      controller.setNetworkClientIdForMetamask(networkClientId);
+      const result = controller.getNetworkClientIdForDomain('example.com');
+      expect(result).toBe(networkClientId);
+    });
   });
 
   describe('getProviderAndBlockTracker', () => {


### PR DESCRIPTION

## References

Fixes https://github.com/MetaMask/MetaMask-planning/issues/1868

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/selected-network-controller`

- **ADDED**: getNetworkClientIdForDomain will return the same networkClientId as used by the domain `"metamask"` when there is no networkClientId set for the domain yet.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
