### PR TITLE
Refactor PermissionLogController tests

### DIFF
--- a/packages/permission-log-controller/src/PermissionLogController.ts
+++ b/packages/permission-log-controller/src/PermissionLogController.ts
@@ -83,9 +83,6 @@ const defaultState: PermissionLogControllerState = {
   permissionActivityLog: [],
 };
 
-/**
- * The name of the {@link PermissionController}.
- */
 const name = 'PermissionLogController';
 
 /**

--- a/packages/permission-log-controller/tests/helpers.ts
+++ b/packages/permission-log-controller/tests/helpers.ts
@@ -288,8 +288,6 @@ export const constants = deepFreeze({
 
   PERM_NAMES: { ...PERM_NAMES },
 
-  RESTRICTED_METHODS: new Set(['eth_accounts', 'test_method']),
-
   /**
    * Mock permissions history objects.
    */


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This pull request is designed to align the tests for `PermissionLogController` with the guidelines outlined in our contributor documentation. The objective is to refactor these tests in accordance with best practices recommended for unit testing, as detailed in the provided documentation [link](https://github.com/MetaMask/contributor-docs/blob/main/docs/unit-testing.md).

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #1827
* Related to #67890
-->

* Fixes #1827

## Changes
- Discontinued the use of beforeEach for the majority of the tests, with exceptions made for certain tests that utilize fake timers. Now, each test individually initializes a new controller and middleware within its own scope, enhancing test isolation and clarity.
- Split long test scenarios for more focused test cases.
## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
