### PR TITLE
move permission controller from devdep to regular dep

### DIFF
--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -34,12 +34,12 @@
     "@metamask/base-controller": "^4.1.1",
     "@metamask/json-rpc-engine": "^7.3.2",
     "@metamask/network-controller": "^17.2.0",
+    "@metamask/permission-controller": "^8.0.1",
     "@metamask/swappable-obj-proxy": "^2.2.0",
     "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/permission-controller": "^8.0.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",
@@ -53,7 +53,8 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^17.2.0"
+    "@metamask/network-controller": "^17.2.0",
+    "@metamask/permission-controller": "^8.0.1"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,6 +2689,7 @@ __metadata:
     typescript: ~4.8.4
   peerDependencies:
     "@metamask/network-controller": ^17.2.0
+    "@metamask/permission-controller": ^8.0.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Explanation

in response to https://github.com/MetaMask/core/pull/3996#pullrequestreview-1907920534

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/selected-network-controller`

- **CHANGED**: Move permissions-controller from devDeps to deps and peerDep


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
