### PR TITLE
test: KeyringController@1.0.1 run conditions 

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -78,6 +78,169 @@ describe('KeyringController', () => {
     sinon.restore();
   });
 
+  describe('run conditions', () => {
+    it('should not break state when submitPassword and setLocked are called multiple times', async () => {
+      const initialOuterControllerState = keyringController.state;
+
+      await Promise.all([
+        keyringController.submitPassword(password),
+        keyringController.setLocked(),
+        keyringController.submitPassword(password),
+        keyringController.setLocked(),
+      ]);
+
+      expect(keyringController.state).toStrictEqual(
+        initialOuterControllerState,
+      );
+    });
+
+    it('should not break state when setLocked and submitPassword are called multiple times', async () => {
+      const initialOuterControllerState = keyringController.state;
+
+      await Promise.all([
+        keyringController.setLocked(),
+        keyringController.submitPassword(password),
+        keyringController.setLocked(),
+        keyringController.submitPassword(password),
+      ]);
+
+      expect(keyringController.state).toStrictEqual(
+        initialOuterControllerState,
+      );
+    });
+
+    it('should not change state when submitPassword is called multiple times', async () => {
+      const initialOuterControllerState = keyringController.state;
+
+      await Promise.all([
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+        keyringController.submitPassword(password),
+      ]);
+
+      expect(keyringController.state).toStrictEqual(
+        initialOuterControllerState,
+      );
+    });
+
+    it('should not break state when submitPassword and fullUpdate are called multiple times', async () => {
+      const initialOuterControllerState = keyringController.state;
+
+      await Promise.all([
+        keyringController.submitPassword(password),
+        keyringController.fullUpdate(),
+        keyringController.submitPassword(password),
+        keyringController.fullUpdate(),
+      ]);
+
+      expect(keyringController.state).toStrictEqual(
+        initialOuterControllerState,
+      );
+    });
+
+    it('should not break state when addNewKeyring and submitPassword are called multiple times', async () => {
+      const initialOuterControllerState = keyringController.state;
+
+      await Promise.all([
+        keyringController.submitPassword(password),
+        keyringController.addNewAccount(),
+        keyringController.submitPassword(password),
+        keyringController.addNewAccount(),
+        keyringController.submitPassword(password),
+        keyringController.addNewAccount(),
+        keyringController.submitPassword(password),
+        keyringController.addNewAccount(),
+        keyringController.submitPassword(password),
+        keyringController.addNewAccount(),
+        keyringController.submitPassword(password),
+        keyringController.addNewAccount(),
+        keyringController.submitPassword(password),
+      ]);
+
+      expect(keyringController.state).toStrictEqual(
+        initialOuterControllerState,
+      );
+    });
+
+    it('should not break state when getOrAddQRKeyring and submitPassword are called multiple times', async () => {
+      const initialOuterControllerState = keyringController.state;
+
+      await Promise.all([
+        keyringController.submitPassword(password),
+        keyringController.getOrAddQRKeyring(),
+        keyringController.submitPassword(password),
+        keyringController.getOrAddQRKeyring(),
+        keyringController.submitPassword(password),
+        keyringController.getOrAddQRKeyring(),
+        keyringController.submitPassword(password),
+        keyringController.getOrAddQRKeyring(),
+        keyringController.submitPassword(password),
+        keyringController.getOrAddQRKeyring(),
+        keyringController.submitPassword(password),
+        keyringController.getOrAddQRKeyring(),
+        keyringController.submitPassword(password),
+      ]);
+
+      expect(keyringController.state).toStrictEqual(
+        initialOuterControllerState,
+      );
+    });
+
+    it('should not allow side effects to break state with `setLocked`', async () => {
+      const initialOuterControllerState = keyringController.state;
+      keyringController.subscribe(async () => {
+        await keyringController.submitPassword(password);
+      });
+
+      await keyringController.setLocked();
+
+      expect(keyringController.state).toStrictEqual(
+        initialOuterControllerState,
+      );
+    });
+
+    it('should not allow side effects to break state with `addNewAccount`', async () => {
+      const initialOuterControllerState = keyringController.state;
+      keyringController.subscribe(async () => {
+        await keyringController.addNewAccount();
+      });
+
+
+      await keyringController.submitPassword(password);
+
+      expect(keyringController.state).toStrictEqual(
+        initialOuterControllerState,
+      );
+    });
+
+    it('should not change state if submitPassword is called when already unlocked', async () => {
+      const initialOuterControllerState = keyringController.state;
+
+      await keyringController.submitPassword(password);
+
+      expect(keyringController.state).toStrictEqual(
+        initialOuterControllerState,
+      );
+    });
+  });
+
   it('should set default state', () => {
     expect(keyringController.state.keyrings).not.toStrictEqual([]);
     const keyring = keyringController.state.keyrings[0];


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
