### PR TITLE
chore: Export ETHERSCAN_SUPPORTED_CHAIN_IDS constant from Preferences Controller

### DIFF
--- a/packages/preferences-controller/src/index.ts
+++ b/packages/preferences-controller/src/index.ts
@@ -1,1 +1,2 @@
 export * from './PreferencesController';
+export { ETHERSCAN_SUPPORTED_CHAIN_IDS } from './constants';


### PR DESCRIPTION

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
Currently ETHERSCAN_SUPPPORTED_CHAIN_IDS is not allowed to be accessed by consumers of PreferencesController
* What is the solution your changes offer and how does it work?
Allow ETHERSCAN_SUPPORTED_CHAIN_IDS be imported from consumers of PreferencesController

* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/preferences-controller`

- **<ADDED>**: export of ETHERSCAN_SUPPORTED_CHAIN_IDS for clients

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
