### PR TITLE
Update snap and keyring api dependencies and fix tests

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -43,10 +43,10 @@
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",
     "@metamask/base-controller": "^5.0.1",
-    "@metamask/eth-snap-keyring": "^2.1.1",
-    "@metamask/keyring-api": "^3.0.0",
-    "@metamask/snaps-sdk": "^1.3.2",
-    "@metamask/snaps-utils": "^5.1.2",
+    "@metamask/eth-snap-keyring": "^2.2.2",
+    "@metamask/keyring-api": "^4.0.2",
+    "@metamask/snaps-sdk": "^3.1.1",
+    "@metamask/snaps-utils": "^7.0.3",
     "@metamask/utils": "^8.3.0",
     "deepmerge": "^4.2.2",
     "ethereum-cryptography": "^2.1.2",
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-controller": "^14.0.1",
-    "@metamask/snaps-controllers": "^4.0.0",
+    "@metamask/snaps-controllers": "^6.0.3",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",
     "jest": "^27.5.1",
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^14.0.0",
-    "@metamask/snaps-controllers": "^4.0.0"
+    "@metamask/snaps-controllers": "^6.0.3"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -43,8 +43,8 @@
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",
     "@metamask/base-controller": "^5.0.1",
-    "@metamask/eth-snap-keyring": "^2.2.2",
-    "@metamask/keyring-api": "^4.0.2",
+    "@metamask/eth-snap-keyring": "^3.0.0",
+    "@metamask/keyring-api": "^5.1.0",
     "@metamask/snaps-sdk": "^3.1.1",
     "@metamask/snaps-utils": "^7.0.3",
     "@metamask/utils": "^8.3.0",

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -66,7 +66,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/keyring-controller": "^14.0.0",
+    "@metamask/keyring-controller": "^14.0.1",
     "@metamask/snaps-controllers": "^6.0.3"
   },
   "engines": {

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/ethjs-provider-http": "^0.3.0",
-    "@metamask/keyring-api": "^4.0.2",
+    "@metamask/keyring-api": "^5.1.0",
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.191",
     "@types/node": "^16.18.54",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/ethjs-provider-http": "^0.3.0",
-    "@metamask/keyring-api": "^3.0.0",
+    "@metamask/keyring-api": "^4.0.2",
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.191",
     "@types/node": "^16.18.54",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -48,7 +48,7 @@
     "@metamask/eth-hd-keyring": "^7.0.1",
     "@metamask/eth-sig-util": "^7.0.1",
     "@metamask/eth-simple-keyring": "^6.0.1",
-    "@metamask/keyring-api": "^4.0.2",
+    "@metamask/keyring-api": "^5.1.0",
     "@metamask/message-manager": "^8.0.1",
     "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -48,7 +48,7 @@
     "@metamask/eth-hd-keyring": "^7.0.1",
     "@metamask/eth-sig-util": "^7.0.1",
     "@metamask/eth-simple-keyring": "^6.0.1",
-    "@metamask/keyring-api": "^3.0.0",
+    "@metamask/keyring-api": "^4.0.2",
     "@metamask/message-manager": "^8.0.1",
     "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6",

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -1644,6 +1644,10 @@ describe('KeyringController', () => {
   });
 
   describe('prepareUserOperation', () => {
+    const chainId = '0x1';
+    const executionContext = {
+      chainId,
+    };
     describe('when the keyring for the given address supports prepareUserOperation', () => {
       it('should prepare base user operation', async () => {
         const address = '0x660265edc169bab511a40c0e049cc1e33774443d';
@@ -1674,6 +1678,7 @@ describe('KeyringController', () => {
                 data: '0x7064',
               },
             ];
+
             jest
               .spyOn(mockKeyring, 'prepareUserOperation')
               .mockResolvedValueOnce(baseUserOp);
@@ -1681,6 +1686,7 @@ describe('KeyringController', () => {
             const result = await controller.prepareUserOperation(
               address,
               baseTxs,
+              executionContext,
             );
 
             expect(result).toStrictEqual(baseUserOp);
@@ -1688,6 +1694,7 @@ describe('KeyringController', () => {
             expect(mockKeyring.prepareUserOperation).toHaveBeenCalledWith(
               address,
               baseTxs,
+              executionContext,
             );
           },
         );
@@ -1704,7 +1711,7 @@ describe('KeyringController', () => {
             await controller.addNewKeyring(MockKeyring.type);
 
             await expect(
-              controller.prepareUserOperation(address, []),
+              controller.prepareUserOperation(address, [], executionContext),
             ).rejects.toThrow(
               KeyringControllerError.UnsupportedPrepareUserOperation,
             );
@@ -1715,6 +1722,11 @@ describe('KeyringController', () => {
   });
 
   describe('patchUserOperation', () => {
+    const chainId = '0x1';
+    const executionContext = {
+      chainId,
+    };
+
     describe('when the keyring for the given address supports patchUserOperation', () => {
       it('should patch an user operation', async () => {
         const address = '0x660265edc169bab511a40c0e049cc1e33774443d';
@@ -1745,13 +1757,18 @@ describe('KeyringController', () => {
               .spyOn(mockKeyring, 'patchUserOperation')
               .mockResolvedValueOnce(patch);
 
-            const result = await controller.patchUserOperation(address, userOp);
+            const result = await controller.patchUserOperation(
+              address,
+              userOp,
+              executionContext,
+            );
 
             expect(result).toStrictEqual(patch);
             expect(mockKeyring.patchUserOperation).toHaveBeenCalledTimes(1);
             expect(mockKeyring.patchUserOperation).toHaveBeenCalledWith(
               address,
               userOp,
+              executionContext,
             );
           },
         );
@@ -1781,7 +1798,7 @@ describe('KeyringController', () => {
             };
 
             await expect(
-              controller.patchUserOperation(address, userOp),
+              controller.patchUserOperation(address, userOp, executionContext),
             ).rejects.toThrow(
               KeyringControllerError.UnsupportedPatchUserOperation,
             );
@@ -1792,6 +1809,10 @@ describe('KeyringController', () => {
   });
 
   describe('signUserOperation', () => {
+    const chainId = '0x1';
+    const executionContext = {
+      chainId,
+    };
     describe('when the keyring for the given address supports signUserOperation', () => {
       it('should sign an user operation', async () => {
         const address = '0x660265edc169bab511a40c0e049cc1e33774443d';
@@ -1820,13 +1841,18 @@ describe('KeyringController', () => {
               .spyOn(mockKeyring, 'signUserOperation')
               .mockResolvedValueOnce(signature);
 
-            const result = await controller.signUserOperation(address, userOp);
+            const result = await controller.signUserOperation(
+              address,
+              userOp,
+              executionContext,
+            );
 
             expect(result).toStrictEqual(signature);
             expect(mockKeyring.signUserOperation).toHaveBeenCalledTimes(1);
             expect(mockKeyring.signUserOperation).toHaveBeenCalledWith(
               address,
               userOp,
+              executionContext,
             );
           },
         );
@@ -1856,7 +1882,7 @@ describe('KeyringController', () => {
             };
 
             await expect(
-              controller.signUserOperation(address, userOp),
+              controller.signUserOperation(address, userOp, executionContext),
             ).rejects.toThrow(
               KeyringControllerError.UnsupportedSignUserOperation,
             );
@@ -2902,6 +2928,11 @@ describe('KeyringController', () => {
     });
 
     describe('prepareUserOperation', () => {
+      const chainId = '0x1';
+      const executionContext = {
+        chainId,
+      };
+
       it('should return a base UserOp', async () => {
         await withController(
           async ({ controller, messenger, initialState }) => {
@@ -2917,11 +2948,13 @@ describe('KeyringController', () => {
               'KeyringController:prepareUserOperation',
               initialState.keyrings[0].accounts[0],
               baseTxs,
+              executionContext,
             );
 
             expect(controller.prepareUserOperation).toHaveBeenCalledWith(
               initialState.keyrings[0].accounts[0],
               baseTxs,
+              executionContext,
             );
           },
         );
@@ -2929,6 +2962,10 @@ describe('KeyringController', () => {
     });
 
     describe('patchUserOperation', () => {
+      const chainId = '0x1';
+      const executionContext = {
+        chainId,
+      };
       it('should return an UserOp patch', async () => {
         await withController(
           async ({ controller, messenger, initialState }) => {
@@ -2950,11 +2987,13 @@ describe('KeyringController', () => {
               'KeyringController:patchUserOperation',
               initialState.keyrings[0].accounts[0],
               userOp,
+              executionContext,
             );
 
             expect(controller.patchUserOperation).toHaveBeenCalledWith(
               initialState.keyrings[0].accounts[0],
               userOp,
+              executionContext,
             );
           },
         );
@@ -2962,6 +3001,10 @@ describe('KeyringController', () => {
     });
 
     describe('signUserOperation', () => {
+      const chainId = '0x1';
+      const executionContext = {
+        chainId,
+      };
       it('should return an UserOp signature', async () => {
         await withController(
           async ({ controller, messenger, initialState }) => {
@@ -2983,11 +3026,13 @@ describe('KeyringController', () => {
               'KeyringController:signUserOperation',
               initialState.keyrings[0].accounts[0],
               userOp,
+              executionContext,
             );
 
             expect(controller.signUserOperation).toHaveBeenCalledWith(
               initialState.keyrings[0].accounts[0],
               userOp,
+              executionContext,
             );
           },
         );

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -26,7 +26,6 @@ import type {
   Eip1024EncryptedData,
   Hex,
   Json,
-  Keyring,
   KeyringClass,
 } from '@metamask/utils';
 import {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -16,6 +16,7 @@ import type {
   EthKeyring,
   EthUserOperation,
   EthUserOperationPatch,
+  KeyringExecutionContext,
 } from '@metamask/keyring-api';
 import type {
   PersonalMessageParams,
@@ -25,6 +26,7 @@ import type {
   Eip1024EncryptedData,
   Hex,
   Json,
+  Keyring,
   KeyringClass,
 } from '@metamask/utils';
 import {
@@ -1235,11 +1237,13 @@ export class KeyringController extends BaseController<
    *
    * @param from - Address of the sender.
    * @param transactions - Base transactions to include in the UserOperation.
+   * @param executionContext - The execution context to use for the UserOperation.
    * @returns A pseudo-UserOperation that can be used to construct a real.
    */
   async prepareUserOperation(
     from: string,
     transactions: EthBaseTransaction[],
+    executionContext: KeyringExecutionContext,
   ): Promise<EthBaseUserOperation> {
     const address = normalize(from) as Hex;
     const keyring = (await this.getKeyringForAccount(
@@ -1250,7 +1254,11 @@ export class KeyringController extends BaseController<
       throw new Error(KeyringControllerError.UnsupportedPrepareUserOperation);
     }
 
-    return await keyring.prepareUserOperation(address, transactions);
+    return await keyring.prepareUserOperation(
+      address,
+      transactions,
+      executionContext,
+    );
   }
 
   /**
@@ -1259,11 +1267,13 @@ export class KeyringController extends BaseController<
    *
    * @param from - Address of the sender.
    * @param userOp - UserOperation to patch.
+   * @param executionContext - The execution context to use for the UserOperation.
    * @returns A patch to apply to the UserOperation.
    */
   async patchUserOperation(
     from: string,
     userOp: EthUserOperation,
+    executionContext: KeyringExecutionContext,
   ): Promise<EthUserOperationPatch> {
     const address = normalize(from) as Hex;
     const keyring = (await this.getKeyringForAccount(
@@ -1274,7 +1284,7 @@ export class KeyringController extends BaseController<
       throw new Error(KeyringControllerError.UnsupportedPatchUserOperation);
     }
 
-    return await keyring.patchUserOperation(address, userOp);
+    return await keyring.patchUserOperation(address, userOp, executionContext);
   }
 
   /**
@@ -1282,11 +1292,13 @@ export class KeyringController extends BaseController<
    *
    * @param from - Address of the sender.
    * @param userOp - UserOperation to sign.
+   * @param executionContext - The execution context to use for the UserOperation.
    * @returns The signature of the UserOperation.
    */
   async signUserOperation(
     from: string,
     userOp: EthUserOperation,
+    executionContext: KeyringExecutionContext,
   ): Promise<string> {
     const address = normalize(from) as Hex;
     const keyring = (await this.getKeyringForAccount(
@@ -1297,7 +1309,7 @@ export class KeyringController extends BaseController<
       throw new Error(KeyringControllerError.UnsupportedSignUserOperation);
     }
 
-    return await keyring.signUserOperation(address, userOp);
+    return await keyring.signUserOperation(address, userOp, executionContext);
   }
 
   /**

--- a/packages/user-operation-controller/src/UserOperationController.test.ts
+++ b/packages/user-operation-controller/src/UserOperationController.test.ts
@@ -954,6 +954,7 @@ describe('UserOperationController', () => {
             maxFeePerGas: '0x6',
             maxPriorityFeePerGas: '0x7',
           }),
+          chainId: CHAIN_ID_MOCK,
         });
       });
 

--- a/packages/user-operation-controller/src/UserOperationController.ts
+++ b/packages/user-operation-controller/src/UserOperationController.ts
@@ -526,13 +526,13 @@ export class UserOperationController extends BaseController<
     metadata: UserOperationMetadata,
     smartContractAccount: SmartContractAccount,
   ) {
-    const { id, userOperation } = metadata;
+    const { id, userOperation, chainId } = metadata;
 
     log('Requesting paymaster data', { id });
 
     const response = await smartContractAccount.updateUserOperation({
       userOperation,
-      chainId: metadata.chainId,
+      chainId,
     });
 
     validateUpdateUserOperationResponse(response);

--- a/packages/user-operation-controller/src/UserOperationController.ts
+++ b/packages/user-operation-controller/src/UserOperationController.ts
@@ -532,6 +532,7 @@ export class UserOperationController extends BaseController<
 
     const response = await smartContractAccount.updateUserOperation({
       userOperation,
+      chainId: metadata.chainId,
     });
 
     validateUpdateUserOperationResponse(response);

--- a/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.test.ts
+++ b/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.test.ts
@@ -10,6 +10,7 @@ import type {
 } from '../types';
 import { type PrepareUserOperationRequest } from '../types';
 import type { UserOperationControllerMessenger } from '../UserOperationController';
+import { toEip155ChainId } from '../utils/chain-id';
 import { SnapSmartContractAccount } from './SnapSmartContractAccount';
 
 const PREPARE_USER_OPERATION_REQUEST_MOCK: PrepareUserOperationRequest = {
@@ -150,7 +151,7 @@ describe('SnapSmartContractAccount', () => {
           },
         ],
         {
-          chainId: PREPARE_USER_OPERATION_REQUEST_MOCK.chainId,
+          chainId: toEip155ChainId(PREPARE_USER_OPERATION_REQUEST_MOCK.chainId),
         },
       );
     });
@@ -174,7 +175,7 @@ describe('SnapSmartContractAccount', () => {
           },
         ],
         {
-          chainId: PREPARE_USER_OPERATION_REQUEST_MOCK.chainId,
+          chainId: toEip155ChainId(PREPARE_USER_OPERATION_REQUEST_MOCK.chainId),
         },
       );
     });
@@ -198,7 +199,7 @@ describe('SnapSmartContractAccount', () => {
           },
         ],
         {
-          chainId: PREPARE_USER_OPERATION_REQUEST_MOCK.chainId,
+          chainId: toEip155ChainId(PREPARE_USER_OPERATION_REQUEST_MOCK.chainId),
         },
       );
     });
@@ -222,7 +223,7 @@ describe('SnapSmartContractAccount', () => {
           },
         ],
         {
-          chainId: PREPARE_USER_OPERATION_REQUEST_MOCK.chainId,
+          chainId: toEip155ChainId(PREPARE_USER_OPERATION_REQUEST_MOCK.chainId),
         },
       );
     });
@@ -250,7 +251,7 @@ describe('SnapSmartContractAccount', () => {
         UPDATE_USER_OPERATION_REQUEST_MOCK.userOperation.sender,
         UPDATE_USER_OPERATION_REQUEST_MOCK.userOperation,
         {
-          chainId: UPDATE_USER_OPERATION_REQUEST_MOCK.chainId,
+          chainId: toEip155ChainId(UPDATE_USER_OPERATION_REQUEST_MOCK.chainId),
         },
       );
     });
@@ -292,7 +293,7 @@ describe('SnapSmartContractAccount', () => {
         SIGN_USER_OPERATION_REQUEST_MOCK.userOperation.sender,
         SIGN_USER_OPERATION_REQUEST_MOCK.userOperation,
         {
-          chainId: SIGN_USER_OPERATION_REQUEST_MOCK.chainId,
+          chainId: toEip155ChainId(SIGN_USER_OPERATION_REQUEST_MOCK.chainId),
         },
       );
     });

--- a/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.test.ts
+++ b/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.test.ts
@@ -34,6 +34,7 @@ const UPDATE_USER_OPERATION_REQUEST_MOCK: UpdateUserOperationRequest = {
     signature: '0xa',
     verificationGasLimit: '0xb',
   },
+  chainId: '0x1',
 };
 
 const SIGN_USER_OPERATION_REQUEST_MOCK: SignUserOperationRequest = {
@@ -145,6 +146,9 @@ describe('SnapSmartContractAccount', () => {
             value: PREPARE_USER_OPERATION_REQUEST_MOCK.value,
           },
         ],
+        {
+          chainId: PREPARE_USER_OPERATION_REQUEST_MOCK.chainId,
+        },
       );
     });
 
@@ -166,6 +170,9 @@ describe('SnapSmartContractAccount', () => {
             value: PREPARE_USER_OPERATION_REQUEST_MOCK.value,
           },
         ],
+        {
+          chainId: PREPARE_USER_OPERATION_REQUEST_MOCK.chainId,
+        },
       );
     });
 
@@ -187,6 +194,9 @@ describe('SnapSmartContractAccount', () => {
             value: PREPARE_USER_OPERATION_REQUEST_MOCK.value,
           },
         ],
+        {
+          chainId: PREPARE_USER_OPERATION_REQUEST_MOCK.chainId,
+        },
       );
     });
 
@@ -208,6 +218,9 @@ describe('SnapSmartContractAccount', () => {
             value: VALUE_ZERO,
           },
         ],
+        {
+          chainId: PREPARE_USER_OPERATION_REQUEST_MOCK.chainId,
+        },
       );
     });
   });
@@ -228,6 +241,9 @@ describe('SnapSmartContractAccount', () => {
       expect(patchMock).toHaveBeenCalledWith(
         UPDATE_USER_OPERATION_REQUEST_MOCK.userOperation.sender,
         UPDATE_USER_OPERATION_REQUEST_MOCK.userOperation,
+        {
+          chainId: UPDATE_USER_OPERATION_REQUEST_MOCK.chainId,
+        },
       );
     });
 
@@ -264,6 +280,9 @@ describe('SnapSmartContractAccount', () => {
       expect(signMock).toHaveBeenCalledWith(
         SIGN_USER_OPERATION_REQUEST_MOCK.userOperation.sender,
         SIGN_USER_OPERATION_REQUEST_MOCK.userOperation,
+        {
+          chainId: SIGN_USER_OPERATION_REQUEST_MOCK.chainId,
+        },
       );
     });
   });

--- a/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.ts
+++ b/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.ts
@@ -35,6 +35,9 @@ export class SnapSmartContractAccount implements SmartContractAccount {
       'KeyringController:prepareUserOperation',
       sender,
       [{ data, to, value }],
+      {
+        chainId: request.chainId,
+      },
     );
 
     const {
@@ -70,6 +73,9 @@ export class SnapSmartContractAccount implements SmartContractAccount {
         'KeyringController:patchUserOperation',
         sender,
         userOperation,
+        {
+          chainId: request.chainId,
+        },
       );
 
     const paymasterAndData =
@@ -92,6 +98,9 @@ export class SnapSmartContractAccount implements SmartContractAccount {
       'KeyringController:signUserOperation',
       sender,
       userOperation,
+      {
+        chainId: request.chainId,
+      },
     );
 
     return { signature };

--- a/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.ts
+++ b/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.ts
@@ -9,6 +9,7 @@ import type {
   UpdateUserOperationResponse,
 } from '../types';
 import type { UserOperationControllerMessenger } from '../UserOperationController';
+import { toEip155ChainId } from '../utils/chain-id';
 
 export class SnapSmartContractAccount implements SmartContractAccount {
   #messenger: UserOperationControllerMessenger;
@@ -21,6 +22,7 @@ export class SnapSmartContractAccount implements SmartContractAccount {
     request: PrepareUserOperationRequest,
   ): Promise<PrepareUserOperationResponse> {
     const {
+      chainId,
       data: requestData,
       from: sender,
       to: requestTo,
@@ -35,9 +37,7 @@ export class SnapSmartContractAccount implements SmartContractAccount {
       'KeyringController:prepareUserOperation',
       sender,
       [{ data, to, value }],
-      {
-        chainId: request.chainId,
-      },
+      { chainId: toEip155ChainId(chainId) },
     );
 
     const {
@@ -77,9 +77,7 @@ export class SnapSmartContractAccount implements SmartContractAccount {
       'KeyringController:patchUserOperation',
       sender,
       userOperation,
-      {
-        chainId,
-      },
+      { chainId: toEip155ChainId(chainId) },
     );
 
     const paymasterAndData =
@@ -105,9 +103,7 @@ export class SnapSmartContractAccount implements SmartContractAccount {
       'KeyringController:signUserOperation',
       sender,
       userOperation,
-      {
-        chainId,
-      },
+      { chainId: toEip155ChainId(chainId) },
     );
 
     return { signature };

--- a/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.ts
+++ b/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.ts
@@ -91,7 +91,7 @@ export class SnapSmartContractAccount implements SmartContractAccount {
   async signUserOperation(
     request: SignUserOperationRequest,
   ): Promise<SignUserOperationResponse> {
-    const { userOperation } = request;
+    const { userOperation, chainId } = request;
     const { sender } = userOperation;
 
     const signature = await this.#messenger.call(
@@ -99,7 +99,7 @@ export class SnapSmartContractAccount implements SmartContractAccount {
       sender,
       userOperation,
       {
-        chainId: request.chainId,
+        chainId,
       },
     );
 

--- a/packages/user-operation-controller/src/types.ts
+++ b/packages/user-operation-controller/src/types.ts
@@ -177,6 +177,9 @@ export type PrepareUserOperationRequest = {
 export type UpdateUserOperationRequest = {
   /** The user operation to update including the dummy signature and dummy paymasterAndData values. */
   userOperation: UserOperation;
+
+  /** The hexadecimal chain ID of the target network. */
+  chainId: string;
 };
 
 /**

--- a/packages/user-operation-controller/src/utils/chain-id.test.ts
+++ b/packages/user-operation-controller/src/utils/chain-id.test.ts
@@ -1,0 +1,18 @@
+import { toEip155ChainId } from './chain-id';
+
+describe('chain-id', () => {
+  describe('toEip155ChainId', () => {
+    it('converts hex to integer number', () => {
+      expect(toEip155ChainId('0x1')).toBe('1');
+    });
+
+    it('converts integer number back to their original reprensentation', () => {
+      expect(toEip155ChainId('1')).toBe('1');
+    });
+
+    it("uses the original chain id if it's not a number", () => {
+      const chainId = 'not-a-number';
+      expect(toEip155ChainId(chainId)).toBe(chainId);
+    });
+  });
+});

--- a/packages/user-operation-controller/src/utils/chain-id.ts
+++ b/packages/user-operation-controller/src/utils/chain-id.ts
@@ -1,0 +1,13 @@
+/**
+ * Converts a chain ID string to a compliant CAIP-2 chain ID reference for EIP-155 chains.
+ *
+ * @param chainId - Chain ID string
+ * @returns An CAIP-2 chain ID reference for EIP-155 chains.
+ */
+export function toEip155ChainId(chainId: string): string {
+  const chainIdNumber = Number(chainId);
+
+  // If for some reason the chainId isn't convertible to a decimal integer representation, we fallback
+  // to the initial `chainId`.
+  return Number.isInteger(chainIdNumber) ? chainIdNumber.toString() : chainId;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,8 +1645,8 @@ __metadata:
     "@ethereumjs/util": ^8.1.0
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.1
-    "@metamask/eth-snap-keyring": ^2.2.2
-    "@metamask/keyring-api": ^4.0.2
+    "@metamask/eth-snap-keyring": ^3.0.0
+    "@metamask/keyring-api": ^5.1.0
     "@metamask/keyring-controller": ^14.0.1
     "@metamask/snaps-controllers": ^6.0.3
     "@metamask/snaps-sdk": ^3.1.1
@@ -2206,21 +2206,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-snap-keyring@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "@metamask/eth-snap-keyring@npm:2.2.2"
+"@metamask/eth-snap-keyring@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/eth-snap-keyring@npm:3.0.0"
   dependencies:
     "@ethereumjs/tx": ^4.2.0
     "@metamask/eth-sig-util": ^7.0.1
-    "@metamask/keyring-api": ^4.0.2
+    "@metamask/keyring-api": ^5.1.0
     "@metamask/snaps-controllers": ^6.0.3
     "@metamask/snaps-sdk": ^3.1.1
     "@metamask/snaps-utils": ^7.0.3
-    "@metamask/utils": ^8.3.0
+    "@metamask/utils": ^8.4.0
     "@types/uuid": ^9.0.1
     superstruct: ^1.0.3
     uuid: ^9.0.0
-  checksum: 10d60291d57b65d7001dbf86d96084b4692ec1e99f71deca356eebae3e38fb89cabdb18550fe9d151f5116264c520b9e22d0508a4ddc893716c246add546d5de
+  checksum: 3f1836b4feb1dd0950a842186a2fbdd894f2ac531955635a925ada50189def9a195b9ae4c664effe9c194e2a4c5dad942c5743a59923f811106372139385d25f
   languageName: node
   linkType: hard
 
@@ -2448,6 +2448,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/keyring-api@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@metamask/keyring-api@npm:5.1.0"
+  dependencies:
+    "@metamask/snaps-sdk": ^3.1.1
+    "@metamask/utils": ^8.3.0
+    "@types/uuid": ^9.0.1
+    superstruct: ^1.0.3
+    uuid: ^9.0.0
+  peerDependencies:
+    "@metamask/providers": ">=15 <17"
+  checksum: 37cc4d35116285762be7167f294a31add9a978eca7652af014355ce691c9b90cfeb52ab8732ebc59d413aeb7ac87e785e4a2a49fd44d3c1563f3796e4ac1bb8f
+  languageName: node
+  linkType: hard
+
 "@metamask/keyring-controller@^14.0.1, @metamask/keyring-controller@workspace:packages/keyring-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-controller@workspace:packages/keyring-controller"
@@ -2464,7 +2479,7 @@ __metadata:
     "@metamask/eth-hd-keyring": ^7.0.1
     "@metamask/eth-sig-util": ^7.0.1
     "@metamask/eth-simple-keyring": ^6.0.1
-    "@metamask/keyring-api": ^4.0.2
+    "@metamask/keyring-api": ^5.1.0
     "@metamask/message-manager": ^8.0.1
     "@metamask/scure-bip39": ^2.1.1
     "@metamask/utils": ^8.3.0
@@ -3183,6 +3198,23 @@ __metadata:
     semver: ^7.5.4
     superstruct: ^1.0.3
   checksum: cd60c49b4c0397fb31e6b38937a0d9346cbb8337cb8add59db8db0e0e2156fb063ff4df93a26410157f0cc02aa9a9b785fc1b53cfc4ab73204462893ed11cacb
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^8.4.0":
+  version: 8.4.0
+  resolution: "@metamask/utils@npm:8.4.0"
+  dependencies:
+    "@ethereumjs/tx": ^4.2.0
+    "@noble/hashes": ^1.3.1
+    "@scure/base": ^1.1.3
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    pony-cause: ^2.1.10
+    semver: ^7.5.4
+    superstruct: ^1.0.3
+    uuid: ^9.0.1
+  checksum: b0397e97bac7192f6189a8625a2dfcb56d3c2cf4dd2cb3d4e012a7e9786f04f59f6917805544bc131a6dacd2c8344e237ae43ad47429bb5eb35c6cf1248440b4
   languageName: node
   linkType: hard
 
@@ -11803,7 +11835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^9.0.0":
+"uuid@npm:^9.0.0, uuid@npm:^9.0.1":
   version: 9.0.1
   resolution: "uuid@npm:9.0.1"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3185,23 +3185,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0, @metamask/utils@npm:^8.2.1, @metamask/utils@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "@metamask/utils@npm:8.3.0"
-  dependencies:
-    "@ethereumjs/tx": ^4.2.0
-    "@noble/hashes": ^1.3.1
-    "@scure/base": ^1.1.3
-    "@types/debug": ^4.1.7
-    debug: ^4.3.4
-    pony-cause: ^2.1.10
-    semver: ^7.5.4
-    superstruct: ^1.0.3
-  checksum: cd60c49b4c0397fb31e6b38937a0d9346cbb8337cb8add59db8db0e0e2156fb063ff4df93a26410157f0cc02aa9a9b785fc1b53cfc4ab73204462893ed11cacb
-  languageName: node
-  linkType: hard
-
-"@metamask/utils@npm:^8.4.0":
+"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0, @metamask/utils@npm:^8.2.1, @metamask/utils@npm:^8.3.0, @metamask/utils@npm:^8.4.0":
   version: 8.4.0
   resolution: "@metamask/utils@npm:8.4.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1664,7 +1664,7 @@ __metadata:
     typescript: ~4.8.4
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/keyring-controller": ^14.0.0
+    "@metamask/keyring-controller": ^14.0.1
     "@metamask/snaps-controllers": ^6.0.3
   languageName: unknown
   linkType: soft
@@ -1764,7 +1764,7 @@ __metadata:
     "@metamask/controller-utils": ^9.0.1
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.3.0
-    "@metamask/keyring-api": ^4.0.2
+    "@metamask/keyring-api": ^5.1.0
     "@metamask/keyring-controller": ^14.0.1
     "@metamask/metamask-eth-abis": 3.0.0
     "@metamask/network-controller": ^18.0.1
@@ -2431,20 +2431,6 @@ __metadata:
     "@noble/secp256k1": ^1.5.5
     "@scure/base": ^1.0.0
   checksum: 5c81f07351ca59b37570d52edcc80d60424630b2a8403ed7149c3343c264878ac5d3fc0584a61635ea7ddda4a789295ded1247846606dc529d8e2fd42f6fc61a
-  languageName: node
-  linkType: hard
-
-"@metamask/keyring-api@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@metamask/keyring-api@npm:4.0.2"
-  dependencies:
-    "@metamask/providers": ^15.0.0
-    "@metamask/snaps-sdk": ^3.1.1
-    "@metamask/utils": ^8.3.0
-    "@types/uuid": ^9.0.1
-    superstruct: ^1.0.3
-    uuid: ^9.0.0
-  checksum: 0e15d7d7d6e35c62f5ab9dcee834113d14ef1cee87682efbd05407eda74edc7c6c504769108274e3fc5077c32c41b00ba00dda2e262af58ee2ca2208eae02551
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,12 +1645,12 @@ __metadata:
     "@ethereumjs/util": ^8.1.0
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.1
-    "@metamask/eth-snap-keyring": ^2.1.1
-    "@metamask/keyring-api": ^3.0.0
+    "@metamask/eth-snap-keyring": ^2.2.2
+    "@metamask/keyring-api": ^4.0.2
     "@metamask/keyring-controller": ^14.0.1
-    "@metamask/snaps-controllers": ^4.0.0
-    "@metamask/snaps-sdk": ^1.3.2
-    "@metamask/snaps-utils": ^5.1.2
+    "@metamask/snaps-controllers": ^6.0.3
+    "@metamask/snaps-sdk": ^3.1.1
+    "@metamask/snaps-utils": ^7.0.3
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/readable-stream": ^2.3.0
@@ -1665,7 +1665,7 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/keyring-controller": ^14.0.0
-    "@metamask/snaps-controllers": ^4.0.0
+    "@metamask/snaps-controllers": ^6.0.3
   languageName: unknown
   linkType: soft
 
@@ -1734,7 +1734,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/approval-controller@npm:^5.1.1":
+"@metamask/approval-controller@npm:^5.1.3":
   version: 5.1.3
   resolution: "@metamask/approval-controller@npm:5.1.3"
   dependencies:
@@ -1764,7 +1764,7 @@ __metadata:
     "@metamask/controller-utils": ^9.0.1
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.3.0
-    "@metamask/keyring-api": ^3.0.0
+    "@metamask/keyring-api": ^4.0.2
     "@metamask/keyring-controller": ^14.0.1
     "@metamask/metamask-eth-abis": 3.0.0
     "@metamask/network-controller": ^18.0.1
@@ -1851,7 +1851,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/base-controller@npm:^4.0.0, @metamask/base-controller@npm:^4.0.1, @metamask/base-controller@npm:^4.1.0, @metamask/base-controller@npm:^4.1.1":
+"@metamask/base-controller@npm:^4.1.0, @metamask/base-controller@npm:^4.1.1":
   version: 4.1.1
   resolution: "@metamask/base-controller@npm:4.1.1"
   dependencies:
@@ -1939,7 +1939,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/controller-utils@npm:^8.0.1, @metamask/controller-utils@npm:^8.0.2":
+"@metamask/controller-utils@npm:^8.0.2, @metamask/controller-utils@npm:^8.0.3":
   version: 8.0.4
   resolution: "@metamask/controller-utils@npm:8.0.4"
   dependencies:
@@ -2206,20 +2206,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-snap-keyring@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "@metamask/eth-snap-keyring@npm:2.1.1"
+"@metamask/eth-snap-keyring@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@metamask/eth-snap-keyring@npm:2.2.2"
   dependencies:
     "@ethereumjs/tx": ^4.2.0
-    "@metamask/eth-sig-util": ^7.0.0
-    "@metamask/keyring-api": ^2.0.0
-    "@metamask/snaps-controllers": ^3.4.1
-    "@metamask/snaps-sdk": ^1.2.0
-    "@metamask/utils": ^8.1.0
+    "@metamask/eth-sig-util": ^7.0.1
+    "@metamask/keyring-api": ^4.0.2
+    "@metamask/snaps-controllers": ^6.0.3
+    "@metamask/snaps-sdk": ^3.1.1
+    "@metamask/snaps-utils": ^7.0.3
+    "@metamask/utils": ^8.3.0
     "@types/uuid": ^9.0.1
     superstruct: ^1.0.3
     uuid: ^9.0.0
-  checksum: 842feeb0e7d1b33e815fad81b0eeed32576d0a4ba4e7337e301795bb6f6103ff6d2af1b00fa05b61468b638aad6f01b979532dd93d9620de6bba2089e4b6ed22
+  checksum: 10d60291d57b65d7001dbf86d96084b4692ec1e99f71deca356eebae3e38fb89cabdb18550fe9d151f5116264c520b9e22d0508a4ddc893716c246add546d5de
   languageName: node
   linkType: hard
 
@@ -2373,7 +2374,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.3.1, @metamask/json-rpc-engine@npm:^7.3.2":
+"@metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.3.2, @metamask/json-rpc-engine@npm:^7.3.3":
   version: 7.3.3
   resolution: "@metamask/json-rpc-engine@npm:7.3.3"
   dependencies:
@@ -2381,6 +2382,18 @@ __metadata:
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.3.0
   checksum: 7bab8b4d2341a6243ba451bc58283f0a6905b09f7257857859848a51a795444ca6899b1a6908b15f8ed236fb574ab85a630c9cb28d127ab52c4630e496c16006
+  languageName: node
+  linkType: hard
+
+"@metamask/json-rpc-middleware-stream@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "@metamask/json-rpc-middleware-stream@npm:6.0.2"
+  dependencies:
+    "@metamask/json-rpc-engine": ^7.3.2
+    "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^8.3.0
+    readable-stream: ^3.6.2
+  checksum: e831041b03e9f48f584f4425188f72b58974f95b60429c9fe8b5561da69c6bbfad2f2b2199acdff06ee718967214b65c05604d4f85f3287186619683487f1060
   languageName: node
   linkType: hard
 
@@ -2421,33 +2434,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@metamask/keyring-api@npm:2.0.0"
+"@metamask/keyring-api@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@metamask/keyring-api@npm:4.0.2"
   dependencies:
-    "@metamask/providers": ^14.0.1
-    "@metamask/snaps-controllers": ^3.4.1
-    "@metamask/snaps-sdk": ^1.2.0
-    "@metamask/snaps-utils": ^5.0.0
-    "@metamask/utils": ^8.1.0
+    "@metamask/providers": ^15.0.0
+    "@metamask/snaps-sdk": ^3.1.1
+    "@metamask/utils": ^8.3.0
     "@types/uuid": ^9.0.1
     superstruct: ^1.0.3
     uuid: ^9.0.0
-  checksum: ea7e02a6b6d37ec6983b00b5032f5bd12b55eae3a979ac8a3abaa84bb870fc5ae3702e09955a90ac6e683691c3fe1d2c13bc5720c491fdc2017acfcfac4a9250
-  languageName: node
-  linkType: hard
-
-"@metamask/keyring-api@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@metamask/keyring-api@npm:3.0.0"
-  dependencies:
-    "@metamask/providers": ^14.0.1
-    "@metamask/snaps-sdk": ^1.3.2
-    "@metamask/utils": ^8.1.0
-    "@types/uuid": ^9.0.1
-    superstruct: ^1.0.3
-    uuid: ^9.0.0
-  checksum: 5e3fdc122789d605681070aa6ed6c656d5c9bb1f037fd4bf1ed2ec5fa453a0fc8b9663ddfd2106c122889682e2ae1c8ddd16913798f24821b22899f743ce1a31
+  checksum: 0e15d7d7d6e35c62f5ab9dcee834113d14ef1cee87682efbd05407eda74edc7c6c504769108274e3fc5077c32c41b00ba00dda2e262af58ee2ca2208eae02551
   languageName: node
   linkType: hard
 
@@ -2467,7 +2464,7 @@ __metadata:
     "@metamask/eth-hd-keyring": ^7.0.1
     "@metamask/eth-sig-util": ^7.0.1
     "@metamask/eth-simple-keyring": ^6.0.1
-    "@metamask/keyring-api": ^3.0.0
+    "@metamask/keyring-api": ^4.0.2
     "@metamask/message-manager": ^8.0.1
     "@metamask/scure-bip39": ^2.1.1
     "@metamask/utils": ^8.3.0
@@ -2663,22 +2660,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/permission-controller@npm:^7.0.0, @metamask/permission-controller@npm:^7.1.0":
-  version: 7.1.0
-  resolution: "@metamask/permission-controller@npm:7.1.0"
+"@metamask/permission-controller@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@metamask/permission-controller@npm:8.0.1"
   dependencies:
-    "@metamask/base-controller": ^4.0.1
-    "@metamask/controller-utils": ^8.0.1
-    "@metamask/json-rpc-engine": ^7.3.1
-    "@metamask/rpc-errors": ^6.1.0
-    "@metamask/utils": ^8.2.0
+    "@metamask/base-controller": ^4.1.1
+    "@metamask/controller-utils": ^8.0.3
+    "@metamask/json-rpc-engine": ^7.3.2
+    "@metamask/rpc-errors": ^6.2.1
+    "@metamask/utils": ^8.3.0
     "@types/deep-freeze-strict": ^1.1.0
     deep-freeze-strict: ^1.1.1
     immer: ^9.0.6
     nanoid: ^3.1.31
   peerDependencies:
-    "@metamask/approval-controller": ^5.1.1
-  checksum: 889213cca32cbf5b32b7e71c70ded0aeea32eae169ec67fb0d0bc8dcaa183b222f9d5417f657e331d7fb21ecb71f250cf1c932110d4b1e2167972b30bd012098
+    "@metamask/approval-controller": ^5.1.2
+  checksum: a8d0b85c04cf5cbebd32bacaacba85be467796e543b123c6f4caac245e7c78541c93ca4dba2a0516d36607e819f0e8435b5f25fced531aa4debc4ed8fe5f1ba1
   languageName: node
   linkType: hard
 
@@ -2703,7 +2700,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/phishing-controller@npm:^8.0.1":
+"@metamask/phishing-controller@npm:^8.0.2":
   version: 8.0.2
   resolution: "@metamask/phishing-controller@npm:8.0.2"
   dependencies:
@@ -2763,13 +2760,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/post-message-stream@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "@metamask/post-message-stream@npm:7.0.0"
+"@metamask/post-message-stream@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@metamask/post-message-stream@npm:8.0.0"
   dependencies:
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^8.1.0
     readable-stream: 3.6.2
-  checksum: a922874f00870e0c666216e592dff6c508e926fae122646d2792c9a7fac4f73323c65046a1eb9dc48a4b0e7de3bbcf753f5ad470688ed4ba2298b4d3a9b39c7d
+  checksum: 3016d8d5f8a5954fd146ce06c0b5fd7a9a070b43284e2bad140e179ee259146b666d56e6dbefa0277f56fbb67806970c9de3067c75f0e56886d0752e7c0f5e22
   languageName: node
   linkType: hard
 
@@ -2794,23 +2791,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/providers@npm:^14.0.1, @metamask/providers@npm:^14.0.2":
-  version: 14.0.2
-  resolution: "@metamask/providers@npm:14.0.2"
+"@metamask/providers@npm:^15.0.0":
+  version: 15.0.0
+  resolution: "@metamask/providers@npm:15.0.0"
   dependencies:
-    "@metamask/json-rpc-engine": ^7.1.1
+    "@metamask/json-rpc-engine": ^7.3.2
+    "@metamask/json-rpc-middleware-stream": ^6.0.2
     "@metamask/object-multiplex": ^2.0.0
-    "@metamask/rpc-errors": ^6.0.0
+    "@metamask/rpc-errors": ^6.2.1
     "@metamask/safe-event-emitter": ^3.0.0
-    "@metamask/utils": ^8.1.0
+    "@metamask/utils": ^8.3.0
     detect-browser: ^5.2.0
     extension-port-stream: ^3.0.0
     fast-deep-equal: ^3.1.3
     is-stream: ^2.0.0
-    json-rpc-middleware-stream: ^5.0.1
     readable-stream: ^3.6.2
     webextension-polyfill: ^0.10.0
-  checksum: 4111e4f9eae53b461a5318e2bdc90189837bc781a89a3904670a2449dfd3f2985b89183655f39ab4c63e6162d7c9ffd10d8a16335f2351ba2bb32365acd454f7
+  checksum: 42571450e79d69d943384f557f6a61e0f73101d49804fb6e8075d791959f76c42b8ff626f711d434674792d77aead6cb8a32b04a3dcd53598c8aff24cbb1ad25
   languageName: node
   linkType: hard
 
@@ -2862,7 +2859,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0, @metamask/rpc-errors@npm:^6.2.1":
+"@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.2.1":
   version: 6.2.1
   resolution: "@metamask/rpc-errors@npm:6.2.1"
   dependencies:
@@ -2959,58 +2956,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^3.4.1":
-  version: 3.6.0
-  resolution: "@metamask/snaps-controllers@npm:3.6.0"
+"@metamask/snaps-controllers@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "@metamask/snaps-controllers@npm:6.0.3"
   dependencies:
-    "@metamask/approval-controller": ^5.1.1
-    "@metamask/base-controller": ^4.0.0
-    "@metamask/json-rpc-engine": ^7.3.1
-    "@metamask/object-multiplex": ^2.0.0
-    "@metamask/permission-controller": ^7.0.0
-    "@metamask/phishing-controller": ^8.0.1
-    "@metamask/post-message-stream": ^7.0.0
-    "@metamask/rpc-errors": ^6.1.0
-    "@metamask/snaps-registry": ^3.0.0
-    "@metamask/snaps-rpc-methods": ^4.1.0
-    "@metamask/snaps-sdk": ^1.3.1
-    "@metamask/snaps-utils": ^5.1.1
-    "@metamask/utils": ^8.2.1
-    "@xstate/fsm": ^2.0.0
-    browserify-zlib: ^0.2.0
-    concat-stream: ^2.0.0
-    get-npm-tarball-url: ^2.0.3
-    immer: ^9.0.6
-    json-rpc-middleware-stream: ^5.0.0
-    nanoid: ^3.1.31
-    readable-stream: ^3.6.2
-    readable-web-to-node-stream: ^3.0.2
-    tar-stream: ^3.1.6
-  peerDependencies:
-    "@metamask/snaps-execution-environments": ^3.4.3
-  peerDependenciesMeta:
-    "@metamask/snaps-execution-environments":
-      optional: true
-  checksum: 5eddb49976ccb6d0d734f009d624ab646aad1f79a2124364edc9ec72f3a4bc96d66eae219022047f35d170cad7775391c0737bcc93f0e9a153046be26bfc864b
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-controllers@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "@metamask/snaps-controllers@npm:4.1.0"
-  dependencies:
-    "@metamask/approval-controller": ^5.1.1
+    "@metamask/approval-controller": ^5.1.3
     "@metamask/base-controller": ^4.1.0
-    "@metamask/json-rpc-engine": ^7.3.1
+    "@metamask/json-rpc-engine": ^7.3.3
     "@metamask/object-multiplex": ^2.0.0
-    "@metamask/permission-controller": ^7.1.0
-    "@metamask/phishing-controller": ^8.0.1
-    "@metamask/post-message-stream": ^7.0.0
-    "@metamask/rpc-errors": ^6.1.0
-    "@metamask/snaps-registry": ^3.0.0
-    "@metamask/snaps-rpc-methods": ^5.0.0
-    "@metamask/snaps-sdk": ^1.4.0
-    "@metamask/snaps-utils": ^5.2.0
+    "@metamask/permission-controller": ^8.0.1
+    "@metamask/phishing-controller": ^8.0.2
+    "@metamask/post-message-stream": ^8.0.0
+    "@metamask/rpc-errors": ^6.2.1
+    "@metamask/snaps-registry": ^3.0.1
+    "@metamask/snaps-rpc-methods": ^7.0.1
+    "@metamask/snaps-sdk": ^3.1.1
+    "@metamask/snaps-utils": ^7.0.3
     "@metamask/utils": ^8.3.0
     "@xstate/fsm": ^2.0.0
     browserify-zlib: ^0.2.0
@@ -3021,87 +2982,71 @@ __metadata:
     nanoid: ^3.1.31
     readable-stream: ^3.6.2
     readable-web-to-node-stream: ^3.0.2
-    tar-stream: ^3.1.6
+    tar-stream: ^3.1.7
   peerDependencies:
-    "@metamask/snaps-execution-environments": ^3.5.0
+    "@metamask/snaps-execution-environments": ^5.0.3
   peerDependenciesMeta:
     "@metamask/snaps-execution-environments":
       optional: true
-  checksum: 73510dbcf1a547c1a5bfd07c47e817b802dc95de6ab4d608e3e99ae02119de6be0f7a0c41a351b48587f1b3c39ada86b09643bc44cf57d2cf3ceabd041ab05c3
+  checksum: 85c4100b1f2d83252d6d5e04b09f4a53f001195a566ccf78c8667dcf45d29c4d664637babf3352cb080b161659fabaa7c3a28100788556a6a2ff8f61e278b05c
   languageName: node
   linkType: hard
 
-"@metamask/snaps-registry@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@metamask/snaps-registry@npm:3.0.0"
+"@metamask/snaps-registry@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@metamask/snaps-registry@npm:3.0.1"
   dependencies:
-    "@metamask/utils": ^8.1.0
+    "@metamask/utils": ^8.3.0
     "@noble/curves": ^1.2.0
     "@noble/hashes": ^1.3.2
     superstruct: ^1.0.3
-  checksum: d816190ee4f345f04b1dcdbbee48fc7153c12192e2deca16f7947c9f3ee437dddc286fd66c21cdf02d18798c4df799bbc377bc839c11a419226aa00b95b645b0
+  checksum: 80d47e336597491d927a39a1679bae2023a1e8af93b62bbf8c8c254e0dfbc601da949fe6d8d88befa7c6cd86e9b72f06d5a39b965952c58b0eb082b54b4740ee
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@metamask/snaps-rpc-methods@npm:4.1.0"
+"@metamask/snaps-rpc-methods@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "@metamask/snaps-rpc-methods@npm:7.0.1"
   dependencies:
     "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^7.0.0
-    "@metamask/rpc-errors": ^6.1.0
-    "@metamask/snaps-sdk": ^1.3.1
-    "@metamask/snaps-utils": ^5.1.1
-    "@metamask/utils": ^8.2.1
-    "@noble/hashes": ^1.3.1
-    superstruct: ^1.0.3
-  checksum: c782ba0e2dd0d9a81e2e8e1c1eb56918972f3acde8699954f422cc545a1f84a7aac8b314c1068ec71646c81dacdc65278e3c6780ad14d6be3aae8011b2d12fe5
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-rpc-methods@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@metamask/snaps-rpc-methods@npm:5.0.0"
-  dependencies:
-    "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^7.1.0
-    "@metamask/rpc-errors": ^6.1.0
-    "@metamask/snaps-sdk": ^1.4.0
-    "@metamask/snaps-utils": ^5.2.0
+    "@metamask/permission-controller": ^8.0.1
+    "@metamask/rpc-errors": ^6.2.1
+    "@metamask/snaps-sdk": ^3.0.1
+    "@metamask/snaps-utils": ^7.0.1
     "@metamask/utils": ^8.3.0
     "@noble/hashes": ^1.3.1
     superstruct: ^1.0.3
-  checksum: 93c27468020cee472750b522c93afb284a34551abfe8fa8ac52c31065750ac162f260686025aa88e7a5ece91265a136bf64d06be36e37566569296b7070e0a9a
+  checksum: 19309ef234cc5cb47c941b4e3bf03df9fc6335ea9aad0b9931bcd63480f63b6d12a10d8d438df3660fe9c6f9b153b9d109a5dabd4576dc68019640b6336f7357
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^1.2.0, @metamask/snaps-sdk@npm:^1.3.1, @metamask/snaps-sdk@npm:^1.3.2, @metamask/snaps-sdk@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@metamask/snaps-sdk@npm:1.4.0"
+"@metamask/snaps-sdk@npm:^3.0.1, @metamask/snaps-sdk@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@metamask/snaps-sdk@npm:3.1.1"
   dependencies:
     "@metamask/key-tree": ^9.0.0
-    "@metamask/providers": ^14.0.2
-    "@metamask/rpc-errors": ^6.1.0
+    "@metamask/providers": ^15.0.0
+    "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
-    is-svg: ^4.4.0
+    fast-xml-parser: ^4.3.4
     superstruct: ^1.0.3
-  checksum: faf3505add1d719bd9640beb5e67a84ed858198b06330d67d675a06e8b1e66250afc097b1a4c3af23bc8fc01bbc899af963bc056a4aafd09780ca59e1bb51917
+  checksum: dbedd7c331bbe7900f7fec96a43bf90ec8637db8ae30b181d6a9f53ed5b14e8b48d7ffe83f5821d97a93530e91f0e0262731e48938c872cb000eb5ad45382d68
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^5.0.0, @metamask/snaps-utils@npm:^5.1.1, @metamask/snaps-utils@npm:^5.1.2, @metamask/snaps-utils@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "@metamask/snaps-utils@npm:5.2.0"
+"@metamask/snaps-utils@npm:^7.0.1, @metamask/snaps-utils@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "@metamask/snaps-utils@npm:7.0.3"
   dependencies:
     "@babel/core": ^7.23.2
     "@babel/types": ^7.23.0
     "@metamask/base-controller": ^4.1.0
     "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^7.1.0
-    "@metamask/rpc-errors": ^6.1.0
+    "@metamask/permission-controller": ^8.0.1
+    "@metamask/rpc-errors": ^6.2.1
     "@metamask/slip44": ^3.1.0
-    "@metamask/snaps-registry": ^3.0.0
-    "@metamask/snaps-sdk": ^1.4.0
+    "@metamask/snaps-registry": ^3.0.1
+    "@metamask/snaps-sdk": ^3.1.1
     "@metamask/utils": ^8.3.0
     "@noble/hashes": ^1.3.1
     "@scure/base": ^1.1.1
@@ -3109,13 +3054,13 @@ __metadata:
     cron-parser: ^4.5.0
     fast-deep-equal: ^3.1.3
     fast-json-stable-stringify: ^2.1.0
-    is-svg: ^4.4.0
+    marked: ^12.0.1
     rfdc: ^1.3.0
     semver: ^7.5.4
     ses: ^1.1.0
     superstruct: ^1.0.3
     validate-npm-package-name: ^5.0.0
-  checksum: 33aab97f4f4b56123b3a74f264f6480950ff7580c8828604dd20f004f69a09608f98fffcf9cb105fd833e8b20a717a67ec7b7fdf59f78a5a8e7841a8383f16c6
+  checksum: 3aef2d59fa332aa4edfc2dd0580bd35c6e07888835259bccb4472379215fb106f8dcc070b3483912e3df4053d2ca0fac262885b5a3794d799dcf78137ac0bec4
   languageName: node
   linkType: hard
 
@@ -3210,19 +3155,6 @@ __metadata:
     "@metamask/transaction-controller": ^25.0.0
   languageName: unknown
   linkType: soft
-
-"@metamask/utils@npm:^5.0.0":
-  version: 5.0.2
-  resolution: "@metamask/utils@npm:5.0.2"
-  dependencies:
-    "@ethereumjs/tx": ^4.1.2
-    "@types/debug": ^4.1.7
-    debug: ^4.3.4
-    semver: ^7.3.8
-    superstruct: ^1.0.3
-  checksum: eca82e42911b2840deb4f32f0f215c5ffd14d22d68afbbe92d3180e920e509e310777b15eab29def3448f3535b66596ceb4c23666ec846adacc8e1bb093ff882
-  languageName: node
-  linkType: hard
 
 "@metamask/utils@npm:^6.0.1":
   version: 6.2.0
@@ -6735,14 +6667,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^4.1.3":
-  version: 4.2.7
-  resolution: "fast-xml-parser@npm:4.2.7"
+"fast-xml-parser@npm:^4.3.4":
+  version: 4.3.5
+  resolution: "fast-xml-parser@npm:4.3.5"
   dependencies:
     strnum: ^1.0.5
   bin:
     fxparser: src/cli/cli.js
-  checksum: d8b0c9e04756f6c43fa0399428f30149acadae21350e42e26e8fe98e24e6afa6b9b00aa554453795036b00e9fee974a1b556fe2ba18be391d51a9bf1ab790e7c
+  checksum: 852064985ca56aa2078be02c92509a675408b57bb9862f696689301bf7df786f9ce9116b812b032c627979a4de5755f9cbfeecc4b90ed9d56be76deccd97c0c6
   languageName: node
   linkType: hard
 
@@ -7832,15 +7764,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-svg@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "is-svg@npm:4.4.0"
-  dependencies:
-    fast-xml-parser: ^4.1.3
-  checksum: cd5a0ba1af653e4897721913b0b80de968fa5b19eb1a592412f4672d3a1203935d183c2a9dbf61d68023739ee43d3761ea795ae1a9f618c6098a9e89eacdd256
-  languageName: node
-  linkType: hard
-
 "is-symbol@npm:^1.0.2, is-symbol@npm:^1.0.3":
   version: 1.0.4
   resolution: "is-symbol@npm:1.0.4"
@@ -8754,7 +8677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-rpc-middleware-stream@npm:^5.0.0, json-rpc-middleware-stream@npm:^5.0.1":
+"json-rpc-middleware-stream@npm:^5.0.0":
   version: 5.0.1
   resolution: "json-rpc-middleware-stream@npm:5.0.1"
   dependencies:
@@ -9074,6 +8997,15 @@ __metadata:
   dependencies:
     tmpl: 1.0.5
   checksum: b38a025a12c8146d6eeea5a7f2bf27d51d8ad6064da8ca9405fcf7bf9b54acd43e3b30ddd7abb9b1bfa4ddb266019133313482570ddb207de568f71ecfcf6060
+  languageName: node
+  linkType: hard
+
+"marked@npm:^12.0.1":
+  version: 12.0.1
+  resolution: "marked@npm:12.0.1"
+  bin:
+    marked: bin/marked.js
+  checksum: 35ebc6c4612fcc028a1cd6419321e336be5b29d3feb68dfd5aaa7fcddb399c7873cd3291d60daf342db3eede747757e4e18515f349f0ee7b84ec24254f3a4190
   languageName: node
   linkType: hard
 
@@ -11225,14 +11157,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-stream@npm:^3.1.6":
-  version: 3.1.6
-  resolution: "tar-stream@npm:3.1.6"
+"tar-stream@npm:^3.1.7":
+  version: 3.1.7
+  resolution: "tar-stream@npm:3.1.7"
   dependencies:
     b4a: ^1.6.4
     fast-fifo: ^1.2.0
     streamx: ^2.15.0
-  checksum: f3627f918581976e954ff03cb8d370551053796b82564f8c7ca8fac84c48e4d042026d0854fc222171a34ff9c682b72fae91be9c9b0a112d4c54f9e4f443e9c5
+  checksum: 6393a6c19082b17b8dcc8e7fd349352bb29b4b8bfe1075912b91b01743ba6bb4298f5ff0b499a3bbaf82121830e96a1a59d4f21a43c0df339e54b01789cb8cc6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request updates the dependencies in the project, including bumping snap dependencies, keyring-api, and eth-snap-keyring. It also fixes the failing tests.

Closes: https://github.com/MetaMask/accounts-planning/issues/307