### PR TITLE
feat(permission-controller): Re-throw all well-formed errors

### DIFF
--- a/packages/permission-controller/jest.config.js
+++ b/packages/permission-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 98.8,
+      branches: 100,
       functions: 100,
-      lines: 99.78,
-      statements: 99.78,
+      lines: 100,
+      statements: 100,
     },
   },
 });

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -2159,14 +2159,15 @@ export class PermissionController<
     try {
       this.validateRequestedPermissions(origin, permissions);
     } catch (error) {
-      if (error instanceof JsonRpcError) {
+      if (error instanceof Error) {
         // Re-throw as an internal error; we should never receive invalid approved
         // permissions.
         throw internalError(
           `Invalid approved permissions request: ${error.message}`,
-          error.data,
+          error instanceof JsonRpcError ? error.data : undefined,
         );
       }
+      /* istanbul ignore next: We should only throw well-formed errors */
       throw internalError('Unrecognized error type', { error });
     }
   }


### PR DESCRIPTION
## Explanation

When re-throwing validation errors in `requestPermissions()`, include original message from all well-formed errors. Also restore 100% unit test coverage.

## Changelog

### `@metamask/permission-controller`

- **ADDED**: Make permission request validation errors more informative

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
