### PR TITLE
TokensController: providerConfig -> selectedNetworkClientId

### DIFF
--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -11,14 +11,11 @@ import {
   ChainId,
   ORIGIN_METAMASK,
   convertHexToDecimal,
-  NetworkType,
-  toHex,
-  NetworksTicker,
+  InfuraNetworkType,
 } from '@metamask/controller-utils';
 import type {
   NetworkClientConfiguration,
   NetworkClientId,
-  ProviderConfig,
 } from '@metamask/network-controller';
 import { defaultState as defaultNetworkState } from '@metamask/network-controller';
 import type { PreferencesState } from '@metamask/preferences-controller';
@@ -60,17 +57,6 @@ const ContractMock = jest.mocked(Contract);
 const uuidV1Mock = jest.mocked(uuidV1);
 const ERC20StandardMock = jest.mocked(ERC20Standard);
 const ERC1155StandardMock = jest.mocked(ERC1155Standard);
-
-const SEPOLIA = {
-  chainId: toHex(11155111),
-  type: NetworkType.sepolia,
-  ticker: NetworksTicker.sepolia,
-};
-const GOERLI = {
-  chainId: toHex(5),
-  type: NetworkType.goerli,
-  ticker: NetworksTicker.goerli,
-};
 
 describe('TokensController', () => {
   beforeEach(() => {
@@ -321,17 +307,17 @@ describe('TokensController', () => {
 
   it('should add token by network', async () => {
     await withController(async ({ controller, changeNetwork }) => {
-      changeNetwork(SEPOLIA);
+      changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
       await controller.addToken({
         address: '0x01',
         symbol: 'bar',
         decimals: 2,
       });
 
-      changeNetwork(GOERLI);
+      changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
       expect(controller.state.tokens).toHaveLength(0);
 
-      changeNetwork(SEPOLIA);
+      changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
       expect(controller.state.tokens[0]).toStrictEqual({
         address: '0x01',
         decimals: 2,
@@ -472,13 +458,13 @@ describe('TokensController', () => {
       ContractMock.mockReturnValue(
         buildMockEthersERC721Contract({ supportsInterface: false }),
       );
-      changeNetwork(SEPOLIA);
+      changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
       await controller.addToken({
         address: '0x02',
         symbol: 'baz',
         decimals: 2,
       });
-      changeNetwork(GOERLI);
+      changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
       await controller.addToken({
         address: '0x01',
         symbol: 'bar',
@@ -488,7 +474,7 @@ describe('TokensController', () => {
       controller.ignoreTokens(['0x01']);
       expect(controller.state.tokens).toHaveLength(0);
 
-      changeNetwork(SEPOLIA);
+      changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
       expect(controller.state.tokens[0]).toStrictEqual({
         address: '0x02',
         decimals: 2,
@@ -544,7 +530,7 @@ describe('TokensController', () => {
             ...getDefaultPreferencesState(),
             selectedAddress,
           });
-          changeNetwork(SEPOLIA);
+          changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
           await controller.addToken({
             address: '0x01',
             symbol: 'bar',
@@ -591,7 +577,7 @@ describe('TokensController', () => {
             ...getDefaultPreferencesState(),
             selectedAddress,
           });
-          changeNetwork(SEPOLIA);
+          changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
           await controller.addToken({
             address: '0x01',
             symbol: 'bar',
@@ -629,7 +615,7 @@ describe('TokensController', () => {
             ...getDefaultPreferencesState(),
             selectedAddress: selectedAddress1,
           });
-          changeNetwork(SEPOLIA);
+          changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
           await controller.addToken({
             address: '0x01',
             symbol: 'bar',
@@ -641,7 +627,7 @@ describe('TokensController', () => {
           expect(controller.state.tokens).toHaveLength(0);
           expect(controller.state.ignoredTokens).toStrictEqual(['0x01']);
 
-          changeNetwork(GOERLI);
+          changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
           expect(controller.state.ignoredTokens).toHaveLength(0);
 
           await controller.addToken({
@@ -903,7 +889,7 @@ describe('TokensController', () => {
             symbol: 'LINK',
             decimals: 18,
           });
-          changeNetwork(GOERLI);
+          changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
 
           await expect(addTokenPromise).rejects.toThrow(
             'TokensController Error: Switched networks while adding token',
@@ -992,9 +978,12 @@ describe('TokensController', () => {
           );
 
           // The currently configured chain + address
-          const CONFIGURED_CHAIN = SEPOLIA;
+          const CONFIGURED_CHAIN = ChainId.sepolia;
+          const CONFIGURED_NETWORK_CLIENT_ID = InfuraNetworkType.sepolia;
           const CONFIGURED_ADDRESS = '0xConfiguredAddress';
-          changeNetwork(CONFIGURED_CHAIN);
+          changeNetwork({
+            selectedNetworkClientId: CONFIGURED_NETWORK_CLIENT_ID,
+          });
           triggerPreferencesStateChange({
             ...getDefaultPreferencesState(),
             selectedAddress: CONFIGURED_ADDRESS,
@@ -1046,12 +1035,12 @@ describe('TokensController', () => {
 
             // Expect tokens under the correct chain + account
             expect(controller.state.allTokens).toStrictEqual({
-              [CONFIGURED_CHAIN.chainId]: {
+              [CONFIGURED_CHAIN]: {
                 [CONFIGURED_ADDRESS]: [addedTokenConfiguredAccount],
               },
             });
             expect(controller.state.allDetectedTokens).toStrictEqual({
-              [CONFIGURED_CHAIN.chainId]: {
+              [CONFIGURED_CHAIN]: {
                 [CONFIGURED_ADDRESS]: [detectedTokenConfiguredAccount],
               },
               [OTHER_CHAIN]: {
@@ -1939,7 +1928,7 @@ describe('TokensController', () => {
           buildMockEthersERC721Contract({ supportsInterface: false }),
         );
 
-        changeNetwork(SEPOLIA);
+        changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
         await controller.addToken({
           address: '0x01',
           symbol: 'A',
@@ -1952,7 +1941,7 @@ describe('TokensController', () => {
         });
         const initialTokensFirst = controller.state.tokens;
 
-        changeNetwork(GOERLI);
+        changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
         await controller.addToken({
           address: '0x03',
           symbol: 'C',
@@ -2009,10 +1998,10 @@ describe('TokensController', () => {
           },
         ]);
 
-        changeNetwork(SEPOLIA);
+        changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
         expect(initialTokensFirst).toStrictEqual(controller.state.tokens);
 
-        changeNetwork(GOERLI);
+        changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
         expect(initialTokensSecond).toStrictEqual(controller.state.tokens);
       });
     });
@@ -2179,7 +2168,9 @@ type WithControllerCallback<ReturnValue> = ({
   triggerPreferencesStateChange,
 }: {
   controller: TokensController;
-  changeNetwork: (providerConfig: ProviderConfig) => void;
+  changeNetwork: (networkControllerState: {
+    selectedNetworkClientId: NetworkClientId;
+  }) => void;
   messenger: UnrestrictedMessenger;
   approvalController: ApprovalController;
   triggerPreferencesStateChange: (state: PreferencesState) => void;
@@ -2259,10 +2250,14 @@ async function withController<ReturnValue>(
     messenger.publish('PreferencesController:stateChange', state, []);
   };
 
-  const changeNetwork = (providerConfig: ProviderConfig) => {
+  const changeNetwork = ({
+    selectedNetworkClientId,
+  }: {
+    selectedNetworkClientId: NetworkClientId;
+  }) => {
     messenger.publish('NetworkController:networkDidChange', {
       ...defaultNetworkState,
-      providerConfig,
+      selectedNetworkClientId,
     });
   };
 

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -260,11 +260,16 @@ export class TokensController extends BaseController<
    * Handles the event when the network changes.
    *
    * @param networkState - The changed network state.
-   * @param networkState.providerConfig - RPC URL and network name provider settings of the currently connected network
+   * @param networkState.selectedNetworkClientId - The ID of the currently
+   * selected network client.
    */
-  #onNetworkDidChange({ providerConfig }: NetworkState) {
+  #onNetworkDidChange({ selectedNetworkClientId }: NetworkState) {
+    const selectedNetworkClient = this.messagingSystem.call(
+      'NetworkController:getNetworkClientById',
+      selectedNetworkClientId,
+    );
     const { allTokens, allIgnoredTokens, allDetectedTokens } = this.state;
-    const { chainId } = providerConfig;
+    const { chainId } = selectedNetworkClient.configuration;
     this.#abortController.abort();
     this.#abortController = new AbortController();
     this.#chainId = chainId;


### PR DESCRIPTION


## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

The `providerConfig` state property is being removed from NetworkController. Currently this property is used in TokensController to get the currently selected chain, but `selectedNetworkClientId` can be used instead. This commit makes that transition so that we can fully drop `providerConfig`.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

Progresses #4185.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

(There should be no functional changes, so no changelog updates are needed.)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
