### PR TITLE
[keyring-controller] Update state in single call when persisting or unlocking

### DIFF
--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -19,8 +19,8 @@ module.exports = merge(baseConfig, {
     global: {
       branches: 95.65,
       functions: 100,
-      lines: 99.17,
-      statements: 99.18,
+      lines: 98.99,
+      statements: 99,
     },
   },
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -3143,6 +3143,36 @@ describe('KeyringController', () => {
       });
     });
   });
+
+  describe('run conditions', () => {
+    describe('submitPassword', () => {
+      it('should not cause run conditions when called multiple times', async () => {
+        await withController(async ({ controller, initialState }) => {
+          await Promise.all([
+            controller.submitPassword(password),
+            controller.submitPassword(password),
+            controller.submitPassword(password),
+            controller.submitPassword(password),
+          ]);
+
+          expect(controller.state).toStrictEqual(initialState);
+        });
+      });
+
+      it('should not cause run conditions when called multiple times in combination with persistAllKeyrings', async () => {
+        await withController(async ({ controller, initialState }) => {
+          await Promise.all([
+            controller.submitPassword(password),
+            controller.persistAllKeyrings(),
+            controller.submitPassword(password),
+            controller.persistAllKeyrings(),
+          ]);
+
+          expect(controller.state).toStrictEqual(initialState);
+        });
+      });
+    });
+  });
 });
 
 type WithControllerCallback<ReturnValue> = ({

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2036,7 +2036,7 @@ export class KeyringController extends BaseController<
     const releaseLock = await this.#vaultOperationMutex.acquire();
 
     try {
-      return fn({ releaseLock });
+      return await fn({ releaseLock });
     } finally {
       releaseLock();
     }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -485,7 +485,9 @@ export class KeyringController extends BaseController<
   KeyringControllerState,
   KeyringControllerMessenger
 > {
-  private readonly mutex = new Mutex();
+  readonly #initVaultMutex = new Mutex();
+
+  readonly #vaultUpdateMutex = new Mutex();
 
   #keyringBuilders: { (): EthKeyring<Json>; type: string }[];
 
@@ -669,7 +671,7 @@ export class KeyringController extends BaseController<
     password: string,
     seed: Uint8Array,
   ): Promise<KeyringControllerMemState> {
-    const releaseLock = await this.mutex.acquire();
+    const releaseLock = await this.#initVaultMutex.acquire();
     if (!password || !password.length) {
       throw new Error('Invalid password');
     }
@@ -695,7 +697,7 @@ export class KeyringController extends BaseController<
    * @returns Newly-created keychain object.
    */
   async createNewVaultAndKeychain(password: string) {
-    const releaseLock = await this.mutex.acquire();
+    const releaseLock = await this.#initVaultMutex.acquire();
     try {
       const accounts = await this.getAccounts();
       if (!accounts.length) {
@@ -931,76 +933,83 @@ export class KeyringController extends BaseController<
    * operation completes.
    */
   async persistAllKeyrings(): Promise<boolean> {
-    const { encryptionKey, encryptionSalt } = this.state;
+    const releaseLock = await this.#vaultUpdateMutex.acquire();
 
-    if (!this.#password && !encryptionKey) {
-      throw new Error(KeyringControllerError.MissingCredentials);
-    }
+    try {
+      const { encryptionKey, encryptionSalt } = this.state;
 
-    const serializedKeyrings = await Promise.all(
-      this.#keyrings.map(async (keyring) => {
-        const [type, data] = await Promise.all([
-          keyring.type,
-          keyring.serialize(),
-        ]);
-        return { type, data };
-      }),
-    );
+      if (!this.#password && !encryptionKey) {
+        throw new Error(KeyringControllerError.MissingCredentials);
+      }
 
-    serializedKeyrings.push(...this.#unsupportedKeyrings);
+      const serializedKeyrings = await Promise.all(
+        this.#keyrings.map(async (keyring) => {
+          const [type, data] = await Promise.all([
+            keyring.type,
+            keyring.serialize(),
+          ]);
+          return { type, data };
+        }),
+      );
 
-    let vault: string | undefined;
-    let newEncryptionKey: string | undefined;
+      serializedKeyrings.push(...this.#unsupportedKeyrings);
 
-    if (this.#cacheEncryptionKey) {
-      assertIsExportableKeyEncryptor(this.#encryptor);
+      let vault: string | undefined;
+      let newEncryptionKey: string | undefined;
 
-      if (encryptionKey) {
-        const key = await this.#encryptor.importKey(encryptionKey);
-        const vaultJSON = await this.#encryptor.encryptWithKey(
-          key,
-          serializedKeyrings,
-        );
-        vaultJSON.salt = encryptionSalt;
-        vault = JSON.stringify(vaultJSON);
-      } else if (this.#password) {
-        const { vault: newVault, exportedKeyString } =
-          await this.#encryptor.encryptWithDetail(
-            this.#password,
+      if (this.#cacheEncryptionKey) {
+        assertIsExportableKeyEncryptor(this.#encryptor);
+
+        if (encryptionKey) {
+          const key = await this.#encryptor.importKey(encryptionKey);
+          const vaultJSON = await this.#encryptor.encryptWithKey(
+            key,
             serializedKeyrings,
           );
+          vaultJSON.salt = encryptionSalt;
+          vault = JSON.stringify(vaultJSON);
+        } else if (this.#password) {
+          const { vault: newVault, exportedKeyString } =
+            await this.#encryptor.encryptWithDetail(
+              this.#password,
+              serializedKeyrings,
+            );
 
-        vault = newVault;
-        newEncryptionKey = exportedKeyString;
+          vault = newVault;
+          newEncryptionKey = exportedKeyString;
+        }
+      } else {
+        if (typeof this.#password !== 'string') {
+          throw new TypeError(KeyringControllerError.WrongPasswordType);
+        }
+        vault = await this.#encryptor.encrypt(
+          this.#password,
+          serializedKeyrings,
+        );
       }
-    } else {
-      if (typeof this.#password !== 'string') {
-        throw new TypeError(KeyringControllerError.WrongPasswordType);
+
+      if (!vault) {
+        throw new Error(KeyringControllerError.MissingVaultData);
       }
-      vault = await this.#encryptor.encrypt(this.#password, serializedKeyrings);
-    }
 
-    if (!vault) {
-      throw new Error(KeyringControllerError.MissingVaultData);
-    }
-
-    this.update((state) => {
-      state.vault = vault;
-    });
-
-    // The keyring updates need to be announced before updating the encryptionKey
-    // so that the updated keyring gets propagated to the extension first.
-    // Not calling {@link updateKeyringsInState} results in the wrong account being selected
-    // in the extension.
-    await this.#updateKeyringsInState();
-    if (newEncryptionKey) {
+      // The keyring updates need to be announced before updating the encryptionKey
+      // so that the updated keyring gets propagated to the extension first.
+      // Not calling {@link updateKeyringsInState} results in the wrong account being selected
+      // in the extension.
+      const updatedKeyrings = await this.#getUpdatedKeyrings();
       this.update((state) => {
-        state.encryptionKey = newEncryptionKey;
-        state.encryptionSalt = JSON.parse(vault as string).salt;
+        state.vault = vault;
+        state.keyrings = updatedKeyrings;
+        if (newEncryptionKey) {
+          state.encryptionKey = newEncryptionKey;
+          state.encryptionSalt = JSON.parse(vault as string).salt;
+        }
       });
-    }
 
-    return true;
+      return true;
+    } finally {
+      releaseLock();
+    }
   }
 
   /**
@@ -1706,13 +1715,13 @@ export class KeyringController extends BaseController<
   }
 
   /**
-   * Update the controller state with its current keyrings.
+   * Get the updated array of each keyring's type and
+   * accounts list.
+   *
+   * @returns A promise resolving to the updated keyrings array.
    */
-  async #updateKeyringsInState(): Promise<void> {
-    const keyrings = await Promise.all(this.#keyrings.map(displayForKeyring));
-    this.update((state) => {
-      state.keyrings = keyrings;
-    });
+  async #getUpdatedKeyrings(): Promise<KeyringObject[]> {
+    return Promise.all(this.#keyrings.map(displayForKeyring));
   }
 
   /**
@@ -1734,9 +1743,10 @@ export class KeyringController extends BaseController<
       throw new Error(KeyringControllerError.VaultError);
     }
 
-    await this.#clearKeyrings();
+    await this.#clearKeyrings(true);
 
     let vault;
+    const updatedState: Partial<KeyringControllerState> = {};
 
     if (this.#cacheEncryptionKey) {
       assertIsExportableKeyEncryptor(this.#encryptor);
@@ -1749,10 +1759,8 @@ export class KeyringController extends BaseController<
         vault = result.vault;
         this.#password = password;
 
-        this.update((state) => {
-          state.encryptionKey = result.exportedKeyString;
-          state.encryptionSalt = result.salt;
-        });
+        updatedState.encryptionKey = result.exportedKeyString;
+        updatedState.encryptionSalt = result.salt;
       } else {
         const parsedEncryptedVault = JSON.parse(encryptedVault);
 
@@ -1769,13 +1777,11 @@ export class KeyringController extends BaseController<
 
         // This call is required on the first call because encryptionKey
         // is not yet inside the memStore
-        this.update((state) => {
-          state.encryptionKey = encryptionKey;
-          // we can safely assume that encryptionSalt is defined here
-          // because we compare it with the salt from the vault
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          state.encryptionSalt = encryptionSalt!;
-        });
+        updatedState.encryptionKey = encryptionKey;
+        // we can safely assume that encryptionSalt is defined here
+        // because we compare it with the salt from the vault
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        updatedState.encryptionSalt = encryptionSalt!;
       }
     } else {
       if (typeof password !== 'string') {
@@ -1791,7 +1797,15 @@ export class KeyringController extends BaseController<
     }
 
     await Promise.all(vault.map(this.#restoreKeyring.bind(this)));
-    await this.#updateKeyringsInState();
+    const updatedKeyrings = await this.#getUpdatedKeyrings();
+
+    this.update((state) => {
+      state.keyrings = updatedKeyrings;
+      if (updatedState.encryptionKey || updatedState.encryptionSalt) {
+        state.encryptionKey = updatedState.encryptionKey;
+        state.encryptionSalt = updatedState.encryptionSalt;
+      }
+    });
 
     if (
       this.#password &&
@@ -1856,15 +1870,19 @@ export class KeyringController extends BaseController<
   /**
    * Remove all managed keyrings, destroying all their
    * instances in memory.
+   *
+   * @param skipStateUpdate - Whether to skip updating the constroller state.
    */
-  async #clearKeyrings() {
+  async #clearKeyrings(skipStateUpdate = false) {
     for (const keyring of this.#keyrings) {
       await this.#destroyKeyring(keyring);
     }
     this.#keyrings = [];
-    this.update((state) => {
-      state.keyrings = [];
-    });
+    if (!skipStateUpdate) {
+      this.update((state) => {
+        state.keyrings = [];
+      });
+    }
   }
 
   /**

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -990,10 +990,6 @@ export class KeyringController extends BaseController<
         throw new Error(KeyringControllerError.MissingVaultData);
       }
 
-      // The keyring updates need to be announced before updating the encryptionKey
-      // so that the updated keyring gets propagated to the extension first.
-      // Not calling {@link updateKeyringsInState} results in the wrong account being selected
-      // in the extension.
       const updatedKeyrings = await this.#getUpdatedKeyrings();
       this.update((state) => {
         state.vault = updatedState.vault;

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2015,6 +2015,17 @@ export class KeyringController extends BaseController<
     };
   }
 
+  /**
+   * Lock the vault mutex before executing the given function,
+   * and release it after the function is resolved or after an
+   * error is thrown.
+   *
+   * This ensures that each operation that interacts with the vault
+   * is executed in a mutually exclusive way.
+   *
+   * @param fn - The function to execute while the vault mutex is locked.
+   * @returns The result of the function.
+   */
   async #withVaultLock<T>(
     fn: ({
       releaseLock,


### PR DESCRIPTION
## Explanation

`persistAllKeyrings` and `#unlockKeyrings` have been refactored to update the state in one single call, to avoid side effects to be executed in the middle of the lock or unlock operations.

`persistAllKeyrings` and `#unlockKeyrings` can now be executed once per time, since they are both behind the same mutex: this ensures that each vault read/write operation is executed in a mutually exclusive way

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

N.D.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/keyring-controller`

- **FIXED**: State updates are executed in a single call when locking or unlocking the `KeyringController`.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
