### PR TITLE
Draft: include `data` property in transaction error

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -4167,6 +4167,7 @@ describe('TransactionController', () => {
         stack: errorMock.stack,
         code: undefined,
         rpc: undefined,
+        data: undefined,
       };
 
       firePendingTransactionTrackerEvent(

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -956,6 +956,16 @@ export type TransactionError = {
   // <https://github.com/immerjs/immer/issues/839>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   rpc?: any;
+
+  /**
+   * Additional data related to the error.
+   */
+  // We are intentionally using `any` here instead of `Json` because it causes
+  // `WritableDraft<TransactionMeta>` from Immer to cause TypeScript to error
+  // with "Type instantiation is excessively deep and possibly infinite". See:
+  // <https://github.com/immerjs/immer/issues/839>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: any;
 };
 
 /**

--- a/packages/transaction-controller/src/utils/utils.test.ts
+++ b/packages/transaction-controller/src/utils/utils.test.ts
@@ -1,3 +1,5 @@
+import { rpcErrors } from '@metamask/rpc-errors';
+
 import type {
   GasPriceValue,
   FeeMarketEIP1559Values,
@@ -192,13 +194,14 @@ describe('utils', () => {
       message: 'An error occurred',
       stack: 'Error stack trace',
     };
-    it('returns the error object with no code and rpc properties', () => {
+    it('returns the error object with name, message and stack properties', () => {
       const normalizedError = util.normalizeTxError(errorBase);
 
       expect(normalizedError).toStrictEqual({
         ...errorBase,
         code: undefined,
         rpc: undefined,
+        data: undefined,
       });
     });
 
@@ -215,6 +218,25 @@ describe('utils', () => {
         ...errorBase,
         code: 'ERROR_CODE',
         rpc: { code: 'rpc data' },
+        data: undefined,
+      });
+    });
+
+    it('returns the message from data if message is generic', () => {
+      const error = {
+        ...errorBase,
+        code: 'ERROR_CODE',
+        message: rpcErrors.internal().message.toString(),
+        data: { message: 'data message mock' },
+      };
+
+      const normalizedError = util.normalizeTxError(error);
+
+      expect(normalizedError).toStrictEqual({
+        ...error,
+        code: 'ERROR_CODE',
+        rpc: undefined,
+        message: error.data.message,
       });
     });
   });


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
