### PR TITLE
fix: remove export of type

### DIFF
--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -159,7 +159,7 @@ export interface Nft extends NftMetadata {
   isCurrentlyOwned?: boolean;
 }
 
-export type NftUpdate = {
+type NftUpdate = {
   nft: Nft;
   newMetadata: NftMetadata;
 };


### PR DESCRIPTION
## Explanation

Removes export of a type because it is not used anywhere else

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **REMOVED**: Removed export on the `NftUpdate` type in `Nftcontroller.ts` because it is not used anywhere else.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
