### PR TITLE
[keyring-controller] Lock controller mutex on write operations

### DIFF
--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -19,8 +19,8 @@ module.exports = merge(baseConfig, {
     global: {
       branches: 95.65,
       functions: 100,
-      lines: 99.17,
-      statements: 99.18,
+      lines: 98.99,
+      statements: 99,
     },
   },
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -529,7 +529,9 @@ describe('KeyringController', () => {
       await withController(async ({ controller }) => {
         expect(controller.isUnlocked()).toBe(true);
         expect(controller.state.isUnlocked).toBe(true);
-        controller.setLocked();
+
+        await controller.setLocked();
+
         expect(controller.isUnlocked()).toBe(false);
         expect(controller.state.isUnlocked).toBe(false);
       });

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2031,7 +2031,7 @@ export class KeyringController extends BaseController<
     const releaseLock = await this.#vaultOperationMutex.acquire();
 
     try {
-      return fn({ releaseLock });
+      return await fn({ releaseLock });
     } finally {
       releaseLock();
     }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -948,8 +948,7 @@ export class KeyringController extends BaseController<
 
       serializedKeyrings.push(...this.#unsupportedKeyrings);
 
-      let vault: string | undefined;
-      let newEncryptionKey: string | undefined;
+      const updatedState: Partial<KeyringControllerState> = {};
 
       if (this.#cacheEncryptionKey) {
         assertIsExportableKeyEncryptor(this.#encryptor);
@@ -961,7 +960,7 @@ export class KeyringController extends BaseController<
             serializedKeyrings,
           );
           vaultJSON.salt = encryptionSalt;
-          vault = JSON.stringify(vaultJSON);
+          updatedState.vault = JSON.stringify(vaultJSON);
         } else if (this.#password) {
           const { vault: newVault, exportedKeyString } =
             await this.#encryptor.encryptWithDetail(
@@ -969,20 +968,20 @@ export class KeyringController extends BaseController<
               serializedKeyrings,
             );
 
-          vault = newVault;
-          newEncryptionKey = exportedKeyString;
+          updatedState.vault = newVault;
+          updatedState.encryptionKey = exportedKeyString;
         }
       } else {
         if (typeof this.#password !== 'string') {
           throw new TypeError(KeyringControllerError.WrongPasswordType);
         }
-        vault = await this.#encryptor.encrypt(
+        updatedState.vault = await this.#encryptor.encrypt(
           this.#password,
           serializedKeyrings,
         );
       }
 
-      if (!vault) {
+      if (!updatedState.vault) {
         throw new Error(KeyringControllerError.MissingVaultData);
       }
 
@@ -992,11 +991,11 @@ export class KeyringController extends BaseController<
       // in the extension.
       const updatedKeyrings = await this.#getUpdatedKeyrings();
       this.update((state) => {
-        state.vault = vault;
+        state.vault = updatedState.vault;
         state.keyrings = updatedKeyrings;
-        if (newEncryptionKey) {
-          state.encryptionKey = newEncryptionKey;
-          state.encryptionSalt = JSON.parse(vault as string).salt;
+        if (updatedState.encryptionKey) {
+          state.encryptionKey = updatedState.encryptionKey;
+          state.encryptionSalt = JSON.parse(updatedState.vault as string).salt;
         }
       });
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -39,6 +39,7 @@ import {
   remove0x,
 } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
+import type { MutexInterface } from 'async-mutex';
 import Wallet, { thirdparty as importers } from 'ethereumjs-wallet';
 import type { Patch } from 'immer';
 
@@ -487,7 +488,7 @@ export class KeyringController extends BaseController<
 > {
   readonly #initVaultMutex = new Mutex();
 
-  readonly #vaultUpdateMutex = new Mutex();
+  readonly #vaultOperationMutex = new Mutex();
 
   #keyringBuilders: { (): EthKeyring<Json>; type: string }[];
 
@@ -928,9 +929,7 @@ export class KeyringController extends BaseController<
    * operation completes.
    */
   async persistAllKeyrings(): Promise<boolean> {
-    const releaseLock = await this.#vaultUpdateMutex.acquire();
-
-    try {
+    return this.#withVaultLock(async () => {
       const { encryptionKey, encryptionSalt } = this.state;
 
       if (!this.#password && !encryptionKey) {
@@ -1002,9 +1001,7 @@ export class KeyringController extends BaseController<
       });
 
       return true;
-    } finally {
-      releaseLock();
-    }
+    });
   }
 
   /**
@@ -1733,86 +1730,94 @@ export class KeyringController extends BaseController<
     encryptionKey?: string,
     encryptionSalt?: string,
   ): Promise<EthKeyring<Json>[]> {
-    const encryptedVault = this.state.vault;
-    if (!encryptedVault) {
-      throw new Error(KeyringControllerError.VaultError);
-    }
+    return this.#withVaultLock(async ({ releaseLock }) => {
+      const encryptedVault = this.state.vault;
+      if (!encryptedVault) {
+        throw new Error(KeyringControllerError.VaultError);
+      }
 
-    await this.#clearKeyrings(true);
+      await this.#clearKeyrings({ skipStateUpdate: true });
 
-    let vault;
-    const updatedState: Partial<KeyringControllerState> = {};
+      let vault;
+      const updatedState: Partial<KeyringControllerState> = {};
 
-    if (this.#cacheEncryptionKey) {
-      assertIsExportableKeyEncryptor(this.#encryptor);
+      if (this.#cacheEncryptionKey) {
+        assertIsExportableKeyEncryptor(this.#encryptor);
 
-      if (password) {
-        const result = await this.#encryptor.decryptWithDetail(
-          password,
-          encryptedVault,
-        );
-        vault = result.vault;
-        this.#password = password;
+        if (password) {
+          const result = await this.#encryptor.decryptWithDetail(
+            password,
+            encryptedVault,
+          );
+          vault = result.vault;
+          this.#password = password;
 
-        updatedState.encryptionKey = result.exportedKeyString;
-        updatedState.encryptionSalt = result.salt;
-      } else {
-        const parsedEncryptedVault = JSON.parse(encryptedVault);
+          updatedState.encryptionKey = result.exportedKeyString;
+          updatedState.encryptionSalt = result.salt;
+        } else {
+          const parsedEncryptedVault = JSON.parse(encryptedVault);
 
-        if (encryptionSalt !== parsedEncryptedVault.salt) {
-          throw new Error(KeyringControllerError.ExpiredCredentials);
+          if (encryptionSalt !== parsedEncryptedVault.salt) {
+            throw new Error(KeyringControllerError.ExpiredCredentials);
+          }
+
+          if (typeof encryptionKey !== 'string') {
+            throw new TypeError(KeyringControllerError.WrongPasswordType);
+          }
+
+          const key = await this.#encryptor.importKey(encryptionKey);
+          vault = await this.#encryptor.decryptWithKey(
+            key,
+            parsedEncryptedVault,
+          );
+
+          // This call is required on the first call because encryptionKey
+          // is not yet inside the memStore
+          updatedState.encryptionKey = encryptionKey;
+          // we can safely assume that encryptionSalt is defined here
+          // because we compare it with the salt from the vault
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          updatedState.encryptionSalt = encryptionSalt!;
         }
-
-        if (typeof encryptionKey !== 'string') {
+      } else {
+        if (typeof password !== 'string') {
           throw new TypeError(KeyringControllerError.WrongPasswordType);
         }
 
-        const key = await this.#encryptor.importKey(encryptionKey);
-        vault = await this.#encryptor.decryptWithKey(key, parsedEncryptedVault);
-
-        // This call is required on the first call because encryptionKey
-        // is not yet inside the memStore
-        updatedState.encryptionKey = encryptionKey;
-        // we can safely assume that encryptionSalt is defined here
-        // because we compare it with the salt from the vault
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        updatedState.encryptionSalt = encryptionSalt!;
-      }
-    } else {
-      if (typeof password !== 'string') {
-        throw new TypeError(KeyringControllerError.WrongPasswordType);
+        vault = await this.#encryptor.decrypt(password, encryptedVault);
+        this.#password = password;
       }
 
-      vault = await this.#encryptor.decrypt(password, encryptedVault);
-      this.#password = password;
-    }
-
-    if (!isSerializedKeyringsArray(vault)) {
-      throw new Error(KeyringControllerError.VaultDataError);
-    }
-
-    await Promise.all(vault.map(this.#restoreKeyring.bind(this)));
-    const updatedKeyrings = await this.#getUpdatedKeyrings();
-
-    this.update((state) => {
-      state.keyrings = updatedKeyrings;
-      if (updatedState.encryptionKey || updatedState.encryptionSalt) {
-        state.encryptionKey = updatedState.encryptionKey;
-        state.encryptionSalt = updatedState.encryptionSalt;
+      if (!isSerializedKeyringsArray(vault)) {
+        throw new Error(KeyringControllerError.VaultDataError);
       }
+
+      await Promise.all(vault.map(this.#restoreKeyring.bind(this)));
+      const updatedKeyrings = await this.#getUpdatedKeyrings();
+
+      this.update((state) => {
+        state.keyrings = updatedKeyrings;
+        if (updatedState.encryptionKey || updatedState.encryptionSalt) {
+          state.encryptionKey = updatedState.encryptionKey;
+          state.encryptionSalt = updatedState.encryptionSalt;
+        }
+      });
+
+      if (
+        this.#password &&
+        (!this.#cacheEncryptionKey || !encryptionKey) &&
+        this.#encryptor.isVaultUpdated &&
+        !this.#encryptor.isVaultUpdated(encryptedVault)
+      ) {
+        // The lock needs to be released before persisting the keyrings
+        // to avoid deadlock
+        releaseLock();
+        // Re-encrypt the vault with safer method if one is available
+        await this.persistAllKeyrings();
+      }
+
+      return this.#keyrings;
     });
-
-    if (
-      this.#password &&
-      (!this.#cacheEncryptionKey || !encryptionKey) &&
-      this.#encryptor.isVaultUpdated &&
-      !this.#encryptor.isVaultUpdated(encryptedVault)
-    ) {
-      // Re-encrypt the vault with safer method if one is available
-      await this.persistAllKeyrings();
-    }
-
-    return this.#keyrings;
   }
 
   /**
@@ -1866,14 +1871,17 @@ export class KeyringController extends BaseController<
    * Remove all managed keyrings, destroying all their
    * instances in memory.
    *
-   * @param skipStateUpdate - Whether to skip updating the constroller state.
+   * @param options - Operations options.
+   * @param options.skipStateUpdate - Whether to skip updating the controller state.
    */
-  async #clearKeyrings(skipStateUpdate = false) {
+  async #clearKeyrings(
+    options: { skipStateUpdate: boolean } = { skipStateUpdate: false },
+  ) {
     for (const keyring of this.#keyrings) {
       await this.#destroyKeyring(keyring);
     }
     this.#keyrings = [];
-    if (!skipStateUpdate) {
+    if (!options.skipStateUpdate) {
       this.update((state) => {
         state.keyrings = [];
       });
@@ -2001,6 +2009,22 @@ export class KeyringController extends BaseController<
       isUnlocked: this.state.isUnlocked,
       keyrings: this.state.keyrings,
     };
+  }
+
+  async #withVaultLock<T>(
+    fn: ({
+      releaseLock,
+    }: {
+      releaseLock: MutexInterface.Releaser;
+    }) => Promise<T>,
+  ): Promise<T> {
+    const releaseLock = await this.#vaultOperationMutex.acquire();
+
+    try {
+      return fn({ releaseLock });
+    } finally {
+      releaseLock();
+    }
   }
 }
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -985,10 +985,6 @@ export class KeyringController extends BaseController<
         throw new Error(KeyringControllerError.MissingVaultData);
       }
 
