### PR TITLE
[base-controller] Make `allowed{Actions,Events}` required parameters of `getRestricted`

### DIFF
--- a/packages/announcement-controller/src/AnnouncementController.test.ts
+++ b/packages/announcement-controller/src/AnnouncementController.test.ts
@@ -23,6 +23,8 @@ function getRestrictedMessenger() {
   >();
   return controllerMessenger.getRestricted({
     name,
+    allowedActions: [],
+    allowedEvents: [],
   });
 }
 const allAnnouncements: AnnouncementMap = {

--- a/packages/approval-controller/src/ApprovalController.test.ts
+++ b/packages/approval-controller/src/ApprovalController.test.ts
@@ -7,7 +7,6 @@ import type {
   AddApprovalOptions,
   ApprovalControllerActions,
   ApprovalControllerEvents,
-  ApprovalControllerMessenger,
   ErrorOptions,
   StartFlowOptions,
   SuccessOptions,
@@ -1151,7 +1150,7 @@ describe('approval controller', () => {
           name: controllerName,
           allowedActions: [],
           allowedEvents: [],
-        }) as ApprovalControllerMessenger,
+        }),
         showApprovalRequest,
       });
 
@@ -1175,7 +1174,7 @@ describe('approval controller', () => {
           name: controllerName,
           allowedActions: [],
           allowedEvents: [],
-        }) as ApprovalControllerMessenger,
+        }),
         showApprovalRequest,
       });
 
@@ -1199,7 +1198,7 @@ describe('approval controller', () => {
           name: controllerName,
           allowedActions: [],
           allowedEvents: [],
-        }) as ApprovalControllerMessenger,
+        }),
         showApprovalRequest,
       });
 

--- a/packages/approval-controller/src/ApprovalController.test.ts
+++ b/packages/approval-controller/src/ApprovalController.test.ts
@@ -233,6 +233,8 @@ function getRestrictedMessenger() {
   >();
   const messenger = controllerMessenger.getRestricted({
     name: 'ApprovalController',
+    allowedActions: [],
+    allowedEvents: [],
   });
   return messenger;
 }
