### PR TITLE
chore(test): Refactor FakeBlockTracker provider injection

### DIFF
--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -871,7 +871,7 @@ describe('NftDetectionController', () => {
         type: NetworkClientType.Custom,
       },
       provider,
-      blockTracker: new FakeBlockTracker({provider}),
+      blockTracker: new FakeBlockTracker({ provider }),
       destroy: () => {
         // do nothing
       },

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -862,6 +862,7 @@ describe('NftDetectionController', () => {
 
   it('should return true if mainnet is detected', async () => {
     const mockAddNft = jest.fn();
+    const provider = new FakeProvider();
     const mockNetworkClient: NetworkClient = {
       configuration: {
         chainId: ChainId.mainnet,
@@ -869,8 +870,8 @@ describe('NftDetectionController', () => {
         ticker: 'TEST',
         type: NetworkClientType.Custom,
       },
-      provider: new FakeProvider(),
-      blockTracker: new FakeBlockTracker(),
+      provider,
+      blockTracker: new FakeBlockTracker({provider}),
       destroy: () => {
         // do nothing
       },

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -7574,7 +7574,7 @@ function buildFakeClient(
       rpcUrl: 'https://test.network',
     },
     provider,
-    blockTracker: new FakeBlockTracker(),
+    blockTracker: new FakeBlockTracker({ provider }),
     destroy: () => {
       // do nothing
     },

--- a/packages/network-controller/tests/helpers.ts
+++ b/packages/network-controller/tests/helpers.ts
@@ -39,10 +39,11 @@ function buildFakeNetworkClient({
   configuration: NetworkClientConfiguration;
   providerStubs?: FakeProviderStub[];
 }): NetworkClient {
+  const provider = new FakeProvider({ stubs: providerStubs });
   return {
     configuration,
-    provider: new FakeProvider({ stubs: providerStubs }),
-    blockTracker: new FakeBlockTracker(),
+    provider,
+    blockTracker: new FakeBlockTracker({ provider }),
     destroy: () => {
       // do nothing
     },

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@babel/runtime": "^7.23.9",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/eth-json-rpc-provider": "^4.0.0",
     "@metamask/ethjs-provider-http": "^0.3.0",
     "@types/bn.js": "^5.1.5",
     "@types/jest": "^27.4.1",

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -14,6 +14,7 @@ import {
   BUILT_IN_NETWORKS,
   ORIGIN_METAMASK,
 } from '@metamask/controller-utils';
+import { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import EthQuery from '@metamask/eth-query';
 import HttpProvider from '@metamask/ethjs-provider-http';
 import type {
@@ -248,8 +249,8 @@ function buildMockEthQuery(): EthQuery {
  * always return.
  * @returns The mocked block tracker.
  */
-function buildMockBlockTracker(latestBlockNumber: string): BlockTracker {
-  const fakeBlockTracker = new FakeBlockTracker();
+function buildMockBlockTracker(latestBlockNumber: string, provider: SafeEventEmitterProvider): BlockTracker {
+  const fakeBlockTracker = new FakeBlockTracker({provider});
   fakeBlockTracker.mockLatestBlockNumber(latestBlockNumber);
   return fakeBlockTracker;
 }
@@ -313,7 +314,7 @@ type MockNetwork = {
 
 const MOCK_NETWORK: MockNetwork = {
   provider: MAINNET_PROVIDER,
-  blockTracker: buildMockBlockTracker('0x102833C'),
+  blockTracker: buildMockBlockTracker('0x102833C', MAINNET_PROVIDER),
   state: {
     selectedNetworkClientId: NetworkType.goerli,
     networksMetadata: {
@@ -333,7 +334,7 @@ const MOCK_NETWORK: MockNetwork = {
 };
 const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
   provider: GOERLI_PROVIDER,
-  blockTracker: buildMockBlockTracker('0x102833C'),
+  blockTracker: buildMockBlockTracker('0x102833C', GOERLI_PROVIDER),
   state: {
     selectedNetworkClientId: NetworkType.goerli,
     networksMetadata: {
@@ -351,7 +352,7 @@ const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
 };
 const MOCK_MAINNET_NETWORK: MockNetwork = {
   provider: MAINNET_PROVIDER,
-  blockTracker: buildMockBlockTracker('0x102833C'),
+  blockTracker: buildMockBlockTracker('0x102833C', MAINNET_PROVIDER),
   state: {
     selectedNetworkClientId: NetworkType.mainnet,
     networksMetadata: {
@@ -372,7 +373,7 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
 
 const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
   provider: PALM_PROVIDER,
-  blockTracker: buildMockBlockTracker('0xA6EDFC'),
+  blockTracker: buildMockBlockTracker('0xA6EDFC', PALM_PROVIDER),
   state: {
     selectedNetworkClientId: NetworkType['linea-mainnet'],
     networksMetadata: {
@@ -393,7 +394,7 @@ const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
 
 const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
   provider: PALM_PROVIDER,
-  blockTracker: buildMockBlockTracker('0xA6EDFC'),
+  blockTracker: buildMockBlockTracker('0xA6EDFC', PALM_PROVIDER),
   state: {
     selectedNetworkClientId: NetworkType['linea-goerli'],
     networksMetadata: {
@@ -414,7 +415,7 @@ const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
 
 const MOCK_CUSTOM_NETWORK: MockNetwork = {
   provider: PALM_PROVIDER,
-  blockTracker: buildMockBlockTracker('0xA6EDFC'),
+  blockTracker: buildMockBlockTracker('0xA6EDFC', PALM_PROVIDER),
   state: {
     selectedNetworkClientId: 'uuid-1',
     networksMetadata: {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -14,7 +14,7 @@ import {
   BUILT_IN_NETWORKS,
   ORIGIN_METAMASK,
 } from '@metamask/controller-utils';
-import { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
+import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import EthQuery from '@metamask/eth-query';
 import HttpProvider from '@metamask/ethjs-provider-http';
 import type {
@@ -247,10 +247,14 @@ function buildMockEthQuery(): EthQuery {
  *
  * @param latestBlockNumber - The block number that the block tracker should
  * always return.
+ * @param provider - json rpc provider
  * @returns The mocked block tracker.
  */
-function buildMockBlockTracker(latestBlockNumber: string, provider: SafeEventEmitterProvider): BlockTracker {
-  const fakeBlockTracker = new FakeBlockTracker({provider});
+function buildMockBlockTracker(
+  latestBlockNumber: string,
+  provider: SafeEventEmitterProvider,
+): BlockTracker {
+  const fakeBlockTracker = new FakeBlockTracker({ provider });
   fakeBlockTracker.mockLatestBlockNumber(latestBlockNumber);
   return fakeBlockTracker;
 }

--- a/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
@@ -220,16 +220,6 @@ function newMultichainTrackingHelper(
 describe('MultichainTrackingHelper', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-
-    for (const network of [
-      'mainnet',
-      'goerli',
-      'sepolia',
-      'customNetworkClientId-1',
-    ] as const) {
-      MOCK_BLOCK_TRACKERS[network] = buildMockBlockTracker(network);
-      MOCK_PROVIDERS[network] = buildMockProvider(network);
-    }
   });
 
   describe('onNetworkStateChange', () => {

--- a/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
@@ -221,7 +221,12 @@ describe('MultichainTrackingHelper', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    for (const network of ['mainnet', 'goerli', 'sepolia', 'customNetworkClientId-1'] as const) {
+    for (const network of [
+      'mainnet',
+      'goerli',
+      'sepolia',
+      'customNetworkClientId-1',
+    ] as const) {
       MOCK_BLOCK_TRACKERS[network] = buildMockBlockTracker(network);
       MOCK_PROVIDERS[network] = buildMockProvider(network);
     }

--- a/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
@@ -220,6 +220,11 @@ function newMultichainTrackingHelper(
 describe('MultichainTrackingHelper', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+
+    for (const network of ['mainnet', 'goerli', 'sepolia', 'customNetworkClientId-1'] as const) {
+      MOCK_BLOCK_TRACKERS[network] = buildMockBlockTracker(network);
+      MOCK_PROVIDERS[network] = buildMockProvider(network);
+    }
   });
 
   describe('onNetworkStateChange', () => {

--- a/tests/fake-block-tracker.ts
+++ b/tests/fake-block-tracker.ts
@@ -1,6 +1,5 @@
 import { PollingBlockTracker } from '@metamask/eth-block-tracker';
-import { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
-import { JsonRpcEngine } from '@metamask/json-rpc-engine';
+import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 
 /**
  * Acts like a PollingBlockTracker, but doesn't start the polling loop or
@@ -9,10 +8,9 @@ import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 export class FakeBlockTracker extends PollingBlockTracker {
   #latestBlockNumber = '0x0';
 
-  constructor({provider}: {provider: SafeEventEmitterProvider}) {
+  constructor({ provider }: { provider: SafeEventEmitterProvider }) {
     super({
       provider,
-      // provider: new SafeEventEmitterProvider({ engine: new JsonRpcEngine() }),
     });
     // Don't start the polling loop
     // TODO: Replace `any` with type

--- a/tests/fake-block-tracker.ts
+++ b/tests/fake-block-tracker.ts
@@ -9,9 +9,10 @@ import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 export class FakeBlockTracker extends PollingBlockTracker {
   #latestBlockNumber = '0x0';
 
-  constructor() {
+  constructor({provider}: {provider: SafeEventEmitterProvider}) {
     super({
-      provider: new SafeEventEmitterProvider({ engine: new JsonRpcEngine() }),
+      provider,
+      // provider: new SafeEventEmitterProvider({ engine: new JsonRpcEngine() }),
     });
     // Don't start the polling loop
     // TODO: Replace `any` with type

--- a/yarn.lock
+++ b/yarn.lock
@@ -3146,6 +3146,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^6.0.0
     "@metamask/controller-utils": ^11.0.0
+    "@metamask/eth-json-rpc-provider": ^4.0.0
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.3.0
     "@metamask/gas-fee-controller": ^17.0.0


### PR DESCRIPTION
## Explanation

`transaction-controller` constructor takes a `provider` and a `blockTracker`. In tests, there is mocking of these. A `BlockTracker` has its own `provider` and while in reality the `blockTracker.provider == provider`, it appears inconsistent in tests where a test may use both a mocked and a "real" provider instance at the same time.

This aims at making this more transparent by making the `provider` parameter of `FakeBlockTracker` mandatory. 

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
