### PR TITLE
Fix layer 1 gas fee polling

### DIFF
--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.1,
-      functions: 98.56,
-      lines: 99.03,
-      statements: 99.04,
+      branches: 93.92,
+      functions: 98.61,
+      lines: 98.96,
+      statements: 98.97,
     },
   },
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -98,7 +98,6 @@ jest.mock('./utils/gas-fees');
 jest.mock('./utils/swaps');
 jest.mock('./utils/layer1-gas-fee-flow');
 jest.mock('./utils/simulation');
-
 jest.mock('uuid');
 
 // TODO: Replace `any` with type
@@ -477,6 +476,9 @@ describe('TransactionController', () => {
   const lineaGasFeeFlowClassMock = jest.mocked(LineaGasFeeFlow);
   const gasFeePollerClassMock = jest.mocked(GasFeePoller);
   const getSimulationDataMock = jest.mocked(getSimulationData);
+  const getTransactionLayer1GasFeeMock = jest.mocked(
+    getTransactionLayer1GasFee,
+  );
 
   let mockEthQuery: EthQuery;
   let getNonceLockSpy: jest.Mock;
@@ -5659,30 +5661,22 @@ describe('TransactionController', () => {
   });
 
   describe('getLayer1GasFee', () => {
-    it('calls getLayer1GasFee with the correct parameters', async () => {
+    it('calls getTransactionLayer1GasFee with the correct parameters', async () => {
       const chainIdMock = '0x1';
       const networkClientIdMock = 'mainnet';
-      const transactionParamsMock = {
-        from: ACCOUNT_MOCK,
-        to: ACCOUNT_2_MOCK,
-        gas: '0x0',
-        gasPrice: '0x50fd51da',
-        value: '0x0',
-      };
       const layer1GasFeeMock = '0x12356';
-      (getTransactionLayer1GasFee as jest.Mock).mockResolvedValueOnce(
-        layer1GasFeeMock,
-      );
+
+      getTransactionLayer1GasFeeMock.mockResolvedValueOnce(layer1GasFeeMock);
 
       const { controller } = setupController();
 
-      expect(
-        await controller.getLayer1GasFee(
-          chainIdMock,
-          networkClientIdMock,
-          transactionParamsMock,
-        ),
-      ).toBe(layer1GasFeeMock);
+      const result = await controller.getLayer1GasFee({
+        transactionParams: TRANSACTION_META_MOCK.txParams,
+        chainId: chainIdMock,
+        networkClientId: networkClientIdMock,
+      });
+
+      expect(result).toBe(layer1GasFeeMock);
       expect(getTransactionLayer1GasFee).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -4449,7 +4449,7 @@ describe('TransactionController', () => {
 
       expect(signSpy).toHaveBeenCalledTimes(1);
 
-      expect(updateTransactionSpy).toHaveBeenCalledTimes(3);
+      expect(updateTransactionSpy).toHaveBeenCalledTimes(2);
       expect(updateTransactionSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           txParams: expect.objectContaining(paramsMock),
@@ -4493,7 +4493,7 @@ describe('TransactionController', () => {
       await wait(0);
 
       expect(signSpy).toHaveBeenCalledTimes(1);
-      expect(updateTransactionSpy).toHaveBeenCalledTimes(2);
+      expect(updateTransactionSpy).toHaveBeenCalledTimes(1);
     });
 
     it('adds a transaction, signs and skips publish the transaction', async () => {
@@ -4519,7 +4519,7 @@ describe('TransactionController', () => {
 
       expect(signSpy).toHaveBeenCalledTimes(1);
 
-      expect(updateTransactionSpy).toHaveBeenCalledTimes(3);
+      expect(updateTransactionSpy).toHaveBeenCalledTimes(2);
       expect(updateTransactionSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           txParams: expect.objectContaining(paramsMock),

--- a/packages/transaction-controller/src/helpers/GasFeePoller.ts
+++ b/packages/transaction-controller/src/helpers/GasFeePoller.ts
@@ -14,7 +14,7 @@ import type {
 } from '../types';
 import { TransactionStatus, type TransactionMeta } from '../types';
 import { getGasFeeFlow } from '../utils/gas-flow';
-import { updateTransactionLayer1GasFee } from '../utils/layer1-gas-fee-flow';
+import { getTransactionLayer1GasFee } from '../utils/layer1-gas-fee-flow';
 
 const log = createModuleLogger(projectLogger, 'gas-fee-poller');
 
@@ -110,36 +110,58 @@ export class GasFeePoller {
   }
 
   async #onTimeout() {
-    await this.#updateTransactionGasFeeEstimates();
+    await this.#updateUnapprovedTransactions();
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.#timeout = setTimeout(() => this.#onTimeout(), INTERVAL_MILLISECONDS);
   }
 
-  async #updateTransactionGasFeeEstimates() {
+  async #updateUnapprovedTransactions() {
     const unapprovedTransactions = this.#getUnapprovedTransactions();
 
-    log('Found unapproved transactions', {
-      count: unapprovedTransactions.length,
-    });
+    if (unapprovedTransactions.length) {
+      log('Found unapproved transactions', unapprovedTransactions.length);
+    }
 
     await Promise.all(
-      unapprovedTransactions.flatMap((tx) => [
-        this.#updateTransactionSuggestedFees(tx),
-        this.#updateTransactionLayer1GasFee(tx),
-      ]),
+      unapprovedTransactions.flatMap((tx) =>
+        this.#updateUnapprovedTransaction(tx),
+      ),
     );
   }
 
-  async #updateTransactionSuggestedFees(transactionMeta: TransactionMeta) {
+  async #updateUnapprovedTransaction(transactionMeta: TransactionMeta) {
+    const { id } = transactionMeta;
+
+    const [gasFeeEstimatesResponse, layer1GasFee] = await Promise.all([
+      this.#updateTransactionGasFeeEstimates(transactionMeta),
+      this.#updateTransactionLayer1GasFee(transactionMeta),
+    ]);
+
+    if (!gasFeeEstimatesResponse && !layer1GasFee) {
+      return;
+    }
+
+    this.hub.emit('transaction-updated', {
+      transactionId: id,
+      gasFeeEstimates: gasFeeEstimatesResponse?.gasFeeEstimates,
+      gasFeeEstimatesLoaded: gasFeeEstimatesResponse?.gasFeeEstimatesLoaded,
+      layer1GasFee,
+    });
+  }
+
+  async #updateTransactionGasFeeEstimates(
+    transactionMeta: TransactionMeta,
+  ): Promise<
+    | { gasFeeEstimates?: GasFeeEstimates; gasFeeEstimatesLoaded: boolean }
+    | undefined
+  > {
     const { chainId, networkClientId } = transactionMeta;
 
     const ethQuery = new EthQuery(this.#getProvider(chainId, networkClientId));
     const gasFeeFlow = getGasFeeFlow(transactionMeta, this.#gasFeeFlows);
 
-    if (!gasFeeFlow) {
-      log('No gas fee flow found', transactionMeta.id);
-    } else {
+    if (gasFeeFlow) {
       log(
         'Found gas fee flow',
         gasFeeFlow.constructor.name,
@@ -165,38 +187,34 @@ export class GasFeePoller {
     }
 
     if (!gasFeeEstimates && transactionMeta.gasFeeEstimatesLoaded) {
-      return;
+      return undefined;
     }
 
-    const updatedTransactionMeta: TransactionMeta = {
-      ...transactionMeta,
+    log('Updated gas fee estimates', {
       gasFeeEstimates,
-      gasFeeEstimatesLoaded: true,
-    };
-
-    this.hub.emit('transaction-updated', updatedTransactionMeta);
-
-    log('Updated suggested gas fees', {
-      gasFeeEstimates: updatedTransactionMeta.gasFeeEstimates,
-      transaction: updatedTransactionMeta.id,
+      transaction: transactionMeta.id,
     });
+
+    return { gasFeeEstimates, gasFeeEstimatesLoaded: true };
   }
 
-  async #updateTransactionLayer1GasFee(transactionMeta: TransactionMeta) {
+  async #updateTransactionLayer1GasFee(
+    transactionMeta: TransactionMeta,
+  ): Promise<Hex | undefined> {
     const { chainId, networkClientId } = transactionMeta;
     const provider = this.#getProvider(chainId, networkClientId);
 
-    await updateTransactionLayer1GasFee({
-      provider,
+    const layer1GasFee = await getTransactionLayer1GasFee({
       layer1GasFeeFlows: this.#layer1GasFeeFlows,
+      provider,
       transactionMeta,
     });
 
-    if (transactionMeta.layer1GasFee === undefined) {
-      return;
+    if (layer1GasFee) {
+      log('Updated layer 1 gas fee', layer1GasFee, transactionMeta.id);
     }
 
-    this.hub.emit('transaction-updated', transactionMeta);
+    return layer1GasFee;
   }
 
   #getUnapprovedTransactions() {

--- a/packages/transaction-controller/src/utils/layer1-gas-fee-flow.ts
+++ b/packages/transaction-controller/src/utils/layer1-gas-fee-flow.ts
@@ -24,10 +24,15 @@ export async function updateTransactionLayer1GasFee(
 ) {
   const layer1GasFee = await getTransactionLayer1GasFee(request);
 
-  if (layer1GasFee) {
-    const { transactionMeta } = request;
-    transactionMeta.layer1GasFee = layer1GasFee;
+  if (!layer1GasFee) {
+    return;
   }
+
+  const { transactionMeta } = request;
+
+  transactionMeta.layer1GasFee = layer1GasFee;
+
+  log('Updated layer 1 gas fee', layer1GasFee, transactionMeta.id);
 }
 
 /**
@@ -61,10 +66,16 @@ export async function getTransactionLayer1GasFee({
     transactionMeta,
     layer1GasFeeFlows,
   );
+
   if (!layer1GasFeeFlow) {
-    log('Layer 1 gas fee flow not found', transactionMeta.id);
     return undefined;
   }
+
+  log(
+    'Found layer 1 gas fee flow',
+    layer1GasFeeFlow.constructor.name,
+    transactionMeta.id,
+  );
 
   try {
     const { layer1Fee } = await layer1GasFeeFlow.getLayer1Fee({


### PR DESCRIPTION
## Explanation

Fix the update of the `layer1GasFee` from the `GasFeePoller` by avoiding mutating a frozen object.

In addition:

- Emit a single `transaction-updated` event from the `GasFeePoller` including the gas fee estimates and layer 1 gas fee.
- Avoiding overlapping updates from the `GasFeePoller` and simulations by refactoring `#updateTransactionInternal` to require a callback rather than the entire `TransactionMeta` instance.
- Update the `getLayer1GasFee` method to use an object argument with an optional `chainId` and `networkClientId`.
- Reduce level of logging from `GasFeePoller` if gas flows are not in use.

## Changelog

### `@metamask/transaction-controller`

- **BREAKING**: Change `getLayer1GasFee` arguments to a request object.
- **FIXED**: Automatic update of layer 1 gas fee after interval.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
