### PR TITLE
feat(permission-controller): Allow passing additional metadata during requestPermissions

### DIFF
--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -1861,6 +1861,7 @@ export class PermissionController<
    * id.
    * @param options.preserveExistingPermissions - Whether to preserve the
    * subject's existing permissions. Defaults to `true`.
+   * @param options.metadata - Additional metadata about the permission request.
    * @returns The granted permissions and request metadata.
    */
   async requestPermissions(

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -102,6 +102,7 @@ export type PermissionSubjectMetadata = {
  */
 export type PermissionsRequestMetadata = PermissionSubjectMetadata & {
   id: string;
+  [key: string]: Json;
 };
 
 /**
@@ -1868,6 +1869,7 @@ export class PermissionController<
     options: {
       id?: string;
       preserveExistingPermissions?: boolean;
+      metadata?: Record<string, Json>;
     } = {},
   ): Promise<
     [
@@ -1885,6 +1887,7 @@ export class PermissionController<
     this.validateRequestedPermissions(origin, requestedPermissions);
 
     const metadata = {
+      ...options.metadata,
       id,
       origin,
     };


### PR DESCRIPTION
## Explanation

For certain use-cases, such as the SDK, it may be beneficial to be able to store additional metadata about permission requests. This PR adds a `metadata` property to the `requestPermission` options which is merged into the existing `metadata` object and ultimately stored in the `ApprovalController`.

## Changelog

### `@metamask/permission-controller`

- **Added**: Allow passing additional metadata during requestPermissions

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
