### PR TITLE
[keyring-controller] Add `withKeyring` method

### DIFF
--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.44,
+      branches: 94.8,
       functions: 100,
-      lines: 98.84,
-      statements: 98.85,
+      lines: 98.87,
+      statements: 98.88,
     },
   },
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2220,6 +2220,140 @@ describe('KeyringController', () => {
     });
   });
 
+  describe('withKeyring', () => {
+    it('should rollback if an error is thrown', async () => {
+      await withController(async ({ controller, initialState }) => {
+        const selector = { type: KeyringTypes.hd };
+        const fn = async (keyring: EthKeyring<Json>) => {
+          await keyring.addAccounts(1);
+          throw new Error('Oops');
+        };
+
+        await expect(controller.withKeyring(selector, fn)).rejects.toThrow(
+          'Oops',
+        );
+        expect(controller.state.keyrings[0].accounts).toHaveLength(1);
+        expect(await controller.getAccounts()).toStrictEqual(
+          initialState.keyrings[0].accounts,
+        );
+      });
+    });
+
+    describe('when the keyring is selected by type', () => {
+      it('should call the given function with the selected keyring', async () => {
+        await withController(async ({ controller }) => {
+          const fn = jest.fn();
+          const selector = { type: KeyringTypes.hd };
+          const keyring = controller.getKeyringsByType(KeyringTypes.hd)[0];
+
+          await controller.withKeyring(selector, fn);
+
+          expect(fn).toHaveBeenCalledWith(keyring);
+        });
+      });
+
+      it('should return the result of the function', async () => {
+        await withController(async ({ controller }) => {
+          const fn = async () => Promise.resolve('hello');
+          const selector = { type: KeyringTypes.hd };
+
+          expect(await controller.withKeyring(selector, fn)).toBe('hello');
+        });
+      });
+
+      it('should throw an error if the callback returns the selected keyring', async () => {
+        await withController(async ({ controller }) => {
+          await expect(
+            controller.withKeyring(
+              { type: KeyringTypes.hd },
+              async (keyring) => {
+                return keyring;
+              },
+            ),
+          ).rejects.toThrow(KeyringControllerError.UnsafeDirectKeyringAccess);
+        });
+      });
+
+      describe('when the keyring is not found', () => {
+        it('should throw an error if the keyring is not found and `createIfMissing` is false', async () => {
+          await withController(async ({ controller }) => {
+            const selector = { type: 'foo' };
+            const fn = jest.fn();
+
+            await expect(controller.withKeyring(selector, fn)).rejects.toThrow(
+              KeyringControllerError.KeyringNotFound,
+            );
+            expect(fn).not.toHaveBeenCalled();
+          });
+        });
+
+        it('should add the keyring if `createIfMissing` is true', async () => {
+          await withController(
+            { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
+            async ({ controller }) => {
+              const selector = { type: MockKeyring.type };
+              const fn = jest.fn();
+
+              await controller.withKeyring(selector, fn, {
+                createIfMissing: true,
+              });
+
+              expect(fn).toHaveBeenCalled();
+              expect(controller.state.keyrings).toHaveLength(2);
+            },
+          );
+        });
+      });
+    });
+
+    describe('when the keyring is selected by address', () => {
+      it('should call the given function with the selected keyring', async () => {
+        await withController(async ({ controller, initialState }) => {
+          const fn = jest.fn();
+          const selector = {
+            address: initialState.keyrings[0].accounts[0] as Hex,
+          };
+          const keyring = controller.getKeyringsByType(KeyringTypes.hd)[0];
+
+          await controller.withKeyring(selector, fn);
+
+          expect(fn).toHaveBeenCalledWith(keyring);
+        });
+      });
+
+      it('should return the result of the function', async () => {
+        await withController(async ({ controller, initialState }) => {
+          const fn = async () => Promise.resolve('hello');
+          const selector = {
+            address: initialState.keyrings[0].accounts[0] as Hex,
+          };
+
+          expect(await controller.withKeyring(selector, fn)).toBe('hello');
+        });
+      });
+
+      describe('when the keyring is not found', () => {
+        [true, false].forEach((value) =>
+          it(`should throw an error if the createIfMissing is ${value}`, async () => {
+            await withController(async ({ controller }) => {
+              const selector = {
+                address: '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4' as Hex,
+              };
+              const fn = jest.fn();
+
+              await expect(
+                controller.withKeyring(selector, fn),
+              ).rejects.toThrow(
+                'KeyringController - No keyring found. Error info: There are keyrings, but none match the address',
+              );
+              expect(fn).not.toHaveBeenCalled();
+            });
+          }),
+        );
+      });
+    });
+  });
+
   describe('QR keyring', () => {
     const composeMockSignature = (
       requestId: string,

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1324,6 +1324,8 @@ export class KeyringController extends BaseController<
    * @param options.createIfMissing - Whether to create a new keyring if the selected one is missing.
    * @param options.createWithData - Optional data to use when creating a new keyring.
    * @returns Promise resolving to the result of the function execution.
+   * @template SelectedKeyring - The type of the selected keyring.
+   * @template CallbackResult - The type of the value resolved by the callback function.
    * @deprecated This method overload is deprecated. Use `withKeyring` without options instead.
    */
   async withKeyring<

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1350,6 +1350,8 @@ export class KeyringController extends BaseController<
    * @param selector - Keyring selector object.
    * @param fn - Function to execute with the selected keyring.
    * @returns Promise resolving to the result of the function execution.
+   * @template SelectedKeyring - The type of the selected keyring.
+   * @template CallbackResult - The type of the value resolved by the callback function.
    */
   async withKeyring<
     SelectedKeyring extends EthKeyring<Json> = EthKeyring<Json>,

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1379,9 +1379,9 @@ export class KeyringController extends BaseController<
       let keyring: SelectedKeyring | undefined;
 
       if ('address' in selector) {
-        keyring = (await this.getKeyringForAccount(
-          normalize(selector.address) as Hex,
-        )) as SelectedKeyring | undefined;
+        keyring = (await this.getKeyringForAccount(selector.address)) as
+          | SelectedKeyring
+          | undefined;
       } else {
         keyring = this.getKeyringsByType(selector.type)[selector.index || 0] as
           | SelectedKeyring

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1310,7 +1310,7 @@ export class KeyringController extends BaseController<
   }
 
   /**
-   * Select a keyring and execute the given function with
+   * Select a keyring and execute the given operation with
    * the selected keyring, as a mutually exclusive atomic
    * operation.
    *
@@ -1319,7 +1319,7 @@ export class KeyringController extends BaseController<
    * is thrown.
    *
    * @param selector - Keyring selector object.
-   * @param fn - Function to execute with the selected keyring.
+   * @param operation - Function to execute with the selected keyring.
    * @param options - Additional options.
    * @param options.createIfMissing - Whether to create a new keyring if the selected one is missing.
    * @param options.createWithData - Optional data to use when creating a new keyring.
@@ -1333,7 +1333,7 @@ export class KeyringController extends BaseController<
     CallbackResult = void,
   >(
     selector: KeyringSelector,
-    fn: (keyring: SelectedKeyring) => Promise<CallbackResult>,
+    operation: (keyring: SelectedKeyring) => Promise<CallbackResult>,
     // eslint-disable-next-line @typescript-eslint/unified-signatures
     options:
       | { createIfMissing?: false }
@@ -1341,7 +1341,7 @@ export class KeyringController extends BaseController<
   ): Promise<CallbackResult>;
 
   /**
-   * Select a keyring and execute the given function with
+   * Select a keyring and execute the given operation with
    * the selected keyring, as a mutually exclusive atomic
    * operation.
    *
@@ -1350,7 +1350,7 @@ export class KeyringController extends BaseController<
    * is thrown.
    *
    * @param selector - Keyring selector object.
-   * @param fn - Function to execute with the selected keyring.
+   * @param operation - Function to execute with the selected keyring.
    * @returns Promise resolving to the result of the function execution.
    * @template SelectedKeyring - The type of the selected keyring.
    * @template CallbackResult - The type of the value resolved by the callback function.
@@ -1360,7 +1360,7 @@ export class KeyringController extends BaseController<
     CallbackResult = void,
   >(
     selector: KeyringSelector,
-    fn: (keyring: SelectedKeyring) => Promise<CallbackResult>,
+    operation: (keyring: SelectedKeyring) => Promise<CallbackResult>,
   ): Promise<CallbackResult>;
 
   async withKeyring<
@@ -1368,7 +1368,7 @@ export class KeyringController extends BaseController<
     CallbackResult = void,
   >(
     selector: KeyringSelector,
-    fn: (keyring: SelectedKeyring) => Promise<CallbackResult>,
+    operation: (keyring: SelectedKeyring) => Promise<CallbackResult>,
     options:
       | { createIfMissing?: false }
       | { createIfMissing: true; createWithData?: unknown } = {
@@ -1399,7 +1399,7 @@ export class KeyringController extends BaseController<
         throw new Error(KeyringControllerError.KeyringNotFound);
       }
 
-      const result = await fn(keyring);
+      const result = await operation(keyring);
 
       if (Object.is(result, keyring)) {
         // Access to a keyring instance outside of controller safeguards

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1325,32 +1325,35 @@ export class KeyringController extends BaseController<
    * @param options.createWithData - Optional data to use when creating a new keyring.
    * @returns Promise resolving to the result of the function execution.
    */
-  async withKeyring<K extends EthKeyring<Json> = EthKeyring<Json>, T = void>(
+  async withKeyring<
+    SelectedKeyring extends EthKeyring<Json> = EthKeyring<Json>,
+    CallbackResult = void,
+  >(
     selector: KeyringSelector,
-    fn: (keyring: K) => Promise<T>,
+    fn: (keyring: SelectedKeyring) => Promise<CallbackResult>,
     options:
       | { createIfMissing?: false }
       | { createIfMissing: true; createWithData?: unknown } = {
       createIfMissing: false,
     },
-  ): Promise<T> {
+  ): Promise<CallbackResult> {
     return this.#persistOrRollback(async () => {
-      let keyring: K | undefined;
+      let keyring: SelectedKeyring | undefined;
 
       if ('address' in selector) {
         keyring = (await this.getKeyringForAccount(
           normalize(selector.address) as Hex,
-        )) as K | undefined;
+        )) as SelectedKeyring | undefined;
       } else {
         keyring = this.getKeyringsByType(selector.type)[selector.index || 0] as
-          | K
+          | SelectedKeyring
           | undefined;
 
         if (!keyring && options.createIfMissing) {
           keyring = (await this.#newKeyring(
             selector.type,
             options.createWithData,
-          )) as K;
+          )) as SelectedKeyring;
         }
       }
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1324,7 +1324,41 @@ export class KeyringController extends BaseController<
    * @param options.createIfMissing - Whether to create a new keyring if the selected one is missing.
    * @param options.createWithData - Optional data to use when creating a new keyring.
    * @returns Promise resolving to the result of the function execution.
+   * @deprecated This method overload is deprecated. Use `withKeyring` without options instead.
    */
+  async withKeyring<
+    SelectedKeyring extends EthKeyring<Json> = EthKeyring<Json>,
+    CallbackResult = void,
+  >(
+    selector: KeyringSelector,
+    fn: (keyring: SelectedKeyring) => Promise<CallbackResult>,
+    // eslint-disable-next-line @typescript-eslint/unified-signatures
+    options:
+      | { createIfMissing?: false }
+      | { createIfMissing: true; createWithData?: unknown },
+  ): Promise<CallbackResult>;
+
+  /**
+   * Select a keyring and execute the given function with
+   * the selected keyring, as a mutually exclusive atomic
+   * operation.
+   *
+   * The method automatically persists changes at the end of the
+   * function execution, or rolls back the changes if an error
+   * is thrown.
+   *
+   * @param selector - Keyring selector object.
+   * @param fn - Function to execute with the selected keyring.
+   * @returns Promise resolving to the result of the function execution.
+   */
+  async withKeyring<
+    SelectedKeyring extends EthKeyring<Json> = EthKeyring<Json>,
+    CallbackResult = void,
+  >(
+    selector: KeyringSelector,
+    fn: (keyring: SelectedKeyring) => Promise<CallbackResult>,
+  ): Promise<CallbackResult>;
+
   async withKeyring<
     SelectedKeyring extends EthKeyring<Json> = EthKeyring<Json>,
     CallbackResult = void,

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -854,7 +854,7 @@ export class KeyringController extends BaseController<
    *
    * @deprecated Use of this method is discouraged as actions executed directly on
    * keyrings are not being reflected in the KeyringController state and not
-   * persisted in the vault.
+   * persisted in the vault. Use `withKeyring` instead.
    * @param account - An account address.
    * @returns Promise resolving to keyring of the `account` if one exists.
    */
@@ -897,7 +897,7 @@ export class KeyringController extends BaseController<
    *
    * @deprecated Use of this method is discouraged as actions executed directly on
    * keyrings are not being reflected in the KeyringController state and not
-   * persisted in the vault.
+   * persisted in the vault. Use `withKeyring` instead.
    * @param type - Keyring type name.
    * @returns An array of keyrings of the given type.
    */
@@ -908,6 +908,7 @@ export class KeyringController extends BaseController<
   /**
    * Persist all serialized keyrings in the vault.
    *
+   * @deprecated This method is being phased out in favor of `withKeyring`.
    * @returns Promise resolving with `true` value when the
    * operation completes.
    */

--- a/packages/keyring-controller/src/constants.ts
+++ b/packages/keyring-controller/src/constants.ts
@@ -1,5 +1,7 @@
 export enum KeyringControllerError {
   NoKeyring = 'KeyringController - No keyring found',
+  KeyringNotFound = 'KeyringController - Keyring not found.',
+  UnsafeDirectKeyringAccess = 'KeyringController - Returning keyring instances is unsafe',
   WrongPasswordType = 'KeyringController - Password must be of type string.',
   NoFirstAccount = 'KeyringController - First Account not found.',
   DuplicatedAccount = 'KeyringController - The account you are trying to import is a duplicate',


### PR DESCRIPTION
## Explanation

Part of `KeyringController` responsibilies is ensuring each operation is [mutually exclusive](https://github.com/MetaMask/core/pull/4182) and [atomic](https://github.com/MetaMask/core/pull/4192), updating keyring instances and the vault (or rolling them back) in the same mutex lock.

However, the ability of clients to have direct access to a keyring instance represents a loophole, as with the current implementation they don’t have to comply with the rules enforced by the controller: we should provide a way for clients to interact with a keyring instance through safeguards provided by KeyringController.

The current behavior is this one:
1. Client obtains a keyring instance through `getKeyringForAccount`
2. Client interacts with the instance
3. Client calls `persistAllKeyrings` 

We should, instead, have something like this:
1. Client calls a `withKeyring` method, passing a _keyring selector_ and a callback
2. KeyringController selects the keyring instance and calls the callback with it, after locking the controller operation mutex
3. Client interacts with the keyring instance safely, inside the callback 
4. KeyringController, after the callback execution, internally updates the vault or rolls back changes in case of error, and then releases the mutex lock

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->
* Fixes #4198 
* Related to #4192 

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/keyring-controller`

- **ADDED**: Added `withKeyring` method
- **DEPRECATED**: Deprecated `persistAllKeyrings` method
  - Use `withKeyring` instead

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
