### PR TITLE
fix: token detection during account change

### DIFF
--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -286,10 +286,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
         this.#selectedAddress = newSelectedAddress;
         this.#isDetectionEnabledFromPreferences = useTokenDetection;
 
-        if (
-          useTokenDetection &&
-          (isSelectedAddressChanged || isDetectionChangedFromPreferences)
-        ) {
+        if (isSelectedAddressChanged || isDetectionChangedFromPreferences) {
           await this.#restartTokenDetection({
             selectedAddress: this.#selectedAddress,
           });
@@ -302,10 +299,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<
       async ({ address: newSelectedAddress }) => {
         const isSelectedAddressChanged =
           this.#selectedAddress !== newSelectedAddress;
-        if (
-          isSelectedAddressChanged &&
-          this.#isDetectionEnabledFromPreferences
-        ) {
+        if (isSelectedAddressChanged) {
           this.#selectedAddress = newSelectedAddress;
           await this.#restartTokenDetection({
             selectedAddress: this.#selectedAddress,


### PR DESCRIPTION
## Explanation

During account change, the token detection trigger was guarded by the `useTokenDetection` setting. But on mainnet, detection should run against the static token list even if the setting is disabled. So remove the guard.

## References

https://github.com/MetaMask/metamask-extension/pull/23798

## Changelog

### `@metamask/assets-controllers`

- **FIXED**: Token detection during account change 

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
