### PR TITLE
fix: Fix `profile-sync-controller` version

### DIFF
--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/profile-sync-controller",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "The profile sync helps developers synchronize data across multiple clients and devices in a privacy-preserving way. All data saved in the user storage database is encrypted client-side to preserve privacy. The user storage provides a modular design, giving developers the flexibility to construct and manage their storage spaces in a way that best suits their needs",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
## Explanation

The version of the `@metamask/profile-sync-controller` package has been updated to `0.0.0`, which is what our publishing automation expects of all unpublished public packages.

The current version is `0.1.0`, which caused problems for our most recent release, requiring a rollback. It broke publishing because our publishing scripts tried to find version `0.1.0` in the package changelog but were unable to.

This should have been caught by our linter, but it wasn't due to a deficiency in the `@metamask/auto-changelog` validation command (it doesn't validate that the current release exists). This problem has been documented here: https://github.com/MetaMask/auto-changelog/issues/192

## References

Unblocks https://github.com/MetaMask/core/pull/4272

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
