### PR TITLE
Ad/fix/update get provider and block tracker for snaps

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -342,8 +342,11 @@ export class SelectedNetworkController extends BaseController<
    * @returns The proxy and block tracker proxies.
    */
   getProviderAndBlockTracker(domain: Domain): NetworkProxy {
-    // If the domain is a snap domain, return the selected network client
-    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
+    // If the domain is 'metamask' or a snap, return the NetworkController's globally selected network client proxy
+    if (
+      domain === METAMASK_DOMAIN ||
+      snapsPrefixes.some((prefix) => domain.startsWith(prefix))
+    ) {
       const networkClient = this.messagingSystem.call(
         'NetworkController:getSelectedNetworkClient',
       );

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -25,6 +25,12 @@ const stateMetadata = {
 
 const getDefaultState = () => ({ domains: {} });
 
+// npm and local are currently the only valid prefixes for snap domains
+// TODO: eventually we maybe want to pull this in from snaps-utils to ensure it stays in sync
+// For now it seems like overkill to add a dependency for this one constant
+// https://github.com/MetaMask/snaps/blob/2beee7803bfe9e540788a3558b546b9f55dc3cb4/packages/snaps-utils/src/types.ts#L120
+const snapsPrefixes = ['npm:', 'local:'] as const;
+
 export type Domain = string;
 
 export const METAMASK_DOMAIN = 'metamask' as const;
@@ -307,10 +313,7 @@ export class SelectedNetworkController extends BaseController<
       );
     }
 
-    // Snaps should be excluded from the domain state
-    // npm and local are currently the only valid prefixes for snap domains
-    // https://github.com/MetaMask/snaps/blob/2beee7803bfe9e540788a3558b546b9f55dc3cb4/packages/snaps-utils/src/types.ts#L120
-    if (domain.startsWith('npm:') || domain.startsWith('local:')) {
+    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
       return;
     }
 
@@ -339,6 +342,17 @@ export class SelectedNetworkController extends BaseController<
    * @returns The proxy and block tracker proxies.
    */
   getProviderAndBlockTracker(domain: Domain): NetworkProxy {
+    // If the domain is a snap domain, return the selected network client
+    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
+      const networkClient = this.messagingSystem.call(
+        'NetworkController:getSelectedNetworkClient',
+      );
+      if (networkClient === undefined) {
+        throw new Error('Selected network not initialized');
+      }
+      return networkClient;
+    }
+
     let networkProxy = this.#domainProxyMap.get(domain);
     if (networkProxy === undefined) {
       let networkClient;

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -559,6 +559,7 @@ describe('SelectedNetworkController', () => {
         });
       });
     });
