### PR TITLE
[base-controller] minor type fixes

### DIFF
--- a/packages/base-controller/src/ControllerMessenger.ts
+++ b/packages/base-controller/src/ControllerMessenger.ts
@@ -450,15 +450,7 @@ export class ControllerMessenger<
     AllowedAction,
     AllowedEvent
   > {
-    return new RestrictedControllerMessenger<
-      Namespace,
-      | NarrowToNamespace<Action, Namespace>
-      | NarrowToAllowed<Action, AllowedAction>,
-      | NarrowToNamespace<Event, Namespace>
-      | NarrowToAllowed<Event, AllowedEvent>,
-      AllowedAction,
-      AllowedEvent
-    >({
+    return new RestrictedControllerMessenger({
       controllerMessenger: this,
       name,
       allowedActions,

--- a/packages/base-controller/src/ControllerMessenger.ts
+++ b/packages/base-controller/src/ControllerMessenger.ts
@@ -90,12 +90,12 @@ type EventSubscriptionMap<
  */
 export type NamespacedBy<
   Namespace extends string,
-  Name,
+  Name extends string,
 > = Name extends `${Namespace}:${string}` ? Name : never;
 
 export type NotNamespacedBy<
   Namespace extends string,
-  Name,
+  Name extends string,
 > = Name extends `${Namespace}:${string}` ? never : Name;
 
 export type NamespacedName<Namespace extends string = string> =


### PR DESCRIPTION
## Changelog

### `@metamask/base-controller`

#### Added

- **BREAKING**: Add `string` as generic constraint to the `Name` generic parameter of the types `NamespacedBy` and `NotNamespacedBy`. 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
