### PR TITLE
Bump TypeScript version to `~4.9.5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "simple-git-hooks": "^2.8.0",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.2",
-    "typescript": "~4.8.4",
+    "typescript": "~4.9.5",
     "yargs": "^17.7.2"
   },
   "packageManager": "yarn@3.3.0",

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -63,7 +63,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^14.0.0",

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -51,7 +51,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -55,7 +55,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -85,7 +85,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@metamask/accounts-controller": "^12.0.0",

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -60,7 +60,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -56,7 +56,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^18.0.0"

--- a/packages/eth-json-rpc-provider/package.json
+++ b/packages/eth-json-rpc-provider/package.json
@@ -58,7 +58,7 @@
     "jest-it-up": "^2.0.2",
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "packageManager": "yarn@3.3.0",
   "engines": {

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -65,7 +65,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^18.0.0"

--- a/packages/json-rpc-engine/package.json
+++ b/packages/json-rpc-engine/package.json
@@ -63,7 +63,7 @@
     "jest-it-up": "^2.0.2",
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "packageManager": "yarn@3.3.0",
   "engines": {

--- a/packages/json-rpc-middleware-stream/package.json
+++ b/packages/json-rpc-middleware-stream/package.json
@@ -57,7 +57,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4",
+    "typescript": "~4.9.5",
     "webextension-polyfill-ts": "^0.26.0"
   },
   "engines": {

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -70,7 +70,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4",
+    "typescript": "~4.9.5",
     "uuid": "^8.3.2"
   },
   "engines": {

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -57,7 +57,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -71,7 +71,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -60,7 +60,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^6.0.0"

--- a/packages/permission-log-controller/package.json
+++ b/packages/permission-log-controller/package.json
@@ -56,7 +56,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -57,7 +57,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -58,7 +58,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^18.0.0"

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^14.0.0"

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -62,7 +62,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^18.0.0",

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -60,7 +60,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^18.0.0",

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -59,7 +59,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^6.0.0",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -77,7 +77,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@babel/runtime": "^7.23.9",

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -67,7 +67,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^6.0.0",

--- a/scripts/create-package/package-template/package.json
+++ b/scripts/create-package/package-template/package.json
@@ -46,7 +46,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": "NODE_VERSIONS"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1661,7 +1661,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/keyring-controller": ^14.0.0
@@ -1694,7 +1694,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -1710,7 +1710,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -1730,7 +1730,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -1791,7 +1791,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/accounts-controller": ^12.0.0
@@ -1847,7 +1847,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -1884,7 +1884,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -1903,7 +1903,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -1935,7 +1935,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -1997,7 +1997,7 @@ __metadata:
     simple-git-hooks: ^2.8.0
     ts-node: ^10.9.1
     tsup: ^8.0.2
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     yargs: ^17.7.2
   languageName: unknown
   linkType: soft
@@ -2041,7 +2041,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   peerDependencies:
     "@metamask/network-controller": ^18.0.0
   languageName: unknown
@@ -2154,7 +2154,7 @@ __metadata:
     jest-it-up: ^2.0.2
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -2347,7 +2347,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/network-controller": ^18.0.0
@@ -2369,7 +2369,7 @@ __metadata:
     jest-it-up: ^2.0.2
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -2402,7 +2402,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     webextension-polyfill-ts: ^0.26.0
   languageName: unknown
   linkType: soft
@@ -2482,7 +2482,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -2500,7 +2500,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -2522,7 +2522,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -2548,7 +2548,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -2583,7 +2583,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     uuid: ^8.3.2
   languageName: unknown
   linkType: soft
@@ -2602,7 +2602,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -2657,7 +2657,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   peerDependencies:
     "@metamask/approval-controller": ^6.0.0
   languageName: unknown
@@ -2699,7 +2699,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -2734,7 +2734,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -2756,7 +2756,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/network-controller": ^18.0.0
@@ -2788,7 +2788,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   peerDependencies:
     "@metamask/keyring-controller": ^14.0.0
   languageName: unknown
@@ -2837,7 +2837,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   peerDependencies:
     "@metamask/network-controller": ^18.0.0
     "@metamask/selected-network-controller": ^10.0.0
@@ -2858,7 +2858,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -2917,7 +2917,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   peerDependencies:
     "@metamask/network-controller": ^18.0.0
     "@metamask/permission-controller": ^9.0.0
@@ -2944,7 +2944,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
   peerDependencies:
     "@metamask/approval-controller": ^6.0.0
     "@metamask/keyring-controller": ^14.0.0
@@ -3163,7 +3163,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     uuid: ^8.3.2
   peerDependencies:
     "@babel/runtime": ^7.23.9
@@ -3199,7 +3199,7 @@ __metadata:
     ts-jest: ^27.1.4
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^2.0.0
-    typescript: ~4.8.4
+    typescript: ~4.9.5
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/approval-controller": ^6.0.0
@@ -11737,23 +11737,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.8.4":
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
+"typescript@npm:~4.9.5":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
+  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.8.4#~builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=0102e9"
+"typescript@patch:typescript@~4.9.5#~builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=d73830"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 301459fc3eb3b1a38fe91bf96d98eb55da88a9cb17b4ef80b4d105d620f4d547ba776cc27b44cc2ef58b66eda23fe0a74142feb5e79a6fb99f54fc018a696afa
+  checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

As part of the Shared Libraries Q2 2024 OKRs (O3/KR4), this commit upgrades the TypeScript versions in all core repo packages to v4.9.

## References

- Closes https://github.com/MetaMask/core/issues/4086

## Changelog

### `@metamask/*`

#### Changed

- Update TypeScript to `~4.9.5` ([#4084](https://github.com/MetaMask/core/pull/4084))

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
