### PR TITLE
Support number gas values in user operation receipts

### DIFF
--- a/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.ts
+++ b/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.ts
@@ -10,6 +10,7 @@ import { projectLogger } from '../logger';
 import type { UserOperationMetadata, UserOperationReceipt } from '../types';
 import { UserOperationStatus } from '../types';
 import type { UserOperationControllerMessenger } from '../UserOperationController';
+import { normalizeGasValue } from '../utils/utils';
 import { Bundler } from './Bundler';
 
 const log = createModuleLogger(projectLogger, 'pending-user-operations');
@@ -158,8 +159,8 @@ export class PendingUserOperationTracker extends BlockTrackerPollingControllerOn
       [blockHash, false],
     );
 
-    metadata.actualGasCost = actualGasCost;
-    metadata.actualGasUsed = actualGasUsed;
+    metadata.actualGasCost = normalizeGasValue(actualGasCost);
+    metadata.actualGasUsed = normalizeGasValue(actualGasUsed);
     metadata.baseFeePerGas = baseFeePerGas;
     metadata.status = UserOperationStatus.Confirmed;
     metadata.transactionHash = transactionHash;

--- a/packages/user-operation-controller/src/types.ts
+++ b/packages/user-operation-controller/src/types.ts
@@ -315,10 +315,10 @@ export type SmartContractAccount = {
  */
 export type UserOperationReceipt = {
   /** Confirmed total cost of the gas for the user operation. */
-  actualGasCost: string;
+  actualGasCost: string | number;
 
   /** Confirmed total amount of gas used by the user operation. */
-  actualGasUsed: string;
+  actualGasUsed: string | number;
 
   /** True if the user operation was successfully confirmed on chain. */
   success: boolean;

--- a/packages/user-operation-controller/src/utils/utils.test.ts
+++ b/packages/user-operation-controller/src/utils/utils.test.ts
@@ -1,0 +1,16 @@
+import { normalizeGasValue } from './utils';
+
+describe('normalizeGasValue', () => {
+  it('should return a hex string when given a number', () => {
+    const gasValue = 1000;
+    const expectedHex = '0x3e8'; // 1000 in hexadecimal
+    const normalizedValue = normalizeGasValue(gasValue);
+    expect(normalizedValue).toBe(expectedHex);
+  });
+
+  it('should return the same string when given a string', () => {
+    const gasValue = '0x3e8';
+    const normalizedValue = normalizeGasValue(gasValue);
+    expect(normalizedValue).toBe(gasValue);
+  });
+});

--- a/packages/user-operation-controller/src/utils/utils.ts
+++ b/packages/user-operation-controller/src/utils/utils.ts
@@ -1,0 +1,14 @@
+import { toHex } from '@metamask/controller-utils';
+
+/**
+ * Normalize the given gas value to a string.
+ *
+ * @param gasValue - The gas value to normalize.
+ * @returns The normalized gas value.
+ */
+export function normalizeGasValue(gasValue: string | number): string {
+  if (typeof gasValue === 'number') {
+    return toHex(gasValue);
+  }
+  return gasValue;
+}


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR aims to add support of standard number gas values in user operation receipts. 

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2367

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/transaction-controller`

- **FIXED**: Add support of standard number type of gas values in user operation receipts

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [] I've highlighted breaking changes using the "BREAKING" category above as appropriate
