### PR TITLE
Refactor: Expose `SelectedNetworkController` proxies map in the constructor params

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -123,7 +123,7 @@ export class SelectedNetworkController extends BaseController<
    * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
    * @param options.state - The controllers initial state.
    * @param options.getUseRequestQueue - feature flag for perDappNetwork & request queueing features
-   * @param options.domainProxyMap - an object that implements the Map interface for Domain to NetworkProxy
+   * @param options.domainProxyMap - A map for storing domain-specific proxies that are held in memory only during use.
    */
   constructor({
     messenger,

--- a/packages/selected-network-controller/src/index.ts
+++ b/packages/selected-network-controller/src/index.ts
@@ -9,6 +9,7 @@ export type {
   SelectedNetworkControllerMessenger,
   SelectedNetworkControllerOptions,
   NetworkProxy,
+  Domain,
 } from './SelectedNetworkController';
 export {
   SelectedNetworkControllerActionTypes,

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -9,6 +9,8 @@ import type {
   SelectedNetworkControllerEvents,
   SelectedNetworkControllerMessenger,
   SelectedNetworkControllerState,
+  Domain,
+  NetworkProxy,
 } from '../src/SelectedNetworkController';
 import {
   SelectedNetworkController,
@@ -92,11 +94,13 @@ const setup = ({
   getSubjectNames = [],
   state,
   getUseRequestQueue = () => false,
+  domainProxyMap = new Map<Domain, NetworkProxy>(),
 }: {
   hasPermissions?: boolean;
   state?: SelectedNetworkControllerState;
   getSubjectNames?: string[];
   getUseRequestQueue?: GetUseRequestQueue;
+  domainProxyMap?: Map<Domain, NetworkProxy>;
 } = {}) => {
   const mockProviderProxy = {
     setTarget: jest.fn(),
@@ -143,6 +147,7 @@ const setup = ({
     messenger: selectedNetworkControllerMessenger,
     state,
     getUseRequestQueue,
+    domainProxyMap,
   });
   return {
     controller,


### PR DESCRIPTION
## Explanation

In a [preceding PR](https://github.com/MetaMask/core/pull/4063), the SelectedNetworkController will start to keep proxy instances for all domains seen without a way to remove them when they become stale. This PR exposes the private proxies cache map as a constructor param which will enable callers to implement their own cache invalidation strategies without needing to concern the SelectedNetworkController of the implementation details themselves. This is needed because Mobile and Extension will need to follow different cache invalidation strategies.

This PR should be merged before https://github.com/MetaMask/core/pull/4063

## References

Fixes: https://github.com/MetaMask/core/issues/4062
See: https://github.com/MetaMask/core/pull/4063

## Changelog

### `@metamask/selected-network-controller`

- **BREAKING**:  `SelectedNetworkController` now expects the `domainProxyMap` param which is a `Map` of `Domain` to `NetworkProxy`
- **ADDED**: exports the `Domain` type

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
