### PR TITLE
fix: Some wallet_switchEthereumChain calls queued incorrectly

### DIFF
--- a/packages/queued-request-controller/src/QueuedRequestController.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.ts
@@ -209,7 +209,8 @@ export class QueuedRequestController extends BaseController<
       try {
         if (
           request.method !== 'wallet_switchEthereumChain' &&
-          request.method !== 'wallet_addEthereumChain'
+          request.method !== 'wallet_addEthereumChain' &&
+          request.method !== 'eth_requestAccounts'
         ) {
           await this.#switchNetworkIfNecessary(request);
         }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

`eth_requestAccounts` is a confirmation method only when there exists no permission yet for the given domain. This requires the request to be queued. We have not optimized the queueing to check if there exists a permission before deciding to enqueue calls to `eth_requestAccounts`, though that is an optimization we could make in the future and is outside the scope of this PR. 

This PR will no longer require the wallet to be on the correct network before the eth_requestAccounts call is made. As an alternative, we could still require that the user be on the correct chain, but only if there is no permission yet.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

fixes https://github.com/MetaMask/MetaMask-planning/issues/2186

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/queued-request-controller`

- **FIXED**: `eth_requestAccounts` should not check to switch chain first

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
