### PR TITLE
fix(accounts): fix normal account indexing naming with index gap

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1799,6 +1799,43 @@ describe('AccountsController', () => {
   });
 
   describe('#getNextAccountNumber', () => {
+    // Account names start at 2 since have 1 HD account + 2 simple keypair accounts (and both
+    // those keyring types are "grouped" together)
+    const mockSimpleKeyring1 = createExpectedInternalAccount({
+      id: 'mock-id2',
+      name: 'Account 2',
+      address: '0x555',
+      keyringType: 'Simple Key Pair',
+    });
+    const mockSimpleKeyring2 = createExpectedInternalAccount({
+      id: 'mock-id3',
+      name: 'Account 3',
+      address: '0x666',
+      keyringType: 'Simple Key Pair',
+    });
+    const mockSimpleKeyring3 = createExpectedInternalAccount({
+      id: 'mock-id4',
+      name: 'Account 4',
+      address: '0x777',
+      keyringType: 'Simple Key Pair',
+    });
+
+    const mockNewKeyringStateWith = (simpleAddressess: string[]) => {
+      return {
+        isUnlocked: true,
+        keyrings: [
+          {
+            type: 'HD Key Tree',
+            accounts: [mockAccount.address],
+          },
+          {
+            type: 'Simple Key Pair',
+            accounts: simpleAddressess,
+          },
+        ],
+      };
+    };
+
     it('should return the next account number', async () => {
       const messenger = buildMessenger();
       mockUUID
@@ -1808,32 +1845,6 @@ describe('AccountsController', () => {
         .mockReturnValueOnce('mock-id2') // call to add account
         .mockReturnValueOnce('mock-id3'); // call to add account
 
-      const mockSimpleKeyring1 = createExpectedInternalAccount({
-        id: 'mock-id2',
-        name: 'Account 2',
-        address: '0x555',
-        keyringType: 'Simple Key Pair',
-      });
-      const mockSimpleKeyring2 = createExpectedInternalAccount({
-        id: 'mock-id3',
-        name: 'Account 3',
-        address: '0x666',
-        keyringType: 'Simple Key Pair',
-      });
-
-      const mockNewKeyringState = {
-        isUnlocked: true,
-        keyrings: [
-          {
-            type: 'HD Key Tree',
-            accounts: [mockAccount.address],
-          },
-          {
-            type: 'Simple Key Pair',
-            accounts: [mockSimpleKeyring1.address, mockSimpleKeyring2.address],
-          },
-        ],
-      };
       const accountsController = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -1848,16 +1859,75 @@ describe('AccountsController', () => {
 
       messenger.publish(
         'KeyringController:stateChange',
-        mockNewKeyringState,
+        mockNewKeyringStateWith([
+          mockSimpleKeyring1.address,
+          mockSimpleKeyring2.address,
+        ]),
         [],
       );
 
       const accounts = accountsController.listAccounts();
-
       expect(accounts).toStrictEqual([
         mockAccount,
         setLastSelectedAsAny(mockSimpleKeyring1),
         setLastSelectedAsAny(mockSimpleKeyring2),
+      ]);
+    });
+
+    it('should return the next account number even with an index gap', async () => {
+      const messenger = buildMessenger();
+      const mockAccountUUIDs = new MockNormalAccountUUID([
+        mockAccount,
+        mockSimpleKeyring1,
+        mockSimpleKeyring2,
+        mockSimpleKeyring3,
+      ]);
+      mockUUID.mockImplementation(mockAccountUUIDs.mock.bind(mockAccountUUIDs));
+
+      const accountsController = setupAccountsController({
+        initialState: {
+          internalAccounts: {
+            accounts: {
+              [mockAccount.id]: mockAccount,
+            },
+            selectedAccount: mockAccount.id,
+          },
+        },
+        messenger,
+      });
+
+      messenger.publish(
+        'KeyringController:stateChange',
+        mockNewKeyringStateWith([
+          mockSimpleKeyring1.address,
+          mockSimpleKeyring2.address,
+        ]),
+        [],
+      );
+
+      // We then remove "Acccount 2" to create a gap
+      messenger.publish(
+        'KeyringController:stateChange',
+        mockNewKeyringStateWith([mockSimpleKeyring2.address]),
+        [],
+      );
+
+      // Finally we add a 3rd account, and it should be named "Account 4" (despite having a gap
+      // since "Account 2" no longer exists)
+      messenger.publish(
+        'KeyringController:stateChange',
+        mockNewKeyringStateWith([
+          mockSimpleKeyring2.address,
+          mockSimpleKeyring3.address,
+        ]),
+        [],
+      );
+
+      const accounts = accountsController.listAccounts();
+      expect(accounts).toStrictEqual([
+        mockAccount,
+        setLastSelectedAsAny(mockSimpleKeyring2),
+        setLastSelectedAsAny(mockSimpleKeyring3),
       ]);
     });
   });

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -1,4 +1,3 @@
-import { toBuffer } from '@ethereumjs/util';
 import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
@@ -657,23 +656,21 @@ export class AccountsController extends BaseController<
    * @returns The list of accounts associcated with this keyring type.
    */
   #getAccountsByKeyringType(keyringType: string) {
-    return this.listAccounts().filter(
-      (internalAccount) => {
-        // We do consider `hd` and `simple` keyrings to be of same type. So we check those 2 types
-        // to group those accounts together!
-        if (
-          keyringType === KeyringTypes.hd ||
-          keyringType === KeyringTypes.simple
-        ) {
-          return (
-            internalAccount.metadata.keyring.type === KeyringTypes.hd ||
-            internalAccount.metadata.keyring.type === KeyringTypes.simple
-          );
-        }
+    return this.listAccounts().filter((internalAccount) => {
+      // We do consider `hd` and `simple` keyrings to be of same type. So we check those 2 types
+      // to group those accounts together!
+      if (
+        keyringType === KeyringTypes.hd ||
+        keyringType === KeyringTypes.simple
+      ) {
+        return (
+          internalAccount.metadata.keyring.type === KeyringTypes.hd ||
+          internalAccount.metadata.keyring.type === KeyringTypes.simple
+        );
+      }
 
-        return internalAccount.metadata.keyring.type === keyringType;
-      },
-    );
+      return internalAccount.metadata.keyring.type === keyringType;
+    });
   }
 
   /**
@@ -687,27 +684,27 @@ export class AccountsController extends BaseController<
   } {
     const keyringName = keyringTypeToName(keyringType);
     const keyringAccounts = this.#getAccountsByKeyringType(keyringType);
-    const lastDefaultIndexUsedForKeyringType =
-      keyringAccounts
-        .reduce((maxInternalAccountIndex, internalAccount) => {
-          // We **DO NOT USE** `\d+` here to only consider valid "human"
-          // number (rounded decimal number)
-          const match = (new RegExp(`${keyringName} ([0-9]+)$`, 'u')).exec(
-            internalAccount.metadata.name,
-          );
+    const lastDefaultIndexUsedForKeyringType = keyringAccounts.reduce(
+      (maxInternalAccountIndex, internalAccount) => {
+        // We **DO NOT USE** `\d+` here to only consider valid "human"
+        // number (rounded decimal number)
+        const match = new RegExp(`${keyringName} ([0-9]+)$`, 'u').exec(
+          internalAccount.metadata.name,
+        );
 
-          if (match) {
-            // Quoting `RegExp.exec` documentation:
-            // > The returned array has the matched text as the first item, and then one item for
-            // > each capturing group of the matched text.
-            // So use `match[1]` to get the captured value
-            const internalAccountIndex = parseInt(match[1], 10);
-            return Math.max(maxInternalAccountIndex, internalAccountIndex);
-          }
+        if (match) {
+          // Quoting `RegExp.exec` documentation:
+          // > The returned array has the matched text as the first item, and then one item for
+          // > each capturing group of the matched text.
+          // So use `match[1]` to get the captured value
+          const internalAccountIndex = parseInt(match[1], 10);
+          return Math.max(maxInternalAccountIndex, internalAccountIndex);
+        }
 
-          return maxInternalAccountIndex;
-
-        }, 0);
+        return maxInternalAccountIndex;
+      },
+      0,
+    );
 
     const indexToUse = Math.max(
       keyringAccounts.length + 1,

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -23,9 +23,7 @@ import type {
 import type { SnapId } from '@metamask/snaps-sdk';
 import type { Snap } from '@metamask/snaps-utils';
 import type { Keyring, Json } from '@metamask/utils';
-import { sha256 } from 'ethereum-cryptography/sha256';
 import type { Draft } from 'immer';
-import { v4 as uuid } from 'uuid';
 
 import { getUUIDFromAddressOfNormalAccount, keyringTypeToName } from './utils';
 
@@ -457,12 +455,9 @@ export class AccountsController extends BaseController<
         'KeyringController:getKeyringForAccount',
         address,
       );
-      const v4options = {
-        random: sha256(toBuffer(address)).slice(0, 16),
-      };
 
       internalAccounts.push({
-        id: uuid(v4options),
+        id: getUUIDFromAddressOfNormalAccount(address),
         address,
         options: {},
         methods: [

--- a/packages/accounts-controller/src/utils.ts
+++ b/packages/accounts-controller/src/utils.ts
@@ -1,7 +1,7 @@
 import { toBuffer } from '@ethereumjs/util';
 import { isCustodyKeyring, KeyringTypes } from '@metamask/keyring-controller';
 import { sha256 } from 'ethereum-cryptography/sha256';
-import { v4 as uuid } from 'uuid';
+import { v4 as uuid, V4Options } from 'uuid';
 
 /**
  * Returns the name of the keyring type.
@@ -45,14 +45,25 @@ export function keyringTypeToName(keyringType: string): string {
 }
 
 /**
+ * Generates a UUID v4 options from a given Ethereum address.
+ * @param address - The Ethereum address to generate the UUID from.
+ * @returns The UUID v4 options.
+ */
+export function getUUIDOptionsFromAddressOfNormalAccount(
+  address: string,
+): V4Options {
+  const v4options = {
+    random: sha256(toBuffer(address)).slice(0, 16),
+  };
+
+  return v4options;
+}
+
+/**
  * Generates a UUID from a given Ethereum address.
  * @param address - The Ethereum address to generate the UUID from.
  * @returns The generated UUID.
  */
 export function getUUIDFromAddressOfNormalAccount(address: string): string {
-  const v4options = {
-    random: sha256(toBuffer(address)).slice(0, 16),
-  };
-
-  return uuid(v4options);
+  return uuid(getUUIDOptionsFromAddressOfNormalAccount(address));
 }

--- a/packages/accounts-controller/src/utils.ts
+++ b/packages/accounts-controller/src/utils.ts
@@ -1,7 +1,8 @@
 import { toBuffer } from '@ethereumjs/util';
 import { isCustodyKeyring, KeyringTypes } from '@metamask/keyring-controller';
 import { sha256 } from 'ethereum-cryptography/sha256';
-import { v4 as uuid, V4Options } from 'uuid';
+import type { V4Options } from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 /**
  * Returns the name of the keyring type.


### PR DESCRIPTION
## Explanation

While reading the implementation of the `AccountsController`, I spotted a unsafe access in the function generating the next account ID.

It seems this code path was never really used, but there still one problem left, the account id generation was wrong when there's a "gap" in between accounts:

```
accounts = ["Account 1", "Account 2"]
`-> next account ID would be: "Account 3"

accounts = ["Account 1", "Account 3"]
`-> next account ID **SHOULD BE**: "Account 4", but current
    implementation will generate "Account 3" (since we fallback to: accounts.length + 1 -> "Account 3")
```

## References

N/A

## Changelog

### `@metamask/accounts-controller`

- **FIXED**: Fixed normal accounts ID generation when there was a "index gap" between accounts.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
