### PR TITLE
Skip simulation if no approval

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.31,
-      functions: 98.52,
-      lines: 99,
-      statements: 99.01,
+      branches: 94.21,
+      functions: 98.55,
+      lines: 99.01,
+      statements: 99.02,
     },
   },
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -74,6 +74,7 @@ import {
   TransactionEnvelopeType,
   TransactionType,
   TransactionStatus,
+  SimulationErrorCode,
 } from './types';
 import { validateConfirmedExternalTransaction } from './utils/external-transactions';
 import { addGasBuffer, estimateGas, updateGas } from './utils/gas';
@@ -1074,8 +1075,12 @@ export class TransactionController extends BaseController<
 
       this.addMetadata(addedTransactionMeta);
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.#updateSimulationData(addedTransactionMeta);
+      if (requireApproval !== false) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.#updateSimulationData(addedTransactionMeta);
+      } else {
+        log('Skipping simulation as approval not required');
+      }
 
       this.messagingSystem.publish(
         `${controllerName}:unapprovedTransactionAdded`,
@@ -3572,8 +3577,8 @@ export class TransactionController extends BaseController<
 
     let simulationData: SimulationData = {
       error: {
+        code: SimulationErrorCode.Disabled,
         message: 'Simulation disabled',
-        isReverted: false,
       },
       tokenBalanceChanges: [],
     };

--- a/packages/transaction-controller/src/errors.ts
+++ b/packages/transaction-controller/src/errors.ts
@@ -1,0 +1,37 @@
+import type { Hex } from '@metamask/utils';
+
+import { SimulationErrorCode } from './types';
+
+export class SimulationError extends Error {
+  code?: string | number;
+
+  constructor(message?: string, code?: string | number) {
+    super(message ?? 'Simulation failed');
+
+    this.code = code;
+  }
+}
+
+export class SimulationChainNotSupportedError extends SimulationError {
+  constructor(chainId: Hex) {
+    super(
+      `Chain is not supported: ${chainId}`,
+      SimulationErrorCode.ChainNotSupported,
+    );
+  }
+}
+
+export class SimulationInvalidResponseError extends SimulationError {
+  constructor() {
+    super(
+      'Invalid response from simulation API',
+      SimulationErrorCode.InvalidResponse,
+    );
+  }
+}
+
+export class SimulationRevertedError extends SimulationError {
+  constructor() {
+    super('Transaction was reverted', SimulationErrorCode.Reverted);
+  }
+}

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -54,6 +54,7 @@ export type {
   TransactionReceipt,
 } from './types';
 export {
+  SimulationErrorCode,
   SimulationTokenStandard,
   TransactionEnvelopeType,
   TransactionStatus,

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1105,16 +1105,20 @@ export type SimulationToken = {
 export type SimulationTokenBalanceChange = SimulationToken &
   SimulationBalanceChange;
 
+export enum SimulationErrorCode {
+  ChainNotSupported = 'chain-not-supported',
+  Disabled = 'disabled',
+  InvalidResponse = 'invalid-response',
+  Reverted = 'reverted',
+}
+
 /** Error data for a failed simulation. */
 export type SimulationError = {
   /** Error code to identify the error type. */
-  code?: number;
+  code?: string | number;
 
   /** Error message to describe the error. */
   message?: string;
-
-  /** Whether the error is due to the transaction being reverted. */
-  isReverted: boolean;
 };
 
 /** Simulation data for a transaction. */

--- a/packages/transaction-controller/src/utils/simulation-api.test.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.test.ts
@@ -120,10 +120,10 @@ describe('Simulation API Utils', () => {
 
       await expect(
         simulateTransactions(CHAIN_ID_MOCK, REQUEST_MOCK),
-      ).rejects.toStrictEqual({
+      ).rejects.toThrow({
         code: ERROR_CODE_MOCK,
         message: ERROR_MESSAGE_MOCK,
-      });
+      } as unknown as Error);
     });
   });
 });

--- a/packages/transaction-controller/src/utils/simulation-api.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.ts
@@ -1,6 +1,7 @@
 import { convertHexToDecimal } from '@metamask/controller-utils';
 import { createModuleLogger, type Hex } from '@metamask/utils';
 
+import { SimulationChainNotSupportedError, SimulationError } from '../errors';
 import { projectLogger } from '../logger';
 
 const log = createModuleLogger(projectLogger, 'simulation-api');
@@ -180,7 +181,8 @@ export async function simulateTransactions(
   log('Received response', responseJson);
 
   if (responseJson.error) {
-    throw responseJson.error;
+    const { code, message } = responseJson.error;
+    throw new SimulationError(message, code);
   }
 
   return responseJson?.result;
@@ -198,7 +200,7 @@ async function getSimulationUrl(chainId: Hex): Promise<string> {
 
   if (!network?.confirmations) {
     log('Chain is not supported', chainId);
-    throw new Error(`Chain is not supported: ${chainId}`);
+    throw new SimulationChainNotSupportedError(chainId);
   }
 
   return getUrl(network.network);


### PR DESCRIPTION
## Explanation

Skip the simulation of new transactions if `requireApproval` is false and therefore no user confirmation is required.

Provide error codes using new `SimulationErrorCode` enum for local simulation errors.

Remove the `isReverted` property.

## References

Fixes [#2307](https://github.com/MetaMask/MetaMask-planning/issues/2307)

## Changelog

### `@metamask/transaction-controller`

- **BREAKING**: Remove `isReverted` property from `SimulationError` type.
- **ADDED**: Add `SimulationErrorCode` enum.
- **CHANGED**: Skip simulation if `requireApproval` is `false`.
- **CHANGED**: Provide simulation error code in locally generated errors.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
