### PR TITLE
Add layer 1 gas fee flow for Scroll network

### DIFF
--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -50,6 +50,7 @@ import { v1 as random } from 'uuid';
 import { DefaultGasFeeFlow } from './gas-flows/DefaultGasFeeFlow';
 import { LineaGasFeeFlow } from './gas-flows/LineaGasFeeFlow';
 import { OptimismLayer1GasFeeFlow } from './gas-flows/OptimismLayer1GasFeeFlow';
+import { ScrollLayer1GasFeeFlow } from './gas-flows/ScrollLayer1GasFeeFlow';
 import { EtherscanRemoteTransactionSource } from './helpers/EtherscanRemoteTransactionSource';
 import { GasFeePoller } from './helpers/GasFeePoller';
 import type { IncomingTransactionOptions } from './helpers/IncomingTransactionHelper';
@@ -3536,7 +3537,7 @@ export class TransactionController extends BaseController<
   }
 
   #getLayer1GasFeeFlows(): Layer1GasFeeFlow[] {
-    return [new OptimismLayer1GasFeeFlow()];
+    return [new OptimismLayer1GasFeeFlow(), new ScrollLayer1GasFeeFlow()];
   }
 
   #updateTransactionInternal(

--- a/packages/transaction-controller/src/constants.ts
+++ b/packages/transaction-controller/src/constants.ts
@@ -27,6 +27,8 @@ export const CHAIN_IDS = {
   ARBITRUM: '0xa4b1',
   ZKSYNC_ERA: '0x144',
   ZORA: '0x76adf1',
+  SCROLL: '0x82750',
+  SCROLL_SEPOLIA: '0x8274f',
 } as const;
 
 export const DEFAULT_ETHERSCAN_DOMAIN = 'etherscan.io';

--- a/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.ts
@@ -1,21 +1,9 @@
-import { Common, Hardfork } from '@ethereumjs/common';
-import { TransactionFactory } from '@ethereumjs/tx';
-import { Contract } from '@ethersproject/contracts';
-import { Web3Provider, type ExternalProvider } from '@ethersproject/providers';
-import { createModuleLogger, type Hex, remove0x } from '@metamask/utils';
-import BN from 'bn.js';
-import { omit } from 'lodash';
+import { type Hex } from '@metamask/utils';
 
 import { CHAIN_IDS } from '../constants';
-import { projectLogger } from '../logger';
-import type {
-  Layer1GasFeeFlow,
-  Layer1GasFeeFlowRequest,
-  Layer1GasFeeFlowResponse,
-  TransactionMeta,
-} from '../types';
+import type { TransactionMeta } from '../types';
+import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
 
