### PR TITLE
fix: Mantle token mispriced

### DIFF
--- a/packages/assets-controllers/src/crypto-compare.ts
+++ b/packages/assets-controllers/src/crypto-compare.ts
@@ -1,5 +1,8 @@
 import { handleFetch } from '@metamask/controller-utils';
 
+/** A map from native currency symbol to CryptoCompare identifier */
+const nativeSymbolOverrides = new Map([['MNT', 'MANTLE']]);
+
 /**
  * Get the CryptoCompare API URL for getting the conversion rate from the given native currency to
  * the given currency. Optionally, the conversion rate from the native currency to USD can also be
@@ -16,9 +19,11 @@ function getPricingURL(
   nativeCurrency: string,
   includeUSDRate?: boolean,
 ) {
+  nativeCurrency = nativeCurrency.toUpperCase();
+  const fsym = nativeSymbolOverrides.get(nativeCurrency) ?? nativeCurrency;
   return (
     `https://min-api.cryptocompare.com/data/price?fsym=` +
-    `${nativeCurrency.toUpperCase()}&tsyms=${currentCurrency.toUpperCase()}` +
+    `${fsym}&tsyms=${currentCurrency.toUpperCase()}` +
     `${includeUSDRate && currentCurrency.toUpperCase() !== 'USD' ? ',USD' : ''}`
   );
 }

--- a/packages/assets-controllers/src/crypto-compare.ts
+++ b/packages/assets-controllers/src/crypto-compare.ts
@@ -1,6 +1,9 @@
 import { handleFetch } from '@metamask/controller-utils';
 
-/** A map from native currency symbol to CryptoCompare identifier */
+/**
+ * A map from native currency symbol to CryptoCompare identifier.
+ * This is only needed when the values don't match.
+ */
 const nativeSymbolOverrides = new Map([['MNT', 'MANTLE']]);
 
 /**


### PR DESCRIPTION
## Explanation

Fixes an issue where prices were incorrect for Mantle, the native token of chain 0x1388.

This happens because the symbol is `MNT`, but that's also the symbol of Mongolia's fiat currency.  CryptoCompare gives symbol preference to the latter, and instead uses `MANTLE` to identify the crypto token:

- https://data-api.cryptocompare.com/asset/v1/data/by/symbol?asset_symbol=MNT
- https://data-api.cryptocompare.com/asset/v1/data/by/symbol?asset_symbol=MANTLE

I fixed this by adding an override mapping for tokens whose CryptoCompare identifiers don't match their symbol, starting with `MNT` -> `MANTLE`.

## References



## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **FIXED**: Fixed price lookups for Mantle token

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
