### PR TITLE
feat: track number of autodetected tokens by network not imported

### DIFF
--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -1909,6 +1909,7 @@ describe('TokenDetectionController', () => {
     it('should invoke the `trackMetaMetricsEvent` callback when token detection is triggered', async () => {
       const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({
         [sampleTokenA.address]: new BN(1),
+        [sampleTokenB.address]: new BN(1),
       });
       const selectedAddress = '0x0000000000000000000000000000000000000001';
       const mockTrackMetaMetricsEvent = jest.fn();
@@ -1938,6 +1939,15 @@ describe('TokenDetectionController', () => {
                     aggregators: sampleTokenA.aggregators,
                     iconUrl: sampleTokenA.image,
                   },
+                  [sampleTokenB.address]: {
+                    name: sampleTokenB.name,
+                    symbol: sampleTokenB.symbol,
+                    decimals: sampleTokenB.decimals,
+                    address: sampleTokenB.address,
+                    occurrences: 1,
+                    aggregators: sampleTokenB.aggregators,
+                    iconUrl: sampleTokenB.image,
+                  },
                 },
               },
             },
@@ -1952,9 +1962,15 @@ describe('TokenDetectionController', () => {
             event: 'Token Detected',
             category: 'Wallet',
             properties: {
-              tokens: [`${sampleTokenA.symbol} - ${sampleTokenA.address}`],
+              tokens: [
+                `${sampleTokenA.symbol} - ${sampleTokenA.address}`,
+                `${sampleTokenB.symbol} - ${sampleTokenB.address}`,
+              ],
               token_standard: 'ERC20',
               asset_type: 'TOKEN',
+              chain_id: '0x1',
+              number: 2,
+              selectedAddress,
             },
           });
         },

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -176,6 +176,9 @@ export class TokenDetectionController extends StaticIntervalPollingController<
       tokens: string[];
       token_standard: string;
       asset_type: string;
+      chain_id: string;
+      number: number;
+      selectedAddress: string;
     };
   }) => void;
 
@@ -605,6 +608,9 @@ export class TokenDetectionController extends StaticIntervalPollingController<
             tokens: eventTokensDetails,
             token_standard: 'ERC20',
             asset_type: 'TOKEN',
+            chain_id: chainId,
+            number: tokensWithBalance.length,
+            selectedAddress,
           },
         });
 


### PR DESCRIPTION
## Explanation

in this PR we want to track the number of autodetected tokens per network on segement

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **ADDED**: Add the track event for the number of the autodetected tokens by network


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
