### PR TITLE
fix: lower occurenceFloor for linea mainnet to 1

### DIFF
--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -1,4 +1,4 @@
-import { toHex } from '@metamask/controller-utils';
+import { ChainId, toHex } from '@metamask/controller-utils';
 import nock from 'nock';
 
 import {
@@ -148,6 +148,23 @@ describe('Token service', () => {
         .persist();
 
       const tokens = await fetchTokenListByChainId(sampleChainId, signal);
+
+      expect(tokens).toStrictEqual(sampleTokenList);
+    });
+
+    it('should call the tokens api and return the list of tokens on linea mainnet', async () => {
+      const { signal } = new AbortController();
+      const lineaChainId = 59144;
+      const lineaHexChain = toHex(lineaChainId);
+
+      nock(TOKEN_END_POINT_API)
+        .get(
+          `/tokens/${lineaChainId}?occurrenceFloor=1&includeNativeAssets=false&includeDuplicateSymbolAssets=false&includeTokenFees=false&includeAssetType=false`,
+        )
+        .reply(200, sampleTokenList)
+        .persist();
+
+      const tokens = await fetchTokenListByChainId(lineaHexChain, signal);
 
       expect(tokens).toStrictEqual(sampleTokenList);
     });

--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -112,6 +112,107 @@ const sampleTokenList = [
   },
 ];
 
