### PR TITLE
chore(queued-request-controller): Remove `countChanged` event

### DIFF
--- a/packages/queued-request-controller/src/QueuedRequestController.test.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.test.ts
@@ -139,7 +139,7 @@ describe('QueuedRequestController', () => {
         await expect(() =>
           controller.enqueueRequest(requestWithError),
         ).rejects.toThrow(new Error('Request failed'));
-        expect(controller.length()).toBe(0);
+        expect(controller.state.queuedRequestCount).toBe(0);
       });
 
       it('correctly updates the request queue count upon failure', async () => {
@@ -189,60 +189,6 @@ describe('QueuedRequestController', () => {
         expect(request2).toHaveBeenCalled();
         expect(request3).toHaveBeenCalled();
       });
-    });
-  });
-
-  describe('length', () => {
-    it('returns the correct queue length', async () => {
-      const options: QueuedRequestControllerOptions = {
-        messenger: buildQueuedRequestControllerMessenger(),
-      };
-
-      const controller = new QueuedRequestController(options);
-
-      // Initially, the queue length should be 0
-      expect(controller.length()).toBe(0);
-
-      const promise = controller.enqueueRequest(async () => {
-        expect(controller.length()).toBe(1);
-        return Promise.resolve();
-      });
-      expect(controller.length()).toBe(1);
-      await promise;
-      expect(controller.length()).toBe(0);
-    });
-
-    it('correctly reflects increasing queue length as requests are enqueued', async () => {
-      const options: QueuedRequestControllerOptions = {
-        messenger: buildQueuedRequestControllerMessenger(),
-      };
-
-      const controller = new QueuedRequestController(options);
-
-      expect(controller.length()).toBe(0);
-
-      controller.enqueueRequest(async () => {
-        expect(controller.length()).toBe(1);
-        return Promise.resolve();
-      });
-      expect(controller.length()).toBe(1);
-
-      const req2 = controller.enqueueRequest(async () => {
-        expect(controller.length()).toBe(2);
-        return Promise.resolve();
-      });
-      expect(controller.length()).toBe(2);
-
-      const req3 = controller.enqueueRequest(async () => {
-        // if we dont wait for the outter enqueueRequest to be complete, the count might not be updated when by the time this nextTick occurs.
-        await req2;
-        expect(controller.length()).toBe(1);
-        return Promise.resolve();
-      });
-
-      expect(controller.length()).toBe(3);
-      await req3;
-      expect(controller.length()).toBe(0);
     });
   });
 });

--- a/packages/queued-request-controller/src/QueuedRequestController.test.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.test.ts
@@ -192,45 +192,6 @@ describe('QueuedRequestController', () => {
     });
   });
 
-  describe('countChanged event', () => {
-    it('gets emitted when the queue length changes', async () => {
-      const options: QueuedRequestControllerOptions = {
-        messenger: buildQueuedRequestControllerMessenger(),
-      };
-
-      const controller = new QueuedRequestController(options);
-
-      // Mock the event listener
-      const eventListener = jest.fn();
-
-      // Subscribe to the countChanged event
-      options.messenger.subscribe(
-        'QueuedRequestController:countChanged',
-        eventListener,
-      );
-
-      // Enqueue a request, which should increase the count
-      controller.enqueueRequest(
-        async () => new Promise((resolve) => setTimeout(resolve, 10)),
-      );
-      expect(eventListener).toHaveBeenNthCalledWith(1, 1);
-
-      // Enqueue another request, which should increase the count
-      controller.enqueueRequest(
-        async () => new Promise((resolve) => setTimeout(resolve, 10)),
-      );
-      expect(eventListener).toHaveBeenNthCalledWith(2, 2);
-
-      // Resolve the first request, which should decrease the count
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      expect(eventListener).toHaveBeenNthCalledWith(3, 1);
-
-      // Resolve the second request, which should decrease the count
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      expect(eventListener).toHaveBeenNthCalledWith(4, 0);
-    });
-  });
-
   describe('length', () => {
     it('returns the correct queue length', async () => {
       const options: QueuedRequestControllerOptions = {

--- a/packages/queued-request-controller/src/QueuedRequestController.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.ts
@@ -101,19 +101,6 @@ export class QueuedRequestController extends BaseController<
     );
   }
 
-  /**
-   * Gets the current count of enqueued requests in the request queue. This count represents the number of
-   * pending requests that are waiting to be processed sequentially.
-   *
-   * @returns The current count of enqueued requests. This count reflects the number of pending
-   * requests in the queue, which are yet to be processed. It allows you to monitor the queue's workload
-   * and assess the volume of requests awaiting execution.
-   * @deprecated This method is deprecated; use `state.queuedRequestCount` directly instead.
-   */
-  length() {
-    return this.state.queuedRequestCount;
-  }
-
   #updateCount(change: -1 | 1) {
     this.update((state) => {
       state.queuedRequestCount += change;

--- a/packages/queued-request-controller/src/QueuedRequestController.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.ts
@@ -27,7 +27,6 @@ export type QueuedRequestControllerEnqueueRequestAction = {
 };
 
 export const QueuedRequestControllerEventTypes = {
-  countChanged: `${controllerName}:countChanged` as const,
   stateChange: `${controllerName}:stateChange` as const,
 };
 
@@ -37,19 +36,8 @@ export type QueuedRequestControllerStateChangeEvent =
     QueuedRequestControllerState
   >;
 
-/**
- * This event is fired when the number of queued requests changes.
- *
- * @deprecated Use the `QueuedRequestController:stateChange` event instead
- */
-export type QueuedRequestControllerCountChangedEvent = {
-  type: typeof QueuedRequestControllerEventTypes.countChanged;
-  payload: [number];
-};
-
 export type QueuedRequestControllerEvents =
-  | QueuedRequestControllerCountChangedEvent
-  | QueuedRequestControllerStateChangeEvent;
+  QueuedRequestControllerStateChangeEvent;
 
 export type QueuedRequestControllerActions =
   | QueuedRequestControllerGetStateAction
@@ -130,10 +118,6 @@ export class QueuedRequestController extends BaseController<
     this.update((state) => {
       state.queuedRequestCount += change;
     });
-    this.messagingSystem.publish(
-      'QueuedRequestController:countChanged',
-      this.state.queuedRequestCount,
-    );
   }
 
   /**

--- a/packages/queued-request-controller/src/index.ts
+++ b/packages/queued-request-controller/src/index.ts
@@ -1,6 +1,5 @@
 export type {
   QueuedRequestControllerState,
-  QueuedRequestControllerCountChangedEvent,
   QueuedRequestControllerEnqueueRequestAction,
   QueuedRequestControllerGetStateAction,
   QueuedRequestControllerStateChangeEvent,


### PR DESCRIPTION
## Explanation

The event `QueuedRequestController:countChanged` and the method `length` have been removed. Both the event and method were deprecated as part of #3919, which also provided an alternative by adding the queued request count to the controller state.

## References

Related to #3919

## Changelog

### `@metamask/queued-request-controller`

#### Removed
- **BREAKING**: Remove the `QueuedRequestController:countChanged` event
  - The number of queued requests is now tracked in controller state, as the `queuedRequestCount` property. Use the `QueuedRequestController:stateChange` event to be notified of count changes instead.
- **BREAKING**: Remove the `length` method
  - The number of queued requests is now tracked in controller state, as the `queuedRequestCount` property.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
