### PR TITLE
fix!: bug 4157, use getAccounts on HD Keyring when calling addNewAccount

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -190,8 +190,10 @@ describe('KeyringController', () => {
           expect(await controller.getAccounts()).toHaveLength(2);
 
           const accountCount = initialState.keyrings[0].accounts.length;
+          // We add a new account for "index 1" (not existing yet)
           const { addedAccountAddress: firstAccountAdded } =
             await controller.addNewAccount(accountCount);
+          // Adding an account for an existing index will return the existing account's address
           const { addedAccountAddress: secondAccountAdded } =
             await controller.addNewAccount(accountCount);
           expect(firstAccountAdded).toBe(secondAccountAdded);
@@ -201,6 +203,20 @@ describe('KeyringController', () => {
           expect(await controller.getAccounts()).toHaveLength(3);
         },
       );
+    });
+
+    it('should throw instead of returning undefined', async () => {
+      await withController(async ({ controller }) => {
+        jest.spyOn(controller, 'getKeyringsByType').mockReturnValueOnce([
+          {
+            getAccounts: () => [undefined, undefined],
+          },
+        ]);
+
+        await expect(controller.addNewAccount(1)).rejects.toThrow(
+          "Can't find account at index 1",
+        );
+      });
     });
   });
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -580,9 +580,15 @@ export class KeyringController extends BaseController<
         throw new Error('Account out of sequence');
       }
       // we return the account already existing at index `accountCount`
+      const existingAccount = oldAccounts[accountCount];
+
+      if (!existingAccount) {
+        throw new Error(`Can't find account at index ${accountCount}`);
+      }
+
       return {
         keyringState: this.#getMemState(),
-        addedAccountAddress: oldAccounts[accountCount],
+        addedAccountAddress: existingAccount,
       };
     }
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -573,17 +573,16 @@ export class KeyringController extends BaseController<
     if (!primaryKeyring) {
       throw new Error('No HD keyring found');
     }
-    const oldAccounts = await this.getAccounts();
+    const oldAccounts = await primaryKeyring.getAccounts();
 
     if (accountCount && oldAccounts.length !== accountCount) {
       if (accountCount > oldAccounts.length) {
         throw new Error('Account out of sequence');
       }
       // we return the account already existing at index `accountCount`
-      const primaryKeyringAccounts = await primaryKeyring.getAccounts();
       return {
         keyringState: this.#getMemState(),
-        addedAccountAddress: primaryKeyringAccounts[accountCount],
+        addedAccountAddress: oldAccounts[accountCount],
       };
     }
 
@@ -797,7 +796,7 @@ export class KeyringController extends BaseController<
   }
 
   /**
-   * Returns the public addresses of all accounts for the current keyring.
+   * Returns the public addresses of all accounts from every keyring.
    *
    * @returns A promise resolving to an array of addresses.
    */


### PR DESCRIPTION
## Explanation

This PR addresses a bug in the keyring controller where invoking addNewAccount inadvertently retrieves addresses from all keyrings, rather than exclusively from the HD keyring. This behavior leads to inconsistencies and errors when accounts from different keyring types are present. The primary symptom of this bug is the retrieval of an incorrect number of accounts, with some operations potentially resulting in an undefined address. This issue is notably impactful as it can cause the selectedAddress to be undefined in clients, leading to unexpected behavior and degraded user experience.

## References

* Fixes #4157

## Changelog

### `@metamask/keyring-controller`

- **BREAKING**: Use getAccounts on HD keyring when calling `addNewAccount` instead of `this.getAccounts` which retrieves every account. 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
