### PR TITLE
[keyring-controller] Remove `#getMemState` returns

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `KeyringController` methods don't return the controller state ([#4199](https://github.com/MetaMask/core/pull/4199))
+  - Changed `addNewAccount` return type to `Promise<string>`
+  - Changed `addNewAccountWithoutUpdate` return type to `Promise<string>`
+  - Changed `createNewVaultAndKeychain` return type to `Promise<void>`
+  - Changed `createNewVaultAndRestore` return type to `Promise<void>`
+  - Changed `importAccountWithStrategy` return type to `Promise<string>`
+  - Changed `removeAccount` return type to `Promise<void>`
+  - Changed `setLocked` return type to `Promise<void>`
+  - Changed `submitEncryptionKey` return type to `Promise<void>`
+  - Changed `submitPassword` return type to `Promise<void>`
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING**: `KeyringController` methods don't return the controller state ([#4199](https://github.com/MetaMask/core/pull/4199))
+- **BREAKING**: Change various `KeyringController` methods so they no longer return the controller state ([#4199](https://github.com/MetaMask/core/pull/4199))
   - Changed `addNewAccount` return type to `Promise<string>`
   - Changed `addNewAccountWithoutUpdate` return type to `Promise<string>`
   - Changed `createNewVaultAndKeychain` return type to `Promise<void>`

--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -19,8 +19,8 @@ module.exports = merge(baseConfig, {
     global: {
       branches: 94.55,
       functions: 100,
-      lines: 98.85,
-      statements: 98.86,
+      lines: 98.84,
+      statements: 98.85,
     },
   },
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -106,7 +106,7 @@ describe('KeyringController', () => {
     describe('when accountCount is not provided', () => {
       it('should add new account', async () => {
         await withController(async ({ controller, initialState }) => {
-          const { addedAccountAddress } = await controller.addNewAccount();
+          const addedAccountAddress = await controller.addNewAccount();
           expect(initialState.keyrings).toHaveLength(1);
           expect(initialState.keyrings[0].accounts).not.toStrictEqual(
             controller.state.keyrings[0].accounts,
@@ -125,7 +125,7 @@ describe('KeyringController', () => {
     describe('when accountCount is provided', () => {
       it('should add new account if accountCount is in sequence', async () => {
         await withController(async ({ controller, initialState }) => {
-          const { addedAccountAddress } = await controller.addNewAccount(
+          const addedAccountAddress = await controller.addNewAccount(
             initialState.keyrings[0].accounts.length,
           );
           expect(initialState.keyrings).toHaveLength(1);
@@ -154,10 +154,12 @@ describe('KeyringController', () => {
       it('should not add a new account if called twice with the same accountCount param', async () => {
         await withController(async ({ controller, initialState }) => {
           const accountCount = initialState.keyrings[0].accounts.length;
-          const { addedAccountAddress: firstAccountAdded } =
-            await controller.addNewAccount(accountCount);
-          const { addedAccountAddress: secondAccountAdded } =
-            await controller.addNewAccount(accountCount);
+          const firstAccountAdded = await controller.addNewAccount(
+            accountCount,
+          );
+          const secondAccountAdded = await controller.addNewAccount(
+            accountCount,
+          );
           expect(firstAccountAdded).toBe(secondAccountAdded);
           expect(controller.state.keyrings[0].accounts).toHaveLength(
             accountCount + 1,
@@ -191,11 +193,13 @@ describe('KeyringController', () => {
 
           const accountCount = initialState.keyrings[0].accounts.length;
           // We add a new account for "index 1" (not existing yet)
-          const { addedAccountAddress: firstAccountAdded } =
-            await controller.addNewAccount(accountCount);
+          const firstAccountAdded = await controller.addNewAccount(
+            accountCount,
+          );
           // Adding an account for an existing index will return the existing account's address
-          const { addedAccountAddress: secondAccountAdded } =
-            await controller.addNewAccount(accountCount);
+          const secondAccountAdded = await controller.addNewAccount(
+            accountCount,
+          );
           expect(firstAccountAdded).toBe(secondAccountAdded);
           expect(controller.state.keyrings[0].accounts).toHaveLength(
             accountCount + 1,
@@ -714,7 +718,7 @@ describe('KeyringController', () => {
     describe('when the keyring for the given address supports getEncryptionPublicKey', () => {
       it('should return the correct encryption public key', async () => {
         await withController(async ({ controller }) => {
-          const { importedAccountAddress } =
+          const importedAccountAddress =
             await controller.importAccountWithStrategy(
               AccountImportStrategy.privateKey,
               [privateKey],
@@ -755,7 +759,7 @@ describe('KeyringController', () => {
     describe('when the keyring for the given address supports decryptMessage', () => {
       it('should successfully decrypt a message with valid parameters and return the raw decryption result', async () => {
         await withController(async ({ controller }) => {
-          const { importedAccountAddress } =
+          const importedAccountAddress =
             await controller.importAccountWithStrategy(
               AccountImportStrategy.privateKey,
               [privateKey],
@@ -936,7 +940,7 @@ describe('KeyringController', () => {
               accounts: [address],
               type: 'Simple Key Pair',
             };
-            const { importedAccountAddress } =
+            const importedAccountAddress =
               await controller.importAccountWithStrategy(
                 AccountImportStrategy.privateKey,
                 [privateKey],
@@ -1002,7 +1006,7 @@ describe('KeyringController', () => {
             const somePassword = 'holachao123';
             const address = '0xb97c80fab7a3793bbe746864db80d236f1345ea7';
 
-            const { importedAccountAddress } =
+            const importedAccountAddress =
               await controller.importAccountWithStrategy(
                 AccountImportStrategy.json,
                 [input, somePassword],


### PR DESCRIPTION
## Explanation

This PR is an intermediate refactor needed for #4192.

Since operations are eventually rolled back, the internal method will not be able to return the last controller state, risking returning a stale one. Moreover, function returns make more sense now.

This PR needs these changes to be merged **first**:
- [x] https://github.com/MetaMask/core/pull/4182

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
--
* Related to #4192

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/keyring-controller`

- **BREAKING**: Change various `KeyringController` methods so they no longer return the controller state
  - Changed `addNewAccount` return type to `Promise<string>` 
  - Changed `addNewAccountWithoutUpdate` return type to `Promise<string>`
  - Changed `createNewVaultAndKeychain` return type to `Promise<void>`
  - Changed `createNewVaultAndRestore` return type to `Promise<void>`
  - Changed `importAccountWithStrategy` return type to `Promise<string>`
  - Changed `removeAccount` return type to `Promise<void>`
  - Changed `setLocked` return type to `Promise<void>`
  - Changed `submitEncryptionKey` return type to `Promise<void>`
  - Changed `submitPassword` return type to `Promise<void>`

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
