### PR TITLE
Fix/flush on revoke perms 2

### DIFF
--- a/packages/queued-request-controller/src/QueuedRequestController.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.ts
@@ -181,7 +181,7 @@ export class QueuedRequestController extends BaseController<
       (_, patch) => {
         patch.forEach(({ op, path }) => {
           if (
-            (op === 'replace' || op === 'add') &&
+            (op === 'replace' || op === 'add' || op === 'remove') &&
             path.length === 2 &&
             path[0] === 'domains' &&
             typeof path[1] === 'string'

--- a/packages/queued-request-controller/src/QueuedRequestController.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.ts
@@ -80,6 +80,7 @@ export type QueuedRequestControllerMessenger = RestrictedControllerMessenger<
 export type QueuedRequestControllerOptions = {
   messenger: QueuedRequestControllerMessenger;
   methodsRequiringNetworkSwitch: string[];
+  clearPendingConfirmations: () => void;
 };
 
 /**
@@ -144,16 +145,20 @@ export class QueuedRequestController extends BaseController<
    */
   readonly #methodsRequiringNetworkSwitch: string[];
 
+  #clearPendingConfirmations: () => void;
+
   /**
    * Construct a QueuedRequestController.
    *
    * @param options - Controller options.
    * @param options.messenger - The restricted controller messenger that facilitates communication with other controllers.
    * @param options.methodsRequiringNetworkSwitch - A list of methods that require the globally selected network to match the dapp selected network.
+   * @param options.clearPendingConfirmations - A function that will clear all the pending confirmations.
    */
   constructor({
     messenger,
     methodsRequiringNetworkSwitch,
+    clearPendingConfirmations,
   }: QueuedRequestControllerOptions) {
     super({
       name: controllerName,
@@ -167,6 +172,7 @@ export class QueuedRequestController extends BaseController<
       state: { queuedRequestCount: 0 },
     });
     this.#methodsRequiringNetworkSwitch = methodsRequiringNetworkSwitch;
+    this.#clearPendingConfirmations = clearPendingConfirmations;
     this.#registerMessageHandlers();
   }
 
@@ -181,12 +187,17 @@ export class QueuedRequestController extends BaseController<
       (_, patch) => {
         patch.forEach(({ op, path }) => {
           if (
-            (op === 'replace' || op === 'add' || op === 'remove') &&
             path.length === 2 &&
             path[0] === 'domains' &&
             typeof path[1] === 'string'
           ) {
-            this.#flushQueueForOrigin(path[1]);
+            const origin = path[1];
+            this.#flushQueueForOrigin(origin);
+            // When a domain is removed from SelectedNetworkController, its because of revoke permissions.
+            // Rather than subscribe to the permissions controller event in addition to the selectedNetworkController ones, we simplify it and just handle remove on this event alone.
+            if (op === 'remove' && origin === this.#originOfCurrentBatch) {
+              this.#clearPendingConfirmations();
+            }
           }
         });
       },


### PR DESCRIPTION
## Explanation

When a user calls revokePermissions, any pending confirmations should be considered invalid, and they should be immediately rejected.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->
https://github.com/MetaMask/core/issues/4152

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/queued-request-controller`

- **fix**: when permissions are revoked for a domain, clear any pending confirmations associated with the domain

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
