### PR TITLE
Support wrapped ERC20 and legacy ERC721 in simulations

### DIFF
--- a/packages/transaction-controller/src/constants.ts
+++ b/packages/transaction-controller/src/constants.ts
@@ -118,3 +118,51 @@ export const GAS_BUFFER_CHAIN_OVERRIDES = {
   [CHAIN_IDS.OPTIMISM]: 1,
   [CHAIN_IDS.OPTIMISM_SEPOLIA]: 1,
 };
+
+/** Extract of the Wrapped ERC-20 ABI required for simulation. */
+export const ABI_SIMULATION_ERC20_WRAPPED = [
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'to', type: 'address' },
+      { indexed: false, name: 'wad', type: 'uint256' },
+    ],
+    name: 'Deposit',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'from', type: 'address' },
+      { indexed: false, name: 'wad', type: 'uint256' },
+    ],
+    name: 'Withdrawal',
+    type: 'event',
+  },
+];
+
+/** Extract of the legacy ERC-721 ABI required for simulation. */
+export const ABI_SIMULATION_ERC721_LEGACY = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: '_from',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: '_to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: '_tokenId',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+];

--- a/packages/transaction-controller/src/utils/simulation.test.ts
+++ b/packages/transaction-controller/src/utils/simulation.test.ts
@@ -701,7 +701,7 @@ describe('Simulation Utils', () => {
         });
       });
 
