### PR TITLE
chore: add user-friendly error messages to user operation controller

### DIFF
--- a/packages/user-operation-controller/src/UserOperationController.ts
+++ b/packages/user-operation-controller/src/UserOperationController.ts
@@ -51,6 +51,7 @@ import {
   validateSignUserOperationResponse,
   validateUpdateUserOperationResponse,
 } from './utils/validation';
+import { errorWithPrefix } from './utils/errors';
 
 const controllerName = 'UserOperationController';
 
@@ -729,9 +730,13 @@ export class UserOperationController extends BaseController<
     }
 
     const ethQuery = new EthQuery(provider);
-    const result = determineTransactionType(transaction, ethQuery);
+    try {
+      const result = determineTransactionType(transaction, ethQuery);
 
-    return (await result).type;
+      return (await result).type;
+    } catch (error) {
+      throw errorWithPrefix(error, 'Failed to determine transaction type');
+    }
   }
 
   async #getProvider(

--- a/packages/user-operation-controller/src/UserOperationController.ts
+++ b/packages/user-operation-controller/src/UserOperationController.ts
@@ -41,6 +41,7 @@ import type {
   UserOperationMetadata,
 } from './types';
 import { UserOperationStatus } from './types';
+import { errorWithPrefix } from './utils/errors';
 import { updateGas } from './utils/gas';
 import { updateGasFees } from './utils/gas-fees';
 import { getTransactionMetadata } from './utils/transaction';
@@ -51,7 +52,6 @@ import {
   validateSignUserOperationResponse,
   validateUpdateUserOperationResponse,
 } from './utils/validation';
-import { errorWithPrefix } from './utils/errors';
 
 const controllerName = 'UserOperationController';
 

--- a/packages/user-operation-controller/src/helpers/Bundler.ts
+++ b/packages/user-operation-controller/src/helpers/Bundler.ts
@@ -2,6 +2,7 @@
 
 import { createModuleLogger, projectLogger } from '../logger';
 import type { UserOperation, UserOperationReceipt } from '../types';
+import { errorWithPrefix } from '../utils/errors';
 
 const log = createModuleLogger(projectLogger, 'bundler');
 
@@ -88,14 +89,16 @@ export class Bundler {
       entrypoint,
     });
 
-    const hash: string = await this.#query('eth_sendUserOperation', [
-      userOperation,
-      entrypoint,
-    ]);
-
-    log('Sent user operation', hash);
-
-    return hash;
+    try {
+      const hash: string = await this.#query('eth_sendUserOperation', [
+        userOperation,
+        entrypoint,
+      ]);
+      log('Sent user operation', hash);
+      return hash;
+    } catch (error) {
+      throw errorWithPrefix(error, 'Failed to send user operation to bundler');
+    }
   }
 
   async #query<T>(method: string, params: unknown[]): Promise<T> {

--- a/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.ts
+++ b/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.ts
@@ -5,13 +5,13 @@ import { BlockTrackerPollingControllerOnly } from '@metamask/polling-controller'
 import type { Json } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import EventEmitter from 'events';
+import { errorWithPrefix } from 'src/utils/errors';
 
 import { projectLogger } from '../logger';
 import type { UserOperationMetadata, UserOperationReceipt } from '../types';
 import { UserOperationStatus } from '../types';
 import type { UserOperationControllerMessenger } from '../UserOperationController';
 import { Bundler } from './Bundler';
-import { errorWithPrefix } from 'src/utils/errors';
 
 const log = createModuleLogger(projectLogger, 'pending-user-operations');
 

--- a/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.ts
+++ b/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.ts
@@ -9,6 +9,7 @@ import type {
   UpdateUserOperationResponse,
 } from '../types';
 import type { UserOperationControllerMessenger } from '../UserOperationController';
