### PR TITLE
Revert "Release 149.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "149.0.0",
+  "version": "148.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,29 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [29.0.0]
-
-### Added
-
-- Add `estimateGasFee` method ([#4216](https://github.com/MetaMask/core/pull/4216))
-  - Add `TestGasFeeFlow` that is activated by optional `testGasFeeFlows` constructor option.
-  - Add related types:
-    - `FeeMarketGasFeeEstimateForLevel`
-    - `FeeMarketGasFeeEstimates`
-    - `GasFeeEstimates`
-    - `GasFeeEstimateLevel`
-    - `GasFeeEstimateType`
-    - `GasPriceGasFeeEstimates`
-    - `LegacyGasFeeEstimates`
-
-### Changed
-
-- **BREAKING:** Update `GasFeeEstimates` type to support alternate estimate types ([#4216](https://github.com/MetaMask/core/pull/4216))
-
-### Removed
-
-- **BREAKING:** Remove `gasFeeControllerEstimateType` property from `mergeGasFeeEstimates` function ([#4216](https://github.com/MetaMask/core/pull/4216))
-
 ## [28.1.1]
 
 ### Changed
@@ -813,8 +790,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@29.0.0...HEAD
-[29.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@28.1.1...@metamask/transaction-controller@29.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@28.1.1...HEAD
 [28.1.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@28.1.0...@metamask/transaction-controller@28.1.1
 [28.1.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@28.0.0...@metamask/transaction-controller@28.1.0
 [28.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@27.0.1...@metamask/transaction-controller@28.0.0

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "29.0.0",
+  "version": "28.1.1",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -51,7 +51,7 @@
     "@metamask/network-controller": "^18.1.0",
     "@metamask/polling-controller": "^6.0.2",
     "@metamask/rpc-errors": "^6.2.1",
-    "@metamask/transaction-controller": "^29.0.0",
+    "@metamask/transaction-controller": "^28.1.1",
     "@metamask/utils": "^8.3.0",
     "bn.js": "^5.2.1",
     "immer": "^9.0.6",
@@ -74,7 +74,7 @@
     "@metamask/gas-fee-controller": "^15.0.0",
     "@metamask/keyring-controller": "^16.0.0",
     "@metamask/network-controller": "^18.0.0",
-    "@metamask/transaction-controller": "^29.0.0"
+    "@metamask/transaction-controller": "^28.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3018,7 +3018,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@^29.0.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
+"@metamask/transaction-controller@^28.1.1, @metamask/transaction-controller@workspace:packages/transaction-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/transaction-controller@workspace:packages/transaction-controller"
   dependencies:
@@ -3081,7 +3081,7 @@ __metadata:
     "@metamask/network-controller": ^18.1.0
     "@metamask/polling-controller": ^6.0.2
     "@metamask/rpc-errors": ^6.2.1
-    "@metamask/transaction-controller": ^29.0.0
+    "@metamask/transaction-controller": ^28.1.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     bn.js: ^5.2.1
@@ -3100,7 +3100,7 @@ __metadata:
     "@metamask/gas-fee-controller": ^15.0.0
     "@metamask/keyring-controller": ^16.0.0
     "@metamask/network-controller": ^18.0.0
-    "@metamask/transaction-controller": ^29.0.0
+    "@metamask/transaction-controller": ^28.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Reverts MetaMask/core#4265

This is being reverted so that we can fix a publishing error