### PR TITLE
fix: NFT detection running too many times

### DIFF
--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -570,6 +570,34 @@ describe('NftDetectionController', () => {
       },
     );
   });
+
+  it('should only re-detect when relevant settings change', async () => {
+    await withController(
+      {},
+      async ({ controller, triggerPreferencesStateChange }) => {
+        const detectNfts = sinon.stub(controller, 'detectNfts');
+
+        // Repeated preference changes should only trigger 1 detection
+        for (let i = 0; i < 5; i++) {
+          triggerPreferencesStateChange({
+            ...getDefaultPreferencesState(),
+            useNftDetection: true,
+          });
+        }
+        await advanceTime({ clock, duration: 1 });
+        expect(detectNfts.callCount).toBe(1);
+
+        // Irrelevant preference changes shouldn't trigger a detection
+        triggerPreferencesStateChange({
+          ...getDefaultPreferencesState(),
+          useNftDetection: true,
+          securityAlertsEnabled: true,
+        });
+        await advanceTime({ clock, duration: 1 });
+        expect(detectNfts.callCount).toBe(1);
+      },
+    );
+  });
 });
 
 type WithControllerCallback<ReturnValue> = ({

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -299,9 +299,6 @@ export class NftDetectionController extends StaticIntervalPollingControllerV1<
         !useNftDetection !== disabled
       ) {
         this.configure({ selectedAddress, disabled: !useNftDetection });
-      }
-
-      if (useNftDetection !== undefined) {
         if (useNftDetection) {
           this.start();
         } else {


### PR DESCRIPTION
## Explanation

The `NftDetectionController` was making unnecessary HTTP requests.

(1) It was fetching NFTs when any setting changes:

https://github.com/MetaMask/core/assets/3500406/297b1889-ee17-4c57-890b-8f94e4b1be4b

(2) When each polling interval arrives, it can send ~7 identical requests instead of 1.  See timeline:

<img width="1001" alt="Screenshot 2024-02-13 at 6 08 53 PM" src="https://github.com/MetaMask/core/assets/3500406/c8052108-7e2e-4d42-8732-05b25311a2bf">

(3) one redundant request when switching accounts

All come from `onPreferencesStateChange` triggering a re-start.

(2)  happens because it fires ~7 times on startup from keyring related updates.  This causes each to run:

```
this.stopPolling();
await this.detectNfts();
this.intervalId = setInterval(...)
```

Because `detectNfts` is async, `intervalId` is still undefined.  So they each schedule their own interval without stopping a previous interval.

Fix: Only start/stop when relevant settings change.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **FIXED**: NFT detection running too many times

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
