### PR TITLE
Include errors in simulation data

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.23,
-      functions: 98.5,
-      lines: 98.93,
-      statements: 98.94,
+      branches: 94.31,
+      functions: 98.51,
+      lines: 98.99,
+      statements: 99,
     },
   },
 

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -45,7 +45,6 @@
     "@ethereumjs/tx": "^4.2.0",
     "@ethereumjs/util": "^8.1.0",
     "@ethersproject/abi": "^5.7.0",
-    "@ethersproject/providers": "^5.7.0",
     "@metamask/approval-controller": "^6.0.1",
     "@metamask/base-controller": "^5.0.1",
     "@metamask/controller-utils": "^9.0.1",

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1685,7 +1685,7 @@ describe('TransactionController', () => {
       });
     });
 
-    it('updates simulation data by default', async () => {
+    it('updates simulation data', async () => {
       getSimulationDataMock.mockResolvedValueOnce(SIMULATION_DATA_MOCK);
 
       const { controller } = setupController();
@@ -5494,6 +5494,34 @@ describe('TransactionController', () => {
         .toThrow(`TransactionsController: Can only call updateEditableParams on an unapproved transaction.
       Current tx status: ${TransactionStatus.submitted}`);
     });
+
+    it.each(['value', 'to', 'data'])(
+      'updates simulation data if %s changes',
+      async (param) => {
+        const { controller } = setupController({
+          options: {
+            state: {
+              transactions: [
+                {
+                  ...transactionMeta,
+                },
+              ],
+            },
+          },
+        });
+
+        expect(getSimulationDataMock).toHaveBeenCalledTimes(0);
+
+        await controller.updateEditableParams(transactionMeta.id, {
+          ...transactionMeta.txParams,
+          [param]: ACCOUNT_2_MOCK,
+        });
+
+        await flushPromises();
+
+        expect(getSimulationDataMock).toHaveBeenCalledTimes(1);
+      },
+    );
   });
 
   describe('abortTransactionSigning', () => {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1378,7 +1378,6 @@ describe('TransactionController', () => {
         origin: undefined,
         securityAlertResponse: undefined,
         sendFlowHistory: expect.any(Array),
-        simulationData: undefined,
         status: TransactionStatus.unapproved as const,
         time: expect.any(Number),
         txParams: expect.anything(),
@@ -1710,7 +1709,7 @@ describe('TransactionController', () => {
       );
     });
 
-    it('does not update simulation data if simulation disabled', async () => {
+    it('includes simulation data with error if simulation disabled', async () => {
       getSimulationDataMock.mockResolvedValueOnce(SIMULATION_DATA_MOCK);
 
       const { controller } = setupController({
@@ -1723,7 +1722,13 @@ describe('TransactionController', () => {
       });
 
       expect(getSimulationDataMock).toHaveBeenCalledTimes(0);
-      expect(controller.state.transactions[0].simulationData).toBeUndefined();
+      expect(controller.state.transactions[0].simulationData).toStrictEqual({
+        error: {
+          message: 'Simulation disabled',
+          isReverted: false,
+        },
+        tokenBalanceChanges: [],
+      });
     });
 
     describe('on approve', () => {
@@ -4404,7 +4409,7 @@ describe('TransactionController', () => {
 
       expect(signSpy).toHaveBeenCalledTimes(1);
 
-      expect(updateTransactionSpy).toHaveBeenCalledTimes(2);
+      expect(updateTransactionSpy).toHaveBeenCalledTimes(3);
       expect(updateTransactionSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           txParams: expect.objectContaining(paramsMock),
@@ -4448,7 +4453,7 @@ describe('TransactionController', () => {
       await wait(0);
 
       expect(signSpy).toHaveBeenCalledTimes(1);
-      expect(updateTransactionSpy).toHaveBeenCalledTimes(1);
+      expect(updateTransactionSpy).toHaveBeenCalledTimes(2);
     });
 
     it('adds a transaction, signs and skips publish the transaction', async () => {
@@ -4474,7 +4479,7 @@ describe('TransactionController', () => {
 
       expect(signSpy).toHaveBeenCalledTimes(1);
 
-      expect(updateTransactionSpy).toHaveBeenCalledTimes(2);
+      expect(updateTransactionSpy).toHaveBeenCalledTimes(3);
       expect(updateTransactionSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           txParams: expect.objectContaining(paramsMock),

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1695,6 +1695,8 @@ describe('TransactionController', () => {
         to: ACCOUNT_MOCK,
       });
 
+      await flushPromises();
+
       expect(getSimulationDataMock).toHaveBeenCalledTimes(1);
       expect(getSimulationDataMock).toHaveBeenCalledWith({
         chainId: MOCK_NETWORK.state.providerConfig.chainId,

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -39,7 +39,7 @@ import { add0x } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 import { MethodRegistry } from 'eth-method-registry';
 import { EventEmitter } from 'events';
-import { cloneDeep, mapValues, merge, pickBy, sortBy } from 'lodash';
+import { cloneDeep, mapValues, merge, pickBy, sortBy, isEqual } from 'lodash';
 import { NonceTracker } from 'nonce-tracker';
 import type {
   NonceLock,
@@ -1039,9 +1039,6 @@ export class TransactionController extends BaseController<
           networkClientId,
         };
 
-    const getSimulationDataPromise =
-      this.#getSimulationData(addedTransactionMeta);
-
     await this.updateGasProperties(addedTransactionMeta);
 
     // Checks if a transaction already exists with a given actionId
@@ -1077,18 +1074,13 @@ export class TransactionController extends BaseController<
 
       this.addMetadata(addedTransactionMeta);
 
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.#updateSimulationData(addedTransactionMeta);
+
       this.messagingSystem.publish(
         `${controllerName}:unapprovedTransactionAdded`,
         addedTransactionMeta,
       );
-
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      getSimulationDataPromise.then(async (simulationData) => {
-        await this.updateSimulationData(
-          addedTransactionMeta.id,
-          simulationData,
-        );
-      });
     }
 
     return {
@@ -3502,6 +3494,9 @@ export class TransactionController extends BaseController<
 
     validateTxParams(normalizedTransaction.txParams);
 
+    const updatedTransactionParams =
+      this.#checkIfTransactionParamsUpdated(transactionMeta);
+
     const transactionWithUpdatedHistory =
       skipHistory === true
         ? normalizedTransaction
@@ -3516,46 +3511,89 @@ export class TransactionController extends BaseController<
       );
       state.transactions[index] = transactionWithUpdatedHistory;
     });
+
+    if (updatedTransactionParams.length > 0) {
+      this.#onTransactionParamsUpdated(
+        transactionMeta,
+        updatedTransactionParams,
+      );
+    }
   }
 
-  async #getSimulationData(
-    transactionMeta: TransactionMeta,
-  ): Promise<SimulationData> {
-    if (!this.#isSimulationEnabled()) {
-      log('Skipping simulation as disabled');
-      return {
-        error: {
-          message: 'Simulation disabled',
-          isReverted: false,
-        },
-        tokenBalanceChanges: [],
-      };
+  #checkIfTransactionParamsUpdated(newTransactionMeta: TransactionMeta) {
+    const { id: transactionId, txParams: newParams } = newTransactionMeta;
+
+    const originalParams = this.getTransaction(transactionId)?.txParams;
+
+    if (!originalParams || isEqual(originalParams, newParams)) {
+      return [];
     }
 
-    const { chainId, txParams } = transactionMeta;
-    const { from, to, value, data } = txParams;
+    const params = Object.keys(newParams) as (keyof TransactionParams)[];
 
-    const simulationData = await getSimulationData({
-      chainId,
-      from: from as Hex,
-      to: to as Hex,
-      value: value as Hex,
-      data: data as Hex,
-    });
+    const updatedProperties = params.filter(
+      (param) => newParams[param] !== originalParams[param],
+    );
 
-    return simulationData;
+    log(
+      'Transaction parameters have been updated',
+      transactionId,
+      updatedProperties,
+      originalParams,
+      newParams,
+    );
+
+    return updatedProperties;
   }
 
-  async updateSimulationData(
-    transactionId: string,
-    simulationData: SimulationData,
+  #onTransactionParamsUpdated(
+    transactionMeta: TransactionMeta,
+    updatedParams: (keyof TransactionParams)[],
   ) {
-    const transactionMeta = this.getTransaction(transactionId);
+    if (
+      (['to', 'value', 'data'] as const).some((param) =>
+        updatedParams.includes(param),
+      )
+    ) {
+      log('Updating simulation data due to transaction parameter update');
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.#updateSimulationData(transactionMeta);
+    }
+  }
 
-    if (!transactionMeta) {
+  async #updateSimulationData(transactionMeta: TransactionMeta) {
+    const { id, chainId, txParams } = transactionMeta;
+    const { from, to, value, data } = txParams;
+
+    let simulationData: SimulationData = {
+      error: {
+        message: 'Simulation disabled',
+        isReverted: false,
+      },
+      tokenBalanceChanges: [],
+    };
+
+    if (this.#isSimulationEnabled()) {
+      this.#updateTransactionInternal(
+        { ...transactionMeta, simulationData: undefined },
+        { skipHistory: true },
+      );
+
+      simulationData = await getSimulationData({
+        chainId,
+        from: from as Hex,
+        to: to as Hex,
+        value: value as Hex,
+        data: data as Hex,
+      });
+    }
+
+    const finalTransactionMeta = this.getTransaction(id);
+
+    if (!finalTransactionMeta) {
       log(
         'Cannot update simulation data as transaction not found',
-        transactionId,
+        id,
         simulationData,
       );
 
@@ -3563,10 +3601,10 @@ export class TransactionController extends BaseController<
     }
 
     this.updateTransaction(
-      { ...transactionMeta, simulationData },
+      { ...finalTransactionMeta, simulationData },
       'TransactionController#updateSimulationData - Update simulation data',
     );
 
-    log('Updated simulation data', transactionId, simulationData);
+    log('Updated simulation data', id, simulationData);
   }
 }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -3494,8 +3494,9 @@ export class TransactionController extends BaseController<
 
     validateTxParams(normalizedTransaction.txParams);
 
-    const updatedTransactionParams =
-      this.#checkIfTransactionParamsUpdated(transactionMeta);
+    const updatedTransactionParams = this.#checkIfTransactionParamsUpdated(
+      normalizedTransaction,
+    );
 
     const transactionWithUpdatedHistory =
       skipHistory === true
@@ -3514,7 +3515,7 @@ export class TransactionController extends BaseController<
 
     if (updatedTransactionParams.length > 0) {
       this.#onTransactionParamsUpdated(
-        transactionMeta,
+        normalizedTransaction,
         updatedTransactionParams,
       );
     }

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -797,9 +797,6 @@ describe('TransactionController Integration', () => {
             isMultichainEnabled: true,
             getPermittedAccounts: async () => [ACCOUNT_MOCK],
             getSelectedAddress: () => ACCOUNT_MOCK,
-            pendingTransactions: {
-              isResubmitEnabled: false,
-            },
           });
         const otherNetworkClientIdOnGoerli =
           await networkController.upsertNetworkConfiguration(

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -762,7 +762,12 @@ describe('TransactionController Integration', () => {
               '0x1',
             ),
             buildEthBlockNumberRequestMock('0x3'),
-            buildEthGetTransactionReceiptRequestMock('0x1', '0x1', '0x3'),
+            buildEthGetTransactionReceiptRequestMock(
+              '0x1',
+              '0x1',
+              '0x3',
+              '0x2',
+            ),
             buildEthGetBlockByHashRequestMock('0x1'),
             buildEthBlockNumberRequestMock('0x3'),
           ],
@@ -782,12 +787,13 @@ describe('TransactionController Integration', () => {
               '0x02e0050201018094e688b84b23f322a994a53dbf8e15fa82cdb711278080c0808080',
               '0x1',
             ),
-            buildEthSendRawTransactionRequestMock(
-              '0x02e0050201018094e688b84b23f322a994a53dbf8e15fa82cdb711278080c0808080',
-              '0x1',
-            ),
             buildEthBlockNumberRequestMock('0x3'),
-            buildEthGetTransactionReceiptRequestMock('0x1', '0x1', '0x3'),
+            buildEthGetTransactionReceiptRequestMock(
+              '0x1',
+              '0x1',
+              '0x3',
+              '0x2',
+            ),
             buildEthGetBlockByHashRequestMock('0x1'),
           ],
         });

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -793,6 +793,9 @@ describe('TransactionController Integration', () => {
             isMultichainEnabled: true,
             getPermittedAccounts: async () => [ACCOUNT_MOCK],
             getSelectedAddress: () => ACCOUNT_MOCK,
+            pendingTransactions: {
+              isResubmitEnabled: false,
+            },
           });
         const otherNetworkClientIdOnGoerli =
           await networkController.upsertNetworkConfiguration(

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -41,6 +41,11 @@ export type {
   SecurityAlertResponse,
   SecurityProviderRequest,
   SendFlowHistoryEntry,
+  SimulationBalanceChange,
+  SimulationData,
+  SimulationError,
+  SimulationToken,
+  SimulationTokenBalanceChange,
   TransactionError,
   TransactionHistory,
   TransactionHistoryEntry,
@@ -49,6 +54,7 @@ export type {
   TransactionReceipt,
 } from './types';
 export {
+  SimulationTokenStandard,
   TransactionEnvelopeType,
   TransactionStatus,
   TransactionType,

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1100,8 +1100,23 @@ export type SimulationToken = {
 export type SimulationTokenBalanceChange = SimulationToken &
   SimulationBalanceChange;
 
+/** Error data for a failed simulation. */
+export type SimulationError = {
+  /** Error code to identify the error type. */
+  code?: number;
+
+  /** Error message to describe the error. */
+  message?: string;
+
+  /** Whether the error is due to the transaction being reverted. */
+  isReverted: boolean;
+};
+
 /** Simulation data for a transaction. */
 export type SimulationData = {
+  /** Error data if the simulation failed or the transaction reverted. */
+  error?: SimulationError;
+
   /** Data concerning a change to the user's native balance. */
   nativeBalanceChange?: SimulationBalanceChange;
 

--- a/packages/transaction-controller/src/utils/simulation-api.test.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.test.ts
@@ -1,13 +1,6 @@
-import { JsonRpcProvider } from '@ethersproject/providers';
-
 import { CHAIN_IDS } from '../constants';
 import type { SimulationRequest, SimulationResponse } from './simulation-api';
 import { simulateTransactions } from './simulation-api';
-
-jest.mock('@ethersproject/providers', () => ({
-  ...jest.requireActual('@ethersproject/providers'),
-  JsonRpcProvider: jest.fn(),
-}));
 
 const CHAIN_ID_MOCK = '0x1';
 
@@ -48,27 +41,27 @@ const RESPONSE_MOCK: SimulationResponse = {
   ],
 };
 
-/**
- * Creates a mock of the JSON-RPC provider.
- * @returns The JSON-RPC provider mock.
- */
-function createJsonRpcProviderMock() {
-  return {
-    send: jest.fn(),
-  } as unknown as jest.Mocked<JsonRpcProvider>;
-}
-
 describe('Simulation API Utils', () => {
-  const jsonRpcProviderClassMock = jest.mocked(JsonRpcProvider);
-  let jsonRpcProviderMock: jest.Mocked<JsonRpcProvider>;
+  let fetchMock: jest.MockedFunction<typeof fetch>;
+
+  /**
+   * Mock a JSON response from fetch.
+   * @param jsonResponse - The response body to return.
+   */
+  function mockFetchResponse(jsonResponse: unknown) {
+    fetchMock.mockResolvedValue({
+      json: jest.fn().mockResolvedValue(jsonResponse),
+    } as unknown as Response);
+  }
 
   beforeEach(() => {
     jest.resetAllMocks();
 
-    jsonRpcProviderMock = createJsonRpcProviderMock();
-    jsonRpcProviderMock.send.mockResolvedValueOnce(RESPONSE_MOCK);
+    fetchMock = jest.spyOn(global, 'fetch') as jest.MockedFunction<
+      typeof fetch
+    >;
 
-    jsonRpcProviderClassMock.mockReturnValue(jsonRpcProviderMock);
+    mockFetchResponse({ result: RESPONSE_MOCK });
   });
 
   describe('simulateTransactions', () => {
@@ -78,14 +71,16 @@ describe('Simulation API Utils', () => {
       );
     });
 
-    it('sends request to RPC provider', async () => {
+    it('sends request', async () => {
       await simulateTransactions(CHAIN_ID_MOCK, REQUEST_MOCK);
 
-      expect(jsonRpcProviderMock.send).toHaveBeenCalledTimes(1);
-      expect(jsonRpcProviderMock.send).toHaveBeenCalledWith(
-        'infura_simulateTransactions',
-        [REQUEST_MOCK],
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      const requestBody = JSON.parse(
+        fetchMock.mock.calls[0][1]?.body?.toString() ?? '{}',
       );
+
+      expect(requestBody.params[0]).toStrictEqual(REQUEST_MOCK);
     });
 
     it('throws if chain ID not supported', async () => {
@@ -99,8 +94,9 @@ describe('Simulation API Utils', () => {
     it('uses URL specific to chain ID', async () => {
       await simulateTransactions(CHAIN_IDS.GOERLI, REQUEST_MOCK);
 
-      expect(jsonRpcProviderClassMock).toHaveBeenCalledWith(
+      expect(fetchMock).toHaveBeenCalledWith(
         'https://tx-sentinel-ethereum-goerli.api.cx.metamask.io/',
+        expect.any(Object),
       );
     });
   });

--- a/packages/transaction-controller/src/utils/simulation-api.test.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.test.ts
@@ -3,6 +3,8 @@ import type { SimulationRequest, SimulationResponse } from './simulation-api';
 import { simulateTransactions } from './simulation-api';
 
 const CHAIN_ID_MOCK = '0x1';
+const ERROR_CODE_MOCK = 123;
+const ERROR_MESSAGE_MOCK = 'Test Error Message';
 
 const REQUEST_MOCK: SimulationRequest = {
   transactions: [{ from: '0x1', to: '0x2', value: '0x1' }],
@@ -98,6 +100,19 @@ describe('Simulation API Utils', () => {
         'https://tx-sentinel-ethereum-goerli.api.cx.metamask.io/',
         expect.any(Object),
       );
+    });
+
+    it('throws if response has error', async () => {
+      mockFetchResponse({
+        error: { code: ERROR_CODE_MOCK, message: ERROR_MESSAGE_MOCK },
+      });
+
+      await expect(
+        simulateTransactions(CHAIN_ID_MOCK, REQUEST_MOCK),
+      ).rejects.toStrictEqual({
+        code: ERROR_CODE_MOCK,
+        message: ERROR_MESSAGE_MOCK,
+      });
     });
   });
 });

--- a/packages/transaction-controller/src/utils/simulation-api.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.ts
@@ -23,17 +23,26 @@ const SUBDOMAIN_BY_CHAIN_ID: Record<Hex, string> = {
 
 /** Single transaction to simulate in a simulation API request.  */
 export type SimulationRequestTransaction = {
+  /** Data to send with the transaction. */
+  data?: Hex;
+
   /** Sender of the transaction. */
   from: Hex;
+
+  /** Gas limit for the transaction. */
+  gas?: Hex;
+
+  /** Maximum fee per gas for the transaction. */
+  maxFeePerGas?: Hex;
+
+  /** Maximum priority fee per gas for the transaction. */
+  maxPriorityFeePerGas?: Hex;
 
   /** Recipient of the transaction. */
   to?: Hex;
 
   /** Value to send with the transaction. */
   value?: Hex;
-
-  /** Data to send with the transaction. */
-  data?: Hex;
 };
 
 /** Request to the simulation API to simulate transactions. */

--- a/packages/transaction-controller/src/utils/simulation-api.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.ts
@@ -145,6 +145,8 @@ export type SimulationResponse = {
   transactions: SimulationResponseTransaction[];
 };
 
+let requestIdCounter = 0;
+
 /**
  * Simulate transactions using the transaction simulation API.
  * @param chainId - The chain ID to simulate transactions on.
@@ -158,10 +160,13 @@ export async function simulateTransactions(
 
   log('Sending request', url, request);
 
+  const requestId = requestIdCounter;
+  requestIdCounter += 1;
+
   const response = await fetch(url, {
     method: 'POST',
     body: JSON.stringify({
-      id: '1',
+      id: String(requestId),
       jsonrpc: '2.0',
       method: RPC_METHOD,
       params: [request],

--- a/packages/transaction-controller/src/utils/simulation.test.ts
+++ b/packages/transaction-controller/src/utils/simulation.test.ts
@@ -537,40 +537,79 @@ describe('Simulation Utils', () => {
       });
     });
 
-    it('returns error if API request throws', async () => {
-      simulateTransactionsMock.mockRejectedValueOnce({
-        code: ERROR_CODE_MOCK,
-        message: ERROR_MESSAGE_MOCK,
-      });
-
-      expect(await getSimulationData(REQUEST_MOCK)).toStrictEqual({
-        error: {
+    describe('returns error', () => {
+      it('if API request throws', async () => {
+        simulateTransactionsMock.mockRejectedValueOnce({
           code: ERROR_CODE_MOCK,
           message: ERROR_MESSAGE_MOCK,
-          isReverted: false,
-        },
-        tokenBalanceChanges: [],
+        });
+
+        expect(await getSimulationData(REQUEST_MOCK)).toStrictEqual({
+          error: {
+            code: ERROR_CODE_MOCK,
+            message: ERROR_MESSAGE_MOCK,
+            isReverted: false,
+          },
+          tokenBalanceChanges: [],
+        });
       });
-    });
 
-    it('returns error if API response has missing transactions', async () => {
-      mockParseLog({ erc20: PARSED_ERC20_TRANSFER_EVENT_MOCK });
+      it('if API request throws without message', async () => {
+        simulateTransactionsMock.mockRejectedValueOnce({
+          code: ERROR_CODE_MOCK,
+        });
 
-      simulateTransactionsMock
-        .mockResolvedValueOnce(
-          createEventResponseMock([createLogMock(CONTRACT_ADDRESS_MOCK)]),
-        )
-        .mockResolvedValueOnce(createBalanceOfResponse([], []));
+        expect(await getSimulationData(REQUEST_MOCK)).toStrictEqual({
+          error: {
+            code: ERROR_CODE_MOCK,
+            message: undefined,
+            isReverted: false,
+          },
+          tokenBalanceChanges: [],
+        });
+      });
 
-      const simulationData = await getSimulationData(REQUEST_MOCK);
+      it('if API response has missing transactions', async () => {
+        mockParseLog({ erc20: PARSED_ERC20_TRANSFER_EVENT_MOCK });
 
-      expect(simulationData).toStrictEqual({
-        error: {
-          code: undefined,
-          message: 'Invalid response from simulation API',
-          isReverted: false,
-        },
-        tokenBalanceChanges: [],
+        simulateTransactionsMock
+          .mockResolvedValueOnce(
+            createEventResponseMock([createLogMock(CONTRACT_ADDRESS_MOCK)]),
+          )
+          .mockResolvedValueOnce(createBalanceOfResponse([], []));
+
+        const simulationData = await getSimulationData(REQUEST_MOCK);
+
+        expect(simulationData).toStrictEqual({
+          error: {
+            code: undefined,
+            message: 'Invalid response from simulation API',
+            isReverted: false,
+          },
+          tokenBalanceChanges: [],
+        });
+      });
+
+      it('if response has reverted transaction', async () => {
+        simulateTransactionsMock.mockResolvedValueOnce({
+          transactions: [
+            {
+              error: 'test execution reverted test',
+              return: '0x',
+            },
+          ],
+        });
+
+        const simulationData = await getSimulationData(REQUEST_MOCK);
+
+        expect(simulationData).toStrictEqual({
+          error: {
+            code: undefined,
+            message: 'test execution reverted test',
+            isReverted: true,
+          },
+          tokenBalanceChanges: [],
+        });
       });
     });
   });

--- a/packages/transaction-controller/src/utils/simulation.test.ts
+++ b/packages/transaction-controller/src/utils/simulation.test.ts
@@ -19,6 +19,8 @@ const BALANCE_2_MOCK = '0x3';
 const DIFFERENCE_MOCK = '0x2';
 const VALUE_MOCK = '0x4';
 const TOKEN_ID_MOCK = '0x5';
+const ERROR_CODE_MOCK = 123;
+const ERROR_MESSAGE_MOCK = 'Test Error';
 
 const REQUEST_MOCK: GetSimulationDataRequest = {
   chainId: '0x1',
@@ -535,13 +537,23 @@ describe('Simulation Utils', () => {
       });
     });
 
-    it('returns undefined if API request throws', async () => {
-      simulateTransactionsMock.mockRejectedValueOnce(new Error());
+    it('returns error if API request throws', async () => {
+      simulateTransactionsMock.mockRejectedValueOnce({
+        code: ERROR_CODE_MOCK,
+        message: ERROR_MESSAGE_MOCK,
+      });
 
-      expect(await getSimulationData(REQUEST_MOCK)).toBeUndefined();
+      expect(await getSimulationData(REQUEST_MOCK)).toStrictEqual({
+        error: {
+          code: ERROR_CODE_MOCK,
+          message: ERROR_MESSAGE_MOCK,
+          isReverted: false,
+        },
+        tokenBalanceChanges: [],
+      });
     });
 
-    it('returns undefined if API response has missing transactions', async () => {
+    it('returns error if API response has missing transactions', async () => {
       mockParseLog({ erc20: PARSED_ERC20_TRANSFER_EVENT_MOCK });
 
       simulateTransactionsMock
@@ -552,7 +564,14 @@ describe('Simulation Utils', () => {
 
       const simulationData = await getSimulationData(REQUEST_MOCK);
 
-      expect(simulationData).toBeUndefined();
+      expect(simulationData).toStrictEqual({
+        error: {
+          code: undefined,
+          message: 'Invalid response from simulation API',
+          isReverted: false,
+        },
+        tokenBalanceChanges: [],
+      });
     });
   });
 });

--- a/packages/transaction-controller/src/utils/simulation.ts
+++ b/packages/transaction-controller/src/utils/simulation.ts
@@ -73,9 +73,11 @@ export async function getSimulationData(
       withLogs: true,
     });
 
-    if (response.transactions?.[0]?.error) {
+    const transactionError = response.transactions?.[0]?.error;
+
+    if (transactionError) {
       // eslint-disable-next-line @typescript-eslint/no-throw-literal
-      throw { message: response.transactions[0].error };
+      throw { message: transactionError };
     }
 
     const nativeBalanceChange = getNativeBalanceChange(request.from, response);

--- a/packages/transaction-controller/src/utils/simulation.ts
+++ b/packages/transaction-controller/src/utils/simulation.ts
@@ -12,13 +12,13 @@ import type {
   SimulationToken,
 } from '../types';
 import { SimulationTokenStandard } from '../types';
+import { simulateTransactions } from './simulation-api';
 import type {
   SimulationResponseLog,
   SimulationRequestTransaction,
   SimulationResponse,
   SimulationResponseCallTrace,
 } from './simulation-api';
-import { simulateTransactions } from './simulation-api';
 
 const log = createModuleLogger(projectLogger, 'simulation');
 
@@ -52,7 +52,7 @@ type ParsedEvent = {
  */
 export async function getSimulationData(
   request: GetSimulationDataRequest,
-): Promise<SimulationData | undefined> {
+): Promise<SimulationData> {
   const { chainId, from, to, value, data } = request;
 
   log('Getting simulation data', request);
@@ -63,6 +63,11 @@ export async function getSimulationData(
       withCallTrace: true,
       withLogs: true,
     });
+
+    if (response.transactions?.[0]?.error) {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw { message: response.transactions[0].error };
+    }
 
     const nativeBalanceChange = getNativeBalanceChange(request.from, response);
     const events = getEvents(response);
@@ -77,7 +82,17 @@ export async function getSimulationData(
     };
   } catch (error) {
     log('Failed to get simulation data', error, request);
-    return undefined;
+
+    const rawError = error as { code?: number; message?: string };
+
+    return {
+      tokenBalanceChanges: [],
+      error: {
+        code: rawError.code,
+        message: rawError.message,
+        isReverted: rawError.message?.includes('execution reverted') ?? false,
+      },
+    };
   }
 }
 
@@ -99,8 +114,8 @@ function getNativeBalanceChange(
   }
 
   const { stateDiff } = transactionResponse;
-  const previousBalance = stateDiff.pre[userAddress]?.balance;
-  const newBalance = stateDiff.post[userAddress]?.balance;
+  const previousBalance = stateDiff?.pre?.[userAddress]?.balance;
+  const newBalance = stateDiff?.post?.[userAddress]?.balance;
 
   if (!previousBalance || !newBalance) {
     return undefined;
@@ -116,7 +131,9 @@ function getNativeBalanceChange(
  */
 function getEvents(response: SimulationResponse): ParsedEvent[] {
   /* istanbul ignore next */
-  const logs = extractLogs(response.transactions[0]?.callTrace ?? {});
+  const logs = extractLogs(
+    response.transactions[0]?.callTrace ?? ({} as SimulationResponseCallTrace),
+  );
 
   log('Extracted logs', logs);
 

--- a/packages/transaction-controller/src/utils/simulation.ts
+++ b/packages/transaction-controller/src/utils/simulation.ts
@@ -59,7 +59,16 @@ export async function getSimulationData(
 
   try {
     const response = await simulateTransactions(chainId, {
-      transactions: [{ from, to, value, data }],
+      transactions: [
+        {
+          data,
+          from,
+          maxFeePerGas: '0x0',
+          maxPriorityFeePerGas: '0x0',
+          to,
+          value,
+        },
+      ],
       withCallTrace: true,
       withLogs: true,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3135,7 +3135,6 @@ __metadata:
     "@ethereumjs/tx": ^4.2.0
     "@ethereumjs/util": ^8.1.0
     "@ethersproject/abi": ^5.7.0
-    "@ethersproject/providers": ^5.7.0
     "@metamask/approval-controller": ^6.0.1
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.1


### PR DESCRIPTION
## Explanation

Multiple additions to the simulation support in the `TransactionController` including:

- Export all simulation types. 
- Include error data in the `SimulationData` type including `code` and `message` if available, plus whether the error is due to the transaction being reverted in the simulation.
- Continue to trigger simulation when adding a transaction, but do not block the creation of the approval request.
- Automatically update the simulation data if the transaction parameters are changed, specifically `to`, `data` and `value`.
- Replace use of `JsonRpcProvider` with `fetch` to allow greater control when parsing error responses.
- Provide zero value gas fees in simulation requests to disable gas fee suggestions.

## References

* Fixes [#2250](https://github.com/MetaMask/MetaMask-planning/issues/2250), [#2251](https://github.com/MetaMask/MetaMask-planning/issues/2251), [#2252](https://github.com/MetaMask/MetaMask-planning/issues/2252)

## Changelog

### `@metamask/transaction-controller`

- **ADDED**: Add simulation types.
  - `SimulationBalanceChange`
  - `SimulationData`
  - `SimulationError`
  - `SimulationToken`
  - `SimulationTokenBalanceChange`
  - `SimulationTokenStandard`
- **CHANGED**: No longer wait for simulation to complete before creating approval request.
- **CHANGED**: Automatically update simulation data if transaction parameters are updated.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
