### PR TITLE
fix: use listMultichainAccount in getAccountByAddress

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -2318,7 +2318,7 @@ describe('AccountsController', () => {
       expect(account).toBeUndefined();
     });
 
-    it('return a nonevm account by address', async () => {
+    it('returns a non-EVM account by address', async () => {
       const mockNonEvmAccount = createExpectedInternalAccount({
         id: 'mock-non-evm',
         name: 'non-evm',

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -2317,6 +2317,33 @@ describe('AccountsController', () => {
 
       expect(account).toBeUndefined();
     });
+
+    it('return a nonevm account by address', async () => {
+      const mockNonEvmAccount = createExpectedInternalAccount({
+        id: 'mock-non-evm',
+        name: 'non-evm',
+        address: 'bc1qzqc2aqlw8nwa0a05ehjkk7dgt8308ac7kzw9a6',
+        keyringType: KeyringTypes.snap,
+        type: BtcAccountType.P2wpkh,
+      });
+      const { accountsController } = setupAccountsController({
+        initialState: {
+          internalAccounts: {
+            accounts: {
+              [mockAccount.id]: mockAccount,
+              [mockNonEvmAccount.id]: mockNonEvmAccount,
+            },
+            selectedAccount: mockAccount.id,
+          },
+        },
+      });
+
+      const account = accountsController.getAccountByAddress(
+        mockNonEvmAccount.address,
+      );
+
+      expect(account).toStrictEqual(mockNonEvmAccount);
+    });
   });
 
   describe('actions', () => {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -349,7 +349,7 @@ export class AccountsController extends BaseController<
    * @returns The account with the specified address, or undefined if not found.
    */
   getAccountByAddress(address: string): InternalAccount | undefined {
-    return this.listAccounts().find(
+    return this.listMultichainAccounts().find(
       (account) => account.address.toLowerCase() === address.toLowerCase(),
     );
   }


### PR DESCRIPTION
## Explanation

This PR fixes the issue where getAccountByAddress doesn't retrieve non evm accounts.

## References

## Changelog

### `@metamask/accounts-controller`

- **FIXED**: `getAccountByAddress` now also consider non-EVM accounts.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