-      // The keyring updates need to be announced before updating the encryptionKey
-      // so that the updated keyring gets propagated to the extension first.
-      // Not calling {@link updateKeyringsInState} results in the wrong account being selected
-      // in the extension.
       const updatedKeyrings = await this.#getUpdatedKeyrings();
       this.update((state) => {
         state.vault = updatedState.vault;

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2010,6 +2010,17 @@ export class KeyringController extends BaseController<
     };
   }
 
+  /**
+   * Lock the vault mutex before executing the given function,
+   * and release it after the function is resolved or after an
+   * error is thrown.
+   *
+   * This ensures that each operation that interacts with the vault
+   * is executed in a mutually exclusive way.
+   *
+   * @param fn - The function to execute while the vault mutex is locked.
+   * @returns The result of the function.
+   */
   async #withVaultLock<T>(
     fn: ({
       releaseLock,

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2063,6 +2063,10 @@ export class KeyringController extends BaseController<
       releaseLock: MutexInterface.Releaser;
     }) => Promise<T>,
   ): Promise<T> {
+    if (!this.#controllerOperationMutex.isLocked()) {
+      throw new Error(KeyringControllerError.ControllerLockRequired);
+    }
+
     return withLock(this.#vaultOperationMutex, fn);
   }
 }

--- a/packages/keyring-controller/src/constants.ts
+++ b/packages/keyring-controller/src/constants.ts
@@ -26,4 +26,5 @@ export enum KeyringControllerError {
   ExpiredCredentials = 'KeyringController - Encryption key and salt provided are expired',
   NoKeyringBuilder = 'KeyringController - No keyringBuilder found for keyring',
   DataType = 'KeyringController - Incorrect data type provided',
+  ControllerLockRequired = 'KeyringController - attempt to update vault during a non mutually exclusive operation',
 }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Since all changes to the state of any keyring held by KeyringController should result in an update to the vault, we need to ensure that what we save into the vault is the result of the _latest executed operation_. In other words, we need to:

