### PR TITLE
fix: issue4157 in addNewAccountForKeyring

### DIFF
--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -616,7 +616,7 @@ export class KeyringController extends BaseController<
     keyring: EthKeyring<Json>,
     accountCount?: number,
   ): Promise<Hex> {
-    const oldAccounts = await this.#getAccountsFromKeyrings();
+    const oldAccounts = await keyring.getAccounts();
 
     if (accountCount && oldAccounts.length !== accountCount) {
       if (accountCount > oldAccounts.length) {


### PR DESCRIPTION
## Explanation

This PR fixes the bug 4157 that also exists for `addNewAccountForKeyring`

## References

Related to #4157 

### `@metamask/keyring-controller`

- **FIXED**: Hd keyring add account logic in `addNewAccountForKeyring`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
