### PR TITLE
fix: price api cache control

### DIFF
--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -356,7 +356,9 @@ export class CodefiTokenPricesServiceV2
     const pricesByCurrencyByTokenAddress: SpotPricesEndpointData<
       Lowercase<Hex>,
       Lowercase<SupportedCurrency>
-    > = await this.#tokenPricePolicy.execute(() => handleFetch(url));
+    > = await this.#tokenPricePolicy.execute(() =>
+      handleFetch(url, { headers: { 'Cache-Control': 'no-cache' } }),
+    );
 
     return tokenAddresses.reduce(
       (


### PR DESCRIPTION
## Explanation

Sets `Cache-Control: no-cache` on price API requests.

See: https://consensys.slack.com/archives/C065W3877E3/p1708468886411439?thread_ts=1708466257.782319&cid=C065W3877E3

## References

## Changelog

### `@metamask/assets-controllers`

- **CHANGED**: HTTP requests to the price API now use the `no-cache` directive.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