1. Ensure that each operation that changes the state is mutually exclusive. That is, if an operation is made of multiple steps, these steps are guaranteed to be executed before any other operation is started
2. Ensure that each operation is persisted to the vault before another operation can start 

Visually:

```mermaid
sequenceDiagram
  create participant Client
  create participant aPublicMethod()
  Client->>aPublicMethod(): Calls a method that changes state
  create participant ControllerMutex
  aPublicMethod()->>ControllerMutex: Acquire Controller Lock
  loop Controller Lock
    ControllerMutex-->ControllerMutex: Wait controller to be available
  end
  rect rgb(230,245,255)
    note right of aPublicMethod(): Exclusive Controller OP
    participant KeyringController State
    destroy KeyringController State
    aPublicMethod()->>KeyringController State: Update Controller State
    create participant VaultMutex
    aPublicMethod()->>VaultMutex: Acquire Vault Lock
    loop Vault Lock
      VaultMutex-->VaultMutex: Wait vault to be available
    end
    rect rgb(190,225,235)
      note right of aPublicMethod(): Exclusive Vault OP
      participant Vault
      destroy Vault
      aPublicMethod()->>Vault: Persist state changes
    end
    destroy VaultMutex
    VaultMutex-->>aPublicMethod(): Release Vault lock
  end
    destroy ControllerMutex
    ControllerMutex-->>aPublicMethod(): Release Controller lock
    destroy aPublicMethod()
    aPublicMethod()-->>Client: Return value
```

To do this, this PR adds the `KeyringController.#withControllerLock` helper function, to be used on any write operation that can potentially mutate the controller state (e.g. any function that calls `this.persistAllKeyrings` at the end).

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

* Related to #4154

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/keyring-controller`

- **CHANGED**: `KeyringController` method calls that change state are now mutually exclusive

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
