### PR TITLE
[base-controller] Narrow return types of `get{Anonymized,Persistent}State`

### DIFF
--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -256,7 +256,7 @@ export class BaseController<
 export function getAnonymizedState<ControllerState extends StateConstraint>(
   state: ControllerState,
   metadata: StateMetadata<ControllerState>,
-): StateConstraint {
+): Record<keyof ControllerState, Json> {
   return deriveStateFromMetadata(state, metadata, 'anonymous');
 }
 
@@ -270,7 +270,7 @@ export function getAnonymizedState<ControllerState extends StateConstraint>(
 export function getPersistentState<ControllerState extends StateConstraint>(
   state: ControllerState,
   metadata: StateMetadata<ControllerState>,
-): StateConstraint {
+): Record<keyof ControllerState, Json> {
   return deriveStateFromMetadata(state, metadata, 'persist');
 }
 


### PR DESCRIPTION
## Explanation

#3949 narrows the return type of the `deriveStateFromMetadata` function from `Record<string, Json>` to `Record<keyof ControllerState, Json>`. However, the resulting changes to functions `getAnonymizedState` and `getPersistentState` weren't reflected in that PR. 

This commit fixes the return type annotations for these functions to the correct type: `Record<keyof ControllerState, Json>`.

## References

- Closes #3962
- Follows from #3949

## Changelog

### `@metamask/base-controller`

#### Changed

- **BREAKING:** Narrow the return types of functions `getAnonymizedState<ControllerState>` and `getPersistentState<ControllerState>` from `Record<string, Json>` to `Record<keyof ControllerState, Json>`. ([#3949](https://github.com/MetaMask/core/pull/3949), [#4040](https://github.com/MetaMask/core/pull/4040))

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
