### PR TITLE
remove redundant perDomainNetwork state

### DIFF
--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -95,11 +95,8 @@ const setup = ({
 }: {
   hasPermissions?: boolean;
   state?: SelectedNetworkControllerState;
-<<<<<<< HEAD
   getSubjectNames?: string[];
-=======
   getUseRequestQueue?: GetUseRequestQueue;
->>>>>>> babf753f (remove redundant perDomainNetwork state)
 } = {}) => {
   const mockProviderProxy = {
     setTarget: jest.fn(),

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -4,6 +4,7 @@ import { createEventEmitterProxy } from '@metamask/swappable-obj-proxy';
 import type {
   AllowedActions,
   AllowedEvents,
+  GetUseRequestQueue,
   SelectedNetworkControllerActions,
   SelectedNetworkControllerEvents,
   SelectedNetworkControllerMessenger,
@@ -90,10 +91,15 @@ const setup = ({
   hasPermissions = true,
   getSubjectNames = [],
   state,
+  getUseRequestQueue = () => false,
 }: {
   hasPermissions?: boolean;
   state?: SelectedNetworkControllerState;
+<<<<<<< HEAD
   getSubjectNames?: string[];
+=======
+  getUseRequestQueue?: GetUseRequestQueue;
+>>>>>>> babf753f (remove redundant perDomainNetwork state)
 } = {}) => {
   const mockProviderProxy = {
     setTarget: jest.fn(),
@@ -139,6 +145,7 @@ const setup = ({
   const controller = new SelectedNetworkController({
     messenger: selectedNetworkControllerMessenger,
     state,
+    getUseRequestQueue,
   });
   return {
     controller,
@@ -158,19 +165,16 @@ describe('SelectedNetworkController', () => {
       const { controller } = setup();
       expect(controller.state).toStrictEqual({
         domains: {},
-        perDomainNetwork: false,
       });
     });
     it('can be instantiated with a state', () => {
       const { controller } = setup({
         state: {
-          perDomainNetwork: true,
           domains: { networkClientId: 'goerli' },
         },
       });
       expect(controller.state).toStrictEqual({
         domains: { networkClientId: 'goerli' },
-        perDomainNetwork: true,
       });
     });
   });
@@ -180,7 +184,6 @@ describe('SelectedNetworkController', () => {
       it('updates the networkClientId for domains which were previously set to the deleted networkClientId', () => {
         const { controller, messenger } = setup({
           state: {
-            perDomainNetwork: true,
             domains: {
               metamask: 'goerli',
               'example.com': 'test-network-client-id',
@@ -223,12 +226,11 @@ describe('SelectedNetworkController', () => {
       );
       expect(controller.state.domains.metamask).toBeUndefined();
     });
-    describe('when the perDomainNetwork state is false', () => {
+    describe('when the useRequestQueue is false', () => {
       describe('when the requesting domain is not metamask', () => {
         it('updates the networkClientId for domain in state', () => {
           const { controller } = setup({
             state: {
-              perDomainNetwork: false,
               domains: {
                 '1.com': 'mainnet',
                 '2.com': 'mainnet',
@@ -250,12 +252,13 @@ describe('SelectedNetworkController', () => {
       });
     });
 
-    describe('when the perDomainNetwork state is true', () => {
+    describe('when the useRequestQueue is true', () => {
       describe('when the requesting domain has existing permissions', () => {
         it('sets the networkClientId for the passed in domain', () => {
           const { controller } = setup({
-            state: { perDomainNetwork: true, domains: {} },
+            state: { domains: {} },
             hasPermissions: true,
+            getUseRequestQueue: () => true,
           });
 
           const domain = 'example.com';
@@ -266,8 +269,9 @@ describe('SelectedNetworkController', () => {
 
         it('updates the provider and block tracker proxy when they already exist for the domain', () => {
           const { controller, mockProviderProxy } = setup({
-            state: { perDomainNetwork: true, domains: {} },
+            state: { domains: {} },
             hasPermissions: true,
+            getUseRequestQueue: () => true,
           });
           const initialNetworkClientId = '123';
 
@@ -294,7 +298,7 @@ describe('SelectedNetworkController', () => {
       describe('when the requesting domain does not have permissions', () => {
         it('throw an error and does not set the networkClientId for the passed in domain', () => {
           const { controller } = setup({
-            state: { perDomainNetwork: true, domains: {} },
+            state: { domains: {} },
             hasPermissions: false,
           });
 
@@ -312,7 +316,7 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('getNetworkClientIdForDomain', () => {
-    describe('when the perDomainNetwork state is false', () => {
+    describe('when the useRequestQueue is false', () => {
       it('returns the selectedNetworkClientId from the NetworkController if not no networkClientId is set for requested domain', () => {
         const { controller } = setup();
         expect(controller.getNetworkClientIdForDomain('example.com')).toBe(
@@ -334,11 +338,12 @@ describe('SelectedNetworkController', () => {
       });
     });
 
-    describe('when the perDomainNetwork state is true', () => {
+    describe('when the useRequestQueue is true', () => {
       it('returns the networkClientId for the passed in domain, when a networkClientId has been set for the requested domain', () => {
         const { controller } = setup({
-          state: { perDomainNetwork: true, domains: {} },
+          state: { domains: {} },
           hasPermissions: true,
+          getUseRequestQueue: () => true,
         });
         const networkClientId1 = 'network5';
         const networkClientId2 = 'network6';
@@ -352,8 +357,9 @@ describe('SelectedNetworkController', () => {
 
       it('returns the selectedNetworkClientId from the NetworkController when no networkClientId has been set for the domain requested', () => {
         const { controller } = setup({
-          state: { perDomainNetwork: true, domains: {} },
+          state: { domains: {} },
           hasPermissions: true,
+          getUseRequestQueue: () => true,
         });
         expect(controller.getNetworkClientIdForDomain('example.com')).toBe(
           'mainnet',
@@ -363,13 +369,13 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('getProviderAndBlockTracker', () => {
-    describe('when perDomainNetwork is true', () => {
+    describe('when useRequestQueue is true', () => {
       it('returns a proxy provider and block tracker when a networkClientId has been set for the requested domain', () => {
         const { controller } = setup({
           state: {
-            perDomainNetwork: true,
             domains: {},
           },
+          getUseRequestQueue: () => true,
         });
         controller.setNetworkClientIdForDomain('example.com', 'network7');
         const result = controller.getProviderAndBlockTracker('example.com');
@@ -379,11 +385,11 @@ describe('SelectedNetworkController', () => {
       it('creates a new proxy provider and block tracker when there isnt one already', () => {
         const { controller } = setup({
           state: {
-            perDomainNetwork: true,
             domains: {
               'test.com': 'mainnet',
             },
           },
+          getUseRequestQueue: () => true,
         });
         const result = controller.getProviderAndBlockTracker('test.com');
         expect(result).toBeDefined();
@@ -392,9 +398,9 @@ describe('SelectedNetworkController', () => {
       it('throws and error when a networkClientId has not been set for the requested domain', () => {
         const { controller } = setup({
           state: {
-            perDomainNetwork: true,
             domains: {},
           },
+          getUseRequestQueue: () => true,
         });
 
         expect(() => {
@@ -402,11 +408,10 @@ describe('SelectedNetworkController', () => {
         }).toThrow('NetworkClientId has not been set for the requested domain');
       });
     });
-    describe('when perDomainNetwork is false', () => {
+    describe('when useRequestQueue is false', () => {
       it('throws and error when a networkClientId has been been set for the requested domain', () => {
         const { controller } = setup({
           state: {
-            perDomainNetwork: false,
             domains: {},
           },
         });
@@ -414,35 +419,8 @@ describe('SelectedNetworkController', () => {
         expect(() => {
           controller.getProviderAndBlockTracker('test.com');
         }).toThrow(
-          'Provider and BlockTracker should be fetched from NetworkController when perDomainNetwork is false',
+          'Provider and BlockTracker should be fetched from NetworkController when useRequestQueue is false',
         );
-      });
-    });
-  });
-
-  describe('setPerDomainNetwork', () => {
-    describe('when toggling from false to true', () => {
-      it('should update perDomainNetwork state to true', () => {
-        const { controller } = setup({
-          state: {
-            perDomainNetwork: false,
-            domains: {},
-          },
-        });
-        controller.setPerDomainNetwork(true);
-        expect(controller.state.perDomainNetwork).toBe(true);
-      });
-    });
-    describe('when toggling from true to false', () => {
-      it('should update perDomainNetwork state to false', () => {
-        const { controller } = setup({
-          state: {
-            perDomainNetwork: true,
-            domains: {},
-          },
-        });
-        controller.setPerDomainNetwork(false);
-        expect(controller.state.perDomainNetwork).toBe(false);
       });
     });
   });
@@ -470,7 +448,7 @@ describe('SelectedNetworkController', () => {
 
     it('should remove domain from domains list on permission removal', async () => {
       const { controller, messenger } = setup({
-        state: { perDomainNetwork: true, domains: { 'example.com': 'foo' } },
+        state: { domains: { 'example.com': 'foo' } },
       });
 
       messenger.publish('PermissionController:stateChange', { subjects: {} }, [
@@ -488,7 +466,7 @@ describe('SelectedNetworkController', () => {
     it('should set networkClientId for domains not already in state', async () => {
       const getSubjectNamesMock = ['newdomain.com'];
       const { controller } = setup({
-        state: { perDomainNetwork: true, domains: {} },
+        state: { domains: {} },
         getSubjectNames: getSubjectNamesMock,
       });
 
@@ -499,7 +477,6 @@ describe('SelectedNetworkController', () => {
     it('should not modify domains already in state', async () => {
       const { controller } = setup({
         state: {
-          perDomainNetwork: true,
           domains: {
             'existingdomain.com': 'initialNetworkId',
           },


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

See [here](https://app.zenhub.com/workspaces/wallet-api-platform-63bee08a4e3b9d001108416e/issues/gh/metamask/metamask-planning/2143) for more details


## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/selected-network-controller`

- **ADDED**: SelectedNetworkController constructor now takes a `getUseRequestQueue` function.
- **REMOVED**: SelectedNetworkController no longer has a perDappNetwork feature flag saved in state.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
