### PR TITLE
Move `bn.js` to `controller-utils` dependencies

### DIFF
--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -36,13 +36,13 @@
     "@metamask/ethjs-unit": "^0.3.0",
     "@metamask/utils": "^8.3.0",
     "@spruceid/siwe-parser": "1.1.3",
+    "bn.js": "^5.2.1",
     "eth-ens-namehash": "^2.0.8",
     "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@types/jest": "^27.4.1",
-    "bn.js": "^5.2.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "nock": "^13.3.1",

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -36,6 +36,7 @@
     "@metamask/ethjs-unit": "^0.3.0",
     "@metamask/utils": "^8.3.0",
     "@spruceid/siwe-parser": "1.1.3",
+    "@types/bn.js": "^5.1.5",
     "bn.js": "^5.2.1",
     "eth-ens-namehash": "^2.0.8",
     "fast-deep-equal": "^3.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,6 +1742,7 @@ __metadata:
     "@metamask/ethjs-unit": ^0.3.0
     "@metamask/utils": ^8.3.0
     "@spruceid/siwe-parser": 1.1.3
+    "@types/bn.js": ^5.1.5
     "@types/jest": ^27.4.1
     bn.js: ^5.2.1
     deepmerge: ^4.2.2


### PR DESCRIPTION
## Explanation

This PR moves `bn.js` to be a non-dev dependency of `controller-utils` as it is used directly in https://github.com/MetaMask/core/blob/main/packages/controller-utils/src/util.ts

It also adds `@types/bn.js` to the dependencies, mirroring the implementation from `assets-controllers`.

For more context see this CI failure: https://github.com/MetaMask/snaps/actions/runs/8154723823/job/22288793408?pr=2245

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/controller-utils`

- **Changed**: Add `bn.js` to dependencies

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
