### PR TITLE
feat: add pause/resume to polling controller

### DIFF
--- a/packages/assets-controllers/src/AccountTrackerController.test.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.test.ts
@@ -535,7 +535,8 @@ describe('AccountTrackerController', () => {
 
     const refreshSpy = jest.spyOn(controller, 'refresh').mockResolvedValue();
 
-    controller.startPollingByNetworkClientId('networkClientId1');
+    const pollToken1 =
+      controller.startPollingByNetworkClientId('networkClientId1');
 
     await advanceTime({ clock, duration: 0 });
     expect(refreshSpy).toHaveBeenNthCalledWith(1, 'networkClientId1');
@@ -546,7 +547,7 @@ describe('AccountTrackerController', () => {
     expect(refreshSpy).toHaveBeenNthCalledWith(2, 'networkClientId1');
     expect(refreshSpy).toHaveBeenCalledTimes(2);
 
-    const pollToken =
+    const pollToken2 =
       controller.startPollingByNetworkClientId('networkClientId2');
 
     await advanceTime({ clock, duration: 0 });
@@ -557,13 +558,13 @@ describe('AccountTrackerController', () => {
     expect(refreshSpy).toHaveBeenNthCalledWith(5, 'networkClientId2');
     expect(refreshSpy).toHaveBeenCalledTimes(5);
 
-    controller.stopPollingByPollingToken(pollToken);
+    controller.stopPollingByPollingToken(pollToken2);
 
     await advanceTime({ clock, duration: 100 });
     expect(refreshSpy).toHaveBeenNthCalledWith(6, 'networkClientId1');
     expect(refreshSpy).toHaveBeenCalledTimes(6);
 
-    controller.stopAllPolling();
+    controller.stopPollingByPollingToken(pollToken1);
 
     await advanceTime({ clock, duration: 100 });
 

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -92,8 +92,6 @@ describe('CurrencyRateController', () => {
         },
       },
     });
-
-    controller.destroy();
   });
 
   it('should initialize with initial state', () => {
@@ -114,14 +112,12 @@ describe('CurrencyRateController', () => {
         },
       },
     });
-
-    controller.destroy();
   });
 
   it('should not poll before being started', async () => {
     const fetchExchangeRateStub = jest.fn();
     const messenger = getRestrictedMessenger();
-    const controller = new CurrencyRateController({
+    new CurrencyRateController({
       interval: 100,
       fetchExchangeRate: fetchExchangeRateStub,
       messenger,
@@ -130,8 +126,6 @@ describe('CurrencyRateController', () => {
     await advanceTime({ clock, duration: 200 });
 
     expect(fetchExchangeRateStub).not.toHaveBeenCalled();
-
-    controller.destroy();
   });
 
   it('should poll and update state in the right interval', async () => {
@@ -156,7 +150,7 @@ describe('CurrencyRateController', () => {
       messenger,
     });
 
-    controller.startPollingByNetworkClientId('mainnet');
+    const pollToken = controller.startPollingByNetworkClientId('mainnet');
     await advanceTime({ clock, duration: 0 });
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
     expect(controller.state.currencyRates).toStrictEqual({
@@ -181,7 +175,7 @@ describe('CurrencyRateController', () => {
       },
     });
 
-    controller.destroy();
+    controller.stopPollingByPollingToken(pollToken);
   });
 
   it('should not poll after being stopped', async () => {
@@ -193,11 +187,11 @@ describe('CurrencyRateController', () => {
       messenger,
     });
 
-    controller.startPollingByNetworkClientId('sepolia');
+    const pollToken = controller.startPollingByNetworkClientId('sepolia');
 
     await advanceTime({ clock, duration: 0 });
 
-    controller.stopAllPolling();
+    controller.stopPollingByPollingToken(pollToken);
 
     // called once upon initial start
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
@@ -205,8 +199,6 @@ describe('CurrencyRateController', () => {
     await advanceTime({ clock, duration: 150, stepSize: 50 });
 
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
-
-    controller.destroy();
   });
 
   it('should poll correctly after being started, stopped, and started again', async () => {
@@ -218,15 +210,15 @@ describe('CurrencyRateController', () => {
       fetchExchangeRate: fetchExchangeRateStub,
       messenger,
     });
-    controller.startPollingByNetworkClientId('sepolia');
+    const pollToken1 = controller.startPollingByNetworkClientId('sepolia');
     await advanceTime({ clock, duration: 0 });
 
-    controller.stopAllPolling();
+    controller.stopPollingByPollingToken(pollToken1);
 
     // called once upon initial start
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
 
-    controller.startPollingByNetworkClientId('sepolia');
+    const pollToken2 = controller.startPollingByNetworkClientId('sepolia');
     await advanceTime({ clock, duration: 0 });
 
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(2);
@@ -234,6 +226,7 @@ describe('CurrencyRateController', () => {
     await advanceTime({ clock, duration: 100 });
 
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(3);
+    controller.stopPollingByPollingToken(pollToken2);
   });
 
   it('should update exchange rate', async () => {
@@ -265,8 +258,6 @@ describe('CurrencyRateController', () => {
         usdConversionRate: 111,
       },
     });
-
-    controller.destroy();
   });
 
   it('should use the exchange rate for ETH when native currency is testnet ETH', async () => {
@@ -313,8 +304,6 @@ describe('CurrencyRateController', () => {
         usdConversionRate: 110,
       },
     });
-
-    controller.destroy();
   });
 
   it('should update current currency then clear and refetch rates', async () => {
@@ -373,8 +362,6 @@ describe('CurrencyRateController', () => {
         },
       },
     });
-
-    controller.destroy();
   });
 
   it('should add usd rate to state when includeUsdRate is configured true', async () => {
@@ -392,8 +379,6 @@ describe('CurrencyRateController', () => {
     expect(fetchExchangeRateStub.mock.calls).toMatchObject([
       ['xyz', 'ETH', true],
     ]);
-
-    controller.destroy();
   });
 
   it('should default to fetching exchange rate from crypto-compare', async () => {
@@ -421,8 +406,6 @@ describe('CurrencyRateController', () => {
         },
       },
     });
-
-    controller.destroy();
   });
 
   it('should throw unexpected errors', async () => {
@@ -444,8 +427,6 @@ describe('CurrencyRateController', () => {
     await expect(controller.updateExchangeRate('ETH')).rejects.toThrow(
       'this method has been deprecated',
     );
-
-    controller.destroy();
   });
 
   it('should catch expected errors', async () => {
@@ -476,7 +457,5 @@ describe('CurrencyRateController', () => {
         },
       },
     });
-
-    controller.destroy();
   });
 });

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -218,16 +218,6 @@ export class CurrencyRateController extends StaticIntervalPollingController<
   }
 
   /**
-   * Prepare to discard this controller.
-   *
-   * This stops any active polling.
-   */
-  override destroy() {
-    super.destroy();
-    this.stopAllPolling();
-  }
-
-  /**
    * Updates exchange rate for the current currency.
    *
    * @param networkClientId - The network client ID used to get a ticker value.

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -318,7 +318,7 @@ describe('NftDetectionController', () => {
           return Promise.resolve();
         });
 
-      controller.startPollingByNetworkClientId('mainnet', {
+      const pollToken = controller.startPollingByNetworkClientId('mainnet', {
         address: '0x1',
       });
 
@@ -355,6 +355,8 @@ describe('NftDetectionController', () => {
           },
         ],
       ]);
+
+      controller.stopPollingByPollingToken(pollToken);
     });
   });
 
@@ -896,6 +898,5 @@ async function withController<ReturnValue>(
     });
   } finally {
     controller.stop();
-    controller.stopAllPolling();
   }
 }

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -1734,15 +1734,18 @@ describe('TokenDetectionController', () => {
               return Promise.resolve();
             });
 
-          controller.startPollingByNetworkClientId('mainnet', {
-            address: '0x1',
-          });
-          controller.startPollingByNetworkClientId('sepolia', {
-            address: '0xdeadbeef',
-          });
-          controller.startPollingByNetworkClientId('goerli', {
-            address: '0x3',
-          });
+          const pollTokens = [
+            controller.startPollingByNetworkClientId('mainnet', {
+              address: '0x1',
+            }),
+            controller.startPollingByNetworkClientId('sepolia', {
+              address: '0xdeadbeef',
+            }),
+            controller.startPollingByNetworkClientId('goerli', {
+              address: '0x3',
+            }),
+          ];
+
           await advanceTime({ clock, duration: 0 });
 
           expect(spy.mock.calls).toMatchObject([
@@ -1760,6 +1763,8 @@ describe('TokenDetectionController', () => {
             [{ networkClientId: 'sepolia', selectedAddress: '0xdeadbeef' }],
             [{ networkClientId: 'goerli', selectedAddress: '0x3' }],
           ]);
+
+          pollTokens.forEach((pt) => controller.stopPollingByPollingToken(pt));
         },
       );
     });
@@ -2195,6 +2200,5 @@ async function withController<ReturnValue>(
     });
   } finally {
     controller.stop();
-    controller.stopAllPolling();
   }
 }

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -1451,7 +1451,7 @@ describe('TokenRatesController', () => {
             },
           );
 
-          controller.startPollingByNetworkClientId('mainnet');
+          const pollToken = controller.startPollingByNetworkClientId('mainnet');
           // flush promises and advance setTimeouts they enqueue 3 times
           // needed because fetch() doesn't resolve immediately, so any
           // downstream promises aren't flushed until the next advanceTime loop
@@ -1468,7 +1468,7 @@ describe('TokenRatesController', () => {
               },
             },
           );
-          controller.stopAllPolling();
+          controller.stopPollingByPollingToken(pollToken);
         });
 
         it('returns the an empty object when market does not exist for pair', async () => {
@@ -1517,7 +1517,7 @@ describe('TokenRatesController', () => {
             },
           );
 
-          controller.startPollingByNetworkClientId('mainnet');
+          const pollToken = controller.startPollingByNetworkClientId('mainnet');
           // flush promises and advance setTimeouts they enqueue 3 times
           // needed because fetch() doesn't resolve immediately, so any
           // downstream promises aren't flushed until the next advanceTime loop
@@ -1530,7 +1530,7 @@ describe('TokenRatesController', () => {
               },
             },
           );
-          controller.stopAllPolling();
+          controller.stopPollingByPollingToken(pollToken);
         });
       });
     });

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -247,7 +247,6 @@ export class TokenRatesController extends StaticIntervalPollingControllerV1<
       ) {
         this.update({ contractExchangeRates: {} });
         this.configure({ chainId, nativeCurrency: ticker });
-        await this.updateExchangeRates();
       }
     });
   }

--- a/packages/polling-controller/src/AbstractPollingController.ts
+++ b/packages/polling-controller/src/AbstractPollingController.ts
@@ -14,6 +14,11 @@ export const getKey = (
   options: Json,
 ): PollingTokenSetId => `${networkClientId}:${stringify(options)}`;
 
+export const parseKey = (key: PollingTokenSetId): [NetworkClientId, Json] => {
+  const [networkClientId, options] = key.split(':');
+  return [networkClientId, JSON.parse(options)];
+};
+
 /**
  * AbstractPollingControllerBaseMixin
  *
@@ -62,14 +67,6 @@ export function AbstractPollingControllerBaseMixin<TBase extends Constructor>(
       }
 
       return pollToken;
-    }
-
-    stopAllPolling() {
-      this.#pollingTokenSets.forEach((tokenSet, _key) => {
-        tokenSet.forEach((token) => {
-          this.stopPollingByPollingToken(token);
-        });
-      });
     }
 
     stopPollingByPollingToken(pollingToken: string) {

--- a/packages/polling-controller/src/BlockTrackerPollingController.test.ts
+++ b/packages/polling-controller/src/BlockTrackerPollingController.test.ts
@@ -94,8 +94,8 @@ describe('BlockTrackerPollingController', () => {
 
   describe('startPollingByNetworkClientId', () => {
     it('should call _executePoll on "latest" block events emitted by blockTrackers for each networkClientId passed to startPollingByNetworkClientId', async () => {
-      controller.startPollingByNetworkClientId('mainnet');
-      controller.startPollingByNetworkClientId('goerli');
+      const pollingToken1 = controller.startPollingByNetworkClientId('mainnet');
+      const pollingToken2 = controller.startPollingByNetworkClientId('goerli');
       // await advanceTime({ clock, duration: 5 });
       mainnetBlockTracker.emitBlockEvent();
 
@@ -137,7 +137,7 @@ describe('BlockTrackerPollingController', () => {
         2,
       );
 
-      controller.startPollingByNetworkClientId('sepolia');
+      const pollingToken3 = controller.startPollingByNetworkClientId('sepolia');
 
       mainnetBlockTracker.emitBlockEvent();
       sepoliaBlockTracker.emitBlockEvent();
@@ -155,7 +155,9 @@ describe('BlockTrackerPollingController', () => {
         2,
       );
 
-      controller.stopAllPolling();
+      controller.stopPollingByPollingToken(pollingToken1);
+      controller.stopPollingByPollingToken(pollingToken2);
+      controller.stopPollingByPollingToken(pollingToken3);
     });
   });
 
@@ -204,7 +206,7 @@ describe('BlockTrackerPollingController', () => {
       ]);
     });
 
-    it('should should stop polling for one networkClientId when all polling tokens for that networkClientId are deleted, without stopping polling for networkClientIds with active pollingTokens', async () => {
+    it('should stop polling for one networkClientId when all polling tokens for that networkClientId are deleted, without stopping polling for networkClientIds with active pollingTokens', async () => {
       const pollingToken1 = controller.startPollingByNetworkClientId('mainnet');
 
       mainnetBlockTracker.emitBlockEvent();
@@ -220,7 +222,7 @@ describe('BlockTrackerPollingController', () => {
         ['mainnet', {}, 2],
       ]);
 
-      controller.startPollingByNetworkClientId('goerli');
+      const pollingToken3 = controller.startPollingByNetworkClientId('goerli');
 
       mainnetBlockTracker.emitBlockEvent();
 
@@ -263,7 +265,7 @@ describe('BlockTrackerPollingController', () => {
         ['goerli', {}, 3],
       ]);
 
-      controller.stopAllPolling();
+      controller.stopPollingByPollingToken(pollingToken3);
     });
   });
 

--- a/packages/polling-controller/src/types.ts
+++ b/packages/polling-controller/src/types.ts
@@ -9,8 +9,6 @@ export type IPollingController = {
     options: Json,
   ): string;
 
-  stopAllPolling(): void;
-
   stopPollingByPollingToken(pollingToken: string): void;
 
   onPollingCompleteByNetworkClientId(


### PR DESCRIPTION
## Explanation

This adds `pause()` and `resume()` to the `StaticIntervalPollingController`, and deprecates `stopAllPolling()`.

See this PR for more context and extension changes:
https://github.com/MetaMask/metamask-extension/pull/23795

Some controllers should pause polling while MM is closed, and resume polling when MM opens again.   We don't want to use the existing start/stop functions, because they would reset the polling interval and perform an initial poll on start.  Polling on each MM open could be too often, if you're quickly + repeadedly opening/closing MM.

We'd rather consult the last poll time so that polling can continue where it left off, maintaining the interval across opens/closes.  e.g after opening MM with a 3 minute polling interval:

- It's been 12 hours since the last poll, so poll now.
- It's been 1 minute since the last poll, so schedule the next poll in 2 minutes.

`pause()` pauses polling for all tokens started with `startPollingByNetworkClientId`.  While paused, new polls can be started (but won't execute) and existing tokens can be stopped.  `resume()` resumes polling for all tokens.

`stopAllPolling()` was removed due to feedback [here](https://consensys.slack.com/archives/C01V1L10W2E/p1711389756740649?thread_ts=1711051357.668119&cid=C01V1L10W2E).  This also forces callers to store their polling tokens if they want to stop.

I removed the old polling mechanism from `TokenRatesController`.
## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

TODO after concept ack from reviewers

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
