### PR TITLE
refactor(accounts-controller): remove extra filter for normal accounts

### DIFF
--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -24,7 +24,11 @@ import type { Snap } from '@metamask/snaps-utils';
 import type { Keyring, Json } from '@metamask/utils';
 import type { Draft } from 'immer';
 
-import { getUUIDFromAddressOfNormalAccount, keyringTypeToName } from './utils';
+import {
+  getUUIDFromAddressOfNormalAccount,
+  isNormalKeyringType,
+  keyringTypeToName,
+} from './utils';
 
 const controllerName = 'AccountsController';
 
@@ -453,6 +457,12 @@ export class AccountsController extends BaseController<
         address,
       );
 
+      const keyringType = (keyring as Keyring<Json>).type;
+      if (!isNormalKeyringType(keyringType as KeyringTypes)) {
+        // We only consider "normal accounts" here, so keep looping
+        continue;
+      }
+
       const id = getUUIDFromAddressOfNormalAccount(address);
 
       internalAccounts.push({
@@ -480,9 +490,7 @@ export class AccountsController extends BaseController<
       });
     }
 
-    return internalAccounts.filter(
-      (account) => account.metadata.keyring.type !== KeyringTypes.snap,
-    );
+    return internalAccounts;
   }
 
   /**

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -317,13 +317,8 @@ export class AccountsController extends BaseController<
    * @returns A Promise that resolves when the accounts have been updated.
    */
   async updateAccounts(): Promise<void> {
-    const snapAccounts: InternalAccount[] = await this.#listSnapAccounts();
-    const normalAccounts = (await this.#listNormalAccounts()).filter(
-      (account) =>
-        !snapAccounts.find(
-          (snapAccount) => snapAccount.address === account.address,
-        ),
-    );
+    const snapAccounts = await this.#listSnapAccounts();
+    const normalAccounts = await this.#listNormalAccounts();
 
     // keyring type map.
     const keyringTypes = new Map<string, number>();

--- a/packages/accounts-controller/src/utils.ts
+++ b/packages/accounts-controller/src/utils.ts
@@ -68,3 +68,14 @@ export function getUUIDOptionsFromAddressOfNormalAccount(
 export function getUUIDFromAddressOfNormalAccount(address: string): string {
   return uuid(getUUIDOptionsFromAddressOfNormalAccount(address));
 }
+
+/**
+ * Check if a keyring type is considered a "normal" keyring.
+ * @param keyringType - The account's keyring type.
+ * @returns True if the keyring type is considered a "normal" keyring, false otherwise.
+ */
+export function isNormalKeyringType(keyringType: KeyringTypes): boolean {
+  // Right now, we only have to "exclude" Snap accounts, but this might need to be
+  // adapted later on if we have new kind of keyrings!
+  return keyringType !== KeyringTypes.snap;
+}


### PR DESCRIPTION
## Explanation

While discussing the logic around `#listNormalAccounts` for non-0x addresses, I found out this function could be rewritten to do the filtering during the accounts listing rather than creating the full list of accounts and then filter out non-normal accounts afterward.

Doing it this way also prevent from calling `getUUIDOptionsFromAddressOfNormalAccount` for non-0x addresses, which is probably better than this solution:
- https://github.com/MetaMask/core/pull/4243

## References

- https://github.com/MetaMask/core/pull/4243

## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
