### PR TITLE
chore(permission-log-controler): preview version

### DIFF
--- a/packages/permission-log-controller/CHANGELOG.md
+++ b/packages/permission-log-controller/CHANGELOG.md
@@ -7,4 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/MetaMask/core/
+## [1.0.0]
+
+### Added
+
+- Initial release
+
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-log-controller@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/permission-log-controller@1.0.0

--- a/packages/permission-log-controller/package.json
+++ b/packages/permission-log-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/permission-log-controller",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Controller with middleware for logging requests and responses to restricted and permissions-related methods",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Explanation

Permission Log Controller first release, the purpose of this PR is to create a preview version to test the changes on metamask-extension, after migration of this controller from extension to core