### PR TITLE
Add SL as codeowners for snaps-owned controllers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,7 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/devs
-
-/packages/permission-controller      @MetaMask/snaps-devs
-/packages/notification-controller    @MetaMask/snaps-devs
-/packages/rate-limit-controller      @MetaMask/snaps-devs
+*                                    @MetaMask/engineering
+/packages/permission-controller      @MetaMask/snaps-devs @MetaMask/shared-libraries-engineers
+/packages/notification-controller    @MetaMask/snaps-devs @MetaMask/shared-libraries-engineers
+/packages/rate-limit-controller      @MetaMask/snaps-devs @MetaMask/shared-libraries-engineers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/engineering
+*                                    @MetaMask/extension-devs @MetaMask/mobile-devs @MetaMask/shared-libraries-engineers
 /packages/permission-controller      @MetaMask/snaps-devs @MetaMask/shared-libraries-engineers
 /packages/notification-controller    @MetaMask/snaps-devs @MetaMask/shared-libraries-engineers
 /packages/rate-limit-controller      @MetaMask/snaps-devs @MetaMask/shared-libraries-engineers


### PR DESCRIPTION


## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Whenever the version of a package in this monorepo is bumped, all dependencies on that package in other workspace packages are also bumped. This happens frequently in release PRs.

The Snaps team is listed as codeowners of `permission-controller`, `notification-controller`, and `rate-limit-controller`, so when any changes to these packages occur in a PR, the Snaps team must approve that PR. This means that if a dependency on a package is bumped in any of these controllers within a release PR, then the Snaps team must approve that release — even if none of those controllers are included in the release. This creates an obstacle to creating releases quickly.

To fix this, this commit adds the Shared Libraries team as codeowners of these controllers as well. This way, they can ask the Snaps team to approve only if it is necessary.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

(N/A)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
