### PR TITLE
Updating name provider labels to be string ids for localization

### DIFF
--- a/packages/name-controller/src/providers/ens.ts
+++ b/packages/name-controller/src/providers/ens.ts
@@ -13,7 +13,7 @@ export type ReverseLookupCallback = (
 ) => Promise<string>;
 
 const ID = 'ens';
-const LABEL = 'Ethereum Name Service (ENS)';
+const LABEL = 'nameProviderEns';
 
 const log = createModuleLogger(projectLogger, 'ens');
 

--- a/packages/name-controller/src/providers/etherscan.ts
+++ b/packages/name-controller/src/providers/etherscan.ts
@@ -12,7 +12,7 @@ import { NameType } from '../types';
 import { handleFetch, assertIsError } from '../util';
 
 const ID = 'etherscan';
-const LABEL = 'Etherscan (Verified Contract Name)';
+const LABEL = 'nameProviderEtherscan';
 const RATE_LIMIT_UPDATE_DELAY = 5; // 5 Seconds
 const RATE_LIMIT_INTERVAL = RATE_LIMIT_UPDATE_DELAY * 1000;
 

--- a/packages/name-controller/src/providers/lens.ts
+++ b/packages/name-controller/src/providers/lens.ts
@@ -9,7 +9,7 @@ import { NameType } from '../types';
 import { graphQL } from '../util';
 
 const ID = 'lens';
-const LABEL = 'Lens Protocol';
+const LABEL = 'nameProviderLens';
 const LENS_URL = `https://api.lens.dev`;
 
 const QUERY = `

--- a/packages/name-controller/src/providers/token.ts
+++ b/packages/name-controller/src/providers/token.ts
@@ -9,7 +9,7 @@ import { NameType } from '../types';
 import { handleFetch } from '../util';
 
 const ID = 'token';
-const LABEL = 'Blockchain (Token Name)';
+const LABEL = 'nameProviderToken';
 
 const log = createModuleLogger(projectLogger, 'token');
 


### PR DESCRIPTION
## Explanation

Updating name provider labels to be string ids for localization.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/name-controller`

- **BREAKING**: name provider labels are now string ids to be localized, and not user-readable text.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
