### PR TITLE
feat: reservoir migration

### DIFF
--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -393,6 +393,21 @@ describe('NftController', () => {
       expect(callActionSpy).toHaveBeenCalledTimes(0);
     });
 
+    it('should error if the call to isNftOwner fail', async function () {
+      const { nftController } = setupController();
+      jest.spyOn(nftController, 'isNftOwner').mockRejectedValue('Random error');
+      try {
+        await nftController.watchNft(
+          ERC721_NFT,
+          ERC721,
+          'https://test-dapp.com',
+        );
+      } catch (err) {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(err).toBe('Random error');
+      }
+    });
+
     it('should error if the user does not own the suggested ERC1155 NFT', async function () {
       const { nftController, messenger } = setupController({
         getERC1155BalanceOf: jest.fn().mockImplementation(() => new BN(0)),

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -2704,6 +2704,31 @@ describe('NftController', () => {
   });
 
   describe('updateNftFavoriteStatus', () => {
+    it('should not set NFT as favorite if nft not found', async () => {
+      const { nftController } = setupController();
+      const { selectedAddress, chainId } = nftController.config;
+      await nftController.addNft(
+        ERC721_DEPRESSIONIST_ADDRESS,
+        ERC721_DEPRESSIONIST_ID,
+        { nftMetadata: { name: '', description: '', image: '', standard: '' } },
+      );
+
+      nftController.updateNftFavoriteStatus(
+        ERC721_DEPRESSIONIST_ADDRESS,
+        '666',
+        true,
+      );
+
+      expect(
+        nftController.state.allNfts[selectedAddress][chainId][0],
+      ).toStrictEqual(
+        expect.objectContaining({
+          address: ERC721_DEPRESSIONIST_ADDRESS,
+          tokenId: ERC721_DEPRESSIONIST_ID,
+          favorite: false,
+        }),
+      );
+    });
     it('should set NFT as favorite', async () => {
       const { nftController } = setupController();
       const { selectedAddress, chainId } = nftController.config;

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -260,25 +260,9 @@ describe('NftController', () => {
         image_url: 'url',
       })
       .get(
-        `/chain/ethereum/contract/0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab/nfts/798958393`,
-      )
-      .replyWithError(new TypeError('Failed to fetch'))
-      .get(
         `/chain/ethereum/contract/0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab`,
       )
       .replyWithError(new TypeError('Failed to fetch'));
-
-    nock(OPENSEA_PROXY_URL)
-      .get(
-        `/chain/ethereum/contract/${ERC1155_NFT_ADDRESS}/nfts/${ERC1155_NFT_ID}`,
-      )
-      .reply(200, {
-        nft: {
-          token_standard: 'erc1155',
-          name: 'name',
-          description: 'description',
-        },
-      });
 
     nock(DEPRESSIONIST_CLOUDFLARE_IPFS_SUBDOMAIN_PATH).get('/').reply(200, {
       name: 'name',
@@ -1750,18 +1734,24 @@ describe('NftController', () => {
           .fn()
           .mockRejectedValue(new Error('Failed to fetch')),
       });
-      nock(OPENSEA_PROXY_URL)
+      nock(NFT_API_BASE_URL)
         .get(
-          `/chain/ethereum/contract/${ERC721_KUDOSADDRESS}/nfts/${ERC721_KUDOS_TOKEN_ID}`,
+          `/tokens?chainIds=1&tokens=${ERC721_KUDOSADDRESS}%3A${ERC721_KUDOS_TOKEN_ID}`,
         )
         .reply(200, {
-          nft: {
-            token_standard: 'erc721',
-            name: 'Kudos Name',
-            description: 'Kudos Description',
-            image_url: 'Kudos image (from proxy API)',
-          },
-        })
+          tokens: [
+            {
+              token: {
+                kind: 'erc721',
+                name: 'Kudos Name',
+                description: 'Kudos Description',
+                image: 'Kudos image (from proxy API)',
+              },
+            },
+          ],
+        });
+
+      nock(OPENSEA_PROXY_URL)
         .get(
           `/chain/ethereum/contract/0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab/`,
         )
@@ -1895,9 +1885,10 @@ describe('NftController', () => {
       const { nftController } = setupController();
       nock(OPENSEA_PROXY_URL)
         .get(`/chain/ethereum/contract/${ERC721_NFT_ADDRESS}`)
-        .replyWithError(new Error('Failed to fetch'))
+        .replyWithError(new Error('Failed to fetch'));
+      nock(NFT_API_BASE_URL)
         .get(
-          `/chain/ethereum/contract/${ERC721_NFT_ADDRESS}/nfts/${ERC721_NFT_ID}`,
+          `/tokens?chainIds=1&tokens=${ERC721_NFT_ADDRESS}%3A${ERC721_NFT_ID}`,
         )
         .replyWithError(new Error('Failed to fetch'));
 

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -253,6 +253,13 @@ describe('NftController', () => {
     });
   });
 
+  it('should set api key', async () => {
+    const { nftController } = setupController();
+
+    nftController.setApiKey('testkey');
+    expect(nftController.openSeaApiKey).toBe('testkey');
+  });
+
   describe('watchNft', function () {
     const ERC721_NFT = {
       address: ERC721_NFT_ADDRESS,

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -716,7 +716,7 @@ export class NftController extends BaseControllerV1<NftConfig, NftState> {
    * @param options - options.
    * @param options.tokenAddress - Hex address of the NFT contract.
    * @param options.userAddress - The address of the account where the NFT is being added.
-   * @param options.nftMetadata - The retrirved NFTMetadata from API.
+   * @param options.nftMetadata - The retrieved NFTMetadata from API.
    * @param options.networkClientId - The networkClientId that can be used to identify the network client to use for this request.
    * @param options.source - Whether the NFT was detected, added manually or suggested by a dapp.
    * @returns Promise resolving to the current NFT contracts list.

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -315,7 +315,7 @@ export class NftController extends BaseControllerV1<NftConfig, NftState> {
         },
       });
     // if we were still unable to fetch the data we return out the default/null of `NftMetadata`
-    if (!nftInformation?.tokens[0].token) {
+    if (!nftInformation?.tokens?.[0]?.token) {
       return {
         name: null,
         description: null,

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -3,6 +3,8 @@ import {
   ChainId,
   toHex,
 } from '@metamask/controller-utils';
+import { NetworkClientType } from '@metamask/network-controller';
+import type { NetworkClient } from '@metamask/network-controller';
 import {
   getDefaultPreferencesState,
   type PreferencesState,
@@ -10,6 +12,8 @@ import {
 import nock from 'nock';
 import * as sinon from 'sinon';
 
+import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
+import { FakeProvider } from '../../../tests/fake-provider';
 import { advanceTime } from '../../../tests/helpers';
 import { Source } from './constants';
 import { getDefaultNftState, type NftState } from './NftController';
@@ -368,6 +372,30 @@ describe('NftDetectionController', () => {
         await controller.detectNfts();
 
         expect(mockAddNft).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it('should return true if mainnet is detected', async () => {
+    const mockAddNft = jest.fn();
+    const mockNetworkClient: NetworkClient = {
+      configuration: {
+        chainId: toHex(1),
+        rpcUrl: 'https://test.network',
+        ticker: 'TEST',
+        type: NetworkClientType.Custom,
+      },
+      provider: new FakeProvider(),
+      blockTracker: new FakeBlockTracker(),
+      destroy: () => {
+        // do nothing
+      },
+    };
+    await withController(
+      { options: { addNft: mockAddNft } },
+      async ({ controller }) => {
+        const result = controller.isMainnetByNetworkClientId(mockNetworkClient);
+        expect(result).toBe(true);
       },
     );
   });

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -1,4 +1,8 @@
-import { OPENSEA_PROXY_URL, ChainId, toHex } from '@metamask/controller-utils';
+import {
+  RESERVOIR_API_BASE_URL,
+  ChainId,
+  toHex,
+} from '@metamask/controller-utils';
 import {
   getDefaultPreferencesState,
   type PreferencesState,
@@ -22,108 +26,95 @@ describe('NftDetectionController', () => {
   beforeEach(async () => {
     clock = sinon.useFakeTimers();
 
-    nock(OPENSEA_PROXY_URL)
+    nock(RESERVOIR_API_BASE_URL)
       .persist()
-      .get(`/chain/ethereum/account/0x1/nfts?limit=200&next=`)
+      .get(`/0x1/tokens?chainIds=1&limit=200&continuation=`)
       .reply(200, {
-        nfts: [
+        tokens: [
           {
-            contract: '0xCE7ec4B2DfB30eB6c0BB5656D33aAd6BFb4001Fc',
-            collection: 'Collection 2577',
-            token_standard: 'erc721',
-            name: 'ID 2577',
-            description: 'Description 2577',
-            image_url: 'image/2577.png',
-            identifier: '2577',
-            metadata_url: '',
-            updated_at: '',
-            is_disabled: false,
-            is_nsfw: false,
+            token: {
+              chainId: 1,
+              contract: '0xCE7ec4B2DfB30eB6c0BB5656D33aAd6BFb4001Fc',
+              tokenId: '2577',
+              kind: 'erc721',
+              name: 'Remilio 632',
+              image: 'https://imgtest',
+              imageSmall: 'https://imgSmall',
+              imageLarge: 'https://imglarge',
+              metadata: {
+                imageOriginal: 'https://remilio.org/remilio/632.png',
+                imageMimeType: 'image/png',
+                tokenURI: 'https://remilio.org/remilio/json/632',
+              },
+              description:
+                "Redacted Remilio Babies is a collection of 10,000 neochibi pfpNFT's expanding the Milady Maker paradigm with the introduction of young J.I.T. energy and schizophrenic reactionary aesthetics. We are #REMILIONAIREs.",
+              rarityScore: 343.443,
+              rarityRank: 8872,
+              supply: '1',
+              isSpam: false,
+            },
           },
           {
-            contract: '0x0B0fa4fF58D28A88d63235bd0756EDca69e49e6d',
-            collection: 'Collection 2577',
-            token_standard: 'erc721',
-            name: 'ID 2578',
-            description: 'Description 2578',
-            image_url: 'image/2578.png',
-            identifier: '2578',
-            metadata_url: '',
-            updated_at: '',
-            is_disabled: false,
-            is_nsfw: false,
+            token: {
+              contract: '0x0B0fa4fF58D28A88d63235bd0756EDca69e49e6d',
+              kind: 'erc721',
+              name: 'ID 2578',
+              description: 'Description 2578',
+              image: 'https://imgtest',
+              imageSmall: 'https://imgSmall',
+              imageLarge: 'https://imglarge',
+              tokenId: '2578',
+              metadata: {
+                imageOriginal: 'https://remilio.org/remilio/632.png',
+                imageMimeType: 'image/png',
+                tokenURI: 'https://remilio.org/remilio/json/632',
+              },
+              rarityScore: 343.443,
+              rarityRank: 8872,
+              supply: '1',
+              isSpam: false,
+            },
           },
           {
-            contract: '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',
-            collection: 'Collection 2574',
-            token_standard: 'erc721',
-            name: 'ID 2574',
-            description: 'Description 2574',
-            image_url: 'image/2574.png',
-            identifier: '2574',
-            metadata_url: '',
-            updated_at: '',
-            is_disabled: false,
-            is_nsfw: false,
+            token: {
+              contract: '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',
+              kind: 'erc721',
+              name: 'ID 2574',
+              description: 'Description 2574',
+              image: 'image/2574.png',
+              tokenId: '2574',
+              metadata: {
+                imageOriginal: 'imageOriginal/2574.png',
+                imageMimeType: 'image/png',
+                tokenURI: 'tokenURITest',
+              },
+              isSpam: false,
+            },
           },
         ],
       })
-      .get(`/chain/ethereum/account/0x9/nfts?limit=200&next=`)
+      .get(`/0x9/tokens?chainIds=1&limit=200&continuation=`)
       .reply(200, {
-        nfts: [
+        tokens: [
           {
-            contract: '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',
-            collection: 'Collection 2574',
-            token_standard: 'erc721',
-            name: 'ID 2574',
-            description: 'Description 2574',
-            image_url: 'image/2574.png',
-            identifier: '2574',
-            metadata_url: '',
-            updated_at: '',
-            is_disabled: false,
-            is_nsfw: false,
+            token: {
+              contract: '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',
+
+              kind: 'erc721',
+              name: 'ID 2574',
+              description: 'Description 2574',
+              image: 'image/2574.png',
+              tokenId: '2574',
+              metadata: {
+                imageOriginal: 'imageOriginal/2574.png',
+                imageMimeType: 'image/png',
+                tokenURI: 'tokenURITest',
+              },
+              isSpam: false,
+            },
           },
         ],
       });
-
-    nock(OPENSEA_PROXY_URL)
-      .persist()
-      .get(
-        `/chain/ethereum/contract/0x1d963688FE2209A98dB35C67A041524822Cf04ff`,
-      )
-      .reply(200, {
-        address: '0x1d963688FE2209A98dB35C67A041524822Cf04ff',
-        chain: 'ethereum',
-        collection: 'Name',
-        contract_standard: 'erc721',
-        name: 'Name',
-        total_supply: 0,
-      })
-      .get(
-        `/chain/ethereum/contract/0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD`,
-      )
-      .reply(200, {
-        address: '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',
-        chain: 'ethereum',
-        collection: 'Name HH',
-        contract_standard: 'erc721',
-        name: 'Name HH',
-        total_supply: 10,
-      })
-      .get(`/collections/Name%20HH`)
-      .reply(200, {
-        description: 'Description HH',
-        image_url: 'url HH',
-      })
-      .get(
-        `/chain/ethereum/contract/0xCE7ec4B2DfB30eB6c0BB5656D33aAd6BFb4001Fc`,
-      )
-      .replyWithError(new Error('Failed to fetch'))
-      .get(
-        `/chain/ethereum/contract/0x0B0fa4fF58D28A88d63235bd0756EDca69e49e6d`,
-      )
-      .replyWithError(new Error('Failed to fetch'));
   });
 
   afterEach(() => {
@@ -266,11 +257,7 @@ describe('NftDetectionController', () => {
               image: 'image/2574.png',
               name: 'ID 2574',
               standard: 'ERC721',
-              creator: {
-                user: { username: '' },
-                profile_img_url: '',
-                address: '',
-              },
+              imageOriginal: 'imageOriginal/2574.png',
             },
             userAddress: selectedAddress,
             source: Source.Detected,
@@ -313,11 +300,7 @@ describe('NftDetectionController', () => {
               image: 'image/2574.png',
               name: 'ID 2574',
               standard: 'ERC721',
-              creator: {
-                user: { username: '' },
-                profile_img_url: '',
-                address: '',
-              },
+              imageOriginal: 'imageOriginal/2574.png',
             },
             userAddress: '0x9',
             source: Source.Detected,
@@ -407,11 +390,11 @@ describe('NftDetectionController', () => {
     );
   });
 
-  it('should do nothing when the request to the OpenSea proxy server fails', async () => {
+  it('should do nothing when the request to Nft API fails', async () => {
     const selectedAddress = '0x3';
-    nock(OPENSEA_PROXY_URL)
-      .get(`/chain/ethereum/account/${selectedAddress}/nfts`)
-      .query({ next: '', limit: '200' })
+    nock(RESERVOIR_API_BASE_URL)
+      .get(`/${selectedAddress}/tokens`)
+      .query({ continuation: '', limit: '200', chainIds: '1' })
       .replyWithError(new Error('Failed to fetch'))
       .persist();
     const mockAddNft = jest.fn();
@@ -437,16 +420,16 @@ describe('NftDetectionController', () => {
     );
   });
 
-  it('should rethrow error when OpenSea proxy server fails with error other than fetch failure', async () => {
+  it('should rethrow error when Nft APi server fails with error other than fetch failure', async () => {
     const selectedAddress = '0x4';
     await withController(
       async ({ controller, triggerPreferencesStateChange }) => {
         // This mock is for the initial detect call after preferences change
-        nock(OPENSEA_PROXY_URL)
-          .get(`/chain/ethereum/account/${selectedAddress}/nfts`)
-          .query({ next: '', limit: '200' })
+        nock(RESERVOIR_API_BASE_URL)
+          .get(`/${selectedAddress}/tokens`)
+          .query({ continuation: '', limit: '200', chainIds: '1' })
           .reply(200, {
-            nfts: [],
+            tokens: [],
           });
         triggerPreferencesStateChange({
           ...getDefaultPreferencesState(),
@@ -459,9 +442,9 @@ describe('NftDetectionController', () => {
           duration: 1,
         });
         // This mock is for the call under test
-        nock(OPENSEA_PROXY_URL)
-          .get(`/chain/ethereum/account/${selectedAddress}/nfts`)
-          .query({ next: '', limit: '200' })
+        nock(RESERVOIR_API_BASE_URL)
+          .get(`/${selectedAddress}/tokens`)
+          .query({ continuation: '', limit: '200', chainIds: '1' })
           .replyWithError(new Error('UNEXPECTED ERROR'));
 
         await expect(() => controller.detectNfts()).rejects.toThrow(
@@ -493,80 +476,6 @@ describe('NftDetectionController', () => {
         await expect(async () => await controller.detectNfts()).rejects.toThrow(
           'UNEXPECTED ERROR',
         );
-      },
-    );
-  });
-
-  it('should fetch the original image url if image_url is null but theres metadata', async () => {
-    const selectedAddress = '0x1994';
-    const nftContract = '0x26B4a381D694c1AC6812eA80C3f3d088572802db';
-    const nftId = '123';
-    nock(OPENSEA_PROXY_URL)
-      .persist()
-      .get(`/chain/ethereum/account/${selectedAddress}/nfts`)
-      .query({ next: '', limit: '200' })
-      .reply(200, {
-        nfts: [
-          {
-            identifier: nftId,
-            contract: nftContract,
-            image_url: null,
-            token_standard: 'erc721',
-            metadata_url: 'https://example.com',
-          },
-        ],
-      })
-      .get(`/chain/ethereum/contract/${nftContract}/nfts/${nftId}`)
-      .reply(200, { nft: { image_url: 'https://example.com/image.gif' } });
-    const mockAddNft = jest.fn();
-    await withController(
-      {
-        options: {
-          addNft: mockAddNft,
-          getNftApi: jest
-            .fn()
-            .mockImplementation(
-              ({
-                contractAddress,
-                tokenId,
-              }: {
-                contractAddress: string;
-                tokenId: string;
-              }) =>
-                `${OPENSEA_PROXY_URL}/chain/ethereum/contract/${contractAddress}/nfts/${tokenId}`,
-            ),
-        },
-      },
-      async ({ controller, triggerPreferencesStateChange }) => {
-        triggerPreferencesStateChange({
-          ...getDefaultPreferencesState(),
-          selectedAddress,
-          useNftDetection: true,
-        });
-        // Wait for detect call triggered by preferences state change to settle
-        await advanceTime({
-          clock,
-          duration: 1,
-        });
-        mockAddNft.mockReset();
-
-        await controller.detectNfts();
-
-        expect(mockAddNft).toHaveBeenCalledWith(nftContract, nftId, {
-          nftMetadata: {
-            imageOriginal: 'https://example.com/image.gif',
-            name: undefined,
-            standard: 'ERC721',
-            creator: {
-              user: { username: '' },
-              profile_img_url: '',
-              address: '',
-            },
-          },
-          userAddress: selectedAddress,
-          source: Source.Detected,
-          networkClientId: undefined,
-        });
       },
     );
   });

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -1,8 +1,4 @@
-import {
-  RESERVOIR_API_BASE_URL,
-  ChainId,
-  toHex,
-} from '@metamask/controller-utils';
+import { NFT_API_BASE_URL, ChainId, toHex } from '@metamask/controller-utils';
 import { NetworkClientType } from '@metamask/network-controller';
 import type { NetworkClient } from '@metamask/network-controller';
 import {
@@ -30,9 +26,9 @@ describe('NftDetectionController', () => {
   beforeEach(async () => {
     clock = sinon.useFakeTimers();
 
-    nock(RESERVOIR_API_BASE_URL)
+    nock(NFT_API_BASE_URL)
       .persist()
-      .get(`/0x1/tokens?chainIds=1&limit=200&continuation=`)
+      .get(`/users/0x1/tokens?chainIds=1&limit=200&continuation=`)
       .reply(200, {
         tokens: [
           {
@@ -97,7 +93,7 @@ describe('NftDetectionController', () => {
           },
         ],
       })
-      .get(`/0x9/tokens?chainIds=1&limit=200&continuation=`)
+      .get(`/users/0x9/tokens?chainIds=1&limit=200&continuation=`)
       .reply(200, {
         tokens: [
           {
@@ -427,8 +423,8 @@ describe('NftDetectionController', () => {
 
   it('should do nothing when the request to Nft API fails', async () => {
     const selectedAddress = '0x3';
-    nock(RESERVOIR_API_BASE_URL)
-      .get(`/${selectedAddress}/tokens`)
+    nock(NFT_API_BASE_URL)
+      .get(`/users/${selectedAddress}/tokens`)
       .query({ continuation: '', limit: '200', chainIds: '1' })
       .replyWithError(new Error('Failed to fetch'))
       .persist();
@@ -460,8 +456,8 @@ describe('NftDetectionController', () => {
     await withController(
       async ({ controller, triggerPreferencesStateChange }) => {
         // This mock is for the initial detect call after preferences change
-        nock(RESERVOIR_API_BASE_URL)
-          .get(`/${selectedAddress}/tokens`)
+        nock(NFT_API_BASE_URL)
+          .get(`/users/${selectedAddress}/tokens`)
           .query({ continuation: '', limit: '200', chainIds: '1' })
           .reply(200, {
             tokens: [],
@@ -477,8 +473,8 @@ describe('NftDetectionController', () => {
           duration: 1,
         });
         // This mock is for the call under test
-        nock(RESERVOIR_API_BASE_URL)
-          .get(`/${selectedAddress}/tokens`)
+        nock(NFT_API_BASE_URL)
+          .get(`/users/${selectedAddress}/tokens`)
           .query({ continuation: '', limit: '200', chainIds: '1' })
           .replyWithError(new Error('UNEXPECTED ERROR'));
 

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -354,7 +354,14 @@ describe('NftDetectionController', () => {
     const mockAddNft = jest.fn();
     await withController(
       { options: { addNft: mockAddNft } },
-      async ({ controller }) => {
+      async ({ controller, triggerPreferencesStateChange }) => {
+        const selectedAddress = ''; // Emtpy selected address
+        triggerPreferencesStateChange({
+          ...getDefaultPreferencesState(),
+          selectedAddress,
+          useNftDetection: true, // auto-detect is enabled so it proceeds to check userAddress
+        });
+
         // confirm that default selected address is an empty string
         expect(controller.config.selectedAddress).toBe('');
 

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -154,11 +154,11 @@ export type ReservoirResponse = {
 };
 
 export type TokensResponse = {
-  token: Token;
+  token: TokenResponse;
   ownership: Ownership;
 };
 
-export type Token = {
+export type TokenResponse = {
   chainId: number;
   contract: string;
   tokenId: string;

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -609,12 +609,11 @@ export class NftDetectionController extends StaticIntervalPollingControllerV1<
         const nftMetadata: NftMetadata = Object.assign(
           {},
           { name },
-          //  creator && { creator },
           description && { description },
           image_url && { image: image_url },
           image_thumbnail_url && { imageThumbnail: image_thumbnail_url },
           image_original_url && { imageOriginal: image_original_url },
-          kind && { standard: kind },
+          kind && { standard: kind.toUpperCase() },
         );
 
         await this.addNft(contract, token_id, {

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -609,7 +609,6 @@ export class NftDetectionController extends StaticIntervalPollingControllerV1<
     }
 
     const apiNfts = await this.getOwnerNfts(userAddress);
-    console.log('🚀 ~ apiNfts:==================', apiNfts);
     const addNftPromises = apiNfts.map(async (nft: TokensResponse) => {
       const {
         tokenId: token_id,

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -185,7 +185,6 @@ export type TokenResponse = {
   chainId: number;
   contract: string;
   tokenId: string;
-  /** @description Can be erc721, erc115, etc. */
   kind?: string;
   name?: string;
   image?: string;
@@ -193,29 +192,21 @@ export type TokenResponse = {
   imageLarge?: string;
   metadata?: Metadata;
   description?: string;
-  /** @description Can be higher than one if erc1155. */
   supply?: number;
   remainingSupply?: number;
-  /** @description No rarity for collections over 100k */
   rarityScore?: number;
   rarity?: number;
-  /** @description No rarity rank for collections over 100k */
   rarityRank?: number;
   media?: string;
-  /** @default false */
   isFlagged?: boolean;
-  /** @default false */
   isSpam?: boolean;
-  /** @default false */
   isNsfw?: boolean;
-  /** @default false */
   metadataDisabled?: boolean;
   lastFlagUpdate?: string;
   lastFlagChange?: string;
   collection?: Collection;
   lastSale?: LastSale;
   topBid?: TopBid;
-  /** @description The value of the last sale.Can be null. */
   lastAppraisalValue?: number;
   attributes?: Attributes[];
 };
@@ -233,9 +224,6 @@ export type TopBid = {
 };
 
 export type LastSale = {
-  /** @description Deprecated. Use `saleId` instead. */
-  id?: string;
-  /** @description Unique identifier made from txn hash, price, etc. */
   saleId?: string;
   token?: {
     contract?: string;
@@ -248,10 +236,6 @@ export type LastSale = {
     };
   };
   orderSource?: string;
-  /**
-   * @description Can be `ask` or `bid`.
-   * @enum {string}
-   */
   orderSide?: 'ask' | 'bid';
   orderKind?: string;
   orderId?: string;
@@ -263,7 +247,6 @@ export type LastSale = {
   txHash?: string;
   logIndex?: number;
   batchIndex?: number;
-  /** @description Time added on the blockchain */
   timestamp?: number;
   price?: Price;
   washTradingScore?: number;
@@ -272,9 +255,7 @@ export type LastSale = {
   paidFullRoyalty?: boolean;
   feeBreakdown?: FeeBreakdown[];
   isDeleted?: boolean;
-  /** @description Time when added to indexer */
   createdAt?: string;
-  /** @description Time when updated in indexer */
   updatedAt?: string;
 };
 
@@ -287,35 +268,27 @@ export type FeeBreakdown = {
 };
 
 export type Attributes = {
-  /** @description Case sensitive */
   key?: string;
-  /** @description Can be `string`, `number, `date, or `range`. */
   kind?: string;
-  /** @description Case sensitive. */
   value: string;
   tokenCount?: number;
   onSaleCount?: number;
-  floorAskPrice?: Price;
-  /** @description Can be null. */
-  topBidValue?: number;
+  floorAskPrice?: Price | null;
+  topBidValue?: number | null;
   createdAt?: string;
 };
 
 export type Collection = {
   id?: string;
   name?: string;
-  /** @description Open Sea slug */
   slug?: string;
   symbol?: string;
   imageUrl?: string;
   image?: string;
-  /** @default false */
   isSpam?: boolean;
-  /** @default false */
   isNsfw?: boolean;
   creator?: string;
   tokenCount?: string;
-  /** @default false */
   metadataDisabled?: boolean;
   openseaVerificationStatus?: string;
   floorAskPrice?: Price;
@@ -609,7 +582,7 @@ export class NftDetectionController extends StaticIntervalPollingControllerV1<
     }
 
     const apiNfts = await this.getOwnerNfts(userAddress);
-    const addNftPromises = apiNfts.map(async (nft: TokensResponse) => {
+    const addNftPromises = apiNfts.map(async (nft) => {
       const {
         tokenId: token_id,
         contract,

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -3,7 +3,7 @@ import {
   fetchWithErrorHandling,
   toChecksumHexAddress,
   ChainId,
-  RESERVOIR_API_BASE_URL,
+  NFT_API_BASE_URL,
 } from '@metamask/controller-utils';
 import type {
   NetworkClientId,
@@ -288,6 +288,7 @@ export type Collection = {
   isSpam?: boolean;
   /** @default false */
   isNsfw?: boolean;
+  creator?: string;
   /** @default false */
   metadataDisabled?: boolean;
   openseaVerificationStatus?: string;
@@ -363,7 +364,7 @@ export class NftDetectionController extends StaticIntervalPollingControllerV1<
     address: string;
     next?: string;
   }) {
-    return `${RESERVOIR_API_BASE_URL}/${address}/tokens?chainIds=1&limit=200&continuation=${
+    return `${NFT_API_BASE_URL}/users/${address}/tokens?chainIds=1&limit=200&continuation=${
       next ?? ''
     }`;
   }

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -9,7 +9,6 @@ import BN from 'bn.js';
 import { CID } from 'multiformats/cid';
 
 import type { Nft, NftMetadata } from './NftController';
-// import type { ApiNftContract } from './NftDetectionController';
 import type { AbstractTokenPricesService } from './token-prices-service';
 import { type ContractExchangeRates } from './TokenRatesController';
 

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -8,15 +8,8 @@ import { remove0x } from '@metamask/utils';
 import BN from 'bn.js';
 import { CID } from 'multiformats/cid';
 
-import type {
-  Nft,
-  NftMetadata,
-  OpenSeaV2Collection,
-  OpenSeaV2Contract,
-  OpenSeaV2DetailedNft,
-  OpenSeaV2Nft,
-} from './NftController';
-import type { ApiNft, ApiNftContract } from './NftDetectionController';
+import type { Nft, NftMetadata } from './NftController';
+// import type { ApiNftContract } from './NftDetectionController';
 import type { AbstractTokenPricesService } from './token-prices-service';
 import { type ContractExchangeRates } from './TokenRatesController';
 
@@ -307,94 +300,6 @@ export async function reduceInBatchesSerially<
   // matches the intended type.
   const finalResult = workingResult as Result;
   return finalResult;
-}
-
-/**
- * Maps an OpenSea V2 NFT to the V1 schema.
- * @param nft - The V2 NFT to map.
- * @returns The NFT in the V1 schema.
- */
-export function mapOpenSeaNftV2ToV1(nft: OpenSeaV2Nft): ApiNft {
-  return {
-    token_id: nft.identifier,
-    num_sales: null,
-    background_color: null,
-    image_url: nft.image_url ?? null,
-    image_preview_url: null,
-    image_thumbnail_url: null,
-    image_original_url: null,
-    animation_url: null,
-    animation_original_url: null,
-    name: nft.name,
-    description: nft.description,
-    external_link: null,
-    asset_contract: {
-      address: nft.contract,
-      asset_contract_type: null,
-      created_date: null,
-      schema_name: nft.token_standard.toUpperCase(),
-      symbol: null,
-      total_supply: null,
-      description: nft.description,
-      external_link: null,
-      collection: {
-        name: nft.collection,
-        image_url: null,
-      },
-    },
-    creator: {
-      user: { username: '' },
-      profile_img_url: '',
-      address: '',
-    },
-    last_sale: null,
-  };
-}
-
-/**
- * Maps an OpenSea V2 detailed NFT to the V1 schema.
- * @param nft - The V2 detailed NFT to map.
- * @returns The NFT in the V1 schema.
- */
-export function mapOpenSeaDetailedNftV2ToV1(nft: OpenSeaV2DetailedNft): ApiNft {
-  const mapped = mapOpenSeaNftV2ToV1(nft);
-  return {
-    ...mapped,
-    animation_url: nft.animation_url ?? null,
-    creator: {
-      ...mapped.creator,
-      address: nft.creator,
-    },
-  };
-}
-
-/**
- * Maps an OpenSea V2 contract to the V1 schema.
- * @param contract - The v2 contract data.
- * @param collection - The v2 collection data.
- * @returns The contract in the v1 schema.
- */
-export function mapOpenSeaContractV2ToV1(
-  contract: OpenSeaV2Contract,
-  collection?: OpenSeaV2Collection,
-): ApiNftContract {
-  return {
-    address: contract.address,
-    asset_contract_type: null,
-    created_date: null,
-    schema_name: contract.contract_standard.toUpperCase(),
-    symbol: null,
-    total_supply:
-      collection?.total_supply?.toString() ??
-      contract.total_supply?.toString() ??
-      null,
-    description: collection?.description ?? null,
-    external_link: collection?.project_url ?? null,
-    collection: {
-      name: collection?.name ?? contract.name,
-      image_url: collection?.image_url,
-    },
-  };
 }
 
 /**

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -108,7 +108,7 @@ export const BUILT_IN_NETWORKS = {
 export const OPENSEA_PROXY_URL =
   'https://proxy.metafi.codefi.network/opensea/v1/api/v2';
 
-export const RESERVOIR_API_BASE_URL = 'https://nft.api.cx.metamask.io/users';
+export const NFT_API_BASE_URL = 'https://nft.api.cx.metamask.io';
 
 // Default origin for controllers
 export const ORIGIN_METAMASK = 'metamask';

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -108,6 +108,8 @@ export const BUILT_IN_NETWORKS = {
 export const OPENSEA_PROXY_URL =
   'https://proxy.metafi.codefi.network/opensea/v1/api/v2';
 
+export const RESERVOIR_API_BASE_URL = 'https://nft.api.cx.metamask.io/users';
+
 // Default origin for controllers
 export const ORIGIN_METAMASK = 'metamask';
 


### PR DESCRIPTION
## Explanation

Migrates the calls from OpenseaV2 to Reservoir.
Removes unused Opensea types and add Reservoir types.

Ideally the types are shared from NFT-API to other consuming clients rather than hardcoding them on core. We will address this in the future.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **REMOVED**: Removed opensea map functions from assetsUtil.ts like `mapOpenSeaNftV2ToV1`,  `mapOpenSeaDetailedNftV2ToV1` and `mapOpenSeaContractV2ToV1`.
- **ADDED**: Added `NFT_API_BASE_URL` in constants.ts
- **ADDED**: Added reservoir types in NftDetectionController.ts
- **REMOVED**: Call to openseaV2 to get user nfts in NftDetectionController.ts
- **Added**: Call to reservoir to get user nfts in NftDetectionController.ts
- **REMOVED**: Removed Opensea types from NftController.ts
- **REMOVED**: Removed call Opensea to get NFT information and added call to reservoir in  NftController.ts
- **REMOVED**: Removed fct getNftContractInformationFromApi that calls OS
- **CHANGED**: Changed fct `getNftContractInformation` to receive `nftMetadataFromApi` as arg (which contains contract information fetched already from reservoir and aggregate the result with `getNftContractInformationFromContract`
- **CHANGED**: Changed the call to `getNftInformation` inside `addNft` function to be before  `addNftContract`, because the nftInformation received from reservoir already includes collection metadata, no need to make another separate call to fetch it.


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
