### PR TITLE
patch: fallback to 95% of block gas limit if gas estimation fails

### DIFF
--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -786,6 +786,8 @@ export class TransactionController extends BaseController<
       ]);
     } catch (error) {
       estimateGasError = ESTIMATE_GAS_ERROR;
+      // Fallback to 95% of the block gasLimit.
+      gasHex = estimatedTransaction.gas;
     }
     // 4. Pad estimated gas without exceeding the most recent block gasLimit. If the network is a
     // a custom network then return the eth_estimateGas value.


### PR DESCRIPTION
## Explanation
This patches transaction-controller 6.1.0, introducing a fallback for gas estimations. In cases of failed gas estimation, the transaction will default to using 95% of the latest block gas limit. This ensures that transactions have viable gas.

Previously, if gas estimation for a transaction failed (for example, due to the transaction being reverted), the `gasHex` value would remain undefined. This issue led to the transaction being assigned zero gas, causing it to be submitted to the mempool where it would get "stuck".

This change is specific to version 6.1.0 of the transaction-controller. Later versions of the TransactionController include this fix.

## References

- related: https://github.com/MetaMask/metamask-mobile/issues/8533

## Changelog

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