@@ -1147,6 +1149,8 @@ describe('approval controller', () => {
       approvalController = new ApprovalController({
         messenger: messenger.getRestricted({
           name: controllerName,
+          allowedActions: [],
+          allowedEvents: [],
         }) as ApprovalControllerMessenger,
         showApprovalRequest,
       });
@@ -1169,6 +1173,8 @@ describe('approval controller', () => {
       approvalController = new ApprovalController({
         messenger: messenger.getRestricted({
           name: controllerName,
+          allowedActions: [],
+          allowedEvents: [],
         }) as ApprovalControllerMessenger,
         showApprovalRequest,
       });
@@ -1191,6 +1197,8 @@ describe('approval controller', () => {
       approvalController = new ApprovalController({
         messenger: messenger.getRestricted({
           name: controllerName,
+          allowedActions: [],
+          allowedEvents: [],
         }) as ApprovalControllerMessenger,
         showApprovalRequest,
       });

--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -55,6 +55,8 @@ async function setupAssetContractControllers() {
   const messenger: NetworkControllerMessenger =
     new ControllerMessenger().getRestricted({
       name: 'NetworkController',
+      allowedActions: [],
+      allowedEvents: [],
     });
   const network = new NetworkController({
     infuraProjectId: networkClientConfiguration.infuraProjectId,

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -58,6 +58,7 @@ function getRestrictedMessenger() {
   >({
     name,
     allowedActions: ['NetworkController:getNetworkClientById'],
+    allowedEvents: [],
   });
   return messenger;
 }

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -165,6 +165,7 @@ function setupController(
   >({
     name: controllerName,
     allowedActions: ['ApprovalController:addRequest'],
+    allowedEvents: [],
   });
 
   const preferencesStateChangeListeners: ((state: PreferencesState) => void)[] =

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -123,6 +123,8 @@ function setupController(
 
   const approvalControllerMessenger = messenger.getRestricted({
     name: 'ApprovalController',
+    allowedActions: [],
+    allowedEvents: [],
   });
 
   const approvalController = new ApprovalController({

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -117,6 +117,8 @@ describe('TokensController', () => {
 
     approvalControllerMessenger = messenger.getRestricted({
       name: 'ApprovalController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     tokensControllerMessenger = messenger.getRestricted<

--- a/packages/base-controller/src/BaseControllerV2.test.ts
+++ b/packages/base-controller/src/BaseControllerV2.test.ts
@@ -64,6 +64,8 @@ function getCountMessenger(
   }
   return controllerMessenger.getRestricted({
     name: countControllerName,
+    allowedActions: [],
+    allowedEvents: [],
   });
 }
 
@@ -147,6 +149,8 @@ function getMessagesMessenger(
   }
   return controllerMessenger.getRestricted({
     name: messagesControllerName,
+    allowedActions: [],
+    allowedEvents: [],
   });
 }
 
@@ -1110,6 +1114,8 @@ describe('getPersistentState', () => {
       >();
       const visitorControllerMessenger = controllerMessenger.getRestricted({
         name: visitorName,
+        allowedActions: [],
+        allowedEvents: [],
       });
       const visitorController = new VisitorController(
         visitorControllerMessenger,

--- a/packages/base-controller/src/ControllerMessenger.ts
+++ b/packages/base-controller/src/ControllerMessenger.ts
@@ -430,15 +430,15 @@ export class ControllerMessenger<
     AllowedEvent extends NotNamespacedBy<Namespace, Event['type']> = never,
   >({
     name,
-    allowedActions = [],
-    allowedEvents = [],
+    allowedActions,
+    allowedEvents,
   }: {
     name: Namespace;
-    allowedActions?: NotNamespacedBy<
+    allowedActions: NotNamespacedBy<
       Namespace,
       Extract<Action['type'], AllowedAction>
     >[];
-    allowedEvents?: NotNamespacedBy<
+    allowedEvents: NotNamespacedBy<
       Namespace,
       Extract<Event['type'], AllowedEvent>
     >[];

--- a/packages/base-controller/src/RestrictedControllerMessenger.test.ts
+++ b/packages/base-controller/src/RestrictedControllerMessenger.test.ts
@@ -11,6 +11,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     let count = 0;
@@ -35,6 +37,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<MessageAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     let message = '';
@@ -69,6 +73,8 @@ describe('RestrictedControllerMessenger', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     let count = 0;
@@ -91,6 +97,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<MessageAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const messages: Record<string, string> = {};
@@ -118,6 +126,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<AddAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MathController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     restrictedControllerMessenger.registerActionHandler(
@@ -140,6 +150,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     restrictedControllerMessenger.registerActionHandler(
@@ -280,6 +292,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     expect(() => {
@@ -354,6 +368,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<PingAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     expect(() => {
@@ -386,6 +402,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     expect(() =>
@@ -408,6 +426,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const handler = sinon.stub();
@@ -437,6 +457,8 @@ describe('RestrictedControllerMessenger', () => {
       >();
       const restrictedControllerMessenger = controllerMessenger.getRestricted({
         name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       restrictedControllerMessenger.registerInitialEventPayload({
         eventType: 'MessageController:complexMessage',
@@ -475,6 +497,8 @@ describe('RestrictedControllerMessenger', () => {
       >();
       const restrictedControllerMessenger = controllerMessenger.getRestricted({
         name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       restrictedControllerMessenger.registerInitialEventPayload({
         eventType: 'MessageController:complexMessage',
@@ -513,6 +537,8 @@ describe('RestrictedControllerMessenger', () => {
       >();
       const restrictedControllerMessenger = controllerMessenger.getRestricted({
         name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const handler = sinon.stub();
       const selector = sinon.fake((obj: Record<string, unknown>) => obj.propA);
@@ -547,6 +573,8 @@ describe('RestrictedControllerMessenger', () => {
       >();
       const restrictedControllerMessenger = controllerMessenger.getRestricted({
         name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const handler = sinon.stub();
       const selector = sinon.fake((obj: Record<string, unknown>) => obj.propA);
@@ -580,6 +608,8 @@ describe('RestrictedControllerMessenger', () => {
       >();
       const restrictedControllerMessenger = controllerMessenger.getRestricted({
         name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const handler = sinon.stub();
       const selector = sinon.fake((obj: Record<string, unknown>) => obj.propA);
@@ -610,6 +640,8 @@ describe('RestrictedControllerMessenger', () => {
       >();
       const restrictedControllerMessenger = controllerMessenger.getRestricted({
         name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
       });
 
       const handler = sinon.stub();
@@ -650,6 +682,8 @@ describe('RestrictedControllerMessenger', () => {
       >();
       const restrictedControllerMessenger = controllerMessenger.getRestricted({
         name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
       });
 
       const handler = sinon.stub();
@@ -682,6 +716,8 @@ describe('RestrictedControllerMessenger', () => {
       >();
       const restrictedControllerMessenger = controllerMessenger.getRestricted({
         name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
       });
 
       const handler = sinon.stub();
@@ -718,6 +754,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const messageHandler = sinon.stub();
@@ -746,6 +784,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, PingEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const handler = sinon.stub();
@@ -764,6 +804,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const handler = sinon.stub();
@@ -790,6 +832,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const handler = sinon.stub();
@@ -816,6 +860,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const handler1 = sinon.stub();
@@ -845,6 +891,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const handler = sinon.stub();
@@ -870,6 +918,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const handler = sinon.stub();
@@ -889,6 +939,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const handler1 = sinon.stub();
@@ -914,6 +966,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const handler = sinon.stub();
@@ -938,6 +992,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     expect(() =>
@@ -955,6 +1011,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     let count = 0;
@@ -978,6 +1036,8 @@ describe('RestrictedControllerMessenger', () => {
     const externalRestrictedControllerMessenger =
       controllerMessenger.getRestricted({
         name: 'CountController',
+        allowedActions: [],
+        allowedEvents: [],
       });
     const restrictedControllerMessenger = controllerMessenger.getRestricted<
       'OtherController',
@@ -1007,6 +1067,8 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     const handler = sinon.stub();
@@ -1030,6 +1092,8 @@ describe('RestrictedControllerMessenger', () => {
     const externalRestrictedControllerMessenger =
       controllerMessenger.getRestricted({
         name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
       });
     const restrictedControllerMessenger = controllerMessenger.getRestricted<
       'OtherController',
@@ -1077,6 +1141,8 @@ describe('RestrictedControllerMessenger', () => {
     });
     const countControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     let count = 0;
@@ -1125,6 +1191,8 @@ describe('RestrictedControllerMessenger', () => {
     });
     const countControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
     });
 
     let pings = 0;

--- a/packages/base-controller/src/RestrictedControllerMessenger.test.ts
+++ b/packages/base-controller/src/RestrictedControllerMessenger.test.ts
@@ -176,6 +176,7 @@ describe('RestrictedControllerMessenger', () => {
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
       allowedActions: [],
+      allowedEvents: [],
     });
 
     expect(() => {
@@ -197,6 +198,7 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
       allowedEvents: [],
     });
 
@@ -224,6 +226,7 @@ describe('RestrictedControllerMessenger', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
       allowedEvents: ['OtherController:other'],
     });
 
@@ -246,6 +249,7 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
       allowedEvents: [],
     });
 
@@ -273,6 +277,7 @@ describe('RestrictedControllerMessenger', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
       allowedEvents: ['OtherController:other'],
     });
 
@@ -314,6 +319,7 @@ describe('RestrictedControllerMessenger', () => {
     >({
       name: 'PingController',
       allowedActions: ['CountController:count'],
+      allowedEvents: [],
     });
 
     expect(() => {
@@ -339,6 +345,7 @@ describe('RestrictedControllerMessenger', () => {
     >({
       name: 'PingController',
       allowedActions: ['CountController:count'],
+      allowedEvents: [],
     });
     expect(() => {
       restrictedControllerMessenger.unregisterActionHandler(
@@ -356,6 +363,7 @@ describe('RestrictedControllerMessenger', () => {
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
       allowedActions: [],
+      allowedEvents: [],
     });
 
     expect(() => {
@@ -1045,6 +1053,7 @@ describe('RestrictedControllerMessenger', () => {
     >({
       name: 'OtherController',
       allowedActions: ['CountController:count'],
+      allowedEvents: [],
     });
 
     let count = 0;
@@ -1101,6 +1110,7 @@ describe('RestrictedControllerMessenger', () => {
       MessageEvent['type']
     >({
       name: 'OtherController',
+      allowedActions: [],
       allowedEvents: ['MessageController:message'],
     });
 
@@ -1138,6 +1148,7 @@ describe('RestrictedControllerMessenger', () => {
     const messageControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
       allowedActions: ['CountController:count'],
+      allowedEvents: [],
     });
     const countControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
@@ -1187,6 +1198,7 @@ describe('RestrictedControllerMessenger', () => {
 
     const messageControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
+      allowedActions: [],
       allowedEvents: ['CountController:update'],
     });
     const countControllerMessenger = controllerMessenger.getRestricted({

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -176,6 +176,7 @@ describe('ComposableController', () => {
         FooControllerEvent['type']
       >({
         name: 'ComposableController',
+        allowedActions: [],
         allowedEvents: ['FooController:stateChange'],
       });
       const composableController = new ComposableController({
@@ -204,6 +205,7 @@ describe('ComposableController', () => {
         FooControllerEvent['type']
       >({
         name: 'ComposableController',
+        allowedActions: [],
         allowedEvents: ['FooController:stateChange'],
       });
       new ComposableController({
@@ -246,6 +248,7 @@ describe('ComposableController', () => {
         FooControllerEvent['type']
       >({
         name: 'ComposableController',
+        allowedActions: [],
         allowedEvents: ['FooController:stateChange'],
       });
       const composableController = new ComposableController({
@@ -276,6 +279,7 @@ describe('ComposableController', () => {
         FooControllerEvent['type']
       >({
         name: 'ComposableController',
+        allowedActions: [],
         allowedEvents: ['FooController:stateChange'],
       });
       new ComposableController({
@@ -318,6 +322,7 @@ describe('ComposableController', () => {
         FooControllerEvent['type']
       >({
         name: 'ComposableController',
+        allowedActions: [],
         allowedEvents: ['FooController:stateChange'],
       });
       new ComposableController({
@@ -382,6 +387,7 @@ describe('ComposableController', () => {
         FooControllerEvent['type']
       >({
         name: 'ComposableController',
+        allowedActions: [],
         allowedEvents: ['FooController:stateChange'],
       });
       expect(

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -112,6 +112,8 @@ describe('ComposableController', () => {
         ComposableControllerEvents
       >().getRestricted({
         name: 'ComposableController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const controller = new ComposableController({
         controllers: [new BarController(), new BazController()],
@@ -131,6 +133,8 @@ describe('ComposableController', () => {
       >();
       const composableMessenger = controllerMessenger.getRestricted({
         name: 'ComposableController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const barController = new BarController();
       new ComposableController({
@@ -161,6 +165,8 @@ describe('ComposableController', () => {
       >();
       const fooControllerMessenger = controllerMessenger.getRestricted({
         name: 'FooController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const fooController = new FooController(fooControllerMessenger);
 
@@ -188,6 +194,8 @@ describe('ComposableController', () => {
       >();
       const fooControllerMessenger = controllerMessenger.getRestricted({
         name: 'FooController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const fooController = new FooController(fooControllerMessenger);
       const composableControllerMessenger = controllerMessenger.getRestricted<
@@ -228,6 +236,8 @@ describe('ComposableController', () => {
       >();
       const fooControllerMessenger = controllerMessenger.getRestricted({
         name: 'FooController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const fooController = new FooController(fooControllerMessenger);
       const composableControllerMessenger = controllerMessenger.getRestricted<
@@ -256,6 +266,8 @@ describe('ComposableController', () => {
       >();
       const fooControllerMessenger = controllerMessenger.getRestricted({
         name: 'FooController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const fooController = new FooController(fooControllerMessenger);
       const composableControllerMessenger = controllerMessenger.getRestricted<
@@ -296,6 +308,8 @@ describe('ComposableController', () => {
       >();
       const fooControllerMessenger = controllerMessenger.getRestricted({
         name: 'FooController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const fooController = new FooController(fooControllerMessenger);
       const composableControllerMessenger = controllerMessenger.getRestricted<
@@ -337,6 +351,8 @@ describe('ComposableController', () => {
       >();
       const fooControllerMessenger = controllerMessenger.getRestricted({
         name: 'FooController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const fooController = new FooController(fooControllerMessenger);
       expect(
@@ -356,6 +372,8 @@ describe('ComposableController', () => {
       >();
       const fooControllerMessenger = controllerMessenger.getRestricted({
         name: 'FooController',
+        allowedActions: [],
+        allowedEvents: [],
       });
       const fooController = new FooController(fooControllerMessenger);
       const composableControllerMessenger = controllerMessenger.getRestricted<

--- a/packages/ens-controller/src/EnsController.test.ts
+++ b/packages/ens-controller/src/EnsController.test.ts
@@ -58,6 +58,8 @@ const name = 'EnsController';
 function getMessenger() {
   return new ControllerMessenger().getRestricted({
     name,
+    allowedActions: [],
+    allowedEvents: [],
   });
 }
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -3119,6 +3119,8 @@ function buildMessenger() {
 function buildKeyringControllerMessenger(messenger = buildMessenger()) {
   return messenger.getRestricted({
     name: 'KeyringController',
+    allowedActions: [],
+    allowedEvents: [],
   });
 }
 

--- a/packages/logging-controller/src/LoggingController.test.ts
+++ b/packages/logging-controller/src/LoggingController.test.ts
@@ -36,6 +36,8 @@ function getRestrictedMessenger(
 ) {
   return controllerMessenger.getRestricted({
     name,
+    allowedActions: [],
+    allowedEvents: [],
   });
 }
 

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -7450,6 +7450,8 @@ function buildMessenger() {
 function buildNetworkControllerMessenger(messenger = buildMessenger()) {
   return messenger.getRestricted({
     name: 'NetworkController',
+    allowedActions: [],
+    allowedEvents: [],
   });
 }
 

--- a/packages/notification-controller/src/NotificationController.test.ts
+++ b/packages/notification-controller/src/NotificationController.test.ts
@@ -31,6 +31,8 @@ function getRestrictedMessenger(
 ) {
   return controllerMessenger.getRestricted({
     name,
+    allowedActions: [],
+    allowedEvents: [],
   });
 }
 

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -484,6 +484,7 @@ function getPermissionControllerMessenger(
         'ApprovalController:rejectRequest',
         'SubjectMetadataController:getSubjectMetadata',
       ],
+      allowedEvents: [],
     },
   ) as PermissionControllerMessenger;
 }

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -19,7 +19,6 @@ import type {
   PermissionConstraint,
   PermissionControllerActions,
   PermissionControllerEvents,
-  PermissionControllerMessenger,
   PermissionOptions,
   RestrictedMethodOptions,
   RestrictedMethodParameters,
@@ -486,7 +485,7 @@ function getPermissionControllerMessenger(
       ],
       allowedEvents: [],
     },
-  ) as PermissionControllerMessenger;
+  );
 }
 
 /**

--- a/packages/permission-controller/src/SubjectMetadataController.test.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.test.ts
@@ -5,7 +5,6 @@ import type { HasPermissions } from './PermissionController';
 import type {
   SubjectMetadataControllerActions,
   SubjectMetadataControllerEvents,
-  SubjectMetadataControllerMessenger,
 } from './SubjectMetadataController';
 import {
   SubjectMetadataController,
@@ -39,7 +38,7 @@ function getSubjectMetadataControllerMessenger() {
       name: controllerName,
       allowedActions: ['PermissionController:hasPermissions'],
       allowedEvents: [],
-    }) as SubjectMetadataControllerMessenger,
+    }),
     hasPermissionsSpy,
   ] as const;
 }

--- a/packages/permission-controller/src/SubjectMetadataController.test.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.test.ts
@@ -38,6 +38,7 @@ function getSubjectMetadataControllerMessenger() {
     >({
       name: controllerName,
       allowedActions: ['PermissionController:hasPermissions'],
+      allowedEvents: [],
     }) as SubjectMetadataControllerMessenger,
     hasPermissionsSpy,
   ] as const;

--- a/packages/permission-log-controller/tests/PermissionLogController.test.ts
+++ b/packages/permission-log-controller/tests/PermissionLogController.test.ts
@@ -43,6 +43,8 @@ const initController = ({
 }): PermissionLogController => {
   const messenger = new ControllerMessenger().getRestricted({
     name,
+    allowedActions: [],
+    allowedEvents: [],
   });
   return new PermissionLogController({
     messenger,

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -28,6 +28,8 @@ function getRestrictedMessenger() {
 
   const messenger = controllerMessenger.getRestricted({
     name: controllerName,
+    allowedActions: [],
+    allowedEvents: [],
   });
 
   return messenger;

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -460,6 +460,7 @@ function setupPreferencesController({
     AllowedEvents['type']
   >({
     name: 'PreferencesController',
+    allowedActions: [],
     allowedEvents: ['KeyringController:stateChange'],
   });
   return new PreferencesController({

--- a/packages/queued-request-controller/src/QueuedRequestController.test.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.test.ts
@@ -865,6 +865,7 @@ function buildQueuedRequestControllerMessenger(
       'NetworkController:setActiveNetwork',
       'SelectedNetworkController:getNetworkClientIdForDomain',
     ],
+    allowedEvents: [],
   });
 }
 

--- a/packages/rate-limit-controller/src/RateLimitController.test.ts
+++ b/packages/rate-limit-controller/src/RateLimitController.test.ts
@@ -2,7 +2,6 @@ import { ControllerMessenger } from '@metamask/base-controller';
 
 import type {
   RateLimitControllerActions,
-  RateLimitMessenger,
   RateLimitControllerEvents,
 } from './RateLimitController';
 import { RateLimitController } from './RateLimitController';
@@ -47,7 +46,7 @@ function getRestrictedMessenger(
     name,
     allowedActions: [],
     allowedEvents: [],
-  }) as RateLimitMessenger<RateLimitedApis>;
+  });
 }
 
 const origin = 'snap_test';

--- a/packages/rate-limit-controller/src/RateLimitController.test.ts
+++ b/packages/rate-limit-controller/src/RateLimitController.test.ts
@@ -45,6 +45,8 @@ function getRestrictedMessenger(
 ) {
   return controllerMessenger.getRestricted({
     name,
+    allowedActions: [],
+    allowedEvents: [],
   }) as RateLimitMessenger<RateLimitedApis>;
 }
 

--- a/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
@@ -27,6 +27,8 @@ describe('createSelectedNetworkMiddleware', () => {
     const middleware = createSelectedNetworkMiddleware(
       messenger.getRestricted({
         name: 'SelectedNetworkController',
+        allowedActions: [],
+        allowedEvents: [],
       }),
     );
     const req: SelectedNetworkMiddlewareJsonRpcRequest = {
@@ -49,6 +51,8 @@ describe('createSelectedNetworkMiddleware', () => {
     const middleware = createSelectedNetworkMiddleware(
       messenger.getRestricted({
         name: 'SelectedNetworkController',
+        allowedActions: [],
+        allowedEvents: [],
       }),
     );
 
@@ -83,6 +87,8 @@ describe('createSelectedNetworkMiddleware', () => {
       createSelectedNetworkMiddleware(
         messenger.getRestricted({
           name: 'SelectedNetworkController',
+          allowedActions: [],
+          allowedEvents: [],
         }),
       ),
     );

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -563,6 +563,7 @@ describe('TransactionController', () => {
           'NetworkController:getNetworkClientById',
           'NetworkController:findNetworkClientIdByChainId',
         ],
+        allowedEvents: [],
       });
 
     const controller = new TransactionController({

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -113,11 +113,12 @@ const setupController = async (
 
   const unrestrictedMessenger: UnrestrictedControllerMessenger =
     new ControllerMessenger();
-  const networkControllerMessenger = unrestrictedMessenger.getRestricted({
-    name: 'NetworkController',
-  });
   const networkController = new NetworkController({
-    messenger: networkControllerMessenger,
+    messenger: unrestrictedMessenger.getRestricted({
+      name: 'NetworkController',
+      allowedActions: [],
+      allowedEvents: [],
+    }),
     trackMetaMetricsEvent: () => {
       // noop
     },
@@ -129,11 +130,12 @@ const setupController = async (
   assert(provider, 'Provider must be available');
   assert(blockTracker, 'Provider must be available');
 
-  const approvalControllerMessenger = unrestrictedMessenger.getRestricted({
-    name: 'ApprovalController',
-  });
   const approvalController = new ApprovalController({
-    messenger: approvalControllerMessenger,
+    messenger: unrestrictedMessenger.getRestricted({
+      name: 'ApprovalController',
+      allowedActions: [],
+      allowedEvents: [],
+    }),
     showApprovalRequest: jest.fn(),
     typesExcludedFromRateLimiting: [ApprovalType.Transaction],
   });

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -113,12 +113,11 @@ const setupController = async (
 
   const unrestrictedMessenger: UnrestrictedControllerMessenger =
     new ControllerMessenger();
+  const networkControllerMessenger = unrestrictedMessenger.getRestricted({
+    name: 'NetworkController',
+  });
   const networkController = new NetworkController({
-    messenger: unrestrictedMessenger.getRestricted({
-      name: 'NetworkController',
-      allowedActions: [],
-      allowedEvents: [],
-    }),
+    messenger: networkControllerMessenger,
     trackMetaMetricsEvent: () => {
       // noop
     },
@@ -130,12 +129,11 @@ const setupController = async (
   assert(provider, 'Provider must be available');
   assert(blockTracker, 'Provider must be available');
 
+  const approvalControllerMessenger = unrestrictedMessenger.getRestricted({
+    name: 'ApprovalController',
+  });
   const approvalController = new ApprovalController({
-    messenger: unrestrictedMessenger.getRestricted({
-      name: 'ApprovalController',
-      allowedActions: [],
-      allowedEvents: [],
-    }),
+    messenger: approvalControllerMessenger,
     showApprovalRequest: jest.fn(),
     typesExcludedFromRateLimiting: [ApprovalType.Transaction],
   });

--- a/packages/transaction-controller/src/utils/swaps.test.ts
+++ b/packages/transaction-controller/src/utils/swaps.test.ts
@@ -55,6 +55,7 @@ describe('updateSwapsTransaction', () => {
         'NetworkController:getNetworkClientById',
         'NetworkController:findNetworkClientIdByChainId',
       ],
+      allowedEvents: [],
     });
     request = {
       isSwapsDisabled: false,


### PR DESCRIPTION
## Explanation

This commit implements a fundamental solution to aligning runtime and type-level behavior for `getRestricted`: removing the option to omit its function parameters altogether. 

### Impact

- This makes the expected runtime behavior of the method explicit and predictable. 
- This completely prevents type inference from deriving ambiguous conclusions from the omission of function or generic parameters, or otherwise exhibiting unexpected behavior.

The downsides of this approach are a bit more redundant code and inconvenience, but having to write an extra empty array or two doesn't seem like a terrible cost for getting unambiguous, explicit behavior.

### Caveat

Note that this solution does not directly resolve the observed bug that motivated this ticket. It does make the bug irrelevant for `getRestricted`, because passing in both allowlist params fixes the issue, but in general, there may still be cases where generic default arguments fail to apply.

See #4033 for repro steps and more details on this bug.

### Overview

- This change is implemented entirely in this commit: https://github.com/MetaMask/core/pull/4035/commits/9988d18b85fa91efecf1f200f382eeae894351b4
- All of the other diffs in the test files are simply applying this breaking change.

## References

- Closes https://github.com/MetaMask/core/issues/4033

## Changelog

### `@metamask/base-controller`

#### Changed

- **BREAKING:** The `getRestricted` method of the `ControllerMessenger` class now expects both `allowedActions` and `allowedEvents` as required parameters.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
