### PR TITLE
Revert "Release 158.0.0 (#4342)"

### DIFF
--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -7,29 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [15.0.0]
-
-### Added
-
-- Add `getNextAvailableAccountName` method and `AccountsController:getNextAvailableAccountName` controller action ([#4326](https://github.com/MetaMask/core/pull/4326))
-- Add `listMultichainAccounts` method for getting accounts on a specific chain or the default chain ([#4330](https://github.com/MetaMask/core/pull/4330))
-- Add `getSelectedMultichainAccount` method and `AccountsController:getSelectedMultichainAccount` controller action for getting the selected account on a specific chain or the default chain ([#4330](https://github.com/MetaMask/core/pull/4330))
-
-### Changed
-
-- **BREAKING:** Bump peer dependency `@metamask/snaps-controllers` to `^8.1.1` ([#4262](https://github.com/MetaMask/core/pull/4262))
-- **BREAKING:** Bump peer dependency `@metamask/keyring-controller` to `^16.1.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** `listAccounts` now filters the list of accounts in state to EVM accounts ([#4330](https://github.com/MetaMask/core/pull/4330))
-- **BREAKING:** `getSelectedAccount` now throws if the selected account is not an EVM account ([#4330](https://github.com/MetaMask/core/pull/4330))
-- Bump `@metamask/eth-snap-keyring` to `^4.1.1` ([#4262](https://github.com/MetaMask/core/pull/4262))
-- Bump `@metamask/keyring-api` to `^6.1.1` ([#4262](https://github.com/MetaMask/core/pull/4262))
-- Bump `@metamask/snaps-sdk` to `^4.2.0` ([#4262](https://github.com/MetaMask/core/pull/4262))
-- Bump `@metamask/snaps-utils` to `^7.4.0` ([#4262](https://github.com/MetaMask/core/pull/4262))
-
-### Fixed
-
-- Fix "Type instantiation is excessively deep and possibly infinite" TypeScript error ([#4331](https://github.com/MetaMask/core/pull/4331))
-
 ## [14.0.0]
 
 ### Changed
@@ -194,8 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#1637](https://github.com/MetaMask/core/pull/1637))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@15.0.0...HEAD
-[15.0.0]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@14.0.0...@metamask/accounts-controller@15.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@14.0.0...HEAD
 [14.0.0]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@13.0.0...@metamask/accounts-controller@14.0.0
 [13.0.0]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@12.0.1...@metamask/accounts-controller@13.0.0
 [12.0.1]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@12.0.0...@metamask/accounts-controller@12.0.1

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/accounts-controller",
-  "version": "15.0.0",
+  "version": "14.0.0",
   "description": "Manages internal accounts",
   "keywords": [
     "MetaMask",
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-controller": "^16.1.0",
+    "@metamask/keyring-controller": "^16.0.0",
     "@metamask/snaps-controllers": "^8.1.1",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",
@@ -66,7 +66,7 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@metamask/keyring-controller": "^16.1.0",
+    "@metamask/keyring-controller": "^16.0.0",
     "@metamask/snaps-controllers": "^8.1.1"
   },
   "engines": {

--- a/packages/address-book-controller/CHANGELOG.md
+++ b/packages/address-book-controller/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.2]
-
-### Changed
-
-- Bump `@metamask/base-controller` to `^5.0.2` ([#4232](https://github.com/MetaMask/core/pull/4232))
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
-### Fixed
-
-- Fix `delete` method to protect against prototype-polluting assignments ([#4041](https://github.com/MetaMask/core/pull/4041))
-
 ## [4.0.1]
 
 ### Fixed
@@ -138,8 +127,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@4.0.2...HEAD
-[4.0.2]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@4.0.1...@metamask/address-book-controller@4.0.2
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@4.0.1...HEAD
 [4.0.1]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@4.0.0...@metamask/address-book-controller@4.0.1
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@3.1.7...@metamask/address-book-controller@4.0.0
 [3.1.7]: https://github.com/MetaMask/core/compare/@metamask/address-book-controller@3.1.6...@metamask/address-book-controller@3.1.7

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/address-book-controller",
-  "version": "4.0.2",
+  "version": "4.0.1",
   "description": "Manages a list of recipient addresses associated with nicknames",
   "keywords": [
     "MetaMask",

--- a/packages/announcement-controller/CHANGELOG.md
+++ b/packages/announcement-controller/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.1.1]
-
-### Changed
-
-- Bump `@metamask/base-controller` to `^5.0.2` ([#4232](https://github.com/MetaMask/core/pull/4232))
-
 ## [6.1.0]
 
 ### Added
@@ -135,8 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.1.1...HEAD
-[6.1.1]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.1.0...@metamask/announcement-controller@6.1.1
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.1.0...HEAD
 [6.1.0]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.0.1...@metamask/announcement-controller@6.1.0
 [6.0.1]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@6.0.0...@metamask/announcement-controller@6.0.1
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/announcement-controller@5.0.2...@metamask/announcement-controller@6.0.0

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/announcement-controller",
-  "version": "6.1.1",
+  "version": "6.1.0",
   "description": "Manages in-app announcements",
   "keywords": [
     "MetaMask",

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,85 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [31.0.0]
-
-### Added
-
-- **BREAKING:** The `NftDetectionController` now takes a `messenger`, which can be used for communication ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - This messenger must allow the following actions `ApprovalController:addRequest`, `NetworkController:getState`, `NetworkController:getNetworkClientById`, and `PreferencesController:getState`, and must allow the events `PreferencesController:stateChange` and `NetworkController:stateChange`
-- Add `NftDetectionControllerMessenger` type ([#4312](https://github.com/MetaMask/core/pull/4312))
-- Add `NftControllerGetStateAction`, `NftControllerActions`, `NftControllerStateChangeEvent`, and `NftControllerEvents` types ([#4310](https://github.com/MetaMask/core/pull/4310))
-- Add `NftController:getState` and `NftController:stateChange` as an available action and event to the `NftController` messenger ([#4310](https://github.com/MetaMask/core/pull/4310))
-
-### Changed
-
-- **BREAKING:** Change `TokensController` to inherit from `BaseController` rather than `BaseControllerV1` ([#4304](https://github.com/MetaMask/core/pull/4304))
-  - The constructor now takes a single options object rather than three arguments, and all properties in `config` are now part of options.
-- **BREAKING:** Rename `TokensState` type to `TokensControllerState` ([#4304](https://github.com/MetaMask/core/pull/4304))
-- **BREAKING:** Make all `TokensController` methods and properties starting with `_` private ([#4304](https://github.com/MetaMask/core/pull/4304))
-- **BREAKING:** Convert `Token` from `interface` to `type` ([#4304](https://github.com/MetaMask/core/pull/4304))
-- **BREAKING:** Replace `balanceError` property in `Token` with `hasBalanceError`; update `TokenBalancesController` so that it no longer captures the error resulting from getting the balance of an ERC-20 token ([#4304](https://github.com/MetaMask/core/pull/4304))
-- **BREAKING:** Change `NftDetectionController` to inherit from `StaticIntervalPollingController` rather than `StaticIntervalPollingControllerV1` ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - The constructor now takes a single options object rather than three arguments, and all properties in `config` are now part of options.
-- **BREAKING:** Convert `ApiNft`, `ApiNftContract`, `ApiNftLastSale`, and `ApiNftCreator` from `interface` to `type` ([#4312](https://github.com/MetaMask/core/pull/4312))
-- **BREAKING:** Change `NftController` to inherit from `BaseController` rather than `BaseControllerV1` ([#4310](https://github.com/MetaMask/core/pull/4310))
-  - The constructor now takes a single options object rather than three arguments, and all properties in `config` are now part of options.
-- **BREAKING:** Convert `Nft`, `NftContract`, and `NftMetadata` from `interface` to `type` ([#4310](https://github.com/MetaMask/core/pull/4310))
-- **BREAKING:** Rename `NftState` to `NftControllerState`, and convert to `type` ([#4310](https://github.com/MetaMask/core/pull/4310))
-- **BREAKING:** Rename `getDefaultNftState` to `getDefaultNftControllerState` ([#4310](https://github.com/MetaMask/core/pull/4310))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/accounts-controller` to `^15.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/approval-controller` to `^6.0.2` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/keyring-controller` to `^16.1.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/network-controller` to `^18.1.3` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/preferences-controller` to `^12.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- Change `NftDetectionController` method `detectNfts` so that `userAddress` option is optional ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - This will default to the currently selected address as kept by PreferencesController.
-- Bump `async-mutex` to `^0.5.0` ([#4335](https://github.com/MetaMask/core/pull/4335))
-- Bump `@metamask/polling-controller` to `^7.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
-### Removed
-
-- **BREAKING:** Remove `config` property and `configure` method from `TokensController` ([#4304](https://github.com/MetaMask/core/pull/4304))
-  - The `TokensController` now takes a single options object which can be used for configuration, and configuration is now kept internally.
-- **BREAKING:** Remove `notify`, `subscribe`, and `unsubscribe` methods from `TokensController` ([#4304](https://github.com/MetaMask/core/pull/4304))
-  - Use the controller messenger for subscribing to and publishing events instead.
-- **BREAKING:** Remove `TokensConfig` type ([#4304](https://github.com/MetaMask/core/pull/4304))
-  - These properties have been merged into the options that `TokensController` takes.
-- **BREAKING:** Remove `config` property and `configure` method from `TokensController` ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - `TokensController` now takes a single options object which can be used for configuration, and configuration is now kept internally.
-- **BREAKING:** Remove `notify`, `subscribe`, and `unsubscribe` methods from `NftDetectionController` ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - Use the controller messenger for subscribing to and publishing events instead.
-- **BREAKING:** Remove `chainId` as a `NftDetectionController` constructor argument ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - The controller will now read the `networkClientId` from the NetworkController state through the messenger when needed.
-- **BREAKING:** Remove `getNetworkClientById` as a `NftDetectionController` constructor argument ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - The controller will now call `NetworkController:getNetworkClientId` through the messenger object.
-- **BREAKING:** Remove `onPreferencesStateChange` as a `NftDetectionController` constructor argument ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - The controller will now call `PreferencesController:stateChange` through the messenger object.
-- **BREAKING:** Remove `onNetworkStateChange` as a `NftDetectionController` constructor argument ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - The controller will now read the `networkClientId` from the NetworkController state through the messenger when needed.
-- **BREAKING:** Remove `getOpenSeaApiKey` as a `NftDetectionController` constructor argument ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - This was never used.
-- **BREAKING:** Remove `getNftApi` as a `NftDetectionController` constructor argument ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - This was never used.
-- **BREAKING:** Remove `NftDetectionConfig` type ([#4312](https://github.com/MetaMask/core/pull/4312))
-  - These properties have been merged into the options that `NftDetectionController` takes.
-- **BREAKING:** Remove `config` property and `configure` method from `NftController` ([#4310](https://github.com/MetaMask/core/pull/4310))
-  - `NftController` now takes a single options object which can be used for configuration, and configuration is now kept internally.
-- **BREAKING:** Remove `notify`, `subscribe`, and `unsubscribe` methods from `NftController` ([#4310](https://github.com/MetaMask/core/pull/4310))
-  - Use the controller messenger for subscribing to and publishing events instead.
-- **BREAKING:** Remove `onPreferencesStateChange` as a `NftController` constructor argument ([#4310](https://github.com/MetaMask/core/pull/4310))
-  - The controller will now call `PreferencesController:stateChange` through the messenger object.
-- **BREAKING:** Remove `onNetworkStateChange` as a `NftController` constructor argument ([#4310](https://github.com/MetaMask/core/pull/4310))
-  - The controller will now call `NetworkController:stateChange` through the messenger object.
-- **BREAKING:** Remove `NftConfig` type ([#4310](https://github.com/MetaMask/core/pull/4310))
-  - These properties have been merged into the options that `NftController` takes.
-- **BREAKING:** Remove `config` property and `configure` method from `NftController` ([#4310](https://github.com/MetaMask/core/pull/4310))
-  - `NftController` now takes a single options object which can be used for configuration, and configuration is now kept internally.
-- **BREAKING:** Remove `hub` property from `NftController` ([#4310](https://github.com/MetaMask/core/pull/4310))
-  - Use the controller messenger for subscribing to and publishing events instead.
-- **BREAKING:** Modify `TokenListController` so that tokens fetched from the API and stored in state will no longer have `storage` and `erc20` properties ([#4235](https://github.com/MetaMask/core/pull/4235))
-  - These properties were never officially supported, but they were present in state anyway.
-
 ## [30.0.0]
 
 ### Added
@@ -875,8 +796,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use Ethers for AssetsContractController ([#845](https://github.com/MetaMask/core/pull/845))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@31.0.0...HEAD
-[31.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@30.0.0...@metamask/assets-controllers@31.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@30.0.0...HEAD
 [30.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@29.0.0...@metamask/assets-controllers@30.0.0
 [29.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@28.0.0...@metamask/assets-controllers@29.0.0
 [28.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@27.2.0...@metamask/assets-controllers@28.0.0

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/assets-controllers",
-  "version": "31.0.0",
+  "version": "30.0.0",
   "description": "Controllers which manage interactions involving ERC-20, ERC-721, and ERC-1155 tokens (including NFTs)",
   "keywords": [
     "MetaMask",
@@ -47,17 +47,17 @@
     "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@metamask/abi-utils": "^2.0.2",
-    "@metamask/accounts-controller": "^15.0.0",
+    "@metamask/accounts-controller": "^14.0.0",
     "@metamask/approval-controller": "^6.0.2",
     "@metamask/base-controller": "^5.0.2",
     "@metamask/contract-metadata": "^2.4.0",
     "@metamask/controller-utils": "^10.0.0",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/keyring-controller": "^16.1.0",
+    "@metamask/keyring-controller": "^16.0.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
-    "@metamask/network-controller": "^18.1.3",
-    "@metamask/polling-controller": "^7.0.0",
-    "@metamask/preferences-controller": "^12.0.0",
+    "@metamask/network-controller": "^18.1.2",
+    "@metamask/polling-controller": "^6.0.2",
+    "@metamask/preferences-controller": "^11.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",
     "@types/bn.js": "^5.1.5",
@@ -88,11 +88,11 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@metamask/accounts-controller": "^15.0.0",
-    "@metamask/approval-controller": "^6.0.2",
-    "@metamask/keyring-controller": "^16.1.0",
-    "@metamask/network-controller": "^18.1.3",
-    "@metamask/preferences-controller": "^12.0.0"
+    "@metamask/accounts-controller": "^14.0.0",
+    "@metamask/approval-controller": "^6.0.0",
+    "@metamask/keyring-controller": "^16.0.0",
+    "@metamask/network-controller": "^18.1.2",
+    "@metamask/preferences-controller": "^11.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/composable-controller/CHANGELOG.md
+++ b/packages/composable-controller/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.0.2]
-
 ### Added
 
 - Adds and exports new types: ([#3952](https://github.com/MetaMask/core/pull/3952))
@@ -20,9 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** The `ComposableController` class is now a generic class that expects one generic argument `ComposableControllerState` ([#3952](https://github.com/MetaMask/core/pull/3952)).
   - **BREAKING:** For the `ComposableController` class to be typed correctly, any of its child controllers that extend `BaseControllerV1` must have an overridden `name` property that is defined using the `as const` assertion.
-- **BREAKING:** The types `ComposableControllerStateChangeEvent`, `ComposableControllerEvents`, `ComposableControllerMessenger` are now generic types that expect one generic argument `ComposableControllerState` ([#3952](https://github.com/MetaMask/core/pull/3952)).
-- Bump `@metamask/json-rpc-engine` to `^8.0.2` ([#4234](https://github.com/MetaMask/core/pull/4234))
-- Bump `@metamask/base-controller` to `^5.0.2` ([#4232](https://github.com/MetaMask/core/pull/4232))
 
 ## [6.0.1]
 
@@ -139,8 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@6.0.2...HEAD
-[6.0.2]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@6.0.1...@metamask/composable-controller@6.0.2
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@6.0.1...HEAD
 [6.0.1]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@6.0.0...@metamask/composable-controller@6.0.1
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@5.0.1...@metamask/composable-controller@6.0.0
 [5.0.1]: https://github.com/MetaMask/core/compare/@metamask/composable-controller@5.0.0...@metamask/composable-controller@5.0.1

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/composable-controller",
-  "version": "6.0.2",
+  "version": "6.0.1",
   "description": "Consolidates the state from multiple controllers into one",
   "keywords": [
     "MetaMask",

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -9,18 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.0.0]
 
-### Added
-
-- Add `NFT_API_VERSION` and `NFT_API_TIMEOUT` constants ([#4312](https://github.com/MetaMask/core/pull/4312))
-
 ### Changed
 
 - **BREAKING:** Changed price and token API endpoints from `*.metafi.codefi.network` to `*.api.cx.metamask.io` ([#4301](https://github.com/MetaMask/core/pull/4301))
-
-### Removed
-
-- **BREAKING:** Remove `EthSign` from `ApprovalType` ([#4319](https://github.com/MetaMask/core/pull/4319))
-  - This represented an `eth_sign` approval, but support for that RPC method is being removed, so this is no longer needed.
 
 ## [9.1.0]
 

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -7,18 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0]
-
-### Changed
-
-- **BREAKING:** Bump peer dependency `@metamask/network-controller` to `^18.1.3` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- Bump `@metamask/base-controller` to `^5.0.2` ([#4232](https://github.com/MetaMask/core/pull/4232))
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
-### Fixed
-
-- Fix `delete` method to protect against prototype-polluting assignments ([#4041](https://github.com/MetaMask/core/pull/4041)
-
 ## [10.0.1]
 
 ### Fixed
@@ -186,8 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@11.0.0...HEAD
-[11.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@10.0.1...@metamask/ens-controller@11.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@10.0.1...HEAD
 [10.0.1]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@10.0.0...@metamask/ens-controller@10.0.1
 [10.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@9.0.0...@metamask/ens-controller@10.0.0
 [9.0.0]: https://github.com/MetaMask/core/compare/@metamask/ens-controller@8.0.0...@metamask/ens-controller@9.0.0

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ens-controller",
-  "version": "11.0.0",
+  "version": "10.0.1",
   "description": "Maps ENS names to their resolved addresses by chain id",
   "keywords": [
     "MetaMask",
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/network-controller": "^18.1.3",
+    "@metamask/network-controller": "^18.1.2",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
@@ -59,7 +59,7 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^18.1.3"
+    "@metamask/network-controller": "^18.1.2"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [16.0.0]
-
-### Changed
-
-- **BREAKING:** Bump dependency and peer dependency `@metamask/network-controller` to `^18.1.3` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- Bump `@metamask/polling-controller` to `^7.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
 ## [15.1.2]
 
 ### Fixed
@@ -283,8 +275,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@16.0.0...HEAD
-[16.0.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@15.1.2...@metamask/gas-fee-controller@16.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@15.1.2...HEAD
 [15.1.2]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@15.1.1...@metamask/gas-fee-controller@15.1.2
 [15.1.1]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@15.1.0...@metamask/gas-fee-controller@15.1.1
 [15.1.0]: https://github.com/MetaMask/core/compare/@metamask/gas-fee-controller@15.0.0...@metamask/gas-fee-controller@15.1.0

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/gas-fee-controller",
-  "version": "16.0.0",
+  "version": "15.1.2",
   "description": "Periodically calculates gas fee estimates based on various gas limits as well as other data displayed on transaction confirm screens",
   "keywords": [
     "MetaMask",
@@ -45,8 +45,8 @@
     "@metamask/controller-utils": "^10.0.0",
     "@metamask/eth-query": "^4.0.0",
     "@metamask/ethjs-unit": "^0.3.0",
-    "@metamask/network-controller": "^18.1.3",
-    "@metamask/polling-controller": "^7.0.0",
+    "@metamask/network-controller": "^18.1.2",
+    "@metamask/polling-controller": "^6.0.2",
     "@metamask/utils": "^8.3.0",
     "@types/bn.js": "^5.1.5",
     "@types/uuid": "^8.3.0",
@@ -67,7 +67,7 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^18.1.3"
+    "@metamask/network-controller": "^18.1.2"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/json-rpc-middleware-stream/CHANGELOG.md
+++ b/packages/json-rpc-middleware-stream/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.2]
-
-### Changed
-
-- Bump `@metamask/json-rpc-engine` to `^8.0.2` ([#4234](https://github.com/MetaMask/core/pull/4234))
-
 ## [7.0.1]
 
 ### Fixed
@@ -122,8 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TypeScript typings ([#11](https://github.com/MetaMask/json-rpc-middleware-stream/pull/11))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@7.0.2...HEAD
-[7.0.2]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@7.0.1...@metamask/json-rpc-middleware-stream@7.0.2
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@7.0.1...HEAD
 [7.0.1]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@7.0.0...@metamask/json-rpc-middleware-stream@7.0.1
 [7.0.0]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@6.0.2...@metamask/json-rpc-middleware-stream@7.0.0
 [6.0.2]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@6.0.1...@metamask/json-rpc-middleware-stream@6.0.2

--- a/packages/json-rpc-middleware-stream/package.json
+++ b/packages/json-rpc-middleware-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/json-rpc-middleware-stream",
-  "version": "7.0.2",
+  "version": "7.0.1",
   "description": "A small toolset for streaming JSON-RPC data and matching requests and responses",
   "keywords": [
     "MetaMask",

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,26 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [16.1.0]
-
 ### Added
 
-- Add `changePassword` method ([#4279](https://github.com/MetaMask/core/pull/4279))
-  - This method can be used to change the password used to encrypt the vault.
-- Add support for non-EVM account addresses to most methods ([#4282](https://github.com/MetaMask/core/pull/4282))
-  - Previously, all addresses were assumed to be Ethereum addresses and normalized, but now only Ethereum addresses are treated as such.
-  - Relax type of `account` argument on `removeAccount` from `Hex` to `string`
-
-### Changed
-
-- Bump `@metamask/keyring-api` to `^6.1.1` ([#4262](https://github.com/MetaMask/core/pull/4262))
-- Bump `@keystonehq/metamask-airgapped-keyring` to `^0.14.1` ([#4277](https://github.com/MetaMask/core/pull/4277))
-- Bump `async-mutex` to `^0.5.0` ([#4335](https://github.com/MetaMask/core/pull/4335))
-- Bump `@metamask/message-manager` to `^9.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
-### Fixed
-
-- Fix QR keyrings so that they are not initialized with invalid state ([#4256](https://github.com/MetaMask/core/pull/4256))
+- Added `changePassword` method ([#4279](https://github.com/MetaMask/core/pull/4279))
+  - This method can be used to change the password used to encrypt the vault
 
 ## [16.0.0]
 
@@ -461,8 +445,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@16.1.0...HEAD
-[16.1.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@16.0.0...@metamask/keyring-controller@16.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@16.0.0...HEAD
 [16.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@15.0.0...@metamask/keyring-controller@16.0.0
 [15.0.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@14.0.1...@metamask/keyring-controller@15.0.0
 [14.0.1]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@14.0.0...@metamask/keyring-controller@14.0.1

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-controller",
-  "version": "16.1.0",
+  "version": "16.0.0",
   "description": "Stores identities seen in the wallet and manages interactions such as signing",
   "keywords": [
     "MetaMask",
@@ -49,7 +49,7 @@
     "@metamask/eth-sig-util": "^7.0.1",
     "@metamask/eth-simple-keyring": "^6.0.1",
     "@metamask/keyring-api": "^6.1.1",
-    "@metamask/message-manager": "^9.0.0",
+    "@metamask/message-manager": "^8.0.2",
     "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.5.0",
     "ethereumjs-wallet": "^1.0.1",

--- a/packages/logging-controller/CHANGELOG.md
+++ b/packages/logging-controller/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.0]
-
-### Changed
-
-- Bump `@metamask/base-controller` to `^5.0.2` ([#4232](https://github.com/MetaMask/core/pull/4232))
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
-### Removed
-
-- **BREAKING:** Remove `EthSign` from `SigningMethod` ([#4319](https://github.com/MetaMask/core/pull/4319))
-
 ## [3.0.1]
 
 ### Fixed
@@ -98,8 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial Release
   - Add logging controller ([#1089](https://github.com/MetaMask/core.git/pull/1089))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@4.0.0...HEAD
-[4.0.0]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@3.0.1...@metamask/logging-controller@4.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@3.0.1...HEAD
 [3.0.1]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@3.0.0...@metamask/logging-controller@3.0.1
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@2.0.3...@metamask/logging-controller@3.0.0
 [2.0.3]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@2.0.2...@metamask/logging-controller@2.0.3

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/logging-controller",
-  "version": "4.0.0",
+  "version": "3.0.1",
   "description": "Manages logging data to assist users and support staff",
   "keywords": [
     "MetaMask",

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.0.0]
-
-### Changed
-
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
-### Removed
-
-- **BREAKING:** Remove `Message`, `MessageParams`, `MessageParamsMetamask`, and `MessageManager` ([#4319](https://github.com/MetaMask/core/pull/4319))
-  - Support for `eth_sign` is being removed, so these are no longer needed.
-
 ## [8.0.2]
 
 ### Changed
@@ -247,8 +236,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/message-manager@9.0.0...HEAD
-[9.0.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@8.0.2...@metamask/message-manager@9.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/message-manager@8.0.2...HEAD
 [8.0.2]: https://github.com/MetaMask/core/compare/@metamask/message-manager@8.0.1...@metamask/message-manager@8.0.2
 [8.0.1]: https://github.com/MetaMask/core/compare/@metamask/message-manager@8.0.0...@metamask/message-manager@8.0.1
 [8.0.0]: https://github.com/MetaMask/core/compare/@metamask/message-manager@7.3.9...@metamask/message-manager@8.0.0

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/message-manager",
-  "version": "9.0.0",
+  "version": "8.0.2",
   "description": "Stores and manages interactions with signing requests",
   "keywords": [
     "MetaMask",

--- a/packages/name-controller/CHANGELOG.md
+++ b/packages/name-controller/CHANGELOG.md
@@ -7,19 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.0]
-
-### Changed
-
-- **BREAKING:** Changed token API endpoint from `*.metafi.codefi.network` to `*.api.cx.metamask.io` ([#4301](https://github.com/MetaMask/core/pull/4301))
-- Bump `@metamask/base-controller` to `^5.0.2` ([#4232](https://github.com/MetaMask/core/pull/4232))
-- Bump `async-mutex` to `^0.5.0` ([#4335](https://github.com/MetaMask/core/pull/4335))
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
-### Fixed
-
-- Fix `setName` and `updateProposedNames` methods to protect against prototype-polluting assignments ([#4041](https://github.com/MetaMask/core/pull/4041)
-
 ## [6.0.1]
 
 ### Fixed
@@ -113,8 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release ([#1647](https://github.com/MetaMask/core/pull/1647))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/name-controller@7.0.0...HEAD
-[7.0.0]: https://github.com/MetaMask/core/compare/@metamask/name-controller@6.0.1...@metamask/name-controller@7.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/name-controller@6.0.1...HEAD
 [6.0.1]: https://github.com/MetaMask/core/compare/@metamask/name-controller@6.0.0...@metamask/name-controller@6.0.1
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/name-controller@5.0.0...@metamask/name-controller@6.0.0
 [5.0.0]: https://github.com/MetaMask/core/compare/@metamask/name-controller@4.2.0...@metamask/name-controller@5.0.0

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/name-controller",
-  "version": "7.0.0",
+  "version": "6.0.1",
   "description": "Stores and suggests names for values such as Ethereum addresses",
   "keywords": [
     "MetaMask",

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [18.1.3]
-
-### Changed
-
-- Bump `async-mutex` to `^0.5.0` ([#4335](https://github.com/MetaMask/core/pull/4335))
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
 ## [18.1.2]
 
 ### Fixed
@@ -495,8 +488,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@18.1.3...HEAD
-[18.1.3]: https://github.com/MetaMask/core/compare/@metamask/network-controller@18.1.2...@metamask/network-controller@18.1.3
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@18.1.2...HEAD
 [18.1.2]: https://github.com/MetaMask/core/compare/@metamask/network-controller@18.1.1...@metamask/network-controller@18.1.2
 [18.1.1]: https://github.com/MetaMask/core/compare/@metamask/network-controller@18.1.0...@metamask/network-controller@18.1.1
 [18.1.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@18.0.1...@metamask/network-controller@18.1.0

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-controller",
-  "version": "18.1.3",
+  "version": "18.1.2",
   "description": "Provides an interface to the currently selected network via a MetaMask-compatible provider object",
   "keywords": [
     "MetaMask",

--- a/packages/notification-controller/CHANGELOG.md
+++ b/packages/notification-controller/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.0.2]
-
-### Changed
-
-- Bump `@metamask/base-controller` to `^5.0.2` ([#4232](https://github.com/MetaMask/core/pull/4232))
-
 ## [5.0.1]
 
 ### Fixed
@@ -116,8 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@5.0.2...HEAD
-[5.0.2]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@5.0.1...@metamask/notification-controller@5.0.2
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@5.0.1...HEAD
 [5.0.1]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@5.0.0...@metamask/notification-controller@5.0.1
 [5.0.0]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@4.0.2...@metamask/notification-controller@5.0.0
 [4.0.2]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@4.0.1...@metamask/notification-controller@4.0.2

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/notification-controller",
-  "version": "5.0.2",
+  "version": "5.0.1",
   "description": "Manages display of notifications within MetaMask",
   "keywords": [
     "MetaMask",

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.1.1]
-
-### Changed
-
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
 ## [9.1.0]
 
 ### Added
@@ -232,8 +226,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@9.1.1...HEAD
-[9.1.1]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@9.1.0...@metamask/permission-controller@9.1.1
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@9.1.0...HEAD
 [9.1.0]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@9.0.2...@metamask/permission-controller@9.1.0
 [9.0.2]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@9.0.1...@metamask/permission-controller@9.0.2
 [9.0.1]: https://github.com/MetaMask/core/compare/@metamask/permission-controller@9.0.0...@metamask/permission-controller@9.0.1

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/permission-controller",
-  "version": "9.1.1",
+  "version": "9.1.0",
   "description": "Mediates access to JSON-RPC methods, used to interact with pieces of the MetaMask stack, via middleware for json-rpc-engine",
   "keywords": [
     "MetaMask",

--- a/packages/permission-log-controller/CHANGELOG.md
+++ b/packages/permission-log-controller/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.2]
-
-### Changed
-
-- Bump `@metamask/base-controller` to `^5.0.2` ([#4234](https://github.com/MetaMask/core/pull/4234))
-- Bump `@metamask/json-rpc-engine` to `^8.0.2` ([#4232](https://github.com/MetaMask/core/pull/4232))
-
 ## [2.0.1]
 
 ### Fixed
@@ -39,8 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-log-controller@2.0.2...HEAD
-[2.0.2]: https://github.com/MetaMask/core/compare/@metamask/permission-log-controller@2.0.1...@metamask/permission-log-controller@2.0.2
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/permission-log-controller@2.0.1...HEAD
 [2.0.1]: https://github.com/MetaMask/core/compare/@metamask/permission-log-controller@2.0.0...@metamask/permission-log-controller@2.0.1
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/permission-log-controller@1.0.0...@metamask/permission-log-controller@2.0.0
 [1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/permission-log-controller@1.0.0

--- a/packages/permission-log-controller/package.json
+++ b/packages/permission-log-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/permission-log-controller",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "Controller with middleware for logging requests and responses to restricted and permissions-related methods",
   "keywords": [
     "MetaMask",

--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.0.4]
-
-### Changed
-
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
 ## [9.0.3]
 
 ### Changed
@@ -190,8 +184,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@9.0.4...HEAD
-[9.0.4]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@9.0.3...@metamask/phishing-controller@9.0.4
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@9.0.3...HEAD
 [9.0.3]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@9.0.2...@metamask/phishing-controller@9.0.3
 [9.0.2]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@9.0.1...@metamask/phishing-controller@9.0.2
 [9.0.1]: https://github.com/MetaMask/core/compare/@metamask/phishing-controller@9.0.0...@metamask/phishing-controller@9.0.1

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/phishing-controller",
-  "version": "9.0.4",
+  "version": "9.0.3",
   "description": "Maintains a periodically updated list of approved and unapproved website origins",
   "keywords": [
     "MetaMask",

--- a/packages/polling-controller/CHANGELOG.md
+++ b/packages/polling-controller/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.0]
-
-### Changed
-
-- **BREAKING:** Bump dependency and peer dependency `@metamask/network-controller` to `^18.1.3` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
-### Fixed
-
-- `StaticIntervalPollingControllerOnly`, `StaticIntervalPollingController`, and `StaticIntervalPollingControllerV1` now properly stops polling when a stop is requested while `_executePoll` has not yet resolved for the current loop ([#4230](https://github.com/MetaMask/core/pull/4230))
-
 ## [6.0.2]
 
 ### Changed
@@ -134,8 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@7.0.0...HEAD
-[7.0.0]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@6.0.2...@metamask/polling-controller@7.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@6.0.2...HEAD
 [6.0.2]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@6.0.1...@metamask/polling-controller@6.0.2
 [6.0.1]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@6.0.0...@metamask/polling-controller@6.0.1
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/polling-controller@5.0.1...@metamask/polling-controller@6.0.0

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/polling-controller",
-  "version": "7.0.0",
+  "version": "6.0.2",
   "description": "Polling Controller is the base for controllers that polling by networkClientId",
   "keywords": [
     "MetaMask",
@@ -43,7 +43,7 @@
   "dependencies": {
     "@metamask/base-controller": "^5.0.2",
     "@metamask/controller-utils": "^10.0.0",
-    "@metamask/network-controller": "^18.1.3",
+    "@metamask/network-controller": "^18.1.2",
     "@metamask/utils": "^8.3.0",
     "@types/uuid": "^8.3.0",
     "fast-json-stable-stringify": "^2.1.0",
@@ -61,7 +61,7 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^18.1.3"
+    "@metamask/network-controller": "^18.1.2"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,26 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [12.0.0]
-
-### Added
-
-- Add `smartTransactionsOptInStatus` preference ([#3815](https://github.com/MetaMask/core/pull/3815))
-  - Add `smartTransactionsOptInStatus` property to the `PreferencesController` state (default: `false`)
-  - Add `setSmartTransactionOptInStatus` method to set this property
-- Add `useTransactionSimulations` preference ([#4283](https://github.com/MetaMask/core/pull/4283))
-  - Add `useTransactionSimulations` property to the `PreferencesController` state (default value: `false`)
-  - Add `setUseTransactionSimulations` method to set this property
-
-### Changed
-
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
-### Removed
-
-- **BREAKING:** Remove state property `disabledRpcMethodPreferences` along with `setDisabledRpcMethodPreferences` method ([#4319](https://github.com/MetaMask/core/pull/4319))
-  - These were for disabling the `eth_sign` RPC method, but support for this method is being removed, so this preference is no longer needed.
-
 ## [11.0.0]
 
 ### Added
@@ -239,8 +219,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@12.0.0...HEAD
-[12.0.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@11.0.0...@metamask/preferences-controller@12.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@11.0.0...HEAD
 [11.0.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@10.0.0...@metamask/preferences-controller@11.0.0
 [10.0.0]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@9.0.1...@metamask/preferences-controller@10.0.0
 [9.0.1]: https://github.com/MetaMask/core/compare/@metamask/preferences-controller@9.0.0...@metamask/preferences-controller@9.0.1

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/preferences-controller",
-  "version": "12.0.0",
+  "version": "11.0.0",
   "description": "Manages user-configurable settings for MetaMask",
   "keywords": [
     "MetaMask",
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-controller": "^16.1.0",
+    "@metamask/keyring-controller": "^16.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.0]
-
-### Changed
-
-- **BREAKING:** Bump peer dependency `@metamask/network-controller` to `^18.1.3` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/selected-network-controller` to `^14.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
 ## [0.10.0]
 
 ### Changed
@@ -189,8 +181,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.11.0...HEAD
-[0.11.0]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.10.0...@metamask/queued-request-controller@0.11.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.10.0...HEAD
 [0.10.0]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.9.0...@metamask/queued-request-controller@0.10.0
 [0.9.0]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.8.0...@metamask/queued-request-controller@0.9.0
 [0.8.0]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@0.7.0...@metamask/queued-request-controller@0.8.0

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/queued-request-controller",
-  "version": "0.11.0",
+  "version": "0.10.0",
   "description": "Includes a controller and middleware that implements a request queue",
   "keywords": [
     "MetaMask",
@@ -50,8 +50,8 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/network-controller": "^18.1.3",
-    "@metamask/selected-network-controller": "^14.0.0",
+    "@metamask/network-controller": "^18.1.2",
+    "@metamask/selected-network-controller": "^13.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",
@@ -65,8 +65,8 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^18.1.3",
-    "@metamask/selected-network-controller": "^14.0.0"
+    "@metamask/network-controller": "^18.1.2",
+    "@metamask/selected-network-controller": "^13.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/rate-limit-controller/CHANGELOG.md
+++ b/packages/rate-limit-controller/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.0.2]
-
-### Changed
-
-- Bump `@metamask/base-controller` to `^5.0.2` ([#4232](https://github.comMetaMask/core/pull/4232))
-
 ## [5.0.1]
 
 ### Fixed
@@ -130,8 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@5.0.2...HEAD
-[5.0.2]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@5.0.1...@metamask/rate-limit-controller@5.0.2
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@5.0.1...HEAD
 [5.0.1]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@5.0.0...@metamask/rate-limit-controller@5.0.1
 [5.0.0]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@4.0.2...@metamask/rate-limit-controller@5.0.0
 [4.0.2]: https://github.com/MetaMask/core/compare/@metamask/rate-limit-controller@4.0.1...@metamask/rate-limit-controller@4.0.2

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rate-limit-controller",
-  "version": "5.0.2",
+  "version": "5.0.1",
   "description": "Contains logic for rate-limiting API endpoints by requesting origin",
   "keywords": [
     "MetaMask",

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [14.0.0]
-
-### Changed
-
-- **BREAKING:** Bump dependency and peer dependency `@metamask/network-controller` to `^18.1.3` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/permission-controller` to `^9.1.1` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
 ## [13.0.0]
 
 ### Changed
@@ -213,8 +206,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release ([#1643](https://github.com/MetaMask/core/pull/1643))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@14.0.0...HEAD
-[14.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@13.0.0...@metamask/selected-network-controller@14.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@13.0.0...HEAD
 [13.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@12.0.1...@metamask/selected-network-controller@13.0.0
 [12.0.1]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@12.0.0...@metamask/selected-network-controller@12.0.1
 [12.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@11.0.0...@metamask/selected-network-controller@12.0.0

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/selected-network-controller",
-  "version": "14.0.0",
+  "version": "13.0.0",
   "description": "Provides an interface to the currently selected networkClientId for a given domain",
   "keywords": [
     "MetaMask",
@@ -43,8 +43,8 @@
   "dependencies": {
     "@metamask/base-controller": "^5.0.2",
     "@metamask/json-rpc-engine": "^8.0.2",
-    "@metamask/network-controller": "^18.1.3",
-    "@metamask/permission-controller": "^9.1.1",
+    "@metamask/network-controller": "^18.1.2",
+    "@metamask/permission-controller": "^9.1.0",
     "@metamask/swappable-obj-proxy": "^2.2.0",
     "@metamask/utils": "^8.3.0"
   },
@@ -63,8 +63,8 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^18.1.3",
-    "@metamask/permission-controller": "^9.1.1"
+    "@metamask/network-controller": "^18.1.2",
+    "@metamask/permission-controller": "^9.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -7,25 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [17.0.0]
-
-### Changed
-
-- **BREAKING:** Update `messages` getter to return `Record<string, PersonalMessage | TypedMessage>` instead of `Record<string, Message | PersonalMessage | TypedMessage>` ([#4319](https://github.com/MetaMask/core/pull/4319))
-- **BREAKING** Bump `@metamask/keyring-controller` peer dependency to `^16.1.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING** Bump `@metamask/logging-controller` peer dependency to `^4.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- Bump `@metamask/message-manager` to `^9.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
-### Removed
-
-- **BREAKING:** Remove state properties `unapprovedMsgs` and `unapprovedMsgCount` ([#4319](https://github.com/MetaMask/core/pull/4319))
-  - These properties were related to handling of the `eth_sign` RPC method, but support for that is being removed, so these are no longer needed.
-- **BREAKING:** Remove `isEthSignEnabled` option from constructor ([#4319](https://github.com/MetaMask/core/pull/4319))
-  - This option governed whether handling of the `eth_sign` RPC method was enabled, but support for that method is being removed, so this is no longer needed.
-- **BREAKING:** Remove `newUnsignedMessage` method ([#4319](https://github.com/MetaMask/core/pull/4319))
-  - This method was called when a dapp used the `eth_sign` RPC method, but support for that method is being removed, so this is no longer needed.
-
 ## [16.0.0]
 
 ### Changed
@@ -258,8 +239,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#1214](https://github.com/MetaMask/core/pull/1214))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@17.0.0...HEAD
-[17.0.0]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@16.0.0...@metamask/signature-controller@17.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@16.0.0...HEAD
 [16.0.0]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@15.0.0...@metamask/signature-controller@16.0.0
 [15.0.0]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@14.0.1...@metamask/signature-controller@15.0.0
 [14.0.1]: https://github.com/MetaMask/core/compare/@metamask/signature-controller@14.0.0...@metamask/signature-controller@14.0.1

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/signature-controller",
-  "version": "17.0.0",
+  "version": "16.0.0",
   "description": "Processes signing requests in order to sign arbitrary and typed data",
   "keywords": [
     "MetaMask",
@@ -44,9 +44,9 @@
     "@metamask/approval-controller": "^6.0.2",
     "@metamask/base-controller": "^5.0.2",
     "@metamask/controller-utils": "^10.0.0",
-    "@metamask/keyring-controller": "^16.1.0",
-    "@metamask/logging-controller": "^4.0.0",
-    "@metamask/message-manager": "^9.0.0",
+    "@metamask/keyring-controller": "^16.0.0",
+    "@metamask/logging-controller": "^3.0.1",
+    "@metamask/message-manager": "^8.0.2",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",
     "lodash": "^4.17.21"
@@ -63,8 +63,8 @@
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^6.0.0",
-    "@metamask/keyring-controller": "^16.1.0",
-    "@metamask/logging-controller": "^4.0.0"
+    "@metamask/keyring-controller": "^16.0.0",
+    "@metamask/logging-controller": "^3.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,25 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [31.0.0]
-
-### Changed
-
-- **BREAKING:** Bump dependency and peer dependency `@metamask/approval-controller` to `^6.0.2` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/gas-fee-controller` to `^16.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/network-controller` to `^18.1.3` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- Bump `async-mutex` to `^0.5.0` ([#4335](https://github.com/MetaMask/core/pull/4335))
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
-### Removed
-
-- **BREAKING:** Remove `sign` from `TransactionType` ([#4319](https://github.com/MetaMask/core/pull/4319))
-  - This represented an `eth_sign` transaction, but support for that RPC method is being removed, so this is no longer needed.
-
-### Fixed
-
-- Pass an unfrozen transaction to the `afterSign` hook so that it is able to modify the transaction ([#4343](https://github.com/MetaMask/core/pull/4343))
-
 ## [30.0.0]
 
 ### Fixed
@@ -865,8 +846,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@31.0.0...HEAD
-[31.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@30.0.0...@metamask/transaction-controller@31.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@30.0.0...HEAD
 [30.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@29.1.0...@metamask/transaction-controller@30.0.0
 [29.1.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@29.0.2...@metamask/transaction-controller@29.1.0
 [29.0.2]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@29.0.1...@metamask/transaction-controller@29.0.2

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "31.0.0",
+  "version": "30.0.0",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",
@@ -51,9 +51,9 @@
     "@metamask/base-controller": "^5.0.2",
     "@metamask/controller-utils": "^10.0.0",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/gas-fee-controller": "^16.0.0",
+    "@metamask/gas-fee-controller": "^15.1.2",
     "@metamask/metamask-eth-abis": "^3.1.1",
-    "@metamask/network-controller": "^18.1.3",
+    "@metamask/network-controller": "^18.1.2",
     "@metamask/nonce-tracker": "^5.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",
@@ -83,9 +83,9 @@
   },
   "peerDependencies": {
     "@babel/runtime": "^7.23.9",
-    "@metamask/approval-controller": "^6.0.2",
-    "@metamask/gas-fee-controller": "^16.0.0",
-    "@metamask/network-controller": "^18.1.3"
+    "@metamask/approval-controller": "^6.0.0",
+    "@metamask/gas-fee-controller": "^15.0.0",
+    "@metamask/network-controller": "^18.1.2"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -7,25 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0]
-
-### Added
-
-- Add support for "swap+send" transactions ([#4298](https://github.com/MetaMask/core/pull/4298))
-  - Add optional properties `destinationTokenAmount`, `sourceTokenAddress`, `sourceTokenAmount`, `sourceTokenDecimals`, and `swapAndSendRecipient` to `TransactionMeta`
-  - Add `swapAndSend` as a new entry in `TransactionType` enum
-  - When persisting this type of transaction, copy source tokens, destination tokens, and recipient from swap data, and emit `TransactionController:newSwapAndSend` controller event
-
-### Changed
-
-- **BREAKING:** Bump dependency and peer dependency `@metamask/approval-controller` to `^6.0.2` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/gas-fee-controller` to `^16.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/keyring-controller` to `^16.1.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/network-controller` to `^18.1.3` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- **BREAKING:** Bump dependency and peer dependency `@metamask/transaction-controller` to `^31.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- Bump `@metamask/controller-utils` to `^10.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-- Bump `@metamask/polling-controller` to `^7.0.0` ([#4342](https://github.com/MetaMask/core/pull/4342))
-
 ## [10.0.0]
 
 ### Changed
@@ -149,8 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release ([#3749](https://github.com/MetaMask/core/pull/3749))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@11.0.0...HEAD
-[11.0.0]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@10.0.0...@metamask/user-operation-controller@11.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@10.0.0...HEAD
 [10.0.0]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@9.0.0...@metamask/user-operation-controller@10.0.0
 [9.0.0]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@8.0.1...@metamask/user-operation-controller@9.0.0
 [8.0.1]: https://github.com/MetaMask/core/compare/@metamask/user-operation-controller@8.0.0...@metamask/user-operation-controller@8.0.1

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/user-operation-controller",
-  "version": "11.0.0",
+  "version": "10.0.0",
   "description": "Creates user operations and manages their life cycle",
   "keywords": [
     "MetaMask",
@@ -46,12 +46,12 @@
     "@metamask/base-controller": "^5.0.2",
     "@metamask/controller-utils": "^10.0.0",
     "@metamask/eth-query": "^4.0.0",
-    "@metamask/gas-fee-controller": "^16.0.0",
-    "@metamask/keyring-controller": "^16.1.0",
-    "@metamask/network-controller": "^18.1.3",
-    "@metamask/polling-controller": "^7.0.0",
+    "@metamask/gas-fee-controller": "^15.1.2",
+    "@metamask/keyring-controller": "^16.0.0",
+    "@metamask/network-controller": "^18.1.2",
+    "@metamask/polling-controller": "^6.0.2",
     "@metamask/rpc-errors": "^6.2.1",
-    "@metamask/transaction-controller": "^31.0.0",
+    "@metamask/transaction-controller": "^30.0.0",
     "@metamask/utils": "^8.3.0",
     "bn.js": "^5.2.1",
     "immer": "^9.0.6",
@@ -70,11 +70,11 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@metamask/approval-controller": "^6.0.2",
-    "@metamask/gas-fee-controller": "^16.0.0",
-    "@metamask/keyring-controller": "^16.1.0",
-    "@metamask/network-controller": "^18.1.3",
-    "@metamask/transaction-controller": "^31.0.0"
+    "@metamask/approval-controller": "^6.0.0",
+    "@metamask/gas-fee-controller": "^15.0.0",
+    "@metamask/keyring-controller": "^16.0.0",
+    "@metamask/network-controller": "^18.1.2",
+    "@metamask/transaction-controller": "^30.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1609,7 +1609,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/accounts-controller@^15.0.0, @metamask/accounts-controller@workspace:packages/accounts-controller":
+"@metamask/accounts-controller@^14.0.0, @metamask/accounts-controller@workspace:packages/accounts-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/accounts-controller@workspace:packages/accounts-controller"
   dependencies:
@@ -1618,7 +1618,7 @@ __metadata:
     "@metamask/base-controller": ^5.0.2
     "@metamask/eth-snap-keyring": ^4.1.1
     "@metamask/keyring-api": ^6.1.1
-    "@metamask/keyring-controller": ^16.1.0
+    "@metamask/keyring-controller": ^16.0.0
     "@metamask/snaps-controllers": ^8.1.1
     "@metamask/snaps-sdk": ^4.2.0
     "@metamask/snaps-utils": ^7.4.0
@@ -1635,7 +1635,7 @@ __metadata:
     typescript: ~4.9.5
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/keyring-controller": ^16.1.0
+    "@metamask/keyring-controller": ^16.0.0
     "@metamask/snaps-controllers": ^8.1.1
   languageName: unknown
   linkType: soft
@@ -1715,7 +1715,7 @@ __metadata:
     "@ethersproject/contracts": ^5.7.0
     "@ethersproject/providers": ^5.7.0
     "@metamask/abi-utils": ^2.0.2
-    "@metamask/accounts-controller": ^15.0.0
+    "@metamask/accounts-controller": ^14.0.0
     "@metamask/approval-controller": ^6.0.2
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.2
@@ -1724,11 +1724,11 @@ __metadata:
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.3.0
     "@metamask/keyring-api": ^6.1.1
-    "@metamask/keyring-controller": ^16.1.0
+    "@metamask/keyring-controller": ^16.0.0
     "@metamask/metamask-eth-abis": ^3.1.1
-    "@metamask/network-controller": ^18.1.3
-    "@metamask/polling-controller": ^7.0.0
-    "@metamask/preferences-controller": ^12.0.0
+    "@metamask/network-controller": ^18.1.2
+    "@metamask/polling-controller": ^6.0.2
+    "@metamask/preferences-controller": ^11.0.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
     "@types/bn.js": ^5.1.5
@@ -1753,11 +1753,11 @@ __metadata:
     typescript: ~4.9.5
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/accounts-controller": ^15.0.0
-    "@metamask/approval-controller": ^6.0.2
-    "@metamask/keyring-controller": ^16.1.0
-    "@metamask/network-controller": ^18.1.3
-    "@metamask/preferences-controller": ^12.0.0
+    "@metamask/accounts-controller": ^14.0.0
+    "@metamask/approval-controller": ^6.0.0
+    "@metamask/keyring-controller": ^16.0.0
+    "@metamask/network-controller": ^18.1.2
+    "@metamask/preferences-controller": ^11.0.0
   languageName: unknown
   linkType: soft
 
@@ -2000,7 +2000,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.2
     "@metamask/controller-utils": ^10.0.0
-    "@metamask/network-controller": ^18.1.3
+    "@metamask/network-controller": ^18.1.2
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
@@ -2011,7 +2011,7 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.9.5
   peerDependencies:
-    "@metamask/network-controller": ^18.1.3
+    "@metamask/network-controller": ^18.1.2
   languageName: unknown
   linkType: soft
 
@@ -2304,7 +2304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gas-fee-controller@^16.0.0, @metamask/gas-fee-controller@workspace:packages/gas-fee-controller":
+"@metamask/gas-fee-controller@^15.1.2, @metamask/gas-fee-controller@workspace:packages/gas-fee-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/gas-fee-controller@workspace:packages/gas-fee-controller"
   dependencies:
@@ -2313,8 +2313,8 @@ __metadata:
     "@metamask/controller-utils": ^10.0.0
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-unit": ^0.3.0
-    "@metamask/network-controller": ^18.1.3
-    "@metamask/polling-controller": ^7.0.0
+    "@metamask/network-controller": ^18.1.2
+    "@metamask/polling-controller": ^6.0.2
     "@metamask/utils": ^8.3.0
     "@types/bn.js": ^5.1.5
     "@types/jest": ^27.4.1
@@ -2331,7 +2331,7 @@ __metadata:
     typescript: ~4.9.5
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/network-controller": ^18.1.3
+    "@metamask/network-controller": ^18.1.2
   languageName: unknown
   linkType: soft
 
@@ -2417,7 +2417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-controller@^16.1.0, @metamask/keyring-controller@workspace:packages/keyring-controller":
+"@metamask/keyring-controller@^16.0.0, @metamask/keyring-controller@workspace:packages/keyring-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-controller@workspace:packages/keyring-controller"
   dependencies:
@@ -2434,7 +2434,7 @@ __metadata:
     "@metamask/eth-sig-util": ^7.0.1
     "@metamask/eth-simple-keyring": ^6.0.1
     "@metamask/keyring-api": ^6.1.1
-    "@metamask/message-manager": ^9.0.0
+    "@metamask/message-manager": ^8.0.2
     "@metamask/scure-bip39": ^2.1.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2453,7 +2453,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/logging-controller@^4.0.0, @metamask/logging-controller@workspace:packages/logging-controller":
+"@metamask/logging-controller@^3.0.1, @metamask/logging-controller@workspace:packages/logging-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/logging-controller@workspace:packages/logging-controller"
   dependencies:
@@ -2471,7 +2471,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/message-manager@^9.0.0, @metamask/message-manager@workspace:packages/message-manager":
+"@metamask/message-manager@^8.0.2, @metamask/message-manager@workspace:packages/message-manager":
   version: 0.0.0-use.local
   resolution: "@metamask/message-manager@workspace:packages/message-manager"
   dependencies:
@@ -2519,7 +2519,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/network-controller@^18.1.3, @metamask/network-controller@workspace:packages/network-controller":
+"@metamask/network-controller@^18.1.2, @metamask/network-controller@workspace:packages/network-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/network-controller@workspace:packages/network-controller"
   dependencies:
@@ -2615,7 +2615,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@^9.0.2, @metamask/permission-controller@^9.1.1, @metamask/permission-controller@workspace:packages/permission-controller":
+"@metamask/permission-controller@^9.0.2, @metamask/permission-controller@^9.1.0, @metamask/permission-controller@workspace:packages/permission-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/permission-controller@workspace:packages/permission-controller"
   dependencies:
@@ -2685,14 +2685,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/polling-controller@^7.0.0, @metamask/polling-controller@workspace:packages/polling-controller":
+"@metamask/polling-controller@^6.0.2, @metamask/polling-controller@workspace:packages/polling-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/polling-controller@workspace:packages/polling-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.2
     "@metamask/controller-utils": ^10.0.0
-    "@metamask/network-controller": ^18.1.3
+    "@metamask/network-controller": ^18.1.2
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     "@types/uuid": ^8.3.0
@@ -2706,7 +2706,7 @@ __metadata:
     typescript: ~4.9.5
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/network-controller": ^18.1.3
+    "@metamask/network-controller": ^18.1.2
   languageName: unknown
   linkType: soft
 
@@ -2720,14 +2720,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/preferences-controller@^12.0.0, @metamask/preferences-controller@workspace:packages/preferences-controller":
+"@metamask/preferences-controller@^11.0.0, @metamask/preferences-controller@workspace:packages/preferences-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/preferences-controller@workspace:packages/preferences-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.2
     "@metamask/controller-utils": ^10.0.0
-    "@metamask/keyring-controller": ^16.1.0
+    "@metamask/keyring-controller": ^16.0.0
     "@types/jest": ^27.4.1
     deepmerge: ^4.2.2
     jest: ^27.5.1
@@ -2790,9 +2790,9 @@ __metadata:
     "@metamask/base-controller": ^5.0.2
     "@metamask/controller-utils": ^10.0.0
     "@metamask/json-rpc-engine": ^8.0.2
-    "@metamask/network-controller": ^18.1.3
+    "@metamask/network-controller": ^18.1.2
     "@metamask/rpc-errors": ^6.2.1
-    "@metamask/selected-network-controller": ^14.0.0
+    "@metamask/selected-network-controller": ^13.0.0
     "@metamask/swappable-obj-proxy": ^2.2.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2807,8 +2807,8 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.9.5
   peerDependencies:
-    "@metamask/network-controller": ^18.1.3
-    "@metamask/selected-network-controller": ^14.0.0
+    "@metamask/network-controller": ^18.1.2
+    "@metamask/selected-network-controller": ^13.0.0
   languageName: unknown
   linkType: soft
 
@@ -2857,15 +2857,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/selected-network-controller@^14.0.0, @metamask/selected-network-controller@workspace:packages/selected-network-controller":
+"@metamask/selected-network-controller@^13.0.0, @metamask/selected-network-controller@workspace:packages/selected-network-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/selected-network-controller@workspace:packages/selected-network-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.2
     "@metamask/json-rpc-engine": ^8.0.2
-    "@metamask/network-controller": ^18.1.3
-    "@metamask/permission-controller": ^9.1.1
+    "@metamask/network-controller": ^18.1.2
+    "@metamask/permission-controller": ^9.1.0
     "@metamask/swappable-obj-proxy": ^2.2.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2880,8 +2880,8 @@ __metadata:
     typedoc-plugin-missing-exports: ^2.0.0
     typescript: ~4.9.5
   peerDependencies:
-    "@metamask/network-controller": ^18.1.3
-    "@metamask/permission-controller": ^9.1.1
+    "@metamask/network-controller": ^18.1.2
+    "@metamask/permission-controller": ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -2893,9 +2893,9 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^5.0.2
     "@metamask/controller-utils": ^10.0.0
-    "@metamask/keyring-controller": ^16.1.0
-    "@metamask/logging-controller": ^4.0.0
-    "@metamask/message-manager": ^9.0.0
+    "@metamask/keyring-controller": ^16.0.0
+    "@metamask/logging-controller": ^3.0.1
+    "@metamask/message-manager": ^8.0.2
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
@@ -2908,8 +2908,8 @@ __metadata:
     typescript: ~4.9.5
   peerDependencies:
     "@metamask/approval-controller": ^6.0.0
-    "@metamask/keyring-controller": ^16.1.0
-    "@metamask/logging-controller": ^4.0.0
+    "@metamask/keyring-controller": ^16.0.0
+    "@metamask/logging-controller": ^3.0.0
   languageName: unknown
   linkType: soft
 
@@ -3036,7 +3036,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@^31.0.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
+"@metamask/transaction-controller@^30.0.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/transaction-controller@workspace:packages/transaction-controller"
   dependencies:
@@ -3053,9 +3053,9 @@ __metadata:
     "@metamask/controller-utils": ^10.0.0
     "@metamask/eth-query": ^4.0.0
     "@metamask/ethjs-provider-http": ^0.3.0
-    "@metamask/gas-fee-controller": ^16.0.0
+    "@metamask/gas-fee-controller": ^15.1.2
     "@metamask/metamask-eth-abis": ^3.1.1
-    "@metamask/network-controller": ^18.1.3
+    "@metamask/network-controller": ^18.1.2
     "@metamask/nonce-tracker": ^5.0.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
@@ -3079,9 +3079,9 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     "@babel/runtime": ^7.23.9
-    "@metamask/approval-controller": ^6.0.2
-    "@metamask/gas-fee-controller": ^16.0.0
-    "@metamask/network-controller": ^18.1.3
+    "@metamask/approval-controller": ^6.0.0
+    "@metamask/gas-fee-controller": ^15.0.0
+    "@metamask/network-controller": ^18.1.2
   languageName: unknown
   linkType: soft
 
@@ -3094,12 +3094,12 @@ __metadata:
     "@metamask/base-controller": ^5.0.2
     "@metamask/controller-utils": ^10.0.0
     "@metamask/eth-query": ^4.0.0
-    "@metamask/gas-fee-controller": ^16.0.0
-    "@metamask/keyring-controller": ^16.1.0
-    "@metamask/network-controller": ^18.1.3
-    "@metamask/polling-controller": ^7.0.0
+    "@metamask/gas-fee-controller": ^15.1.2
+    "@metamask/keyring-controller": ^16.0.0
+    "@metamask/network-controller": ^18.1.2
+    "@metamask/polling-controller": ^6.0.2
     "@metamask/rpc-errors": ^6.2.1
-    "@metamask/transaction-controller": ^31.0.0
+    "@metamask/transaction-controller": ^30.0.0
     "@metamask/utils": ^8.3.0
     "@types/jest": ^27.4.1
     bn.js: ^5.2.1
@@ -3114,11 +3114,11 @@ __metadata:
     typescript: ~4.9.5
     uuid: ^8.3.2
   peerDependencies:
-    "@metamask/approval-controller": ^6.0.2
-    "@metamask/gas-fee-controller": ^16.0.0
-    "@metamask/keyring-controller": ^16.1.0
-    "@metamask/network-controller": ^18.1.3
-    "@metamask/transaction-controller": ^31.0.0
+    "@metamask/approval-controller": ^6.0.0
+    "@metamask/gas-fee-controller": ^15.0.0
+    "@metamask/keyring-controller": ^16.0.0
+    "@metamask/network-controller": ^18.1.2
+    "@metamask/transaction-controller": ^30.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This reverts commit c2e675256a5dc7f5b73e23f58867e8f29098f689.

We need to redo this release because the version set in `package.json` was wrong and therefore the release did not go out. 🤦🏻 