### PR TITLE
Release 124.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "123.0.0",
+  "version": "124.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {
@@ -55,8 +55,8 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
-    "@metamask/eth-json-rpc-provider": "^2.3.2",
-    "@metamask/json-rpc-engine": "^7.3.3",
+    "@metamask/eth-json-rpc-provider": "^3.0.0",
+    "@metamask/json-rpc-engine": "^8.0.0",
     "@metamask/utils": "^8.3.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.18.54",

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- **BREAKING:** Bump peer dependency on `@metamask/keyring-controller` to `^14.0.0` (TODO: This PR)
+- **BREAKING:** Bump peer dependency on `@metamask/keyring-controller` to `^14.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ### Removed
 

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [12.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- **BREAKING:** Bump peer dependency on `@metamask/keyring-controller` to `^14.0.0` (TODO: This PR)
+
+### Removed
+
+- **BREAKING:** Remove action and event types unrelated to `AccountsController` from `AccountsControllerActions` and `AccountsControllerEvents` ([#4031](https://github.com/MetaMask/core/pull/4031))
+
+### Fixed
+
+- **BREAKING:** Narrow allowed actions and event type for `AccountsController` messenger ([#4021](https://github.com/MetaMask/core/pull/4021), [#4031](https://github.com/MetaMask/core/pull/4031))
+  - Narrow type parameter `AllowedAction` from `string` to `KeyringControllerGetKeyringForAccountAction | KeyringControllerGetKeyringsByTypeAction | KeyringControllerGetAccountsAction`.
+  - Narrow type parameter `AllowedEvent` from `string` to `SnapStateChange | KeyringControllerStateChangeEvent`, removing other events from `SnapController` and `KeyringController`.
+
 ## [11.0.0]
 
 ### Changed
@@ -126,7 +149,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#1637](https://github.com/MetaMask/core/pull/1637))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@11.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@12.0.0...HEAD
+[12.0.0]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@11.0.0...@metamask/accounts-controller@12.0.0
 [11.0.0]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@10.0.0...@metamask/accounts-controller@11.0.0
 [10.0.0]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@9.0.0...@metamask/accounts-controller@10.0.0
 [9.0.0]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@8.0.0...@metamask/accounts-controller@9.0.0

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -27,8 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **BREAKING:** Narrow allowed actions and event type for `AccountsController` messenger ([#4021](https://github.com/MetaMask/core/pull/4021), [#4031](https://github.com/MetaMask/core/pull/4031))
-  - Narrow type parameter `AllowedAction` from `string` to `KeyringControllerGetKeyringForAccountAction | KeyringControllerGetKeyringsByTypeAction | KeyringControllerGetAccountsAction`.
-  - Narrow type parameter `AllowedEvent` from `string` to `SnapStateChange | KeyringControllerStateChangeEvent`, removing other events from `SnapController` and `KeyringController`.
+  - Narrow type parameter `AllowedAction` from `string` to `(KeyringControllerGetKeyringForAccountAction | KeyringControllerGetKeyringsByTypeAction | KeyringControllerGetAccountsAction)['type']`.
+  - Narrow type parameter `AllowedEvent` from `string` to `(SnapStateChange | KeyringControllerStateChangeEvent)['type']`, removing other events from `SnapController` and `KeyringController`.
 
 ## [11.0.0]
 

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/accounts-controller",
-  "version": "11.0.0",
+  "version": "12.0.0",
   "description": "Manages internal accounts",
   "keywords": [
     "MetaMask",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",
-    "@metamask/base-controller": "^4.1.1",
+    "@metamask/base-controller": "^5.0.0",
     "@metamask/eth-snap-keyring": "^2.1.1",
     "@metamask/keyring-api": "^3.0.0",
     "@metamask/snaps-sdk": "^1.3.2",
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-controller": "^13.0.0",
+    "@metamask/keyring-controller": "^14.0.0",
     "@metamask/snaps-controllers": "^4.0.0",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",
@@ -66,7 +66,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/keyring-controller": "^13.0.0",
+    "@metamask/keyring-controller": "^14.0.0",
     "@metamask/snaps-controllers": "^4.0.0"
   },
   "engines": {

--- a/packages/address-book-controller/CHANGELOG.md
+++ b/packages/address-book-controller/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: Fill in PR number)
+
 ## [3.1.7]
 
 ### Changed
@@ -108,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@3.1.7...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@4.0.0...HEAD
+[4.0.0]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@3.1.7...@metamask/address-book-controller@4.0.0
 [3.1.7]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@3.1.6...@metamask/address-book-controller@3.1.7
 [3.1.6]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@3.1.5...@metamask/address-book-controller@3.1.6
 [3.1.5]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@3.1.4...@metamask/address-book-controller@3.1.5

--- a/packages/address-book-controller/CHANGELOG.md
+++ b/packages/address-book-controller/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: Fill in PR number)
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [3.1.7]
 

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/address-book-controller",
-  "version": "3.1.7",
+  "version": "4.0.0",
   "description": "Manages a list of recipient addresses associated with nicknames",
   "keywords": [
     "MetaMask",
@@ -41,8 +41,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
     "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {

--- a/packages/announcement-controller/CHANGELOG.md
+++ b/packages/announcement-controller/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
 
 ## [5.0.2]

--- a/packages/announcement-controller/CHANGELOG.md
+++ b/packages/announcement-controller/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+
 ## [5.0.2]
 
 ### Changed
@@ -105,7 +117,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@5.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.0.0...HEAD
+[6.0.0]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@5.0.2...@metamask/announcement-controller@6.0.0
 [5.0.2]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@5.0.1...@metamask/announcement-controller@5.0.2
 [5.0.1]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@5.0.0...@metamask/announcement-controller@5.0.1
 [5.0.0]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@4.0.3...@metamask/announcement-controller@5.0.0

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/announcement-controller",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "description": "Manages in-app announcements",
   "keywords": [
     "MetaMask",
@@ -41,7 +41,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1"
+    "@metamask/base-controller": "^5.0.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
 
 ### Fixed

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **BREAKING:** Narrow `ApprovalControllerMessenger` type parameters `AllowedAction` and `AllowedEvent` from `string` to `never` ([#4031](https://github.com/MetaMask/core/pull/4031))
-  - Allowlisting any actions or events will now produce a type error.
+  - Allowlisting or using any external actions or events will now produce a type error.
 
 ## [5.1.3]
 

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+
+### Fixed
+
+- **BREAKING:** Narrow `ApprovalControllerMessenger` type parameters `AllowedAction` and `AllowedEvent` from `string` to `never` ([#4031](https://github.com/MetaMask/core/pull/4031))
+  - Allowlisting any actions or events will now produce a type error.
+
 ## [5.1.3]
 
 ### Changed
@@ -163,7 +180,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@5.1.3...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@6.0.0...HEAD
+[6.0.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@5.1.3...@metamask/approval-controller@6.0.0
 [5.1.3]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@5.1.2...@metamask/approval-controller@5.1.3
 [5.1.2]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@5.1.1...@metamask/approval-controller@5.1.2
 [5.1.1]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@5.1.0...@metamask/approval-controller@5.1.1

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/approval-controller",
-  "version": "5.1.3",
+  "version": "6.0.0",
   "description": "Manages requests that require user approval",
   "keywords": [
     "MetaMask",
@@ -41,7 +41,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
+    "@metamask/base-controller": "^5.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",
     "nanoid": "^3.1.31"

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -16,16 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/accounts-controller` to `^12.0.0` (TODO: This PR)
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` (TODO: This PR)
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/accounts-controller` to `^12.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/keyring-controller` to `^14.0.0` (TODO: This PR)
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/preferences-controller` to `^9.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/keyring-controller` to `^14.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/preferences-controller` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 - Relax `TokensControllerGetStateAction` and `TokensControllerStateChangeEvent` types so that they no longer constrain the `TokensController` state in the action handler and event payload to `Record<string, Json>` ([#3949](https://github.com/MetaMask/core/pull/3949))
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
-- Bump `@metamask/polling-controller` to `^6.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- Bump `@metamask/polling-controller` to `^6.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [26.0.0]
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [27.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/accounts-controller` to `^12.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/keyring-controller` to `^14.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/preferences-controller` to `^9.0.0` (TODO: This PR)
+- Relax `TokensControllerGetStateAction` and `TokensControllerStateChangeEvent` types so that they no longer constrain the `TokensController` state in the action handler and event payload to `Record<string, Json>` ([#3949](https://github.com/MetaMask/core/pull/3949))
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- Bump `@metamask/polling-controller` to `^6.0.0` (TODO: This PR)
+
 ## [26.0.0]
 
 ### Added
@@ -697,7 +717,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use Ethers for AssetsContractController ([#845](https://github.com/MetaMask/core/pull/845))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@26.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@27.0.0...HEAD
+[27.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@26.0.0...@metamask/assets-controllers@27.0.0
 [26.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@25.0.0...@metamask/assets-controllers@26.0.0
 [25.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@24.0.0...@metamask/assets-controllers@25.0.0
 [24.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@23.1.0...@metamask/assets-controllers@24.0.0

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/assets-controllers",
-  "version": "26.0.0",
+  "version": "27.0.0",
   "description": "Controllers which manage interactions involving ERC-20, ERC-721, and ERC-1155 tokens (including NFTs)",
   "keywords": [
     "MetaMask",
@@ -47,17 +47,17 @@
     "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@metamask/abi-utils": "^2.0.2",
-    "@metamask/accounts-controller": "^11.0.0",
-    "@metamask/approval-controller": "^5.1.3",
-    "@metamask/base-controller": "^4.1.1",
+    "@metamask/accounts-controller": "^12.0.0",
+    "@metamask/approval-controller": "^6.0.0",
+    "@metamask/base-controller": "^5.0.0",
     "@metamask/contract-metadata": "^2.4.0",
-    "@metamask/controller-utils": "^8.0.4",
+    "@metamask/controller-utils": "^9.0.0",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/keyring-controller": "^13.0.0",
+    "@metamask/keyring-controller": "^14.0.0",
     "@metamask/metamask-eth-abis": "3.0.0",
-    "@metamask/network-controller": "^17.2.1",
-    "@metamask/polling-controller": "^5.0.1",
-    "@metamask/preferences-controller": "^8.0.0",
+    "@metamask/network-controller": "^18.0.0",
+    "@metamask/polling-controller": "^6.0.0",
+    "@metamask/preferences-controller": "^9.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",
     "@types/bn.js": "^5.1.5",
@@ -88,11 +88,11 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/accounts-controller": "^11.0.0",
-    "@metamask/approval-controller": "^5.1.2",
-    "@metamask/keyring-controller": "^13.0.0",
-    "@metamask/network-controller": "^17.2.0",
-    "@metamask/preferences-controller": "^8.0.0"
+    "@metamask/accounts-controller": "^12.0.0",
+    "@metamask/approval-controller": "^6.0.0",
+    "@metamask/keyring-controller": "^14.0.0",
+    "@metamask/network-controller": "^18.0.0",
+    "@metamask/preferences-controller": "^9.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -7,27 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0]
+
 ### Added
 
-- Add and export type `StateConstraint`, which is an alias for `Record<string, Json>`, and represents the narrowest supertype encompassing the state of all controllers.
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+- Add and export type `StateConstraint`, which is an alias for `Record<string, Json>` ([#3949](https://github.com/MetaMask/core/pull/3949))
+  - This type represents the narrowest supertype of the state of all controllers.
+  - Importing this type enables controllers to constrain state objects and types to be JSON-serializable without having to directly add `@metamask/utils` as a dependency.
 
 ### Changed
 
-- **BREAKING:** Narrow the generic constraint of the `ControllerState` parameter from `Record<string, unknown>` to `Record<string, Json>` for types `ControllerGetStateAction`, `ControllerStateChangeEvent`, `ControllerActions`, `ControllerEvents`.
-- **BREAKING:** Narrow the return type of the function `deriveStateFromMetadata<ControllerState>` from `Record<string, Json>` to `Record<keyof ControllerState, Json>`.
-- **BREAKING:** The `getRestricted` method of the `ControllerMessenger` class has major API changes that may require updates to its existing instances in downstream code. These changes align the type-level and runtime behavior of `getRestricted`, so that omitted or empty inputs consistently represent a set of empty allowlists. ([$4013](https://github.com/MetaMask/core/pull/4013))
-  - If the `AllowedActions`, `AllowedEvents` generic parameters are omitted, they are always assumed to be `never`.
-    - Previously, omission of these generic parameters resulted in the full allowlists for the controller being inferred as type constraints for the `allowedActions`, `allowedEvents` function parameters.
-  - If the function parameters `allowedActions`, `allowedEvents` are a non-empty array, their corresponding type names must be explicitly passed into generic parameters `AllowedActions`, `AllowedEvents` to avoid type errors.
+- **BREAKING:** Narrow the return type of the function `deriveStateFromMetadata<ControllerState>` from `Record<string, Json>` to `Record<keyof ControllerState, Json>` ([#3949](https://github.com/MetaMask/core/pull/3949))
+  - TODO: What's the result of this change? `deriveStateFromMetadata` is not public, but `getAnonymizedState` and `getPersistentState` are.
+- **BREAKING:** Align type-level and runtime behavior of `getRestricted` so that omitted or empty inputs consistently represent a set of empty allowlists ([#4013](https://github.com/MetaMask/core/pull/4013))
+  - If the `AllowedActions` and `AllowedEvents` generic parameters are omitted, they are always assumed to be `never`.
+    - Previously, omission of these generic parameters resulted in the full allowlists for the controller being inferred as type constraints for the `allowedActions` and `allowedEvents` function parameters.
+  - If the function parameters `allowedActions` and `allowedEvents` are a non-empty array, their corresponding type names must be explicitly passed into generic parameters `AllowedActions` and `AllowedEvents` to avoid type errors.
     - This may cause some duplication of allowlists between type-level and value-level code.
     - This requirement is only relevant for TypeScript code. A JavaScript consumer only needs to pass in the correct value-level function parameters. Because of this, these changes should not affect downstream JavaScript code, but may be disruptive to TypeScript code.
-    - `getRestricted` is still able to flag `AllowedActions` and `AllowedEvents` members that should not be included in the allowlists, based on the `Action`, `Event` generic arguments passed into the `ControllerMessenger` instance.
-- **BREAKING:** The `RestrictedControllerMessenger` class constructor now expects `allowedActions` and `allowedEvents` as required options. ([$4013](https://github.com/MetaMask/core/pull/4013))
-- Convert interface `StatePropertyMetadata<T extends Json>` into a type.
+    - `getRestricted` is still able to flag `AllowedActions` and `AllowedEvents` members that should not be included in the allowlists, based on the `Action` and `Event` generic arguments passed into the `ControllerMessenger` instance.
+- **BREAKING:** The `RestrictedControllerMessenger` class constructor now expects `allowedActions` and `allowedEvents` as required options ([#4013](https://github.com/MetaMask/core/pull/4013))
+- **BREAKING**: Add `string` as generic constraint to the `Name` generic parameter of the types `NamespacedBy` and `NotNamespacedBy` ([#4036](https://github.com/MetaMask/core/pull/4036))
+  - TODO: `NamespacedBy` and `NotNamespacedBy` aren't public. What does this affect?
+- **BREAKING:** The `getRestricted` method of the `ControllerMessenger` class now expects both `allowedActions` and `allowedEvents` as required parameters.
+  - An empty array is required if no allowed actions or events are desired.
+- Convert interface `StatePropertyMetadata` into a type alias ([#3949](https://github.com/MetaMask/core/pull/3949))
 
 ### Removed
 
-- **BREAKING:** Remove the deprecated `subscribe` class field from `BaseControllerV2`.
+- **BREAKING:** Remove the deprecated `subscribe` class field from `BaseController` ([#3949](https://github.com/MetaMask/core/pull/3949))
+  - This property was used to differentiate between `BaseControllerV1` and `BaseController` (v2) controllers. It is no longer used.
+
+### Fixed
+
+- **BREAKING:** Narrow the generic constraint of the `ControllerState` parameter from `Record<string, unknown>` to `Record<string, Json>` for types `ControllerGetStateAction`, `ControllerStateChangeEvent`, `ControllerActions`, and `ControllerEvents` ([#3949](https://github.com/MetaMask/core/pull/3949))
+- **BREAKING:** Fix `BaseController` so that mutating state directly now results in a runtime error ([#4011](https://github.com/MetaMask/core/pull/4011))
+  - Directly modifying the state outside of an `update` call may lead to parts of the application being out of sync, because such modifications do not result in the `stateChange` event being fired.
+  - Instead of mutating the state of a controller after instantiation, consumers should either initialize that controller with the proper state via options or should use the `update` method to safely modify the state.
+- **BREAKING**: Fix `subscribe` on `ControllerMessenger` and `RestrictedControllerMessenger` to infer correct types for `selector` arguments ([#4012](https://github.com/MetaMask/core/pull/4012))
+  - Previously, the types of the arguments that the `selector` function received would always be inferred as `never`, but now the types match those of `publish` (the "event payload"). This means that you shouldn't need to add use type annotations or assertions to type the `selector` arguments.
 
 ## [4.1.1]
 
@@ -177,7 +197,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/base-controller@4.1.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/base-controller@5.0.0...HEAD
+[5.0.0]: https://github.com/MetaMask/core/compare/@metamask/base-controller@4.1.1...@metamask/base-controller@5.0.0
 [4.1.1]: https://github.com/MetaMask/core/compare/@metamask/base-controller@4.1.0...@metamask/base-controller@4.1.1
 [4.1.0]: https://github.com/MetaMask/core/compare/@metamask/base-controller@4.0.1...@metamask/base-controller@4.1.0
 [4.0.1]: https://github.com/MetaMask/core/compare/@metamask/base-controller@4.0.0...@metamask/base-controller@4.0.1

--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -19,8 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Narrow the return type of the function `deriveStateFromMetadata<ControllerState>` from `Record<string, Json>` to `Record<keyof ControllerState, Json>` ([#3949](https://github.com/MetaMask/core/pull/3949))
-  - TODO: What's the result of this change? `deriveStateFromMetadata` is not public, but `getAnonymizedState` and `getPersistentState` are.
+- **BREAKING:** Narrow the return types of functions `getAnonymizedState<ControllerState>` and `getPersistentState<ControllerState>` from `Record<string, Json>` to `Record<keyof ControllerState, Json>`. ([#3949](https://github.com/MetaMask/core/pull/3949), [#4040](https://github.com/MetaMask/core/pull/4040))
 - **BREAKING:** Align type-level and runtime behavior of `getRestricted` so that omitted or empty inputs consistently represent a set of empty allowlists ([#4013](https://github.com/MetaMask/core/pull/4013))
   - If the `AllowedActions` and `AllowedEvents` generic parameters are omitted, they are always assumed to be `never`.
     - Previously, omission of these generic parameters resulted in the full allowlists for the controller being inferred as type constraints for the `allowedActions` and `allowedEvents` function parameters.

--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `getRestricted` is still able to flag `AllowedActions` and `AllowedEvents` members that should not be included in the allowlists, based on the `Action` and `Event` generic arguments passed into the `ControllerMessenger` instance.
 - **BREAKING:** The `RestrictedControllerMessenger` class constructor now expects `allowedActions` and `allowedEvents` as required options ([#4013](https://github.com/MetaMask/core/pull/4013))
 - **BREAKING**: Add `string` as generic constraint to the `Name` generic parameter of the types `NamespacedBy` and `NotNamespacedBy` ([#4036](https://github.com/MetaMask/core/pull/4036))
-  - TODO: `NamespacedBy` and `NotNamespacedBy` aren't public. What does this affect?
 - **BREAKING:** The `getRestricted` method of the `ControllerMessenger` class now expects both `allowedActions` and `allowedEvents` as required parameters.
   - An empty array is required if no allowed actions or events are desired.
 - Convert interface `StatePropertyMetadata` into a type alias ([#3949](https://github.com/MetaMask/core/pull/3949))

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/base-controller",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "Provides scaffolding for controllers as well a communication system for all controllers",
   "keywords": [
     "MetaMask",

--- a/packages/build-utils/CHANGELOG.md
+++ b/packages/build-utils/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
 ## [1.0.2]
 
 ### Changed
@@ -25,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#3577](https://github.com/MetaMask/core/pull/3577) [#3588](https://github.com/MetaMask/core/pull/3588))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/build-utils@1.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/build-utils@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/build-utils@1.0.2...@metamask/build-utils@2.0.0
 [1.0.2]: https://github.com/MetaMask/core/compare/@metamask/build-utils@1.0.1...@metamask/build-utils@1.0.2
 [1.0.1]: https://github.com/MetaMask/core/compare/@metamask/build-utils@1.0.0...@metamask/build-utils@1.0.1
 [1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/build-utils@1.0.0

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/build-utils",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Utilities for building MetaMask applications",
   "keywords": [
     "MetaMask",

--- a/packages/composable-controller/CHANGELOG.md
+++ b/packages/composable-controller/CHANGELOG.md
@@ -22,10 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** The `AllowedAction` parameter of the `ComposableControllerMessenger` type is narrowed from `string` to `never`, as `ComposableController` does not use any external controller actions ([#3904](https://github.com/MetaMask/core/pull/3904))
 - **BREAKING:** Constrain allowed event handler `payload`s for `ComposableControllerMessenger` to correctly accommodate `BaseControllerV1` and `BaseController` instead of allowing `Record<string, unknown>` ([#3949](https://github.com/MetaMask/core/pull/3949))
   - TODO: Is this necessary now?
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
 - Relax `payload` in `ComposableControllerStateChangeEvent` to use `Record<string, any>` rather than `Record<string, unknown>` ([#3949](https://github.com/MetaMask/core/pull/3949))
-- Bump `@metamask/json-rpc-engine` to `^8.0.0` (TODO: Set URL to this PR)
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ### Removed
 

--- a/packages/composable-controller/CHANGELOG.md
+++ b/packages/composable-controller/CHANGELOG.md
@@ -20,8 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Passing a non-controller into `controllers` constructor option now throws an error ([#3904](https://github.com/MetaMask/core/pull/3904))
 - **BREAKING:** The `AllowedAction` parameter of the `ComposableControllerMessenger` type is narrowed from `string` to `never`, as `ComposableController` does not use any external controller actions ([#3904](https://github.com/MetaMask/core/pull/3904))
-- **BREAKING:** Constrain allowed event handler `payload`s for `ComposableControllerMessenger` to correctly accommodate `BaseControllerV1` and `BaseController` instead of allowing `Record<string, unknown>` ([#3949](https://github.com/MetaMask/core/pull/3949))
-  - TODO: Is this necessary now?
 - **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
 - Relax `payload` in `ComposableControllerStateChangeEvent` to use `Record<string, any>` rather than `Record<string, unknown>` ([#3949](https://github.com/MetaMask/core/pull/3949))

--- a/packages/composable-controller/CHANGELOG.md
+++ b/packages/composable-controller/CHANGELOG.md
@@ -7,19 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0]
+
 ### Added
 
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
 - Add and export functions `isBaseControllerV1` and `isBaseController`, which are type guards for validating controller instances ([#3904](https://github.com/MetaMask/core/pull/3904))
+- `ComposableController` now accommodates `BaseControllerV1` controllers that use a messenger (specifically, which have a `messagingSystem` property which is an instance of `RestrictedControllerMessenger`), by subscribing to the `stateChange` event of the messenger instead of using the `subscribe` method on the controller ([#3964](https://github.com/MetaMask/core/pull/3964))
 
 ### Changed
 
 - **BREAKING:** Passing a non-controller into `controllers` constructor option now throws an error ([#3904](https://github.com/MetaMask/core/pull/3904))
-- **BREAKING:** The `AllowedActions` parameter of the `ComposableControllerMessenger` type is narrowed from `string` to `never`, as `ComposableController` does not use any external controller actions. ([#3904](https://github.com/MetaMask/core/pull/3904))
-- Subscribe to the `stateChange` events of `BaseControllerV1` controllers that have a `messagingSystem` class field with an assigned instance of the `RestrictedControllerMessenger` class. ([#3964](https://github.com/MetaMask/core/pull/3964))
+- **BREAKING:** The `AllowedAction` parameter of the `ComposableControllerMessenger` type is narrowed from `string` to `never`, as `ComposableController` does not use any external controller actions ([#3904](https://github.com/MetaMask/core/pull/3904))
+- **BREAKING:** Constrain allowed event handler `payload`s for `ComposableControllerMessenger` to correctly accommodate `BaseControllerV1` and `BaseController` instead of allowing `Record<string, unknown>` ([#3949](https://github.com/MetaMask/core/pull/3949))
+  - TODO: Is this necessary now?
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- Relax `payload` in `ComposableControllerStateChangeEvent` to use `Record<string, any>` rather than `Record<string, unknown>` ([#3949](https://github.com/MetaMask/core/pull/3949))
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` (TODO: Set URL to this PR)
 
 ### Removed
 
-- **BREAKING:** Remove `ControllerList` as an exported type. ([#3904](https://github.com/MetaMask/core/pull/3904))
+- **BREAKING:** Remove `flatState` getter from `ComposableController` ([#3877](https://github.com/MetaMask/core/pull/3877))
+  - This method was confusing to use in practice. Consumers should use the `ComposableController` state directly.
+- **BREAKING:** Remove `ControllerList` as an exported type ([#3904](https://github.com/MetaMask/core/pull/3904))
+  - There is no replacement.
 
 ## [5.0.1]
 
@@ -105,7 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@5.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@6.0.0...HEAD
+[6.0.0]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@5.0.1...@metamask/composable-controller@6.0.0
 [5.0.1]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@5.0.0...@metamask/composable-controller@5.0.1
 [5.0.0]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@4.0.0...@metamask/composable-controller@5.0.0
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@3.0.3...@metamask/composable-controller@4.0.0

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/composable-controller",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Consolidates the state from multiple controllers into one",
   "keywords": [
     "MetaMask",
@@ -41,11 +41,11 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1"
+    "@metamask/base-controller": "^5.0.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/json-rpc-engine": "^7.3.3",
+    "@metamask/json-rpc-engine": "^8.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+- Add support for Linea Sepolia to various constants, types, and type guards ([#3995](https://github.com/MetaMask/core/pull/3995))
+  - Add `LINEA_SEPOLIA` to `TESTNET_TICKER_SYMBOLS` constant
+  - Add `0xe705` to `CHAIN_ID_TO_ETHERS_NETWORK_NAME_MAP` constant
+  - Add `linea-sepolia` to `BUILT_IN_NETWORKS` constant and `InfuraNetworkType`, `NetworkType`, `ChainId`, and `NetworksTicker` types
+  - Add `LineaSepolia` to `BuiltInNetworkName` enum
+  - `isNetworkType` and `isInfuraNetworkType` now return `true` when given "linea-sepolia"
+
+### Changed
+
+- Update `normalizeEnsName` so that it does not attempt to normalize `"."` ([#4006](https://github.com/MetaMask/core/pull/4006))
+- Move `bn.js` from `devDependencies` to `dependencies` ([#4023](https://github.com/MetaMask/core/pull/4023))
+
+### Fixed
+
+- **BREAKING**: Narrow argument type for `BNToHex` and `fractionBN` from `any` to `BN` to enhance type safety ([#3975](https://github.com/MetaMask/core/pull/3975))
+- **BREAKING**: Narrow argument type for `logOrRethrowError` from `any` to `unknown` to enhance type safety ([#3975](https://github.com/MetaMask/core/pull/3975))
+- **BREAKING**: Narrow argument type for `isNetworkType` from `any` to `string` to enhance type safety ([#3975](https://github.com/MetaMask/core/pull/3975))
+
 ## [8.0.4]
 
 ### Changed
@@ -276,7 +300,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@8.0.4...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@9.0.0...HEAD
+[9.0.0]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@8.0.4...@metamask/controller-utils@9.0.0
 [8.0.4]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@8.0.3...@metamask/controller-utils@8.0.4
 [8.0.3]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@8.0.2...@metamask/controller-utils@8.0.3
 [8.0.2]: https://github.com/MetaMask/core/compare/@metamask/controller-utils@8.0.1...@metamask/controller-utils@8.0.2

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/controller-utils",
-  "version": "8.0.4",
+  "version": "9.0.0",
   "description": "Data and convenience functions shared by multiple packages",
   "keywords": [
     "MetaMask",

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -21,10 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- **BREAKING:** Bump peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: Update PR)
+- **BREAKING:** Bump peer dependency on `@metamask/network-controller` to `^18.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [9.0.0]
 

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+- Add support for Holesky and Sepolia registries ([#4006](https://github.com/MetaMask/core/pull/4006))
+- Add optional constructor option `registriesByChainId`, which allows overriding the default ENS network map ([#4006](https://github.com/MetaMask/core/pull/4006))
+- Update default value of `ensEntries` state property to include entry for `.` ([#4006](https://github.com/MetaMask/core/pull/4006))
+- Update `get` so that it now returns registry address for chain when queried for the name `.` ([#4006](https://github.com/MetaMask/core/pull/4006))
+- Update `delete` so that entry for `.` can be removed ([#4006](https://github.com/MetaMask/core/pull/4006))
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- **BREAKING:** Bump peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: Update PR)
+
 ## [9.0.0]
 
 ### Changed
@@ -149,7 +168,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@9.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@10.0.0...HEAD
+[10.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@9.0.0...@metamask/ens-controller@10.0.0
 [9.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@8.0.0...@metamask/ens-controller@9.0.0
 [8.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@7.0.0...@metamask/ens-controller@8.0.0
 [7.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@6.0.1...@metamask/ens-controller@7.0.0

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ens-controller",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Maps ENS names to their resolved addresses by chain id",
   "keywords": [
     "MetaMask",
@@ -42,14 +42,14 @@
   },
   "dependencies": {
     "@ethersproject/providers": "^5.7.0",
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
     "@metamask/utils": "^8.3.0",
     "punycode": "^2.1.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/network-controller": "^17.2.1",
+    "@metamask/network-controller": "^18.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
@@ -59,7 +59,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^17.2.0"
+    "@metamask/network-controller": "^18.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/eth-json-rpc-provider/CHANGELOG.md
+++ b/packages/eth-json-rpc-provider/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` (TODO: Update this PR)
+
 ## [2.3.2]
 
 ### Changed
@@ -76,7 +87,8 @@ Release `v2.0.0` is identical to `v1.0.1` aside from Node.js version requirement
 
 - Initial release, including `providerFromEngine` and `providerFromMiddleware`.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/eth-json-rpc-provider@2.3.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/eth-json-rpc-provider@3.0.0...HEAD
+[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/eth-json-rpc-provider@2.3.2...@metamask/eth-json-rpc-provider@3.0.0
 [2.3.2]: https://github.com/MetaMask/core/compare/@metamask/eth-json-rpc-provider@2.3.1...@metamask/eth-json-rpc-provider@2.3.2
 [2.3.1]: https://github.com/MetaMask/core/compare/@metamask/eth-json-rpc-provider@2.3.0...@metamask/eth-json-rpc-provider@2.3.1
 [2.3.0]: https://github.com/MetaMask/core/compare/@metamask/eth-json-rpc-provider@2.2.0...@metamask/eth-json-rpc-provider@2.3.0

--- a/packages/eth-json-rpc-provider/CHANGELOG.md
+++ b/packages/eth-json-rpc-provider/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `@metamask/json-rpc-engine` to `^8.0.0` (TODO: Update this PR)
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [2.3.2]
 

--- a/packages/eth-json-rpc-provider/package.json
+++ b/packages/eth-json-rpc-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-json-rpc-provider",
-  "version": "2.3.2",
+  "version": "3.0.0",
   "description": "Create an Ethereum provider using a JSON-RPC engine or middleware",
   "keywords": [
     "MetaMask",
@@ -46,7 +46,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/json-rpc-engine": "^7.3.3",
+    "@metamask/json-rpc-engine": "^8.0.0",
     "@metamask/safe-event-emitter": "^3.0.0",
     "@metamask/utils": "^8.3.0"
   },

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -16,11 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
-- Bump `@metamask/polling-controller` to `^6.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- Bump `@metamask/polling-controller` to `^6.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [13.0.2]
 

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- Bump `@metamask/polling-controller` to `^6.0.0` (TODO: This PR)
+
 ## [13.0.2]
 
 ### Changed
@@ -217,7 +232,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@13.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@14.0.0...HEAD
+[14.0.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@13.0.2...@metamask/gas-fee-controller@14.0.0
 [13.0.2]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@13.0.1...@metamask/gas-fee-controller@13.0.2
 [13.0.1]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@13.0.0...@metamask/gas-fee-controller@13.0.1
 [13.0.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@12.0.0...@metamask/gas-fee-controller@13.0.0

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/gas-fee-controller",
-  "version": "13.0.2",
+  "version": "14.0.0",
   "description": "Periodically calculates gas fee estimates based on various gas limits as well as other data displayed on transaction confirm screens",
   "keywords": [
     "MetaMask",
@@ -41,12 +41,12 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
     "@metamask/eth-query": "^4.0.0",
     "@metamask/ethjs-unit": "^0.3.0",
-    "@metamask/network-controller": "^17.2.1",
-    "@metamask/polling-controller": "^5.0.1",
+    "@metamask/network-controller": "^18.0.0",
+    "@metamask/polling-controller": "^6.0.0",
     "@metamask/utils": "^8.3.0",
     "@types/bn.js": "^5.1.5",
     "@types/uuid": "^8.3.0",
@@ -68,7 +68,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^17.2.0"
+    "@metamask/network-controller": "^18.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/json-rpc-engine/CHANGELOG.md
+++ b/packages/json-rpc-engine/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
 ## [7.3.3]
 
 ### Changed
@@ -137,7 +144,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     This change may affect consumers that depend on the eager execution of middleware _during_ request processing, _outside of_ middleware functions and request handlers.
     - In general, it is a bad practice to work with state that depends on middleware execution, while the middleware are executing.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-engine@7.3.3...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-engine@8.0.0...HEAD
+[8.0.0]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-engine@7.3.3...@metamask/json-rpc-engine@8.0.0
 [7.3.3]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-engine@7.3.2...@metamask/json-rpc-engine@7.3.3
 [7.3.2]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-engine@7.3.1...@metamask/json-rpc-engine@7.3.2
 [7.3.1]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-engine@7.3.0...@metamask/json-rpc-engine@7.3.1

--- a/packages/json-rpc-engine/package.json
+++ b/packages/json-rpc-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/json-rpc-engine",
-  "version": "7.3.3",
+  "version": "8.0.0",
   "description": "A tool for processing JSON-RPC messages",
   "keywords": [
     "MetaMask",

--- a/packages/json-rpc-middleware-stream/CHANGELOG.md
+++ b/packages/json-rpc-middleware-stream/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `@metamask/json-rpc-engine` to `^8.0.0` (TODO: Use this PR)
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [6.0.2]
 

--- a/packages/json-rpc-middleware-stream/CHANGELOG.md
+++ b/packages/json-rpc-middleware-stream/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` (TODO: Use this PR)
+
 ## [6.0.2]
 
 ### Changed
@@ -99,7 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TypeScript typings ([#11](https://github.com/MetaMask/json-rpc-middleware-stream/pull/11))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@6.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@7.0.0...HEAD
+[7.0.0]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@6.0.2...@metamask/json-rpc-middleware-stream@7.0.0
 [6.0.2]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@6.0.1...@metamask/json-rpc-middleware-stream@6.0.2
 [6.0.1]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@6.0.0...@metamask/json-rpc-middleware-stream@6.0.1
 [6.0.0]: https://github.com/MetaMask/core/compare/json-rpc-middleware-stream@5.0.1...@metamask/json-rpc-middleware-stream@6.0.0

--- a/packages/json-rpc-middleware-stream/package.json
+++ b/packages/json-rpc-middleware-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/json-rpc-middleware-stream",
-  "version": "6.0.2",
+  "version": "7.0.0",
   "description": "A small toolset for streaming JSON-RPC data and matching requests and responses",
   "keywords": [
     "MetaMask",
@@ -41,7 +41,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/json-rpc-engine": "^7.3.3",
+    "@metamask/json-rpc-engine": "^8.0.0",
     "@metamask/safe-event-emitter": "^3.0.0",
     "@metamask/utils": "^8.3.0",
     "readable-stream": "^3.6.2"

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- Bump `@metamask/message-manager` to `^8.0.0` (TODO: This PR)
+- Bump `@metamask/message-manager` to `^8.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ### Fixed
 

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **BREAKING:** Narrow `KeyringControllerMessenger` type parameters `AllowedAction` and `AllowedEvent` from `string` to `never` ([#4031](https://github.com/MetaMask/core/pull/4031))
-  - Allowlisting any actions or events will now produce a type error.
+  - Allowlisting or using any external actions or events will now produce a type error.
 
 ## [13.0.0]
 

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- Bump `@metamask/message-manager` to `^8.0.0` (TODO: This PR)
+
+### Fixed
+
+- **BREAKING:** Narrow `KeyringControllerMessenger` type parameters `AllowedAction` and `AllowedEvent` from `string` to `never` ([#4031](https://github.com/MetaMask/core/pull/4031))
+  - Allowlisting any actions or events will now produce a type error.
+
 ## [13.0.0]
 
 ### Added
@@ -376,7 +394,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@13.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@14.0.0...HEAD
+[14.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@13.0.0...@metamask/keyring-controller@14.0.0
 [13.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@12.2.0...@metamask/keyring-controller@13.0.0
 [12.2.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@12.1.0...@metamask/keyring-controller@12.2.0
 [12.1.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@12.0.0...@metamask/keyring-controller@12.1.0

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-controller",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "description": "Stores identities seen in the wallet and manages interactions such as signing",
   "keywords": [
     "MetaMask",
@@ -43,13 +43,13 @@
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",
     "@keystonehq/metamask-airgapped-keyring": "^0.13.1",
-    "@metamask/base-controller": "^4.1.1",
+    "@metamask/base-controller": "^5.0.0",
     "@metamask/browser-passworder": "^4.3.0",
     "@metamask/eth-hd-keyring": "^7.0.1",
     "@metamask/eth-sig-util": "^7.0.1",
     "@metamask/eth-simple-keyring": "^6.0.1",
     "@metamask/keyring-api": "^3.0.0",
-    "@metamask/message-manager": "^7.3.9",
+    "@metamask/message-manager": "^8.0.0",
     "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6",
     "ethereumjs-wallet": "^1.0.1",

--- a/packages/logging-controller/CHANGELOG.md
+++ b/packages/logging-controller/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+
 ## [2.0.3]
 
 ### Changed
@@ -68,7 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial Release
   - Add logging controller ([#1089](https://github.com/MetaMask/core.git/pull/1089))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@2.0.3...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@3.0.0...HEAD
+[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@2.0.3...@metamask/logging-controller@3.0.0
 [2.0.3]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@2.0.2...@metamask/logging-controller@2.0.3
 [2.0.2]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@2.0.1...@metamask/logging-controller@2.0.2
 [2.0.1]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@2.0.0...@metamask/logging-controller@2.0.1

--- a/packages/logging-controller/CHANGELOG.md
+++ b/packages/logging-controller/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [2.0.3]
 

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/logging-controller",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "description": "Manages logging data to assist users and support staff",
   "keywords": [
     "MetaMask",
@@ -41,8 +41,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [7.3.9]
 

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+
 ## [7.3.9]
 
 ### Changed
@@ -209,7 +222,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.3.9...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/message-manager@8.0.0...HEAD
+[8.0.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.3.9...@metamask/message-manager@8.0.0
 [7.3.9]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.3.8...@metamask/message-manager@7.3.9
 [7.3.8]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.3.7...@metamask/message-manager@7.3.8
 [7.3.7]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.3.6...@metamask/message-manager@7.3.7

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/message-manager",
-  "version": "7.3.9",
+  "version": "8.0.0",
   "description": "Stores and manages interactions with signing requests",
   "keywords": [
     "MetaMask",
@@ -41,8 +41,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
     "@metamask/eth-sig-util": "^7.0.1",
     "@metamask/utils": "^8.3.0",
     "@types/uuid": "^8.3.0",

--- a/packages/name-controller/CHANGELOG.md
+++ b/packages/name-controller/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+- Add support for Linea Sepolia (chain ID `0xe705`) ([#3995](https://github.com/MetaMask/core/pull/3995))
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- **BREAKING:** Remove support for Optimism Goerli (chain ID `0x1a4`); replace with support for Optimism Sepolia (chain ID `0xaa37dc`) ([#3999](https://github.com/MetaMask/core/pull/3999))
+
 ## [5.0.0]
 
 ### Changed
@@ -80,7 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release ([#1647](https://github.com/MetaMask/core/pull/1647))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/name-controller@5.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/name-controller@6.0.0...HEAD
+[6.0.0]: https://github.com/MetaMask/core/compare/@metamask/name-controller@5.0.0...@metamask/name-controller@6.0.0
 [5.0.0]: https://github.com/MetaMask/core/compare/@metamask/name-controller@4.2.0...@metamask/name-controller@5.0.0
 [4.2.0]: https://github.com/MetaMask/core/compare/@metamask/name-controller@4.1.0...@metamask/name-controller@4.2.0
 [4.1.0]: https://github.com/MetaMask/core/compare/@metamask/name-controller@4.0.1...@metamask/name-controller@4.1.0

--- a/packages/name-controller/CHANGELOG.md
+++ b/packages/name-controller/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
 - **BREAKING:** Remove support for Optimism Goerli (chain ID `0x1a4`); replace with support for Optimism Sepolia (chain ID `0xaa37dc`) ([#3999](https://github.com/MetaMask/core/pull/3999))
 

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/name-controller",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Stores and suggests names for values such as Ethereum addresses",
   "keywords": [
     "MetaMask",
@@ -42,7 +42,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
+    "@metamask/base-controller": "^5.0.0",
     "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6"
   },

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **BREAKING:** Narrow `NetworkControllerMessenger` type parameters `AllowedAction` and `AllowedEvent` from `string` to `never` ([#4031](https://github.com/MetaMask/core/pull/4031))
-  - Allowlisting any actions or events will now produce a type error.
+  - Allowlisting or using any external actions or events will now produce a type error.
 
 ## [17.2.1]
 

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [18.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+- Add network client for Linea Sepolia (chain ID `0xe705`) ([#3995](https://github.com/MetaMask/core/pull/3995))
+  - Bump `@metamask/eth-json-rpc-infura` to `^9.1.0` to bring this change.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+
+### Fixed
+
+- **BREAKING:** Narrow `NetworkControllerMessenger` type parameters `AllowedAction` and `AllowedEvent` from `string` to `never` ([#4031](https://github.com/MetaMask/core/pull/4031))
+  - Allowlisting any actions or events will now produce a type error.
+
 ## [17.2.1]
 
 ### Changed
@@ -432,7 +452,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@17.2.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@18.0.0...HEAD
+[18.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@17.2.1...@metamask/network-controller@18.0.0
 [17.2.1]: https://github.com/MetaMask/core/compare/@metamask/network-controller@17.2.0...@metamask/network-controller@17.2.1
 [17.2.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@17.1.0...@metamask/network-controller@17.2.0
 [17.1.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@17.0.0...@metamask/network-controller@17.1.0

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -18,9 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ### Fixed
 

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-controller",
-  "version": "17.2.1",
+  "version": "18.0.0",
   "description": "Provides an interface to the currently selected network via a MetaMask-compatible provider object",
   "keywords": [
     "MetaMask",
@@ -41,13 +41,13 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
     "@metamask/eth-json-rpc-infura": "^9.1.0",
     "@metamask/eth-json-rpc-middleware": "^12.1.0",
-    "@metamask/eth-json-rpc-provider": "^2.3.2",
+    "@metamask/eth-json-rpc-provider": "^3.0.0",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/json-rpc-engine": "^7.3.3",
+    "@metamask/json-rpc-engine": "^8.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/swappable-obj-proxy": "^2.2.0",
     "@metamask/utils": "^8.3.0",

--- a/packages/notification-controller/CHANGELOG.md
+++ b/packages/notification-controller/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
 
 ## [4.0.2]

--- a/packages/notification-controller/CHANGELOG.md
+++ b/packages/notification-controller/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+
 ## [4.0.2]
 
 ### Changed
@@ -92,7 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@4.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@5.0.0...HEAD
+[5.0.0]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@4.0.2...@metamask/notification-controller@5.0.0
 [4.0.2]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@4.0.1...@metamask/notification-controller@4.0.2
 [4.0.1]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@4.0.0...@metamask/notification-controller@4.0.1
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@3.1.3...@metamask/notification-controller@4.0.0

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/notification-controller",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "Manages display of notifications within MetaMask",
   "keywords": [
     "MetaMask",
@@ -41,7 +41,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
+    "@metamask/base-controller": "^5.0.0",
     "@metamask/utils": "^8.3.0",
     "nanoid": "^3.1.31"
   },

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump peer dependency on `@metamask/approval-controller` to `^6.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` (TODO: This PR)
+
+### Fixed
+
+- **BREAKING:** Fix `SideEffectMessenger` so that it's defined with a `RestrictedControllerMessenger` that has access to `PermissionController` allowed actions ([#4031](https://github.com/MetaMask/core/pull/4031))
+  - The messenger's `Action` generic parameter is widened to include the `PermissionController` actions allowlist.
+  - The messenger's `AllowedAction` generic parameter is narrowed from `string` to the `PermissionController` actions allowlist.
+
 ## [8.0.1]
 
 ### Fixed
@@ -185,7 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@8.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@9.0.0...HEAD
+[9.0.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@8.0.1...@metamask/permission-controller@9.0.0
 [8.0.1]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@8.0.0...@metamask/permission-controller@8.0.1
 [8.0.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@7.1.0...@metamask/permission-controller@8.0.0
 [7.1.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@7.0.0...@metamask/permission-controller@7.1.0

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -16,11 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump peer dependency on `@metamask/approval-controller` to `^6.0.0` (TODO: This PR)
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump peer dependency on `@metamask/approval-controller` to `^6.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
-- Bump `@metamask/json-rpc-engine` to `^8.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ### Fixed
 

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/permission-controller",
-  "version": "8.0.1",
+  "version": "9.0.0",
   "description": "Mediates access to JSON-RPC methods, used to interact with pieces of the MetaMask stack, via middleware for json-rpc-engine",
   "keywords": [
     "MetaMask",
@@ -41,9 +41,9 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
-    "@metamask/json-rpc-engine": "^7.3.3",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
+    "@metamask/json-rpc-engine": "^8.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",
     "@types/deep-freeze-strict": "^1.1.0",
@@ -52,7 +52,7 @@
     "nanoid": "^3.1.31"
   },
   "devDependencies": {
-    "@metamask/approval-controller": "^5.1.3",
+    "@metamask/approval-controller": "^6.0.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
@@ -63,7 +63,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/approval-controller": "^5.1.2"
+    "@metamask/approval-controller": "^6.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/permission-log-controller/CHANGELOG.md
+++ b/packages/permission-log-controller/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- Bump `@metamask/json-rpc-engine` to `^8.0.0` (TODO: This PR)
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [1.0.0]
 

--- a/packages/permission-log-controller/CHANGELOG.md
+++ b/packages/permission-log-controller/CHANGELOG.md
@@ -7,11 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` (TODO: This PR)
+
 ## [1.0.0]
 
 ### Added
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-log-controller@1.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-log-controller@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/permission-log-controller@1.0.0...@metamask/permission-log-controller@2.0.0
 [1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/permission-log-controller@1.0.0

--- a/packages/permission-log-controller/package.json
+++ b/packages/permission-log-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/permission-log-controller",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Controller with middleware for logging requests and responses to restricted and permissions-related methods",
   "keywords": [
     "MetaMask",
@@ -41,8 +41,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/json-rpc-engine": "^7.3.3",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/json-rpc-engine": "^8.0.0",
     "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {

--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+
 ## [8.0.2]
 
 ### Changed
@@ -149,7 +162,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@8.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@9.0.0...HEAD
+[9.0.0]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@8.0.2...@metamask/phishing-controller@9.0.0
 [8.0.2]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@8.0.1...@metamask/phishing-controller@8.0.2
 [8.0.1]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@8.0.0...@metamask/phishing-controller@8.0.1
 [8.0.0]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@7.0.1...@metamask/phishing-controller@8.0.0

--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [8.0.2]
 

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/phishing-controller",
-  "version": "8.0.2",
+  "version": "9.0.0",
   "description": "Maintains a periodically updated list of approved and unapproved website origins",
   "keywords": [
     "MetaMask",
@@ -41,8 +41,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
     "@types/punycode": "^2.1.0",
     "eth-phishing-detect": "^1.2.0",
     "punycode": "^2.1.1"

--- a/packages/polling-controller/CHANGELOG.md
+++ b/packages/polling-controller/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+
 ## [5.0.1]
 
 ### Changed
@@ -95,7 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@5.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@6.0.0...HEAD
+[6.0.0]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@5.0.1...@metamask/polling-controller@6.0.0
 [5.0.1]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@5.0.0...@metamask/polling-controller@5.0.1
 [5.0.0]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@4.0.0...@metamask/polling-controller@5.0.0
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@3.0.0...@metamask/polling-controller@4.0.0

--- a/packages/polling-controller/CHANGELOG.md
+++ b/packages/polling-controller/CHANGELOG.md
@@ -16,10 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [5.0.1]
 

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/polling-controller",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Polling Controller is the base for controllers that polling by networkClientId",
   "keywords": [
     "MetaMask",
@@ -41,9 +41,9 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
-    "@metamask/network-controller": "^17.2.1",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
+    "@metamask/network-controller": "^18.0.0",
     "@metamask/utils": "^8.3.0",
     "@types/uuid": "^8.3.0",
     "fast-json-stable-stringify": "^2.1.0",
@@ -61,7 +61,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^17.2.0"
+    "@metamask/network-controller": "^18.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -18,10 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- **BREAKING:** Bump peer dependency on `@metamask/keyring-controller` to `^14.0.0` (TODO: This PR)
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- **BREAKING:** Bump peer dependency on `@metamask/keyring-controller` to `^14.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [8.0.0]
 

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+- Add support for Linea Sepolia (chain ID `0xe705`) ([#3995](https://github.com/MetaMask/core/pull/3995))
+  - Update default controller state so `0xe705` is automatically enabled in `showIncomingTransactions`.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- **BREAKING:** Bump peer dependency on `@metamask/keyring-controller` to `^14.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+
 ## [8.0.0]
 
 ### Changed
@@ -179,7 +195,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@8.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@9.0.0...HEAD
+[9.0.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@8.0.0...@metamask/preferences-controller@9.0.0
 [8.0.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@7.0.0...@metamask/preferences-controller@8.0.0
 [7.0.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@6.0.0...@metamask/preferences-controller@7.0.0
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@5.0.1...@metamask/preferences-controller@6.0.0

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/preferences-controller",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Manages user-configurable settings for MetaMask",
   "keywords": [
     "MetaMask",
@@ -41,12 +41,12 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4"
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-controller": "^13.0.0",
+    "@metamask/keyring-controller": "^14.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
@@ -57,7 +57,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/keyring-controller": "^13.0.0"
+    "@metamask/keyring-controller": "^14.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -40,9 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The number of queued requests is now tracked in controller state, as the `queuedRequestCount` property. Use the `QueuedRequestController:stateChange` event to be notified of count changes instead.
 - **BREAKING**: Remove the `length` method ([#3985](https://github.com/MetaMask/core/pull/3985))
   - The number of queued requests is now tracked in controller state, as the `queuedRequestCount` property.
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- **BREAKING:** Bump peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
+- **BREAKING:** Bump peer dependency on `@metamask/network-controller` to `^18.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 - **BREAKING:** Bump peer dependency on `@metamask/selected-network-controller` to `^10.0.0` ([#3996](https://github.com/MetaMask/core/pull/3996))
 - Bump `@metamask/controller-utils` to `^9.0.0` ([#4007](https://github.com/MetaMask/core/pull/4007))
 - Bump `@metamask/json-rpc-engine` to `^8.0.0` ([#4007](https://github.com/MetaMask/core/pull/4007))

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -17,11 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING**: The `QueuedRequestController` will now batch queued requests by origin ([#3781](https://github.com/MetaMask/core/pull/3781))
+- **BREAKING**: The `QueuedRequestController` will now batch queued requests by origin ([#3781](https://github.com/MetaMask/core/pull/3781), [#4038](https://github.com/MetaMask/core/pull/4038))
   - All of the requests in a single batch will be processed in parallel.
   - Requests get processed in order of insertion, even across origins/batches.
   - All requests get processed even in the event of preceding requests failing.
-- **BREAKING:** The `queuedRequestCount` state no longer includes requests that are currently being processed. It just counts requests that are queued ([#3781](https://github.com/MetaMask/core/pull/3781))
+- **BREAKING:** The `queuedRequestCount` state no longer includes requests that are currently being processed; it just counts requests that are queued ([#3781](https://github.com/MetaMask/core/pull/3781))
 - **BREAKING:** The `QueuedRequestController` no longer triggers a confirmation when a network switch is needed ([#3781](https://github.com/MetaMask/core/pull/3781))
   - The network switch now happens automatically, with no confirmation.
   - A new `QueuedRequestController:networkSwitched` event has been added to communicate when this has happened.

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -11,25 +11,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
 - Export `QueuedRequestControllerGetStateAction` and `QueuedRequestControllerStateChangeEvent` ([#3984](https://github.com/MetaMask/core/pull/3984))
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/selected-network-controller` peer dependency to `^9.0.0` ([#3996](https://github.com/MetaMask/core/pull/3996))
-- **BREAKING**: Remove the `QueuedRequestController:countChanged` event ([#3985](https://github.com/MetaMask/core/pull/3985))
-  - The number of queued requests is now tracked in controller state, as the `queuedRequestCount` property. Use the `QueuedRequestController:stateChange` event to be notified of count changes instead.
-- **BREAKING**: Remove the `length` method ([#3985](https://github.com/MetaMask/core/pull/3985))
-  - The number of queued requests is now tracked in controller state, as the `queuedRequestCount` property.
-- **BREAKING:** The `QueuedRequestController` method `enqueueRequest` is now responsible for switching the network before processing a request, rather than the `QueuedRequestMiddleware` ([#3986](https://github.com/MetaMask/core/pull/3986))
+- **BREAKING**: The `QueuedRequestController` will now batch queued requests by origin ([#3781](https://github.com/MetaMask/core/pull/3781))
+  - All of the requests in a single batch will be processed in parallel.
+  - Requests get processed in order of insertion, even across origins/batches.
+  - All requests get processed even in the event of preceding requests failing.
+- **BREAKING:** The `queuedRequestCount` state no longer includes requests that are currently being processed. It just counts requests that are queued ([#3781](https://github.com/MetaMask/core/pull/3781))
+- **BREAKING:** The `QueuedRequestController` no longer triggers a confirmation when a network switch is needed ([#3781](https://github.com/MetaMask/core/pull/3781))
+  - The network switch now happens automatically, with no confirmation.
+  - A new `QueuedRequestController:networkSwitched` event has been added to communicate when this has happened.
+  - The `QueuedRequestController` messenger no longer needs access to the actions `NetworkController:getNetworkConfigurationByNetworkClientId` and `ApprovalController:addRequest`.
+  - The package `@metamask/approval-controller` has been completely removed as a dependency
+- **BREAKING:** The `QueuedRequestController` method `enqueueRequest` is now responsible for switching the network before processing a request, rather than the `QueuedRequestMiddleware` ([#3968](https://github.com/MetaMask/core/pull/3968))
   - Functionally the behavior is the same: before processing each request, we compare the request network client with the current selected network client, and we switch the current selected network client if necessary.
-  - The `QueuedRequestController` messenger has four additional allowed actions:
+  - The `QueuedRequestController` messenger now requires four additional allowed actions:
     - `NetworkController:getState`
     - `NetworkController:setActiveNetwork`
     - `NetworkController:getNetworkConfigurationByNetworkClientId`
     - `ApprovalController:addRequest`
-  - The `QueuedRequestController` method `enqueueRequest` now takes one additional parameter, the request object
-  - The `QueuedRequestMiddleware` no longer has a controller messenger. Instead it takes the `enqueueRequest` method as a parameter.
-- Bump `@metamask/rpc-errors` from `^6.2.0` to `^6.2.1` ([#3970](https://github.com/MetaMask/core/pull/3970))
+  - The `QueuedRequestController` method `enqueueRequest` now takes one additional parameter, the request object.
+  - `createQueuedRequestMiddleware` no longer takes a controller messenger; instead it takes the `enqueueRequest` method from `QueuedRequestController` as a parameter.
+- **BREAKING**: Remove the `QueuedRequestController:countChanged` event ([#3985](https://github.com/MetaMask/core/pull/3985))
+  - The number of queued requests is now tracked in controller state, as the `queuedRequestCount` property. Use the `QueuedRequestController:stateChange` event to be notified of count changes instead.
+- **BREAKING**: Remove the `length` method ([#3985](https://github.com/MetaMask/core/pull/3985))
+  - The number of queued requests is now tracked in controller state, as the `queuedRequestCount` property.
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- **BREAKING:** Bump peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
+- **BREAKING:** Bump peer dependency on `@metamask/selected-network-controller` to `^10.0.0` ([#3996](https://github.com/MetaMask/core/pull/3996))
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4007](https://github.com/MetaMask/core/pull/4007))
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` ([#4007](https://github.com/MetaMask/core/pull/4007))
+- Bump `@metamask/rpc-errors` to `^6.2.1` ([#3970](https://github.com/MetaMask/core/pull/3970))
 
 ## [0.5.0]
 

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/queued-request-controller",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Includes a controller and middleware that implements a request queue",
   "keywords": [
     "MetaMask",
@@ -41,17 +41,17 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
-    "@metamask/json-rpc-engine": "^7.3.3",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
+    "@metamask/json-rpc-engine": "^8.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/swappable-obj-proxy": "^2.2.0",
     "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/network-controller": "^17.2.1",
-    "@metamask/selected-network-controller": "^9.0.0",
+    "@metamask/network-controller": "^18.0.0",
+    "@metamask/selected-network-controller": "^10.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",
@@ -65,8 +65,8 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^17.2.0",
-    "@metamask/selected-network-controller": "^9.0.0"
+    "@metamask/network-controller": "^18.0.0",
+    "@metamask/selected-network-controller": "^10.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/rate-limit-controller/CHANGELOG.md
+++ b/packages/rate-limit-controller/CHANGELOG.md
@@ -7,24 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0]
+
 ### Added
 
-- Add and export types `RateLimitedApiMap`, `RateLimitedRequests`. ([#3963](https://github.com/MetaMask/core/pull/3963))
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+- Add and export types `RateLimitedApiMap` and `RateLimitedRequests` ([#3963](https://github.com/MetaMask/core/pull/3963))
   - `RateLimitedApiMap` represents the type of the `RateLimitedApis` generic parameter used throughout the controller.
   - `RateLimitedRequests` represents the type of the `request` property of `RateLimitState`.
 
 ### Changed
 
-- **BREAKING:** Rename types to align with conventions followed by other controllers. ([#3963](https://github.com/MetaMask/core/pull/3963))
+- **BREAKING:** Rename types to align with conventions followed by other controllers ([#3963](https://github.com/MetaMask/core/pull/3963))
   - `GetRateLimitState` is now `RateLimitControllerGetStateAction`.
   - `RateLimitStateChange` is now `RateLimitControllerStateChangeEvent`.
   - `CallApi` is now `RateLimitControllerCallApiAction`.
-- Add `@metamask/utils` `^8.3.0` as a dependency. ([#3963](https://github.com/MetaMask/core/pull/3963))
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- Bump `@metamask/rpc-errors` to `^6.2.1` ([#3970](https://github.com/MetaMask/core/pull/3970))
+- Add `@metamask/utils` `^8.3.0` as a dependency ([#3963](https://github.com/MetaMask/core/pull/3963))
 
 ### Fixed
 
-- **BREAKING:** Fix `GetRateLimitState`, `RateLimitStateChange` types by replacing `RateLimitedApis` with `RateLimitState<RateLimitedApis>` as the state type passed in as generic arguments to `ControllerGetStateAction` and `ControllerStateChangeEvent` ([#3949](https://github.com/MetaMask/core/pull/3949))
-  - This bug was introduced in v4.0.0.
+- **BREAKING:** Correct action and event payloads for `RateLimitControllerGetStateAction` (formerly `GetRateLimitState)` and `RateLimitStateChange` (formerly `RateLimitControllerStateChangeEvent`) by replacing `RateLimitedApis` with `RateLimitState<RateLimitedApis>` ([#3949](https://github.com/MetaMask/core/pull/3949))
+  - The wrong type was introduced in 4.0.0.
 
 ## [4.0.2]
 
@@ -111,7 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@4.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@5.0.0...HEAD
+[5.0.0]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@4.0.2...@metamask/rate-limit-controller@5.0.0
 [4.0.2]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@4.0.1...@metamask/rate-limit-controller@4.0.2
 [4.0.1]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@4.0.0...@metamask/rate-limit-controller@4.0.1
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@3.0.3...@metamask/rate-limit-controller@4.0.0

--- a/packages/rate-limit-controller/CHANGELOG.md
+++ b/packages/rate-limit-controller/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `GetRateLimitState` is now `RateLimitControllerGetStateAction`.
   - `RateLimitStateChange` is now `RateLimitControllerStateChangeEvent`.
   - `CallApi` is now `RateLimitControllerCallApiAction`.
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
 - Bump `@metamask/rpc-errors` to `^6.2.1` ([#3970](https://github.com/MetaMask/core/pull/3970))
 - Add `@metamask/utils` `^8.3.0` as a dependency ([#3963](https://github.com/MetaMask/core/pull/3963))

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rate-limit-controller",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "Contains logic for rate-limiting API endpoints by requesting origin",
   "keywords": [
     "MetaMask",
@@ -41,7 +41,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
+    "@metamask/base-controller": "^5.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0"
   },

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` ([#4007](https://github.com/MetaMask/core/pull/4007))
 - **BREAKING:** Bump dependency and peer dependency on `@metamask/permission-controller` to `^9.0.0` ([#4007](https://github.com/MetaMask/core/pull/4007))

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` ([#4007](https://github.com/MetaMask/core/pull/4007))
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/permission-controller` to `^9.0.0` ([#4007](https://github.com/MetaMask/core/pull/4007))
+- Bump `@metamask/json-rpc-engine` to `^8.0.0` ([#4007](https://github.com/MetaMask/core/pull/4007))
+
 ## [9.0.0]
 
 ### Added
@@ -136,7 +151,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release ([#1643](https://github.com/MetaMask/core/pull/1643))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@9.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@10.0.0...HEAD
+[10.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@9.0.0...@metamask/selected-network-controller@10.0.0
 [9.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@8.0.0...@metamask/selected-network-controller@9.0.0
 [8.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@7.0.1...@metamask/selected-network-controller@8.0.0
 [7.0.1]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@7.0.0...@metamask/selected-network-controller@7.0.1

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/selected-network-controller",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Provides an interface to the currently selected networkClientId for a given domain",
   "keywords": [
     "MetaMask",
@@ -41,10 +41,10 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/json-rpc-engine": "^7.3.3",
-    "@metamask/network-controller": "^17.2.1",
-    "@metamask/permission-controller": "^8.0.1",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/json-rpc-engine": "^8.0.0",
+    "@metamask/network-controller": "^18.0.0",
+    "@metamask/permission-controller": "^9.0.0",
     "@metamask/swappable-obj-proxy": "^2.2.0",
     "@metamask/utils": "^8.3.0"
   },
@@ -63,8 +63,8 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^17.2.0",
-    "@metamask/permission-controller": "^8.0.1"
+    "@metamask/network-controller": "^18.0.0",
+    "@metamask/permission-controller": "^9.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/keyring-controller` to `^14.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/logging-controller` to `^3.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- Bump `@metamask/message-manager` to `^8.0.0` (TODO: This PR)
+
 ## [13.0.0]
 
 ### Changed
@@ -201,7 +218,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#1214](https://github.com/MetaMask/core/pull/1214))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@13.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@14.0.0...HEAD
+[14.0.0]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@13.0.0...@metamask/signature-controller@14.0.0
 [13.0.0]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@12.0.0...@metamask/signature-controller@13.0.0
 [12.0.0]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@11.0.0...@metamask/signature-controller@12.0.0
 [11.0.0]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@10.0.0...@metamask/signature-controller@11.0.0

--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -16,13 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` (TODO: This PR)
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/keyring-controller` to `^14.0.0` (TODO: This PR)
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/logging-controller` to `^3.0.0` (TODO: This PR)
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
-- Bump `@metamask/message-manager` to `^8.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/keyring-controller` to `^14.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/logging-controller` to `^3.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- Bump `@metamask/message-manager` to `^8.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [13.0.0]
 

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/signature-controller",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "description": "Processes signing requests in order to sign arbitrary and typed data",
   "keywords": [
     "MetaMask",
@@ -41,12 +41,12 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/approval-controller": "^5.1.3",
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
-    "@metamask/keyring-controller": "^13.0.0",
-    "@metamask/logging-controller": "^2.0.3",
-    "@metamask/message-manager": "^7.3.9",
+    "@metamask/approval-controller": "^6.0.0",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
+    "@metamask/keyring-controller": "^14.0.0",
+    "@metamask/logging-controller": "^3.0.0",
+    "@metamask/message-manager": "^8.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",
     "lodash": "^4.17.21"
@@ -62,9 +62,9 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/approval-controller": "^5.1.2",
-    "@metamask/keyring-controller": "^13.0.0",
-    "@metamask/logging-controller": "^2.0.2"
+    "@metamask/approval-controller": "^6.0.0",
+    "@metamask/keyring-controller": "^14.0.0",
+    "@metamask/logging-controller": "^3.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -75,13 +75,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - As dictated by BaseController v2, any types that are part of state need to be compatible with the `Json` type from `@metamask/utils`.
 - **BREAKING:** Transform `rpc` property on transaction errors so they're JSON-encodable ([#3827](https://github.com/MetaMask/core/pull/3827))
   - This change also results in typing this property as `Json` instead of `unknown`, avoiding a "Type instantiation is excessively deep and possibly infinite" error when resolving the `TransactionControllerState` type.
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` (TODO: This PR)
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/gas-fee-controller` to `^14.0.0` (TODO: This PR)
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
-- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/gas-fee-controller` to `^14.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
   - This version has a number of breaking changes. See the changelog for more.
 - Add dependency on `@ethersproject/providers` `^5.7.0` ([#4020](https://github.com/MetaMask/core/pull/4020))
-- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ### Removed
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,122 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [25.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+- Add new types for TransactionController messenger actions ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - `TransactionControllerActions`
+  - `TransactionControllerGetStateAction`
+- Add new types for TransactionController messenger events ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - `TransactionControllerEvents`
+  - `TransactionControllerIncomingTransactionBlockReceivedEvent`
+  - `TransactionControllerPostTransactionBalanceUpdatedEvent`
+  - `TransactionControllerSpeedupTransactionAddedEvent`
+  - `TransactionControllerStateChangeEvent`
+  - `TransactionControllerTransactionApprovedEvent`
+  - `TransactionControllerTransactionConfirmedEvent`
+  - `TransactionControllerTransactionDroppedEvent`
+  - `TransactionControllerTransactionFailedEvent`
+  - `TransactionControllerTransactionFinishedEvent`
+  - `TransactionControllerTransactionNewSwapApprovalEvent`
+  - `TransactionControllerTransactionNewSwapEvent`
+  - `TransactionControllerTransactionPublishingSkipped`
+  - `TransactionControllerTransactionRejectedEvent`
+  - `TransactionControllerTransactionStatusUpdatedEvent`
+  - `TransactionControllerTransactionSubmittedEvent`
+  - `TransactionControllerUnapprovedTransactionAddedEvent`
+- Add optional `simulationData` property to `TransactionMeta` which will be automatically populated ([#4020](https://github.com/MetaMask/core/pull/4020))
+- Add optional `isSimulationEnabled` constructor option to dynamically disable simulation ([#4020](https://github.com/MetaMask/core/pull/4020))
+- Add support for Linea Sepolia (chain ID `0xe705`) ([#3995](https://github.com/MetaMask/core/pull/3995))
+
+### Changed
+
+- **BREAKING:** Change superclass of TransactionController from BaseController v1 to BaseController v2 ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - Instead of accepting three arguments, the constructor now takes a single options argument. All of the existing options that were supported in the second argument are now a part of this options object, including `messenger`; `state` (the previous third argument) is also an option.
+- **BREAKING:** Rename `txHistoryLimit` option to `transactionHistoryLimit` ([#3827](https://github.com/MetaMask/core/pull/3827))
+- **BREAKING:** Switch some type definitions from `interface` to `type` ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - These types are affected:
+    - `DappSuggestedGasFees`
+    - `Log`
+    - `MethodData`
+    - `TransactionControllerState` (formerly `TransactionState`)
+    - `TransactionParams`
+    - `TransactionReceipt`
+  - This is a breaking change because type aliases have different behavior from interfaces. Specifically, the `Json` type in `@metamask/utils`, which BaseController v2 controller state must conform to, is not compatible with interfaces.
+- **BREAKING:** Align `parsedRegistryMethod` in `MethodData` type with usage ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - The type of this is now `{ name: string; args: { type: string }[]; } | { name?: any; args?: any; }`, which is a `Json`-compatible version of a type found in `eth-method-registry`.
+- **BREAKING:** Rename `TransactionState` to `TransactionControllerState` ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - This change aligns this controller with other MetaMask controllers.
+- **BREAKING:** Update allowed events for the `TransactionControllerMessenger` ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - The restricted messenger must allow the following events:
+    - `TransactionController:incomingTransactionBlockReceived`
+    - `TransactionController:postTransactionBalanceUpdated`
+    - `TransactionController:speedUpTransactionAdded`
+    - `TransactionController:transactionApproved`
+    - `TransactionController:transactionConfirmed`
+    - `TransactionController:transactionDropped`
+    - `TransactionController:transactionFinished`
+    - `TransactionController:transactionFinished`
+    - `TransactionController:transactionPublishingSkipped`
+    - `TransactionController:transactionRejected`
+    - `TransactionController:transactionStatusUpdated`
+    - `TransactionController:transactionSubmitted`
+    - `TransactionController:unapprovedTransactionAdded`
+- **BREAKING:** Update `TransactionMeta` type to be compatible with `Json` ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - As dictated by BaseController v2, any types that are part of state need to be compatible with the `Json` type from `@metamask/utils`.
+- **BREAKING:** Transform `rpc` property on transaction errors so they're JSON-encodable ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - This change also results in typing this property as `Json` instead of `unknown`, avoiding a "Type instantiation is excessively deep and possibly infinite" error when resolving the `TransactionControllerState` type.
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/gas-fee-controller` to `^14.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/base-controller` to `^5.0.0` (TODO: This PR)
+  - This version has a number of breaking changes. See the changelog for more.
+- Add dependency on `@ethersproject/providers` `^5.7.0` ([#4020](https://github.com/MetaMask/core/pull/4020))
+- Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+
+### Removed
+
+- **BREAKING:** Remove `TransactionConfig` type ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - The properties in this type have been absorbed into `TransactionControllerOptions`.
+- **BREAKING:** Remove `hub` property from TransactionController ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - TransactionController now fully makes use of its messenger object to announce various kinds of activities. Instead of subscribing to an event like this:
+    ```
+    transactionController.hub.on(eventName, ...)
+    ```
+    use this:
+    ```
+    messenger.subscribe('TransactionController:${eventName}', ...)
+    ```
+  - The complete list of renamed events are:
+    - `incomingTransactionBlock` -> `TransactionController:incomingTransactionBlockReceived`
+    - `post-transaction-balance-updated` -> `TransactionController:postTransactionBalanceUpdated`
+    - `transaction-approved` -> `TransactionController:transactionApproved`
+    - `transaction-confirmed` -> `TransactionController:transactionConfirmed`
+    - `transaction-dropped` -> `TransactionController:transactionDropped`
+    - `transaction-finished` -> `TransactionController:transactionFinished`
+    - `transaction-rejected` -> `TransactionController:transactionRejected`
+    - `transaction-status-update` -> `TransactionController:transactionStatusUpdated`
+    - `transaction-submitted` -> `TransactionController:transactionSubmitted`
+    - `unapprovedTransaction` -> `TransactionController:unapprovedTransactionAdded`
+  - Some events announced the state of specific transactions. These have been removed. Instead, subscribe to the appropriate generic event and check for a specific transaction ID in your event handler:
+    - `${transactionId}:finished` -> `TransactionController:transactionFinished`
+    - `${transactionId}:speedup` -> `TransactionController:speedUpTransactionAdded`
+    - `${transactionId}:publish-skip` -> `TransactionController:transactionPublishingSkipped`
+
+### Fixed
+
+- Fix various methods so that they no longer update transactions in state directly but only via `update` ([#3827](https://github.com/MetaMask/core/pull/3827))
+  - `addTransaction`
+  - `confirmExternalTransaction`
+  - `speedUpTransaction`
+  - `updateCustodialTransaction`
+  - `updateSecurityAlertResponse`
+  - `updateTransaction`
+- Fix `handleMethodData` method to update state with an empty registry object instead of blowing up if registry could be found ([#3827](https://github.com/MetaMask/core/pull/3827))
+
 ## [24.0.0]
 
 ### Added
@@ -558,7 +674,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@24.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@25.0.0...HEAD
+[25.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@24.0.0...@metamask/transaction-controller@25.0.0
 [24.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@23.1.0...@metamask/transaction-controller@24.0.0
 [23.1.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@23.0.0...@metamask/transaction-controller@23.1.0
 [23.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@22.0.0...@metamask/transaction-controller@23.0.0

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "24.0.0",
+  "version": "25.0.0",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",
@@ -46,13 +46,13 @@
     "@ethereumjs/util": "^8.1.0",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
-    "@metamask/approval-controller": "^5.1.3",
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
+    "@metamask/approval-controller": "^6.0.0",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/gas-fee-controller": "^13.0.2",
+    "@metamask/gas-fee-controller": "^14.0.0",
     "@metamask/metamask-eth-abis": "^3.0.0",
-    "@metamask/network-controller": "^17.2.1",
+    "@metamask/network-controller": "^18.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6",
@@ -82,9 +82,9 @@
   },
   "peerDependencies": {
     "@babel/runtime": "^7.23.9",
-    "@metamask/approval-controller": "^5.1.2",
-    "@metamask/gas-fee-controller": "^13.0.0",
-    "@metamask/network-controller": "^17.2.0"
+    "@metamask/approval-controller": "^6.0.0",
+    "@metamask/gas-fee-controller": "^14.0.0",
+    "@metamask/network-controller": "^18.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0]
+
+### Added
+
+- **BREAKING**: Add ESM build ([#3998](https://github.com/MetaMask/core/pull/3998))
+  - It's no longer possible to import files from `./dist` directly.
+
+### Changed
+
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/gas-fee-controller` to `^14.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/keyring-controller` to `^14.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/transaction-controller` to `^25.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
+- **BREAKING:** Bump `@metamask/polling-controller` to `^6.0.0` (TODO: This PR)
+
 ## [5.0.0]
 
 ### Changed
@@ -63,7 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release ([#3749](https://github.com/MetaMask/core/pull/3749))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@5.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@6.0.0...HEAD
+[6.0.0]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@5.0.0...@metamask/user-operation-controller@6.0.0
 [5.0.0]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@4.0.0...@metamask/user-operation-controller@5.0.0
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@3.0.0...@metamask/user-operation-controller@4.0.0
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@2.0.0...@metamask/user-operation-controller@3.0.0

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -16,13 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` (TODO: This PR)
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/gas-fee-controller` to `^14.0.0` (TODO: This PR)
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/keyring-controller` to `^14.0.0` (TODO: This PR)
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` (TODO: This PR)
-- **BREAKING:** Bump dependency and peer dependency on `@metamask/transaction-controller` to `^25.0.0` (TODO: This PR)
-- **BREAKING:** Bump `@metamask/controller-utils` to `^9.0.0` (TODO: This PR)
-- **BREAKING:** Bump `@metamask/polling-controller` to `^6.0.0` (TODO: This PR)
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/approval-controller` to `^6.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/gas-fee-controller` to `^14.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/keyring-controller` to `^14.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/network-controller` to `^18.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump dependency and peer dependency on `@metamask/transaction-controller` to `^25.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump `@metamask/controller-utils` to `^9.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
+- **BREAKING:** Bump `@metamask/polling-controller` to `^6.0.0` ([#4039](https://github.com/MetaMask/core/pull/4039))
 
 ## [5.0.0]
 

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/user-operation-controller",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Creates user operations and manages their life cycle",
   "keywords": [
     "MetaMask",
@@ -42,16 +42,16 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/approval-controller": "^5.1.3",
-    "@metamask/base-controller": "^4.1.1",
-    "@metamask/controller-utils": "^8.0.4",
+    "@metamask/approval-controller": "^6.0.0",
+    "@metamask/base-controller": "^5.0.0",
+    "@metamask/controller-utils": "^9.0.0",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/gas-fee-controller": "^13.0.2",
-    "@metamask/keyring-controller": "^13.0.0",
-    "@metamask/network-controller": "^17.2.1",
-    "@metamask/polling-controller": "^5.0.1",
+    "@metamask/gas-fee-controller": "^14.0.0",
+    "@metamask/keyring-controller": "^14.0.0",
+    "@metamask/network-controller": "^18.0.0",
+    "@metamask/polling-controller": "^6.0.0",
     "@metamask/rpc-errors": "^6.2.1",
-    "@metamask/transaction-controller": "^24.0.0",
+    "@metamask/transaction-controller": "^25.0.0",
     "@metamask/utils": "^8.3.0",
     "bn.js": "^5.2.1",
     "immer": "^9.0.6",
@@ -70,11 +70,11 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/approval-controller": "^5.1.2",
-    "@metamask/gas-fee-controller": "^13.0.0",
-    "@metamask/keyring-controller": "^13.0.0",
-    "@metamask/network-controller": "^17.2.0",
-    "@metamask/transaction-controller": "^24.0.0"
+    "@metamask/approval-controller": "^6.0.0",
+    "@metamask/gas-fee-controller": "^14.0.0",
+    "@metamask/keyring-controller": "^14.0.0",
+    "@metamask/network-controller": "^18.0.0",
+    "@metamask/transaction-controller": "^25.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,16 +1638,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/accounts-controller@^11.0.0, @metamask/accounts-controller@workspace:packages/accounts-controller":
+"@metamask/accounts-controller@^12.0.0, @metamask/accounts-controller@workspace:packages/accounts-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/accounts-controller@workspace:packages/accounts-controller"
   dependencies:
     "@ethereumjs/util": ^8.1.0
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
+    "@metamask/base-controller": ^5.0.0
     "@metamask/eth-snap-keyring": ^2.1.1
     "@metamask/keyring-api": ^3.0.0
-    "@metamask/keyring-controller": ^13.0.0
+    "@metamask/keyring-controller": ^14.0.0
     "@metamask/snaps-controllers": ^4.0.0
     "@metamask/snaps-sdk": ^1.3.2
     "@metamask/snaps-utils": ^5.1.2
@@ -1664,7 +1664,7 @@ __metadata:
     typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/keyring-controller": ^13.0.0
+    "@metamask/keyring-controller": ^14.0.0
     "@metamask/snaps-controllers": ^4.0.0
   languageName: unknown
   linkType: soft
@@ -1685,8 +1685,8 @@ __metadata:
   resolution: "@metamask/address-book-controller@workspace:packages/address-book-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -1703,7 +1703,7 @@ __metadata:
   resolution: "@metamask/announcement-controller@workspace:packages/announcement-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
+    "@metamask/base-controller": ^5.0.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -1714,12 +1714,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/approval-controller@^5.1.1, @metamask/approval-controller@^5.1.3, @metamask/approval-controller@workspace:packages/approval-controller":
+"@metamask/approval-controller@^6.0.0, @metamask/approval-controller@workspace:packages/approval-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/approval-controller@workspace:packages/approval-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
+    "@metamask/base-controller": ^5.0.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -1734,6 +1734,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/approval-controller@npm:^5.1.1":
+  version: 5.1.3
+  resolution: "@metamask/approval-controller@npm:5.1.3"
+  dependencies:
+    "@metamask/base-controller": ^4.1.1
+    "@metamask/rpc-errors": ^6.2.1
+    "@metamask/utils": ^8.3.0
+    nanoid: ^3.1.31
+  checksum: db34992be786a4addcbdc57a5651486c730ce9957bf1aefd0157ac90fe79150cddfb60e508f2c470d6bfaa82a62997ffa9bd1ef357109ac26277f5b528601e70
+  languageName: node
+  linkType: hard
+
 "@metamask/assets-controllers@workspace:packages/assets-controllers":
   version: 0.0.0-use.local
   resolution: "@metamask/assets-controllers@workspace:packages/assets-controllers"
@@ -1744,20 +1756,20 @@ __metadata:
     "@ethersproject/contracts": ^5.7.0
     "@ethersproject/providers": ^5.7.0
     "@metamask/abi-utils": ^2.0.2
-    "@metamask/accounts-controller": ^11.0.0
-    "@metamask/approval-controller": ^5.1.3
+    "@metamask/accounts-controller": ^12.0.0
+    "@metamask/approval-controller": ^6.0.0
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
+    "@metamask/base-controller": ^5.0.0
     "@metamask/contract-metadata": ^2.4.0
-    "@metamask/controller-utils": ^8.0.4
+    "@metamask/controller-utils": ^9.0.0
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.3.0
     "@metamask/keyring-api": ^3.0.0
-    "@metamask/keyring-controller": ^13.0.0
+    "@metamask/keyring-controller": ^14.0.0
     "@metamask/metamask-eth-abis": 3.0.0
-    "@metamask/network-controller": ^17.2.1
-    "@metamask/polling-controller": ^5.0.1
-    "@metamask/preferences-controller": ^8.0.0
+    "@metamask/network-controller": ^18.0.0
+    "@metamask/polling-controller": ^6.0.0
+    "@metamask/preferences-controller": ^9.0.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
     "@types/bn.js": ^5.1.5
@@ -1782,11 +1794,11 @@ __metadata:
     typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/accounts-controller": ^11.0.0
-    "@metamask/approval-controller": ^5.1.2
-    "@metamask/keyring-controller": ^13.0.0
-    "@metamask/network-controller": ^17.2.0
-    "@metamask/preferences-controller": ^8.0.0
+    "@metamask/accounts-controller": ^12.0.0
+    "@metamask/approval-controller": ^6.0.0
+    "@metamask/keyring-controller": ^14.0.0
+    "@metamask/network-controller": ^18.0.0
+    "@metamask/preferences-controller": ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -1820,7 +1832,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@^4.0.0, @metamask/base-controller@^4.0.1, @metamask/base-controller@^4.1.0, @metamask/base-controller@^4.1.1, @metamask/base-controller@workspace:packages/base-controller":
+"@metamask/base-controller@^5.0.0, @metamask/base-controller@workspace:packages/base-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/base-controller@workspace:packages/base-controller"
   dependencies:
@@ -1838,6 +1850,16 @@ __metadata:
     typescript: ~4.8.4
   languageName: unknown
   linkType: soft
+
+"@metamask/base-controller@npm:^4.0.0, @metamask/base-controller@npm:^4.0.1, @metamask/base-controller@npm:^4.1.0, @metamask/base-controller@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@metamask/base-controller@npm:4.1.1"
+  dependencies:
+    "@metamask/utils": ^8.3.0
+    immer: ^9.0.6
+  checksum: adfbc9815506f41342036743b481236179ffd8378e58dad4ffd5b55158d1a5d5509b113d17af5fe1de35d02c448a7c92fffd5234da1893374aab498356585f76
+  languageName: node
+  linkType: hard
 
 "@metamask/browser-passworder@npm:^4.3.0":
   version: 4.3.0
@@ -1871,8 +1893,8 @@ __metadata:
   resolution: "@metamask/composable-controller@workspace:packages/composable-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/json-rpc-engine": ^7.3.3
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/json-rpc-engine": ^8.0.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     immer: ^9.0.6
@@ -1892,7 +1914,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@^8.0.1, @metamask/controller-utils@^8.0.4, @metamask/controller-utils@workspace:packages/controller-utils":
+"@metamask/controller-utils@^9.0.0, @metamask/controller-utils@workspace:packages/controller-utils":
   version: 0.0.0-use.local
   resolution: "@metamask/controller-utils@workspace:packages/controller-utils"
   dependencies:
@@ -1917,6 +1939,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/controller-utils@npm:^8.0.1, @metamask/controller-utils@npm:^8.0.2":
+  version: 8.0.4
+  resolution: "@metamask/controller-utils@npm:8.0.4"
+  dependencies:
+    "@ethereumjs/util": ^8.1.0
+    "@metamask/eth-query": ^4.0.0
+    "@metamask/ethjs-unit": ^0.3.0
+    "@metamask/utils": ^8.3.0
+    "@spruceid/siwe-parser": 1.1.3
+    eth-ens-namehash: ^2.0.8
+    fast-deep-equal: ^3.1.3
+  checksum: eb259daf51c18991cb86ae4c10235a1d2d59e910ff92e60a7aab3e0f0b3030234acbaf2173e1744616bef60e4061c1fdaa651ab8ffcf06d09394bf6beae248f3
+  languageName: node
+  linkType: hard
+
 "@metamask/core-monorepo@workspace:.":
   version: 0.0.0-use.local
   resolution: "@metamask/core-monorepo@workspace:."
@@ -1930,8 +1967,8 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/eth-json-rpc-provider": ^2.3.2
-    "@metamask/json-rpc-engine": ^7.3.3
+    "@metamask/eth-json-rpc-provider": ^3.0.0
+    "@metamask/json-rpc-engine": ^8.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/node": ^16.18.54
@@ -1993,9 +2030,9 @@ __metadata:
   dependencies:
     "@ethersproject/providers": ^5.7.0
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
-    "@metamask/network-controller": ^17.2.1
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
+    "@metamask/network-controller": ^18.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -2006,7 +2043,7 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
   peerDependencies:
-    "@metamask/network-controller": ^17.2.0
+    "@metamask/network-controller": ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -2103,12 +2140,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-provider@^2.1.0, @metamask/eth-json-rpc-provider@^2.3.2, @metamask/eth-json-rpc-provider@workspace:packages/eth-json-rpc-provider":
+"@metamask/eth-json-rpc-provider@^3.0.0, @metamask/eth-json-rpc-provider@workspace:packages/eth-json-rpc-provider":
   version: 0.0.0-use.local
   resolution: "@metamask/eth-json-rpc-provider@workspace:packages/eth-json-rpc-provider"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/json-rpc-engine": ^7.3.3
+    "@metamask/json-rpc-engine": ^8.0.0
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2120,6 +2157,17 @@ __metadata:
     typescript: ~4.8.4
   languageName: unknown
   linkType: soft
+
+"@metamask/eth-json-rpc-provider@npm:^2.1.0":
+  version: 2.3.2
+  resolution: "@metamask/eth-json-rpc-provider@npm:2.3.2"
+  dependencies:
+    "@metamask/json-rpc-engine": ^7.3.2
+    "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^8.3.0
+  checksum: e6731271aad3b972d85b9230c26d35a9b88722f3bd3024675ad2f568e634e9fdfef4717ef2892f3cc512d381cf17a4e20dbd5eb808ced765082bea3379ad6ddc
+  languageName: node
+  linkType: hard
 
 "@metamask/eth-query@npm:^4.0.0":
   version: 4.0.0
@@ -2274,17 +2322,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gas-fee-controller@^13.0.2, @metamask/gas-fee-controller@workspace:packages/gas-fee-controller":
+"@metamask/gas-fee-controller@^14.0.0, @metamask/gas-fee-controller@workspace:packages/gas-fee-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/gas-fee-controller@workspace:packages/gas-fee-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-unit": ^0.3.0
-    "@metamask/network-controller": ^17.2.1
-    "@metamask/polling-controller": ^5.0.1
+    "@metamask/network-controller": ^18.0.0
+    "@metamask/polling-controller": ^6.0.0
     "@metamask/utils": ^8.3.0
     "@types/bn.js": ^5.1.5
     "@types/jest": ^27.4.1
@@ -2302,11 +2350,11 @@ __metadata:
     typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/network-controller": ^17.2.0
+    "@metamask/network-controller": ^18.0.0
   languageName: unknown
   linkType: soft
 
-"@metamask/json-rpc-engine@^7.1.1, @metamask/json-rpc-engine@^7.3.1, @metamask/json-rpc-engine@^7.3.3, @metamask/json-rpc-engine@workspace:packages/json-rpc-engine":
+"@metamask/json-rpc-engine@^8.0.0, @metamask/json-rpc-engine@workspace:packages/json-rpc-engine":
   version: 0.0.0-use.local
   resolution: "@metamask/json-rpc-engine@workspace:packages/json-rpc-engine"
   dependencies:
@@ -2325,12 +2373,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.3.1, @metamask/json-rpc-engine@npm:^7.3.2":
+  version: 7.3.3
+  resolution: "@metamask/json-rpc-engine@npm:7.3.3"
+  dependencies:
+    "@metamask/rpc-errors": ^6.2.1
+    "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^8.3.0
+  checksum: 7bab8b4d2341a6243ba451bc58283f0a6905b09f7257857859848a51a795444ca6899b1a6908b15f8ed236fb574ab85a630c9cb28d127ab52c4630e496c16006
+  languageName: node
+  linkType: hard
+
 "@metamask/json-rpc-middleware-stream@workspace:packages/json-rpc-middleware-stream":
   version: 0.0.0-use.local
   resolution: "@metamask/json-rpc-middleware-stream@workspace:packages/json-rpc-middleware-stream"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/json-rpc-engine": ^7.3.3
+    "@metamask/json-rpc-engine": ^8.0.0
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2392,7 +2451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-controller@^13.0.0, @metamask/keyring-controller@workspace:packages/keyring-controller":
+"@metamask/keyring-controller@^14.0.0, @metamask/keyring-controller@workspace:packages/keyring-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-controller@workspace:packages/keyring-controller"
   dependencies:
@@ -2403,13 +2462,13 @@ __metadata:
     "@keystonehq/metamask-airgapped-keyring": ^0.13.1
     "@lavamoat/allow-scripts": ^3.0.2
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
+    "@metamask/base-controller": ^5.0.0
     "@metamask/browser-passworder": ^4.3.0
     "@metamask/eth-hd-keyring": ^7.0.1
     "@metamask/eth-sig-util": ^7.0.1
     "@metamask/eth-simple-keyring": ^6.0.1
     "@metamask/keyring-api": ^3.0.0
-    "@metamask/message-manager": ^7.3.9
+    "@metamask/message-manager": ^8.0.0
     "@metamask/scure-bip39": ^2.1.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2428,13 +2487,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/logging-controller@^2.0.3, @metamask/logging-controller@workspace:packages/logging-controller":
+"@metamask/logging-controller@^3.0.0, @metamask/logging-controller@workspace:packages/logging-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/logging-controller@workspace:packages/logging-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -2446,13 +2505,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/message-manager@^7.3.9, @metamask/message-manager@workspace:packages/message-manager":
+"@metamask/message-manager@^8.0.0, @metamask/message-manager@workspace:packages/message-manager":
   version: 0.0.0-use.local
   resolution: "@metamask/message-manager@workspace:packages/message-manager"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
     "@metamask/eth-sig-util": ^7.0.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2480,7 +2539,7 @@ __metadata:
   resolution: "@metamask/name-controller@workspace:packages/name-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
+    "@metamask/base-controller": ^5.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     async-mutex: ^0.2.6
@@ -2493,19 +2552,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/network-controller@^17.2.1, @metamask/network-controller@workspace:packages/network-controller":
+"@metamask/network-controller@^18.0.0, @metamask/network-controller@workspace:packages/network-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/network-controller@workspace:packages/network-controller"
   dependencies:
     "@json-rpc-specification/meta-schema": ^1.0.6
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
     "@metamask/eth-json-rpc-infura": ^9.1.0
     "@metamask/eth-json-rpc-middleware": ^12.1.0
-    "@metamask/eth-json-rpc-provider": ^2.3.2
+    "@metamask/eth-json-rpc-provider": ^3.0.0
     "@metamask/eth-query": ^4.0.0
-    "@metamask/json-rpc-engine": ^7.3.3
+    "@metamask/json-rpc-engine": ^8.0.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/swappable-obj-proxy": ^2.2.0
     "@metamask/utils": ^8.3.0
@@ -2534,7 +2593,7 @@ __metadata:
   resolution: "@metamask/notification-controller@workspace:packages/notification-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
+    "@metamask/base-controller": ^5.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -2577,15 +2636,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@^8.0.1, @metamask/permission-controller@workspace:packages/permission-controller":
+"@metamask/permission-controller@^9.0.0, @metamask/permission-controller@workspace:packages/permission-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/permission-controller@workspace:packages/permission-controller"
   dependencies:
-    "@metamask/approval-controller": ^5.1.3
+    "@metamask/approval-controller": ^6.0.0
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
-    "@metamask/json-rpc-engine": ^7.3.3
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
+    "@metamask/json-rpc-engine": ^8.0.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
     "@types/deep-freeze-strict": ^1.1.0
@@ -2600,7 +2659,7 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
   peerDependencies:
-    "@metamask/approval-controller": ^5.1.2
+    "@metamask/approval-controller": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -2628,8 +2687,8 @@ __metadata:
   resolution: "@metamask/permission-log-controller@workspace:packages/permission-log-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/json-rpc-engine": ^7.3.3
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/json-rpc-engine": ^8.0.0
     "@metamask/utils": ^8.3.0
     "@types/deep-freeze-strict": ^1.1.0
     "@types/jest": ^27.4.1
@@ -2644,13 +2703,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/phishing-controller@^8.0.1, @metamask/phishing-controller@workspace:packages/phishing-controller":
+"@metamask/phishing-controller@npm:^8.0.1":
+  version: 8.0.2
+  resolution: "@metamask/phishing-controller@npm:8.0.2"
+  dependencies:
+    "@metamask/base-controller": ^4.1.1
+    "@metamask/controller-utils": ^8.0.2
+    "@types/punycode": ^2.1.0
+    eth-phishing-detect: ^1.2.0
+    punycode: ^2.1.1
+  checksum: 2263f8c696ae81b233cc21ad927515c24e32132ddb297ab04ca45a8d92bbd0e8b0d7b43d53a074277cc441d51ce95d03efccecac0c7da9493540d489f4aecb81
+  languageName: node
+  linkType: hard
+
+"@metamask/phishing-controller@workspace:packages/phishing-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/phishing-controller@workspace:packages/phishing-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
     "@types/jest": ^27.4.1
     "@types/punycode": ^2.1.0
     deepmerge: ^4.2.2
@@ -2666,14 +2738,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/polling-controller@^5.0.1, @metamask/polling-controller@workspace:packages/polling-controller":
+"@metamask/polling-controller@^6.0.0, @metamask/polling-controller@workspace:packages/polling-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/polling-controller@workspace:packages/polling-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
-    "@metamask/network-controller": ^17.2.1
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
+    "@metamask/network-controller": ^18.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/uuid": ^8.3.0
@@ -2687,7 +2759,7 @@ __metadata:
     typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/network-controller": ^17.2.0
+    "@metamask/network-controller": ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -2701,14 +2773,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/preferences-controller@^8.0.0, @metamask/preferences-controller@workspace:packages/preferences-controller":
+"@metamask/preferences-controller@^9.0.0, @metamask/preferences-controller@workspace:packages/preferences-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/preferences-controller@workspace:packages/preferences-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
-    "@metamask/keyring-controller": ^13.0.0
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
+    "@metamask/keyring-controller": ^14.0.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -2718,7 +2790,7 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
   peerDependencies:
-    "@metamask/keyring-controller": ^13.0.0
+    "@metamask/keyring-controller": ^14.0.0
   languageName: unknown
   linkType: soft
 
@@ -2747,12 +2819,12 @@ __metadata:
   resolution: "@metamask/queued-request-controller@workspace:packages/queued-request-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
-    "@metamask/json-rpc-engine": ^7.3.3
-    "@metamask/network-controller": ^17.2.1
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
+    "@metamask/json-rpc-engine": ^8.0.0
+    "@metamask/network-controller": ^18.0.0
     "@metamask/rpc-errors": ^6.2.1
-    "@metamask/selected-network-controller": ^9.0.0
+    "@metamask/selected-network-controller": ^10.0.0
     "@metamask/swappable-obj-proxy": ^2.2.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2767,8 +2839,8 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
   peerDependencies:
-    "@metamask/network-controller": ^17.2.0
-    "@metamask/selected-network-controller": ^9.0.0
+    "@metamask/network-controller": ^18.0.0
+    "@metamask/selected-network-controller": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2777,7 +2849,7 @@ __metadata:
   resolution: "@metamask/rate-limit-controller@workspace:packages/rate-limit-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
+    "@metamask/base-controller": ^5.0.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2824,15 +2896,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/selected-network-controller@^9.0.0, @metamask/selected-network-controller@workspace:packages/selected-network-controller":
+"@metamask/selected-network-controller@^10.0.0, @metamask/selected-network-controller@workspace:packages/selected-network-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/selected-network-controller@workspace:packages/selected-network-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/json-rpc-engine": ^7.3.3
-    "@metamask/network-controller": ^17.2.1
-    "@metamask/permission-controller": ^8.0.1
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/json-rpc-engine": ^8.0.0
+    "@metamask/network-controller": ^18.0.0
+    "@metamask/permission-controller": ^9.0.0
     "@metamask/swappable-obj-proxy": ^2.2.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2847,8 +2919,8 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
   peerDependencies:
-    "@metamask/network-controller": ^17.2.0
-    "@metamask/permission-controller": ^8.0.1
+    "@metamask/network-controller": ^18.0.0
+    "@metamask/permission-controller": ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -2856,13 +2928,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/signature-controller@workspace:packages/signature-controller"
   dependencies:
-    "@metamask/approval-controller": ^5.1.3
+    "@metamask/approval-controller": ^6.0.0
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
-    "@metamask/keyring-controller": ^13.0.0
-    "@metamask/logging-controller": ^2.0.3
-    "@metamask/message-manager": ^7.3.9
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
+    "@metamask/keyring-controller": ^14.0.0
+    "@metamask/logging-controller": ^3.0.0
+    "@metamask/message-manager": ^8.0.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2874,9 +2946,9 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.8.4
   peerDependencies:
-    "@metamask/approval-controller": ^5.1.2
-    "@metamask/keyring-controller": ^13.0.0
-    "@metamask/logging-controller": ^2.0.2
+    "@metamask/approval-controller": ^6.0.0
+    "@metamask/keyring-controller": ^14.0.0
+    "@metamask/logging-controller": ^3.0.0
   languageName: unknown
   linkType: soft
 
@@ -3054,7 +3126,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@^24.0.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
+"@metamask/transaction-controller@^25.0.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/transaction-controller@workspace:packages/transaction-controller"
   dependencies:
@@ -3064,15 +3136,15 @@ __metadata:
     "@ethereumjs/util": ^8.1.0
     "@ethersproject/abi": ^5.7.0
     "@ethersproject/providers": ^5.7.0
-    "@metamask/approval-controller": ^5.1.3
+    "@metamask/approval-controller": ^6.0.0
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.3.0
-    "@metamask/gas-fee-controller": ^13.0.2
+    "@metamask/gas-fee-controller": ^14.0.0
     "@metamask/metamask-eth-abis": ^3.0.0
-    "@metamask/network-controller": ^17.2.1
+    "@metamask/network-controller": ^18.0.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
     "@types/bn.js": ^5.1.5
@@ -3096,9 +3168,9 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     "@babel/runtime": ^7.23.9
-    "@metamask/approval-controller": ^5.1.2
-    "@metamask/gas-fee-controller": ^13.0.0
-    "@metamask/network-controller": ^17.2.0
+    "@metamask/approval-controller": ^6.0.0
+    "@metamask/gas-fee-controller": ^14.0.0
+    "@metamask/network-controller": ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -3106,17 +3178,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/user-operation-controller@workspace:packages/user-operation-controller"
   dependencies:
-    "@metamask/approval-controller": ^5.1.3
+    "@metamask/approval-controller": ^6.0.0
     "@metamask/auto-changelog": ^3.4.4
-    "@metamask/base-controller": ^4.1.1
-    "@metamask/controller-utils": ^8.0.4
+    "@metamask/base-controller": ^5.0.0
+    "@metamask/controller-utils": ^9.0.0
     "@metamask/eth-query": ^4.0.0
-    "@metamask/gas-fee-controller": ^13.0.2
-    "@metamask/keyring-controller": ^13.0.0
-    "@metamask/network-controller": ^17.2.1
-    "@metamask/polling-controller": ^5.0.1
+    "@metamask/gas-fee-controller": ^14.0.0
+    "@metamask/keyring-controller": ^14.0.0
+    "@metamask/network-controller": ^18.0.0
+    "@metamask/polling-controller": ^6.0.0
     "@metamask/rpc-errors": ^6.2.1
-    "@metamask/transaction-controller": ^24.0.0
+    "@metamask/transaction-controller": ^25.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     bn.js: ^5.2.1
@@ -3131,11 +3203,11 @@ __metadata:
     typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/approval-controller": ^5.1.2
-    "@metamask/gas-fee-controller": ^13.0.0
-    "@metamask/keyring-controller": ^13.0.0
-    "@metamask/network-controller": ^17.2.0
-    "@metamask/transaction-controller": ^24.0.0
+    "@metamask/approval-controller": ^6.0.0
+    "@metamask/gas-fee-controller": ^14.0.0
+    "@metamask/keyring-controller": ^14.0.0
+    "@metamask/network-controller": ^18.0.0
+    "@metamask/transaction-controller": ^25.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This release is large and includes a fair number of breaking changes:

- There are number of breaking changes to `@metamask/base-controller`. This forces releasing all of the controller packages.
- Each package now ships with ESM-compatible files, and an `exports` field has been added to facilitate this. This means that importing subpaths is no longer allowed. This forces releasing every package.