### PR TITLE
fix(queued-request-controller): Add missing type exports

### DIFF
--- a/packages/queued-request-controller/src/index.ts
+++ b/packages/queued-request-controller/src/index.ts
@@ -2,6 +2,8 @@ export type {
   QueuedRequestControllerState,
   QueuedRequestControllerCountChangedEvent,
   QueuedRequestControllerEnqueueRequestAction,
+  QueuedRequestControllerGetStateAction,
+  QueuedRequestControllerStateChangeEvent,
   QueuedRequestControllerEvents,
   QueuedRequestControllerActions,
   QueuedRequestControllerMessenger,


### PR DESCRIPTION
## Explanation

These two types were added in #3919, but these exports were accidentally omitted.

## References

This change was missing from #3919

## Changelog

This change was documented already in #3919

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
