### PR TITLE
Adds 'tokenMethodIncreaseAllowance'

### DIFF
--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -54,7 +54,7 @@
     "@metamask/controller-utils": "^9.0.2",
     "@metamask/eth-query": "^4.0.0",
     "@metamask/keyring-controller": "^14.0.1",
-    "@metamask/metamask-eth-abis": "3.0.0",
+    "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/network-controller": "^18.0.1",
     "@metamask/polling-controller": "^6.0.1",
     "@metamask/preferences-controller": "^9.0.1",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -50,7 +50,7 @@
     "@metamask/controller-utils": "^9.0.2",
     "@metamask/eth-query": "^4.0.0",
     "@metamask/gas-fee-controller": "^14.0.1",
-    "@metamask/metamask-eth-abis": "^3.0.0",
+    "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/network-controller": "^18.0.1",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -566,6 +566,11 @@ export enum TransactionType {
    * spend on behalf of the user.
    */
   tokenMethodSetApprovalForAll = 'setapprovalforall',
+
+  /**
+   * Increase the allowance by a given increment
+   */
+  tokenMethodIncreaseAllowance = 'increaseAllowance',
 }
 
 /**

--- a/packages/transaction-controller/src/utils/transaction-type.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.ts
@@ -2,7 +2,7 @@ import type { TransactionDescription } from '@ethersproject/abi';
 import { Interface } from '@ethersproject/abi';
 import { query } from '@metamask/controller-utils';
 import type EthQuery from '@metamask/eth-query';
-import { abiERC721, abiERC20, abiERC1155 } from '@metamask/metamask-eth-abis';
+import { abiERC721, abiERC20, abiERC1155, USDC_ABI } from '@metamask/metamask-eth-abis';
 
 import type { InferTransactionTypeResult, TransactionParams } from '../types';
 import { TransactionType } from '../types';
@@ -12,6 +12,7 @@ export const ESTIMATE_GAS_ERROR = 'eth_estimateGas rpc method error';
 const ERC20Interface = new Interface(abiERC20);
 const ERC721Interface = new Interface(abiERC721);
 const ERC1155Interface = new Interface(abiERC1155);
+const USDCInterface = new Interface(USDC_ABI);
 
 /**
  * Determines the type of the transaction by analyzing the txParams.
@@ -62,7 +63,8 @@ export async function determineTransactionType(
     TransactionType.tokenMethodTransfer,
     TransactionType.tokenMethodTransferFrom,
     TransactionType.tokenMethodSafeTransferFrom,
-  ].find((methodName) => methodName.toLowerCase() === name.toLowerCase());
+    TransactionType.tokenMethodIncreaseAllowance,
+  ].find((methodName) => methodName.toLowerCase() === (name as string).toLowerCase());
 
   if (tokenMethodName) {
     return { type: tokenMethodName, getCodeResponse };
@@ -100,6 +102,12 @@ function parseStandardTokenTransactionData(
 
   try {
     return ERC1155Interface.parseTransaction({ data });
+  } catch {
+    // ignore and return undefined
+  }
+
+  try {
+    return USDCInterface.parseTransaction({ data });
   } catch {
     // ignore and return undefined
   }

--- a/packages/transaction-controller/src/utils/transaction-type.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.ts
@@ -2,7 +2,12 @@ import type { TransactionDescription } from '@ethersproject/abi';
 import { Interface } from '@ethersproject/abi';
 import { query } from '@metamask/controller-utils';
 import type EthQuery from '@metamask/eth-query';
-import { abiERC721, abiERC20, abiERC1155, USDC_ABI } from '@metamask/metamask-eth-abis';
+import {
+  abiERC721,
+  abiERC20,
+  abiERC1155,
+  abiFiatTokenV2,
+} from '@metamask/metamask-eth-abis';
 
 import type { InferTransactionTypeResult, TransactionParams } from '../types';
 import { TransactionType } from '../types';
@@ -12,7 +17,7 @@ export const ESTIMATE_GAS_ERROR = 'eth_estimateGas rpc method error';
 const ERC20Interface = new Interface(abiERC20);
 const ERC721Interface = new Interface(abiERC721);
 const ERC1155Interface = new Interface(abiERC1155);
-const USDCInterface = new Interface(USDC_ABI);
+const USDCInterface = new Interface(abiFiatTokenV2);
 
 /**
  * Determines the type of the transaction by analyzing the txParams.
@@ -64,7 +69,9 @@ export async function determineTransactionType(
     TransactionType.tokenMethodTransferFrom,
     TransactionType.tokenMethodSafeTransferFrom,
     TransactionType.tokenMethodIncreaseAllowance,
-  ].find((methodName) => methodName.toLowerCase() === (name as string).toLowerCase());
+  ].find(
+    (methodName) => methodName.toLowerCase() === (name as string).toLowerCase(),
+  );
 
   if (tokenMethodName) {
     return { type: tokenMethodName, getCodeResponse };

--- a/packages/user-operation-controller/src/utils/validation.test.ts
+++ b/packages/user-operation-controller/src/utils/validation.test.ts
@@ -307,7 +307,7 @@ describe('validation', () => {
         'type',
         'wrong type',
         123,
-        'Expected one of `"cancel","contractInteraction","contractDeployment","eth_decrypt","eth_getEncryptionPublicKey","incoming","personal_sign","retry","simpleSend","eth_sign","eth_signTypedData","smart","swap","swapApproval","approve","safetransferfrom","transfer","transferfrom","setapprovalforall"`, but received: 123',
+        'Expected one of `"cancel","contractInteraction","contractDeployment","eth_decrypt","eth_getEncryptionPublicKey","incoming","personal_sign","retry","simpleSend","eth_sign","eth_signTypedData","smart","swap","swapApproval","approve","safetransferfrom","transfer","transferfrom","setapprovalforall","increaseAllowance"`, but received: 123',
       ],
     ])(
       'throws if %s is %s',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,7 +1766,7 @@ __metadata:
     "@metamask/ethjs-provider-http": ^0.3.0
     "@metamask/keyring-api": ^3.0.0
     "@metamask/keyring-controller": ^14.0.1
-    "@metamask/metamask-eth-abis": 3.0.0
+    "@metamask/metamask-eth-abis": ^3.1.1
     "@metamask/network-controller": ^18.0.1
     "@metamask/polling-controller": ^6.0.1
     "@metamask/preferences-controller": ^9.0.1
@@ -2527,10 +2527,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/metamask-eth-abis@npm:3.0.0, @metamask/metamask-eth-abis@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@metamask/metamask-eth-abis@npm:3.0.0"
-  checksum: a9e3020dd8deda91b4957cc38f0041944fd60a374d7f9d19b3bc2706c5ca70b3c2a5f679b5ef390b722a2c047a2852ebecd3aaa91c054cf5a60d9ca02ee45fe6
+"@metamask/metamask-eth-abis@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@metamask/metamask-eth-abis@npm:3.1.1"
+  checksum: b453fafbcf43462af0deae44182bbf4a7b0a2c4e7bc36e80c4a6cc854a8a87be28cf60e8203f1b5ec21bd53d996f6a379cd8f4268facd2bb042af211b3db83dc
   languageName: node
   linkType: hard
 
@@ -3143,7 +3143,7 @@ __metadata:
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.3.0
     "@metamask/gas-fee-controller": ^14.0.1
-    "@metamask/metamask-eth-abis": ^3.0.0
+    "@metamask/metamask-eth-abis": ^3.1.1
     "@metamask/network-controller": ^18.0.1
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0


### PR DESCRIPTION
## Explanation

Creates the `tokenMethodIncreaseAllowance` transaction type, and adds the FiatTokenV2 token to be able to parse transactions with the increaseAllowance method, since it's not part of the ERC20 standard.

## References


* Related to [#2224](https://github.com/MetaMask/MetaMask-planning/issues/2224)

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **ADDED**: Adds support for `increaseAllowance` token method and corresponding transaction type.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
