### PR TITLE
Release 133.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "132.0.0",
+  "version": "133.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/announcement-controller/CHANGELOG.md
+++ b/packages/announcement-controller/CHANGELOG.md
@@ -130,7 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     All changes listed after this point were applied to this package following the monorepo conversion.
 
 [Unreleased]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.1.0...HEAD
-[6.1.0]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.0.0...@metamask/announcement-controller@6.1.0
+[6.1.0]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.0.1...@metamask/announcement-controller@6.1.0
 [6.0.1]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.0.0...@metamask/announcement-controller@6.0.1
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@5.0.2...@metamask/announcement-controller@6.0.0
 [5.0.2]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@5.0.1...@metamask/announcement-controller@5.0.2

--- a/packages/announcement-controller/CHANGELOG.md
+++ b/packages/announcement-controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.0]
+
+### Added
+
+- Add `resetViewed` method to `AnnouncementController` to reset the `isShown` status for all announcements ([#4088](https://github.com/MetaMask/core/pull/4088))
+
 ## [6.0.1]
 
 ### Fixed
@@ -123,7 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.1.0...HEAD
+[6.1.0]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.0.0...@metamask/announcement-controller@6.1.0
 [6.0.1]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.0.0...@metamask/announcement-controller@6.0.1
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@5.0.2...@metamask/announcement-controller@6.0.0
 [5.0.2]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@5.0.1...@metamask/announcement-controller@5.0.2

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/announcement-controller",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Manages in-app announcements",
   "keywords": [
     "MetaMask",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -55,7 +55,7 @@
     "@metamask/eth-query": "^4.0.0",
     "@metamask/keyring-controller": "^14.0.1",
     "@metamask/metamask-eth-abis": "^3.1.1",
-    "@metamask/network-controller": "^18.0.1",
+    "@metamask/network-controller": "^18.1.0",
     "@metamask/polling-controller": "^6.0.1",
     "@metamask/preferences-controller": "^9.0.1",
     "@metamask/rpc-errors": "^6.2.1",

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/network-controller": "^18.0.1",
+    "@metamask/network-controller": "^18.1.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0]
+
+### Changed
+
+- **BREAKING**: The controller's constructor now requires `infuraAPIKey`. This is used to construct and send the `Authorization` header for Infura gas API requests. ([#4068](https://github.com/MetaMask/core/pull/4068))
+- Bump dependency `@metamask/network-controller` to `^18.1.0`
+
+### Removed
+
+- **BREAKING**: Remove the constructor options `legacyAPIEndpoint` and `EIP1559APIEndpoint`. These URLs are now hardcoded within the controller. [#4068](https://github.com/MetaMask/core/pull/4068))
+
 ## [14.0.1]
 
 ### Fixed
@@ -238,7 +249,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@14.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@15.0.0...HEAD
+[15.0.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@14.0.1...@metamask/gas-fee-controller@15.0.0
 [14.0.1]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@14.0.0...@metamask/gas-fee-controller@14.0.1
 [14.0.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@13.0.2...@metamask/gas-fee-controller@14.0.0
 [13.0.2]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@13.0.1...@metamask/gas-fee-controller@13.0.2

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING**: The controller's constructor now requires `infuraAPIKey`. This is used to construct and send the `Authorization` header for Infura gas API requests. ([#4068](https://github.com/MetaMask/core/pull/4068))
-- Bump dependency `@metamask/network-controller` to `^18.1.0`
+- Bump dependency `@metamask/network-controller` to `^18.1.0` ([#4121](https://github.com/MetaMask/core/pull/4121))
 
 ### Removed
 
-- **BREAKING**: Remove the constructor options `legacyAPIEndpoint` and `EIP1559APIEndpoint`. These URLs are now hardcoded within the controller. [#4068](https://github.com/MetaMask/core/pull/4068))
+- **BREAKING**: Remove the constructor options `legacyAPIEndpoint` and `EIP1559APIEndpoint`. These URLs are now hardcoded within the controller. ([#4068](https://github.com/MetaMask/core/pull/4068))
 
 ## [14.0.1]
 

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/gas-fee-controller",
-  "version": "14.0.1",
+  "version": "15.0.0",
   "description": "Periodically calculates gas fee estimates based on various gas limits as well as other data displayed on transaction confirm screens",
   "keywords": [
     "MetaMask",
@@ -45,7 +45,7 @@
     "@metamask/controller-utils": "^9.0.2",
     "@metamask/eth-query": "^4.0.0",
     "@metamask/ethjs-unit": "^0.3.0",
-    "@metamask/network-controller": "^18.0.1",
+    "@metamask/network-controller": "^18.1.0",
     "@metamask/polling-controller": "^6.0.1",
     "@metamask/utils": "^8.3.0",
     "@types/bn.js": "^5.1.5",

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [18.1.0]
+
+### Added
+
+- Add `getSelectedNetworkClient` method that returns the provider and blockTracker for the currently selected network but with a more easily used type than `getProviderAndBlockTracker` ([#4063](https://github.com/MetaMask/core/pull/4063))
+- Add `NetworkController:getSelectedNetworkClient` action ([#4063](https://github.com/MetaMask/core/pull/4063))
+
+### Changed
+
+- `getProviderAndBlockTracker` is now marked as deprecated and will be removed in a future release. ([#4063](https://github.com/MetaMask/core/pull/4063))
+
 ## [18.0.1]
 
 ### Fixed
@@ -458,7 +469,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@18.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@18.1.0...HEAD
+[18.1.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@18.0.1...@metamask/network-controller@18.1.0
 [18.0.1]: https://github.com/MetaMask/core/compare/@metamask/network-controller@18.0.0...@metamask/network-controller@18.0.1
 [18.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@17.2.1...@metamask/network-controller@18.0.0
 [17.2.1]: https://github.com/MetaMask/core/compare/@metamask/network-controller@17.2.0...@metamask/network-controller@17.2.1

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-controller",
-  "version": "18.0.1",
+  "version": "18.1.0",
   "description": "Provides an interface to the currently selected network via a MetaMask-compatible provider object",
   "keywords": [
     "MetaMask",

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@metamask/base-controller": "^5.0.1",
     "@metamask/controller-utils": "^9.0.2",
-    "@metamask/network-controller": "^18.0.1",
+    "@metamask/network-controller": "^18.1.0",
     "@metamask/utils": "^8.3.0",
     "@types/uuid": "^8.3.0",
     "fast-json-stable-stringify": "^2.1.0",

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0]
+
+### Changed
+
+- **BREAKING:** Bump peer dependency `@metamask/selected-network-controller` to `^11.0.0`
+- Bump `@metamask/controller-utils` to `^9.0.2` ([#4065](https://github.com/MetaMask/core/pull/4065))
+
 ## [0.6.1]
 
 ### Fixed
@@ -147,7 +154,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.6.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.7.0...HEAD
+[0.7.0]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.6.1...@metamask/queued-request-controller@0.7.0
 [0.6.1]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.6.0...@metamask/queued-request-controller@0.6.1
 [0.6.0]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.5.0...@metamask/queued-request-controller@0.6.0
 [0.5.0]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.4.0...@metamask/queued-request-controller@0.5.0

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump peer dependency `@metamask/selected-network-controller` to `^11.0.0`
+- **BREAKING:** Bump peer dependency `@metamask/selected-network-controller` to `^11.0.0` ([#4121](https://github.com/MetaMask/core/pull/4121))
 - Bump `@metamask/controller-utils` to `^9.0.2` ([#4065](https://github.com/MetaMask/core/pull/4065))
 
 ## [0.6.1]

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/queued-request-controller",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Includes a controller and middleware that implements a request queue",
   "keywords": [
     "MetaMask",
@@ -50,8 +50,8 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/network-controller": "^18.0.1",
-    "@metamask/selected-network-controller": "^10.0.1",
+    "@metamask/network-controller": "^18.1.0",
+    "@metamask/selected-network-controller": "^11.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",
@@ -66,7 +66,7 @@
   },
   "peerDependencies": {
     "@metamask/network-controller": "^18.0.0",
-    "@metamask/selected-network-controller": "^10.0.0"
+    "@metamask/selected-network-controller": "^11.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **BREAKING:** `SelectedNetworkController` now requires `NetworkController:getSelectedNetworkClient` as an allowed action ([#4063](https://github.com/MetaMask/core/pull/4063))
   - `getProviderAndBlockTracker` method no longer throws an error if the `useRequestQueue` flag is false ([#4063](https://github.com/MetaMask/core/pull/4063))
   - `getProviderAndBlockTracker` method no longer throws an error if there is no `networkClientId` set for the passed domain. Now it returns a proxy pointed at the globally selected network instead. ([#4063](https://github.com/MetaMask/core/pull/4063))
-- Bump dependency `@metamask/network-controller` to `^18.1.0`
+- Bump dependency `@metamask/network-controller` to `^18.1.0` ([#4121](https://github.com/MetaMask/core/pull/4121))
 
 ### Fixed
 

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0]
+
+### Added
+
+- Now exports the `Domain` type ([#4104](https://github.com/MetaMask/core/pull/4104))
+
+### Changed
+
+- Previously the `SelectedNetworkController` only constructed proxies for domains that had permissions. Other domains have no associated proxy and the `getProviderAndBlockTracker` method would throw an error. This was problematic because we grab the network client for an origin a single time when constructing an RPC pipeline for that origin in the MetaMask extension. We don't re-create the RPC pipeline when permissions change. That means that the pipeline is setup with the wrong network client and cannot be updated. The following changes ensure seamlessly proxying calls during sessions where a dapp connects/disconnects and provides a path for clients to prune inactive proxies:
+  - **BREAKING:** `SelectedNetworkController` now expects a `domainProxyMap` param - which is a Map of Domain to NetworkProxy - in its constructor ([#4104](https://github.com/MetaMask/core/pull/4104))
+    - This `domainProxyMap` is expected to automatically delete entries for domains that are no longer connected to the wallet. The `SelectedNetworkController` handles _adding_ entries, but it can't handle removal, as it doesn't know which connections are active.
+    - You can pass in a plain `Map` here and it will work, but during longer sessions this might grow unbounded, resulting in a memory leak.
+  - **BREAKING:** `SelectedNetworkController` now requires `NetworkController:getSelectedNetworkClient` as an allowed action ([#4063](https://github.com/MetaMask/core/pull/4063))
+  - `getProviderAndBlockTracker` method no longer throws an error if the `useRequestQueue` flag is false ([#4063](https://github.com/MetaMask/core/pull/4063))
+  - `getProviderAndBlockTracker` method no longer throws an error if there is no `networkClientId` set for the passed domain. Now it returns a proxy pointed at the globally selected network instead. ([#4063](https://github.com/MetaMask/core/pull/4063))
+- Bump dependency `@metamask/network-controller` to `^18.1.0`
+
+### Fixed
+
+- Previously when a domain's permission was removed from `PermissionsController`, it's network client proxy would continue to point at the `networkClientId` it was last set to. Now it is set to follow the globally selected network ([#4063](https://github.com/MetaMask/core/pull/4063))
+
 ## [10.0.1]
 
 ### Fixed
@@ -157,7 +178,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release ([#1643](https://github.com/MetaMask/core/pull/1643))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@10.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@11.0.0...HEAD
+[11.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@10.0.1...@metamask/selected-network-controller@11.0.0
 [10.0.1]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@10.0.0...@metamask/selected-network-controller@10.0.1
 [10.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@9.0.0...@metamask/selected-network-controller@10.0.0
 [9.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@8.0.0...@metamask/selected-network-controller@9.0.0

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/selected-network-controller",
-  "version": "10.0.1",
+  "version": "11.0.0",
   "description": "Provides an interface to the currently selected networkClientId for a given domain",
   "keywords": [
     "MetaMask",
@@ -43,7 +43,7 @@
   "dependencies": {
     "@metamask/base-controller": "^5.0.1",
     "@metamask/json-rpc-engine": "^8.0.1",
-    "@metamask/network-controller": "^18.0.1",
+    "@metamask/network-controller": "^18.1.0",
     "@metamask/permission-controller": "^9.0.2",
     "@metamask/swappable-obj-proxy": "^2.2.0",
     "@metamask/utils": "^8.3.0"

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [26.0.0]
+
+### Added
+
+- Run `OptimismLayer1GasFeeFlow` on Optimism stack based transactions in order to add `layer1GasFee` property to transaction meta. ([#4055](https://github.com/MetaMask/core/pull/4055))
+- Add `getLayer1GasFee` method to `TransactionController` to get the layer 1 gas fee for the given transaction params ([#4055](https://github.com/MetaMask/core/pull/4055))
+- Add `SimulationErrorCode` enum ([#4106](https://github.com/MetaMask/core/pull/4106))
+
+### Changed
+
+- **BREAKING:** Bump peer dependency `@metamask/gas-fee-controller` to `^15.0.0`
+- Update `addTransaction` to skip simulation if `requireApproval` is specified as `false` ([#4106](https://github.com/MetaMask/core/pull/4106))
+- Provide simulation error code in locally generated errors (under the `code` property) ([#4106](https://github.com/MetaMask/core/pull/4106))
+- Add dependency `@ethersproject/contracts` `^5.7.0` ([#4055](https://github.com/MetaMask/core/pull/4055))
+- Add dependency `@ethersproject/providers` `^5.7.0` ([#4055](https://github.com/MetaMask/core/pull/4055))
+- Bump dependency `@metamask/network-controller` to `^18.1.0`
+
+### Removed
+
+- **BREAKING**: Remove `isReverted` property from `SimulationError` type. ([#4106](https://github.com/MetaMask/core/pull/4106))
+
 ## [25.3.0]
 
 ### Added
@@ -727,7 +748,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@25.3.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@26.0.0...HEAD
+[26.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@25.3.0...@metamask/transaction-controller@26.0.0
 [25.3.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@25.2.1...@metamask/transaction-controller@25.3.0
 [25.2.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@25.2.0...@metamask/transaction-controller@25.2.1
 [25.2.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@25.1.0...@metamask/transaction-controller@25.2.0

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -17,12 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump peer dependency `@metamask/gas-fee-controller` to `^15.0.0`
+- **BREAKING:** Bump peer dependency `@metamask/gas-fee-controller` to `^15.0.0` ([#4121](https://github.com/MetaMask/core/pull/4121))
 - Update `addTransaction` to skip simulation if `requireApproval` is specified as `false` ([#4106](https://github.com/MetaMask/core/pull/4106))
 - Provide simulation error code in locally generated errors (under the `code` property) ([#4106](https://github.com/MetaMask/core/pull/4106))
 - Add dependency `@ethersproject/contracts` `^5.7.0` ([#4055](https://github.com/MetaMask/core/pull/4055))
 - Add dependency `@ethersproject/providers` `^5.7.0` ([#4055](https://github.com/MetaMask/core/pull/4055))
-- Bump dependency `@metamask/network-controller` to `^18.1.0`
+- Bump dependency `@metamask/network-controller` to `^18.1.0` ([#4121](https://github.com/MetaMask/core/pull/4121))
 
 ### Removed
 

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "25.3.0",
+  "version": "26.0.0",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",
@@ -51,9 +51,9 @@
     "@metamask/base-controller": "^5.0.1",
     "@metamask/controller-utils": "^9.0.2",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/gas-fee-controller": "^14.0.1",
+    "@metamask/gas-fee-controller": "^15.0.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
-    "@metamask/network-controller": "^18.0.1",
+    "@metamask/network-controller": "^18.1.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.2.6",
@@ -84,7 +84,7 @@
   "peerDependencies": {
     "@babel/runtime": "^7.23.9",
     "@metamask/approval-controller": "^6.0.0",
-    "@metamask/gas-fee-controller": "^14.0.0",
+    "@metamask/gas-fee-controller": "^15.0.0",
     "@metamask/network-controller": "^18.0.0"
   },
   "engines": {

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump peer dependency `@metamask/gas-fee-controller` to `^15.0.0`
-- **BREAKING:** Bump peer dependency `@metamask/transaction-controller` to `^26.0.0`
-- Bump dependency `@metamask/network-controller` to `^18.1.0`
+- **BREAKING:** Bump peer dependency `@metamask/gas-fee-controller` to `^15.0.0` ([#4121](https://github.com/MetaMask/core/pull/4121))
+- **BREAKING:** Bump peer dependency `@metamask/transaction-controller` to `^26.0.0` ([#4121](https://github.com/MetaMask/core/pull/4121))
+- Bump dependency `@metamask/network-controller` to `^18.1.0` ([#4121](https://github.com/MetaMask/core/pull/4121))
 
 ## [6.0.2]
 

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0]
+
+### Changed
+
+- **BREAKING:** Bump peer dependency `@metamask/gas-fee-controller` to `^15.0.0`
+- **BREAKING:** Bump peer dependency `@metamask/transaction-controller` to `^26.0.0`
+- Bump dependency `@metamask/network-controller` to `^18.1.0`
+
 ## [6.0.2]
 
 ### Fixed
@@ -92,7 +100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release ([#3749](https://github.com/MetaMask/core/pull/3749))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@6.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@7.0.0...HEAD
+[7.0.0]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@6.0.2...@metamask/user-operation-controller@7.0.0
 [6.0.2]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@6.0.1...@metamask/user-operation-controller@6.0.2
 [6.0.1]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@6.0.0...@metamask/user-operation-controller@6.0.1
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@5.0.0...@metamask/user-operation-controller@6.0.0

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/user-operation-controller",
-  "version": "6.0.2",
+  "version": "7.0.0",
   "description": "Creates user operations and manages their life cycle",
   "keywords": [
     "MetaMask",
@@ -46,12 +46,12 @@
     "@metamask/base-controller": "^5.0.1",
     "@metamask/controller-utils": "^9.0.2",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/gas-fee-controller": "^14.0.1",
+    "@metamask/gas-fee-controller": "^15.0.0",
     "@metamask/keyring-controller": "^14.0.1",
-    "@metamask/network-controller": "^18.0.1",
+    "@metamask/network-controller": "^18.1.0",
     "@metamask/polling-controller": "^6.0.1",
     "@metamask/rpc-errors": "^6.2.1",
-    "@metamask/transaction-controller": "^25.3.0",
+    "@metamask/transaction-controller": "^26.0.0",
     "@metamask/utils": "^8.3.0",
     "bn.js": "^5.2.1",
     "immer": "^9.0.6",
@@ -71,10 +71,10 @@
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^6.0.0",
-    "@metamask/gas-fee-controller": "^14.0.0",
+    "@metamask/gas-fee-controller": "^15.0.0",
     "@metamask/keyring-controller": "^14.0.0",
     "@metamask/network-controller": "^18.0.0",
-    "@metamask/transaction-controller": "^25.0.0"
+    "@metamask/transaction-controller": "^26.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,7 +1767,7 @@ __metadata:
     "@metamask/keyring-api": ^3.0.0
     "@metamask/keyring-controller": ^14.0.1
     "@metamask/metamask-eth-abis": ^3.1.1
-    "@metamask/network-controller": ^18.0.1
+    "@metamask/network-controller": ^18.1.0
     "@metamask/polling-controller": ^6.0.1
     "@metamask/preferences-controller": ^9.0.1
     "@metamask/rpc-errors": ^6.2.1
@@ -2032,7 +2032,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.1
     "@metamask/controller-utils": ^9.0.2
-    "@metamask/network-controller": ^18.0.1
+    "@metamask/network-controller": ^18.1.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -2322,7 +2322,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gas-fee-controller@^14.0.1, @metamask/gas-fee-controller@workspace:packages/gas-fee-controller":
+"@metamask/gas-fee-controller@^15.0.0, @metamask/gas-fee-controller@workspace:packages/gas-fee-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/gas-fee-controller@workspace:packages/gas-fee-controller"
   dependencies:
@@ -2331,7 +2331,7 @@ __metadata:
     "@metamask/controller-utils": ^9.0.2
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-unit": ^0.3.0
-    "@metamask/network-controller": ^18.0.1
+    "@metamask/network-controller": ^18.1.0
     "@metamask/polling-controller": ^6.0.1
     "@metamask/utils": ^8.3.0
     "@types/bn.js": ^5.1.5
@@ -2552,7 +2552,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/network-controller@^18.0.1, @metamask/network-controller@workspace:packages/network-controller":
+"@metamask/network-controller@^18.1.0, @metamask/network-controller@workspace:packages/network-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/network-controller@workspace:packages/network-controller"
   dependencies:
@@ -2745,7 +2745,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.1
     "@metamask/controller-utils": ^9.0.2
-    "@metamask/network-controller": ^18.0.1
+    "@metamask/network-controller": ^18.1.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/uuid": ^8.3.0
@@ -2822,9 +2822,9 @@ __metadata:
     "@metamask/base-controller": ^5.0.1
     "@metamask/controller-utils": ^9.0.2
     "@metamask/json-rpc-engine": ^8.0.1
-    "@metamask/network-controller": ^18.0.1
+    "@metamask/network-controller": ^18.1.0
     "@metamask/rpc-errors": ^6.2.1
-    "@metamask/selected-network-controller": ^10.0.1
+    "@metamask/selected-network-controller": ^11.0.0
     "@metamask/swappable-obj-proxy": ^2.2.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2840,7 +2840,7 @@ __metadata:
     typescript: ~4.9.5
   peerDependencies:
     "@metamask/network-controller": ^18.0.0
-    "@metamask/selected-network-controller": ^10.0.0
+    "@metamask/selected-network-controller": ^11.0.0
   languageName: unknown
   linkType: soft
 
@@ -2896,14 +2896,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/selected-network-controller@^10.0.1, @metamask/selected-network-controller@workspace:packages/selected-network-controller":
+"@metamask/selected-network-controller@^11.0.0, @metamask/selected-network-controller@workspace:packages/selected-network-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/selected-network-controller@workspace:packages/selected-network-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.1
     "@metamask/json-rpc-engine": ^8.0.1
-    "@metamask/network-controller": ^18.0.1
+    "@metamask/network-controller": ^18.1.0
     "@metamask/permission-controller": ^9.0.2
     "@metamask/swappable-obj-proxy": ^2.2.0
     "@metamask/utils": ^8.3.0
@@ -3126,7 +3126,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@^25.3.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
+"@metamask/transaction-controller@^26.0.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/transaction-controller@workspace:packages/transaction-controller"
   dependencies:
@@ -3143,9 +3143,9 @@ __metadata:
     "@metamask/controller-utils": ^9.0.2
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.3.0
-    "@metamask/gas-fee-controller": ^14.0.1
+    "@metamask/gas-fee-controller": ^15.0.0
     "@metamask/metamask-eth-abis": ^3.1.1
-    "@metamask/network-controller": ^18.0.1
+    "@metamask/network-controller": ^18.1.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
     "@types/bn.js": ^5.1.5
@@ -3170,7 +3170,7 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.23.9
     "@metamask/approval-controller": ^6.0.0
-    "@metamask/gas-fee-controller": ^14.0.0
+    "@metamask/gas-fee-controller": ^15.0.0
     "@metamask/network-controller": ^18.0.0
   languageName: unknown
   linkType: soft
@@ -3184,12 +3184,12 @@ __metadata:
     "@metamask/base-controller": ^5.0.1
     "@metamask/controller-utils": ^9.0.2
     "@metamask/eth-query": ^4.0.0
-    "@metamask/gas-fee-controller": ^14.0.1
+    "@metamask/gas-fee-controller": ^15.0.0
     "@metamask/keyring-controller": ^14.0.1
-    "@metamask/network-controller": ^18.0.1
+    "@metamask/network-controller": ^18.1.0
     "@metamask/polling-controller": ^6.0.1
     "@metamask/rpc-errors": ^6.2.1
-    "@metamask/transaction-controller": ^25.3.0
+    "@metamask/transaction-controller": ^26.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     bn.js: ^5.2.1
@@ -3205,10 +3205,10 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/approval-controller": ^6.0.0
-    "@metamask/gas-fee-controller": ^14.0.0
+    "@metamask/gas-fee-controller": ^15.0.0
     "@metamask/keyring-controller": ^14.0.0
     "@metamask/network-controller": ^18.0.0
-    "@metamask/transaction-controller": ^25.0.0
+    "@metamask/transaction-controller": ^26.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This release includes:

- `@metamask/announcement-controller` 6.0.1 -> 6.1.0
- `@metamask/gas-fee-controller` 14.0.1 -> 15.0.0
- `@metamask/network-controller` 18.0.1 -> 18.1.0
- `@metamask/queued-request-controller` 0.6.1 -> 0.7.0
- `@metamask/selected-network-controller` 10.0.1 -> 11.0.0
- `@metamask/transaction-controller` 25.3.0 -> 26.0.0
- `@metamask/user-operation-controller` 6.0.0 -> 7.0.0