### PR TITLE
Jl/transaction multichain approve transactions with same nonce network client id fallback

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -637,11 +637,28 @@ describe('TransactionController', () => {
         }
       });
 
+      const mockFindNetworkClientIdByChainId = jest
+      .fn()
+      .mockImplementation((chainId) => {
+        switch(chainId) {
+          case '0x1':
+            return 'mainnet'
+          case ChainId.sepolia:
+            return 'sepolia'
+          case ChainId.goerli:
+            return 'goerli'
+          case '0xa':
+            return 'customNetworkClientId-1'
+          default:
+            throw new Error("Couldn't find networkClientId for chainId")
+        }
+      });
+
     ({ messenger: messengerMock, approve: approveTransaction } =
       buildMockMessenger({
         addRequest: addRequestMockOptions,
         getNetworkClientById: mockGetNetworkClientById,
-        findNetworkClientIdByChainId: jest.fn(),
+        findNetworkClientIdByChainId: mockFindNetworkClientIdByChainId,
       }));
 
     return new TransactionController(
@@ -3861,6 +3878,39 @@ describe('TransactionController', () => {
       );
 
       expect(getNonceLockMock).not.toHaveBeenCalled();
+    });
+
+    it('uses the nonceTracker for the networkClientId matching the chainId', async () => {
+      const controller = newController({
+        options: { isMultichainEnabled: true },
+      });
+
+      const getNonceLockMock = jest
+      .spyOn(controller, 'getNonceLock')
+
+      const mockTransactionParam = {
+        from: ACCOUNT_MOCK,
+        nonce: '0x1',
+        gas: '0x111',
+        to: ACCOUNT_2_MOCK,
+        value: '0x0',
+        chainId: MOCK_NETWORK.state.providerConfig.chainId,
+      };
+
+      const mockTransactionParam2 = {
+        from: ACCOUNT_MOCK,
+        nonce: '0x1',
+        gas: '0x222',
+        to: ACCOUNT_2_MOCK,
+        value: '0x1',
+        chainId: MOCK_NETWORK.state.providerConfig.chainId,
+      };
+
+      await controller.approveTransactionsWithSameNonce(
+        [mockTransactionParam, mockTransactionParam2]
+      );
+
+      expect(getNonceLockMock).toHaveBeenCalledWith(ACCOUNT_MOCK, 'goerli')
     });
   });
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1783,6 +1783,21 @@ export class TransactionController extends BaseControllerV1<
     const initialTx = listOfTxParams[0];
     const common = this.getCommonConfiguration(initialTx.chainId);
 
+    // We need to ensure we get the nonce using the the NonceTracker on the chain matching
+    // the txParams. In this context we only have chainId available to us, but the
+    // NonceTrackers are keyed by networkClientId. To workaround this, we attempt to find
+    // a networkClientId that matches the chainId. As a fallback, the globally selected
+    // network's NonceTracker will be used instead.
+    let networkClientId: NetworkClientId | undefined;
+    try {
+      networkClientId = this.messagingSystem.call(
+        `NetworkController:findNetworkClientIdByChainId`,
+        initialTx.chainId,
+      );
+    } catch (err) {
+      log('failed to find networkClientId from chainId', err);
+    }
+
     const initialTxAsEthTx = TransactionFactory.fromTxData(initialTx, {
       common,
     });
@@ -1801,7 +1816,7 @@ export class TransactionController extends BaseControllerV1<
       const requiresNonce = hasNonce !== true;
 
       nonceLock = requiresNonce
-        ? await this.getNonceLock(fromAddress)
+        ? await this.getNonceLock(fromAddress, networkClientId)
         : undefined;
 
       const nonce = nonceLock


### PR DESCRIPTION
## Explanation

Currently `approveTransactionsWithSameNonce` may need to populate the txParams it is passed with a nonce, but the current implementation only works correctly when calling this method while globally selected network is on the same chainId. To get this to work with multichain, we attempt to resolve the txParams chainId to a networkClientId which we then use to pull a NonceTracker on the right chain out of the trackingMap. One downside of this approach is that it's possible to use the NonceTracker for a different network client that's also on the same chain than the network client that this tx is being submitted on.

## References

See: https://github.com/MetaMask/MetaMask-planning/issues/2023#issuecomment-1930555110

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