+const sampleTokenListLinea = [
+  {
+    address: '0xbbbbca6a901c926f240b89eacb641d8aec7aeafd',
+    symbol: 'LRC',
+    decimals: 18,
+    occurrences: 11,
+    aggregators: [
+      'lineaTeam',
+      'pmm',
+      'airswapLight',
+      'zeroEx',
+      'bancor',
+      'coinGecko',
+      'zapper',
+      'kleros',
+      'zerion',
+      'cmc',
+      'oneInch',
+    ],
+  },
+  {
+    address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
+    symbol: 'SNX',
+    decimals: 18,
+    occurrences: 11,
+    aggregators: [
+      'lineaTeam',
+      'pmm',
+      'airswapLight',
+      'zeroEx',
+      'bancor',
+      'coinGecko',
+      'zapper',
+      'kleros',
+      'zerion',
+      'cmc',
+      'oneInch',
+    ],
+    name: 'Synthetix',
+  },
+  {
+    address: '0x408e41876cccdc0f92210600ef50372656052a38',
+    symbol: 'REN',
+    decimals: 18,
+    occurrences: 11,
+    aggregators: [
+      'lineaTeam',
+      'pmm',
+      'airswapLight',
+      'zeroEx',
+      'bancor',
+      'coinGecko',
+      'zapper',
+      'kleros',
+      'zerion',
+      'cmc',
+      'oneInch',
+    ],
+  },
+  {
+    address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+    symbol: 'LINK',
+    decimals: 18,
+    occurrences: 11,
+    aggregators: [
+      'lineaTeam',
+      'pmm',
+      'airswapLight',
+      'zeroEx',
+      'bancor',
+      'coinGecko',
+      'zapper',
+      'kleros',
+      'zerion',
+      'cmc',
+      'oneInch',
+    ],
+    name: 'Chainlink',
+  },
+  {
+    address: '0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',
+    symbol: 'BNT',
+    decimals: 18,
+    occurrences: 11,
+    aggregators: [
+      'paraswap',
+      'pmm',
+      'airswapLight',
+      'zeroEx',
+      'bancor',
+      'coinGecko',
+      'zapper',
+      'kleros',
+      'zerion',
+      'cmc',
+      'oneInch',
+    ],
+    name: 'Bancor',
+  },
+];
+
 const sampleToken = {
   address: '0x514910771af9ca656af840dff83e8264ecf986ca',
   symbol: 'LINK',
@@ -161,12 +262,13 @@ describe('Token service', () => {
         .get(
           `/tokens/${lineaChainId}?occurrenceFloor=1&includeNativeAssets=false&includeDuplicateSymbolAssets=false&includeTokenFees=false&includeAssetType=false`,
         )
-        .reply(200, sampleTokenList)
+        .reply(200, sampleTokenListLinea)
         .persist();
 
       const tokens = await fetchTokenListByChainId(lineaHexChain, signal);
+      const expectedLineaTeamtokens = sampleTokenListLinea.slice(0, 4);
 
-      expect(tokens).toStrictEqual(sampleTokenList);
+      expect(tokens).toStrictEqual(expectedLineaTeamtokens);
     });
 
     it('should return undefined if the fetch is aborted', async () => {

--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -1,4 +1,4 @@
-import { ChainId, toHex } from '@metamask/controller-utils';
+import { toHex } from '@metamask/controller-utils';
 import nock from 'nock';
 
 import {

--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -266,9 +266,8 @@ describe('Token service', () => {
         .persist();
 
       const tokens = await fetchTokenListByChainId(lineaHexChain, signal);
-      const expectedLineaTeamtokens = sampleTokenListLinea.slice(0, 4);
 
-      expect(tokens).toStrictEqual(expectedLineaTeamtokens);
+      expect(tokens).toStrictEqual(sampleTokenListLinea);
     });
 
     it('should return undefined if the fetch is aborted', async () => {

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -1,4 +1,8 @@
-import { convertHexToDecimal, timeoutFetch } from '@metamask/controller-utils';
+import {
+  ChainId,
+  convertHexToDecimal,
+  timeoutFetch,
+} from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 
 import { isTokenListSupportedForNetwork } from './assetsUtil';
@@ -14,9 +18,10 @@ export const TOKEN_METADATA_NO_SUPPORT_ERROR =
  * @returns The tokens URL.
  */
 function getTokensURL(chainId: Hex) {
+  const occurrenceFloor = chainId === ChainId['linea-mainnet'] ? 1 : 3;
   return `${TOKEN_END_POINT_API}/tokens/${convertHexToDecimal(
     chainId,
-  )}?occurrenceFloor=3&includeNativeAssets=false&includeDuplicateSymbolAssets=false&includeTokenFees=false&includeAssetType=false`;
+  )}?occurrenceFloor=${occurrenceFloor}&includeNativeAssets=false&includeDuplicateSymbolAssets=false&includeTokenFees=false&includeAssetType=false`;
 }
 
 /**

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -63,7 +63,10 @@ export async function fetchTokenListByChainId(
   if (response) {
     const result = await parseJsonResponse(response);
     if (Array.isArray(result) && chainId === ChainId['linea-mainnet']) {
-      return result.filter((elm) => elm.aggregators.includes('lineaTeam'));
+      return result.filter(
+        (elm) =>
+          elm.aggregators.includes('lineaTeam') || elm.aggregators.length >= 3,
+      );
     }
     return result;
   }

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -61,7 +61,11 @@ export async function fetchTokenListByChainId(
   const tokenURL = getTokensURL(chainId);
   const response = await queryApi(tokenURL, abortSignal, timeout);
   if (response) {
-    return parseJsonResponse(response);
+    const result = await parseJsonResponse(response);
+    if (Array.isArray(result) && chainId === ChainId['linea-mainnet']) {
+      return result.filter((elm) => elm.aggregators.includes('lineaTeam'));
+    }
+    return result;
   }
   return undefined;
 }


### PR DESCRIPTION
## Explanation

Lower occurenceFloor for linea mainnet to only 1 list instead of 3.
Add a filter for lineaTeam aggregator when we fetch token list from token-api when the user is on linea-mainnet.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **CHANGED**: Changed query parameter occurenceFloor in getTokensURL to equal 1 for linea-mainnet and default to 3 for other networks.
- **Added**: Added a filter for `lineaTeam` aggregator on the returned list by `fetchTokenListByChainId`  when the user is on linea mainnet.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
