### PR TITLE
chore: adjust `permission-controller` CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 
 *                                    @MetaMask/engineering
 
-/packages/permission-controller      @MetaMask/snaps-devs
+/packages/permission-controller      @MetaMask/snaps-devs @rekmarks
 /packages/notification-controller    @MetaMask/snaps-devs
 /packages/rate-limit-controller      @MetaMask/snaps-devs


### PR DESCRIPTION
## Explanation

Adjusts the CODEOWNERS to allow @rekmarks once again to help own the PermissionController 

![image](https://i.imgur.com/sI7Mvbk.gif)
