### PR TITLE
Fix `getProviderAndBlockTracker` client selection logic

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -332,22 +332,25 @@ export class SelectedNetworkController extends BaseController<
    * @returns The proxy and block tracker proxies.
    */
   getProviderAndBlockTracker(domain: Domain): NetworkProxy {
-    const networkClientId = this.getNetworkClientIdForDomain(domain);
     let networkProxy = this.#domainProxyMap.get(domain);
     if (networkProxy === undefined) {
       let networkClient;
-      if (networkClientId === undefined || !this.#useRequestQueuePreference) {
+      if (
+        this.#useRequestQueuePreference &&
+        this.#domainHasPermissions(domain)
+      ) {
+        const networkClientId = this.getNetworkClientIdForDomain(domain);
+        networkClient = this.messagingSystem.call(
+          'NetworkController:getNetworkClientById',
+          networkClientId,
+        );
+      } else {
         networkClient = this.messagingSystem.call(
           'NetworkController:getSelectedNetworkClient',
         );
         if (networkClient === undefined) {
           throw new Error('Selected network not initialized');
         }
-      } else {
-        networkClient = this.messagingSystem.call(
-          'NetworkController:getNetworkClientById',
-          networkClientId,
-        );
       }
       networkProxy = {
         provider: createEventEmitterProxy(networkClient.provider),

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -458,7 +458,7 @@ describe('SelectedNetworkController', () => {
     describe('when the domain does not have a cached networkProxy in the domainProxyMap', () => {
       describe('when the useRequestQueue preference is true', () => {
         describe('when the domain has permissions', () => {
-          it('calls to NetworkController:getNetworkClientById and creates a new proxy provider and block tracker with the global network client', () => {
+          it('calls to NetworkController:getNetworkClientById and creates a new proxy provider and block tracker with the non-proxied globally selected network client', () => {
             const { controller, messenger } = setup({
               state: {
                 domains: {},
@@ -476,7 +476,7 @@ describe('SelectedNetworkController', () => {
               'mainnet',
             );
           });
-          it('throws an error if the global network client is not initialized', () => {
+          it('throws an error if the globally selected network client is not initialized', () => {
             const { controller, mockGetSelectedNetworkClient } = setup({
               state: {
                 domains: {},
@@ -490,7 +490,7 @@ describe('SelectedNetworkController', () => {
           });
         });
         describe('when the domain does not have permissions', () => {
-          it('calls to NetworkController:getSelectedNetworkClient and creates a new proxy provider and block tracker with the global network client', () => {
+          it('calls to NetworkController:getSelectedNetworkClient and creates a new proxy provider and block tracker with the proxied globally selected network client', () => {
             const { controller, messenger, mockHasPermissions } = setup({
               state: {
                 domains: {},
@@ -511,7 +511,7 @@ describe('SelectedNetworkController', () => {
         });
       });
       describe('when the useRequestQueue preference is false', () => {
-        it('calls to NetworkController:getSelectedNetworkClient and creates a new proxy provider and block tracker with the global network client', () => {
+        it('calls to NetworkController:getSelectedNetworkClient and creates a new proxy provider and block tracker with the proxied globally selected network client', () => {
           const { controller, messenger } = setup({
             state: {
               domains: {},

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -415,76 +415,119 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('getProviderAndBlockTracker', () => {
-    describe('provider and block tracker are not cached for the passed domain and networkClientId has been set for the requesting domain', () => {
-      it('creates a proxy provider and block tracker with the domain network client', () => {
+    describe('when the domain already has a cached networkProxy the domainProxyMap', () => {
+      it('returns the cached proxy provider and block tracker', () => {
+        const mockProxyProvider = {
+          setTarget: jest.fn(),
+        } as unknown as ProviderProxy;
+        const mockProxyBlockTracker = {
+          setTarget: jest.fn(),
+        } as unknown as BlockTrackerProxy;
+
+        const domainProxyMap = new Map<Domain, NetworkProxy>([
+          [
+            'example.com',
+            {
+              provider: mockProxyProvider,
+              blockTracker: mockProxyBlockTracker,
+            },
+          ],
+          [
+            'test.com',
+            {
+              provider: mockProxyProvider,
+              blockTracker: mockProxyBlockTracker,
+            },
+          ],
+        ]);
         const { controller } = setup({
           state: {
-            domains: {
-              'example.com': 'mainnet',
-            },
+            domains: {},
           },
           useRequestQueuePreference: true,
+          domainProxyMap,
         });
+
         const result = controller.getProviderAndBlockTracker('example.com');
-        expect(result).toBeDefined();
-      });
-
-      it('throws an error if the domain network client is not initialized', () => {
-        const { controller, mockGetNetworkClientById } = setup({
-          state: {
-            domains: {
-              'example.com': 'mainnet',
-            },
-          },
-          useRequestQueuePreference: true,
+        expect(result).toStrictEqual({
+          provider: mockProxyProvider,
+          blockTracker: mockProxyBlockTracker,
         });
-        mockGetNetworkClientById.mockImplementation(() => {
-          throw new Error('No network client was found with the ID');
-        });
-
-        expect(() =>
-          controller.getProviderAndBlockTracker('example.com'),
-        ).toThrow('No network client was found with the ID');
       });
     });
+    describe('when the domain does not have a cached networkProxy in the domainProxyMap', () => {
+      describe('when the useRequestQueue preference is true', () => {
+        describe('when the domain has permissions', () => {
+          it('calls to NetworkController:getNetworkClientById and creates a new proxy provider and block tracker with the global network client', () => {
+            const { controller, messenger } = setup({
+              state: {
+                domains: {},
+              },
+              useRequestQueuePreference: true,
+            });
+            jest.spyOn(messenger, 'call');
 
-    describe('provider and block tracker are not cached for the passed domain and networkClientId has not been set for the requesting domain', () => {
-      it('creates a new proxy provider and block tracker with the global network client', () => {
-        const { controller } = setup({
-          state: {
-            domains: {},
-          },
-          useRequestQueuePreference: true,
+            const result = controller.getProviderAndBlockTracker('example.com');
+            expect(result).toBeDefined();
+            // unfortunately checking which networkController method is called is the best
+            // proxy (no pun intended) for checking that the correct instance of the networkClient is used
+            expect(messenger.call).toHaveBeenCalledWith(
+              'NetworkController:getNetworkClientById',
+              'mainnet',
+            );
+          });
+          it('throws an error if the global network client is not initialized', () => {
+            const { controller, mockGetSelectedNetworkClient } = setup({
+              state: {
+                domains: {},
+              },
+              useRequestQueuePreference: false,
+            });
+            mockGetSelectedNetworkClient.mockReturnValue(undefined);
+            expect(() =>
+              controller.getProviderAndBlockTracker('example.com'),
+            ).toThrow('Selected network not initialized');
+          });
         });
-        const result = controller.getProviderAndBlockTracker('test.com');
-        expect(result).toBeDefined();
+        describe('when the domain does not have permissions', () => {
+          it('calls to NetworkController:getSelectedNetworkClient and creates a new proxy provider and block tracker with the global network client', () => {
+            const { controller, messenger, mockHasPermissions } = setup({
+              state: {
+                domains: {},
+              },
+              useRequestQueuePreference: true,
+            });
+            jest.spyOn(messenger, 'call');
+            mockHasPermissions.mockReturnValue(false);
+            const result = controller.getProviderAndBlockTracker('example.com');
+            expect(result).toBeDefined();
+            // unfortunately checking which networkController method is called is the best
+            // proxy (no pun intended) for checking that the correct instance of the networkClient is used
+            expect(messenger.call).not.toHaveBeenCalledWith(
+              'NetworkController:getNetworkClientById',
+              'mainnet',
+            );
+          });
+        });
       });
+      describe('when the useRequestQueue preference is false', () => {
+        it('calls to NetworkController:getSelectedNetworkClient and creates a new proxy provider and block tracker with the global network client', () => {
+          const { controller, messenger } = setup({
+            state: {
+              domains: {},
+            },
+            useRequestQueuePreference: false,
+          });
+          jest.spyOn(messenger, 'call');
 
-      it('throws an error if the global network client is not initialized', () => {
-        const { controller, mockGetSelectedNetworkClient } = setup({
-          state: {
-            domains: {},
-          },
-          useRequestQueuePreference: false,
+          const result = controller.getProviderAndBlockTracker('example.com');
+          expect(result).toBeDefined();
+          // unfortunately checking which networkController method is called is the best
+          // proxy (no pun intended) for checking that the correct instance of the networkClient is used
+          expect(messenger.call).toHaveBeenCalledWith(
+            'NetworkController:getSelectedNetworkClient',
+          );
         });
-        mockGetSelectedNetworkClient.mockReturnValue(undefined);
-        expect(() => controller.getProviderAndBlockTracker('test.com')).toThrow(
-          'Selected network not initialized',
-        );
-      });
-    });
-
-    describe('provider and block tracker are cached for the passed domain', () => {
-      it('returns the cached proxy provider and block tracker if set', () => {
-        const { controller } = setup({
-          state: {
-            domains: {},
-          },
-          useRequestQueuePreference: true,
-        });
-        controller.setNetworkClientIdForDomain('example.com', 'network7');
-        const result = controller.getProviderAndBlockTracker('example.com');
-        expect(result).toBeDefined();
       });
     });
   });

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -415,7 +415,7 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('getProviderAndBlockTracker', () => {
-    describe('when the domain already has a cached networkProxy the domainProxyMap', () => {
+    describe('when the domain already has a cached networkProxy in the domainProxyMap', () => {
       it('returns the cached proxy provider and block tracker', () => {
         const mockProxyProvider = {
           setTarget: jest.fn(),


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This change fixes a bug where if `getProviderAndBlockTracker` is called with a domain that 1) does not have permissions, 2) does not have a cached proxy and 3) the `useRequestQueue` preference is on, it's newly created networkProxy will not be pointed correctly. Under these conditions the network proxy for this domain should point to the NetworkController's own proxied selectedNetworkClient. 

I've added tests to ensure that all possible permutations are pointing the proxy correctly:
e.g. 
- useRequestQueue preference on + domain does not have permissions 
- useRequestQueue preference off + domain does have permissions
- useRequestQueue preference on + domain does have permissions
- etc

## Changelog

### `@metamask/selected-network-controller`

- **FIXED**: When `getProviderBlockTracker` is called with domain for which there is no cached `networkProxy` in the `domainProxyMap`, if the `useRequestQueue` preference  is off and the domain does not have permissions the newly created network proxy for this domain should be pointed at the `NetworkController`'s own proxied `selectedNetworkClient`.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
