### PR TITLE
deps: async-mutex@^0.2.6->^0.5.0

### DIFF
--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -62,7 +62,7 @@
     "@metamask/utils": "^8.3.0",
     "@types/bn.js": "^5.1.5",
     "@types/uuid": "^8.3.0",
-    "async-mutex": "^0.2.6",
+    "async-mutex": "^0.5.0",
     "bn.js": "^5.2.1",
     "cockatiel": "^3.1.2",
     "lodash": "^4.17.21",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -51,7 +51,7 @@
     "@metamask/keyring-api": "^6.1.1",
     "@metamask/message-manager": "^8.0.2",
     "@metamask/utils": "^8.3.0",
-    "async-mutex": "^0.2.6",
+    "async-mutex": "^0.5.0",
     "ethereumjs-wallet": "^1.0.1",
     "immer": "^9.0.6"
   },

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -45,7 +45,7 @@
     "@metamask/base-controller": "^5.0.2",
     "@metamask/controller-utils": "^10.0.0",
     "@metamask/utils": "^8.3.0",
-    "async-mutex": "^0.2.6"
+    "async-mutex": "^0.5.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -52,7 +52,7 @@
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/swappable-obj-proxy": "^2.2.0",
     "@metamask/utils": "^8.3.0",
-    "async-mutex": "^0.2.6",
+    "async-mutex": "^0.5.0",
     "immer": "^9.0.6",
     "uuid": "^8.3.2"
   },

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -57,7 +57,7 @@
     "@metamask/nonce-tracker": "^5.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",
-    "async-mutex": "^0.2.6",
+    "async-mutex": "^0.5.0",
     "bn.js": "^5.2.1",
     "eth-method-registry": "^4.0.0",
     "fast-json-patch": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,7 +1736,7 @@ __metadata:
     "@types/lodash": ^4.14.191
     "@types/node": ^16.18.54
     "@types/uuid": ^8.3.0
-    async-mutex: ^0.2.6
+    async-mutex: ^0.5.0
     bn.js: ^5.2.1
     cockatiel: ^3.1.2
     deepmerge: ^4.2.2
@@ -2438,7 +2438,7 @@ __metadata:
     "@metamask/scure-bip39": ^2.1.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
-    async-mutex: ^0.2.6
+    async-mutex: ^0.5.0
     deepmerge: ^4.2.2
     ethereumjs-wallet: ^1.0.1
     immer: ^9.0.6
@@ -2509,7 +2509,7 @@ __metadata:
     "@metamask/controller-utils": ^10.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
-    async-mutex: ^0.2.6
+    async-mutex: ^0.5.0
     deepmerge: ^4.2.2
     jest: ^27.5.1
     ts-jest: ^27.1.4
@@ -2539,7 +2539,7 @@ __metadata:
     "@types/jest": ^27.4.1
     "@types/jest-when": ^2.7.3
     "@types/lodash": ^4.14.191
-    async-mutex: ^0.2.6
+    async-mutex: ^0.5.0
     deepmerge: ^4.2.2
     immer: ^9.0.6
     jest: ^27.5.1
@@ -3062,7 +3062,7 @@ __metadata:
     "@types/bn.js": ^5.1.5
     "@types/jest": ^27.4.1
     "@types/node": ^16.18.54
-    async-mutex: ^0.2.6
+    async-mutex: ^0.5.0
     bn.js: ^5.2.1
     deepmerge: ^4.2.2
     eth-method-registry: ^4.0.0
@@ -4506,21 +4506,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async-mutex@npm:^0.2.6":
-  version: 0.2.6
-  resolution: "async-mutex@npm:0.2.6"
-  dependencies:
-    tslib: ^2.0.0
-  checksum: f50102e0c57f6a958528cff7dff13da070897f17107b42274417a7248905b927b6e51c3387f8aed1f5cd6005b0e692d64a83a0789be602e4e7e7da4afe08b889
-  languageName: node
-  linkType: hard
-
 "async-mutex@npm:^0.3.1":
   version: 0.3.2
   resolution: "async-mutex@npm:0.3.2"
   dependencies:
     tslib: ^2.3.1
   checksum: 620b771dfdea1cad0a6b712915c31a1e3ca880a8cf1eae92b4590f435995e0260929c6ebaae0b9126b1456790ea498064b5bb9a506948cda760f48d3d0dcc4c8
+  languageName: node
+  linkType: hard
+
+"async-mutex@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "async-mutex@npm:0.5.0"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: be1587f4875f3bb15e34e9fcce82eac2966daef4432c8d0046e61947fb9a1b95405284601bc7ce4869319249bc07c75100880191db6af11d1498931ac2a2f9ea
   languageName: node
   linkType: hard
 
@@ -11437,7 +11437,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.6.2":
+"tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad


### PR DESCRIPTION
## Explanation

Update `async-mutex` to latest.


## References

[Changelog](https://github.com/DirtyHairy/async-mutex/blob/master/CHANGELOG.md)

## Changelog

### `@metamask/assets-controller`

- **FIXED**: Update `async-mutex` from `^0.2.6` to `^0.5.0`

### `@metamask/keyring-controller`

- **FIXED**: Update `async-mutex` from `^0.2.6` to `^0.5.0`

### `@metamask/name-controller`

- **FIXED**: Update `async-mutex` from `^0.2.6` to `^0.5.0`

### `@metamask/transaction-controller`

- **FIXED**: Update `async-mutex` from `^0.2.6` to `^0.5.0`

### `@metamask/network-controller`

- **FIXED**: Update `async-mutex` from `^0.2.6` to `^0.5.0`


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
