### PR TITLE
fix: export const

### DIFF
--- a/packages/assets-controllers/src/Standards/NftStandards/ERC1155/ERC1155Standard.test.ts
+++ b/packages/assets-controllers/src/Standards/NftStandards/ERC1155/ERC1155Standard.test.ts
@@ -48,4 +48,21 @@ describe('ERC1155Standard', () => {
       );
     expect(contractSupportsUri).toBe(true);
   });
+
+  it('should determine if contract supports token receiver interface correctly', async () => {
+    nock('https://mainnet.infura.io:443', { encodedQueryParams: true })
+      .post('/v3/341eacb578dd44a1a049cbc5f6fd4035')
+      .reply(200, {
+        jsonrpc: '2.0',
+        id: 1,
+        result:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+      })
+      .persist();
+    const contractSupportsUri =
+      await erc1155Standard.contractSupportsTokenReceiverInterface(
+        ERC1155_ADDRESS,
+      );
+    expect(contractSupportsUri).toBe(true);
+  });
 });

--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -54,4 +54,7 @@ export {
   getFormattedIpfsUrl,
   fetchTokenContractExchangeRates,
 } from './assetsUtil';
-export { CodefiTokenPricesServiceV2 } from './token-prices-service';
+export {
+  CodefiTokenPricesServiceV2,
+  SUPPORTED_CHAIN_IDS,
+} from './token-prices-service';

--- a/packages/assets-controllers/src/token-prices-service/index.test.ts
+++ b/packages/assets-controllers/src/token-prices-service/index.test.ts
@@ -5,6 +5,7 @@ describe('token-prices-service', () => {
     expect(Object.keys(allExports)).toMatchInlineSnapshot(`
       Array [
         "CodefiTokenPricesServiceV2",
+        "SUPPORTED_CHAIN_IDS",
       ]
     `);
   });

--- a/packages/assets-controllers/src/token-prices-service/index.ts
+++ b/packages/assets-controllers/src/token-prices-service/index.ts
@@ -1,2 +1,2 @@
 export type { AbstractTokenPricesService } from './abstract-token-prices-service';
-export { CodefiTokenPricesServiceV2 } from './codefi-v2';
+export { CodefiTokenPricesServiceV2, SUPPORTED_CHAIN_IDS } from './codefi-v2';


### PR DESCRIPTION
## Explanation

PR to export `SUPPORTED_CHAIN_IDS` constant.
This constant is imported in extension like this:
`import { SUPPORTED_CHAIN_IDS } from '@metamask/assets-controllers/dist/token-prices-service/codefi-v2';`
Which was causing issues when trying to upgrade assets-controllers to latest. It was not able to find it.
With this change we can import it like this instead of from dist which can abstract how the code is transpiled;
`import { SUPPORTED_CHAIN_IDS } from '@metamask/assets-controllers';`

## References

* Related to [#67890](https://github.com/MetaMask/metamask-extension/pull/23574)


## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **ADDED**: Added export for const SUPPORTED_CHAIN_IDS 

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
