### PR TITLE
fix: fix getting nft tokenURI

### DIFF
--- a/packages/assets-controllers/src/Standards/NftStandards/ERC721/ERC721Standard.ts
+++ b/packages/assets-controllers/src/Standards/NftStandards/ERC721/ERC721Standard.ts
@@ -91,7 +91,10 @@ export class ERC721Standard {
       address,
     );
     if (!supportsMetadata) {
-      throw new Error('Contract does not support ERC721 metadata interface.');
+      // Do not throw error here, supporting Metadata interface is optional even though majority of ERC721 nfts do support it.
+      // This change is made because of instances of NFTs that are ERC404( mixed ERC20 / ERC721 implementation).
+      // As of today, ERC404 is unofficial but some people use it, the contract does not support Metadata interface, but it has the tokenURI() fct.
+      console.error('Contract does not support ERC721 metadata interface.');
     }
     return contract.tokenURI(tokenId);
   };


### PR DESCRIPTION
## Explanation

User has reached out because when they import their NFT they are not able to see it.
The smart contract is deployed on linea-mainnet. It is a ERC404 contract (mixed implementation of ERC721/ERC20).
The contract does not support Metadata interface but it has the function tokenURI().

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-assets-controllers`

- **Fixed**: Instead of throwing error inside getTokenURI fct when the contract does not support Metadata interface, i am only logging the error.


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
