### PR TITLE
Exclude Snaps from `SelectedNetworkController` domains state

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -307,6 +307,13 @@ export class SelectedNetworkController extends BaseController<
       );
     }
 
+    // Snaps should be excluded from the domain state
+    // npm and local are currently the only valid prefixes for snap domains
+    // https://github.com/MetaMask/snaps/blob/2beee7803bfe9e540788a3558b546b9f55dc3cb4/packages/snaps-utils/src/types.ts#L120
+    if (domain.startsWith('npm:') || domain.startsWith('local:')) {
+      return;
+    }
+
     if (!this.#domainHasPermissions(domain)) {
       throw new Error(
         'NetworkClientId for domain cannot be called with a domain that has not yet been granted permissions',

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -298,6 +298,34 @@ describe('SelectedNetworkController', () => {
     });
 
     describe('when the useRequestQueue is true', () => {
+      describe('when the requesting domain is a snap (starts with "npm:" or "local:"', () => {
+        it('skips setting the networkClientId for the passed in domain', () => {
+          const { controller, mockHasPermissions } = setup({
+            state: { domains: {} },
+            useRequestQueuePreference: true,
+          });
+          mockHasPermissions.mockReturnValue(true);
+          const snapDomainOne = 'npm:@metamask/bip32-example-snap';
+          const snapDomainTwo = 'local:@metamask/bip32-example-snap';
+          const nonSnapDomain = 'example.com';
+          const networkClientId = 'network1';
+          controller.setNetworkClientIdForDomain(
+            nonSnapDomain,
+            networkClientId,
+          );
+          controller.setNetworkClientIdForDomain(
+            snapDomainOne,
+            networkClientId,
+          );
+          controller.setNetworkClientIdForDomain(
+            snapDomainTwo,
+            networkClientId,
+          );
+          expect(controller.state.domains).toStrictEqual({
+            [nonSnapDomain]: networkClientId,
+          });
+        });
+      });
       describe('when the requesting domain has existing permissions', () => {
         it('sets the networkClientId for the passed in domain', () => {
           const { controller, mockHasPermissions } = setup({


### PR DESCRIPTION
## Explanation

Currently Snaps should not be included in the `SelectedNetworkController`'s `domains` state since they have no way of changing their network (they cannot call `wallet_switchEthereumChain` and have no UI exposed to manually switch their connected chain). This means that with the `useRequestQueue` toggle on they are stuck permanently connected to whatever chain is selected when they are installed.

## References

- See [this thread](https://consensys.slack.com/archives/C02GENU377A/p1714755002823189?thread_ts=1714501325.186459&cid=C02GENU377A)

## Changelog

### `@metamask/selected-network-controller`

- **FIX**: Adds logic to exclude connecting Snaps from setting selected network state and proxies in the `SelectedNetworkController`



## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
