### PR TITLE
fix: Convert BN to hexadecimal when balance from chain is defined

### DIFF
--- a/packages/assets-controllers/src/AccountTrackerController.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.ts
@@ -272,9 +272,12 @@ export class AccountTrackerController extends StaticIntervalPollingControllerV1<
 
       const accountsForChain = { ...accountsByChainId[chainId] };
       for (const address of accountsToUpdate) {
-        accountsForChain[address] = {
-          balance: BNToHex(await this.getBalanceFromChain(address, ethQuery)),
-        };
+        const balance = await this.getBalanceFromChain(address, ethQuery);
+        if (balance) {
+          accountsForChain[address] = {
+            balance: BNToHex(balance),
+          };
+        }
       }
 
       this.update({


### PR DESCRIPTION
## Explanation

Currently, we are trying to convert to hexadecimal a balance that is undefined because ethQuery is not initialized yet and we are not able to fetch the balance.

## References

## Changelog

### `@metamask/assets-controllers`

- **<FIXED>**:  Added condition on `refresh` function to only convert to hexadecimal if balance is defined

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
