### PR TITLE
clean up securityAlertProvider from signature controller

### DIFF
--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -207,14 +207,12 @@ export abstract class AbstractMessageManager<
    *
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
-   * @param securityProviderRequest - A function for verifying a message, whether it is malicious or not.
    * @param additionalFinishStatuses - Optional list of statuses that are accepted to emit a finished event.
    * @param getCurrentChainId - Optional function to get the current chainId.
    */
   constructor(
     config?: Partial<BaseConfig>,
     state?: Partial<MessageManagerState<M>>,
-    securityProviderRequest?: SecurityProviderRequest,
     additionalFinishStatuses?: string[],
     getCurrentChainId?: getCurrentChainId,
   ) {
@@ -224,7 +222,6 @@ export abstract class AbstractMessageManager<
       unapprovedMessagesCount: 0,
     };
     this.messages = [];
-    this.securityProviderRequest = securityProviderRequest;
     this.additionalFinishStatuses = additionalFinishStatuses ?? [];
     this.getCurrentChainId = getCurrentChainId;
     this.initialize();

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -124,14 +124,6 @@ export type SignatureControllerOptions = {
   messenger: SignatureControllerMessenger;
   isEthSignEnabled: () => boolean;
   getAllState: () => unknown;
-  securityProviderRequest?: (
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    requestData: any,
-    methodName: string,
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ) => Promise<any>;
   getCurrentChainId: () => Hex;
 };
 
@@ -164,14 +156,12 @@ export class SignatureController extends BaseController<
    * @param options.messenger - The restricted controller messenger for the sign controller.
    * @param options.isEthSignEnabled - Callback to return true if eth_sign is enabled.
    * @param options.getAllState - Callback to retrieve all user state.
-   * @param options.securityProviderRequest - A function for verifying a message, whether it is malicious or not.
    * @param options.getCurrentChainId - A function for retrieving the current chainId.
    */
   constructor({
     messenger,
     isEthSignEnabled,
     getAllState,
-    securityProviderRequest,
     getCurrentChainId,
   }: SignatureControllerOptions) {
     super({
@@ -185,20 +175,14 @@ export class SignatureController extends BaseController<
     this.#getAllState = getAllState;
 
     this.hub = new EventEmitter();
-    this.#messageManager = new MessageManager(
-      undefined,
-      undefined,
-      securityProviderRequest,
-    );
+    this.#messageManager = new MessageManager(undefined, undefined);
     this.#personalMessageManager = new PersonalMessageManager(
       undefined,
       undefined,
-      securityProviderRequest,
     );
     this.#typedMessageManager = new TypedMessageManager(
       undefined,
       undefined,
-      securityProviderRequest,
       undefined,
       getCurrentChainId,
     );


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
