### PR TITLE
Fix: Keep proxies in sync across "Select networks for each site" toggling on/off

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -92,12 +92,13 @@ export type SelectedNetworkControllerMessenger = RestrictedControllerMessenger<
   AllowedEvents['type']
 >;
 
-export type GetUseRequestQueue = () => boolean;
-
 export type SelectedNetworkControllerOptions = {
   state?: SelectedNetworkControllerState;
   messenger: SelectedNetworkControllerMessenger;
-  getUseRequestQueue: GetUseRequestQueue;
+  useRequestQueuePreference: boolean;
+  onPreferencesStateChange: (
+    listener: (preferencesState: { useRequestQueue: boolean }) => void,
+  ) => void;
   domainProxyMap: Map<Domain, NetworkProxy>;
 };
 
@@ -116,7 +117,7 @@ export class SelectedNetworkController extends BaseController<
 > {
   #domainProxyMap: Map<Domain, NetworkProxy>;
 
-  #getUseRequestQueue: GetUseRequestQueue;
+  #useRequestQueuePreference: boolean;
 
   /**
    * Construct a SelectedNetworkController controller.
@@ -124,13 +125,15 @@ export class SelectedNetworkController extends BaseController<
    * @param options - The controller options.
    * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
    * @param options.state - The controllers initial state.
-   * @param options.getUseRequestQueue - feature flag for perDappNetwork & request queueing features
+   * @param options.useRequestQueuePreference - A boolean indicating whether to use the request queue preference.
+   * @param options.onPreferencesStateChange - A callback that is called when the preference state changes.
    * @param options.domainProxyMap - A map for storing domain-specific proxies that are held in memory only during use.
    */
   constructor({
     messenger,
     state = getDefaultState(),
-    getUseRequestQueue,
+    useRequestQueuePreference,
+    onPreferencesStateChange,
     domainProxyMap,
   }: SelectedNetworkControllerOptions) {
     super({
@@ -139,7 +142,7 @@ export class SelectedNetworkController extends BaseController<
       messenger,
       state,
     });
-    this.#getUseRequestQueue = getUseRequestQueue;
+    this.#useRequestQueuePreference = useRequestQueuePreference;
     this.#domainProxyMap = domainProxyMap;
     this.#registerMessageHandlers();
 
@@ -201,6 +204,32 @@ export class SelectedNetworkController extends BaseController<
         });
       },
     );
+
+    onPreferencesStateChange(({ useRequestQueue }) => {
+      if (this.#useRequestQueuePreference !== useRequestQueue) {
+        if (!useRequestQueue) {
+          Object.keys(this.state.domains).forEach((domain) => {
+            this.#unsetNetworkClientIdForDomain(domain);
+          });
+        } else {
+          this.#domainProxyMap.forEach((_: NetworkProxy, domain: string) => {
+            const { selectedNetworkClientId } = this.messagingSystem.call(
+              'NetworkController:getState',
+            );
+            // can't use public setNetworkClientIdForDomain because it will throw an error
+            // rather than simply skip if the domain doesn't have permissions which can happen
+            // in this case since proxies are added for each site the user visits
+            if (this.#domainHasPermissions(domain)) {
+              this.#setNetworkClientIdForDomain(
+                domain,
+                selectedNetworkClientId,
+              );
+            }
+          });
+        }
+        this.#useRequestQueuePreference = useRequestQueue;
+      }
+    });
   }
 
   #registerMessageHandlers(): void {
@@ -284,7 +313,7 @@ export class SelectedNetworkController extends BaseController<
   getNetworkClientIdForDomain(domain: Domain): NetworkClientId {
     const { selectedNetworkClientId: metamaskSelectedNetworkClientId } =
       this.messagingSystem.call('NetworkController:getState');
-    if (!this.#getUseRequestQueue()) {
+    if (!this.#useRequestQueuePreference) {
       return metamaskSelectedNetworkClientId;
     }
     return this.state.domains[domain] ?? metamaskSelectedNetworkClientId;
@@ -297,11 +326,11 @@ export class SelectedNetworkController extends BaseController<
    * @returns The proxy and block tracker proxies.
    */
   getProviderAndBlockTracker(domain: Domain): NetworkProxy {
-    const networkClientId = this.state.domains[domain];
+    const networkClientId = this.getNetworkClientIdForDomain(domain);
     let networkProxy = this.#domainProxyMap.get(domain);
     if (networkProxy === undefined) {
       let networkClient;
-      if (networkClientId === undefined) {
+      if (networkClientId === undefined || !this.#useRequestQueuePreference) {
         networkClient = this.messagingSystem.call(
           'NetworkController:getSelectedNetworkClient',
         );
@@ -322,7 +351,6 @@ export class SelectedNetworkController extends BaseController<
       };
       this.#domainProxyMap.set(domain, networkProxy);
     }
-
     return networkProxy;
   }
 }

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -725,7 +725,7 @@ describe('SelectedNetworkController', () => {
       });
     });
     describe('when toggled from on to off', () => {
-      it('loops through domains in the domainsProxyMap and sets the target of the existing proxies to the (itself proxied) networkClient for the globally selectedNetworkClient', () => {
+      it('sets the target of the existing proxies to the proxied globally selected networkClient', () => {
         const domainProxyMap = new Map<Domain, NetworkProxy>([
           [
             'example.com',

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -687,7 +687,7 @@ describe('SelectedNetworkController', () => {
         });
       });
       describe('when domains do not have permissions', () => {
-        it('does not set the target of the existing proxy to the networkClient for the globally selectedNetworkClientId', () => {
+        it('does not change the target of the existing proxy', () => {
           const domainProxyMap = new Map<Domain, NetworkProxy>([
             [
               'example.com',

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -637,7 +637,7 @@ describe('SelectedNetworkController', () => {
     });
     describe('when toggled from off to on', () => {
       describe('when domains have permissions', () => {
-        it('loops through domains in the domainsProxyMap and sets the target of the existing proxies to an independent networkClient for the globally selected networkClientId', () => {
+        it('sets the target of the existing proxies to the non-proxied networkClient for the globally selected networkClientId', () => {
           const domainProxyMap = new Map<Domain, NetworkProxy>([
             [
               'example.com',


### PR DESCRIPTION
## Explanation

This PR fixes a bug where the proxies used to manage per dapp selected network connections do not stay in sync when the user toggles on or off the "Select networks for each site" preference (which turns request queueing on and off):
<img width="367" alt="Screenshot 2024-04-12 at 10 54 52 AM" src="https://github.com/MetaMask/core/assets/34557516/31f6acef-da3e-4ff4-b402-efdde1c6c7bb">

This PR fixes this bug by subscribing to `PreferenceController` changes and, when the "Select networks for each site" toggle is flipped repointing the proxy from the (nested) globally selected network proxy to its own independently managed proxy, and when flipped off repoint the proxy to the globally selected network proxy.

To test: pull into [this extension PR](https://github.com/MetaMask/metamask-extension/compare/ad/fix/queue-toggle-proxies?expand=1) -> you'll need to link to a local build of selected-network-controller with these commits.

## Changelog

### `@metamask/selected-network-controller`

- **ADD**:  **BREAKING:** A parameter `useRequestQueuePreference` which should point to the current preferences state for useRequestQueue is now required by the constructor
- **ADD**: An `onPreferencesStateChange` argument that should subscribe to `PreferencesController` state changes and call a callback with the updated state is now a required parameter in the constructor options object.
- **REMOVED** - The `getUseRequestQueue` parameter is no longer accepted by the constructor.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
