### PR TITLE
fix: add 'never' type on actions/events to reflect baseController t…

### DIFF
--- a/packages/approval-controller/src/ApprovalController.ts
+++ b/packages/approval-controller/src/ApprovalController.ts
@@ -122,8 +122,8 @@ export type ApprovalControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
   ApprovalControllerActions,
   ApprovalControllerEvents,
-  string,
-  string
+  never,
+  never
 >;
 
 // Option Types

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -58,7 +58,7 @@ type CurrencyRateMessenger = RestrictedControllerMessenger<
   typeof name,
   CurrencyRateControllerActions | AllowedActions,
   CurrencyRateControllerEvents,
-  AllowedActions['type'],
+  AllowedActions['type'] | never,
   never
 >;
 

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -296,7 +296,7 @@ export type NftControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
   AllowedActions,
   never,
-  AllowedActions['type'],
+  AllowedActions['type'] | never,
   never
 >;
 

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -74,8 +74,8 @@ export type TokenListControllerMessenger = RestrictedControllerMessenger<
   typeof name,
   TokenListControllerActions | AllowedActions,
   TokenListControllerEvents | AllowedEvents,
-  AllowedActions['type'],
-  AllowedEvents['type']
+  AllowedActions['type'] | never,
+  AllowedEvents['type'] | never
 >;
 
 const metadata = {

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -147,8 +147,8 @@ export type TokensControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
   TokensControllerActions | AllowedActions,
   TokensControllerEvents | AllowedEvents,
-  AllowedActions['type'],
-  AllowedEvents['type']
+  AllowedActions['type'] | never,
+  AllowedEvents['type'] | never
 >;
 
 export const getDefaultTokensState = (): TokensState => {

--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -239,7 +239,7 @@ type GasFeeMessenger = RestrictedControllerMessenger<
   typeof name,
   GasFeeControllerActions | AllowedActions,
   GasFeeControllerEvents | NetworkControllerNetworkDidChangeEvent,
-  AllowedActions['type'],
+  AllowedActions['type'] | never,
   NetworkControllerNetworkDidChangeEvent['type']
 >;
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -208,8 +208,8 @@ export type KeyringControllerMessenger = RestrictedControllerMessenger<
   typeof name,
   KeyringControllerActions,
   KeyringControllerEvents,
-  string,
-  string
+  never,
+  never
 >;
 
 export type KeyringControllerOptions = {

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -472,8 +472,8 @@ export type NetworkControllerMessenger = RestrictedControllerMessenger<
   typeof name,
   NetworkControllerActions,
   NetworkControllerEvents,
-  string,
-  string
+  never,
+  never
 >;
 
 export type NetworkControllerOptions = {

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -116,7 +116,7 @@ export type SignatureControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
   SignatureControllerActions | AllowedActions,
   SignatureControllerEvents,
-  AllowedActions['type'],
+  never,
   never
 >;
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -299,8 +299,8 @@ export type TransactionControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
   AllowedActions,
   AllowedEvents,
-  AllowedActions['type'],
-  AllowedEvents['type']
+  AllowedActions['type'] | never,
+  AllowedEvents['type'] | never
 >;
 
 // This interface was created before this ESLint rule was added.


### PR DESCRIPTION
…ypes

## Explanation

This PR adds the type `never` on controllers Actions and Events to be aligned with the baseController typing.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
