### PR TITLE
fix(preferences-controller): skip sync when locking

### DIFF
--- a/packages/preferences-controller/jest.config.js
+++ b/packages/preferences-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 85.71,
-      functions: 93.75,
-      lines: 92.54,
-      statements: 92.54,
+      branches: 88.23,
+      functions: 95.12,
+      lines: 95.87,
+      statements: 95.87,
     },
   },
 });

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -325,6 +325,13 @@ describe('PreferencesController', () => {
     expect(controller.state.selectedAddress).toBe('0x00');
   });
 
+  it('should throw error when syncing identities with empty array', () => {
+    const controller = setupPreferencesController();
+    expect(() => {
+      controller.syncIdentities([]);
+    }).toThrow('Expected non-empty array of addresses');
+  });
+
   it('should add new identities', () => {
     const controller = setupPreferencesController();
     controller.updateIdentities(['0x00', '0x01']);

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -240,7 +240,9 @@ export class PreferencesController extends BaseController<
             accounts.add(account);
           }
         }
-        this.syncIdentities(Array.from(accounts));
+        if (accounts.size > 0) {
+          this.syncIdentities(Array.from(accounts));
+        }
       },
     );
   }
@@ -323,6 +325,10 @@ export class PreferencesController extends BaseController<
    * @deprecated This will be removed in a future release
    */
   syncIdentities(addresses: string[]) {
+    if (!addresses.length) {
+      throw new Error('Expected non-empty array of addresses');
+    }
+
     addresses = addresses.map((address: string) =>
       toChecksumHexAddress(address),
     );


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Upon wallet lock, `PreferencesController` will capture a `KeyringController:stateChange` event, with an empty keyring array in the payload. While this is normal behaviour, `PreferencesController` will sync its identities with this empty array of identities, which will result in setting the selected address to `undefined`.

With these changes `PreferencesController` will skip the sync when there is no identity, and throw an error in case the `syncIdentities` method is called with an empty array.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

* See: https://github.com/MetaMask/metamask-extension/pull/22949#discussion_r1495890404

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/preferences-controller`

- **FIXED**: Identities are not synced when locking anymore

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
