### PR TITLE
Fix: When querying bundler, use existing gas prices if available 

### DIFF
--- a/packages/user-operation-controller/src/constants.ts
+++ b/packages/user-operation-controller/src/constants.ts
@@ -1,3 +1,4 @@
 export const EMPTY_BYTES = '0x';
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
 export const VALUE_ZERO = '0x0';
+export const VALUE_ONE = '0x1';

--- a/packages/user-operation-controller/src/utils/gas.ts
+++ b/packages/user-operation-controller/src/utils/gas.ts
@@ -1,7 +1,7 @@
 import { hexToBN } from '@metamask/controller-utils';
 import { BN, addHexPrefix } from 'ethereumjs-util';
 
-import { VALUE_ZERO } from '../constants';
+import { VALUE_ZERO, VALUE_ONE } from '../constants';
 import { Bundler } from '../helpers/Bundler';
 import { createModuleLogger, projectLogger } from '../logger';
 import type {
@@ -27,7 +27,13 @@ export async function updateGas(
   prepareResponse: PrepareUserOperationResponse,
   entrypoint: string,
 ) {
-  const { userOperation } = metadata;
+  const { userOperation, transactionParams } = metadata;
+  let gasPrice, maxFeePerGas, maxPriorityFeePerGas;
+  if (transactionParams) {
+    gasPrice = transactionParams.gasPrice;
+    maxFeePerGas = transactionParams.maxFeePerGas;
+    maxPriorityFeePerGas = transactionParams.maxPriorityFeePerGas;
+  }
 
   if (prepareResponse.gas) {
     userOperation.callGasLimit = prepareResponse.gas.callGasLimit;
@@ -46,8 +52,8 @@ export async function updateGas(
 
   const payload = {
     ...userOperation,
-    maxFeePerGas: VALUE_ZERO,
-    maxPriorityFeePerGas: VALUE_ZERO,
+    maxFeePerGas: maxFeePerGas || gasPrice || VALUE_ONE,
+    maxPriorityFeePerGas: maxPriorityFeePerGas || gasPrice || VALUE_ONE,
     callGasLimit: VALUE_ZERO,
     preVerificationGas: VALUE_ZERO,
     verificationGasLimit: '0xF4240',


### PR DESCRIPTION
## Explanation

This PR fixes issue where the gas prices being sent to the bundler is always set as 0. `maxFeePerGas` and `maxPriorityFeePerGas` from the transaction params will be used by default with the `gasPrice` and `VALUE_ONE` as the fallback. 

## References

* Fixes [#257](https://github.com/MetaMask/accounts-planning/issues/257)


## Changelog

### `@metamask/user-operations-controller`

- **CHANGED**: Use gas prices from transactions params when sending a query to a bundler.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
