### PR TITLE
Query networks supporting simulation

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -18,9 +18,9 @@ module.exports = merge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 94.31,
-      functions: 98.51,
-      lines: 98.99,
-      statements: 99,
+      functions: 98.52,
+      lines: 99,
+      statements: 99.01,
     },
   },
 

--- a/packages/transaction-controller/src/utils/simulation-api.test.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.test.ts
@@ -3,6 +3,7 @@ import type { SimulationRequest, SimulationResponse } from './simulation-api';
 import { simulateTransactions } from './simulation-api';
 
 const CHAIN_ID_MOCK = '0x1';
+const CHAIN_ID_MOCK_DECIMAL = 1;
 const ERROR_CODE_MOCK = 123;
 const ERROR_MESSAGE_MOCK = 'Test Error Message';
 
@@ -43,6 +44,13 @@ const RESPONSE_MOCK: SimulationResponse = {
   ],
 };
 
+const RESPONSE_MOCK_NETWORKS = {
+  [CHAIN_ID_MOCK_DECIMAL]: {
+    network: 'test-subdomain',
+    confirmations: true,
+  },
+};
+
 describe('Simulation API Utils', () => {
   let fetchMock: jest.MockedFunction<typeof fetch>;
 
@@ -51,7 +59,7 @@ describe('Simulation API Utils', () => {
    * @param jsonResponse - The response body to return.
    */
   function mockFetchResponse(jsonResponse: unknown) {
-    fetchMock.mockResolvedValue({
+    fetchMock.mockResolvedValueOnce({
       json: jest.fn().mockResolvedValue(jsonResponse),
     } as unknown as Response);
   }
@@ -63,6 +71,7 @@ describe('Simulation API Utils', () => {
       typeof fetch
     >;
 
+    mockFetchResponse(RESPONSE_MOCK_NETWORKS);
     mockFetchResponse({ result: RESPONSE_MOCK });
   });
 
@@ -73,13 +82,13 @@ describe('Simulation API Utils', () => {
       );
     });
 
-    it('sends request', async () => {
+    it('sends simulation request', async () => {
       await simulateTransactions(CHAIN_ID_MOCK, REQUEST_MOCK);
 
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
 
       const requestBody = JSON.parse(
-        fetchMock.mock.calls[0][1]?.body?.toString() ?? '{}',
+        fetchMock.mock.calls[1][1]?.body?.toString() ?? '{}',
       );
 
       expect(requestBody.params[0]).toStrictEqual(REQUEST_MOCK);
@@ -94,15 +103,17 @@ describe('Simulation API Utils', () => {
     });
 
     it('uses URL specific to chain ID', async () => {
-      await simulateTransactions(CHAIN_IDS.GOERLI, REQUEST_MOCK);
+      await simulateTransactions(CHAIN_IDS.MAINNET, REQUEST_MOCK);
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://tx-sentinel-ethereum-goerli.api.cx.metamask.io/',
+        'https://tx-sentinel-test-subdomain.api.cx.metamask.io/',
         expect.any(Object),
       );
     });
 
     it('throws if response has error', async () => {
+      fetchMock.mockReset();
+      mockFetchResponse(RESPONSE_MOCK_NETWORKS);
       mockFetchResponse({
         error: { code: ERROR_CODE_MOCK, message: ERROR_MESSAGE_MOCK },
       });

--- a/packages/transaction-controller/src/utils/simulation-api.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.ts
@@ -1,25 +1,13 @@
+import { convertHexToDecimal } from '@metamask/controller-utils';
 import { createModuleLogger, type Hex } from '@metamask/utils';
 
-import { CHAIN_IDS } from '../constants';
 import { projectLogger } from '../logger';
 
 const log = createModuleLogger(projectLogger, 'simulation-api');
 
 const RPC_METHOD = 'infura_simulateTransactions';
 const BASE_URL = 'https://tx-sentinel-{0}.api.cx.metamask.io/';
-
-const SUBDOMAIN_BY_CHAIN_ID: Record<Hex, string> = {
-  [CHAIN_IDS.MAINNET]: 'ethereum-mainnet',
-  [CHAIN_IDS.GOERLI]: 'ethereum-goerli',
-  [CHAIN_IDS.SEPOLIA]: 'ethereum-sepolia',
-  [CHAIN_IDS.LINEA_MAINNET]: 'linea-mainnet',
-  [CHAIN_IDS.LINEA_GOERLI]: 'linea-goerli',
-  [CHAIN_IDS.ARBITRUM]: 'arbitrum-mainnet',
-  [CHAIN_IDS.AVALANCHE]: 'avalanche-mainnet',
-  [CHAIN_IDS.OPTIMISM]: 'optimism-mainnet',
-  [CHAIN_IDS.POLYGON]: 'polygon-mainnet',
-  [CHAIN_IDS.BSC]: 'bsc-mainnet',
-};
+const ENDPOINT_NETWORKS = 'networks';
 
 /** Single transaction to simulate in a simulation API request.  */
 export type SimulationRequestTransaction = {
@@ -145,6 +133,20 @@ export type SimulationResponse = {
   transactions: SimulationResponseTransaction[];
 };
 
+/** Data for a network supported by the Simulation API. */
+type SimulationNetwork = {
+  /** Subdomain of the API for the network.  */
+  network: string;
+
+  /** Whether the network supports confirmation simulations. */
+  confirmations: boolean;
+};
+
+/** Response from the simulation API containing supported networks. */
+type SimulationNetworkResponse = {
+  [chainIdDecimal: string]: SimulationNetwork;
+};
+
 let requestIdCounter = 0;
 
 /**
@@ -156,7 +158,7 @@ export async function simulateTransactions(
   chainId: Hex,
   request: SimulationRequest,
 ): Promise<SimulationResponse> {
-  const url = getUrl(chainId);
+  const url = await getSimulationUrl(chainId);
 
   log('Sending request', url, request);
 
@@ -189,13 +191,33 @@ export async function simulateTransactions(
  * @param chainId - The chain ID to get the URL for.
  * @returns The URL for the transaction simulation API.
  */
-function getUrl(chainId: Hex): string {
-  const subdomain = SUBDOMAIN_BY_CHAIN_ID[chainId];
+async function getSimulationUrl(chainId: Hex): Promise<string> {
+  const networkData = await getNetworkData();
+  const chainIdDecimal = convertHexToDecimal(chainId);
+  const network = networkData[chainIdDecimal];
 
-  if (!subdomain) {
+  if (!network?.confirmations) {
     log('Chain is not supported', chainId);
     throw new Error(`Chain is not supported: ${chainId}`);
   }
 
+  return getUrl(network.network);
+}
+
+/**
+ * Retrieve the supported network data from the simulation API.
+ */
+async function getNetworkData(): Promise<SimulationNetworkResponse> {
+  const url = `${getUrl('ethereum-mainnet')}${ENDPOINT_NETWORKS}`;
+  const response = await fetch(url);
+  return response.json();
+}
+
+/**
+ * Generate the URL for the specified subdomain in the simulation API.
+ * @param subdomain - The subdomain to generate the URL for.
+ * @returns The URL for the transaction simulation API.
+ */
+function getUrl(subdomain: string): string {
   return BASE_URL.replace('{0}', subdomain);
 }


### PR DESCRIPTION
## Explanation

Currently the networks supporting transaction simulation are hardcoded along with their associated subdomains.

This PR instead queries the supported networks dynamically using the `/networks` endpoint to automatically support new networks without requiring a new controller and client release.

## References

Fixes [#2268](https://github.com/MetaMask/MetaMask-planning/issues/2268)

## Changelog

### `@metamask/transaction-controller`

- **CHANGED**: Determine networks supporting simulation dynamically using API.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
