### PR TITLE
fix: update setSelectedAccount to throw if the id is not found

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1782,6 +1782,7 @@ describe('AccountsController', () => {
     });
 
     it('should throw an error if the account ID is not found', () => {
+      const accountId = 'unknown account';
       const accountsController = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -1791,8 +1792,8 @@ describe('AccountsController', () => {
         },
       });
       expect(() =>
-        accountsController.setAccountName('unknown account', 'new name'),
-      ).toThrow(`Account Id unknown account not found`);
+        accountsController.setAccountName(accountId, 'new name'),
+      ).toThrow(`Account Id ${accountId} not found`);
     });
   });
 

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1729,7 +1729,7 @@ describe('AccountsController', () => {
     });
 
     it('should throw error if the account is not found', () => {
-      const accountId = 'unknown';
+      const accountId = 'unknown id';
       const accountsController = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -1784,7 +1784,7 @@ describe('AccountsController', () => {
     });
 
     it('should throw an error if the account ID is not found', () => {
-      const accountId = 'unknown account';
+      const accountId = 'unknown id';
       const accountsController = setupAccountsController({
         initialState: {
           internalAccounts: {

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1727,25 +1727,6 @@ describe('AccountsController', () => {
         accountsController.state.internalAccounts.selectedAccount,
       ).toStrictEqual(mockAccount2.id);
     });
-
-    it('should throw error if the account is not found', () => {
-      const accountId = 'unknown id';
-      const accountsController = setupAccountsController({
-        initialState: {
-          internalAccounts: {
-            accounts: {
-              [mockAccount.id]: mockAccount,
-              [mockAccount2.id]: mockAccount2,
-            },
-            selectedAccount: mockAccount.id,
-          },
-        },
-      });
-
-      expect(() => accountsController.setSelectedAccount(accountId)).toThrow(
-        `Account Id "${accountId}" not found`,
-      );
-    });
   });
 
   describe('setAccountName', () => {
@@ -1781,21 +1762,6 @@ describe('AccountsController', () => {
       expect(() =>
         accountsController.setAccountName(mockAccount.id, 'Account 2'),
       ).toThrow('Account name already exists');
-    });
-
-    it('should throw an error if the account ID is not found', () => {
-      const accountId = 'unknown id';
-      const accountsController = setupAccountsController({
-        initialState: {
-          internalAccounts: {
-            accounts: { [mockAccount.id]: mockAccount },
-            selectedAccount: mockAccount.id,
-          },
-        },
-      });
-      expect(() =>
-        accountsController.setAccountName(accountId, 'new name'),
-      ).toThrow(`Account Id "${accountId}" not found`);
     });
   });
 

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1697,7 +1697,7 @@ describe('AccountsController', () => {
       ).toStrictEqual(mockAccount2.id);
     });
 
-    it("should set the selected account to '' if the account is not found", () => {
+    it('should throw error if the account is not found', () => {
       const accountsController = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -1710,10 +1710,8 @@ describe('AccountsController', () => {
         },
       });
 
-      accountsController.setSelectedAccount('unknown');
-
-      expect(accountsController.state.internalAccounts.selectedAccount).toBe(
-        '',
+      expect(() => accountsController.setSelectedAccount('unknown')).toThrow(
+        'Account Id unknown not found',
       );
     });
   });

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1647,6 +1647,7 @@ describe('AccountsController', () => {
     });
 
     it('should throw an error for an unknown account ID', () => {
+      const accountId = 'unknown id';
       const accountsController = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -1656,8 +1657,8 @@ describe('AccountsController', () => {
         },
       });
 
-      expect(() => accountsController.getAccountExpect('unknown id')).toThrow(
-        `Account Id unknown id not found`,
+      expect(() => accountsController.getAccountExpect(accountId)).toThrow(
+        `Account Id "${accountId}" not found`,
       );
     });
 
@@ -1728,6 +1729,7 @@ describe('AccountsController', () => {
     });
 
     it('should throw error if the account is not found', () => {
+      const accountId = 'unknown';
       const accountsController = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -1740,8 +1742,8 @@ describe('AccountsController', () => {
         },
       });
 
-      expect(() => accountsController.setSelectedAccount('unknown')).toThrow(
-        'Account Id unknown not found',
+      expect(() => accountsController.setSelectedAccount(accountId)).toThrow(
+        `Account Id "${accountId}" not found`,
       );
     });
   });
@@ -1793,7 +1795,7 @@ describe('AccountsController', () => {
       });
       expect(() =>
         accountsController.setAccountName(accountId, 'new name'),
-      ).toThrow(`Account Id ${accountId} not found`);
+      ).toThrow(`Account Id "${accountId}" not found`);
     });
   });
 

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -230,7 +230,7 @@ export class AccountsController extends BaseController<
 
     const account = this.getAccount(accountId);
     if (account === undefined) {
-      throw new Error(`Account Id ${accountId} not found`);
+      throw new Error(`Account Id "${accountId}" not found`);
     }
     return account;
   }
@@ -265,7 +265,7 @@ export class AccountsController extends BaseController<
     const account = this.getAccount(accountId);
 
     if (!account) {
-      throw new Error(`Account Id ${accountId} not found`);
+      throw new Error(`Account Id "${accountId}" not found`);
     }
 
     this.update((currentState: Draft<AccountsControllerState>) => {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -262,11 +262,7 @@ export class AccountsController extends BaseController<
    * @param accountId - The ID of the account to be selected.
    */
   setSelectedAccount(accountId: string): void {
-    const account = this.getAccount(accountId);
-
-    if (!account) {
-      throw new Error(`Account Id "${accountId}" not found`);
-    }
+    const account = this.getAccountExpect(accountId);
 
     this.update((currentState: Draft<AccountsControllerState>) => {
       currentState.internalAccounts.accounts[account.id].metadata.lastSelected =


### PR DESCRIPTION
## Explanation

This PR updates the logic of setSelectedAccount to reject unknown account ids. 

## References

## Changelog

### `@metamask/accounts-controller`

- **CHANGED**: Reject unknown account ids in setSelectedAccount

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
