### PR TITLE
Support dynamic enablement of automatic resubmit

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -811,6 +811,18 @@ describe('TransactionController', () => {
       );
     });
 
+    it('checks pending transactions', () => {
+      expect(
+        pendingTransactionTrackerMock.startIfPendingTransactions,
+      ).toHaveBeenCalledTimes(0);
+
+      setupController();
+
+      expect(
+        pendingTransactionTrackerMock.startIfPendingTransactions,
+      ).toHaveBeenCalledTimes(1);
+    });
+
     describe('nonce tracker', () => {
       it('uses external pending transactions', async () => {
         const nonceTrackerMock = jest

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -229,7 +229,7 @@ export type TransactionControllerActions = TransactionControllerGetStateAction;
  * @property isResubmitEnabled - Whether transaction publishing is automatically retried.
  */
 export type PendingTransactionOptions = {
-  isResubmitEnabled?: boolean;
+  isResubmitEnabled?: () => boolean;
 };
 
 /**
@@ -891,6 +891,7 @@ export class TransactionController extends BaseController<
     });
 
     this.onBootCleanup();
+    this.#checkForPendingTransactionAndStartPolling();
   }
 
   /**

--- a/packages/transaction-controller/src/helpers/PendingTransactionTracker.test.ts
+++ b/packages/transaction-controller/src/helpers/PendingTransactionTracker.test.ts
@@ -976,17 +976,33 @@ describe('PendingTransactionTracker', () => {
 
         it('unless resubmit disabled', async () => {
           const transaction = { ...TRANSACTION_SUBMITTED_MOCK };
+          const getTransactions = jest
+            .fn()
+            .mockReturnValueOnce(freeze([transaction], true));
 
           pendingTransactionTracker = new PendingTransactionTracker({
             ...options,
-            getTransactions: () => freeze([transaction], true),
-            isResubmitEnabled: false,
+            getTransactions,
+            isResubmitEnabled: () => false,
           });
 
           queryMock.mockResolvedValueOnce(undefined);
           queryMock.mockResolvedValueOnce('0x1');
 
           await onLatestBlock(BLOCK_NUMBER_MOCK);
+
+          getTransactions.mockReturnValue(
+            freeze(
+              [
+                {
+                  ...transaction,
+                  firstRetryBlockNumber: BLOCK_NUMBER_MOCK,
+                },
+              ],
+              true,
+            ),
+          );
+
           await onLatestBlock('0x124');
 
           expect(options.publishTransaction).toHaveBeenCalledTimes(0);

--- a/packages/transaction-controller/src/helpers/PendingTransactionTracker.ts
+++ b/packages/transaction-controller/src/helpers/PendingTransactionTracker.ts
@@ -71,7 +71,7 @@ export class PendingTransactionTracker {
 
   #getTransactions: () => TransactionMeta[];
 
-  #isResubmitEnabled: boolean;
+  #isResubmitEnabled: () => boolean;
 
   // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -103,7 +103,7 @@ export class PendingTransactionTracker {
     getChainId: () => string;
     getEthQuery: (networkClientId?: NetworkClientId) => EthQuery;
     getTransactions: () => TransactionMeta[];
-    isResubmitEnabled?: boolean;
+    isResubmitEnabled?: () => boolean;
     getGlobalLock: () => Promise<() => void>;
     publishTransaction: (ethQuery: EthQuery, rawTx: string) => Promise<string>;
     hooks?: {
@@ -121,7 +121,7 @@ export class PendingTransactionTracker {
     this.#getChainId = getChainId;
     this.#getEthQuery = getEthQuery;
     this.#getTransactions = getTransactions;
-    this.#isResubmitEnabled = isResubmitEnabled ?? true;
+    this.#isResubmitEnabled = isResubmitEnabled ?? (() => true);
     this.#listener = this.#onLatestBlock.bind(this);
     this.#getGlobalLock = getGlobalLock;
     this.#publishTransaction = publishTransaction;
@@ -222,7 +222,7 @@ export class PendingTransactionTracker {
   }
 
   async #resubmitTransactions(latestBlockNumber: string) {
-    if (!this.#isResubmitEnabled || !this.#running) {
+    if (!this.#isResubmitEnabled() || !this.#running) {
       return;
     }
 


### PR DESCRIPTION
## Explanation

Change `isResubmitEnabled` constructor boolean to a callback to support dynamic support in the client based on preferences and other functionality.

Force an initial check of the pending transaction tracker during construction to ensure any previously pending transactions are updated after restarting the browser. 

## Changelog

### `@metamask/transaction-controller`

- **BREAKING**: Change `pendingTransactions.isResubmitEnabled` from optional `boolean` to  optional callback.
- **CHANGED**: Check pending transactions on startup.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