-      it('if response has reverted transaction', async () => {
+      it('if API response has transaction revert error', async () => {
         simulateTransactionsMock.mockResolvedValueOnce({
           transactions: [
             {
@@ -722,7 +722,7 @@ describe('Simulation Utils', () => {
         });
       });
 
-      it('if response has transaction error', async () => {
+      it('if API response has transaction error', async () => {
         simulateTransactionsMock.mockResolvedValueOnce({
           transactions: [
             {
@@ -738,6 +738,23 @@ describe('Simulation Utils', () => {
           error: {
             code: undefined,
             message: 'test 1 2 3',
+          },
+          tokenBalanceChanges: [],
+        });
+      });
+
+      it('if API response has insufficient gas error', async () => {
+        simulateTransactionsMock.mockRejectedValueOnce({
+          code: ERROR_CODE_MOCK,
+          message: 'test insufficient funds for gas test',
+        });
+
+        const simulationData = await getSimulationData(REQUEST_MOCK);
+
+        expect(simulationData).toStrictEqual({
+          error: {
+            code: SimulationErrorCode.Reverted,
+            message: new SimulationRevertedError().message,
           },
           tokenBalanceChanges: [],
         });

--- a/packages/transaction-controller/src/utils/simulation.test.ts
+++ b/packages/transaction-controller/src/utils/simulation.test.ts
@@ -6,7 +6,11 @@ import {
   SimulationRevertedError,
 } from '../errors';
 import { SimulationErrorCode, SimulationTokenStandard } from '../types';
-import { getSimulationData, type GetSimulationDataRequest } from './simulation';
+import {
+  getSimulationData,
+  SupportedToken,
+  type GetSimulationDataRequest,
+} from './simulation';
 import type { SimulationResponseLog } from './simulation-api';
 import {
   simulateTransactions,
@@ -18,11 +22,12 @@ jest.mock('./simulation-api');
 const USER_ADDRESS_MOCK = '0x123';
 const OTHER_ADDRESS_MOCK = '0x456';
 const CONTRACT_ADDRESS_MOCK = '0x789';
-const BALANCE_1_MOCK = '0x1';
-const BALANCE_2_MOCK = '0x3';
-const DIFFERENCE_MOCK = '0x2';
+const BALANCE_1_MOCK = '0x0';
+const BALANCE_2_MOCK = '0x1';
+const DIFFERENCE_MOCK = '0x1';
 const VALUE_MOCK = '0x4';
 const TOKEN_ID_MOCK = '0x5';
+const OTHER_TOKEN_ID_MOCK = '0x6';
 const ERROR_CODE_MOCK = 123;
 const ERROR_MESSAGE_MOCK = 'Test Error';
 
@@ -69,6 +74,12 @@ const PARSED_ERC1155_TRANSFER_BATCH_EVENT_MOCK = {
     [TOKEN_ID_MOCK],
     [{ toHexString: () => VALUE_MOCK }],
   ],
+} as unknown as LogDescription;
+
+const PARSED_WRAPPED_ERC20_DEPOSIT_EVENT_MOCK = {
+  name: 'Deposit',
+  contractAddress: CONTRACT_ADDRESS_MOCK,
+  args: [USER_ADDRESS_MOCK, { toHexString: () => VALUE_MOCK }],
 } as unknown as LogDescription;
 
 const RESPONSE_NESTED_LOGS_MOCK: SimulationResponse = {
@@ -220,19 +231,25 @@ function createBalanceOfResponse(
  * @param options.erc20 - The parsed event with the ERC-20 ABI.
  * @param options.erc721 - The parsed event with the ERC-721 ABI.
  * @param options.erc1155 - The parsed event with the ERC-1155 ABI.
+ * @param options.erc20Wrapped - The parsed event with the wrapped ERC-20 ABI.
+ * @param options.erc721Legacy - The parsed event with the legacy ERC-721 ABI.
  */
 function mockParseLog({
   erc20,
   erc721,
   erc1155,
+  erc20Wrapped,
+  erc721Legacy,
 }: {
   erc20?: LogDescription;
   erc721?: LogDescription;
   erc1155?: LogDescription;
+  erc20Wrapped?: LogDescription;
+  erc721Legacy?: LogDescription;
 }) {
   const parseLogMock = jest.spyOn(Interface.prototype, 'parseLog');
 
-  for (const value of [erc20, erc721, erc1155]) {
+  for (const value of [erc20, erc721, erc1155, erc20Wrapped, erc721Legacy]) {
     if (value) {
       parseLogMock.mockReturnValueOnce(value);
       return;
@@ -294,58 +311,98 @@ describe('Simulation Utils', () => {
 
     describe('returns token balance changes', () => {
       it.each([
-        [
-          'ERC-20 token',
-          PARSED_ERC20_TRANSFER_EVENT_MOCK,
-          SimulationTokenStandard.erc20,
-          undefined,
-        ],
-        [
-          'ERC-721 token',
-          PARSED_ERC721_TRANSFER_EVENT_MOCK,
-          SimulationTokenStandard.erc721,
-          TOKEN_ID_MOCK,
-        ],
-        [
-          'ERC-1155 token via single event',
-          PARSED_ERC1155_TRANSFER_SINGLE_EVENT_MOCK,
-          SimulationTokenStandard.erc1155,
-          TOKEN_ID_MOCK,
-        ],
-        [
-          'ERC-1155 token via batch event',
-          PARSED_ERC1155_TRANSFER_BATCH_EVENT_MOCK,
-          SimulationTokenStandard.erc1155,
-          TOKEN_ID_MOCK,
-        ],
-      ])('on %s', async (_title, parsedEvent, standard, id) => {
-        mockParseLog({ [standard]: parsedEvent });
+        {
+          title: 'ERC-20 token',
+          parsedEvent: PARSED_ERC20_TRANSFER_EVENT_MOCK,
+          tokenType: SupportedToken.ERC20,
+          tokenStandard: SimulationTokenStandard.erc20,
+          tokenId: undefined,
+          previousBalances: [BALANCE_1_MOCK],
+          newBalances: [BALANCE_2_MOCK],
+        },
+        {
+          title: 'ERC-721 token',
+          parsedEvent: PARSED_ERC721_TRANSFER_EVENT_MOCK,
+          tokenType: SupportedToken.ERC721,
+          tokenStandard: SimulationTokenStandard.erc721,
+          tokenId: TOKEN_ID_MOCK,
+          previousBalances: [OTHER_ADDRESS_MOCK],
+          newBalances: [USER_ADDRESS_MOCK],
+        },
+        {
+          title: 'ERC-1155 token via single event',
+          parsedEvent: PARSED_ERC1155_TRANSFER_SINGLE_EVENT_MOCK,
+          tokenType: SupportedToken.ERC1155,
+          tokenStandard: SimulationTokenStandard.erc1155,
+          tokenId: TOKEN_ID_MOCK,
+          previousBalances: [BALANCE_1_MOCK],
+          newBalances: [BALANCE_2_MOCK],
+        },
+        {
+          title: 'ERC-1155 token via batch event',
+          parsedEvent: PARSED_ERC1155_TRANSFER_BATCH_EVENT_MOCK,
+          tokenType: SupportedToken.ERC1155,
+          tokenStandard: SimulationTokenStandard.erc1155,
+          tokenId: TOKEN_ID_MOCK,
+          previousBalances: [BALANCE_1_MOCK],
+          newBalances: [BALANCE_2_MOCK],
+        },
+        {
+          title: 'wrapped ERC-20 token',
+          parsedEvent: PARSED_WRAPPED_ERC20_DEPOSIT_EVENT_MOCK,
+          tokenType: SupportedToken.ERC20_WRAPPED,
+          tokenStandard: SimulationTokenStandard.erc20,
+          tokenId: undefined,
+          previousBalances: [BALANCE_1_MOCK],
+          newBalances: [BALANCE_2_MOCK],
+        },
+        {
+          title: 'legacy ERC-721 token',
+          parsedEvent: PARSED_ERC721_TRANSFER_EVENT_MOCK,
+          tokenType: SupportedToken.ERC721_LEGACY,
+          tokenStandard: SimulationTokenStandard.erc721,
+          tokenId: TOKEN_ID_MOCK,
+          previousBalances: [OTHER_ADDRESS_MOCK],
+          newBalances: [USER_ADDRESS_MOCK],
+        },
+      ])(
+        'on $title',
+        async ({
+          parsedEvent,
+          tokenStandard,
+          tokenType,
+          tokenId,
+          previousBalances,
+          newBalances,
+        }) => {
+          mockParseLog({ [tokenType]: parsedEvent });
 
-        simulateTransactionsMock
-          .mockResolvedValueOnce(
-            createEventResponseMock([createLogMock(CONTRACT_ADDRESS_MOCK)]),
-          )
-          .mockResolvedValueOnce(
-            createBalanceOfResponse([BALANCE_1_MOCK], [BALANCE_2_MOCK]),
-          );
+          simulateTransactionsMock
+            .mockResolvedValueOnce(
+              createEventResponseMock([createLogMock(CONTRACT_ADDRESS_MOCK)]),
+            )
+            .mockResolvedValueOnce(
+              createBalanceOfResponse(previousBalances, newBalances),
+            );
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+          const simulationData = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
-          nativeBalanceChange: undefined,
-          tokenBalanceChanges: [
-            {
-              standard,
-              address: CONTRACT_ADDRESS_MOCK,
-              id,
-              previousBalance: BALANCE_1_MOCK,
-              newBalance: BALANCE_2_MOCK,
-              difference: DIFFERENCE_MOCK,
-              isDecrease: false,
-            },
-          ],
-        });
-      });
+          expect(simulationData).toStrictEqual({
+            nativeBalanceChange: undefined,
+            tokenBalanceChanges: [
+              {
+                standard: tokenStandard,
+                address: CONTRACT_ADDRESS_MOCK,
+                id: tokenId,
+                previousBalance: BALANCE_1_MOCK,
+                newBalance: BALANCE_2_MOCK,
+                difference: DIFFERENCE_MOCK,
+                isDecrease: false,
+              },
+            ],
+          });
+        },
+      );
 
       it('on multiple different tokens', async () => {
         mockParseLog({
@@ -370,8 +427,8 @@ describe('Simulation Utils', () => {
           )
           .mockResolvedValueOnce(
             createBalanceOfResponse(
-              ['0x1', '0x2', '0x3'],
-              ['0x6', '0x5', '0x4'],
+              ['0x1', OTHER_ADDRESS_MOCK, '0x3'],
+              ['0x6', USER_ADDRESS_MOCK, '0x4'],
             ),
           );
 
@@ -393,9 +450,9 @@ describe('Simulation Utils', () => {
               standard: SimulationTokenStandard.erc721,
               address: '0x8',
               id: TOKEN_ID_MOCK,
-              previousBalance: '0x2',
-              newBalance: '0x5',
-              difference: '0x3',
+              previousBalance: '0x0',
+              newBalance: '0x1',
+              difference: '0x1',
               isDecrease: false,
             },
             {
@@ -411,7 +468,7 @@ describe('Simulation Utils', () => {
         });
       });
 
-      it('with multiple events on same token', async () => {
+      it('with multiple events on same ERC-20 contract', async () => {
         mockParseLog({
           erc20: PARSED_ERC20_TRANSFER_EVENT_MOCK,
         });
@@ -444,6 +501,59 @@ describe('Simulation Utils', () => {
               newBalance: BALANCE_1_MOCK,
               difference: DIFFERENCE_MOCK,
               isDecrease: true,
+            },
+          ],
+        });
+      });
+
+      it('with multiple events on same ERC-721 contract', async () => {
+        mockParseLog({
+          erc721: PARSED_ERC721_TRANSFER_EVENT_MOCK,
+        });
+
+        mockParseLog({
+          erc721: {
+            ...PARSED_ERC721_TRANSFER_EVENT_MOCK,
+            args: [OTHER_ADDRESS_MOCK, USER_ADDRESS_MOCK, OTHER_TOKEN_ID_MOCK],
+          },
+        });
+
+        simulateTransactionsMock
+          .mockResolvedValueOnce(
+            createEventResponseMock([
+              createLogMock(CONTRACT_ADDRESS_MOCK),
+              createLogMock(CONTRACT_ADDRESS_MOCK),
+            ]),
+          )
+          .mockResolvedValueOnce(
+            createBalanceOfResponse(
+              [OTHER_ADDRESS_MOCK, OTHER_ADDRESS_MOCK],
+              [USER_ADDRESS_MOCK, USER_ADDRESS_MOCK],
+            ),
+          );
+
+        const simulationData = await getSimulationData(REQUEST_MOCK);
+
+        expect(simulationData).toStrictEqual({
+          nativeBalanceChange: undefined,
+          tokenBalanceChanges: [
+            {
+              standard: SimulationTokenStandard.erc721,
+              address: CONTRACT_ADDRESS_MOCK,
+              id: TOKEN_ID_MOCK,
+              previousBalance: BALANCE_1_MOCK,
+              newBalance: BALANCE_2_MOCK,
+              difference: DIFFERENCE_MOCK,
+              isDecrease: false,
+            },
+            {
+              standard: SimulationTokenStandard.erc721,
+              address: CONTRACT_ADDRESS_MOCK,
+              id: OTHER_TOKEN_ID_MOCK,
+              previousBalance: BALANCE_1_MOCK,
+              newBalance: BALANCE_2_MOCK,
+              difference: DIFFERENCE_MOCK,
+              isDecrease: false,
             },
           ],
         });

--- a/packages/transaction-controller/src/utils/simulation.ts
+++ b/packages/transaction-controller/src/utils/simulation.ts
@@ -5,6 +5,10 @@ import { abiERC20, abiERC721, abiERC1155 } from '@metamask/metamask-eth-abis';
 import { createModuleLogger, type Hex } from '@metamask/utils';
 
 import {
+  ABI_SIMULATION_ERC20_WRAPPED,
+  ABI_SIMULATION_ERC721_LEGACY,
+} from '../constants';
+import {
   SimulationError,
   SimulationInvalidResponseError,
   SimulationRevertedError,
@@ -23,11 +27,16 @@ import type {
   SimulationRequestTransaction,
   SimulationResponse,
   SimulationResponseCallTrace,
+  SimulationResponseTransaction,
 } from './simulation-api';
 
-const log = createModuleLogger(projectLogger, 'simulation');
-
-const REVERTED_ERRORS = ['execution reverted', 'insufficient funds for gas'];
+export enum SupportedToken {
+  ERC20 = 'erc20',
+  ERC721 = 'erc721',
+  ERC1155 = 'erc1155',
+  ERC20_WRAPPED = 'erc20Wrapped',
+  ERC721_LEGACY = 'erc721Legacy',
+}
 
 type ABI = Fragment[];
 
@@ -46,6 +55,41 @@ type ParsedEvent = {
   args: Record<string, Hex | Hex[]>;
   abi: ABI;
 };
+
+const log = createModuleLogger(projectLogger, 'simulation');
+
+const SUPPORTED_EVENTS = [
+  'Transfer',
+  'TransferSingle',
+  'TransferBatch',
+  'Deposit',
+  'Withdrawal',
+];
+
+const SUPPORTED_TOKENS = {
+  [SupportedToken.ERC20]: {
+    abi: abiERC20,
+    standard: SimulationTokenStandard.erc20,
+  },
+  [SupportedToken.ERC721]: {
+    abi: abiERC721,
+    standard: SimulationTokenStandard.erc721,
+  },
+  [SupportedToken.ERC1155]: {
+    abi: abiERC1155,
+    standard: SimulationTokenStandard.erc1155,
+  },
+  [SupportedToken.ERC20_WRAPPED]: {
+    abi: ABI_SIMULATION_ERC20_WRAPPED,
+    standard: SimulationTokenStandard.erc20,
+  },
+  [SupportedToken.ERC721_LEGACY]: {
+    abi: ABI_SIMULATION_ERC721_LEGACY,
+    standard: SimulationTokenStandard.erc721,
+  },
+};
+
+const REVERTED_ERRORS = ['execution reverted', 'insufficient funds for gas'];
 
 /**
  * Generate simulation data for a transaction.
@@ -157,18 +201,11 @@ function getEvents(response: SimulationResponse): ParsedEvent[] {
 
   log('Extracted logs', logs);
 
-  const erc20Interface = new Interface(abiERC20);
-  const erc721Interface = new Interface(abiERC721);
-  const erc1155Interface = new Interface(abiERC1155);
+  const interfaces = getContractInterfaces();
 
   return logs
     .map((currentLog) => {
-      const event = parseLog(
-        currentLog,
-        erc20Interface,
-        erc721Interface,
-        erc1155Interface,
-      );
+      const event = parseLog(currentLog, interfaces);
 
       if (!event) {
         log('Failed to parse log', currentLog);
@@ -266,12 +303,16 @@ async function getTokenBalanceChanges(
 
   return [...balanceTransactionsByToken.keys()]
     .map((token, index) => {
-      const previousBalance = normalizeReturnValue(
-        response.transactions[index].return,
+      const previousBalance = getValueFromBalanceTransaction(
+        request.from,
+        token,
+        response.transactions[index],
       );
 
-      const newBalance = normalizeReturnValue(
-        response.transactions[index + balanceTransactions.length + 1].return,
+      const newBalance = getValueFromBalanceTransaction(
+        request.from,
+        token,
+        response.transactions[index + balanceTransactions.length + 1],
       );
 
       const balanceChange = getSimulationBalanceChange(
@@ -303,35 +344,16 @@ function getTokenBalanceTransactions(
 ): Map<SimulationToken, SimulationRequestTransaction> {
   const tokenKeys = new Set();
 
-  return events.reduce((result, event) => {
-    if (
-      !['Transfer', 'TransferSingle', 'TransferBatch'].includes(event.name) ||
-      ![event.args.from, event.args.to].includes(request.from)
-    ) {
-      log('Ignoring event', event);
-      return result;
-    }
+  const userEvents = events.filter(
+    (event) =>
+      SUPPORTED_EVENTS.includes(event.name) &&
+      [event.args.from, event.args.to].includes(request.from),
+  );
 
-    // ERC-20 does not have a token ID so default to undefined.
-    let tokenIds: (Hex | undefined)[] = [undefined];
+  log('Filtered user events', userEvents);
 
-    if (event.tokenStandard === SimulationTokenStandard.erc721) {
-      tokenIds = [event.args.tokenId as Hex];
-    }
-
-    if (
-      event.tokenStandard === SimulationTokenStandard.erc1155 &&
-      event.name === 'TransferSingle'
-    ) {
-      tokenIds = [event.args.id as Hex];
-    }
-
-    if (
-      event.tokenStandard === SimulationTokenStandard.erc1155 &&
-      event.name === 'TransferBatch'
-    ) {
-      tokenIds = event.args.ids as Hex[];
-    }
+  return userEvents.reduce((result, event) => {
+    const tokenIds = getEventTokenIds(event);
 
     log('Extracted token ids', tokenIds);
 
@@ -354,19 +376,16 @@ function getTokenBalanceTransactions(
 
       tokenKeys.add(tokenKey);
 
-      const parameters = [request.from];
-
-      if (event.tokenStandard === SimulationTokenStandard.erc1155) {
-        parameters.push(tokenId as Hex);
-      }
+      const data = getBalanceTransactionData(
+        event.tokenStandard,
+        request.from,
+        tokenId,
+      );
 
       result.set(simulationToken, {
         from: request.from,
         to: event.contractAddress,
-        data: new Interface(event.abi).encodeFunctionData(
-          'balanceOf',
-          parameters,
-        ) as Hex,
+        data,
       });
     }
 
@@ -375,41 +394,104 @@ function getTokenBalanceTransactions(
 }
 
 /**
+ * Extract token IDs from a parsed event.
+ * @param event - The parsed event.
+ * @returns An array of token IDs.
+ */
+function getEventTokenIds(event: ParsedEvent): (Hex | undefined)[] {
+  if (event.tokenStandard === SimulationTokenStandard.erc721) {
+    return [event.args.tokenId as Hex];
+  }
+
+  if (
+    event.tokenStandard === SimulationTokenStandard.erc1155 &&
+    event.name === 'TransferSingle'
+  ) {
+    return [event.args.id as Hex];
+  }
+
+  if (
+    event.tokenStandard === SimulationTokenStandard.erc1155 &&
+    event.name === 'TransferBatch'
+  ) {
+    return event.args.ids as Hex[];
+  }
+
+  // ERC-20 does not have a token ID so default to undefined.
+  return [undefined];
+}
+
+/**
+ * Extract the value from a balance transaction response.
+ * @param from - The address to check the balance of.
+ * @param token - The token to check the balance of.
+ * @param response - The balance transaction response.
+ * @returns The value of the balance transaction.
+ */
+function getValueFromBalanceTransaction(
+  from: Hex,
+  token: SimulationToken,
+  response: SimulationResponseTransaction,
+): Hex {
+  const normalizedReturn = normalizeReturnValue(response.return);
+
+  if (token.standard === SimulationTokenStandard.erc721) {
+    return normalizedReturn === from ? '0x1' : '0x0';
+  }
+
+  return normalizedReturn;
+}
+
+/**
+ * Generate the balance transaction data for a token.
+ * @param tokenStandard - The token standard.
+ * @param from - The address to check the balance of.
+ * @param tokenId - The token ID to check the balance of.
+ * @returns The balance transaction data.
+ */
+function getBalanceTransactionData(
+  tokenStandard: SimulationTokenStandard,
+  from: Hex,
+  tokenId?: Hex,
+): Hex {
+  switch (tokenStandard) {
+    case SimulationTokenStandard.erc721:
+      return new Interface(abiERC721).encodeFunctionData('ownerOf', [
+        tokenId,
+      ]) as Hex;
+
+    case SimulationTokenStandard.erc1155:
+      return new Interface(abiERC1155).encodeFunctionData('balanceOf', [
+        from,
+        tokenId,
+      ]) as Hex;
+
+    default:
+      return new Interface(abiERC20).encodeFunctionData('balanceOf', [
+        from,
+      ]) as Hex;
+  }
+}
+
+/**
  * Parse a raw event log using known ABIs.
  * @param eventLog - The raw event log.
- * @param erc20 - The ERC-20 ABI interface.
- * @param erc721 - The ERC-721 ABI interface.
- * @param erc1155 - The ERC-1155 ABI interface.
+ * @param interfaces - The contract interfaces.
  * @returns The parsed event log or undefined if it could not be parsed.
  */
 function parseLog(
   eventLog: SimulationResponseLog,
-  erc20: Interface,
-  erc721: Interface,
-  erc1155: Interface,
+  interfaces: Map<SupportedToken, Interface>,
 ):
   | (LogDescription & { abi: ABI; standard: SimulationTokenStandard })
   | undefined {
-  const abisByStandard = [
-    {
-      abi: abiERC20,
-      contractInterface: erc20,
-      standard: SimulationTokenStandard.erc20,
-    },
-    {
-      abi: abiERC721,
-      contractInterface: erc721,
-      standard: SimulationTokenStandard.erc721,
-    },
-    {
-      abi: abiERC1155,
-      contractInterface: erc1155,
-      standard: SimulationTokenStandard.erc1155,
-    },
-  ];
+  const supportedTokens = Object.values(SupportedToken);
 
-  for (const { abi, contractInterface, standard } of abisByStandard) {
+  for (const token of supportedTokens) {
     try {
+      const contractInterface = interfaces.get(token) as Interface;
+      const { abi, standard } = SUPPORTED_TOKENS[token];
+
       return {
         ...contractInterface.parseLog(eventLog),
         abi,
@@ -477,4 +559,19 @@ function getSimulationBalanceChange(
  */
 function normalizeReturnValue(value: Hex): Hex {
   return toHex(hexToBN(value));
+}
+
+/**
+ * Get the contract interfaces for all supported tokens.
+ * @returns A map of supported tokens to their contract interfaces.
+ */
+function getContractInterfaces(): Map<SupportedToken, Interface> {
+  const supportedTokens = Object.values(SupportedToken);
+
+  return supportedTokens.reduce((acc, key) => {
+    const { abi } = SUPPORTED_TOKENS[key];
+    const contractInterface = new Interface(abi);
+    acc.set(key, contractInterface);
+    return acc;
+  }, new Map<SupportedToken, Interface>());
 }


### PR DESCRIPTION
## Explanation

Add simulation support for:

- Wrapped ERC-20 tokens, such as WETH.
- Legacy ERC-721 tokens where none of the `Transfer` event fields are indexed, such as CryptoKitties.

In addition, verify ERC-721 balances using the `ownerOf` method rather than `balanceOf` to ensure correct balances in the token balance changes.

## References

Fixes [#2311](https://github.com/MetaMask/MetaMask-planning/issues/2311) [#2312](https://github.com/MetaMask/MetaMask-planning/issues/2312)

## Changelog

### `@metamask/transaction-controller`

- **ADDED**: Include wrapped ERC20 and legacy ERC721 tokens in simulation balance changes.
- **CHANGED**: Verify ERC-721 balances using `ownerOf` method.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
