### PR TITLE
[keyring-controller] Atomic Operations

### DIFF
--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.55,
+      branches: 94.44,
       functions: 100,
-      lines: 98.85,
-      statements: 98.86,
+      lines: 98.84,
+      statements: 98.85,
     },
   },
 

--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,7 +17,7 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.63,
+      branches: 94.55,
       functions: 100,
       lines: 98.85,
       statements: 98.86,

--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.55,
+      branches: 94.63,
       functions: 100,
-      lines: 98.84,
-      statements: 98.85,
+      lines: 98.85,
+      statements: 98.86,
     },
   },
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -550,7 +550,7 @@ describe('KeyringController', () => {
                   password,
                 );
                 expect(initialSeedWord).toBeDefined();
-                expect(initialState).toBe(controller.state);
+                expect(initialState).toStrictEqual(controller.state);
                 expect(currentSeedWord).toBeDefined();
                 expect(initialSeedWord).toBe(currentSeedWord);
                 expect(initialVault).toStrictEqual(controller.state.vault);

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -3217,7 +3217,7 @@ describe('KeyringController', () => {
   describe('atomic operations', () => {
     describe('addNewKeyring', () => {
       it('should rollback the controller keyrings if the keyring creation fails', async () => {
-        const mockAddress = '0x1234';
+        const mockAddress = '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4';
         stubKeyringClassWithAccount(MockKeyring, mockAddress);
         // Mocking the serialize method to throw an error will
         // halt the controller everytime it tries to persist the keyring,
@@ -3234,12 +3234,11 @@ describe('KeyringController', () => {
               controller.addNewKeyring(MockKeyring.type),
             ).rejects.toThrow('You will never be able to persist me!');
 
-            expect(controller.state.keyrings).toHaveLength(1);
-            // getAccounts calls each keyring to get its accounts
-            // resulting in an additional '0x1234' account being added
-            // in case of test failure
-            expect(await controller.getAccounts()).toStrictEqual(
-              initialState.keyrings[0].accounts,
+            expect(controller.state).toStrictEqual(initialState);
+            await expect(
+              controller.exportAccount(password, mockAddress),
+            ).rejects.toThrow(
+              'KeyringController - No keyring found. Error info: There are keyrings, but none match the address',
             );
           },
         );

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -900,9 +900,7 @@ export class KeyringController extends BaseController<
    * operation completes.
    */
   async persistAllKeyrings(): Promise<boolean> {
-    return this.#asAtomicOperation(async () => this.#updateVault(), {
-      skipUpdate: true,
-    });
+    return this.#asAtomicOperation(async () => true);
   }
 
   /**

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2097,6 +2097,7 @@ export class KeyringController extends BaseController<
   async #persistOrRollback<T>(fn: MutuallyExclusiveCallback<T>): Promise<T> {
     return this.#withControllerLock(async ({ releaseLock }) => {
       const currentSerializedKeyrings = await this.#getSerializedKeyrings();
+      const currentPassword = this.#password;
 
       try {
         const callbackResult = await fn({ releaseLock });
@@ -2105,9 +2106,10 @@ export class KeyringController extends BaseController<
 
         return callbackResult;
       } catch (e) {
-        // Keyrings are cleared and restored to their previous state
+        // Keyrings and password are cleared and restored to their previous state
         await this.#clearKeyrings({ skipStateUpdate: true });
         await this.#restoreSerializedKeyrings(currentSerializedKeyrings);
+        this.#password = currentPassword;
 
         throw e;
       }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -652,7 +652,6 @@ export class KeyringController extends BaseController<
         throw new Error('No HD keyring found');
       }
       const [addedAccountAddress] = await primaryKeyring.addAccounts(1);
-      await this.#updateVault();
       await this.verifySeedPhrase();
       return addedAccountAddress;
     });

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2068,7 +2068,10 @@ export class KeyringController extends BaseController<
 
         try {
           const callbackResult = await fn({ releaseLock });
+
+          // State is committed only if the operation is successful
           await this.#updateVault();
+
           return callbackResult;
         } catch (e) {
           // We rollback the keyrings to the previous state

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -364,6 +364,12 @@ export type ExportableKeyEncryptor = GenericEncryptor & {
   importKey: (key: string) => Promise<unknown>;
 };
 
+/**
+ * A function executed within a mutually exclusive lock, with
+ * a mutex releaser in its option bag.
+ *
+ * @param releaseLock - A function to release the lock.
+ */
 type MutuallyExclusiveCallback<T> = ({
   releaseLock,
 }: {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2055,6 +2055,17 @@ export class KeyringController extends BaseController<
     this.messagingSystem.publish(`${name}:unlock`);
   }
 
+  /**
+   * Execute the given function after acquiring the controller lock
+   * and save the keyrings to state after it, or rolling back to their
+   * previous state in case of error.
+   *
+   * @param fn - The function to execute.
+   * @param options - Options for the operation.
+   * @param options.skipUpdate - Whether to skip updating the vault after the operation.
+   * @param options.onSuccess - Callback to execute after the operation is successful.
+   * @returns The result of the function.
+   */
   async #asAtomicOperation<T>(
     fn: MutuallyExclusiveCallback<T>,
     options: {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1663,6 +1663,8 @@ export class KeyringController extends BaseController<
   async #restoreSerializedKeyrings(
     serializedKeyrings: SerializedKeyring[],
   ): Promise<void> {
+    await this.#clearKeyrings();
+
     for (const serializedKeyring of serializedKeyrings) {
       await this.#restoreKeyring(serializedKeyring);
     }
@@ -1687,8 +1689,6 @@ export class KeyringController extends BaseController<
       if (!encryptedVault) {
         throw new Error(KeyringControllerError.VaultError);
       }
-
-      await this.#clearKeyrings();
 
       let vault;
       const updatedState: Partial<KeyringControllerState> = {};
@@ -2110,8 +2110,7 @@ export class KeyringController extends BaseController<
       try {
         return await fn({ releaseLock });
       } catch (e) {
-        // Keyrings and password are cleared and restored to their previous state
-        await this.#clearKeyrings();
+        // Keyrings and password are restored to their previous state
         await this.#restoreSerializedKeyrings(currentSerializedKeyrings);
         this.#password = currentPassword;
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR makes `KeyringController` operations atomic, with the addition of `#persistOrRollback`. Each of these operations will be executed mutually exclusively, and before each of them, a snapshot of the current keyrings state is kept and restored in case of errors in the operation execution.

More details on why this is needed [here](https://github.com/MetaMask/MetaMask-planning/issues/2382)

This PR needs these changes to be merged **first**:
- https://github.com/MetaMask/core/pull/4182
- https://github.com/MetaMask/core/pull/4199

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://github.com/MetaMask/MetaMask-planning/issues/2382

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/keyring-controller`

- **FIXED**: All mutable operations are now atomic: each method will roll back keyring instances in case of errors

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
