### PR TITLE
feat: token detection on 7 more networks

### DIFF
--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -48,6 +48,20 @@ export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID: Record<Hex, string> = {
     '0x6AA75276052D96696134252587894ef5FFA520af',
   [SupportedTokenDetectionNetworks.zksync]:
     '0x458fEd3144680a5b8bcfaa0F9594aa19B4Ea2D34',
+  [SupportedTokenDetectionNetworks.cronos]:
+    '0x768ca200f0fc702ac9ea502498c18f5eff176378',
+  [SupportedTokenDetectionNetworks.celo]:
+    '0x6aa75276052d96696134252587894ef5ffa520af',
+  [SupportedTokenDetectionNetworks.gnosis]:
+    '0x6aa75276052d96696134252587894ef5ffa520af',
+  [SupportedTokenDetectionNetworks.fantom]:
+    '0x6aa75276052d96696134252587894ef5ffa520af',
+  [SupportedTokenDetectionNetworks.polygon_zkevm]:
+    '0x6aa75276052d96696134252587894ef5ffa520af',
+  [SupportedTokenDetectionNetworks.moonbeam]:
+    '0x6aa75276052d96696134252587894ef5ffa520af',
+  [SupportedTokenDetectionNetworks.moonriver]:
+    '0x6aa75276052d96696134252587894ef5ffa520af',
 };
 
 export const MISSING_PROVIDER_ERROR =

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -111,7 +111,7 @@ export const formatIconUrlWithProxy = ({
 };
 
 /**
- * Networks where token detection is supported - Values are in decimal format
+ * Networks where token detection is supported - Values are in hex format
  */
 export enum SupportedTokenDetectionNetworks {
   mainnet = '0x1', // decimal: 1
@@ -125,6 +125,13 @@ export enum SupportedTokenDetectionNetworks {
   optimism = '0xa', // decimal: 10
   base = '0x2105', // decimal: 8453
   zksync = '0x144', // decimal: 324
+  cronos = '0x19', // decimal: 25
+  celo = '0xa4ec', // decimal: 42220
+  gnosis = '0x64', // decimal: 100
+  fantom = '0xfa', // decimal: 250
+  polygon_zkevm = '0x44d', // decimal: 1101
+  moonbeam = '0x504', // decimal: 1284
+  moonriver = '0x505', // decimal: 1285
 }
 
 /**


### PR DESCRIPTION
## Explanation

Adds support for erc20 token detection on 7 more networks.  After this, we match the set of networks supported by MetaMask Portfolio.

## References

https://consensyssoftware.atlassian.net/browse/MMASSETS-207

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controller`

- **CHANGED**: Token detection is now supported on cronos, celo, gnosis, fantom, polygon_zkevm, moonbeam, and moonriver.


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
