### PR TITLE
[TokenRatesController] - Keep addresses in checksum format

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -555,7 +555,7 @@ export class TokenRatesController extends StaticIntervalPollingControllerV1<
       (obj, [tokenAddress, token]) => {
         obj = {
           ...obj,
-          [tokenAddress.toLowerCase()]: { ...token },
+          [tokenAddress]: { ...token },
         };
 
         return obj;


### PR DESCRIPTION
## Explanation

When adding market data for tokens in https://github.com/MetaMask/core/pull/4206, it also changed the token addresses to be lowercased instead of checksum.  This PR moves it back to the checksum format, since some places on the client expected it.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **CHANGED**: Token rates controller uses checksum instead of lowercase format for token addresses

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
