### PR TITLE
docs: Remove various TypeScript@4.4 TODOs

### DIFF
--- a/packages/approval-controller/src/ApprovalController.ts
+++ b/packages/approval-controller/src/ApprovalController.ts
@@ -95,7 +95,6 @@ export type ApprovalRequest<RequestData extends ApprovalRequestData> = {
 
   /**
    * Additional data associated with the request.
-   * TODO:TS4.4 make optional
    */
   requestData: RequestData;
 

--- a/packages/permission-controller/src/Caveat.ts
+++ b/packages/permission-controller/src/Caveat.ts
@@ -24,7 +24,6 @@ export type CaveatConstraint = {
    */
   readonly type: string;
 
-  // TODO:TS4.4 Make optional
   /**
    * Any additional data necessary to enforce the caveat.
    */
@@ -50,7 +49,6 @@ export type Caveat<Type extends string, Value extends Json> = {
    */
   readonly type: Type;
 
-  // TODO:TS4.4 Make optional
   /**
    * Any additional data necessary to enforce the caveat.
    */

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -45,7 +45,6 @@ export type PermissionConstraint = {
    */
   readonly '@context'?: NonEmptyArray<string>;
 
-  // TODO:TS4.4 Make optional
   /**
    * The caveats of the permission.
    *
@@ -92,7 +91,6 @@ export type ValidPermission<
   Name extends TargetName,
   AllowedCaveat extends CaveatConstraint,
 > = PermissionConstraint & {
-  // TODO:TS4.4 Make optional
   /**
    * The caveats of the permission.
    *

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -162,7 +162,6 @@ export type PermissionControllerSubjects<
   PermissionSubjectEntry<SubjectPermission>
 >;
 
-// TODO:TS4.4 Enable compiler flags to forbid unchecked member access
 /**
  * The state of a {@link PermissionController}.
  *

--- a/packages/permission-controller/src/SubjectMetadataController.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.ts
@@ -30,7 +30,6 @@ export enum SubjectType {
 
 export type SubjectMetadata = PermissionSubjectMetadata & {
   [key: string]: Json;
-  // TODO:TS4.4 make optional
   name: string | null;
   subjectType: SubjectType | null;
   extensionId: string | null;


### PR DESCRIPTION
## Explanation

Prior to TypeScript@4.4, I added various TODOs about marking certain object interfaces properties as optional instead of `type | null`. Now, years later and a long time after TS4.4 shipped, I have concluded that it's not worth the trouble. The same goes for a TODO exhorting us to enable `noUncheckedIndexedAcces` in the PermissionController, which appears to be something we have to do in a monorepo-wide fashion, if the test failures it produced doing it in just one package are any indication.

## Changelog

None.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
