### PR TITLE
refactor(permission-controller): Clean up use of `any`

### DIFF
--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -302,7 +302,6 @@ export class AccountsController extends BaseController<
         metadata: { ...account.metadata, name: accountName },
       };
       currentState.internalAccounts.accounts[accountId] =
-        // @ts-expect-error Assigning a complex type `T` to `Draft<T>` causes an excessive type instantiation depth error.
         internalAccount as Draft<InternalAccount>;
     });
   }

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -302,8 +302,7 @@ export class AccountsController extends BaseController<
         ...account,
         metadata: { ...account.metadata, name: accountName },
       };
-      currentState.internalAccounts.accounts[accountId] =
-        internalAccount as Draft<InternalAccount>;
+      currentState.internalAccounts.accounts[accountId] = internalAccount;
     });
   }
 

--- a/packages/permission-controller/src/Caveat.test.ts
+++ b/packages/permission-controller/src/Caveat.test.ts
@@ -1,4 +1,4 @@
-import type { PermissionConstraint } from '.';
+import type { Caveat, PermissionConstraint } from '.';
 import { decorateWithCaveats, PermissionType } from '.';
 import * as errors from './errors';
 
@@ -9,10 +9,11 @@ describe('decorateWithCaveats', () => {
     const caveatSpecifications = {
       reverse: {
         type: 'reverse',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        decorator: (method: any, _caveat: any) => async () => {
-          return (await method()).reverse();
-        },
+        decorator:
+          (method: () => Promise<unknown[]>, _caveat: Caveat<string, null>) =>
+          async () => {
+            return (await method()).reverse();
+          },
       },
     };
 
@@ -45,17 +46,19 @@ describe('decorateWithCaveats', () => {
     const caveatSpecifications = {
       reverse: {
         type: 'reverse',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        decorator: (method: any, _caveat: any) => async () => {
-          return (await method()).reverse();
-        },
+        decorator:
+          (method: () => Promise<unknown[]>, _caveat: Caveat<string, null>) =>
+          async () => {
+            return (await method()).reverse();
+          },
       },
       slice: {
         type: 'slice',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        decorator: (method: any, caveat: any) => async () => {
-          return (await method()).slice(0, caveat.value);
-        },
+        decorator:
+          (method: () => Promise<unknown[]>, caveat: Caveat<string, number>) =>
+          async () => {
+            return (await method()).slice(0, caveat.value);
+          },
       },
     };
 
@@ -111,10 +114,11 @@ describe('decorateWithCaveats', () => {
     const caveatSpecifications = {
       reverse: {
         type: 'reverse',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        decorator: (method: any, _caveat: any) => async () => {
-          return (await method()).reverse();
-        },
+        decorator:
+          (method: () => Promise<unknown[]>, _caveat: Caveat<string, null>) =>
+          async () => {
+            return (await method()).reverse();
+          },
       },
     };
 

--- a/packages/permission-controller/src/Caveat.test.ts
+++ b/packages/permission-controller/src/Caveat.test.ts
@@ -9,7 +9,6 @@ describe('decorateWithCaveats', () => {
     const caveatSpecifications = {
       reverse: {
         type: 'reverse',
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         decorator: (method: any, _caveat: any) => async () => {
           return (await method()).reverse();
@@ -46,7 +45,6 @@ describe('decorateWithCaveats', () => {
     const caveatSpecifications = {
       reverse: {
         type: 'reverse',
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         decorator: (method: any, _caveat: any) => async () => {
           return (await method()).reverse();
@@ -54,7 +52,6 @@ describe('decorateWithCaveats', () => {
       },
       slice: {
         type: 'slice',
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         decorator: (method: any, caveat: any) => async () => {
           return (await method()).slice(0, caveat.value);
@@ -114,7 +111,6 @@ describe('decorateWithCaveats', () => {
     const caveatSpecifications = {
       reverse: {
         type: 'reverse',
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         decorator: (method: any, _caveat: any) => async () => {
           return (await method()).reverse();

--- a/packages/permission-controller/src/Caveat.ts
+++ b/packages/permission-controller/src/Caveat.ts
@@ -82,15 +82,12 @@ export type CaveatDecorator<ParentCaveat extends CaveatConstraint> = (
  * @template Decorator - The {@link CaveatDecorator} to extract a caveat value
  * type from.
  */
-// TODO: Replace `any` with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ExtractCaveatValueFromDecorator<Decorator extends CaveatDecorator<any>> =
   Decorator extends (
-    // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     decorated: any,
     caveat: infer ParentCaveat,
-    // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) => AsyncRestrictedMethod<any, any>
     ? ParentCaveat extends CaveatConstraint
@@ -129,7 +126,6 @@ export type CaveatSpecificationBase = {
    * performed. Although caveats can also be validated by permission validators,
    * validating caveat values separately is strongly recommended.
    */
-  // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   validator?: CaveatValidator<any>;
 };
@@ -140,7 +136,6 @@ export type RestrictedMethodCaveatSpecificationConstraint =
      * The decorator function used to apply the caveat to restricted method
      * requests.
      */
-    // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     decorator: CaveatDecorator<any>;
   };
@@ -180,7 +175,6 @@ type CaveatSpecificationBuilderOptions<
  * tailored to their requirements.
  */
 export type CaveatSpecificationBuilder<
-  // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Options extends CaveatSpecificationBuilderOptions<any, any>,
   Specification extends CaveatSpecificationConstraint,
@@ -192,7 +186,6 @@ export type CaveatSpecificationBuilder<
  */
 export type CaveatSpecificationBuilderExportConstraint = {
   specificationBuilder: CaveatSpecificationBuilder<
-    // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     CaveatSpecificationBuilderOptions<any, any>,
     CaveatSpecificationConstraint
@@ -220,7 +213,6 @@ export type CaveatSpecificationMap<
  */
 export type ExtractCaveats<
   CaveatSpecification extends CaveatSpecificationConstraint,
-  // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 > = CaveatSpecification extends any
   ? CaveatSpecification extends RestrictedMethodCaveatSpecificationConstraint

--- a/packages/permission-controller/src/Caveat.ts
+++ b/packages/permission-controller/src/Caveat.ts
@@ -82,18 +82,16 @@ export type CaveatDecorator<ParentCaveat extends CaveatConstraint> = (
  * @template Decorator - The {@link CaveatDecorator} to extract a caveat value
  * type from.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ExtractCaveatValueFromDecorator<Decorator extends CaveatDecorator<any>> =
-  Decorator extends (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    decorated: any,
-    caveat: infer ParentCaveat,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ) => AsyncRestrictedMethod<any, any>
-    ? ParentCaveat extends CaveatConstraint
-      ? ParentCaveat['value']
-      : never
-    : never;
+type ExtractCaveatValueFromDecorator<
+  Decorator extends CaveatDecorator<CaveatConstraint>,
+> = Decorator extends (
+  decorated: AsyncRestrictedMethod<RestrictedMethodParameters, Json>,
+  caveat: infer ParentCaveat,
+) => AsyncRestrictedMethod<RestrictedMethodParameters, Json>
+  ? ParentCaveat extends CaveatConstraint
+    ? ParentCaveat['value']
+    : never
+  : never;
 
 /**
  * A function for validating caveats of a particular type.
@@ -126,6 +124,7 @@ export type CaveatSpecificationBase = {
    * performed. Although caveats can also be validated by permission validators,
    * validating caveat values separately is strongly recommended.
    */
+  // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   validator?: CaveatValidator<any>;
 };
@@ -136,8 +135,7 @@ export type RestrictedMethodCaveatSpecificationConstraint =
      * The decorator function used to apply the caveat to restricted method
      * requests.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    decorator: CaveatDecorator<any>;
+    decorator: CaveatDecorator<CaveatConstraint>;
   };
 
 export type EndowmentCaveatSpecificationConstraint = CaveatSpecificationBase;
@@ -175,8 +173,10 @@ type CaveatSpecificationBuilderOptions<
  * tailored to their requirements.
  */
 export type CaveatSpecificationBuilder<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Options extends CaveatSpecificationBuilderOptions<any, any>,
+  Options extends CaveatSpecificationBuilderOptions<
+    Record<string, unknown>,
+    Record<string, unknown>
+  >,
   Specification extends CaveatSpecificationConstraint,
 > = (options: Options) => Specification;
 
@@ -186,8 +186,10 @@ export type CaveatSpecificationBuilder<
  */
 export type CaveatSpecificationBuilderExportConstraint = {
   specificationBuilder: CaveatSpecificationBuilder<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    CaveatSpecificationBuilderOptions<any, any>,
+    CaveatSpecificationBuilderOptions<
+      Record<string, unknown>,
+      Record<string, unknown>
+    >,
     CaveatSpecificationConstraint
   >;
   decoratorHookNames?: Record<string, true>;
@@ -213,17 +215,14 @@ export type CaveatSpecificationMap<
  */
 export type ExtractCaveats<
   CaveatSpecification extends CaveatSpecificationConstraint,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-> = CaveatSpecification extends any
-  ? CaveatSpecification extends RestrictedMethodCaveatSpecificationConstraint
-    ? Caveat<
-        CaveatSpecification['type'],
-        ExtractCaveatValueFromDecorator<
-          RestrictedMethodCaveatSpecificationConstraint['decorator']
-        >
+> = CaveatSpecification extends RestrictedMethodCaveatSpecificationConstraint
+  ? Caveat<
+      CaveatSpecification['type'],
+      ExtractCaveatValueFromDecorator<
+        RestrictedMethodCaveatSpecificationConstraint['decorator']
       >
-    : Caveat<CaveatSpecification['type'], Json>
-  : never;
+    >
+  : Caveat<CaveatSpecification['type'], Json>;
 
 /**
  * Extracts the type of a specific {@link Caveat} from a union of caveat

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -444,7 +444,7 @@ export type RestrictedMethodSpecificationConstraint =
      */
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    methodImplementation: RestrictedMethod<any, any>;
+    methodImplementation: RestrictedMethod<any, Json>;
   };
 
 /**

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -118,9 +118,7 @@ export type ValidPermission<
  */
 type ExtractArrayMembers<ArrayType> = ArrayType extends []
   ? never
-  : // TODO: Replace `any` with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ArrayType extends any[] | readonly any[]
+  : ArrayType extends unknown[] | readonly unknown[]
   ? ArrayType[number]
   : never;
 
@@ -209,9 +207,7 @@ export type RequestedPermissions = Record<TargetName, RequestedPermission>;
  */
 type RestrictedMethodContext = Readonly<{
   origin: OriginString;
-  // TODO: Replace `any` with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  [key: string]: unknown;
 }>;
 
 export type RestrictedMethodParameters = Json[] | Record<string, Json>;
@@ -265,9 +261,10 @@ export type RestrictedMethod<
   | AsyncRestrictedMethod<Params, Result>;
 
 export type ValidRestrictedMethod<
-  // TODO: Replace `any` with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  MethodImplementation extends RestrictedMethod<any, any>,
+  MethodImplementation extends RestrictedMethod<
+    RestrictedMethodParameters,
+    Json
+  >,
 > = MethodImplementation extends (args: infer Options) => Json | Promise<Json>
   ? Options extends RestrictedMethodOptions<RestrictedMethodParameters>
     ? MethodImplementation
@@ -404,7 +401,6 @@ type PermissionSpecificationBase<Type extends PermissionType> = {
    * used, and the validator function (if specified) will be called on newly
    * constructed permissions.
    */
-  // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   factory?: PermissionFactory<any, Record<string, unknown>>;
 
@@ -423,7 +419,6 @@ type PermissionSpecificationBase<Type extends PermissionType> = {
    *
    * If the side-effect action fails, the permission that triggered it is revoked.
    */
-  // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sideEffect?: PermissionSideEffect<any, any>;
 
@@ -449,7 +444,6 @@ export type RestrictedMethodSpecificationConstraint =
      * The implementation of the restricted method that the permission
      * corresponds to.
      */
-    // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     methodImplementation: RestrictedMethod<any, any>;
   };
@@ -469,7 +463,6 @@ export type EndowmentSpecificationConstraint =
      * permission is invoked, after which the host can apply the endowments to
      * the requesting subject in the intended manner.
      */
-    // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     endowmentGetter: EndowmentGetter<any>;
   };
@@ -511,7 +504,6 @@ type PermissionSpecificationBuilderOptions<
  */
 export type PermissionSpecificationBuilder<
   Type extends PermissionType,
-  // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Options extends PermissionSpecificationBuilderOptions<any, any, any>,
   Specification extends PermissionSpecificationConstraint & {
@@ -527,7 +519,6 @@ export type PermissionSpecificationBuilderExportConstraint = {
   targetName: string;
   specificationBuilder: PermissionSpecificationBuilder<
     PermissionType,
-    // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     PermissionSpecificationBuilderOptions<any, any, any>,
     PermissionSpecificationConstraint

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -401,6 +401,7 @@ type PermissionSpecificationBase<Type extends PermissionType> = {
    * used, and the validator function (if specified) will be called on newly
    * constructed permissions.
    */
+  // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   factory?: PermissionFactory<any, Record<string, unknown>>;
 
@@ -419,8 +420,7 @@ type PermissionSpecificationBase<Type extends PermissionType> = {
    *
    * If the side-effect action fails, the permission that triggered it is revoked.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  sideEffect?: PermissionSideEffect<any, any>;
+  sideEffect?: PermissionSideEffect<ActionConstraint, EventConstraint>;
 
   /**
    * The Permission may be available to only a subset of the subject types. If so, specify the subject types as an array.
@@ -444,6 +444,7 @@ export type RestrictedMethodSpecificationConstraint =
      * The implementation of the restricted method that the permission
      * corresponds to.
      */
+    // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     methodImplementation: RestrictedMethod<any, any>;
   };
@@ -463,8 +464,7 @@ export type EndowmentSpecificationConstraint =
      * permission is invoked, after which the host can apply the endowments to
      * the requesting subject in the intended manner.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    endowmentGetter: EndowmentGetter<any>;
+    endowmentGetter: EndowmentGetter<Json>;
   };
 
 /**
@@ -504,8 +504,11 @@ type PermissionSpecificationBuilderOptions<
  */
 export type PermissionSpecificationBuilder<
   Type extends PermissionType,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Options extends PermissionSpecificationBuilderOptions<any, any, any>,
+  Options extends PermissionSpecificationBuilderOptions<
+    Record<string, unknown>,
+    Record<string, unknown>,
+    Record<string, unknown>
+  >,
   Specification extends PermissionSpecificationConstraint & {
     permissionType: Type;
   },
@@ -519,8 +522,11 @@ export type PermissionSpecificationBuilderExportConstraint = {
   targetName: string;
   specificationBuilder: PermissionSpecificationBuilder<
     PermissionType,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    PermissionSpecificationBuilderOptions<any, any, any>,
+    PermissionSpecificationBuilderOptions<
+      Record<string, unknown>,
+      Record<string, unknown>,
+      Record<string, unknown>
+    >,
     PermissionSpecificationConstraint
   >;
   factoryHookNames?: Record<string, true>;

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -12,7 +12,6 @@ import type {
   JsonRpcFailure,
   JsonRpcRequest,
   JsonRpcSuccess,
-  PendingJsonRpcResponse,
 } from '@metamask/utils';
 import { hasProperty } from '@metamask/utils';
 import assert from 'assert';
@@ -27,6 +26,7 @@ import type {
   PermissionControllerActions,
   PermissionControllerEvents,
   PermissionOptions,
+  PermissionsRequest,
   RestrictedMethodOptions,
   RestrictedMethodParameters,
   ValidPermission,
@@ -457,6 +457,18 @@ type AllowedActions =
   | AcceptApprovalRequest
   | RejectApprovalRequest
   | GetSubjectMetadata;
+
+/**
+ * Params for `ApprovalController:addRequest` of type `wallet_requestPermissions`.
+ */
+type AddPermissionRequestParams = {
+  id: string;
+  origin: string;
+  requestData: PermissionsRequest;
+  type: MethodNames.requestPermissions;
+};
+
+type AddPermissionRequestArgs = [string, AddPermissionRequestParams];
 
 /**
  * Gets a unrestricted controller messenger. Used for tests.
@@ -2888,9 +2900,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: { ...requestData.permissions },
@@ -2939,9 +2950,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: { ...requestData.permissions },
@@ -2991,9 +3001,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: { ...requestData.permissions },
@@ -3052,9 +3061,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: { ...requestData.permissions },
@@ -3117,9 +3125,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: { ...requestData.permissions },
@@ -3191,9 +3198,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: { ...requestData.permissions },
@@ -3247,9 +3253,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: { ...requestData.permissions },
@@ -3300,9 +3305,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: { ...requestData.permissions },
@@ -3346,9 +3350,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: { ...requestData.permissions },
@@ -3402,9 +3405,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: { ...requestData.permissions },
@@ -3472,9 +3474,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             // endowmentAnySubject is added to the request
@@ -3551,9 +3552,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           const approvedPermissions = { ...requestData.permissions };
           delete approvedPermissions[PermissionNames.wallet_getSecretArray];
 
@@ -3626,9 +3626,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           const approvedPermissions = { ...requestData.permissions };
           approvedPermissions[PermissionNames.wallet_getSecretObject] = {
             caveats: [
@@ -3921,9 +3920,8 @@ describe('PermissionController', () => {
             extensionId: null,
           };
         })
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: { ...requestData.permissions },
@@ -4113,9 +4111,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             // different id
             metadata: { ...requestData.metadata, id: 'foo' },
@@ -4164,9 +4161,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             // different origin
             metadata: { ...requestData.metadata, origin: 'foo.com' },
@@ -4215,9 +4211,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: {}, // no permissions
@@ -4268,8 +4263,7 @@ describe('PermissionController', () => {
       const callActionSpy = jest.spyOn(messenger, 'call');
 
       // The metadata is valid, but the permissions are invalid
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const getInvalidRequestObject = (invalidPermissions: any) => {
+      const getInvalidRequestObject = (invalidPermissions: unknown) => {
         return {
           metadata: { origin, id },
           permissions: invalidPermissions,
@@ -4327,9 +4321,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: {
@@ -4401,9 +4394,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (...args: any) => {
-          const [, { requestData }] = args;
+        .mockImplementationOnce(async (...args) => {
+          const [, { requestData }] = args as AddPermissionRequestArgs;
           return {
             metadata: { ...requestData.metadata },
             permissions: {

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -1848,7 +1848,6 @@ describe('PermissionController', () => {
       expect(() =>
         controller.removeCaveat(
           origin,
-          // @ts-expect-error Abusing types for testing purposes
           PermissionNames.wallet_noopWithRequiredCaveat,
           CaveatTypes.noopCaveat,
         ),
@@ -2081,16 +2080,15 @@ describe('PermissionController', () => {
       const mutator = () => {
         counter += 1;
         return counter === 1
-          ? { operation: CaveatMutatorOperation.noop }
+          ? { operation: CaveatMutatorOperation.noop as const}
           : {
-              operation: CaveatMutatorOperation.updateValue,
+              operation: CaveatMutatorOperation.updateValue as const,
               value: ['a', 'b'],
             };
       };
 
       controller.updatePermissionsByCaveat(
         CaveatTypes.filterArrayResponse,
-        // @ts-expect-error Abusing types for testing purposes
         mutator,
       );
 

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -692,10 +692,8 @@ describe('PermissionController', () => {
     });
 
     it('throws if a permission specification lists unrecognized caveats', () => {
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const permissionSpecifications: any =
-        getDefaultPermissionSpecifications();
+      const permissionSpecifications = getDefaultPermissionSpecifications();
+      // @ts-expect-error Abusing types for testing purposes
       permissionSpecifications.wallet_getSecretArray.allowedCaveats.push('foo');
 
       expect(
@@ -1652,9 +1650,7 @@ describe('PermissionController', () => {
           origin,
           PermissionNames.wallet_getSecretObject,
           CaveatTypes.noopCaveat,
-          // TODO: Replace `any` with type
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          'bar' as any,
+          'bar',
         ),
       ).toThrow(new Error('NoopCaveat value must be null'));
     });
@@ -1852,7 +1848,7 @@ describe('PermissionController', () => {
       expect(() =>
         controller.removeCaveat(
           origin,
-          // @ts-expect-error - Testing invalid permission name.
+          // @ts-expect-error Abusing types for testing purposes
           PermissionNames.wallet_noopWithRequiredCaveat,
           CaveatTypes.noopCaveat,
         ),
@@ -2082,9 +2078,7 @@ describe('PermissionController', () => {
       const controller = getMultiCaveatController();
 
       let counter = 0;
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mutator: any = () => {
+      const mutator = () => {
         counter += 1;
         return counter === 1
           ? { operation: CaveatMutatorOperation.noop }
@@ -2096,6 +2090,7 @@ describe('PermissionController', () => {
 
       controller.updatePermissionsByCaveat(
         CaveatTypes.filterArrayResponse,
+        // @ts-expect-error Abusing types for testing purposes
         mutator,
       );
 
@@ -2173,9 +2168,7 @@ describe('PermissionController', () => {
       const controller = getMultiCaveatController();
 
       let counter = 0;
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mutator: any = () => {
+      const mutator = () => {
         counter += 1;
         return {
           operation:
@@ -2187,13 +2180,13 @@ describe('PermissionController', () => {
 
       controller.updatePermissionsByCaveat(
         CaveatTypes.filterArrayResponse,
+        // @ts-expect-error Abusing types for testing purposes
         mutator,
       );
 
       const matcher = getMultiCaveatStateMatcher();
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      delete (matcher.subjects as any)[MultiCaveatOrigins.a];
+      // @ts-expect-error Abusing types for testing purposes
+      delete matcher.subjects[MultiCaveatOrigins.a];
 
       expect(controller.state).toStrictEqual(matcher);
     });
@@ -2230,10 +2223,9 @@ describe('PermissionController', () => {
       expect(() =>
         controller.updatePermissionsByCaveat(
           CaveatTypes.filterArrayResponse,
+          // @ts-expect-error Abusing types for testing purposes
           () => {
-            // TODO: Replace `any` with type
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            return { operation: 'foobar' } as any;
+            return { operation: 'foobar' };
           },
         ),
       ).toThrow(`Unrecognized mutation result: "foobar"`);
@@ -2503,9 +2495,8 @@ describe('PermissionController', () => {
 
       expect(() =>
         controller.grantPermissions({
-          // TODO: Replace `any` with type
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          subject: { origin: 2 as any },
+          // @ts-expect-error Abusing types for testing purposes
+          subject: { origin: 2 },
           approvedPermissions: {
             wallet_getSecretArray: {},
           },
@@ -2605,9 +2596,8 @@ describe('PermissionController', () => {
           subject: { origin },
           approvedPermissions: {
             wallet_getSecretArray: {
-              // TODO: Replace `any` with type
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              caveats: [[]] as any,
+              // @ts-expect-error Abusing types for testing purposes
+              caveats: [[]],
             },
           },
         }),
@@ -2624,9 +2614,8 @@ describe('PermissionController', () => {
           subject: { origin },
           approvedPermissions: {
             wallet_getSecretArray: {
-              // TODO: Replace `any` with type
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              caveats: ['foo'] as any,
+              // @ts-expect-error Abusing types for testing purposes
+              caveats: ['foo'],
             },
           },
         }),
@@ -2651,11 +2640,10 @@ describe('PermissionController', () => {
               caveats: [
                 {
                   ...{ type: CaveatTypes.filterArrayResponse, value: ['foo'] },
+                  // @ts-expect-error Abusing types for testing purposes
                   bar: 'bar',
                 },
-                // TODO: Replace `any` with type
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              ] as any,
+              ],
             },
           },
         }),
@@ -2682,12 +2670,11 @@ describe('PermissionController', () => {
             wallet_getSecretArray: {
               caveats: [
                 {
+                  // @ts-expect-error Abusing types for testing purposes
                   type: 2,
                   value: ['foo'],
                 },
-                // TODO: Replace `any` with type
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              ] as any,
+              ],
             },
           },
         }),
@@ -2737,11 +2724,10 @@ describe('PermissionController', () => {
               caveats: [
                 {
                   type: CaveatTypes.filterArrayResponse,
+                  // @ts-expect-error Abusing types for testing purposes
                   foo: 'bar',
                 },
-                // TODO: Replace `any` with type
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              ] as any,
+              ],
             },
           },
         }),
@@ -2761,7 +2747,6 @@ describe('PermissionController', () => {
       const controller = getDefaultPermissionController();
       const origin = 'metamask.io';
 
-      // TODO: Replace `any` with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const circular: any = { foo: 'bar' };
       circular.circular = circular;
@@ -2898,7 +2883,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -2950,7 +2934,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3012,7 +2995,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3078,7 +3060,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3153,7 +3134,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3210,7 +3190,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3264,7 +3243,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3311,7 +3289,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3368,7 +3345,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3439,7 +3415,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3519,7 +3494,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3595,7 +3569,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3691,9 +3664,8 @@ describe('PermissionController', () => {
           async () =>
             await controller.requestPermissions(
               { origin },
-              // TODO: Replace `any` with type
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              invalidInput as any,
+              // @ts-expect-error Abusing types for testing purposes
+              invalidInput,
             ),
         ).rejects.toThrow(
           errors.invalidParams({
@@ -3892,7 +3864,6 @@ describe('PermissionController', () => {
             extensionId: null,
           };
         })
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -3986,9 +3957,8 @@ describe('PermissionController', () => {
               { origin },
               {
                 [PermissionNames.wallet_getSecretArray]: {
-                  // TODO: Replace `any` with type
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  caveats: invalidCaveatsValue as any,
+                  // @ts-expect-error Abusing types for testing purposes
+                  caveats: invalidCaveatsValue,
                 },
               },
             ),
@@ -4086,7 +4056,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -4138,7 +4107,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -4190,7 +4158,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -4244,7 +4211,6 @@ describe('PermissionController', () => {
       const callActionSpy = jest.spyOn(messenger, 'call');
 
       // The metadata is valid, but the permissions are invalid
-      // TODO: Replace `any` with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const getInvalidRequestObject = (invalidPermissions: any) => {
         return {
@@ -4304,7 +4270,6 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockImplementationOnce(async (...args: any) => {
           const [, { requestData }] = args;
@@ -4442,12 +4407,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce((..._args: any) => true)
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce((..._args: any) => undefined);
+        .mockImplementationOnce(() => true)
+        .mockImplementationOnce(() => undefined);
 
       const controller = getDefaultPermissionController(options);
 
@@ -4488,12 +4449,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce((..._args: any) => true)
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce((..._args: any) => undefined);
+        .mockImplementationOnce(() => true)
+        .mockImplementationOnce(() => undefined);
 
       const controller = getDefaultPermissionController(options);
 
@@ -4529,9 +4486,7 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce((..._args: any) => false);
+        .mockImplementationOnce(() => false);
 
       const controller = getDefaultPermissionController(options);
 
@@ -4563,17 +4518,11 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce((..._args: any) => true)
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce((..._args: any) => {
+        .mockImplementationOnce(() => true)
+        .mockImplementationOnce(() => {
           throw new Error('unexpected failure');
         })
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce((..._args: any) => undefined);
+        .mockImplementationOnce(() => undefined);
 
       const controller = getDefaultPermissionController(options);
 
@@ -4625,12 +4574,8 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (..._args: any) => true)
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce(async (..._args: any) => undefined);
+        .mockImplementationOnce(async () => true)
+        .mockImplementationOnce(async () => undefined);
 
       const controller = getDefaultPermissionController(options);
 
@@ -4660,9 +4605,7 @@ describe('PermissionController', () => {
 
       const callActionSpy = jest
         .spyOn(messenger, 'call')
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .mockImplementationOnce((..._args: any) => false);
+        .mockImplementationOnce(() => false);
 
       const controller = getDefaultPermissionController(options);
 
@@ -4715,9 +4658,8 @@ describe('PermissionController', () => {
       await expect(
         controller.getEndowments(
           origin,
-          // TODO: Replace `any` with type
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          PermissionNames.wallet_getSecretArray as any,
+          // @ts-expect-error Abusing types for testing purposes
+          PermissionNames.wallet_getSecretArray,
         ),
       ).rejects.toThrow(
         new errors.EndowmentPermissionDoesNotExistError(
@@ -4847,17 +4789,14 @@ describe('PermissionController', () => {
       const origin = 'metamask.io';
 
       await expect(
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        controller.executeRestrictedMethod(origin, 'wallet_getMeTacos' as any),
+        // @ts-expect-error Abusing types for testing purposes
+        controller.executeRestrictedMethod(origin, 'wallet_getMeTacos'),
       ).rejects.toThrow(errors.methodNotFound('wallet_getMeTacos', { origin }));
     });
 
     it('throws if the restricted method returns undefined', async () => {
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const permissionSpecifications: any =
-        getDefaultPermissionSpecifications();
+      const permissionSpecifications = getDefaultPermissionSpecifications();
+      // @ts-expect-error Abusing types for testing purposes
       permissionSpecifications.wallet_doubleNumber.methodImplementation = () =>
         undefined;
 
@@ -5343,14 +5282,13 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response: any = await engine.handle({
+      const response = await engine.handle({
         jsonrpc: '2.0',
         id: 1,
         method: PermissionNames.wallet_getSecretArray,
       });
 
+      // @ts-expect-error Abusing types for testing purposes
       expect(response.result).toStrictEqual(['a', 'b', 'c']);
     });
 
@@ -5370,14 +5308,13 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response: any = await engine.handle({
+      const response = await engine.handle({
         jsonrpc: '2.0',
         id: 1,
         method: PermissionNames.wallet_getSecretArray,
       });
 
+      // @ts-expect-error Abusing types for testing purposes
       expect(response.result).toStrictEqual(['b']);
     });
 
@@ -5400,14 +5337,13 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response: any = await engine.handle({
+      const response = await engine.handle({
         jsonrpc: '2.0',
         id: 1,
         method: PermissionNames.wallet_getSecretArray,
       });
 
+      // @ts-expect-error Abusing types for testing purposes
       expect(response.result).toStrictEqual(['c', 'a']);
     });
 
@@ -5419,30 +5355,23 @@ describe('PermissionController', () => {
       engine.push(controller.createPermissionMiddleware({ origin }));
       engine.push(
         (
-          // TODO: Replace `any` with type
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          _req: any,
+          _req: unknown,
           res: PendingJsonRpcResponse<'success'>,
-          // TODO: Replace `any` with type
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          _next: any,
-          // TODO: Replace `any` with type
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          end: () => any,
+          _next: unknown,
+          end: () => unknown,
         ) => {
           res.result = 'success';
           end();
         },
       );
 
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response: any = await engine.handle({
+      const response = await engine.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'wallet_unrestrictedMethod',
       });
 
+      // @ts-expect-error Abusing types for testing purposes
       expect(response.result).toBe('success');
     });
 
@@ -5452,9 +5381,8 @@ describe('PermissionController', () => {
       ['', null, undefined, 2].forEach((invalidOrigin) => {
         expect(() =>
           controller.createPermissionMiddleware({
-            // TODO: Replace `any` with type
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            origin: invalidOrigin as any,
+            // @ts-expect-error Abusing types for testing purposes
+            origin: invalidOrigin,
           }),
         ).toThrow(
           new Error('The subject "origin" must be a non-empty string.'),
@@ -5469,9 +5397,7 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const request: any = {
+      const request = {
         jsonrpc: '2.0',
         id: 1,
         method: PermissionNames.wallet_getSecretArray,
@@ -5487,9 +5413,8 @@ describe('PermissionController', () => {
           'Unauthorized to perform action. Try requesting the required permission(s) first. For more information, see: https://docs.metamask.io/guide/rpc-api.html#permissions',
       });
 
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error }: any = await engine.handle(request);
+      // @ts-expect-error Abusing types for testing purposes
+      const { error } = await engine.handle(request);
       expect(error).toMatchObject(expect.objectContaining(expectedError));
     });
 
@@ -5500,9 +5425,7 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const request: any = {
+      const request = {
         jsonrpc: '2.0',
         id: 1,
         method: 'wallet_foo',
@@ -5510,9 +5433,8 @@ describe('PermissionController', () => {
 
       const expectedError = errors.methodNotFound('wallet_foo', { origin });
 
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error }: any = await engine.handle(request);
+      // @ts-expect-error Abusing types for testing purposes
+      const { error } = await engine.handle(request);
 
       expect(error.message).toStrictEqual(expectedError.message);
       expect(error.data.cause).toBeNull();
@@ -5522,10 +5444,8 @@ describe('PermissionController', () => {
     });
 
     it('returns an error if the restricted method returns undefined', async () => {
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const permissionSpecifications: any =
-        getDefaultPermissionSpecifications();
+      const permissionSpecifications = getDefaultPermissionSpecifications();
+      // @ts-expect-error Abusing types for testing purposes
       permissionSpecifications.wallet_doubleNumber.methodImplementation = () =>
         undefined;
 
@@ -5549,9 +5469,7 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const request: any = {
+      const request = {
         jsonrpc: '2.0',
         id: 1,
         method: PermissionNames.wallet_doubleNumber,
@@ -5562,9 +5480,8 @@ describe('PermissionController', () => {
         { request: { ...request } },
       );
 
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error }: any = await engine.handle(request);
+      // @ts-expect-error Abusing types for testing purposes
+      const { error } = await engine.handle(request);
       expect(error.message).toStrictEqual(expectedError.message);
       expect(error.data.cause).toBeNull();
       delete error.message;

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -7,7 +7,13 @@ import type {
 import { ControllerMessenger } from '@metamask/base-controller';
 import { isPlainObject } from '@metamask/controller-utils';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
-import type { Json, PendingJsonRpcResponse } from '@metamask/utils';
+import type {
+  Json,
+  JsonRpcFailure,
+  JsonRpcRequest,
+  JsonRpcSuccess,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
 import { hasProperty } from '@metamask/utils';
 import assert from 'assert';
 
@@ -15,6 +21,7 @@ import type {
   AsyncRestrictedMethod,
   Caveat,
   CaveatConstraint,
+  CaveatMutator,
   ExtractSpecifications,
   PermissionConstraint,
   PermissionControllerActions,
@@ -693,7 +700,7 @@ describe('PermissionController', () => {
 
     it('throws if a permission specification lists unrecognized caveats', () => {
       const permissionSpecifications = getDefaultPermissionSpecifications();
-      // @ts-expect-error Abusing types for testing purposes
+      // @ts-expect-error Intentional destructive testing
       permissionSpecifications.wallet_getSecretArray.allowedCaveats.push('foo');
 
       expect(
@@ -2080,7 +2087,7 @@ describe('PermissionController', () => {
       const mutator = () => {
         counter += 1;
         return counter === 1
-          ? { operation: CaveatMutatorOperation.noop as const}
+          ? { operation: CaveatMutatorOperation.noop as const }
           : {
               operation: CaveatMutatorOperation.updateValue as const,
               value: ['a', 'b'],
@@ -2166,7 +2173,7 @@ describe('PermissionController', () => {
       const controller = getMultiCaveatController();
 
       let counter = 0;
-      const mutator = () => {
+      const mutator: CaveatMutator<FilterArrayCaveat> = () => {
         counter += 1;
         return {
           operation:
@@ -2178,12 +2185,11 @@ describe('PermissionController', () => {
 
       controller.updatePermissionsByCaveat(
         CaveatTypes.filterArrayResponse,
-        // @ts-expect-error Abusing types for testing purposes
         mutator,
       );
 
       const matcher = getMultiCaveatStateMatcher();
-      // @ts-expect-error Abusing types for testing purposes
+      // @ts-expect-error Intentional destructive testing
       delete matcher.subjects[MultiCaveatOrigins.a];
 
       expect(controller.state).toStrictEqual(matcher);
@@ -2221,7 +2227,7 @@ describe('PermissionController', () => {
       expect(() =>
         controller.updatePermissionsByCaveat(
           CaveatTypes.filterArrayResponse,
-          // @ts-expect-error Abusing types for testing purposes
+          // @ts-expect-error Intentional destructive testing
           () => {
             return { operation: 'foobar' };
           },
@@ -2493,7 +2499,7 @@ describe('PermissionController', () => {
 
       expect(() =>
         controller.grantPermissions({
-          // @ts-expect-error Abusing types for testing purposes
+          // @ts-expect-error Intentional destructive testing
           subject: { origin: 2 },
           approvedPermissions: {
             wallet_getSecretArray: {},
@@ -2594,7 +2600,7 @@ describe('PermissionController', () => {
           subject: { origin },
           approvedPermissions: {
             wallet_getSecretArray: {
-              // @ts-expect-error Abusing types for testing purposes
+              // @ts-expect-error Intentional destructive testing
               caveats: [[]],
             },
           },
@@ -2612,7 +2618,7 @@ describe('PermissionController', () => {
           subject: { origin },
           approvedPermissions: {
             wallet_getSecretArray: {
-              // @ts-expect-error Abusing types for testing purposes
+              // @ts-expect-error Intentional destructive testing
               caveats: ['foo'],
             },
           },
@@ -2638,7 +2644,7 @@ describe('PermissionController', () => {
               caveats: [
                 {
                   ...{ type: CaveatTypes.filterArrayResponse, value: ['foo'] },
-                  // @ts-expect-error Abusing types for testing purposes
+                  // @ts-expect-error Intentional destructive testing
                   bar: 'bar',
                 },
               ],
@@ -2668,7 +2674,7 @@ describe('PermissionController', () => {
             wallet_getSecretArray: {
               caveats: [
                 {
-                  // @ts-expect-error Abusing types for testing purposes
+                  // @ts-expect-error Intentional destructive testing
                   type: 2,
                   value: ['foo'],
                 },
@@ -2722,7 +2728,7 @@ describe('PermissionController', () => {
               caveats: [
                 {
                   type: CaveatTypes.filterArrayResponse,
-                  // @ts-expect-error Abusing types for testing purposes
+                  // @ts-expect-error Intentional destructive testing
                   foo: 'bar',
                 },
               ],
@@ -3714,7 +3720,7 @@ describe('PermissionController', () => {
           async () =>
             await controller.requestPermissions(
               { origin },
-              // @ts-expect-error Abusing types for testing purposes
+              // @ts-expect-error Intentional destructive testing
               invalidInput,
             ),
         ).rejects.toThrow(
@@ -4007,7 +4013,7 @@ describe('PermissionController', () => {
               { origin },
               {
                 [PermissionNames.wallet_getSecretArray]: {
-                  // @ts-expect-error Abusing types for testing purposes
+                  // @ts-expect-error Intentional destructive testing
                   caveats: invalidCaveatsValue,
                 },
               },
@@ -4708,7 +4714,7 @@ describe('PermissionController', () => {
       await expect(
         controller.getEndowments(
           origin,
-          // @ts-expect-error Abusing types for testing purposes
+          // @ts-expect-error Intentional destructive testing
           PermissionNames.wallet_getSecretArray,
         ),
       ).rejects.toThrow(
@@ -4839,14 +4845,14 @@ describe('PermissionController', () => {
       const origin = 'metamask.io';
 
       await expect(
-        // @ts-expect-error Abusing types for testing purposes
+        // @ts-expect-error Intentional destructive testing
         controller.executeRestrictedMethod(origin, 'wallet_getMeTacos'),
       ).rejects.toThrow(errors.methodNotFound('wallet_getMeTacos', { origin }));
     });
 
     it('throws if the restricted method returns undefined', async () => {
       const permissionSpecifications = getDefaultPermissionSpecifications();
-      // @ts-expect-error Abusing types for testing purposes
+      // @ts-expect-error Intentional destructive testing
       permissionSpecifications.wallet_doubleNumber.methodImplementation = () =>
         undefined;
 
@@ -5332,13 +5338,12 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      const response = await engine.handle({
+      const response = (await engine.handle({
         jsonrpc: '2.0',
         id: 1,
         method: PermissionNames.wallet_getSecretArray,
-      });
+      })) as JsonRpcSuccess<string[]>;
 
-      // @ts-expect-error Abusing types for testing purposes
       expect(response.result).toStrictEqual(['a', 'b', 'c']);
     });
 
@@ -5358,13 +5363,12 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      const response = await engine.handle({
+      const response = (await engine.handle({
         jsonrpc: '2.0',
         id: 1,
         method: PermissionNames.wallet_getSecretArray,
-      });
+      })) as JsonRpcSuccess<string[]>;
 
-      // @ts-expect-error Abusing types for testing purposes
       expect(response.result).toStrictEqual(['b']);
     });
 
@@ -5387,13 +5391,12 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      const response = await engine.handle({
+      const response = (await engine.handle({
         jsonrpc: '2.0',
         id: 1,
         method: PermissionNames.wallet_getSecretArray,
-      });
+      })) as JsonRpcSuccess<string[]>;
 
-      // @ts-expect-error Abusing types for testing purposes
       expect(response.result).toStrictEqual(['c', 'a']);
     });
 
@@ -5415,13 +5418,12 @@ describe('PermissionController', () => {
         },
       );
 
-      const response = await engine.handle({
+      const response = (await engine.handle({
         jsonrpc: '2.0',
         id: 1,
         method: 'wallet_unrestrictedMethod',
-      });
+      })) as JsonRpcSuccess<string[]>;
 
-      // @ts-expect-error Abusing types for testing purposes
       expect(response.result).toBe('success');
     });
 
@@ -5431,7 +5433,7 @@ describe('PermissionController', () => {
       ['', null, undefined, 2].forEach((invalidOrigin) => {
         expect(() =>
           controller.createPermissionMiddleware({
-            // @ts-expect-error Abusing types for testing purposes
+            // @ts-expect-error Intentional destructive testing
             origin: invalidOrigin,
           }),
         ).toThrow(
@@ -5447,7 +5449,7 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      const request = {
+      const request: JsonRpcRequest<[]> = {
         jsonrpc: '2.0',
         id: 1,
         method: PermissionNames.wallet_getSecretArray,
@@ -5463,8 +5465,7 @@ describe('PermissionController', () => {
           'Unauthorized to perform action. Try requesting the required permission(s) first. For more information, see: https://docs.metamask.io/guide/rpc-api.html#permissions',
       });
 
-      // @ts-expect-error Abusing types for testing purposes
-      const { error } = await engine.handle(request);
+      const { error } = (await engine.handle(request)) as JsonRpcFailure;
       expect(error).toMatchObject(expect.objectContaining(expectedError));
     });
 
@@ -5475,7 +5476,7 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      const request = {
+      const request: JsonRpcRequest<[]> = {
         jsonrpc: '2.0',
         id: 1,
         method: 'wallet_foo',
@@ -5483,19 +5484,19 @@ describe('PermissionController', () => {
 
       const expectedError = errors.methodNotFound('wallet_foo', { origin });
 
-      // @ts-expect-error Abusing types for testing purposes
-      const { error } = await engine.handle(request);
+      const { error } = (await engine.handle(request)) as JsonRpcFailure;
 
       expect(error.message).toStrictEqual(expectedError.message);
-      expect(error.data.cause).toBeNull();
-      delete error.message;
+      // @ts-expect-error We do expect this property to exist.
+      expect(error.data?.cause).toBeNull();
+      // @ts-expect-error Intentional destructive testing
       delete error.data.cause;
       expect(error).toMatchObject(expect.objectContaining(expectedError));
     });
 
     it('returns an error if the restricted method returns undefined', async () => {
       const permissionSpecifications = getDefaultPermissionSpecifications();
-      // @ts-expect-error Abusing types for testing purposes
+      // @ts-expect-error Intentional destructive testing
       permissionSpecifications.wallet_doubleNumber.methodImplementation = () =>
         undefined;
 
@@ -5519,7 +5520,7 @@ describe('PermissionController', () => {
       const engine = new JsonRpcEngine();
       engine.push(controller.createPermissionMiddleware({ origin }));
 
-      const request = {
+      const request: JsonRpcRequest<[]> = {
         jsonrpc: '2.0',
         id: 1,
         method: PermissionNames.wallet_doubleNumber,
@@ -5530,11 +5531,11 @@ describe('PermissionController', () => {
         { request: { ...request } },
       );
 
-      // @ts-expect-error Abusing types for testing purposes
-      const { error } = await engine.handle(request);
+      const { error } = (await engine.handle(request)) as JsonRpcFailure;
       expect(error.message).toStrictEqual(expectedError.message);
-      expect(error.data.cause).toBeNull();
-      delete error.message;
+      // @ts-expect-error We do expect this property to exist.
+      expect(error.data?.cause).toBeNull();
+      // @ts-expect-error Intentional destructive testing
       delete error.data.cause;
       expect(error).toMatchObject(expect.objectContaining(expectedError));
     });

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -120,10 +120,14 @@ export type PermissionsRequest = {
 };
 
 export type SideEffects = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  permittedHandlers: Record<string, SideEffectHandler<any, any>>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  failureHandlers: Record<string, SideEffectHandler<any, any>>;
+  permittedHandlers: Record<
+    string,
+    SideEffectHandler<ActionConstraint, EventConstraint>
+  >;
+  failureHandlers: Record<
+    string,
+    SideEffectHandler<ActionConstraint, EventConstraint>
+  >;
 };
 
 /**

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -119,10 +119,8 @@ export type PermissionsRequest = {
 };
 
 export type SideEffects = {
-  // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   permittedHandlers: Record<string, SideEffectHandler<any, any>>;
-  // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   failureHandlers: Record<string, SideEffectHandler<any, any>>;
 };
@@ -1292,13 +1290,12 @@ export class PermissionController<
           permission.caveats.splice(caveatIndex, 1, caveat);
         }
       } else {
-        // Typecast: At this point, we don't know if the specific permission
-        // is allowed to have caveats, but it should be impossible to call
-        // this method for a permission that may not have any caveats.
-        // If all else fails, the permission validator is also called.
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        permission.caveats = [caveat] as any;
+        // At this point, we don't know if the specific permission is allowed
+        // to have caveats, but it should be impossible to call this method
+        // for a permission that may not have any caveats. If all else fails,
+        // the permission validator is also called.
+        // @ts-expect-error See above comment
+        permission.caveats = [caveat];
       }
 
       this.validateModifiedPermission(permission, origin);
@@ -1388,12 +1385,11 @@ export class PermissionController<
             default: {
               // This type check ensures that the switch statement is
               // exhaustive.
-              const _exhaustiveCheck: never = mutatorResult;
+              const exhaustiveCheck: never = mutatorResult;
               throw new Error(
                 `Unrecognized mutation result: "${
-                  // TODO: Replace `any` with type
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  (_exhaustiveCheck as any).operation
+                  // @ts-expect-error We need to override the "never"
+                  exhaustiveCheck.operation
                 }"`,
               );
             }
@@ -2234,15 +2230,7 @@ export class PermissionController<
    * @returns Whether the specified request exists.
    */
   private hasApprovalRequest(options: { id: string }): boolean {
-    return this.messagingSystem.call(
-      'ApprovalController:hasRequest',
-      // Typecast: For some reason, the type here expects all of the possible
-      // HasApprovalRequest options to be specified, when they're actually all
-      // optional. Passing just the id is definitely valid, so we just cast it.
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      options as any,
-    );
+    return this.messagingSystem.call('ApprovalController:hasRequest', options);
   }
 
   /**

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -1350,7 +1350,8 @@ export class PermissionController<
           // The mutator may modify the caveat value in place, and must always
           // return a valid mutation result.
           const mutatorResult = mutator(targetCaveat.value);
-          switch (mutatorResult.operation) {
+          const { operation } = mutatorResult;
+          switch (operation) {
             case CaveatMutatorOperation.noop:
               break;
 
@@ -1383,15 +1384,10 @@ export class PermissionController<
               break;
 
             default: {
-              // This type check ensures that the switch statement is
-              // exhaustive.
-              const exhaustiveCheck: never = mutatorResult;
-              throw new Error(
-                `Unrecognized mutation result: "${
-                  // @ts-expect-error We need to override the "never"
-                  exhaustiveCheck.operation
-                }"`,
-              );
+              // Overriding as `never` is the expected result of exhaustiveness checking,
+              // and is intended to represent unchecked exception cases.
+              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+              throw new Error(`Unrecognized mutation result: "${operation}"`);
             }
           }
         });

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -1410,10 +1410,7 @@ export class PermissionController<
    * @param caveatType - The type of the caveat to remove.
    */
   removeCaveat<
-    TargetName extends ExtractPermission<
-      ControllerPermissionSpecification,
-      ControllerCaveatSpecification
-    >['parentCapability'],
+    TargetName extends ControllerPermissionSpecification['targetName'],
     CaveatType extends ExtractAllowedCaveatTypes<ControllerPermissionSpecification>,
   >(origin: OriginString, target: TargetName, caveatType: CaveatType): void {
     this.update((draftState) => {

--- a/packages/permission-controller/src/SubjectMetadataController.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.ts
@@ -210,10 +210,7 @@ export class SubjectMetadataController extends BaseController<
     this.subjectsWithoutPermissionsEncounteredSinceStartup.add(origin);
 
     this.update((draftState) => {
-      // Typecast: ts(2589)
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      draftState.subjectMetadata[origin] = newMetadata as any;
+      draftState.subjectMetadata[origin] = newMetadata;
       if (typeof originToForget === 'string') {
         delete draftState.subjectMetadata[originToForget];
       }
@@ -235,11 +232,9 @@ export class SubjectMetadataController extends BaseController<
    */
   trimMetadataState(): void {
     this.update((draftState) => {
+      // @ts-expect-error ts(2589)
       return SubjectMetadataController.getTrimmedState(
-        // Typecast: ts(2589)
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        draftState as any,
+        draftState,
         this.subjectHasPermissions,
       );
     });

--- a/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
@@ -1,10 +1,6 @@
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
-import type {
-  Json,
-  JsonRpcRequest,
-  JsonRpcSuccess,
-  PendingJsonRpcResponse,
-} from '@metamask/utils';
+import type { JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
+import { assertIsJsonRpcSuccess } from '@metamask/utils';
 
 import type { PermissionConstraint } from '../Permission';
 import { getPermissionsHandler } from './getPermissions';
@@ -34,11 +30,8 @@ describe('getPermissions RPC method', () => {
       id: 1,
       method: 'arbitraryName',
     });
-    expect((response as JsonRpcSuccess<Json>).result).toStrictEqual([
-      'a',
-      'b',
-      'c',
-    ]);
+    assertIsJsonRpcSuccess(response);
+    expect(response.result).toStrictEqual(['a', 'b', 'c']);
     expect(mockGetPermissionsForOrigin).toHaveBeenCalledTimes(1);
   });
 
@@ -66,7 +59,8 @@ describe('getPermissions RPC method', () => {
       id: 1,
       method: 'arbitraryName',
     });
-    expect((response as JsonRpcSuccess<Json>).result).toStrictEqual([]);
+    assertIsJsonRpcSuccess(response);
+    expect(response.result).toStrictEqual([]);
     expect(mockGetPermissionsForOrigin).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
@@ -11,20 +11,18 @@ describe('getPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push((req, res, next, end) =>
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      implementation(req as any, res as any, next, end, {
+      // @ts-expect-error Abusing types for testing purposes
+      implementation(req, res, next, end, {
         getPermissionsForOrigin: mockGetPermissionsForOrigin,
       }),
     );
 
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response: any = await engine.handle({
+    const response = await engine.handle({
       jsonrpc: '2.0',
       id: 1,
       method: 'arbitraryName',
     });
+    // @ts-expect-error Abusing types for testing purposes
     expect(response.result).toStrictEqual(['a', 'b', 'c']);
     expect(mockGetPermissionsForOrigin).toHaveBeenCalledTimes(1);
   });
@@ -37,20 +35,18 @@ describe('getPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push((req, res, next, end) =>
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      implementation(req as any, res as any, next, end, {
+      // @ts-expect-error Abusing types for testing purposes
+      implementation(req, res, next, end, {
         getPermissionsForOrigin: mockGetPermissionsForOrigin,
       }),
     );
 
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response: any = await engine.handle({
+    const response = await engine.handle({
       jsonrpc: '2.0',
       id: 1,
       method: 'arbitraryName',
     });
+    // @ts-expect-error Abusing types for testing purposes
     expect(response.result).toStrictEqual([]);
     expect(mockGetPermissionsForOrigin).toHaveBeenCalledTimes(1);
   });

--- a/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
@@ -1,5 +1,12 @@
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
+import type {
+  Json,
+  JsonRpcRequest,
+  JsonRpcSuccess,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
 
+import type { PermissionConstraint } from '../Permission';
 import { getPermissionsHandler } from './getPermissions';
 
 describe('getPermissions RPC method', () => {
@@ -10,11 +17,16 @@ describe('getPermissions RPC method', () => {
     });
 
     const engine = new JsonRpcEngine();
-    engine.push((req, res, next, end) =>
-      // @ts-expect-error Abusing types for testing purposes
-      implementation(req, res, next, end, {
-        getPermissionsForOrigin: mockGetPermissionsForOrigin,
-      }),
+    engine.push(
+      (
+        req: JsonRpcRequest<[]>,
+        res: PendingJsonRpcResponse<PermissionConstraint[]>,
+        next,
+        end,
+      ) =>
+        implementation(req, res, next, end, {
+          getPermissionsForOrigin: mockGetPermissionsForOrigin,
+        }),
     );
 
     const response = await engine.handle({
@@ -22,8 +34,11 @@ describe('getPermissions RPC method', () => {
       id: 1,
       method: 'arbitraryName',
     });
-    // @ts-expect-error Abusing types for testing purposes
-    expect(response.result).toStrictEqual(['a', 'b', 'c']);
+    expect((response as JsonRpcSuccess<Json>).result).toStrictEqual([
+      'a',
+      'b',
+      'c',
+    ]);
     expect(mockGetPermissionsForOrigin).toHaveBeenCalledTimes(1);
   });
 
@@ -34,11 +49,16 @@ describe('getPermissions RPC method', () => {
       .mockImplementationOnce(() => null);
 
     const engine = new JsonRpcEngine();
-    engine.push((req, res, next, end) =>
-      // @ts-expect-error Abusing types for testing purposes
-      implementation(req, res, next, end, {
-        getPermissionsForOrigin: mockGetPermissionsForOrigin,
-      }),
+    engine.push(
+      (
+        req: JsonRpcRequest<[]>,
+        res: PendingJsonRpcResponse<PermissionConstraint[]>,
+        next,
+        end,
+      ) =>
+        implementation(req, res, next, end, {
+          getPermissionsForOrigin: mockGetPermissionsForOrigin,
+        }),
     );
 
     const response = await engine.handle({
@@ -46,8 +66,7 @@ describe('getPermissions RPC method', () => {
       id: 1,
       method: 'arbitraryName',
     });
-    // @ts-expect-error Abusing types for testing purposes
-    expect(response.result).toStrictEqual([]);
+    expect((response as JsonRpcSuccess<Json>).result).toStrictEqual([]);
     expect(mockGetPermissionsForOrigin).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
@@ -23,22 +23,20 @@ describe('requestPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push((req, res, next, end) =>
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      implementation(req as any, res as any, next, end, {
+      // @ts-expect-error Abusing types for testing purposes
+      implementation(req, res, next, end, {
         requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
       }),
     );
 
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response: any = await engine.handle({
+    const response = await engine.handle({
       jsonrpc: '2.0',
       id: 1,
       method: 'arbitraryName',
       params: [{}],
     });
 
+    // @ts-expect-error Abusing types for testing purposes
     expect(response.result).toStrictEqual(['a', 'b', 'c']);
     expect(mockRequestPermissionsForOrigin).toHaveBeenCalledTimes(1);
     expect(mockRequestPermissionsForOrigin).toHaveBeenCalledWith({});
@@ -53,39 +51,35 @@ describe('requestPermissions RPC method', () => {
       });
 
     const engine = new JsonRpcEngine();
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const end: any = () => undefined; // this won't be called
+    const end = () => undefined; // this won't be called
 
     // Pass the middleware function to createAsyncMiddleware so the error
     // is catched.
     engine.push(
-      createAsyncMiddleware(
-        (req, res, next) =>
-          // TODO: Replace `any` with type
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          implementation(req as any, res as any, next, end, {
-            requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
-            // TODO: Replace `any` with type
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          }) as any,
+      createAsyncMiddleware((req, res, next) =>
+        // @ts-expect-error Abusing types for testing purposes
+        implementation(req, res, next, end, {
+          requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
+        }),
       ),
     );
 
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response: any = await engine.handle({
+    const response = await engine.handle({
       jsonrpc: '2.0',
       id: 1,
       method: 'arbitraryName',
       params: [{}],
     });
 
+    // @ts-expect-error Abusing types for testing purposes
     expect(response.result).toBeUndefined();
+    // @ts-expect-error Abusing types for testing purposes
     delete response.error.stack;
+    // @ts-expect-error Abusing types for testing purposes
     delete response.error.data.cause.stack;
     const expectedError = new Error('foo');
     delete expectedError.stack;
+    // @ts-expect-error Abusing types for testing purposes
     expect(response.error).toStrictEqual(
       serializeError(expectedError, { shouldIncludeStack: false }),
     );
@@ -99,9 +93,8 @@ describe('requestPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push((req, res, next, end) =>
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      implementation(req as any, res as any, next, end, {
+      // @ts-expect-error Abusing types for testing purposes
+      implementation(req, res, next, end, {
         requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
       }),
     );
@@ -121,10 +114,11 @@ describe('requestPermissions RPC method', () => {
         .serialize();
       delete expectedError.stack;
 
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response: any = await engine.handle(req as any);
+      // @ts-expect-error Abusing types for testing purposes
+      const response = await engine.handle(req);
+      // @ts-expect-error Abusing types for testing purposes
       delete response.error.stack;
+      // @ts-expect-error Abusing types for testing purposes
       expect(response.error).toStrictEqual(expectedError);
       expect(mockRequestPermissionsForOrigin).not.toHaveBeenCalled();
     }

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -1,6 +1,13 @@
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import { rpcErrors } from '@metamask/rpc-errors';
+import type {
+  Json,
+  JsonRpcFailure,
+  JsonRpcRequest,
+  JsonRpcSuccess,
+} from '@metamask/utils';
 
+import type { RevokePermissionArgs } from './revokePermissions';
 import { revokePermissionsHandler } from './revokePermissions';
 
 describe('revokePermissionsHandler', () => {
@@ -21,14 +28,14 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push((req, res, next, end) =>
-      // @ts-expect-error Abusing types for testing purposes
-      implementation(req, res, next, end, {
-        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
-      }),
+    engine.push<RevokePermissionArgs, null>(
+      async (req, res, next, end) =>
+        await implementation(req, res, next, end, {
+          revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+        }),
     );
 
-    const response = await engine.handle({
+    const response = (await engine.handle({
       jsonrpc: '2.0',
       id: 1,
       method: 'wallet_revokePermissions',
@@ -37,9 +44,8 @@ describe('revokePermissions RPC method', () => {
           snap_dialog: {},
         },
       ],
-    });
+    })) as JsonRpcSuccess<null>;
 
-    // @ts-expect-error Abusing types for testing purposes
     expect(response.result).toBeNull();
     expect(mockRevokePermissionsForOrigin).toHaveBeenCalledTimes(1);
     expect(mockRevokePermissionsForOrigin).toHaveBeenCalledWith([
@@ -52,14 +58,14 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push((req, res, next, end) =>
-      // @ts-expect-error Abusing types for testing purposes
-      implementation(req, res, next, end, {
-        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
-      }),
+    engine.push<RevokePermissionArgs, null>(
+      async (req, res, next, end) =>
+        await implementation(req, res, next, end, {
+          revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+        }),
     );
 
-    const req = {
+    const req: JsonRpcRequest<Record<string, Json>> = {
       jsonrpc: '2.0',
       id: 1,
       method: 'wallet_revokePermissions',
@@ -73,11 +79,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // @ts-expect-error Abusing types for testing purposes
-    const response = await engine.handle(req);
-    // @ts-expect-error Abusing types for testing purposes
+    const response = (await engine.handle(req)) as JsonRpcFailure;
     delete response.error.stack;
-    // @ts-expect-error Abusing types for testing purposes
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
   });
@@ -87,14 +90,14 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push((req, res, next, end) =>
-      // @ts-expect-error Abusing types for testing purposes
-      implementation(req, res, next, end, {
-        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
-      }),
+    engine.push<RevokePermissionArgs, null>(
+      async (req, res, next, end) =>
+        await implementation(req, res, next, end, {
+          revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+        }),
     );
 
-    const req = {
+    const req: JsonRpcRequest<[Record<string, Json>]> = {
       jsonrpc: '2.0',
       id: 1,
       method: 'wallet_revokePermissions',
@@ -108,11 +111,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // @ts-expect-error Abusing types for testing purposes
-    const response = await engine.handle(req);
-    // @ts-expect-error Abusing types for testing purposes
+    const response = (await engine.handle(req)) as JsonRpcFailure;
     delete response.error.stack;
-    // @ts-expect-error Abusing types for testing purposes
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
   });
@@ -122,14 +122,14 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push((req, res, next, end) =>
-      // @ts-expect-error Abusing types for testing purposes
-      implementation(req, res, next, end, {
-        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
-      }),
+    engine.push<RevokePermissionArgs, null>(
+      async (req, res, next, end) =>
+        await implementation(req, res, next, end, {
+          revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+        }),
     );
 
-    const req = {
+    const req: JsonRpcRequest<[]> = {
       jsonrpc: '2.0',
       id: 1,
       method: 'wallet_revokePermissions',
@@ -142,11 +142,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // @ts-expect-error Abusing types for testing purposes
-    const response = await engine.handle(req);
-    // @ts-expect-error Abusing types for testing purposes
+    const response = (await engine.handle(req)) as JsonRpcFailure;
     delete response.error.stack;
-    // @ts-expect-error Abusing types for testing purposes
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
   });
@@ -156,14 +153,14 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push((req, res, next, end) =>
-      // @ts-expect-error Abusing types for testing purposes
-      implementation(req, res, next, end, {
-        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
-      }),
+    engine.push<RevokePermissionArgs, null>(
+      async (req, res, next, end) =>
+        await implementation(req, res, next, end, {
+          revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+        }),
     );
 
-    const req = {
+    const req: JsonRpcRequest<Json[]> = {
       jsonrpc: '2.0',
       id: 1,
       method: 'wallet_revokePermissions',
@@ -177,11 +174,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // @ts-expect-error Abusing types for testing purposes
-    const response = await engine.handle(req);
-    // @ts-expect-error Abusing types for testing purposes
+    const response = (await engine.handle(req)) as JsonRpcFailure;
     delete response.error.stack;
-    // @ts-expect-error Abusing types for testing purposes
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
   });

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -1,10 +1,9 @@
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import { rpcErrors } from '@metamask/rpc-errors';
-import type {
-  Json,
-  JsonRpcFailure,
-  JsonRpcRequest,
-  JsonRpcSuccess,
+import type { Json, JsonRpcRequest } from '@metamask/utils';
+import {
+  assertIsJsonRpcFailure,
+  assertIsJsonRpcSuccess,
 } from '@metamask/utils';
 
 import type { RevokePermissionArgs } from './revokePermissions';
@@ -35,7 +34,7 @@ describe('revokePermissions RPC method', () => {
         }),
     );
 
-    const response = (await engine.handle({
+    const response = await engine.handle({
       jsonrpc: '2.0',
       id: 1,
       method: 'wallet_revokePermissions',
@@ -44,7 +43,8 @@ describe('revokePermissions RPC method', () => {
           snap_dialog: {},
         },
       ],
-    })) as JsonRpcSuccess<null>;
+    });
+    assertIsJsonRpcSuccess(response);
 
     expect(response.result).toBeNull();
     expect(mockRevokePermissionsForOrigin).toHaveBeenCalledTimes(1);
@@ -79,7 +79,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    const response = (await engine.handle(req)) as JsonRpcFailure;
+    const response = await engine.handle(req);
+    assertIsJsonRpcFailure(response);
     delete response.error.stack;
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
@@ -111,7 +112,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    const response = (await engine.handle(req)) as JsonRpcFailure;
+    const response = await engine.handle(req);
+    assertIsJsonRpcFailure(response);
     delete response.error.stack;
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
@@ -142,7 +144,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    const response = (await engine.handle(req)) as JsonRpcFailure;
+    const response = await engine.handle(req);
+    assertIsJsonRpcFailure(response);
     delete response.error.stack;
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
@@ -174,7 +177,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    const response = (await engine.handle(req)) as JsonRpcFailure;
+    const response = await engine.handle(req);
+    assertIsJsonRpcFailure(response);
     delete response.error.stack;
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -22,16 +22,13 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push((req, res, next, end) =>
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      implementation(req as any, res as any, next, end, {
+      // @ts-expect-error Abusing types for testing purposes
+      implementation(req, res, next, end, {
         revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
       }),
     );
 
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response: any = await engine.handle({
+    const response = await engine.handle({
       jsonrpc: '2.0',
       id: 1,
       method: 'wallet_revokePermissions',
@@ -42,6 +39,7 @@ describe('revokePermissions RPC method', () => {
       ],
     });
 
+    // @ts-expect-error Abusing types for testing purposes
     expect(response.result).toBeNull();
     expect(mockRevokePermissionsForOrigin).toHaveBeenCalledTimes(1);
     expect(mockRevokePermissionsForOrigin).toHaveBeenCalledWith([
@@ -55,9 +53,8 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push((req, res, next, end) =>
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      implementation(req as any, res as any, next, end, {
+      // @ts-expect-error Abusing types for testing purposes
+      implementation(req, res, next, end, {
         revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
       }),
     );
@@ -76,10 +73,11 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response: any = await engine.handle(req as any);
+    // @ts-expect-error Abusing types for testing purposes
+    const response = await engine.handle(req);
+    // @ts-expect-error Abusing types for testing purposes
     delete response.error.stack;
+    // @ts-expect-error Abusing types for testing purposes
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
   });
@@ -90,9 +88,8 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push((req, res, next, end) =>
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      implementation(req as any, res as any, next, end, {
+      // @ts-expect-error Abusing types for testing purposes
+      implementation(req, res, next, end, {
         revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
       }),
     );
@@ -111,10 +108,11 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response: any = await engine.handle(req as any);
+    // @ts-expect-error Abusing types for testing purposes
+    const response = await engine.handle(req);
+    // @ts-expect-error Abusing types for testing purposes
     delete response.error.stack;
+    // @ts-expect-error Abusing types for testing purposes
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
   });
@@ -125,9 +123,8 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push((req, res, next, end) =>
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      implementation(req as any, res as any, next, end, {
+      // @ts-expect-error Abusing types for testing purposes
+      implementation(req, res, next, end, {
         revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
       }),
     );
@@ -145,10 +142,11 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response: any = await engine.handle(req as any);
+    // @ts-expect-error Abusing types for testing purposes
+    const response = await engine.handle(req);
+    // @ts-expect-error Abusing types for testing purposes
     delete response.error.stack;
+    // @ts-expect-error Abusing types for testing purposes
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
   });
@@ -159,9 +157,8 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push((req, res, next, end) =>
-      // TODO: Replace `any` with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      implementation(req as any, res as any, next, end, {
+      // @ts-expect-error Abusing types for testing purposes
+      implementation(req, res, next, end, {
         revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
       }),
     );
@@ -180,10 +177,11 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response: any = await engine.handle(req as any);
+    // @ts-expect-error Abusing types for testing purposes
+    const response = await engine.handle(req);
+    // @ts-expect-error Abusing types for testing purposes
     delete response.error.stack;
+    // @ts-expect-error Abusing types for testing purposes
     expect(response.error).toStrictEqual(expectedError);
     expect(mockRevokePermissionsForOrigin).not.toHaveBeenCalled();
   });

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.ts
@@ -24,7 +24,7 @@ export const revokePermissionsHandler: PermittedHandlerExport<
   },
 };
 
-type RevokePermissionArgs = Record<
+export type RevokePermissionArgs = Record<
   PermissionConstraint['parentCapability'],
   Json
 >;


### PR DESCRIPTION
## Explanation

Replaces almost all `any` type casts with `@ts-expect-error` directives or more specific types. Of the original 81 `any` type casts in the permission controller and its tests, only 3 remain. No behavioral changes.

## Changelog

None.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate