### PR TITLE
change(phishing-controller): validate hostname is provided to phishing-controller `test` and `bypass` methods

### DIFF
--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -780,6 +780,24 @@ describe('PhishingController', () => {
     });
   });
 
+  it('raises an error if test input is an origin instead of a hostname', async () => {
+    const url = 'https://opensea.io';
+    const controller = getPhishingController();
+
+    expect(() => {
+      controller.test(url);
+    }).toThrow(`Invalid Input: Expected a valid hostname, recieved ${url}`);
+  });
+
+  it('raises an error if bypass input is an origin instead of a domain', async () => {
+    const url = 'https://opensea.io';
+    const controller = getPhishingController();
+
+    expect(() => {
+      controller.bypass(url);
+    }).toThrow(`Invalid Input: Expected a valid hostname, recieved ${url}`);
+  });
+
   it('should bypass a given domain, and return a negative result', async () => {
     nock(PHISHING_CONFIG_BASE_URL)
       .get(METAMASK_STALELIST_FILE)

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -224,12 +224,12 @@ export type MaybeUpdateState = {
   handler: PhishingController['maybeUpdateState'];
 };
 
-export type TestOrigin = {
-  type: `${typeof controllerName}:testOrigin`;
+export type TestHostname = {
+  type: `${typeof controllerName}:testHostname`;
   handler: PhishingController['test'];
 };
 
-export type PhishingControllerActions = MaybeUpdateState | TestOrigin;
+export type PhishingControllerActions = MaybeUpdateState | TestHostname;
 
 export type PhishingControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
@@ -302,7 +302,7 @@ export class PhishingController extends BaseController<
     );
 
     this.messagingSystem.registerActionHandler(
-      `${controllerName}:testOrigin` as const,
+      `${controllerName}:testHostname` as const,
       this.test.bind(this),
     );
   }

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -30,12 +30,12 @@ export type ListTypes = 'fuzzylist' | 'blocklist' | 'allowlist';
  * @type EthPhishingResponse
  *
  * Configuration response from the eth-phishing-detect package
- * consisting of approved and unapproved website origins
- * @property blacklist - List of unapproved origins
- * @property fuzzylist - List of fuzzy-matched unapproved origins
+ * consisting of approved and unapproved website hostnames
+ * @property blacklist - List of unapproved hostnames
+ * @property fuzzylist - List of fuzzy-matched unapproved hostnames
  * @property tolerance - Fuzzy match tolerance level
  * @property version - Version number of this configuration
- * @property whitelist - List of approved origins
+ * @property whitelist - List of approved hostnames
  */
 export type EthPhishingResponse = {
   blacklist: string[];
@@ -67,9 +67,9 @@ export type PhishingStalelist = {
  * @type PhishingListState
  *
  * type defining the persisted list state. This is the persisted state that is updated frequently with `this.maybeUpdateState()`.
- * @property allowlist - List of approved origins (legacy naming "whitelist")
- * @property blocklist - List of unapproved origins (legacy naming "blacklist")
- * @property fuzzylist - List of fuzzy-matched unapproved origins
+ * @property allowlist - List of approved hostnames (legacy naming "whitelist")
+ * @property blocklist - List of unapproved hostnames (legacy naming "blacklist")
+ * @property fuzzylist - List of fuzzy-matched unapproved hostnames
  * @property tolerance - Fuzzy match tolerance level
  * @property lastUpdated - Timestamp of last update.
  * @property version - Version of the phishing list state.
@@ -92,7 +92,7 @@ export type PhishingListState = {
  * @property name - Name of the config on which a match was found.
  * @property version - Version of the config on which a match was found.
  * @property result - Whether a domain was detected as a phishing domain. True means an unsafe domain.
- * @property match - The matching fuzzylist origin when a fuzzylist match is found. Returned as undefined for non-fuzzy true results.
+ * @property match - The matching fuzzylist hostname when a fuzzylist match is found. Returned as undefined for non-fuzzy true results.
  * @property type - The field of the config on which a match was found.
  */
 export type EthPhishingDetectResult = {
@@ -196,7 +196,7 @@ const getDefaultState = (): PhishingControllerState => {
  *
  * Phishing controller state
  * @property phishing - eth-phishing-detect configuration
- * @property whitelist - array of temporarily-approved origins
+ * @property whitelist - array of temporarily-approved hostnames
  */
 export type PhishingControllerState = {
   phishingLists: PhishingListState[];
@@ -240,7 +240,7 @@ export type PhishingControllerMessenger = RestrictedControllerMessenger<
 >;
 
 /**
- * Controller that manages community-maintained lists of approved and unapproved website origins.
+ * Controller that manages community-maintained lists of approved and unapproved website hostnames.
  */
 export class PhishingController extends BaseController<
   typeof controllerName,
@@ -381,14 +381,14 @@ export class PhishingController extends BaseController<
   }
 
   /**
-   * Determines if a given origin is unapproved.
+   * Determines if a given hostname is unapproved.
    *
    * It is strongly recommended that you call {@link maybeUpdateState} before calling this,
    * to check whether the phishing configuration is up-to-date. It will be updated if necessary
    * by calling {@link updateStalelist} or {@link updateHotlist}.
    *
-   * @param origin - Domain origin of a website.
-   * @returns Whether the origin is an unapproved origin.
+   * @param hostname - Hostname of a given website.
+   * @returns Whether the hostname is an unapproved domain.
    */
   test(hostname: string): EthPhishingDetectResult {
     this.#validateHostname(hostname);
@@ -401,9 +401,9 @@ export class PhishingController extends BaseController<
   }
 
   /**
-   * Temporarily marks a given origin as approved.
+   * Temporarily marks a given hostname as approved.
    *
-   * @param origin - The origin to mark as approved.
+   * @param hostname - The hostname to mark as approved.
    */
   bypass(hostname: string) {
     this.#validateHostname(hostname);

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -224,12 +224,12 @@ export type MaybeUpdateState = {
   handler: PhishingController['maybeUpdateState'];
 };
 
-export type TestHostname = {
-  type: `${typeof controllerName}:testHostname`;
+export type TestPhishing = {
+  type: `${typeof controllerName}:testPhishing`;
   handler: PhishingController['test'];
 };
 
-export type PhishingControllerActions = MaybeUpdateState | TestHostname;
+export type PhishingControllerActions = MaybeUpdateState | TestPhishing;
 
 export type PhishingControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
@@ -302,7 +302,7 @@ export class PhishingController extends BaseController<
     );
 
     this.messagingSystem.registerActionHandler(
-      `${controllerName}:testHostname` as const,
+      `${controllerName}:testPhishing` as const,
       this.test.bind(this),
     );
   }

--- a/packages/phishing-controller/src/utils.test.ts
+++ b/packages/phishing-controller/src/utils.test.ts
@@ -171,4 +171,7 @@ describe('isValidHostname', () => {
 
   it('returns false if hash provided', () =>
     expect(isValidHostname('example.com#')).toBe(false));
+
+  it('returns false if invalid URL provided', () =>
+    expect(isValidHostname('@')).toBe(false));
 });

--- a/packages/phishing-controller/src/utils.test.ts
+++ b/packages/phishing-controller/src/utils.test.ts
@@ -1,7 +1,7 @@
 import * as sinon from 'sinon';
 
 import { ListKeys, ListNames } from './PhishingController';
-import { applyDiffs, fetchTimeNow } from './utils';
+import { applyDiffs, fetchTimeNow, isValidHostname } from './utils';
 
 const exampleBlockedUrl = 'https://example-blocked-website.com';
 const exampleBlockedUrlOne = 'https://another-example-blocked-website.com';
@@ -139,4 +139,36 @@ describe('applyDiffs', () => {
       name: ListNames.Phishfort,
     });
   });
+});
+
+describe('isValidHostname', () => {
+  it('returns true for a valid hostname', () =>
+    expect(isValidHostname('example.com')).toBe(true));
+
+  it('returns true for FQDN', () =>
+    expect(isValidHostname('example.com.')).toBe(true));
+
+  it('returns true for IPv4 addresses', () =>
+    expect(isValidHostname('192.168.1.1')).toBe(true));
+
+  it('returns true for IPv6 addresses', () =>
+    expect(isValidHostname('[2001:db8::1]')).toBe(true));
+
+  it('returns true for internationalized domain names', () =>
+    expect(isValidHostname('münchen.de')).toBe(true));
+
+  it('returns true for hostnames with hyphens', () =>
+    expect(isValidHostname('example-test.com')).toBe(true));
+
+  it('returns false for origin', () =>
+    expect(isValidHostname('http://example.com')).toBe(false));
+
+  it('returns false if port provided', () =>
+    expect(isValidHostname('example.com:443')).toBe(false));
+
+  it('returns false if query string provided', () =>
+    expect(isValidHostname('example.com?x=foo')).toBe(false));
+
+  it('returns false if hash provided', () =>
+    expect(isValidHostname('example.com#')).toBe(false));
 });

--- a/packages/phishing-controller/src/utils.test.ts
+++ b/packages/phishing-controller/src/utils.test.ts
@@ -174,4 +174,7 @@ describe('isValidHostname', () => {
 
   it('returns false if invalid URL provided', () =>
     expect(isValidHostname('@')).toBe(false));
+
+  it('returns false if hostname has trailing slash', () =>
+    expect(isValidHostname('example.com/')).toBe(false));
 });

--- a/packages/phishing-controller/src/utils.ts
+++ b/packages/phishing-controller/src/utils.ts
@@ -1,9 +1,12 @@
+import { toASCII } from 'punycode/';
+
 import type {
   Hotlist,
   ListKeys,
   PhishingListState,
 } from './PhishingController';
 import { phishingListKeyNameMap } from './PhishingController';
+
 /**
  * Fetches current epoch time in seconds.
  *
@@ -80,4 +83,21 @@ export const applyDiffs = (
     tolerance: listState.tolerance,
     lastUpdated: latestDiffTimestamp,
   };
+};
+
+/**
+ * Checks if a given string is a valid hostname.
+ *
+ * @param str - The hostname string to check.
+ * @returns True if the string is a valid hostname, false otherwise.
+ */
+export const isValidHostname = (str: string): boolean => {
+  try {
+    const url = new URL(`https://${str}`);
+    const punycodeHostname = toASCII(str);
+
+    return url.hostname === punycodeHostname;
+  } catch (e) {
+    return false;
+  }
 };


### PR DESCRIPTION
## Explanation

This pull requests introduces validation to the phishing-controller `test` and `bypass` methods to ensure that the value being provided is a hostname. The way the code is currently written suggests to the consumer that an origin should be provided. 

However, this is problematic given that our phishing list contains hostnames not origins (see [here](https://github.com/MetaMask/eth-phishing-detect/blob/main/src/config.json)). This can also be validated checking our [API endpoint](https://phishing-detection.metafi.codefi.network/v1/stalelist).

While we currently do not pass in an origin to either of these functions, the impact of doing so would result in our phishing detection mechanisms failing. This is because `https://evil.com` would not match with `evil.com`/

In order to minimize the potential for an origin to be passed in, this PR adds validation to better catch implementation errors during development cycles. It does so by raising an error. 

## Reasons not to make this change

I had debated whether this change would have fit better in the `eth-phishing-detect` [detector](https://github.com/MetaMask/eth-phishing-detect/blob/main/src/detector.js) itself. However, I decided on implementing it here as its the place that developers will most likely be looking to for guidance on how to best implement their integrations with the phishing controller.

This does have tradeoffs, as now the controller is opinionated about the type of input provided. This may or may not be desired and is open to discussion. 

In addition, we may _prefer_ to accept full URL's and have the phishing controller do the parsing itself to minimize the burden on external consumers.

## References


## Changelog

### `@metamask/phishing-controller`
- **BREAKING**: `#test` and `#bypass` raise an error if input other than a hostname is provided to
    - We recommend using `new URL("...").hostname` or other mechanisms to pass the hostname instead of the full origin to the phishing controller functions.
- **BREAKING**: Controller action handler renamed from `PhishingController:testOrigin` to `PhishingController:testPhishing`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
