### PR TITLE
fix: add HD keyring check to `persistAllKeyrings`

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -1069,12 +1069,20 @@ describe('KeyringController', () => {
        * If there is only HD Key Tree keyring with 1 account and removeAccount is called passing that account
        * It deletes keyring object also from state - not sure if this is correct behavior.
        * https://github.com/MetaMask/core/issues/801
+       *
+       * Update: The behaviour is now modified to never remove the HD keyring as a preventive and temporal solution to the current race
+       * condition case we have been seeing lately. https://github.com/MetaMask/mobile-planning/issues/1507
+       * Enforcing this behaviour is not a 100% correct and it should be responsibility of the consumer to handle the accounts
+       * and keyrings in a way that it matches the expected behaviour.
        */
-      it('should remove HD Key Tree keyring from state when single account associated with it is deleted', async () => {
+      it('should not remove HD Key Tree keyring nor the single account from state', async () => {
         await withController(async ({ controller, initialState }) => {
           const account = initialState.keyrings[0].accounts[0] as Hex;
-          await controller.removeAccount(account);
-          expect(controller.state.keyrings).toHaveLength(0);
+          await expect(controller.removeAccount(account)).rejects.toThrow(
+            KeyringControllerError.NoHdKeyring,
+          );
+          expect(controller.state.keyrings).toHaveLength(1);
+          expect(controller.state.keyrings[0].accounts).toHaveLength(1);
         });
       });
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -944,6 +944,12 @@ export class KeyringController extends BaseController<
 
     serializedKeyrings.push(...this.#unsupportedKeyrings);
 
+    if (
+      !serializedKeyrings.some((keyring) => keyring.type === KeyringTypes.hd)
+    ) {
+      throw new Error(KeyringControllerError.NoHdKeyring);
+    }
+
     let vault: string | undefined;
     let newEncryptionKey: string | undefined;
 

--- a/packages/keyring-controller/src/constants.ts
+++ b/packages/keyring-controller/src/constants.ts
@@ -26,4 +26,5 @@ export enum KeyringControllerError {
   ExpiredCredentials = 'KeyringController - Encryption key and salt provided are expired',
   NoKeyringBuilder = 'KeyringController - No keyringBuilder found for keyring',
   DataType = 'KeyringController - Incorrect data type provided',
+  NoHdKeyring = 'KeyringController - No HD Keyring found',
 }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR adds a check to the `persistAllKeyrings` method to avoid removing the HD Key Tree keyring.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

Related to https://github.com/MetaMask/mobile-planning/issues/1507

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/keyring-controller`

- **CHANGED**: Add check to avoid removing HD Key Tree keyring during execution of `persistAllKeyrings`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