-// This gas flow to be used for the following OP stack chains
 const OPTIMISM_STACK_CHAIN_IDS: Hex[] = [
   CHAIN_IDS.OPTIMISM,
   CHAIN_IDS.OPTIMISM_TESTNET,
@@ -26,119 +14,19 @@ const OPTIMISM_STACK_CHAIN_IDS: Hex[] = [
   CHAIN_IDS.ZORA,
 ];
 
-const log = createModuleLogger(projectLogger, 'optimisim-layer1-gas-fee-flow');
-
-// Snippet of the ABI that we need
-// Should we need more of it at some point, the full ABI can be found here:
-// https://github.com/ethereum-optimism/optimism/blob/develop/gas-oracle/abis/OVM_GasPriceOracle.json
-const OPTIMISM_GAS_PRICE_ORACLE_ABI = [
-  {
-    inputs: [{ internalType: 'bytes', name: '_data', type: 'bytes' }],
-    name: 'getL1Fee',
-    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-];
-
 // BlockExplorer link: https://optimistic.etherscan.io/address/0x420000000000000000000000000000000000000f#code
 const OPTIMISM_GAS_PRICE_ORACLE_ADDRESS =
   '0x420000000000000000000000000000000000000F';
 
 /**
- * Optimism layer 1 gas fee flow that obtains gas fee estimate using Optimisim oracle contract.
+ * Optimism layer 1 gas fee flow that obtains gas fee estimate using an oracle contract.
  */
-export class OptimismLayer1GasFeeFlow implements Layer1GasFeeFlow {
+export class OptimismLayer1GasFeeFlow extends OracleLayer1GasFeeFlow {
+  constructor() {
+    super(OPTIMISM_GAS_PRICE_ORACLE_ADDRESS);
+  }
+
   matchesTransaction(transactionMeta: TransactionMeta): boolean {
     return OPTIMISM_STACK_CHAIN_IDS.includes(transactionMeta.chainId);
-  }
-
-  async getLayer1Fee(
-    request: Layer1GasFeeFlowRequest,
-  ): Promise<Layer1GasFeeFlowResponse> {
-    try {
-      return await this.#getOptimisimLayer1GasFee(request);
-    } catch (error) {
-      log('Failed to get Optimism layer 1 gas fee due to error', error);
-      throw new Error(`Failed to get Optimism layer 1 gas fee`);
-    }
-  }
-
-  async #getOptimisimLayer1GasFee(
-    request: Layer1GasFeeFlowRequest,
-  ): Promise<Layer1GasFeeFlowResponse> {
-    const { provider, transactionMeta } = request;
-
-    const contract = new Contract(
-      OPTIMISM_GAS_PRICE_ORACLE_ADDRESS,
-      OPTIMISM_GAS_PRICE_ORACLE_ABI,
-      // Network controller provider type is uncompatible with ethers provider
-      new Web3Provider(provider as unknown as ExternalProvider),
-    );
-
-    const serializedTransaction =
-      this.#buildUnserializedTransaction(transactionMeta).serialize();
-
-    const result = await contract.getL1Fee(serializedTransaction);
-
-    if (result === undefined) {
-      throw new Error(
-        'Failed to retrieve layer 1 gas fee from Optimism Gas Price Oracle.',
-      );
-    }
-
-    return {
-      layer1Fee: result.toHexString(),
-    };
-  }
-
-  /**
-   * Build an unserialized transaction for a transaction.
-   *
-   * @param transactionMeta - The transaction to build an unserialized transaction for.
-   * @returns The unserialized transaction.
-   */
-  #buildUnserializedTransaction(transactionMeta: TransactionMeta) {
-    const txParams = this.#buildTransactionParams(transactionMeta);
-    const common = this.#buildTransactionCommon(transactionMeta);
-    return TransactionFactory.fromTxData(txParams, { common });
-  }
-
-  /**
-   * Build transactionParams to be used in the unserialized transaction.
-   *
-   * @param transactionMeta - The transaction to build transactionParams.
-   * @returns The transactionParams for the unserialized transaction.
-   */
-  #buildTransactionParams(
-    transactionMeta: TransactionMeta,
-  ): TransactionMeta['txParams'] {
-    return {
-      ...omit(transactionMeta.txParams, 'gas'),
-      gasLimit: transactionMeta.txParams.gas,
-    };
-  }
-
-  /**
-   * This produces a transaction whose information does not completely match an
-   * Optimism transaction — for instance, DEFAULT_CHAIN is still 'mainnet' and
-   * genesis points to the mainnet genesis, not the Optimism genesis — but
-   * considering that all we want to do is serialize a transaction, this works
-   * fine for our use case.
-   *
-   * @param transactionMeta - The transaction to build an unserialized transaction for.
-   * @returns The unserialized transaction.
-   */
-  #buildTransactionCommon(transactionMeta: TransactionMeta) {
-    return Common.custom({
-      chainId: new BN(
-        remove0x(transactionMeta.chainId),
-        16,
-      ) as unknown as number,
-      // Optimism only supports type-0 transactions; it does not support any of
-      // the newer EIPs since EIP-155. Source:
-      // <https://github.com/ethereum-optimism/optimism/blob/develop/specs/l2geth/transaction-types.md>
-      defaultHardfork: Hardfork.London,
-    });
   }
 }

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
@@ -1,0 +1,166 @@
+import type { TypedTransaction } from '@ethereumjs/tx';
+import { TransactionFactory } from '@ethereumjs/tx';
+import { Contract } from '@ethersproject/contracts';
+import type { Provider } from '@metamask/network-controller';
+
+import { CHAIN_IDS } from '../constants';
+import type { Layer1GasFeeFlowRequest, TransactionMeta } from '../types';
+import { TransactionStatus } from '../types';
+import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
+
+jest.mock('@ethersproject/contracts', () => ({
+  Contract: jest.fn(),
+}));
+
+jest.mock('../utils/layer1-gas-fee-flow', () => ({
+  buildUnserializedTransaction: jest.fn(),
+}));
+
+jest.mock('@ethersproject/providers');
+
+const TRANSACTION_PARAMS_MOCK = {
+  from: '0x123',
+  gas: '0x1234',
+};
+
+const TRANSACTION_META_MOCK: TransactionMeta = {
+  id: '1',
+  chainId: CHAIN_IDS.OPTIMISM,
+  status: TransactionStatus.unapproved,
+  time: 0,
+  txParams: TRANSACTION_PARAMS_MOCK,
+};
+
+const SERIALIZED_TRANSACTION_MOCK = '0x1234';
+const ORACLE_ADDRESS_MOCK = '0x5678';
+const LAYER_1_FEE_MOCK = '0x9ABCD';
+
+/**
+ * Creates a mock TypedTransaction object.
+ * @param serializedBuffer - The buffer returned by the serialize method.
+ * @returns The mock TypedTransaction object.
+ */
+function createMockTypedTransaction(serializedBuffer: Buffer) {
+  const instance = {
+    serialize: () => serializedBuffer,
+    sign: jest.fn(),
+  };
+
+  jest.spyOn(instance, 'sign').mockReturnValue(instance);
+
+  return instance as unknown as jest.Mocked<TypedTransaction>;
+}
+
+class MockOracleLayer1GasFeeFlow extends OracleLayer1GasFeeFlow {
+  matchesTransaction(_transactionMeta: TransactionMeta): boolean {
+    return true;
+  }
+}
+
+describe('OracleLayer1GasFeeFlow', () => {
+  const contractMock = jest.mocked(Contract);
+  const contractGetL1FeeMock: jest.MockedFn<
+    () => Promise<{ toHexString: () => string }>
+  > = jest.fn();
+
+  let request: Layer1GasFeeFlowRequest;
+
+  beforeEach(() => {
+    request = {
+      provider: {} as Provider,
+      transactionMeta: TRANSACTION_META_MOCK,
+    };
+
+    contractGetL1FeeMock.mockResolvedValue({
+      toHexString: () => LAYER_1_FEE_MOCK,
+    });
+
+    contractMock.mockReturnValue({
+      getL1Fee: contractGetL1FeeMock,
+    } as unknown as Contract);
+  });
+
+  describe('getLayer1GasFee', () => {
+    it('returns value from smart contract call', async () => {
+      const serializedTransactionMock = Buffer.from(
+        SERIALIZED_TRANSACTION_MOCK,
+        'hex',
+      );
+
+      const transactionFactoryMock = jest
+        .spyOn(TransactionFactory, 'fromTxData')
+        .mockReturnValueOnce(
+          createMockTypedTransaction(serializedTransactionMock),
+        );
+
+      const flow = new MockOracleLayer1GasFeeFlow(ORACLE_ADDRESS_MOCK, false);
+      const response = await flow.getLayer1Fee(request);
+
+      expect(response).toStrictEqual({
+        layer1Fee: LAYER_1_FEE_MOCK,
+      });
+
+      expect(transactionFactoryMock).toHaveBeenCalledTimes(1);
+      expect(transactionFactoryMock).toHaveBeenCalledWith(
+        {
+          from: TRANSACTION_PARAMS_MOCK.from,
+          gasLimit: TRANSACTION_PARAMS_MOCK.gas,
+        },
+        expect.anything(),
+      );
+
+      expect(contractGetL1FeeMock).toHaveBeenCalledTimes(1);
+      expect(contractGetL1FeeMock).toHaveBeenCalledWith(
+        serializedTransactionMock,
+      );
+    });
+
+    it('signs transaction with dummy key if supported by flow', async () => {
+      const serializedTransactionMock = Buffer.from(
+        SERIALIZED_TRANSACTION_MOCK,
+        'hex',
+      );
+
+      const typedTransactionMock = createMockTypedTransaction(
+        serializedTransactionMock,
+      );
+
+      jest
+        .spyOn(TransactionFactory, 'fromTxData')
+        .mockReturnValueOnce(typedTransactionMock);
+
+      const flow = new MockOracleLayer1GasFeeFlow(ORACLE_ADDRESS_MOCK, true);
+      const response = await flow.getLayer1Fee(request);
+
+      expect(response).toStrictEqual({
+        layer1Fee: LAYER_1_FEE_MOCK,
+      });
+
+      expect(typedTransactionMock.sign).toHaveBeenCalledTimes(1);
+    });
+
+    describe('throws', () => {
+      it('if getL1Fee fails', async () => {
+        contractGetL1FeeMock.mockRejectedValue(new Error('error'));
+
+        const flow = new MockOracleLayer1GasFeeFlow(ORACLE_ADDRESS_MOCK, false);
+
+        await expect(flow.getLayer1Fee(request)).rejects.toThrow(
+          'Failed to get oracle layer 1 gas fee',
+        );
+      });
+
+      it('if getL1Fee returns undefined', async () => {
+        contractGetL1FeeMock.mockResolvedValue(
+          undefined as unknown as ReturnType<typeof contractGetL1FeeMock>,
+        );
+
+        const flow = new MockOracleLayer1GasFeeFlow(ORACLE_ADDRESS_MOCK, false);
+
+        await expect(flow.getLayer1Fee(request)).rejects.toThrow(
+          'Failed to get oracle layer 1 gas fee',
+        );
+      });
+    });
+  });
+});

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
@@ -14,7 +14,7 @@ import type {
   TransactionMeta,
 } from '../types';
 
