### PR TITLE
chore(devDependencies): @lavamoat/allow-scripts@^3.0.2>^3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/core": "^7.23.5",
     "@babel/plugin-transform-modules-commonjs": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
-    "@lavamoat/allow-scripts": "^3.0.2",
+    "@lavamoat/allow-scripts": "^3.0.4",
     "@metamask/create-release-branch": "^3.0.0",
     "@metamask/eslint-config": "^12.2.0",
     "@metamask/eslint-config-jest": "^12.1.0",

--- a/packages/json-rpc-engine/package.json
+++ b/packages/json-rpc-engine/package.json
@@ -55,7 +55,7 @@
     "@metamask/utils": "^8.3.0"
   },
   "devDependencies": {
-    "@lavamoat/allow-scripts": "^3.0.2",
+    "@lavamoat/allow-scripts": "^3.0.4",
     "@metamask/auto-changelog": "^3.4.4",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -59,7 +59,7 @@
     "@ethereumjs/common": "^3.2.0",
     "@ethereumjs/tx": "^4.2.0",
     "@keystonehq/bc-ur-registry-eth": "^0.19.0",
-    "@lavamoat/allow-scripts": "^3.0.2",
+    "@lavamoat/allow-scripts": "^3.0.4",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/scure-bip39": "^2.1.1",
     "@types/jest": "^27.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,7 +1584,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lavamoat/allow-scripts@npm:^3.0.2":
+"@lavamoat/allow-scripts@npm:^3.0.4":
   version: 3.0.4
   resolution: "@lavamoat/allow-scripts@npm:3.0.4"
   dependencies:
@@ -1929,7 +1929,7 @@ __metadata:
     "@babel/core": ^7.23.5
     "@babel/plugin-transform-modules-commonjs": ^7.23.3
     "@babel/preset-typescript": ^7.23.3
-    "@lavamoat/allow-scripts": ^3.0.2
+    "@lavamoat/allow-scripts": ^3.0.4
     "@metamask/create-release-branch": ^3.0.0
     "@metamask/eslint-config": ^12.2.0
     "@metamask/eslint-config-jest": ^12.1.0
@@ -2339,7 +2339,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/json-rpc-engine@workspace:packages/json-rpc-engine"
   dependencies:
-    "@lavamoat/allow-scripts": ^3.0.2
+    "@lavamoat/allow-scripts": ^3.0.4
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/safe-event-emitter": ^3.0.0
@@ -2426,7 +2426,7 @@ __metadata:
     "@ethereumjs/util": ^8.1.0
     "@keystonehq/bc-ur-registry-eth": ^0.19.0
     "@keystonehq/metamask-airgapped-keyring": ^0.14.1
-    "@lavamoat/allow-scripts": ^3.0.2
+    "@lavamoat/allow-scripts": ^3.0.4
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.2
     "@metamask/browser-passworder": ^4.3.0


### PR DESCRIPTION
## Explanation

This bumps ranges for `@lavamoat/allow-scripts` to latest.

Effectively no-op as the latest version is already resolved in `yarn.lock`.

## References


## Changelog


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