+import { errorWithPrefix } from '../utils/errors';
 
 export class SnapSmartContractAccount implements SmartContractAccount {
   #messenger: UserOperationControllerMessenger;
@@ -30,33 +31,36 @@ export class SnapSmartContractAccount implements SmartContractAccount {
     const data = requestData ?? EMPTY_BYTES;
     const to = requestTo ?? ADDRESS_ZERO;
     const value = requestValue ?? VALUE_ZERO;
+    try {
+      const response = await this.#messenger.call(
+        'KeyringController:prepareUserOperation',
+        sender,
+        [{ data, to, value }],
+      );
 
-    const response = await this.#messenger.call(
-      'KeyringController:prepareUserOperation',
-      sender,
-      [{ data, to, value }],
-    );
+      const {
+        bundlerUrl: bundler,
+        callData,
+        dummyPaymasterAndData,
+        dummySignature,
+        gasLimits: gas,
+        initCode,
+        nonce,
+      } = response;
 
-    const {
-      bundlerUrl: bundler,
-      callData,
-      dummyPaymasterAndData,
-      dummySignature,
-      gasLimits: gas,
-      initCode,
-      nonce,
-    } = response;
-
-    return {
-      bundler,
-      callData,
-      dummyPaymasterAndData,
-      dummySignature,
-      gas,
-      initCode,
-      nonce,
-      sender,
-    };
+      return {
+        bundler,
+        callData,
+        dummyPaymasterAndData,
+        dummySignature,
+        gas,
+        initCode,
+        nonce,
+        sender,
+      };
+    } catch (error) {
+      throw errorWithPrefix(error, 'Failed to prepare user operation');
+    }
   }
 
   async updateUserOperation(
@@ -64,22 +68,25 @@ export class SnapSmartContractAccount implements SmartContractAccount {
   ): Promise<UpdateUserOperationResponse> {
     const { userOperation } = request;
     const { sender } = userOperation;
+    try {
+      const { paymasterAndData: responsePaymasterAndData } =
+        await this.#messenger.call(
+          'KeyringController:patchUserOperation',
+          sender,
+          userOperation,
+        );
 
-    const { paymasterAndData: responsePaymasterAndData } =
-      await this.#messenger.call(
-        'KeyringController:patchUserOperation',
-        sender,
-        userOperation,
-      );
+      const paymasterAndData =
+        responsePaymasterAndData === EMPTY_BYTES
+          ? undefined
+          : responsePaymasterAndData;
 
-    const paymasterAndData =
-      responsePaymasterAndData === EMPTY_BYTES
-        ? undefined
-        : responsePaymasterAndData;
-
-    return {
-      paymasterAndData,
-    };
+      return {
+        paymasterAndData,
+      };
+    } catch (error) {
+      throw errorWithPrefix(error, 'Failed to update user operation');
+    }
   }
 
   async signUserOperation(
@@ -87,13 +94,16 @@ export class SnapSmartContractAccount implements SmartContractAccount {
   ): Promise<SignUserOperationResponse> {
     const { userOperation } = request;
     const { sender } = userOperation;
+    try {
+      const signature = await this.#messenger.call(
+        'KeyringController:signUserOperation',
+        sender,
+        userOperation,
+      );
 
-    const signature = await this.#messenger.call(
-      'KeyringController:signUserOperation',
-      sender,
-      userOperation,
-    );
-
-    return { signature };
+      return { signature };
+    } catch (error) {
+      throw errorWithPrefix(error, 'Failed to sign user operation');
+    }
   }
 }

--- a/packages/user-operation-controller/src/utils/errors.test.ts
+++ b/packages/user-operation-controller/src/utils/errors.test.ts
@@ -1,0 +1,14 @@
+import { errorWithPrefix } from './errors';
+
+describe('errorWithPrefix', () => {
+  it('should prefix the error message', () => {
+    const error = new Error('error message');
+    const prefixedError = errorWithPrefix(error, 'prefix');
+    expect(prefixedError.message).toBe('prefix: error message');
+  });
+  it('should prefix non-Error values', () => {
+    const error = 'error message';
+    const prefixedError = errorWithPrefix(error, 'prefix');
+    expect(prefixedError.message).toBe('prefix: error message');
+  });
+});

--- a/packages/user-operation-controller/src/utils/errors.ts
+++ b/packages/user-operation-controller/src/utils/errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Prepends the given prefix to the error message.
+ *
+ * @param error - The error to prefix.
+ * @param prefix - The prefix to prepend to the error message.
+ * @returns The error with the prefixed message.
+ */
+export function errorWithPrefix(error: unknown, prefix: string): Error {
+  if (error instanceof Error) {
+    error.message = `${prefix}: ${error.message}`;
+    return error;
+  }
+
+  return new Error(`${prefix}: ${String(error)}`);
+}


### PR DESCRIPTION
## Explanation
Introduce custom error messages and prefixes to add additional clarity to the user in the event of an error.

### Background
@matthewwalsh0 wrote in [internal ticket](https://github.com/MetaMask/MetaMask-planning/issues/2003): 

> The `UserOperationController` communicates with other entities throughout the lifecycle of each user operation. This includes:
> 
> - Submitting requests to the bundler.
> - Sending requests to the `SmartContractAccount` and therefore the `KeyringController` by default.
> - Sending requests to the RPC provider.
> 
> In all these instances, there is currently no custom error capturing logic meaning the errors from these entities present directly to the user in the case of an error. This can lead to ambiguous or technical error messages that are undesirable to surface in the clients.

## References

* Fixes https://github.com/MetaMask/MetaMask-planning/issues/2003

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/user-operation-controller`

- **CHANGED**: Added user-friendly error messages

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
