### PR TITLE
refactor: Fix misnamed parameter name

### DIFF
--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -289,7 +289,7 @@ function deriveStateFromMetadata<ControllerState extends StateConstraint>(
 ): Record<keyof ControllerState, Json> {
   return (Object.keys(state) as (keyof ControllerState)[]).reduce<
     Record<keyof ControllerState, Json>
-  >((persistedState, key) => {
+  >((derivedState, key) => {
     try {
       const stateMetadata = metadata[key];
       if (!stateMetadata) {
@@ -298,18 +298,18 @@ function deriveStateFromMetadata<ControllerState extends StateConstraint>(
       const propertyMetadata = stateMetadata[metadataProperty];
       const stateProperty = state[key];
       if (typeof propertyMetadata === 'function') {
-        persistedState[key] = propertyMetadata(stateProperty);
+        derivedState[key] = propertyMetadata(stateProperty);
       } else if (propertyMetadata) {
-        persistedState[key] = stateProperty;
+        derivedState[key] = stateProperty;
       }
-      return persistedState;
+      return derivedState;
     } catch (error) {
       // Throw error after timeout so that it is captured as a console error
       // (and by Sentry) without interrupting state-related operations
       setTimeout(() => {
         throw error;
       });
-      return persistedState;
+      return derivedState;
     }
   }, {} as never);
 }


### PR DESCRIPTION
## Explanation

The parameter name of the "derived state" was named `persistedState` because that function was originally written for the `getPersistedState` function, and was later moved to a separate function because the state derivation process was identical for `getAnonymizedState`.

## References

N/A

## Changelog

N/A

## Checklist

- x ] I've updated the test suite for new or updated code as appropriate
- x ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- x ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
