### PR TITLE
feat: add AnnouncementController#resetViewed

### DIFF
--- a/packages/announcement-controller/src/AnnouncementController.test.ts
+++ b/packages/announcement-controller/src/AnnouncementController.test.ts
@@ -120,6 +120,25 @@ describe('announcement controller', () => {
     expect(controller.state.announcements[3].isShown).toBe(false);
   });
 
+  describe('resetIsShownStates', () => {
+    it('resets all announcement isShown states to false', () => {
+      const controller = new AnnouncementController({
+        messenger: getRestrictedMessenger(),
+        state: state2,
+        allAnnouncements: allAnnouncements2,
+      });
+
+      controller.updateViewed({ 1: true, 3: true });
+      expect(controller.state.announcements[1].isShown).toBe(true);
+      expect(controller.state.announcements[3].isShown).toBe(true);
+
+      controller.resetIsShownStates();
+      Object.values(controller.state.announcements).forEach((announcement) => {
+        expect(announcement.isShown).toBe(false);
+      });
+    });
+  });
+
   describe('update viewed announcements', () => {
     it('should update isShown status', () => {
       const controller = new AnnouncementController({

--- a/packages/announcement-controller/src/AnnouncementController.test.ts
+++ b/packages/announcement-controller/src/AnnouncementController.test.ts
@@ -120,7 +120,7 @@ describe('announcement controller', () => {
     expect(controller.state.announcements[3].isShown).toBe(false);
   });
 
-  describe('resetIsShownStates', () => {
+  describe('resetViewed', () => {
     it('resets all announcement isShown states to false', () => {
       const controller = new AnnouncementController({
         messenger: getRestrictedMessenger(),
@@ -132,7 +132,7 @@ describe('announcement controller', () => {
       expect(controller.state.announcements[1].isShown).toBe(true);
       expect(controller.state.announcements[3].isShown).toBe(true);
 
-      controller.resetIsShownStates();
+      controller.resetViewed();
       Object.values(controller.state.announcements).forEach((announcement) => {
         expect(announcement.isShown).toBe(false);
       });

--- a/packages/announcement-controller/src/AnnouncementController.ts
+++ b/packages/announcement-controller/src/AnnouncementController.ts
@@ -127,13 +127,9 @@ export class AnnouncementController extends BaseController<
    */
   resetIsShownStates(): void {
     this.update(({ announcements }) => {
-      Object.values(announcements).forEach(
-        (announcement: StateAnnouncement) => {
-          if (announcement.isShown) {
-            announcement.isShown = false;
-          }
-        },
-      );
+      for (const announcement of Object.values(announcements)) {
+        announcement.isShown = false;
+      }
     });
   }
 

--- a/packages/announcement-controller/src/AnnouncementController.ts
+++ b/packages/announcement-controller/src/AnnouncementController.ts
@@ -101,7 +101,7 @@ export class AnnouncementController extends BaseController<
   }) {
     const mergedState = { ...defaultState, ...state };
     super({ messenger, metadata, name: controllerName, state: mergedState });
-    this.#addAnnouncements(allAnnouncements);
+    this.addAnnouncements(allAnnouncements);
   }
 
   /**
@@ -112,13 +112,28 @@ export class AnnouncementController extends BaseController<
    *
    * @param allAnnouncements - all announcements to compare with the announcements from state
    */
-  #addAnnouncements(allAnnouncements: AnnouncementMap): void {
+  addAnnouncements(allAnnouncements: AnnouncementMap): void {
     this.update((state) => {
       Object.values(allAnnouncements).forEach((announcement: Announcement) => {
         state.announcements[announcement.id] = state.announcements[
           announcement.id
         ] ?? { ...announcement, isShown: false };
       });
+    });
+  }
+
+  /**
+   * Resets the isShown status for all announcements
+   */
+  resetIsShownStates(): void {
+    this.update(({ announcements }) => {
+      Object.values(announcements).forEach(
+        (announcement: StateAnnouncement) => {
+          if (announcement.isShown) {
+            announcement.isShown = false;
+          }
+        },
+      );
     });
   }
 

--- a/packages/announcement-controller/src/AnnouncementController.ts
+++ b/packages/announcement-controller/src/AnnouncementController.ts
@@ -125,7 +125,7 @@ export class AnnouncementController extends BaseController<
   /**
    * Resets the isShown status for all announcements
    */
-  resetIsShownStates(): void {
+  resetViewed(): void {
     this.update(({ announcements }) => {
       for (const announcement of Object.values(announcements)) {
         announcement.isShown = false;

--- a/packages/announcement-controller/src/AnnouncementController.ts
+++ b/packages/announcement-controller/src/AnnouncementController.ts
@@ -101,7 +101,7 @@ export class AnnouncementController extends BaseController<
   }) {
     const mergedState = { ...defaultState, ...state };
     super({ messenger, metadata, name: controllerName, state: mergedState });
-    this.addAnnouncements(allAnnouncements);
+    this.#addAnnouncements(allAnnouncements);
   }
 
   /**
@@ -112,7 +112,7 @@ export class AnnouncementController extends BaseController<
    *
    * @param allAnnouncements - all announcements to compare with the announcements from state
    */
-  addAnnouncements(allAnnouncements: AnnouncementMap): void {
+  #addAnnouncements(allAnnouncements: AnnouncementMap): void {
     this.update((state) => {
       Object.values(allAnnouncements).forEach((announcement: Announcement) => {
         state.announcements[announcement.id] = state.announcements[


### PR DESCRIPTION
## Explanation

Adds a method in the AnnouncementController to support the new Developer Options Settings Page → Reset State → What's New Announcements

## References

Partially Fixes: https://github.com/MetaMask/metamask-extension/issues/23592
Blocks: https://github.com/MetaMask/metamask-extension/pull/22382

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/announcement-controller`

- **Feat**: Add resetIsShownStates method 


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
