### PR TITLE
fix: remove setting new account as the last selected account

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -839,6 +839,50 @@ describe('AccountsController', () => {
 
         expect(selectedAccount).toBe('');
       });
+
+      it('selectedAccount remains the same after adding a new account', async () => {
+        const messenger = buildMessenger();
+        mockUUID
+          .mockReturnValueOnce('mock-id') // call to check if its a new account
+          .mockReturnValueOnce('mock-id2') // call to check if its a new account
+          .mockReturnValueOnce('mock-id2'); // call to add account
+
+        const mockNewKeyringState = {
+          isUnlocked: true,
+          keyrings: [
+            {
+              type: KeyringTypes.hd,
+              accounts: [mockAccount.address, mockAccount2.address],
+            },
+          ],
+        };
+        const { accountsController } = setupAccountsController({
+          initialState: {
+            internalAccounts: {
+              accounts: {
+                [mockAccount.id]: mockAccount,
+                [mockAccount3.id]: mockAccount3,
+              },
+              selectedAccount: mockAccount.id,
+            },
+          },
+          messenger,
+        });
+
+        messenger.publish(
+          'KeyringController:stateChange',
+          mockNewKeyringState,
+          [],
+        );
+
+        const accounts = accountsController.listAccounts();
+
+        expect(accounts).toStrictEqual([
+          mockAccount,
+          setLastSelectedAsAny(mockAccount2),
+        ]);
+        expect(accountsController.getSelectedAccount().id).toBe(mockAccount.id);
+      });
     });
 
     describe('deleting account', () => {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -922,14 +922,12 @@ export class AccountsController extends BaseController<
           ...newAccount.metadata,
           name: accountName,
           importTime: Date.now(),
-          lastSelected: Date.now(),
+          lastSelected: 0,
         },
       };
 
       return newState;
     });
-
-    this.setSelectedAccount(newAccount.id);
   }
 
   /**


### PR DESCRIPTION
## Explanation

This PR remove the setting of a newly added account as the last selected account. 

## References

Related: https://github.com/MetaMask/metamask-mobile/pull/9764

## Changelog

### `@metamask/accounts-controller`

- **CHANGED**: Newly added account is no longer set as the last selected account.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
