### PR TITLE
Fix publish hook by providing final transaction metadata

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -4552,6 +4552,37 @@ describe('TransactionController', () => {
 
       expect(mockEthQuery.sendRawTransaction).toHaveBeenCalledTimes(1);
     });
+
+    it('submits to publish hook with final transaction meta', async () => {
+      const publishHook = jest
+        .fn()
+        .mockResolvedValue({ transactionHash: TRANSACTION_META_MOCK.hash });
+
+      const { controller } = setupController({
+        options: {
+          hooks: {
+            publish: publishHook,
+          },
+        },
+        messengerOptions: {
+          addTransactionApprovalRequest: {
+            state: 'approved',
+          },
+        },
+      });
+
+      const { result } = await controller.addTransaction(paramsMock);
+
+      await result;
+
+      expect(publishHook).toHaveBeenCalledTimes(1);
+      expect(publishHook).toHaveBeenCalledWith(
+        expect.objectContaining({
+          txParams: expect.objectContaining({ nonce: toHex(NONCE_MOCK) }),
+        }),
+        expect.any(String),
+      );
+    });
   });
 
   describe('updateSecurityAlertResponse', () => {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -2620,7 +2620,7 @@ export class TransactionController extends BaseController<
       log('Publishing transaction', txParams);
 
       let { transactionHash: hash } = await this.publish(
-        transactionMeta,
+        updatedTransactionMeta,
         rawTx,
       );
 


### PR DESCRIPTION
## Explanation

Fix the use of the `publishHook` by ensuring the updated transaction metadata is provided to it, rather than the initial data lacking values such as the `nonce`.

## Changelog

### `@metamask/transaction-controller`

- **FIXED**: Provide updated transaction metadata to publish hook.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
