### PR TITLE
fix: fix detecting NFTs after closing browser

### DIFF
--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -443,6 +443,7 @@ export class NftDetectionController extends StaticIntervalPollingControllerV1<
       addNft,
       getNftApi,
       getNftState,
+      disabled: initialDisabled,
     }: {
       chainId: Hex;
       getNetworkClientById: NetworkController['getNetworkClientById'];
@@ -457,6 +458,7 @@ export class NftDetectionController extends StaticIntervalPollingControllerV1<
       addNft: NftController['addNft'];
       getNftApi: NftController['getNftApi'];
       getNftState: () => NftState;
+      disabled: boolean
     },
     config?: Partial<NftDetectionConfig>,
     state?: Partial<BaseState>,
@@ -466,7 +468,7 @@ export class NftDetectionController extends StaticIntervalPollingControllerV1<
       interval: DEFAULT_INTERVAL,
       chainId: initialChainId,
       selectedAddress: '',
-      disabled: true,
+      disabled: initialDisabled,
     };
     this.initialize();
     this.getNftState = getNftState;
@@ -475,16 +477,17 @@ export class NftDetectionController extends StaticIntervalPollingControllerV1<
       const { selectedAddress: previouslySelectedAddress, disabled } =
         this.config;
 
-      if (
-        selectedAddress !== previouslySelectedAddress ||
-        !useNftDetection !== disabled
-      ) {
-        this.configure({ selectedAddress, disabled: !useNftDetection });
-        if (useNftDetection) {
-          this.start();
-        } else {
-          this.stop();
-        }
+      if(selectedAddress !== previouslySelectedAddress){
+          this.configure({ selectedAddress });
+      }
+      if (!useNftDetection !== disabled) {
+          this.configure({ disabled: !useNftDetection });
+          if (useNftDetection) {
+              this.start();
+          }
+          else {
+              this.stop();
+          }
       }
     });
 


### PR DESCRIPTION
## Explanation

This PR goes together with this extension PR https://github.com/MetaMask/metamask-extension/pull/24026

We want to reduce third party calls for nft detection when a user has closed the MM popup/window.
To do that we are leveraging `stopNetworkRequests` and `triggerNetworkrequests`  functions inside extension to either `stop()` or `start()` the nft detection.
While doing this fixed the following scenario:

1- User imports MM wallet
2- User enables nft detection toggle
3- User closes MM tab or popup
4- We are no longuer making calls to third party because we called stop() function on nftDetectionController.

It does not fix this scenario:
1- User imports MM wallet
2- User enabled nft detection toggle
3- User closes chrome all together
4- User reopens chrome without opening MM, and we notice that it is making calls in the background to third party even though MM is not open.

This behavior was happening because of a couple of reasons; the property `disabled` being set to `true` in `defaultConfig`
```
    this.defaultConfig = {
      interval: DEFAULT_INTERVAL,
      chainId: initialChainId,
      selectedAddress: '',
      disabled: true,
    };
```
 made the check on this line pass https://github.com/MetaMask/core/blob/15518442513fbeaade83e4993851acdc1f038e4a/packages/assets-controllers/src/NftDetectionController.ts#L480 
and triggered the `start()` function (because the useNftDetection is true).

I fixed this by having extension pass the `disabled` in the contructor rather than having the `true` value hardcoded in the controller.

I have also refactored the `onPreferencesStateChange` to have it make this check
```
      if(selectedAddress !== previouslySelectedAddress){
          this.configure({ selectedAddress });
      }
```
Separately.
When the user first opens the selectedAddress is '' because its also set in default config which, because of the `OR` statement triggered the code to also go into the `start()`

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Related to [#67890](https://github.com/MetaMask/metamask-extension/pull/24026/files#diff-6fbff2cfe97ac01b77296ef2122c7e0a5b3ff6a84b584b4d1a87482f35eea3d6)
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **ADDED**: Added disabled inside contructor of nftDetectionController
- **CHANGED**: Pass new disabled value instead of true in the default config
- **CHANGED**: Made the check for the selected address separate from the check of useNftDetection value


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
