### PR TITLE
feat(queued-request-controller): Replace confirmation with switch event

### DIFF
--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -39,7 +39,6 @@
     "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {
-    "@metamask/approval-controller": "^5.1.2",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/network-controller": "^17.2.0",
     "@metamask/selected-network-controller": "^8.0.0",
@@ -56,7 +55,6 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/approval-controller": "^5.1.2",
     "@metamask/network-controller": "^17.2.0",
     "@metamask/selected-network-controller": "^8.0.0"
   },

--- a/packages/queued-request-controller/src/index.ts
+++ b/packages/queued-request-controller/src/index.ts
@@ -3,6 +3,7 @@ export type {
   QueuedRequestControllerEnqueueRequestAction,
   QueuedRequestControllerGetStateAction,
   QueuedRequestControllerStateChangeEvent,
+  QueuedRequestControllerNetworkSwitched,
   QueuedRequestControllerEvents,
   QueuedRequestControllerActions,
   QueuedRequestControllerMessenger,

--- a/packages/queued-request-controller/tsconfig.build.json
+++ b/packages/queued-request-controller/tsconfig.build.json
@@ -8,7 +8,6 @@
   "references": [
     { "path": "../base-controller/tsconfig.build.json" },
     { "path": "../network-controller/tsconfig.build.json" },
-    { "path": "../approval-controller/tsconfig.build.json" },
     { "path": "../selected-network-controller/tsconfig.build.json" },
     { "path": "../controller-utils/tsconfig.build.json" },
     { "path": "../json-rpc-engine/tsconfig.build.json" }

--- a/packages/queued-request-controller/tsconfig.json
+++ b/packages/queued-request-controller/tsconfig.json
@@ -12,9 +12,6 @@
       "path": "../network-controller"
     },
     {
-      "path": "../approval-controller"
-    },
-    {
       "path": "../selected-network-controller"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2586,7 +2586,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/queued-request-controller@workspace:packages/queued-request-controller"
   dependencies:
-    "@metamask/approval-controller": ^5.1.2
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^4.1.1
     "@metamask/controller-utils": ^8.0.3
@@ -2608,7 +2607,6 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
   peerDependencies:
-    "@metamask/approval-controller": ^5.1.2
     "@metamask/network-controller": ^17.2.0
     "@metamask/selected-network-controller": ^8.0.0
   languageName: unknown


### PR DESCRIPTION
## Explanation

When the `QueuedRequestController` requires the globally selected network to be changed, we now emit an event rather than triggering a confirmation. This aligns with recent designs for this use case.

The actions `NetworkController:getNetworkConfigurationByNetworkClientId` and `ApprovalController:addRequest` were only used for triggering the switch network confirmation, so they are no longer needed now. They have been removed. This removes the last dependency of this controller on the `ApprovalController`, so it has been removed as a dependency as well.

## References

Closes #3983

## Changelog

### `@metamask/package-a`

#### Changed
- **BREAKING:** The `QueuedRequestController` no longer triggers a confirmation when a network switch is needed
  - The network switch now happens automatically, with no confirmation.
  - A new `QueuedRequestController:networkSwitched` event has been added to communicate when this has happened.
  - The `QueuedRequestController` messenger no longer needs access to the actions `NetworkController:getNetworkConfigurationByNetworkClientId` and `ApprovalController:addRequest`.
  - The package `@metamask/approval-controller` has been completely removed as a dependency

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