+    // TODO - improve these tests by using a full NetworkController and doing more robust behavioral testing
     describe('when the domain is a snap (starts with "npm:" or "local:")', () => {
       it('returns a proxied globally selected networkClient and does not create a new proxy in the domainProxyMap', () => {
         const { controller, domainProxyMap, messenger } = setup({
@@ -569,7 +570,9 @@ describe('SelectedNetworkController', () => {
         });
         jest.spyOn(messenger, 'call');
         const snapDomain = 'npm:@metamask/bip32-example-snap';
+
         const result = controller.getProviderAndBlockTracker(snapDomain);
+
         expect(domainProxyMap.get(snapDomain)).toBeUndefined();
         expect(messenger.call).toHaveBeenCalledWith(
           'NetworkController:getSelectedNetworkClient',
@@ -586,7 +589,9 @@ describe('SelectedNetworkController', () => {
           useRequestQueuePreference: true,
         });
         jest.spyOn(messenger, 'call');
+
         const result = controller.getProviderAndBlockTracker(METAMASK_DOMAIN);
+
         expect(result).toBeDefined();
         expect(domainProxyMap.get(METAMASK_DOMAIN)).toBeUndefined();
         expect(messenger.call).toHaveBeenCalledWith(

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -606,6 +606,7 @@ describe('SelectedNetworkController', () => {
           useRequestQueuePreference: false,
         });
         mockGetSelectedNetworkClient.mockReturnValue(undefined);
+
         expect(() =>
           controller.getProviderAndBlockTracker(METAMASK_DOMAIN),
         ).toThrow('Selected network not initialized');

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -310,6 +310,7 @@ describe('SelectedNetworkController', () => {
           const snapDomainTwo = 'local:@metamask/bip32-example-snap';
           const nonSnapDomain = 'example.com';
           const networkClientId = 'network1';
+
           controller.setNetworkClientIdForDomain(
             nonSnapDomain,
             networkClientId,
@@ -322,6 +323,7 @@ describe('SelectedNetworkController', () => {
             snapDomainTwo,
             networkClientId,
           );
+
           expect(controller.state.domains).toStrictEqual({
             [nonSnapDomain]: networkClientId,
           });

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -15,6 +15,7 @@ import type {
   NetworkProxy,
 } from '../src/SelectedNetworkController';
 import {
+  METAMASK_DOMAIN,
   SelectedNetworkController,
   controllerName,
 } from '../src/SelectedNetworkController';
@@ -556,6 +557,41 @@ describe('SelectedNetworkController', () => {
             'NetworkController:getSelectedNetworkClient',
           );
         });
+      });
+    });
+    describe('when the domain is a snap (starts with "npm:" or "local:")', () => {
+      it('returns a proxied globally selected networkClient and does not create a new proxy in the domainProxyMap', () => {
+        const { controller, domainProxyMap, messenger } = setup({
+          state: {
+            domains: {},
+          },
+          useRequestQueuePreference: true,
+        });
+        jest.spyOn(messenger, 'call');
+        const snapDomain = 'npm:@metamask/bip32-example-snap';
+        const result = controller.getProviderAndBlockTracker(snapDomain);
+        expect(domainProxyMap.get(snapDomain)).toBeUndefined();
+        expect(messenger.call).toHaveBeenCalledWith(
+          'NetworkController:getSelectedNetworkClient',
+        );
+        expect(result).toBeDefined();
+      });
+    });
+    describe('when the domain is a "metamask"', () => {
+      it('returns a proxied globally selected networkClient and does not create a new proxy in the domainProxyMap', () => {
+        const { controller, domainProxyMap, messenger } = setup({
+          state: {
+            domains: {},
+          },
+          useRequestQueuePreference: true,
+        });
+        jest.spyOn(messenger, 'call');
+        const result = controller.getProviderAndBlockTracker(METAMASK_DOMAIN);
+        expect(result).toBeDefined();
+        expect(domainProxyMap.get(METAMASK_DOMAIN)).toBeUndefined();
+        expect(messenger.call).toHaveBeenCalledWith(
+          'NetworkController:getSelectedNetworkClient',
+        );
       });
     });
   });

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -593,6 +593,18 @@ describe('SelectedNetworkController', () => {
           'NetworkController:getSelectedNetworkClient',
         );
       });
+      it('throws an error if the globally selected network client is not initialized', () => {
+        const { controller, mockGetSelectedNetworkClient } = setup({
+          state: {
+            domains: {},
+          },
+          useRequestQueuePreference: false,
+        });
+        mockGetSelectedNetworkClient.mockReturnValue(undefined);
+        expect(() =>
+          controller.getProviderAndBlockTracker(METAMASK_DOMAIN),
+        ).toThrow('Selected network not initialized');
+      });
     });
   });
 


### PR DESCRIPTION
## Explanation
Modifies `SelectedNetworkController`'s, `getProviderAndBlockTracker` method to return the `NetworkController`'s globally selected network client proxy if the domain arg is either `metamask` or a snap (identified by if prefixed by `npm:` or `local:`)

## References

see [this thread](https://consensys.slack.com/archives/C02GENU377A/p1715013497414909?thread_ts=1714501325.186459&cid=C02GENU377A) for further information
## Changelog

### `@metamask/selected-network-controller`

- **CHANGE**: Modifies `SelectedNetworkController`'s, `getProviderAndBlockTracker` method to return the `NetworkController`'s globally selected network client proxy if the `domain` arg is either `metamask` or a snap (identified as starting with `npm:` or `local:`)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
