### PR TITLE
feat: add mantle to price api supported chains

### DIFF
--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -215,6 +215,8 @@ export const SUPPORTED_CHAIN_IDS = [
   '0x504',
   // Moonriver
   '0x505',
+  // Mantle
+  '0x1388',
   // Base
   '0x2105',
   // Shiden


### PR DESCRIPTION
## Explanation

The price API added support for mantle network.  Adding it here too.

## References

https://github.com/consensys-vertical-apps/va-mmcx-price-api/pull/302

### `@metamask/assets-controllers`

- **ADDED**: Token price API support for mantle network

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
