### PR TITLE
Zb/queue flush event

### DIFF
--- a/packages/queued-request-controller/src/QueuedRequestController.test.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.test.ts
@@ -10,6 +10,7 @@ import { cloneDeep } from 'lodash';
 
 import type {
   AllowedActions,
+  AllowedEvents,
   QueuedRequestControllerActions,
   QueuedRequestControllerEvents,
   QueuedRequestControllerMessenger,
@@ -801,6 +802,85 @@ describe('QueuedRequestController', () => {
         expect(request3).toHaveBeenCalled();
       });
     });
+
+    it('rejects requests for an origin when the SelectedNetworkController "domains" state for that origin has changed, but preserves requests for other origins', async () => {
+      const { messenger } = buildControllerMessenger();
+
+      const options: QueuedRequestControllerOptions = {
+        messenger: buildQueuedRequestControllerMessenger(messenger),
+      };
+
+      const controller = new QueuedRequestController(options);
+
+      const request1 = jest.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        messenger.publish(
+          'SelectedNetworkController:stateChange',
+          { domains: {} },
+          [
+            {
+              op: 'replace',
+              path: ['domains', 'https://abc.123'],
+            },
+            {
+              op: 'add',
+              path: ['domains', 'https://abc.123'],
+            },
+          ],
+        );
+      });
+
+      const request2 = jest.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      const request3 = jest.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Enqueue the requests
+      const promise1 = controller.enqueueRequest(
+        {
+          ...buildRequest(),
+          method: 'wallet_switchEthereumChain',
+          origin: 'https://abc.123',
+        },
+        request1,
+      );
+      const promise2 = controller.enqueueRequest(
+        {
+          ...buildRequest(),
+          method: 'eth_sendTransaction',
+          origin: 'https://foo.bar',
+        },
+        request2,
+      );
+      const promise3 = controller.enqueueRequest(
+        {
+          ...buildRequest(),
+          method: 'eth_sendTransaction',
+          origin: 'https://abc.123',
+        },
+        request3,
+      );
+
+      expect(
+        await Promise.allSettled([promise1, promise2, promise3]),
+      ).toStrictEqual([
+        { status: 'fulfilled', value: undefined },
+        { status: 'fulfilled', value: undefined },
+        {
+          status: 'rejected',
+          reason: new Error(
+            'The request has been rejected due to a change in selected network. Please verify the selected network and retry the request.',
+          ),
+        },
+      ]);
+      expect(request1).toHaveBeenCalled();
+      expect(request2).toHaveBeenCalled();
+      expect(request3).not.toHaveBeenCalled();
+    });
   });
 });
 
@@ -828,7 +908,7 @@ function buildControllerMessenger({
 } = {}): {
   messenger: ControllerMessenger<
     QueuedRequestControllerActions | AllowedActions,
-    QueuedRequestControllerEvents
+    QueuedRequestControllerEvents | AllowedEvents
   >;
   mockNetworkControllerGetState: jest.Mocked<
     NetworkControllerGetStateAction['handler']
@@ -842,7 +922,7 @@ function buildControllerMessenger({
 } {
   const messenger = new ControllerMessenger<
     QueuedRequestControllerActions | AllowedActions,
-    QueuedRequestControllerEvents
+    QueuedRequestControllerEvents | AllowedEvents
   >();
 
   const mockNetworkControllerGetState =
@@ -891,7 +971,7 @@ function buildQueuedRequestControllerMessenger(
       'NetworkController:setActiveNetwork',
       'SelectedNetworkController:getNetworkClientIdForDomain',
     ],
-    allowedEvents: [],
+    allowedEvents: ['SelectedNetworkController:stateChange'],
   });
 }
 

--- a/packages/queued-request-controller/src/QueuedRequestController.test.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.test.ts
@@ -808,6 +808,7 @@ describe('QueuedRequestController', () => {
 
       const options: QueuedRequestControllerOptions = {
         messenger: buildQueuedRequestControllerMessenger(messenger),
+        methodsRequiringNetworkSwitch: ['eth_sendTransaction'],
       };
 
       const controller = new QueuedRequestController(options);


### PR DESCRIPTION
## Explanation

This PR is a follow up to [this](https://github.com/MetaMask/core/pull/4064/files) - where instead of calling the flush method directly after successfully handling a request, we instead subscribe to SelectedNetworkController state changes and flush the queue for the domain in question when the network changes.

One potential issue that may arise is relating to a possible race condition. The question is when will the subscriptions fire - will they happen before processing the next request starts? It's hard to say for certain.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/request-queue-controller`

- **ADDED**: A method for flushing or clearing the queue of items for a particular domain
- **FIXED**: calling `wallet_switchEthereumChain` will clear all queued transactions from the domain, across all queued 'batches'

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
