### PR TITLE
fix: update OPTIMISM_TESTNET to OPTIMISM_SEPOLIA

### DIFF
--- a/packages/transaction-controller/src/constants.ts
+++ b/packages/transaction-controller/src/constants.ts
@@ -4,7 +4,7 @@ export const CHAIN_IDS = {
   BSC: '0x38',
   BSC_TESTNET: '0x61',
   OPTIMISM: '0xa',
-  OPTIMISM_TESTNET: '0x1a4',
+  OPTIMISM_SEPOLIA: '0xaa37dc',
   POLYGON: '0x89',
   POLYGON_TESTNET: '0x13881',
   AVALANCHE: '0xa86a',
@@ -64,10 +64,10 @@ export const ETHERSCAN_SUPPORTED_NETWORKS = {
     subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-optimistic`,
     networkId: parseInt(CHAIN_IDS.OPTIMISM, 16).toString(),
   },
-  [CHAIN_IDS.OPTIMISM_TESTNET]: {
+  [CHAIN_IDS.OPTIMISM_SEPOLIA]: {
     domain: DEFAULT_ETHERSCAN_DOMAIN,
-    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-goerli-optimistic`,
-    networkId: parseInt(CHAIN_IDS.OPTIMISM_TESTNET, 16).toString(),
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-sepolia-optimistic`,
+    networkId: parseInt(CHAIN_IDS.OPTIMISM_SEPOLIA, 16).toString(),
   },
   [CHAIN_IDS.POLYGON]: {
     domain: 'polygonscan.com',


### PR DESCRIPTION
## Explanation

This PR replaces the reference to OP goerli to OP sepolia. It also renames the variable `OPTIMISM_TESTNET` to `OPTIMISM_SEPOLIA`.

Only made this change on the transaction controller.

Renaming the variable and switching to Sepolia is a breaking change, please use Sepolia and `OPTIMISM_SEPOLIA` instead of `OPTIMISM_TESTNET`.

## References

* Fixes https://github.com/MetaMask/mobile-planning/issues/1569
* Related to [#67890](https://github.com/MetaMask/metamask-mobile/pull/8784)

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

**Removed**

- **BREAKING**: Renamed `OPTIMISM_TESTNET` to `OPTIMISM_SEPOLIA` and updated the chainId accordingly.
- **BREAKING**: Updated the etherscan subdomain that was for  OPTIMISM_TESTNET from goerli to sepolia.


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
