### PR TITLE
refactor: update Nft Controllers to use selectedAccountId instead of selectedAddress

### DIFF
--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -3024,6 +3024,7 @@ describe('NftController', () => {
       const {
         nftController,
         triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
         getInternalAccountMock,
       } = setupController({
         options: {
@@ -3032,6 +3033,7 @@ describe('NftController', () => {
         },
       });
       getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         isIpfsGatewayEnabled: false,

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -1,5 +1,14 @@
 import type { Network } from '@ethersproject/providers';
-import type { ApprovalControllerMessenger } from '@metamask/approval-controller';
+import type {
+  AccountsControllerGetAccountAction,
+  AccountsControllerGetSelectedAccountAction,
+  AccountsControllerSelectedEvmAccountChangeEvent,
+} from '@metamask/accounts-controller';
+import type {
+  AddApprovalRequest,
+  ApprovalStateChange,
+  ApprovalControllerMessenger,
+} from '@metamask/approval-controller';
 import { ApprovalController } from '@metamask/approval-controller';
 import { ControllerMessenger } from '@metamask/base-controller';
 import {
@@ -15,11 +24,15 @@ import {
   NFT_API_BASE_URL,
   InfuraNetworkType,
 } from '@metamask/controller-utils';
+import type { InternalAccount } from '@metamask/keyring-api';
 import type {
   NetworkClientConfiguration,
   NetworkClientId,
+  NetworkControllerGetNetworkClientByIdAction,
+  NetworkControllerNetworkDidChangeEvent,
 } from '@metamask/network-controller';
 import { defaultState as defaultNetworkState } from '@metamask/network-controller';
+import type { PreferencesControllerStateChangeEvent } from '@metamask/preferences-controller';
 import {
   getDefaultPreferencesState,
   type PreferencesState,
@@ -29,6 +42,7 @@ import nock from 'nock';
 import * as sinon from 'sinon';
 import { v4 } from 'uuid';
 
+import { createMockInternalAccount } from '../../accounts-controller/src/tests/mocks';
 import type {
   ExtractAvailableAction,
   ExtractAvailableEvent,
@@ -62,6 +76,11 @@ const ERC721_DEPRESSIONIST_ADDRESS =
   '0x18E8E76aeB9E2d9FA2A2b88DD9CF3C8ED45c3660';
 const ERC721_DEPRESSIONIST_ID = '36';
 const OWNER_ADDRESS = '0x5a3CA5cD63807Ce5e4d7841AB32Ce6B6d9BbBa2D';
+const OWNER_ID = '54d1e7bc-1dce-4220-a15f-2f454bae7869';
+const OWNER_ACCOUNT = createMockInternalAccount({
+  id: OWNER_ID,
+  address: OWNER_ADDRESS,
+});
 const SECOND_OWNER_ADDRESS = '0x500017171kasdfbou081';
 
 const DEPRESSIONIST_CID_V1 =
@@ -83,6 +102,17 @@ const GOERLI = {
   type: NetworkType.goerli,
   ticker: NetworksTicker.goerli,
 };
+
+type ApprovalActions =
+  | AddApprovalRequest
+  | AccountsControllerGetAccountAction
+  | AccountsControllerGetSelectedAccountAction
+  | NetworkControllerGetNetworkClientByIdAction;
+type ApprovalEvents =
+  | ApprovalStateChange
+  | PreferencesControllerStateChangeEvent
+  | NetworkControllerNetworkDidChangeEvent
+  | AccountsControllerSelectedEvmAccountChangeEvent;
 
 const controllerName = 'NftController' as const;
 
@@ -149,6 +179,20 @@ function setupController({
     getNetworkClientById,
   );
 
+  const getInternalAccountMock = jest.fn().mockReturnValue(OWNER_ACCOUNT);
+
+  messenger.registerActionHandler(
+    'AccountsController:getAccount',
+    getInternalAccountMock,
+  );
+
+  const getSelectedAccountMock = jest.fn().mockReturnValue(OWNER_ACCOUNT);
+
+  messenger.registerActionHandler(
+    'AccountsController:getSelectedAccount',
+    getSelectedAccountMock,
+  );
+
   const approvalControllerMessenger = messenger.getRestricted({
     name: 'ApprovalController',
     allowedActions: [],
@@ -160,15 +204,27 @@ function setupController({
     showApprovalRequest: jest.fn(),
   });
 
-  const nftControllerMessenger = messenger.getRestricted({
+  const nftControllerMessenger = messenger.getRestricted<
+    typeof controllerName,
+    ApprovalActions['type'],
+    Extract<
+      ApprovalEvents,
+      | PreferencesControllerStateChangeEvent
+      | AccountsControllerSelectedEvmAccountChangeEvent
+      | NetworkControllerNetworkDidChangeEvent
+    >['type']
+  >({
     name: controllerName,
     allowedActions: [
       'ApprovalController:addRequest',
+      'AccountsController:getSelectedAccount',
+      'AccountsController:getAccount',
       'NetworkController:getNetworkClientById',
     ],
     allowedEvents: [
-      'NetworkController:networkDidChange',
+      'AccountsController:selectedEvmAccountChange',
       'PreferencesController:stateChange',
+      'NetworkController:networkDidChange',
     ],
   });
 
@@ -203,8 +259,20 @@ function setupController({
   triggerPreferencesStateChange({
     ...getDefaultPreferencesState(),
     openSeaEnabled: true,
-    selectedAddress: OWNER_ADDRESS,
   });
+
+  const triggerSelectedAccountChange = (
+    internalAccount: InternalAccount,
+  ): void => {
+    messenger.publish(
+      'AccountsController:selectedEvmAccountChange',
+      internalAccount,
+    );
+  };
+
+  if (!options.selectedAccountId) {
+    triggerSelectedAccountChange(OWNER_ACCOUNT);
+  }
 
   return {
     nftController,
@@ -212,6 +280,9 @@ function setupController({
     approvalController,
     changeNetwork,
     triggerPreferencesStateChange,
+    triggerSelectedAccountChange,
+    getInternalAccountMock,
+    getSelectedAccountMock,
   };
 }
 
@@ -402,12 +473,17 @@ describe('NftController', () => {
         },
       });
 
-      const callActionSpy = jest.spyOn(messenger, 'call').mockResolvedValue({});
+      const callActionSpy = jest.spyOn(messenger, 'call');
 
       await expect(() =>
         nftController.watchNft(ERC721_NFT, ERC721, 'https://test-dapp.com'),
       ).rejects.toThrow('Suggested NFT is not owned by the selected account');
-      expect(callActionSpy).toHaveBeenCalledTimes(0);
+      // First call is getInternalAccount. Second call is the approval request.
+      expect(callActionSpy).not.toHaveBeenNthCalledWith(
+        2,
+        'ApprovalController:addRequest',
+        expect.any(Object),
+      );
     });
 
     it('should error if the call to isNftOwner fail', async function () {
@@ -432,12 +508,13 @@ describe('NftController', () => {
         },
       });
 
-      const callActionSpy = jest.spyOn(messenger, 'call').mockResolvedValue({});
+      const callActionSpy = jest.spyOn(messenger, 'call');
 
       await expect(() =>
         nftController.watchNft(ERC1155_NFT, ERC1155, 'https://test-dapp.com'),
       ).rejects.toThrow('Suggested NFT is not owned by the selected account');
-      expect(callActionSpy).toHaveBeenCalledTimes(0);
+      // First call is to get InternalAccount
+      expect(callActionSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should handle ERC721 type and add pending request to ApprovalController with the OpenSea API disabled and IPFS gateway enabled', async function () {
@@ -451,20 +528,24 @@ describe('NftController', () => {
             description: 'testERC721Description',
           }),
         );
-      const { nftController, messenger, triggerPreferencesStateChange } =
-        setupController({
-          options: {
-            getERC721TokenURI: jest
-              .fn()
-              .mockImplementation(() => 'https://testtokenuri.com'),
-            getERC721OwnerOf: jest.fn().mockImplementation(() => OWNER_ADDRESS),
-          },
-        });
+      const {
+        nftController,
+        messenger,
+        triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
+      } = setupController({
+        options: {
+          getERC721TokenURI: jest
+            .fn()
+            .mockImplementation(() => 'https://testtokenuri.com'),
+          getERC721OwnerOf: jest.fn().mockImplementation(() => OWNER_ADDRESS),
+        },
+      });
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         isIpfsGatewayEnabled: true,
         openSeaEnabled: false,
-        selectedAddress: OWNER_ADDRESS,
       });
 
       const requestId = 'approval-request-id-1';
@@ -473,11 +554,17 @@ describe('NftController', () => {
 
       (v4 as jest.Mock).mockImplementationOnce(() => requestId);
 
-      const callActionSpy = jest.spyOn(messenger, 'call').mockResolvedValue({});
+      const callActionSpy = jest
+        .spyOn(messenger, 'call')
+        .mockReturnValueOnce(OWNER_ACCOUNT)
+        .mockResolvedValueOnce({})
+        .mockReturnValueOnce(OWNER_ACCOUNT);
 
       await nftController.watchNft(ERC721_NFT, ERC721, 'https://test-dapp.com');
-      expect(callActionSpy).toHaveBeenCalledTimes(1);
-      expect(callActionSpy).toHaveBeenCalledWith(
+      // First call is getInternalAccount. Second call is the approval request.
+      expect(callActionSpy).toHaveBeenCalledTimes(3);
+      expect(callActionSpy).toHaveBeenNthCalledWith(
+        2,
         'ApprovalController:addRequest',
         {
           id: requestId,
@@ -512,20 +599,24 @@ describe('NftController', () => {
             description: 'testERC721Description',
           }),
         );
-      const { nftController, messenger, triggerPreferencesStateChange } =
-        setupController({
-          options: {
-            getERC721TokenURI: jest
-              .fn()
-              .mockImplementation(() => 'https://testtokenuri.com'),
-            getERC721OwnerOf: jest.fn().mockImplementation(() => OWNER_ADDRESS),
-          },
-        });
+      const {
+        nftController,
+        messenger,
+        triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
+      } = setupController({
+        options: {
+          getERC721TokenURI: jest
+            .fn()
+            .mockImplementation(() => 'https://testtokenuri.com'),
+          getERC721OwnerOf: jest.fn().mockImplementation(() => OWNER_ADDRESS),
+        },
+      });
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         isIpfsGatewayEnabled: true,
         openSeaEnabled: true,
-        selectedAddress: OWNER_ADDRESS,
       });
 
       const requestId = 'approval-request-id-1';
@@ -534,11 +625,17 @@ describe('NftController', () => {
 
       (v4 as jest.Mock).mockImplementationOnce(() => requestId);
 
-      const callActionSpy = jest.spyOn(messenger, 'call').mockResolvedValue({});
+      const callActionSpy = jest
+        .spyOn(messenger, 'call')
+        .mockReturnValueOnce(OWNER_ACCOUNT)
+        .mockResolvedValueOnce({})
+        .mockReturnValueOnce(OWNER_ACCOUNT);
 
       await nftController.watchNft(ERC721_NFT, ERC721, 'https://test-dapp.com');
-      expect(callActionSpy).toHaveBeenCalledTimes(1);
-      expect(callActionSpy).toHaveBeenCalledWith(
+      // First call is getInternalAccount. Second call is the approval request.
+      expect(callActionSpy).toHaveBeenCalledTimes(3);
+      expect(callActionSpy).toHaveBeenNthCalledWith(
+        2,
         'ApprovalController:addRequest',
         {
           id: requestId,
@@ -573,20 +670,24 @@ describe('NftController', () => {
             description: 'testERC721Description',
           }),
         );
-      const { nftController, messenger, triggerPreferencesStateChange } =
-        setupController({
-          options: {
-            getERC721TokenURI: jest
-              .fn()
-              .mockImplementation(() => 'ipfs://testtokenuri.com'),
-            getERC721OwnerOf: jest.fn().mockImplementation(() => OWNER_ADDRESS),
-          },
-        });
+      const {
+        nftController,
+        messenger,
+        triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
+      } = setupController({
+        options: {
+          getERC721TokenURI: jest
+            .fn()
+            .mockImplementation(() => 'ipfs://testtokenuri.com'),
+          getERC721OwnerOf: jest.fn().mockImplementation(() => OWNER_ADDRESS),
+        },
+      });
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         isIpfsGatewayEnabled: false,
         openSeaEnabled: false,
-        selectedAddress: OWNER_ADDRESS,
       });
 
       const requestId = 'approval-request-id-1';
@@ -595,11 +696,17 @@ describe('NftController', () => {
 
       (v4 as jest.Mock).mockImplementationOnce(() => requestId);
 
-      const callActionSpy = jest.spyOn(messenger, 'call').mockResolvedValue({});
+      const callActionSpy = jest
+        .spyOn(messenger, 'call')
+        .mockReturnValueOnce(OWNER_ACCOUNT)
+        .mockResolvedValueOnce({})
+        .mockReturnValueOnce(OWNER_ACCOUNT);
 
       await nftController.watchNft(ERC721_NFT, ERC721, 'https://test-dapp.com');
-      expect(callActionSpy).toHaveBeenCalledTimes(1);
-      expect(callActionSpy).toHaveBeenCalledWith(
+      // First call is getInternalAccount. Second call is the approval request.
+      expect(callActionSpy).toHaveBeenCalledTimes(3);
+      expect(callActionSpy).toHaveBeenNthCalledWith(
+        2,
         'ApprovalController:addRequest',
         {
           id: requestId,
@@ -634,20 +741,25 @@ describe('NftController', () => {
             description: 'testERC721Description',
           }),
         );
-      const { nftController, messenger, triggerPreferencesStateChange } =
-        setupController({
-          options: {
-            getERC721TokenURI: jest
-              .fn()
-              .mockImplementation(() => 'ipfs://testtokenuri.com'),
-            getERC721OwnerOf: jest.fn().mockImplementation(() => OWNER_ADDRESS),
-          },
-        });
+      const {
+        nftController,
+        messenger,
+        triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
+      } = setupController({
+        options: {
+          getERC721TokenURI: jest
+            .fn()
+            .mockImplementation(() => 'ipfs://testtokenuri.com'),
+          getERC721OwnerOf: jest.fn().mockImplementation(() => OWNER_ADDRESS),
+        },
+      });
+
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         isIpfsGatewayEnabled: false,
         openSeaEnabled: true,
-        selectedAddress: OWNER_ADDRESS,
       });
 
       const requestId = 'approval-request-id-1';
@@ -656,11 +768,17 @@ describe('NftController', () => {
 
       (v4 as jest.Mock).mockImplementationOnce(() => requestId);
 
-      const callActionSpy = jest.spyOn(messenger, 'call').mockResolvedValue({});
+      const callActionSpy = jest
+        .spyOn(messenger, 'call')
+        .mockReturnValueOnce(OWNER_ACCOUNT)
+        .mockResolvedValueOnce({})
+        .mockReturnValueOnce(OWNER_ACCOUNT);
 
       await nftController.watchNft(ERC721_NFT, ERC721, 'https://test-dapp.com');
-      expect(callActionSpy).toHaveBeenCalledTimes(1);
-      expect(callActionSpy).toHaveBeenCalledWith(
+      // First call is getInternalAccount. Second call is the approval request.
+      expect(callActionSpy).toHaveBeenCalledTimes(3);
+      expect(callActionSpy).toHaveBeenNthCalledWith(
+        2,
         'ApprovalController:addRequest',
         {
           id: requestId,
@@ -696,23 +814,28 @@ describe('NftController', () => {
           }),
         );
 
-      const { nftController, messenger, triggerPreferencesStateChange } =
-        setupController({
-          options: {
-            getERC721TokenURI: jest
-              .fn()
-              .mockRejectedValue(new Error('Not an ERC721 contract')),
-            getERC1155TokenURI: jest
-              .fn()
-              .mockImplementation(() => 'https://testtokenuri.com'),
-            getERC1155BalanceOf: jest.fn().mockImplementation(() => new BN(1)),
-          },
-        });
+      const {
+        nftController,
+        messenger,
+        triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
+      } = setupController({
+        options: {
+          getERC721TokenURI: jest
+            .fn()
+            .mockRejectedValue(new Error('Not an ERC721 contract')),
+          getERC1155TokenURI: jest
+            .fn()
+            .mockImplementation(() => 'https://testtokenuri.com'),
+          getERC1155BalanceOf: jest.fn().mockImplementation(() => new BN(1)),
+        },
+      });
+
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         isIpfsGatewayEnabled: true,
         openSeaEnabled: false,
-        selectedAddress: OWNER_ADDRESS,
       });
       const requestId = 'approval-request-id-1';
 
@@ -720,15 +843,21 @@ describe('NftController', () => {
 
       (v4 as jest.Mock).mockImplementationOnce(() => requestId);
 
-      const callActionSpy = jest.spyOn(messenger, 'call').mockResolvedValue({});
+      const callActionSpy = jest
+        .spyOn(messenger, 'call')
+        .mockReturnValueOnce(OWNER_ACCOUNT)
+        .mockResolvedValueOnce({})
+        .mockReturnValueOnce(OWNER_ACCOUNT);
 
       await nftController.watchNft(
         ERC1155_NFT,
         ERC1155,
         'https://etherscan.io',
       );
-      expect(callActionSpy).toHaveBeenCalledTimes(1);
-      expect(callActionSpy).toHaveBeenCalledWith(
+      // First call is getInternalAccount. Second call is the approval request.
+      expect(callActionSpy).toHaveBeenCalledTimes(3);
+      expect(callActionSpy).toHaveBeenNthCalledWith(
+        2,
         'ApprovalController:addRequest',
         {
           id: requestId,
@@ -780,7 +909,6 @@ describe('NftController', () => {
         ...getDefaultPreferencesState(),
         isIpfsGatewayEnabled: true,
         openSeaEnabled: true,
-        selectedAddress: OWNER_ADDRESS,
       });
       const requestId = 'approval-request-id-1';
 
@@ -788,15 +916,21 @@ describe('NftController', () => {
 
       (v4 as jest.Mock).mockImplementationOnce(() => requestId);
 
-      const callActionSpy = jest.spyOn(messenger, 'call').mockResolvedValue({});
+      const callActionSpy = jest
+        .spyOn(messenger, 'call')
+        .mockReturnValueOnce(OWNER_ACCOUNT)
+        .mockResolvedValueOnce({})
+        .mockReturnValue(OWNER_ACCOUNT);
 
       await nftController.watchNft(
         ERC1155_NFT,
         ERC1155,
         'https://etherscan.io',
       );
-      expect(callActionSpy).toHaveBeenCalledTimes(1);
-      expect(callActionSpy).toHaveBeenCalledWith(
+      // First call is getInternalAccount. Second call is the approval request.
+      expect(callActionSpy).toHaveBeenCalledTimes(3);
+      expect(callActionSpy).toHaveBeenNthCalledWith(
+        2,
         'ApprovalController:addRequest',
         {
           id: requestId,
@@ -838,6 +972,7 @@ describe('NftController', () => {
         approvalController,
         changeNetwork,
         triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
       } = setupController({
         options: {
           getERC721OwnerOf: jest
@@ -882,10 +1017,10 @@ describe('NftController', () => {
       expect(nftController.state.allNfts).toStrictEqual({});
 
       // this is our account and network status when the watchNFT request is made
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: OWNER_ADDRESS,
       });
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
 
@@ -938,6 +1073,7 @@ describe('NftController', () => {
         messenger,
         approvalController,
         triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
         changeNetwork,
       } = setupController({
         options: {
@@ -981,6 +1117,7 @@ describe('NftController', () => {
       expect(nftController.state.allNfts).toStrictEqual({});
 
       // this is our account and network status when the watchNFT request is made
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
@@ -994,10 +1131,13 @@ describe('NftController', () => {
       await pendingRequest;
 
       // change the network and selectedAddress before accepting the request
+      const differentAccount = createMockInternalAccount({
+        address: '0xDifferentAddress',
+      });
+      triggerSelectedAccountChange(differentAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: '0xDifferentAddress',
       });
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
       // now accept the request
@@ -1048,15 +1188,23 @@ describe('NftController', () => {
         "Unable to verify ownership. Possibly because the standard is not supported or the user's currently selected network does not match the chain of the asset in question.",
       );
     });
+
+    // it('handle unset selectedAccount', async function () {
+    //   const { nftController } = setupController({
+    //     options: { selectedAccountId: '' },
+    //   });
+    //   jest.spyOn(nftController, 'addNft');
+
+    //   const erc721Result = nftController.watchNft(ERC721_NFT, type);
+    // });
   });
 
   describe('addNft', () => {
     it('should add NFT and NFT contract', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
           chainId: ChainId.mainnet,
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           getERC721AssetName: jest.fn().mockResolvedValue('Name'),
         },
       });
@@ -1076,7 +1224,7 @@ describe('NftController', () => {
       });
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: '0x01',
         description: 'description',
@@ -1093,7 +1241,7 @@ describe('NftController', () => {
       });
 
       expect(
-        nftController.state.allNftContracts[selectedAddress][
+        nftController.state.allNftContracts[OWNER_ACCOUNT.address][
           ChainId.mainnet
         ][0],
       ).toStrictEqual({
@@ -1165,15 +1313,26 @@ describe('NftController', () => {
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
       const mockGetERC1155TokenURI = jest.fn().mockRejectedValue('');
 
-      const { nftController, triggerPreferencesStateChange } = setupController({
+      const {
+        nftController,
+        triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
+        getInternalAccountMock,
+      } = setupController({
         options: {
           getERC721TokenURI: mockGetERC721TokenURI,
           getERC1155TokenURI: mockGetERC1155TokenURI,
         },
       });
       const firstAddress = '0x123';
+      const firstAccount = createMockInternalAccount({ address: firstAddress });
       const secondAddress = '0x321';
+      const secondAccount = createMockInternalAccount({
+        address: secondAddress,
+      });
 
+      getInternalAccountMock.mockReturnValue(firstAccount);
+      triggerSelectedAccountChange(firstAccount);
       nock('https://url').get('/').reply(200, {
         name: 'name',
         image: 'url',
@@ -1182,19 +1341,20 @@ describe('NftController', () => {
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: firstAddress,
       });
       await nftController.addNft('0x01', '1234');
+      getInternalAccountMock.mockReturnValue(secondAccount);
+      triggerSelectedAccountChange(secondAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: secondAddress,
       });
       await nftController.addNft('0x02', '4321');
+      getInternalAccountMock.mockReturnValue(firstAccount);
+      triggerSelectedAccountChange(firstAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: firstAddress,
       });
       expect(
         nftController.state.allNfts[firstAddress][ChainId.mainnet][0],
@@ -1212,10 +1372,9 @@ describe('NftController', () => {
     });
 
     it('should update NFT if image is different', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
@@ -1230,7 +1389,7 @@ describe('NftController', () => {
       });
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: '0x01',
         description: 'description',
@@ -1253,7 +1412,7 @@ describe('NftController', () => {
       });
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: '0x01',
         description: 'description',
@@ -1267,10 +1426,9 @@ describe('NftController', () => {
     });
 
     it('should not duplicate NFT nor NFT contract if already added', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
@@ -1295,19 +1453,20 @@ describe('NftController', () => {
       });
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
       ).toHaveLength(1);
 
       expect(
-        nftController.state.allNftContracts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNftContracts[OWNER_ACCOUNT.address][
+          ChainId.mainnet
+        ],
       ).toHaveLength(1);
     });
 
     it('should add NFT and get information from NFT-API', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           getERC721TokenURI: jest
             .fn()
             .mockRejectedValue(new Error('Not an ERC721 contract')),
@@ -1319,7 +1478,7 @@ describe('NftController', () => {
 
       await nftController.addNft('0x01', '1');
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: '0x01',
         description: 'Description',
@@ -1336,10 +1495,9 @@ describe('NftController', () => {
     });
 
     it('should add NFT erc721 and aggregate NFT data from both contract and NFT-API', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           getERC721AssetName: jest.fn().mockResolvedValue('KudosToken'),
           getERC721AssetSymbol: jest.fn().mockResolvedValue('KDO'),
           getERC721TokenURI: jest
@@ -1377,7 +1535,7 @@ describe('NftController', () => {
       await nftController.addNft(ERC721_KUDOSADDRESS, ERC721_KUDOS_TOKEN_ID);
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: ERC721_KUDOSADDRESS,
         image: 'Kudos Image (directly from tokenURI)',
@@ -1392,7 +1550,7 @@ describe('NftController', () => {
       });
 
       expect(
-        nftController.state.allNftContracts[selectedAddress][
+        nftController.state.allNftContracts[OWNER_ACCOUNT.address][
           ChainId.mainnet
         ][0],
       ).toStrictEqual({
@@ -1404,10 +1562,9 @@ describe('NftController', () => {
     });
 
     it('should add NFT erc1155 and get NFT information from contract when NFT API call fail', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           getERC721TokenURI: jest
             .fn()
             .mockRejectedValue(new Error('Not a 721 contract')),
@@ -1433,7 +1590,7 @@ describe('NftController', () => {
       await nftController.addNft(ERC1155_NFT_ADDRESS, ERC1155_NFT_ID);
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: ERC1155_NFT_ADDRESS,
         image: 'image (directly from tokenURI)',
@@ -1449,10 +1606,9 @@ describe('NftController', () => {
     });
 
     it('should add NFT erc721 and get NFT information only from contract', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           getERC721AssetName: jest.fn().mockResolvedValue('KudosToken'),
           getERC721AssetSymbol: jest.fn().mockResolvedValue('KDO'),
           getERC721TokenURI: jest.fn().mockImplementation((tokenAddress) => {
@@ -1482,7 +1638,7 @@ describe('NftController', () => {
       await nftController.addNft(ERC721_KUDOSADDRESS, ERC721_KUDOS_TOKEN_ID);
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: ERC721_KUDOSADDRESS,
         image: 'Kudos Image (directly from tokenURI)',
@@ -1497,7 +1653,7 @@ describe('NftController', () => {
       });
 
       expect(
-        nftController.state.allNftContracts[selectedAddress][
+        nftController.state.allNftContracts[OWNER_ACCOUNT.address][
           ChainId.mainnet
         ][0],
       ).toStrictEqual({
@@ -1509,12 +1665,11 @@ describe('NftController', () => {
     });
 
     it('should add NFT by provider type', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
       const { nftController, changeNetwork } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           getERC721TokenURI: mockGetERC721TokenURI,
         },
       });
@@ -1530,11 +1685,15 @@ describe('NftController', () => {
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
 
       expect(
-        nftController.state.allNfts[selectedAddress]?.[ChainId[GOERLI.type]],
+        nftController.state.allNfts[OWNER_ACCOUNT.address]?.[
+          ChainId[GOERLI.type]
+        ],
       ).toBeUndefined();
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId[SEPOLIA.type]][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][
+          ChainId[SEPOLIA.type]
+        ][0],
       ).toStrictEqual({
         address: '0x01',
         description: 'description',
@@ -1554,10 +1713,9 @@ describe('NftController', () => {
       const mockGetERC721AssetSymbol = jest.fn().mockResolvedValue('');
       const mockGetERC721AssetName = jest.fn().mockResolvedValue('');
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           onNftAdded: mockOnNftAdded,
           getERC721AssetSymbol: mockGetERC721AssetSymbol,
           getERC721AssetName: mockGetERC721AssetName,
@@ -1574,7 +1732,7 @@ describe('NftController', () => {
       await nftController.addNft('0x01234abcdefg', '1234');
 
       expect(nftController.state.allNftContracts).toStrictEqual({
-        [selectedAddress]: {
+        [OWNER_ACCOUNT.address]: {
           [ChainId.mainnet]: [
             {
               address: '0x01234abcdefg',
@@ -1585,7 +1743,7 @@ describe('NftController', () => {
       });
 
       expect(nftController.state.allNfts).toStrictEqual({
-        [selectedAddress]: {
+        [OWNER_ACCOUNT.address]: {
           [ChainId.mainnet]: [
             {
               address: '0x01234abcdefg',
@@ -1676,11 +1834,10 @@ describe('NftController', () => {
     });
 
     it('should add an nft and nftContract when there is valid contract information and source is "detected"', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const mockOnNftAdded = jest.fn();
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           onNftAdded: mockOnNftAdded,
           getERC721AssetName: jest
             .fn()
@@ -1716,26 +1873,28 @@ describe('NftController', () => {
         '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
         '123',
         {
-          userAddress: selectedAddress,
+          userAddress: OWNER_ACCOUNT.address,
           source: Source.Detected,
         },
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress]?.[ChainId.mainnet],
+        nftController.state.allNfts[OWNER_ACCOUNT.address]?.[ChainId.mainnet],
       ).toBeUndefined();
 
       expect(
-        nftController.state.allNftContracts[selectedAddress]?.[ChainId.mainnet],
+        nftController.state.allNftContracts[OWNER_ACCOUNT.address]?.[
+          ChainId.mainnet
+        ],
       ).toBeUndefined();
 
       await nftController.addNft(ERC721_KUDOSADDRESS, ERC721_KUDOS_TOKEN_ID, {
-        userAddress: selectedAddress,
+        userAddress: OWNER_ACCOUNT.address,
         source: Source.Detected,
       });
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
       ).toStrictEqual([
         {
           address: ERC721_KUDOSADDRESS,
@@ -1756,7 +1915,9 @@ describe('NftController', () => {
       ]);
 
       expect(
-        nftController.state.allNftContracts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNftContracts[OWNER_ACCOUNT.address][
+          ChainId.mainnet
+        ],
       ).toStrictEqual([
         {
           address: ERC721_KUDOSADDRESS,
@@ -1776,11 +1937,10 @@ describe('NftController', () => {
     });
 
     it('should not add an nft and nftContract when there is not valid contract information (or an issue fetching it) and source is "detected"', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const mockOnNftAdded = jest.fn();
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           onNftAdded: mockOnNftAdded,
           getERC721AssetName: jest
             .fn()
@@ -1799,12 +1959,12 @@ describe('NftController', () => {
         '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
         '123',
         {
-          userAddress: selectedAddress,
+          userAddress: OWNER_ACCOUNT.address,
           source: Source.Detected,
         },
       );
       await nftController.addNft(ERC721_KUDOSADDRESS, ERC721_KUDOS_TOKEN_ID, {
-        userAddress: selectedAddress,
+        userAddress: OWNER_ACCOUNT.address,
         source: Source.Detected,
       });
 
@@ -1814,10 +1974,9 @@ describe('NftController', () => {
     });
 
     it('should not add duplicate NFTs to the ignoredNfts list', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
@@ -1840,13 +1999,13 @@ describe('NftController', () => {
       });
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
       ).toHaveLength(2);
       expect(nftController.state.ignoredNfts).toHaveLength(0);
 
       nftController.removeAndIgnoreNft('0x01', '1');
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
       ).toHaveLength(1);
       expect(nftController.state.ignoredNfts).toHaveLength(1);
 
@@ -1860,20 +2019,23 @@ describe('NftController', () => {
       });
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
       ).toHaveLength(2);
       expect(nftController.state.ignoredNfts).toHaveLength(1);
 
       nftController.removeAndIgnoreNft('0x01', '1');
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
       ).toHaveLength(1);
       expect(nftController.state.ignoredNfts).toHaveLength(1);
     });
 
     it('should add NFT with metadata hosted in IPFS', async () => {
-      const selectedAddress = OWNER_ADDRESS;
-      const { nftController, triggerPreferencesStateChange } = setupController({
+      const {
+        nftController,
+        triggerPreferencesStateChange,
+        getInternalAccountMock,
+      } = setupController({
         options: {
           getERC721AssetName: jest
             .fn()
@@ -1892,9 +2054,9 @@ describe('NftController', () => {
             .mockRejectedValue(new Error('Not an ERC1155 token')),
         },
       });
+      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
-        selectedAddress,
         ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,
       });
 
@@ -1904,7 +2066,7 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNftContracts[selectedAddress][
+        nftController.state.allNftContracts[OWNER_ACCOUNT.address][
           ChainId.mainnet
         ][0],
       ).toStrictEqual({
@@ -1914,7 +2076,7 @@ describe('NftController', () => {
         schemaName: ERC721,
       });
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: ERC721_DEPRESSIONIST_ADDRESS,
         tokenId: '36',
@@ -1930,7 +2092,6 @@ describe('NftController', () => {
     });
 
     it('should add NFT erc721 when call to NFT API fail', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController();
       nock(NFT_API_BASE_URL)
         .get(
@@ -1941,7 +2102,7 @@ describe('NftController', () => {
       await nftController.addNft(ERC721_NFT_ADDRESS, ERC721_NFT_ID);
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: ERC721_NFT_ADDRESS,
         image: null,
@@ -2191,6 +2352,34 @@ describe('NftController', () => {
         },
       ]);
     });
+
+    it('should handle unset selectedAccount', async () => {
+      const { nftController, getInternalAccountMock } = setupController({
+        options: {
+          chainId: ChainId.mainnet,
+          selectedAccountId: '',
+          getERC721AssetName: jest.fn().mockResolvedValue('Name'),
+        },
+      });
+
+      getInternalAccountMock.mockReturnValue(null);
+
+      await nftController.addNft('0x01', '1', {
+        nftMetadata: {
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+          favorite: false,
+          collection: {
+            tokenCount: '0',
+            image: 'url',
+          },
+        },
+      });
+
+      expect(nftController.state.allNftContracts['']).toBeUndefined();
+    });
   });
 
   describe('addNftVerifyOwnership', () => {
@@ -2198,13 +2387,28 @@ describe('NftController', () => {
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
 
-      const { nftController, triggerPreferencesStateChange } = setupController({
+      const {
+        nftController,
+        getInternalAccountMock,
+        triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
+      } = setupController({
         options: {
           getERC721TokenURI: mockGetERC721TokenURI,
         },
       });
       const firstAddress = '0x123';
+      const firstAccount = createMockInternalAccount({
+        address: firstAddress,
+        id: '22c022b5-309c-45e4-a82d-64bb11fc0e74',
+      });
       const secondAddress = '0x321';
+      const secondAccount = createMockInternalAccount({
+        address: secondAddress,
+        id: 'f9a42417-6071-4b51-8ecd-f7b14abd8851',
+      });
+      getInternalAccountMock.mockReturnValue(firstAccount);
+      triggerSelectedAccountChange(firstAccount);
 
       jest.spyOn(nftController, 'isNftOwner').mockResolvedValue(true);
       nock('https://url').get('/').reply(200, {
@@ -2215,22 +2419,23 @@ describe('NftController', () => {
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: firstAddress,
       });
       await nftController.addNftVerifyOwnership('0x01', '1234');
+      getInternalAccountMock.mockReturnValue(secondAccount);
+      triggerSelectedAccountChange(secondAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: secondAddress,
       });
       await nftController.addNftVerifyOwnership('0x02', '4321');
+      getInternalAccountMock.mockReturnValue(firstAccount);
+      triggerSelectedAccountChange(firstAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: firstAddress,
       });
       expect(
-        nftController.state.allNfts[firstAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[firstAccount.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: '0x01',
         description: 'description',
@@ -2245,14 +2450,24 @@ describe('NftController', () => {
     });
 
     it('should throw an error if selected address is not owner of input NFT', async () => {
-      const { nftController, triggerPreferencesStateChange } =
-        setupController();
+      const {
+        nftController,
+        getInternalAccountMock,
+        triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
+      } = setupController();
+      // TODO: Replace `any` with type
       jest.spyOn(nftController, 'isNftOwner').mockResolvedValue(false);
       const firstAddress = '0x123';
+      const firstAccount = createMockInternalAccount({
+        address: firstAddress,
+        id: '22c022b5-309c-45e4-a82d-64bb11fc0e74',
+      });
+      getInternalAccountMock.mockReturnValue(firstAccount);
+      triggerSelectedAccountChange(firstAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: firstAddress,
       });
       const result = async () =>
         await nftController.addNftVerifyOwnership('0x01', '1234');
@@ -2263,14 +2478,27 @@ describe('NftController', () => {
     it('should verify ownership by selected address and add NFT by the correct chainId when passed networkClientId', async () => {
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const { nftController, triggerPreferencesStateChange } = setupController({
+      const {
+        nftController,
+        triggerPreferencesStateChange,
+        getInternalAccountMock,
+        triggerSelectedAccountChange,
+      } = setupController({
         options: {
           getERC721TokenURI: mockGetERC721TokenURI,
         },
       });
 
       const firstAddress = '0x123';
+      const firstAccount = createMockInternalAccount({
+        address: firstAddress,
+        id: '22c022b5-309c-45e4-a82d-64bb11fc0e74',
+      });
       const secondAddress = '0x321';
+      const secondAccount = createMockInternalAccount({
+        address: secondAddress,
+        id: 'f9a42417-6071-4b51-8ecd-f7b14abd8851',
+      });
 
       jest.spyOn(nftController, 'isNftOwner').mockResolvedValue(true);
 
@@ -2282,25 +2510,27 @@ describe('NftController', () => {
           description: 'description',
         })
         .persist();
+      getInternalAccountMock.mockReturnValue(firstAccount);
+      triggerSelectedAccountChange(firstAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: firstAddress,
       });
       await nftController.addNftVerifyOwnership('0x01', '1234', {
         networkClientId: 'sepolia',
       });
+      getInternalAccountMock.mockReturnValue(secondAccount);
+      triggerSelectedAccountChange(secondAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: secondAddress,
       });
       await nftController.addNftVerifyOwnership('0x02', '4321', {
         networkClientId: 'goerli',
       });
 
       expect(
-        nftController.state.allNfts[firstAddress][SEPOLIA.chainId][0],
+        nftController.state.allNfts[firstAccount.address][SEPOLIA.chainId][0],
       ).toStrictEqual({
         address: '0x01',
         description: 'description',
@@ -2313,7 +2543,7 @@ describe('NftController', () => {
         tokenURI,
       });
       expect(
-        nftController.state.allNfts[secondAddress][GOERLI.chainId][0],
+        nftController.state.allNfts[secondAccount.address][GOERLI.chainId][0],
       ).toStrictEqual({
         address: '0x02',
         description: 'description',
@@ -2330,17 +2560,21 @@ describe('NftController', () => {
     it('should verify ownership by selected address and add NFT by the correct userAddress when passed userAddress', async () => {
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const { nftController, changeNetwork, triggerPreferencesStateChange } =
-        setupController({
-          options: {
-            getERC721TokenURI: mockGetERC721TokenURI,
-          },
-        });
+      const {
+        nftController,
+        changeNetwork,
+        triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
+      } = setupController({
+        options: {
+          getERC721TokenURI: mockGetERC721TokenURI,
+        },
+      });
       // Ensure that the currently selected address is not the same as either of the userAddresses
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: OWNER_ADDRESS,
       });
 
       const firstAddress = '0x123';
@@ -2396,10 +2630,9 @@ describe('NftController', () => {
 
   describe('removeNft', () => {
     it('should remove NFT and NFT contract', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
@@ -2413,16 +2646,17 @@ describe('NftController', () => {
       });
       nftController.removeNft('0x01', '1');
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
       ).toHaveLength(0);
 
       expect(
-        nftController.state.allNftContracts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNftContracts[OWNER_ACCOUNT.address][
+          ChainId.mainnet
+        ],
       ).toHaveLength(0);
     });
 
     it('should not remove NFT contract if NFT still exists', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController();
 
       await nftController.addNft('0x01', '1', {
@@ -2444,18 +2678,25 @@ describe('NftController', () => {
       });
       nftController.removeNft('0x01', '1');
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
       ).toHaveLength(1);
 
       expect(
-        nftController.state.allNftContracts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNftContracts[OWNER_ACCOUNT.address][
+          ChainId.mainnet
+        ],
       ).toHaveLength(1);
     });
 
     it('should remove NFT by selected address', async () => {
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const { nftController, triggerPreferencesStateChange } = setupController({
+      const {
+        nftController,
+        triggerPreferencesStateChange,
+        getInternalAccountMock,
+        triggerSelectedAccountChange,
+      } = setupController({
         options: {
           getERC721TokenURI: mockGetERC721TokenURI,
         },
@@ -2466,30 +2707,39 @@ describe('NftController', () => {
         description: 'description',
       });
       const firstAddress = '0x123';
+      const firstAccount = createMockInternalAccount({
+        address: firstAddress,
+        id: '22c022b5-309c-45e4-a82d-64bb11fc0e74',
+      });
       const secondAddress = '0x321';
+      const secondAccount = createMockInternalAccount({
+        address: secondAddress,
+        id: 'f9a42417-6071-4b51-8ecd-f7b14abd8851',
+      });
+      getInternalAccountMock.mockReturnValue(firstAccount);
+      triggerSelectedAccountChange(firstAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: firstAddress,
       });
       await nftController.addNft('0x02', '4321');
+      getInternalAccountMock.mockReturnValue(secondAccount);
+      triggerSelectedAccountChange(secondAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: secondAddress,
       });
       await nftController.addNft('0x01', '1234');
       nftController.removeNft('0x01', '1234');
       expect(
-        nftController.state.allNfts[secondAddress][ChainId.mainnet],
+        nftController.state.allNfts[secondAccount.address][ChainId.mainnet],
       ).toHaveLength(0);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: firstAddress,
       });
       expect(
-        nftController.state.allNfts[firstAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[firstAccount.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: '0x02',
         description: 'description',
@@ -2504,12 +2754,11 @@ describe('NftController', () => {
     });
 
     it('should remove NFT by provider type', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
       const { nftController, changeNetwork } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           getERC721TokenURI: mockGetERC721TokenURI,
         },
       });
@@ -2525,13 +2774,13 @@ describe('NftController', () => {
       await nftController.addNft('0x01', '1234');
       nftController.removeNft('0x01', '1234');
       expect(
-        nftController.state.allNfts[selectedAddress][GOERLI.chainId],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][GOERLI.chainId],
       ).toHaveLength(0);
 
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
 
       expect(
-        nftController.state.allNfts[selectedAddress][SEPOLIA.chainId][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][SEPOLIA.chainId][0],
       ).toStrictEqual({
         address: '0x02',
         description: 'description',
@@ -2546,17 +2795,31 @@ describe('NftController', () => {
     });
 
     it('should remove correct NFT and NFT contract when passed networkClientId and userAddress in options', async () => {
-      const { nftController, changeNetwork, triggerPreferencesStateChange } =
-        setupController();
+      const {
+        nftController,
+        changeNetwork,
+        triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
+        getInternalAccountMock,
+      } = setupController();
 
       const userAddress1 = '0x123';
+      const userAccount1 = createMockInternalAccount({
+        address: userAddress1,
+        id: '5fd59cae-95d3-4a1d-ba97-657c8f83c300',
+      });
       const userAddress2 = '0x321';
+      const userAccount2 = createMockInternalAccount({
+        address: userAddress2,
+        id: '9ea40063-a95c-4f79-a4b6-0c065549245e',
+      });
 
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
+      getInternalAccountMock.mockReturnValue(userAccount1);
+      triggerSelectedAccountChange(userAccount1);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: userAddress1,
       });
 
       await nftController.addNft('0x01', '1', {
@@ -2582,10 +2845,11 @@ describe('NftController', () => {
       });
 
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
+      getInternalAccountMock.mockReturnValue(userAccount2);
+      triggerSelectedAccountChange(userAccount2);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: userAddress2,
       });
 
       // now remove the nft after changing to a different network and account from the one where it was added
@@ -2605,10 +2869,9 @@ describe('NftController', () => {
   });
 
   it('should be able to clear the ignoredNfts list', async () => {
-    const selectedAddress = OWNER_ADDRESS;
     const { nftController } = setupController({
       options: {
-        selectedAddress,
+        selectedAccountId: OWNER_ACCOUNT.id,
       },
     });
 
@@ -2623,13 +2886,13 @@ describe('NftController', () => {
     });
 
     expect(
-      nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+      nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
     ).toHaveLength(1);
     expect(nftController.state.ignoredNfts).toHaveLength(0);
 
     nftController.removeAndIgnoreNft('0x02', '1');
     expect(
-      nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+      nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
     ).toHaveLength(0);
     expect(nftController.state.ignoredNfts).toHaveLength(1);
 
@@ -2766,17 +3029,19 @@ describe('NftController', () => {
     });
 
     it('should add NFT with null metadata if the ipfs gateway is disabled and opensea is disabled', async () => {
-      const selectedAddress = OWNER_ADDRESS;
-      const { nftController, triggerPreferencesStateChange } = setupController({
+      const {
+        nftController,
+        triggerPreferencesStateChange,
+        getInternalAccountMock,
+      } = setupController({
         options: {
           getERC721TokenURI: jest.fn().mockRejectedValue(''),
           getERC1155TokenURI: jest.fn().mockResolvedValue('ipfs://*'),
         },
       });
-
+      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
-        selectedAddress,
         isIpfsGatewayEnabled: false,
         openSeaEnabled: false,
       });
@@ -2784,7 +3049,7 @@ describe('NftController', () => {
       await nftController.addNft(ERC1155_NFT_ADDRESS, ERC1155_NFT_ID);
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual({
         address: ERC1155_NFT_ADDRESS,
         name: null,
@@ -2801,10 +3066,9 @@ describe('NftController', () => {
 
   describe('updateNftFavoriteStatus', () => {
     it('should not set NFT as favorite if nft not found', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
@@ -2821,7 +3085,7 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual(
         expect.objectContaining({
           address: ERC721_DEPRESSIONIST_ADDRESS,
@@ -2831,10 +3095,9 @@ describe('NftController', () => {
       );
     });
     it('should set NFT as favorite', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
@@ -2851,7 +3114,7 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual(
         expect.objectContaining({
           address: ERC721_DEPRESSIONIST_ADDRESS,
@@ -2862,10 +3125,9 @@ describe('NftController', () => {
     });
 
     it('should set NFT as favorite and then unset it', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
@@ -2882,7 +3144,7 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual(
         expect.objectContaining({
           address: ERC721_DEPRESSIONIST_ADDRESS,
@@ -2898,7 +3160,7 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual(
         expect.objectContaining({
           address: ERC721_DEPRESSIONIST_ADDRESS,
@@ -2909,10 +3171,9 @@ describe('NftController', () => {
     });
 
     it('should keep the favorite status as true after updating metadata', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
@@ -2929,7 +3190,7 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual(
         expect.objectContaining({
           address: ERC721_DEPRESSIONIST_ADDRESS,
@@ -2952,7 +3213,7 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual(
         expect.objectContaining({
           image: 'new_image',
@@ -2966,15 +3227,14 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
       ).toHaveLength(1);
     });
 
     it('should keep the favorite status as false after updating metadata', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
@@ -2985,7 +3245,7 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual(
         expect.objectContaining({
           address: ERC721_DEPRESSIONIST_ADDRESS,
@@ -3008,7 +3268,7 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual(
         expect.objectContaining({
           image: 'new_image',
@@ -3022,22 +3282,36 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet],
       ).toHaveLength(1);
     });
 
     it('should set NFT as favorite when passed networkClientId and userAddress in options', async () => {
-      const { nftController, triggerPreferencesStateChange, changeNetwork } =
-        setupController();
+      const {
+        nftController,
+        triggerPreferencesStateChange,
+        changeNetwork,
+        triggerSelectedAccountChange,
+        getInternalAccountMock,
+      } = setupController();
 
       const userAddress1 = '0x123';
+      const userAccount1 = createMockInternalAccount({
+        address: userAddress1,
+        id: '0a2a9a41-2b35-4863-8f36-baceec4e9686',
+      });
       const userAddress2 = '0x321';
+      const userAccount2 = createMockInternalAccount({
+        address: userAddress2,
+        id: '09b239a4-c229-4a2b-9739-1cb4b9dea7b9',
+      });
 
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
+      getInternalAccountMock.mockReturnValue(userAccount1);
+      triggerSelectedAccountChange(userAccount1);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: userAddress1,
       });
 
       await nftController.addNft(
@@ -3047,7 +3321,7 @@ describe('NftController', () => {
       );
 
       expect(
-        nftController.state.allNfts[userAddress1][SEPOLIA.chainId][0],
+        nftController.state.allNfts[userAccount1.address][SEPOLIA.chainId][0],
       ).toStrictEqual(
         expect.objectContaining({
           address: ERC721_DEPRESSIONIST_ADDRESS,
@@ -3057,10 +3331,11 @@ describe('NftController', () => {
       );
 
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
+      getInternalAccountMock.mockReturnValue(userAccount2);
+      triggerSelectedAccountChange(userAccount2);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
-        selectedAddress: userAddress2,
       });
 
       // now favorite the nft after changing to a different account from the one where it was added
@@ -3070,12 +3345,12 @@ describe('NftController', () => {
         true,
         {
           networkClientId: SEPOLIA.type,
-          userAddress: userAddress1,
+          userAddress: userAccount1.address,
         },
       );
 
       expect(
-        nftController.state.allNfts[userAddress1][SEPOLIA.chainId][0],
+        nftController.state.allNfts[userAccount1.address][SEPOLIA.chainId][0],
       ).toStrictEqual(
         expect.objectContaining({
           address: ERC721_DEPRESSIONIST_ADDRESS,
@@ -3088,11 +3363,10 @@ describe('NftController', () => {
 
   describe('checkAndUpdateNftsOwnershipStatus', () => {
     describe('checkAndUpdateAllNftsOwnershipStatus', () => {
-      it('should check whether NFTs for the current selectedAddress/chainId combination are still owned by the selectedAddress and update the isCurrentlyOwned value to false when NFT is not still owned', async () => {
-        const selectedAddress = OWNER_ADDRESS;
+      it('should check whether NFTs for the current selectedAccount/chainId combination are still owned by the selectedAccount and update the isCurrentlyOwned value to false when NFT is not still owned', async () => {
         const { nftController } = setupController({
           options: {
-            selectedAddress,
+            selectedAccountId: OWNER_ACCOUNT.id,
           },
         });
         jest.spyOn(nftController, 'isNftOwner').mockResolvedValue(false);
@@ -3107,23 +3381,22 @@ describe('NftController', () => {
           },
         });
         expect(
-          nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+          nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
             .isCurrentlyOwned,
         ).toBe(true);
 
         await nftController.checkAndUpdateAllNftsOwnershipStatus();
 
         expect(
-          nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+          nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
             .isCurrentlyOwned,
         ).toBe(false);
       });
 
-      it('should check whether NFTs for the current selectedAddress/chainId combination are still owned by the selectedAddress and leave/set the isCurrentlyOwned value to true when NFT is still owned', async () => {
-        const selectedAddress = OWNER_ADDRESS;
+      it('should check whether NFTs for the current selectedAccount/chainId combination are still owned by the selectedAccount and leave/set the isCurrentlyOwned value to true when NFT is still owned', async () => {
         const { nftController } = setupController({
           options: {
-            selectedAddress,
+            selectedAccountId: OWNER_ACCOUNT.id,
           },
         });
         jest.spyOn(nftController, 'isNftOwner').mockResolvedValue(true);
@@ -3139,22 +3412,21 @@ describe('NftController', () => {
         });
 
         expect(
-          nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+          nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
             .isCurrentlyOwned,
         ).toBe(true);
 
         await nftController.checkAndUpdateAllNftsOwnershipStatus();
         expect(
-          nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+          nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
             .isCurrentlyOwned,
         ).toBe(true);
       });
 
-      it('should check whether NFTs for the current selectedAddress/chainId combination are still owned by the selectedAddress and leave the isCurrentlyOwned value as is when NFT ownership check fails', async () => {
-        const selectedAddress = OWNER_ADDRESS;
+      it('should check whether NFTs for the current selectedAccount/chainId combination are still owned by the selectedAccount and leave the isCurrentlyOwned value as is when NFT ownership check fails', async () => {
         const { nftController } = setupController({
           options: {
-            selectedAddress,
+            selectedAccountId: OWNER_ACCOUNT.id,
           },
         });
         jest
@@ -3172,26 +3444,29 @@ describe('NftController', () => {
         });
 
         expect(
-          nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+          nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
             .isCurrentlyOwned,
         ).toBe(true);
 
         await nftController.checkAndUpdateAllNftsOwnershipStatus();
         expect(
-          nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+          nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
             .isCurrentlyOwned,
         ).toBe(true);
       });
 
-      it('should check whether NFTs for the current selectedAddress/chainId combination are still owned by the selectedAddress and update the isCurrentlyOwned value to false when NFT is not still owned, when the currently configured selectedAddress/chainId are different from those passed', async () => {
-        const selectedAddress = OWNER_ADDRESS;
-        const { nftController, changeNetwork, triggerPreferencesStateChange } =
-          setupController();
+      it('should check whether NFTs for the current selectedAccount/chainId combination are still owned by the selectedAccount and update the isCurrentlyOwned value to false when NFT is not still owned, when the currently configured selectedAccount/chainId are different from those passed', async () => {
+        const {
+          nftController,
+          changeNetwork,
+          triggerPreferencesStateChange,
+          getInternalAccountMock,
+        } = setupController();
 
+        getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
         triggerPreferencesStateChange({
           ...getDefaultPreferencesState(),
           openSeaEnabled: true,
-          selectedAddress,
         });
         changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
 
@@ -3206,7 +3481,7 @@ describe('NftController', () => {
         });
 
         expect(
-          nftController.state.allNfts[selectedAddress][ChainId.sepolia][0]
+          nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.sepolia][0]
             .isCurrentlyOwned,
         ).toBe(true);
 
@@ -3215,7 +3490,6 @@ describe('NftController', () => {
         triggerPreferencesStateChange({
           ...getDefaultPreferencesState(),
           openSeaEnabled: true,
-          selectedAddress: SECOND_OWNER_ADDRESS,
         });
         changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
 
@@ -3229,14 +3503,38 @@ describe('NftController', () => {
             .isCurrentlyOwned,
         ).toBe(false);
       });
+
+      it('should handle default case where selectedAccount is not set', async () => {
+        const { nftController, getInternalAccountMock } = setupController({
+          options: {
+            selectedAccountId: '',
+          },
+        });
+        getInternalAccountMock.mockReturnValue(null);
+        jest.spyOn(nftController, 'isNftOwner').mockResolvedValue(false);
+
+        await nftController.addNft('0x02', '1', {
+          nftMetadata: {
+            name: 'name',
+            image: 'image',
+            description: 'description',
+            standard: 'standard',
+            favorite: false,
+          },
+        });
+        expect(nftController.state.allNfts['']).toBeUndefined();
+
+        await nftController.checkAndUpdateAllNftsOwnershipStatus();
+
+        expect(nftController.state.allNfts['']).toBeUndefined();
+      });
     });
 
     describe('checkAndUpdateSingleNftOwnershipStatus', () => {
-      it('should check whether the passed NFT is still owned by the the current selectedAddress/chainId combination and update its isCurrentlyOwned property in state if batch is false and isNftOwner returns false', async () => {
-        const selectedAddress = OWNER_ADDRESS;
+      it('should check whether the passed NFT is still owned by the the current selectedAccount/chainId combination and update its isCurrentlyOwned property in state if batch is false and isNftOwner returns false', async () => {
         const { nftController } = setupController({
           options: {
-            selectedAddress,
+            selectedAccountId: OWNER_ACCOUNT.id,
           },
         });
 
@@ -3255,7 +3553,7 @@ describe('NftController', () => {
         });
 
         expect(
-          nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+          nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
             .isCurrentlyOwned,
         ).toBe(true);
 
@@ -3264,16 +3562,15 @@ describe('NftController', () => {
         await nftController.checkAndUpdateSingleNftOwnershipStatus(nft, false);
 
         expect(
-          nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+          nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
             .isCurrentlyOwned,
         ).toBe(false);
       });
 
       it('should check whether the passed NFT is still owned by the the current selectedAddress/chainId combination and return the updated NFT object without updating state if batch is true', async () => {
-        const selectedAddress = OWNER_ADDRESS;
         const { nftController } = setupController({
           options: {
-            selectedAddress,
+            selectedAccountId: OWNER_ACCOUNT.id,
           },
         });
 
@@ -3292,7 +3589,7 @@ describe('NftController', () => {
         });
 
         expect(
-          nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+          nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
             .isCurrentlyOwned,
         ).toBe(true);
 
@@ -3302,22 +3599,26 @@ describe('NftController', () => {
           await nftController.checkAndUpdateSingleNftOwnershipStatus(nft, true);
 
         expect(
-          nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+          nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
             .isCurrentlyOwned,
         ).toBe(true);
 
-        expect(updatedNft.isCurrentlyOwned).toBe(false);
+        expect(updatedNft?.isCurrentlyOwned).toBe(false);
       });
 
       it('should check whether the passed NFT is still owned by the the selectedAddress/chainId combination passed in the accountParams argument and update its isCurrentlyOwned property in state, when the currently configured selectedAddress/chainId are different from those passed', async () => {
-        const firstSelectedAddress = OWNER_ADDRESS;
-        const { nftController, changeNetwork, triggerPreferencesStateChange } =
-          setupController();
+        const firstSelectedAddress = OWNER_ACCOUNT.address;
+        const {
+          nftController,
+          changeNetwork,
+          triggerPreferencesStateChange,
+          triggerSelectedAccountChange,
+        } = setupController();
 
+        triggerSelectedAccountChange(OWNER_ACCOUNT);
         triggerPreferencesStateChange({
           ...getDefaultPreferencesState(),
           openSeaEnabled: true,
-          selectedAddress: firstSelectedAddress,
         });
         changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
 
@@ -3341,11 +3642,13 @@ describe('NftController', () => {
         ).toBe(true);
 
         jest.spyOn(nftController, 'isNftOwner').mockResolvedValue(false);
-
+        const secondAccount = createMockInternalAccount({
+          address: SECOND_OWNER_ADDRESS,
+        });
+        triggerSelectedAccountChange(secondAccount);
         triggerPreferencesStateChange({
           ...getDefaultPreferencesState(),
           openSeaEnabled: true,
-          selectedAddress: SECOND_OWNER_ADDRESS,
         });
         changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
 
@@ -3361,14 +3664,18 @@ describe('NftController', () => {
       });
 
       it('should check whether the passed NFT is still owned by the the selectedAddress/chainId combination passed in the accountParams argument and return the updated NFT object without updating state, when the currently configured selectedAddress/chainId are different from those passed and batch is true', async () => {
-        const firstSelectedAddress = OWNER_ADDRESS;
-        const { nftController, changeNetwork, triggerPreferencesStateChange } =
-          setupController();
+        const firstSelectedAddress = OWNER_ACCOUNT.address;
+        const {
+          nftController,
+          changeNetwork,
+          triggerPreferencesStateChange,
+          triggerSelectedAccountChange,
+        } = setupController();
 
+        triggerSelectedAccountChange(OWNER_ACCOUNT);
         triggerPreferencesStateChange({
           ...getDefaultPreferencesState(),
           openSeaEnabled: true,
-          selectedAddress: OWNER_ADDRESS,
         });
         changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
 
@@ -3392,11 +3699,13 @@ describe('NftController', () => {
         ).toBe(true);
 
         jest.spyOn(nftController, 'isNftOwner').mockResolvedValue(false);
-
+        const secondAccount = createMockInternalAccount({
+          address: SECOND_OWNER_ADDRESS,
+        });
+        triggerSelectedAccountChange(secondAccount);
         triggerPreferencesStateChange({
           ...getDefaultPreferencesState(),
           openSeaEnabled: true,
-          selectedAddress: SECOND_OWNER_ADDRESS,
         });
         changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
 
@@ -3435,10 +3744,9 @@ describe('NftController', () => {
     };
 
     it('should return null if the NFT does not exist in the state', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
@@ -3446,20 +3754,19 @@ describe('NftController', () => {
         nftController.findNftByAddressAndTokenId(
           mockNft.address,
           mockNft.tokenId,
-          selectedAddress,
+          OWNER_ACCOUNT.address,
           ChainId.mainnet,
         ),
       ).toBeNull();
     });
 
     it('should return the NFT by the address and tokenId', () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           state: {
             allNfts: {
-              [OWNER_ADDRESS]: { [ChainId.mainnet]: [mockNft] },
+              [OWNER_ACCOUNT.address]: { [ChainId.mainnet]: [mockNft] },
             },
           },
         },
@@ -3469,7 +3776,7 @@ describe('NftController', () => {
         nftController.findNftByAddressAndTokenId(
           mockNft.address,
           mockNft.tokenId,
-          selectedAddress,
+          OWNER_ACCOUNT.address,
           ChainId.mainnet,
         ),
       ).toStrictEqual({ nft: mockNft, index: 0 });
@@ -3477,7 +3784,6 @@ describe('NftController', () => {
   });
 
   describe('updateNftByAddressAndTokenId', () => {
-    const selectedAddress = OWNER_ADDRESS;
     const mockTransactionId = '60d36710-b150-11ec-8a49-c377fbd05e27';
     const mockNft = {
       address: '0x02',
@@ -3503,10 +3809,10 @@ describe('NftController', () => {
     it('should update the NFT if the NFT exist', async () => {
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           state: {
             allNfts: {
-              [OWNER_ADDRESS]: { [ChainId.mainnet]: [mockNft] },
+              [OWNER_ACCOUNT.address]: { [ChainId.mainnet]: [mockNft] },
             },
           },
         },
@@ -3517,19 +3823,19 @@ describe('NftController', () => {
         {
           transactionId: mockTransactionId,
         },
-        selectedAddress,
+        OWNER_ACCOUNT.address,
         ChainId.mainnet,
       );
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0],
       ).toStrictEqual(expectedMockNft);
     });
 
     it('should return undefined if the NFT does not exist', () => {
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
@@ -3539,7 +3845,7 @@ describe('NftController', () => {
           {
             transactionId: mockTransactionId,
           },
-          selectedAddress,
+          OWNER_ACCOUNT.address,
           ChainId.mainnet,
         ),
       ).toBeUndefined();
@@ -3562,27 +3868,25 @@ describe('NftController', () => {
     };
 
     it('should not update any NFT state and should return false when passed a transaction id that does not match that of any NFT', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
         },
       });
 
       expect(
         nftController.resetNftTransactionStatusByTransactionId(
           nonExistTransactionId,
-          selectedAddress,
+          OWNER_ACCOUNT.address,
           ChainId.mainnet,
         ),
       ).toBe(false);
     });
 
     it('should set the transaction id of an NFT in state to undefined, and return true when it has successfully updated this state', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const { nftController } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           state: {
             allNfts: {
               [OWNER_ADDRESS]: { [ChainId.mainnet]: [mockNft] },
@@ -3592,20 +3896,20 @@ describe('NftController', () => {
       });
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
           .transactionId,
       ).toBe(mockTransactionId);
 
       expect(
         nftController.resetNftTransactionStatusByTransactionId(
           mockTransactionId,
-          selectedAddress,
+          OWNER_ACCOUNT.address,
           ChainId.mainnet,
         ),
       ).toBe(true);
 
       expect(
-        nftController.state.allNfts[selectedAddress][ChainId.mainnet][0]
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
           .transactionId,
       ).toBeUndefined();
     });
@@ -3613,17 +3917,17 @@ describe('NftController', () => {
 
   describe('updateNftMetadata', () => {
     it('should update Nft metadata successfully', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const tokenURI = 'https://api.pudgypenguins.io/lil/4';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const { nftController } = setupController({
+      const { nftController, getInternalAccountMock } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           getERC721TokenURI: mockGetERC721TokenURI,
         },
       });
       const spy = jest.spyOn(nftController, 'updateNft');
       const testNetworkClientId = 'sepolia';
+      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
       await nftController.addNft('0xtest', '3', {
         nftMetadata: { name: '', description: '', image: '', standard: '' },
         networkClientId: testNetworkClientId,
@@ -3655,7 +3959,7 @@ describe('NftController', () => {
       expect(spy).toHaveBeenCalledTimes(1);
 
       expect(
-        nftController.state.allNfts[selectedAddress][SEPOLIA.chainId][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][SEPOLIA.chainId][0],
       ).toStrictEqual({
         address: '0xtest',
         description: 'description pudgy',
@@ -3670,17 +3974,17 @@ describe('NftController', () => {
     });
 
     it('should not update metadata when state nft and fetched nft are the same', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const { nftController } = setupController({
+      const { nftController, getInternalAccountMock } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           getERC721TokenURI: mockGetERC721TokenURI,
         },
       });
       const updateNftSpy = jest.spyOn(nftController, 'updateNft');
       const testNetworkClientId = 'sepolia';
+      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
       await nftController.addNft('0xtest', '3', {
         nftMetadata: {
           name: 'toto',
@@ -3713,6 +4017,7 @@ describe('NftController', () => {
         },
       ];
 
+      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
       await nftController.updateNftMetadata({
         nfts: testInputNfts,
         networkClientId: testNetworkClientId,
@@ -3720,7 +4025,7 @@ describe('NftController', () => {
 
       expect(updateNftSpy).toHaveBeenCalledTimes(0);
       expect(
-        nftController.state.allNfts[selectedAddress][SEPOLIA.chainId][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][SEPOLIA.chainId][0],
       ).toStrictEqual({
         address: '0xtest',
         description: 'description',
@@ -3735,17 +4040,17 @@ describe('NftController', () => {
     });
 
     it('should trigger update metadata when state nft and fetched nft are not the same', async () => {
-      const selectedAddress = OWNER_ADDRESS;
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const { nftController } = setupController({
+      const { nftController, getInternalAccountMock } = setupController({
         options: {
-          selectedAddress,
+          selectedAccountId: OWNER_ACCOUNT.id,
           getERC721TokenURI: mockGetERC721TokenURI,
         },
       });
       const spy = jest.spyOn(nftController, 'updateNft');
       const testNetworkClientId = 'sepolia';
+      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
       await nftController.addNft('0xtest', '3', {
         nftMetadata: {
           name: 'toto',
@@ -3781,7 +4086,7 @@ describe('NftController', () => {
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(
-        nftController.state.allNfts[selectedAddress][SEPOLIA.chainId][0],
+        nftController.state.allNfts[OWNER_ACCOUNT.address][SEPOLIA.chainId][0],
       ).toStrictEqual({
         address: '0xtest',
         description: 'description',
@@ -3796,8 +4101,11 @@ describe('NftController', () => {
     });
 
     it('should not update metadata when nfts has image/name/description already', async () => {
-      const { nftController, triggerPreferencesStateChange } =
-        setupController();
+      const {
+        nftController,
+        triggerPreferencesStateChange,
+        triggerSelectedAccountChange,
+      } = setupController();
       const spy = jest.spyOn(nftController, 'updateNftMetadata');
       const testNetworkClientId = 'sepolia';
 
@@ -3813,12 +4121,12 @@ describe('NftController', () => {
         networkClientId: testNetworkClientId,
       });
 
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
       // trigger preference change
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         isIpfsGatewayEnabled: false,
         openSeaEnabled: true,
-        selectedAddress: OWNER_ADDRESS,
       });
 
       expect(spy).toHaveBeenCalledTimes(0);
@@ -3827,12 +4135,16 @@ describe('NftController', () => {
     it('should trigger calling updateNftMetadata when preferences change - openseaEnabled', async () => {
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const { nftController, triggerPreferencesStateChange, changeNetwork } =
-        setupController({
-          options: {
-            getERC721TokenURI: mockGetERC721TokenURI,
-          },
-        });
+      const {
+        nftController,
+        triggerPreferencesStateChange,
+        changeNetwork,
+        triggerSelectedAccountChange,
+      } = setupController({
+        options: {
+          getERC721TokenURI: mockGetERC721TokenURI,
+        },
+      });
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
       const spy = jest.spyOn(nftController, 'updateNftMetadata');
 
@@ -3865,21 +4177,24 @@ describe('NftController', () => {
         ...getDefaultPreferencesState(),
         isIpfsGatewayEnabled: false,
         openSeaEnabled: true,
-        selectedAddress: OWNER_ADDRESS,
       });
-
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should trigger calling updateNftMetadata when preferences change - ipfs enabled', async () => {
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const { nftController, triggerPreferencesStateChange, changeNetwork } =
-        setupController({
-          options: {
-            getERC721TokenURI: mockGetERC721TokenURI,
-          },
-        });
+      const {
+        nftController,
+        triggerPreferencesStateChange,
+        changeNetwork,
+        triggerSelectedAccountChange,
+      } = setupController({
+        options: {
+          getERC721TokenURI: mockGetERC721TokenURI,
+        },
+      });
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
       const spy = jest.spyOn(nftController, 'updateNftMetadata');
 
@@ -3912,8 +4227,8 @@ describe('NftController', () => {
         ...getDefaultPreferencesState(),
         isIpfsGatewayEnabled: true,
         openSeaEnabled: false,
-        selectedAddress: OWNER_ADDRESS,
       });
+      triggerSelectedAccountChange(OWNER_ACCOUNT);
 
       expect(spy).toHaveBeenCalledTimes(1);
     });

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -2,6 +2,7 @@ import type { Network } from '@ethersproject/providers';
 import type {
   AccountsControllerGetAccountAction,
   AccountsControllerGetSelectedAccountAction,
+  AccountsControllerSelectedAccountChangeEvent,
   AccountsControllerSelectedEvmAccountChangeEvent,
 } from '@metamask/accounts-controller';
 import type {
@@ -63,7 +64,6 @@ import {
   type AllowedActions,
   type AllowedEvents,
 } from './NftController';
-import { AccountsControllerSelectedAccountChangeEvent } from '@metamask/accounts-controller';
 
 const CRYPTOPUNK_ADDRESS = '0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB';
 const ERC721_KUDOSADDRESS = '0x2aEa4Add166EBf38b63d09a75dE1a7b94Aa24163';
@@ -4223,7 +4223,10 @@ describe('NftController', () => {
     const updateNftMetadataSpy = jest.spyOn(nftController, 'updateNftMetadata');
     messenger.publish(
       'AccountsController:selectedAccountChange',
-      createMockInternalAccount(),
+      createMockInternalAccount({
+        id: 'new-id',
+        address: '0x5284deb594c4b593268d7c98e5ecd29dcafa5b49',
+      }),
     );
 
     expect(updateNftMetadataSpy).not.toHaveBeenCalled();

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -184,13 +184,13 @@ function setupController({
     getNetworkClientById,
   );
 
-  const getInternalAccountMock = jest
+  const mockGetAccount = jest
     .fn()
     .mockReturnValue(defaultSelectedAccount ?? OWNER_ACCOUNT);
 
   messenger.registerActionHandler(
     'AccountsController:getAccount',
-    getInternalAccountMock,
+    mockGetAccount,
   );
 
   const mockGetSelectedAccount = jest
@@ -290,7 +290,7 @@ function setupController({
     changeNetwork,
     triggerPreferencesStateChange,
     triggerSelectedAccountChange,
-    getInternalAccountMock,
+    mockGetAccount,
     mockGetSelectedAccount,
   };
 }
@@ -1316,7 +1316,7 @@ describe('NftController', () => {
         nftController,
         triggerPreferencesStateChange,
         triggerSelectedAccountChange,
-        getInternalAccountMock,
+        mockGetAccount,
       } = setupController({
         options: {
           getERC721TokenURI: mockGetERC721TokenURI,
@@ -1330,7 +1330,7 @@ describe('NftController', () => {
         address: secondAddress,
       });
 
-      getInternalAccountMock.mockReturnValue(firstAccount);
+      mockGetAccount.mockReturnValue(firstAccount);
       triggerSelectedAccountChange(firstAccount);
       nock('https://url').get('/').reply(200, {
         name: 'name',
@@ -1342,14 +1342,14 @@ describe('NftController', () => {
         openSeaEnabled: true,
       });
       await nftController.addNft('0x01', '1234');
-      getInternalAccountMock.mockReturnValue(secondAccount);
+      mockGetAccount.mockReturnValue(secondAccount);
       triggerSelectedAccountChange(secondAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
       });
       await nftController.addNft('0x02', '4321');
-      getInternalAccountMock.mockReturnValue(firstAccount);
+      mockGetAccount.mockReturnValue(firstAccount);
       triggerSelectedAccountChange(firstAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
@@ -2027,30 +2027,27 @@ describe('NftController', () => {
     });
 
     it('should add NFT with metadata hosted in IPFS', async () => {
-      const {
-        nftController,
-        triggerPreferencesStateChange,
-        getInternalAccountMock,
-      } = setupController({
-        options: {
-          getERC721AssetName: jest
-            .fn()
-            .mockResolvedValue("Maltjik.jpg's Depressionists"),
-          getERC721AssetSymbol: jest.fn().mockResolvedValue('DPNS'),
-          getERC721TokenURI: jest.fn().mockImplementation((tokenAddress) => {
-            switch (tokenAddress) {
-              case ERC721_DEPRESSIONIST_ADDRESS:
-                return `ipfs://${DEPRESSIONIST_CID_V1}`;
-              default:
-                throw new Error('Not an ERC721 token');
-            }
-          }),
-          getERC1155TokenURI: jest
-            .fn()
-            .mockRejectedValue(new Error('Not an ERC1155 token')),
-        },
-      });
-      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
+      const { nftController, triggerPreferencesStateChange, mockGetAccount } =
+        setupController({
+          options: {
+            getERC721AssetName: jest
+              .fn()
+              .mockResolvedValue("Maltjik.jpg's Depressionists"),
+            getERC721AssetSymbol: jest.fn().mockResolvedValue('DPNS'),
+            getERC721TokenURI: jest.fn().mockImplementation((tokenAddress) => {
+              switch (tokenAddress) {
+                case ERC721_DEPRESSIONIST_ADDRESS:
+                  return `ipfs://${DEPRESSIONIST_CID_V1}`;
+                default:
+                  throw new Error('Not an ERC721 token');
+              }
+            }),
+            getERC1155TokenURI: jest
+              .fn()
+              .mockRejectedValue(new Error('Not an ERC1155 token')),
+          },
+        });
+      mockGetAccount.mockReturnValue(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,
@@ -2350,14 +2347,14 @@ describe('NftController', () => {
     });
 
     it('should handle unset selectedAccount', async () => {
-      const { nftController, getInternalAccountMock } = setupController({
+      const { nftController, mockGetAccount } = setupController({
         options: {
           chainId: ChainId.mainnet,
           getERC721AssetName: jest.fn().mockResolvedValue('Name'),
         },
       });
 
-      getInternalAccountMock.mockReturnValue(null);
+      mockGetAccount.mockReturnValue(null);
 
       await nftController.addNft('0x01', '1', {
         nftMetadata: {
@@ -2384,7 +2381,7 @@ describe('NftController', () => {
 
       const {
         nftController,
-        getInternalAccountMock,
+        mockGetAccount,
         triggerPreferencesStateChange,
         triggerSelectedAccountChange,
       } = setupController({
@@ -2402,7 +2399,7 @@ describe('NftController', () => {
         address: secondAddress,
         id: 'f9a42417-6071-4b51-8ecd-f7b14abd8851',
       });
-      getInternalAccountMock.mockReturnValue(firstAccount);
+      mockGetAccount.mockReturnValue(firstAccount);
       triggerSelectedAccountChange(firstAccount);
 
       jest.spyOn(nftController, 'isNftOwner').mockResolvedValue(true);
@@ -2416,14 +2413,14 @@ describe('NftController', () => {
         openSeaEnabled: true,
       });
       await nftController.addNftVerifyOwnership('0x01', '1234');
-      getInternalAccountMock.mockReturnValue(secondAccount);
+      mockGetAccount.mockReturnValue(secondAccount);
       triggerSelectedAccountChange(secondAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
       });
       await nftController.addNftVerifyOwnership('0x02', '4321');
-      getInternalAccountMock.mockReturnValue(firstAccount);
+      mockGetAccount.mockReturnValue(firstAccount);
       triggerSelectedAccountChange(firstAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
@@ -2447,7 +2444,7 @@ describe('NftController', () => {
     it('should throw an error if selected address is not owner of input NFT', async () => {
       const {
         nftController,
-        getInternalAccountMock,
+        mockGetAccount,
         triggerPreferencesStateChange,
         triggerSelectedAccountChange,
       } = setupController();
@@ -2457,7 +2454,7 @@ describe('NftController', () => {
         address: firstAddress,
         id: '22c022b5-309c-45e4-a82d-64bb11fc0e74',
       });
-      getInternalAccountMock.mockReturnValue(firstAccount);
+      mockGetAccount.mockReturnValue(firstAccount);
       triggerSelectedAccountChange(firstAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
@@ -2475,7 +2472,7 @@ describe('NftController', () => {
       const {
         nftController,
         triggerPreferencesStateChange,
-        getInternalAccountMock,
+        mockGetAccount,
         triggerSelectedAccountChange,
       } = setupController({
         options: {
@@ -2504,7 +2501,7 @@ describe('NftController', () => {
           description: 'description',
         })
         .persist();
-      getInternalAccountMock.mockReturnValue(firstAccount);
+      mockGetAccount.mockReturnValue(firstAccount);
       triggerSelectedAccountChange(firstAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
@@ -2513,7 +2510,7 @@ describe('NftController', () => {
       await nftController.addNftVerifyOwnership('0x01', '1234', {
         networkClientId: 'sepolia',
       });
-      getInternalAccountMock.mockReturnValue(secondAccount);
+      mockGetAccount.mockReturnValue(secondAccount);
       triggerSelectedAccountChange(secondAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
@@ -2687,7 +2684,7 @@ describe('NftController', () => {
       const {
         nftController,
         triggerPreferencesStateChange,
-        getInternalAccountMock,
+        mockGetAccount,
         triggerSelectedAccountChange,
       } = setupController({
         options: {
@@ -2709,14 +2706,14 @@ describe('NftController', () => {
         address: secondAddress,
         id: 'f9a42417-6071-4b51-8ecd-f7b14abd8851',
       });
-      getInternalAccountMock.mockReturnValue(firstAccount);
+      mockGetAccount.mockReturnValue(firstAccount);
       triggerSelectedAccountChange(firstAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
         openSeaEnabled: true,
       });
       await nftController.addNft('0x02', '4321');
-      getInternalAccountMock.mockReturnValue(secondAccount);
+      mockGetAccount.mockReturnValue(secondAccount);
       triggerSelectedAccountChange(secondAccount);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
@@ -2793,7 +2790,7 @@ describe('NftController', () => {
         changeNetwork,
         triggerPreferencesStateChange,
         triggerSelectedAccountChange,
-        getInternalAccountMock,
+        mockGetAccount,
       } = setupController();
 
       const userAddress1 = '0x123';
@@ -2808,7 +2805,7 @@ describe('NftController', () => {
       });
 
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
-      getInternalAccountMock.mockReturnValue(userAccount1);
+      mockGetAccount.mockReturnValue(userAccount1);
       triggerSelectedAccountChange(userAccount1);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
@@ -2838,7 +2835,7 @@ describe('NftController', () => {
       });
 
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
-      getInternalAccountMock.mockReturnValue(userAccount2);
+      mockGetAccount.mockReturnValue(userAccount2);
       triggerSelectedAccountChange(userAccount2);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
@@ -3280,7 +3277,7 @@ describe('NftController', () => {
         triggerPreferencesStateChange,
         changeNetwork,
         triggerSelectedAccountChange,
-        getInternalAccountMock,
+        mockGetAccount,
       } = setupController();
 
       const userAddress1 = '0x123';
@@ -3295,7 +3292,7 @@ describe('NftController', () => {
       });
 
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
-      getInternalAccountMock.mockReturnValue(userAccount1);
+      mockGetAccount.mockReturnValue(userAccount1);
       triggerSelectedAccountChange(userAccount1);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
@@ -3319,7 +3316,7 @@ describe('NftController', () => {
       );
 
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
-      getInternalAccountMock.mockReturnValue(userAccount2);
+      mockGetAccount.mockReturnValue(userAccount2);
       triggerSelectedAccountChange(userAccount2);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
@@ -3445,10 +3442,10 @@ describe('NftController', () => {
           nftController,
           changeNetwork,
           triggerPreferencesStateChange,
-          getInternalAccountMock,
+          mockGetAccount,
         } = setupController();
 
-        getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
+        mockGetAccount.mockReturnValue(OWNER_ACCOUNT);
         triggerPreferencesStateChange({
           ...getDefaultPreferencesState(),
           openSeaEnabled: true,
@@ -3490,10 +3487,10 @@ describe('NftController', () => {
       });
 
       it('should handle default case where selectedAccount is not set', async () => {
-        const { nftController, getInternalAccountMock } = setupController({
+        const { nftController, mockGetAccount } = setupController({
           options: {},
         });
-        getInternalAccountMock.mockReturnValue(null);
+        mockGetAccount.mockReturnValue(null);
         jest.spyOn(nftController, 'isNftOwner').mockResolvedValue(false);
 
         await nftController.addNft('0x02', '1', {
@@ -3896,7 +3893,7 @@ describe('NftController', () => {
     it('should update Nft metadata successfully', async () => {
       const tokenURI = 'https://api.pudgypenguins.io/lil/4';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const { nftController, getInternalAccountMock } = setupController({
+      const { nftController, mockGetAccount } = setupController({
         options: {
           getERC721TokenURI: mockGetERC721TokenURI,
         },
@@ -3904,7 +3901,7 @@ describe('NftController', () => {
       });
       const spy = jest.spyOn(nftController, 'updateNft');
       const testNetworkClientId = 'sepolia';
-      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
+      mockGetAccount.mockReturnValue(OWNER_ACCOUNT);
       await nftController.addNft('0xtest', '3', {
         nftMetadata: { name: '', description: '', image: '', standard: '' },
         networkClientId: testNetworkClientId,
@@ -3953,7 +3950,7 @@ describe('NftController', () => {
     it('should not update metadata when state nft and fetched nft are the same', async () => {
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const { nftController, getInternalAccountMock } = setupController({
+      const { nftController, mockGetAccount } = setupController({
         options: {
           getERC721TokenURI: mockGetERC721TokenURI,
         },
@@ -3961,7 +3958,7 @@ describe('NftController', () => {
       });
       const updateNftSpy = jest.spyOn(nftController, 'updateNft');
       const testNetworkClientId = 'sepolia';
-      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
+      mockGetAccount.mockReturnValue(OWNER_ACCOUNT);
       await nftController.addNft('0xtest', '3', {
         nftMetadata: {
           name: 'toto',
@@ -3994,7 +3991,7 @@ describe('NftController', () => {
         },
       ];
 
-      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
+      mockGetAccount.mockReturnValue(OWNER_ACCOUNT);
       await nftController.updateNftMetadata({
         nfts: testInputNfts,
         networkClientId: testNetworkClientId,
@@ -4019,7 +4016,7 @@ describe('NftController', () => {
     it('should trigger update metadata when state nft and fetched nft are not the same', async () => {
       const tokenURI = 'https://url/';
       const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
-      const { nftController, getInternalAccountMock } = setupController({
+      const { nftController, mockGetAccount } = setupController({
         options: {
           getERC721TokenURI: mockGetERC721TokenURI,
         },
@@ -4027,7 +4024,7 @@ describe('NftController', () => {
       });
       const spy = jest.spyOn(nftController, 'updateNft');
       const testNetworkClientId = 'sepolia';
-      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
+      mockGetAccount.mockReturnValue(OWNER_ACCOUNT);
       await nftController.addNft('0xtest', '3', {
         nftMetadata: {
           name: 'toto',

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -193,13 +193,13 @@ function setupController({
     getInternalAccountMock,
   );
 
-  const getSelectedAccountMock = jest
+  const mockGetSelectedAccount = jest
     .fn()
     .mockReturnValue(defaultSelectedAccount ?? OWNER_ACCOUNT);
 
   messenger.registerActionHandler(
     'AccountsController:getSelectedAccount',
-    getSelectedAccountMock,
+    mockGetSelectedAccount,
   );
 
   const approvalControllerMessenger = messenger.getRestricted({
@@ -291,7 +291,7 @@ function setupController({
     triggerPreferencesStateChange,
     triggerSelectedAccountChange,
     getInternalAccountMock,
-    getSelectedAccountMock,
+    mockGetSelectedAccount,
   };
 }
 
@@ -3025,14 +3025,13 @@ describe('NftController', () => {
         nftController,
         triggerPreferencesStateChange,
         triggerSelectedAccountChange,
-        getInternalAccountMock,
       } = setupController({
         options: {
           getERC721TokenURI: jest.fn().mockRejectedValue(''),
           getERC1155TokenURI: jest.fn().mockResolvedValue('ipfs://*'),
         },
+        defaultSelectedAccount: OWNER_ACCOUNT,
       });
-      getInternalAccountMock.mockReturnValue(OWNER_ACCOUNT);
       triggerSelectedAccountChange(OWNER_ACCOUNT);
       triggerPreferencesStateChange({
         ...getDefaultPreferencesState(),
@@ -4315,7 +4314,7 @@ describe('NftController', () => {
     });
   });
 
-  // Testing to make sure selectedAccountChange isn't used. This can return non evm accounts.
+  // Testing to make sure selectedAccountChange isn't used. This can return non-EVM accounts.
   it('triggering selectedAccountChange would not trigger anything', async () => {
     const tokenURI = 'https://url/';
     const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1556,13 +1556,7 @@ export class NftController extends BaseController<
       userAddress,
     }: { networkClientId?: NetworkClientId; userAddress?: string } = {},
   ) {
-    const userAccount = this.messagingSystem.call(
-      'AccountsController:getAccount',
-      this.#selectedAccountId,
-    );
-
-    // Previously selectedAddress could be an empty string. This is to preserve the behaviour
-    const addressToSearch = userAddress || userAccount?.address || '';
+    const addressToSearch = this.#getAddressOrSelectedAddress(userAddress);
     const chainId = this.#getCorrectChainId({ networkClientId });
     const checksumHexAddress = toChecksumHexAddress(address);
     this.#removeIndividualNft(checksumHexAddress, tokenId, {

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -300,7 +300,7 @@ describe('NftDetectionController', () => {
         options: {
           interval: 10,
         },
-        getSelectedAccount: mockGetSelectedAccount,
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         const mockNfts = sinon
@@ -515,9 +515,9 @@ describe('NftDetectionController', () => {
 
   it('should respond to chain ID changing when using legacy polling', async () => {
     const mockAddNft = jest.fn();
-    const mockGetSelectedAccount = jest.fn();
     const pollingInterval = 100;
     const selectedAccount = createMockInternalAccount({ address: '0x1' });
+    const mockGetSelectedAccount = jest.fn().mockReturnValue(selectedAccount);
 
     await withController(
       {
@@ -535,8 +535,7 @@ describe('NftDetectionController', () => {
           selectedNetworkClientId: 'mainnet',
         },
         mockPreferencesState: {},
-        getSelectedAccount:
-          mockGetSelectedAccount.mockReturnValue(selectedAccount),
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         await controller.start();
@@ -617,11 +616,12 @@ describe('NftDetectionController', () => {
     const selectedAccount = createMockInternalAccount({
       address: selectedAddress,
     });
+    const mockGetSelectedAccount = jest.fn().mockReturnValue(selectedAccount);
     await withController(
       {
         options: { addNft: mockAddNft },
         mockPreferencesState: {},
-        getSelectedAccount: jest.fn().mockReturnValue(selectedAccount),
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         controllerEvents.triggerPreferencesStateChange({
@@ -663,11 +663,12 @@ describe('NftDetectionController', () => {
     const selectedAccount = createMockInternalAccount({
       address: selectedAddress,
     });
+    const mockGetSelectedAccount = jest.fn().mockReturnValue(selectedAccount);
     await withController(
       {
         options: { addNft: mockAddNft },
         mockPreferencesState: {},
-        getSelectedAccount: jest.fn().mockReturnValue(selectedAccount),
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         controllerEvents.triggerPreferencesStateChange({
@@ -718,11 +719,12 @@ describe('NftDetectionController', () => {
     const selectedAccount = createMockInternalAccount({
       address: selectedAddress,
     });
+    const mockGetSelectedAccount = jest.fn().mockReturnValue(selectedAccount);
     await withController(
       {
         options: { addNft: mockAddNft },
         mockPreferencesState: {},
-        getSelectedAccount: jest.fn().mockReturnValue(selectedAccount),
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         controllerEvents.triggerPreferencesStateChange({
@@ -787,7 +789,7 @@ describe('NftDetectionController', () => {
         options: {
           addNft: mockAddNft,
         },
-        getSelectedAccount: mockGetSelectedAccount,
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         const selectedAddress = '0x1';
@@ -856,7 +858,7 @@ describe('NftDetectionController', () => {
       {
         options: { addNft: mockAddNft, getNftState: mockGetNftState },
         mockPreferencesState: { selectedAddress },
-        getSelectedAccount: mockGetSelectedAccount,
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         mockGetSelectedAccount.mockReturnValue(selectedAccount);
@@ -881,14 +883,12 @@ describe('NftDetectionController', () => {
   it('should not detect and add NFTs if there is no selectedAddress', async () => {
     const mockAddNft = jest.fn();
     // mock uninitialised selectedAccount when it is ''
-    const mockGetSelectedInternalAccount = jest
-      .fn()
-      .mockReturnValue({ address: '' });
+    const mockGetSelectedAccount = jest.fn().mockReturnValue({ address: '' });
     await withController(
       {
         options: { addNft: mockAddNft },
         mockPreferencesState: {},
-        getSelectedAccount: mockGetSelectedInternalAccount,
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         controllerEvents.triggerPreferencesStateChange({
@@ -966,7 +966,7 @@ describe('NftDetectionController', () => {
       {
         options: { addNft: mockAddNft, disabled: false },
         mockPreferencesState: {},
-        getSelectedAccount: mockGetSelectedAccount,
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         mockGetSelectedAccount.mockReturnValue(selectedAccount);
@@ -1007,7 +1007,7 @@ describe('NftDetectionController', () => {
         options: {
           addNft: mockAddNft,
         },
-        getSelectedAccount: mockGetSelectedAccount,
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         controllerEvents.triggerPreferencesStateChange({
@@ -1033,11 +1033,11 @@ describe('NftDetectionController', () => {
     const selectedAccount = createMockInternalAccount({
       address: selectedAddress,
     });
-    const mockSelectedAccount = jest.fn().mockReturnValue(selectedAccount);
+    const mockGetSelectedAccount = jest.fn().mockReturnValue(selectedAccount);
     await withController(
       {
         mockPreferencesState: {},
-        getSelectedAccount: mockSelectedAccount,
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         // This mock is for the initial detect call after preferences change
@@ -1090,7 +1090,7 @@ describe('NftDetectionController', () => {
       {
         options: { addNft: mockAddNft },
         mockPreferencesState: {},
-        getSelectedAccount: mockGetSelectedAccount,
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         mockGetSelectedAccount.mockReturnValue(selectedAccount);
@@ -1120,7 +1120,7 @@ describe('NftDetectionController', () => {
     await withController(
       {
         options: {},
-        getSelectedAccount: mockGetSelectedAccount,
+        mockGetSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         const detectNfts = sinon.stub(controller, 'detectNfts');
@@ -1172,7 +1172,7 @@ type WithControllerOptions = {
   >;
   mockNetworkState?: Partial<NetworkState>;
   mockPreferencesState?: Partial<PreferencesState>;
-  getSelectedAccount?: jest.Mock<AccountsController['getSelectedAccount']>;
+  mockGetSelectedAccount?: jest.Mock<AccountsController['getSelectedAccount']>;
 };
 
 type WithControllerArgs<ReturnValue> =
@@ -1197,7 +1197,9 @@ async function withController<ReturnValue>(
       mockNetworkClientConfigurationsByNetworkClientId = {},
       mockNetworkState = {},
       mockPreferencesState = {},
-      getSelectedAccount = jest.fn().mockReturnValue(defaultSelectedAccount),
+      mockGetSelectedAccount = jest
+        .fn()
+        .mockReturnValue(defaultSelectedAccount),
     },
     testFunction,
   ] = args.length === 2 ? args : [{}, args[0]];
@@ -1214,7 +1216,7 @@ async function withController<ReturnValue>(
 
   messenger.registerActionHandler(
     'AccountsController:getSelectedAccount',
-    getSelectedAccount,
+    mockGetSelectedAccount,
   );
 
   const getNetworkClientById = buildMockGetNetworkClientById(

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -302,7 +302,6 @@ describe('NftDetectionController', () => {
         },
         getSelectedAccount: mockGetSelectedAccount,
       },
-
       async ({ controller, controllerEvents }) => {
         const mockNfts = sinon
           .stub(controller, 'detectNfts')
@@ -894,7 +893,7 @@ describe('NftDetectionController', () => {
       async ({ controller, controllerEvents }) => {
         controllerEvents.triggerPreferencesStateChange({
           ...getDefaultPreferencesState(),
-          useNftDetection: true, // auto-detect is enableds
+          useNftDetection: true, // auto-detect is enabled so it proceeds to check userAddress
         });
 
         await controller.detectNfts();
@@ -1034,10 +1033,11 @@ describe('NftDetectionController', () => {
     const selectedAccount = createMockInternalAccount({
       address: selectedAddress,
     });
+    const mockSelectedAccount = jest.fn().mockReturnValue(selectedAccount);
     await withController(
       {
         mockPreferencesState: {},
-        getSelectedAccount: jest.fn().mockReturnValue(selectedAccount),
+        getSelectedAccount: mockSelectedAccount,
       },
       async ({ controller, controllerEvents }) => {
         // This mock is for the initial detect call after preferences change

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -1,3 +1,4 @@
+import type { AccountsControllerGetSelectedAccountAction } from '@metamask/accounts-controller';
 import type { AddApprovalRequest } from '@metamask/approval-controller';
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
 import {
@@ -37,7 +38,8 @@ export type AllowedActions =
   | AddApprovalRequest
   | NetworkControllerGetStateAction
   | NetworkControllerGetNetworkClientByIdAction
-  | PreferencesControllerGetStateAction;
+  | PreferencesControllerGetStateAction
+  | AccountsControllerGetSelectedAccountAction;
 
 export type AllowedEvents =
   | PreferencesControllerStateChangeEvent
@@ -542,8 +544,8 @@ export class NftDetectionController extends StaticIntervalPollingController<
   }) {
     const userAddress =
       options?.userAddress ??
-      this.messagingSystem.call('PreferencesController:getState')
-        .selectedAddress;
+      this.messagingSystem.call('AccountsController:getSelectedAccount')
+        .address;
     /* istanbul ignore if */
     if (!this.isMainnet() || this.#disabled) {
       return;


### PR DESCRIPTION
## Explanation

This PR updates removes `selectedAddress` and uses the controller messenger to get InternalAccounts in the Nft Controllers

## References

Fixes https://github.com/MetaMask/accounts-planning/issues/381

## Changelog

### `@metamask/assets-controllers`

- **BREAKING**: `NftController` constructor argument `selectedAddress` has been removed.
- **BREAKING**: `NftController` now requires `AccountsControlelr:get{Account,SelectedAccount}` messenger actions.
- **BREAKING**: `NftController` now requires `AccountsController:selectedEvmAccountChange` event.
- **BREAKING**: `NftDetectionController` now requires `AccountsControlelr:getSelectedAccount` messenger actions.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
