### PR TITLE
[base-controller] Fix `any` usage in `BaseControllerV1`

### DIFF
--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Convert `BaseConfig`, `BaseState` interfaces to types.
+  - As types, `BaseConfig`, `BaseState` now extend `Record` and have an index signature of `string`.
+
 ## [4.1.1]
 
 ### Changed

--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **BREAKING:** Convert `BaseConfig`, `BaseState` interfaces to types ([#3959](https://github.com/MetaMask/core/pull/3959))
-  - As types, `BaseConfig`, `BaseState` now extend `Record` and have an index signature of `string`.
-
 ## [4.1.1]
 
 ### Changed

--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Convert `BaseConfig`, `BaseState` interfaces to types.
+- **BREAKING:** Convert `BaseConfig`, `BaseState` interfaces to types ([#3959](https://github.com/MetaMask/core/pull/3959))
   - As types, `BaseConfig`, `BaseState` now extend `Record` and have an index signature of `string`.
 
 ## [4.1.1]

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -9,9 +9,12 @@ export type Listener<T> = (state: T) => void;
  * Base controller configuration
  * @property disabled - Determines if this controller is enabled
  */
-export type BaseConfig = {
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export interface BaseConfig {
   disabled?: boolean;
-};
+}
 
 /**
  * @type BaseState
@@ -19,9 +22,12 @@ export type BaseConfig = {
  * Base state representation
  * @property name - Unique name for this controller
  */
-export type BaseState = {
+// This interface was created before this ESLint rule was added.
+// Convert to a `type` in a future major version.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export interface BaseState {
   name?: string;
-};
+}
 
 /**
  * @deprecated This class has been renamed to BaseControllerV1 and is no longer recommended for use for controllers. Please use BaseController (formerly BaseControllerV2) instead.

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -71,6 +71,8 @@ export class BaseControllerV1<C extends BaseConfig, S extends BaseState> {
    * @param state - Initial state to set on this controller.
    */
   constructor(config: Partial<C> = {}, state: Partial<S> = {}) {
+    this.initialState = { ...(state as S) };
+    this.initialConfig = { ...(config as C) };
   }
 
   /**

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -36,12 +36,12 @@ export class BaseControllerV1<C extends BaseConfig, S extends BaseState> {
   /**
    * Default options used to configure this controller
    */
-  defaultConfig: C = {} as C;
+  defaultConfig: C = {} as never;
 
   /**
    * Default state set on this controller
    */
-  defaultState: S = {} as S;
+  defaultState: S = {} as never;
 
   /**
    * Determines if listeners are notified of state changes
@@ -70,10 +70,7 @@ export class BaseControllerV1<C extends BaseConfig, S extends BaseState> {
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
    */
-  constructor(config: Partial<C> = {} as C, state: Partial<S> = {} as S) {
-    // Use assign since generics can't be spread: https://git.io/vpRhY
-    this.initialState = state as S;
-    this.initialConfig = config as C;
+  constructor(config: Partial<C> = {}, state: Partial<S> = {}) {
   }
 
   /**

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -53,9 +53,9 @@ export class BaseControllerV1<C extends BaseConfig, S extends BaseState> {
    */
   name = 'BaseController';
 
-  private readonly initialConfig: C;
+  private readonly initialConfig: Partial<C>;
 
-  private readonly initialState: S;
+  private readonly initialState: Partial<S>;
 
   private internalConfig: C = this.defaultConfig;
 
@@ -71,8 +71,8 @@ export class BaseControllerV1<C extends BaseConfig, S extends BaseState> {
    * @param state - Initial state to set on this controller.
    */
   constructor(config: Partial<C> = {}, state: Partial<S> = {}) {
-    this.initialState = { ...(state as S) };
-    this.initialConfig = { ...(config as C) };
+    this.initialState = state;
+    this.initialConfig = config;
   }
 
   /**

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -9,12 +9,9 @@ export type Listener<T> = (state: T) => void;
  * Base controller configuration
  * @property disabled - Determines if this controller is enabled
  */
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export interface BaseConfig {
+export type BaseConfig = {
   disabled?: boolean;
-}
+};
 
 /**
  * @type BaseState
@@ -22,12 +19,9 @@ export interface BaseConfig {
  * Base state representation
  * @property name - Unique name for this controller
  */
-// This interface was created before this ESLint rule was added.
-// Convert to a `type` in a future major version.
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export interface BaseState {
+export type BaseState = {
   name?: string;
-}
+};
 
 /**
  * @deprecated This class has been renamed to BaseControllerV1 and is no longer recommended for use for controllers. Please use BaseController (formerly BaseControllerV2) instead.

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -128,21 +128,19 @@ export class BaseControllerV1<C extends BaseConfig, S extends BaseState> {
         ? (config as C)
         : Object.assign(this.internalConfig, config);
 
-      for (const [key, value] of Object.entries(this.internalConfig)) {
+      for (const key of Object.keys(this.internalConfig) as (keyof C)[]) {
+        const value = this.internalConfig[key];
         if (value !== undefined) {
-          // TODO: Replace `any` with type
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (this as any)[key] = value;
+          (this as unknown as C)[key] = value;
         }
       }
     } else {
       for (const key of Object.keys(config) as (keyof C)[]) {
         /* istanbul ignore else */
-        if (typeof this.internalConfig[key] !== 'undefined') {
-          this.internalConfig[key] = (config as C)[key];
-          // TODO: Replace `any` with type
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (this as any)[key] = config[key];
+        if (this.internalConfig[key] !== undefined) {
+          const value = (config as C)[key];
+          this.internalConfig[key] = value;
+          (this as unknown as C)[key] = value;
         }
       }
     }


### PR DESCRIPTION
## Explanation

- For runtime property assignment, use `as unknown as` instead of `as any`.
- Change the types for `BaseControllerV1` class fields `initialConfig`, `initialState` from `C`, `S` to `Partial<C>`, `Partial<S>`.
  - Initial user-supplied constructor options do not need to be complete `C`, `S` objects, since `internal{Config,State}` will be populated with `default{Config,State}`.
- For empty objects, prefer no type assertions or `as never` (`never` is assignable to all types).
- Fix code written based on outdated TypeScript limitation.
  - Generic spread expressions for object literals are supported by TypeScript: https://github.com/microsoft/TypeScript/pull/28234

## References

- Closes #3715 

## Changelog

### [`@metamask/base-controller`](https://github.com/MetaMask/core/pull/3959/files#diff-a8212838da15b445582e5622bd4cc8195e4c52bcf87210af8074555f806706a9)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
