### PR TITLE
fix: fix update nft metadata when toggles off

### DIFF
--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -3672,26 +3672,28 @@ describe('NftController', () => {
     });
 
     it('should not update metadata when nfts has image/name/description already', async () => {
-      const { nftController } = setupController();
-      const spy = jest.spyOn(nftController, 'updateNft');
+      const { nftController, triggerPreferencesStateChange } = setupController();
+      const spy = jest.spyOn(nftController, 'updateNftMetadata');
       const testNetworkClientId = 'sepolia';
 
-      const testInputNfts: Nft[] = [
-        {
-          address: '0xtest',
-          description: 'test description',
-          favorite: false,
-          image: 'test image',
-          isCurrentlyOwned: true,
+      // Add nfts
+      await nftController.addNft('0xtest', '3', {
+        nftMetadata: {
           name: 'test name',
+          description: 'test description',
+          image: 'test image',
           standard: 'ERC721',
-          tokenId: '3',
         },
-      ];
-
-      await nftController.updateNftMetadata({
-        nfts: testInputNfts,
+        userAddress: OWNER_ADDRESS,
         networkClientId: testNetworkClientId,
+      });
+
+      // trigger preference change
+      triggerPreferencesStateChange({
+        ...getDefaultPreferencesState(),
+        isIpfsGatewayEnabled: false,
+        openSeaEnabled: true,
+        selectedAddress: OWNER_ADDRESS,
       });
 
       expect(spy).toHaveBeenCalledTimes(0);

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -3446,7 +3446,12 @@ describe('NftController', () => {
       const spy = jest.spyOn(nftController, 'updateNft');
       const testNetworkClientId = 'sepolia';
       await nftController.addNft('0xtest', '3', {
-        nftMetadata: { name: '', description: '', image: '', standard: '' },
+        nftMetadata: {
+          name: '',
+          description: '',
+          image: '',
+          standard: 'ERC721',
+        },
         networkClientId: testNetworkClientId,
       });
       sinon
@@ -3455,23 +3460,10 @@ describe('NftController', () => {
           name: 'name pudgy',
           image: 'url pudgy',
           description: 'description pudgy',
-        });
-      const testInputNfts: Nft[] = [
-        {
-          address: '0xtest',
-          description: null,
-          favorite: false,
-          image: null,
-          isCurrentlyOwned: true,
-          name: null,
-          standard: 'ERC721',
-          tokenId: '3',
           tokenURI: 'https://api.pudgypenguins.io/lil/4',
-        },
-      ];
+        });
 
       await nftController.updateNftMetadata({
-        nfts: testInputNfts,
         networkClientId: testNetworkClientId,
       });
       expect(spy).toHaveBeenCalledTimes(1);
@@ -3508,21 +3500,8 @@ describe('NftController', () => {
       sinon
         .stub(nftController, 'getNftInformation' as keyof typeof nftController)
         .rejects(new Error('Error'));
-      const testInputNfts: Nft[] = [
-        {
-          address: '0xtest',
-          description: null,
-          favorite: false,
-          image: null,
-          isCurrentlyOwned: true,
-          name: null,
-          standard: 'ERC721',
-          tokenId: '3',
-        },
-      ];
 
       await nftController.updateNftMetadata({
-        nfts: testInputNfts,
         networkClientId: testNetworkClientId,
       });
 
@@ -3591,41 +3570,7 @@ describe('NftController', () => {
         .onThirdCall()
         .rejects(new Error('Error'));
 
-      const testInputNfts: Nft[] = [
-        {
-          address: '0xtest1',
-          description: null,
-          favorite: false,
-          image: null,
-          isCurrentlyOwned: true,
-          name: null,
-          standard: 'ERC721',
-          tokenId: '1',
-        },
-        {
-          address: '0xtest2',
-          description: null,
-          favorite: false,
-          image: null,
-          isCurrentlyOwned: true,
-          name: null,
-          standard: 'ERC721',
-          tokenId: '2',
-        },
-        {
-          address: '0xtest3',
-          description: null,
-          favorite: false,
-          image: null,
-          isCurrentlyOwned: true,
-          name: null,
-          standard: 'ERC721',
-          tokenId: '3',
-        },
-      ];
-
       await nftController.updateNftMetadata({
-        nfts: testInputNfts,
         networkClientId: testNetworkClientId,
       });
 

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -3672,7 +3672,8 @@ describe('NftController', () => {
     });
 
     it('should not update metadata when nfts has image/name/description already', async () => {
-      const { nftController, triggerPreferencesStateChange } = setupController();
+      const { nftController, triggerPreferencesStateChange } =
+        setupController();
       const spy = jest.spyOn(nftController, 'updateNftMetadata');
       const testNetworkClientId = 'sepolia';
 

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -33,7 +33,6 @@ import { v4 } from 'uuid';
 
 import { getFormattedIpfsUrl } from './assetsUtil';
 import { Source } from './constants';
-import type { Nft } from './NftController';
 import { NftController } from './NftController';
 
 const CRYPTOPUNK_ADDRESS = '0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB';

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1207,7 +1207,6 @@ export class NftController extends BaseControllerV1<NftConfig, NftState> {
               userAddress: selectedAddress,
             });
           }
-
         }
       },
     );


### PR DESCRIPTION
## Explanation

This PR fixes a bug on extension, where when a user imports an NFT when IPFS and display media toggles are off, then enables them, the metadata wont be refreshed.
We added a check in NftController to see if any of the toggles are on then proceed to update nft metadata.
We will update the metadata only for NFTs that are missing name/image or description.

### **Before**

https://github.com/MetaMask/metamask-extension/assets/10994169/c0d09b77-1cd2-495e-aec8-a4ba965ed38f

### **After**

https://github.com/MetaMask/metamask-extension/assets/10994169/06e56b4f-5c1b-4402-b6e2-154daff291d5


## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **ADDED**: Added a check inside `onPreferencesStateChange` to check if IPFS toggle or display media toggle is ON. If so i update the users nft metadata.
- **REMOVED**: Removed Nfts argument from `updateNftMetadata` function.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
