### PR TITLE
Fix `SideEffectMessenger` type not respecting generic parameter types

### DIFF
--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -365,8 +365,8 @@ export type SideEffectMessenger<
   typeof controllerName,
   Actions | AllowedActions,
   Events,
-  AllowedActions['type'],
-  never
+  AllowedActions['type'] | Actions['type'],
+  Events['type']
 >;
 
 /**


### PR DESCRIPTION
## Explanation

Fixes a problem with the `SideEffectMessenger` type introduced in a recent release. The type was changed and would disallow permission specifications adding further actions and events to the messenger allowlist. This PR fixes that problem and lets permission specifications once again extend the messenger by leveraging the existing generic types.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/permission-controller`

- **Fixed**: Fix `SideEffectMessenger` type not respecting generic parameter types

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