-const log = createModuleLogger(projectLogger, 'optimisim-layer1-gas-fee-flow');
+const log = createModuleLogger(projectLogger, 'oracle-layer1-gas-fee-flow');
 
 const DUMMY_KEY =
   'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
@@ -1,0 +1,122 @@
+import { Common, Hardfork } from '@ethereumjs/common';
+import { TransactionFactory } from '@ethereumjs/tx';
+import { Contract } from '@ethersproject/contracts';
+import { Web3Provider, type ExternalProvider } from '@ethersproject/providers';
+import type { Hex } from '@metamask/utils';
+import { createModuleLogger } from '@metamask/utils';
+import { omit } from 'lodash';
+
+import { projectLogger } from '../logger';
+import type {
+  Layer1GasFeeFlow,
+  Layer1GasFeeFlowRequest,
+  Layer1GasFeeFlowResponse,
+  TransactionMeta,
+} from '../types';
+
+const log = createModuleLogger(projectLogger, 'optimisim-layer1-gas-fee-flow');
+
+const DUMMY_KEY =
+  'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+
+const GAS_PRICE_ORACLE_ABI = [
+  {
+    inputs: [{ internalType: 'bytes', name: '_data', type: 'bytes' }],
+    name: 'getL1Fee',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+/**
+ * Layer 1 gas fee flow that obtains gas fee estimate using an oracle smart contract.
+ */
+export abstract class OracleLayer1GasFeeFlow implements Layer1GasFeeFlow {
+  #oracleAddress: Hex;
+
+  #signTransaction: boolean;
+
+  constructor(oracleAddress: Hex, signTransaction?: boolean) {
+    this.#oracleAddress = oracleAddress;
+    this.#signTransaction = signTransaction ?? false;
+  }
+
+  abstract matchesTransaction(transactionMeta: TransactionMeta): boolean;
+
+  async getLayer1Fee(
+    request: Layer1GasFeeFlowRequest,
+  ): Promise<Layer1GasFeeFlowResponse> {
+    try {
+      return await this.#getOracleLayer1GasFee(request);
+    } catch (error) {
+      log('Failed to get oracle layer 1 gas fee', error);
+      throw new Error(`Failed to get oracle layer 1 gas fee`);
+    }
+  }
+
+  async #getOracleLayer1GasFee(
+    request: Layer1GasFeeFlowRequest,
+  ): Promise<Layer1GasFeeFlowResponse> {
+    const { provider, transactionMeta } = request;
+
+    const contract = new Contract(
+      this.#oracleAddress,
+      GAS_PRICE_ORACLE_ABI,
+      // Network controller provider type is incompatible with ethers provider
+      new Web3Provider(provider as unknown as ExternalProvider),
+    );
+
+    const serializedTransaction = this.#buildUnserializedTransaction(
+      transactionMeta,
+      this.#signTransaction,
+    ).serialize();
+
+    const result = await contract.getL1Fee(serializedTransaction);
+
+    if (result === undefined) {
+      throw new Error('No value returned from oracle contract');
+    }
+
+    return {
+      layer1Fee: result.toHexString(),
+    };
+  }
+
+  #buildUnserializedTransaction(
+    transactionMeta: TransactionMeta,
+    sign: boolean,
+  ) {
+    const txParams = this.#buildTransactionParams(transactionMeta);
+    const common = this.#buildTransactionCommon(transactionMeta);
+
+    let unserializedTransaction = TransactionFactory.fromTxData(txParams, {
+      common,
+    });
+
+    if (sign) {
+      const keyBuffer = Buffer.from(DUMMY_KEY, 'hex');
+      unserializedTransaction = unserializedTransaction.sign(keyBuffer);
+    }
+
+    return unserializedTransaction;
+  }
+
+  #buildTransactionParams(
+    transactionMeta: TransactionMeta,
+  ): TransactionMeta['txParams'] {
+    return {
+      ...omit(transactionMeta.txParams, 'gas'),
+      gasLimit: transactionMeta.txParams.gas,
+    };
+  }
+
+  #buildTransactionCommon(transactionMeta: TransactionMeta) {
+    const chainId = Number(transactionMeta.chainId);
+
+    return Common.custom({
+      chainId,
+      defaultHardfork: Hardfork.London,
+    });
+  }
+}

--- a/packages/transaction-controller/src/gas-flows/ScrollLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/ScrollLayer1GasFeeFlow.test.ts
@@ -1,7 +1,7 @@
 import { CHAIN_IDS } from '../constants';
 import type { TransactionMeta } from '../types';
 import { TransactionStatus } from '../types';
-import { OptimismLayer1GasFeeFlow } from './OptimismLayer1GasFeeFlow';
+import { ScrollLayer1GasFeeFlow } from './ScrollLayer1GasFeeFlow';
 
 const TRANSACTION_META_MOCK: TransactionMeta = {
   id: '1',
@@ -14,13 +14,13 @@ const TRANSACTION_META_MOCK: TransactionMeta = {
   },
 };
 
-describe('OptimismLayer1GasFeeFlow', () => {
+describe('ScrollLayer1GasFeeFlow', () => {
   describe('matchesTransaction', () => {
     it.each([
-      ['Optimisim mainnet', CHAIN_IDS.OPTIMISM],
-      ['Optimisim testnet', CHAIN_IDS.OPTIMISM_TESTNET],
+      ['Scroll', CHAIN_IDS.SCROLL],
+      ['Scroll Sepolia', CHAIN_IDS.SCROLL_SEPOLIA],
     ])('returns true if chain ID is %s', (_title, chainId) => {
-      const flow = new OptimismLayer1GasFeeFlow();
+      const flow = new ScrollLayer1GasFeeFlow();
 
       const transaction = {
         ...TRANSACTION_META_MOCK,

--- a/packages/transaction-controller/src/gas-flows/ScrollLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/ScrollLayer1GasFeeFlow.ts
@@ -1,0 +1,24 @@
+import { type Hex } from '@metamask/utils';
+
+import { CHAIN_IDS } from '../constants';
+import type { TransactionMeta } from '../types';
+import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
+
+const SCROLL_CHAIN_IDS: Hex[] = [CHAIN_IDS.SCROLL, CHAIN_IDS.SCROLL_SEPOLIA];
+
+// BlockExplorer link: https://scrollscan.com/address/0x5300000000000000000000000000000000000002#code
+const SCROLL_GAS_PRICE_ORACLE_ADDRESS =
+  '0x5300000000000000000000000000000000000002';
+
+/**
+ * Scroll layer 1 gas fee flow that obtains gas fee estimate using an oracle contract.
+ */
+export class ScrollLayer1GasFeeFlow extends OracleLayer1GasFeeFlow {
+  constructor() {
+    super(SCROLL_GAS_PRICE_ORACLE_ADDRESS, true);
+  }
+
+  matchesTransaction(transactionMeta: TransactionMeta): boolean {
+    return SCROLL_CHAIN_IDS.includes(transactionMeta.chainId);
+  }
+}


### PR DESCRIPTION
## Explanation

Create the abstract `OracleLayer1GasFeeFlow` to provide a template for all layer 1 fees derived through smart contract oracles.

Create the `ScrollLayer1GasFeeFlow` to provide layer 1 gas fees on scroll networks.

## References

Fixes [#2368](https://github.com/MetaMask/MetaMask-planning/issues/2368)

## Changelog

### `@metamask/transaction-controller`

- **ADDED**: Support retrieval of layer 1 gas fees on Scroll networks.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
