### PR TITLE
Restore ESLint warnings as errors (ignoring them for now)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,19 +48,13 @@ module.exports = {
         // TODO: auto-fix breaks stuff
         '@typescript-eslint/promise-function-async': 'off',
 
-        // TODO: re-enble most of these rules
-        '@typescript-eslint/await-thenable': 'warn',
-        '@typescript-eslint/naming-convention': 'off',
-        '@typescript-eslint/no-floating-promises': 'warn',
-        '@typescript-eslint/no-misused-promises': 'warn',
+        // TODO: re-enable most of these rules
         '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         '@typescript-eslint/unbound-method': 'off',
         '@typescript-eslint/prefer-enum-initializers': 'off',
         '@typescript-eslint/prefer-nullish-coalescing': 'off',
         '@typescript-eslint/prefer-optional-chain': 'off',
         '@typescript-eslint/prefer-reduce-type-parameter': 'off',
-        '@typescript-eslint/restrict-plus-operands': 'warn',
-        '@typescript-eslint/restrict-template-expressions': 'warn',
         'no-restricted-syntax': 'off',
         'no-restricted-globals': 'off',
       },

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -189,7 +189,11 @@ function createExpectedInternalAccount({
 }): InternalAccount {
   const accountTypeToMethods = {
     [`${EthAccountType.Eoa}`]: [...Object.values(ETH_EOA_METHODS)],
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     [`${EthAccountType.Erc4337}`]: [...Object.values(ETH_ERC_4337_METHODS)],
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     [`${BtcAccountType.P2wpkh}`]: [...Object.values(BtcMethod)],
   };
 

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -948,6 +948,8 @@ export class AccountsController extends BaseController<
    * @param metadataKey - The key of the metadata to retrieve.
    * @returns The value of the specified metadata key, or undefined if the account or metadata key does not exist.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   #populateExistingMetadata<T extends keyof InternalAccount['metadata']>(
     accountId: string,
     metadataKey: T,

--- a/packages/address-book-controller/src/AddressBookController.ts
+++ b/packages/address-book-controller/src/AddressBookController.ts
@@ -27,8 +27,14 @@ export interface ContactEntry {
 }
 
 export enum AddressType {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   externallyOwnedAccounts = 'EXTERNALLY_OWNED_ACCOUNTS',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   contractAccounts = 'CONTRACT_ACCOUNTS',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   nonAccounts = 'NON_ACCOUNTS',
 }
 

--- a/packages/approval-controller/src/ApprovalController.test.ts
+++ b/packages/approval-controller/src/ApprovalController.test.ts
@@ -740,12 +740,16 @@ describe('approval controller', () => {
     });
 
     it('returns true for existing entry by origin', () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: TYPE });
 
       expect(approvalController.has({ origin: 'bar.baz' })).toBe(true);
     });
 
     it('returns true for existing entry by origin and type', () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' });
 
       expect(
@@ -754,24 +758,32 @@ describe('approval controller', () => {
     });
 
     it('returns true for existing type', () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' });
 
       expect(approvalController.has({ type: 'myType' })).toBe(true);
     });
 
     it('returns false for non-existing entry by id', () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: TYPE });
 
       expect(approvalController.has({ id: 'fizz' })).toBe(false);
     });
 
     it('returns false for non-existing entry by origin', () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: TYPE });
 
       expect(approvalController.has({ origin: 'fizz.buzz' })).toBe(false);
     });
 
     it('returns false for non-existing entry by existing origin and non-existing type', () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: TYPE });
 
       expect(
@@ -780,6 +792,8 @@ describe('approval controller', () => {
     });
 
     it('returns false for non-existing entry by non-existing origin and existing type', () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' });
 
       expect(
@@ -788,6 +802,8 @@ describe('approval controller', () => {
     });
 
     it('returns false for non-existing entry by type', () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType1' });
 
       expect(approvalController.has({ type: 'myType2' })).toBe(false);
@@ -801,6 +817,8 @@ describe('approval controller', () => {
         origin: 'bar.baz',
         type: 'myType',
       });
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept('foo', 'success');
 
       const result = await approvalPromise;
@@ -819,11 +837,15 @@ describe('approval controller', () => {
         type: 'myType2',
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept('foo2', 'success2');
 
       let result = await approvalPromise2;
       expect(result).toBe('success2');
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept('foo1', 'success1');
 
       result = await approvalPromise1;
@@ -886,6 +908,8 @@ describe('approval controller', () => {
         expectsResult: true,
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept(ID_MOCK, VALUE_MOCK);
 
       expect(await approvalPromise).toStrictEqual({
@@ -895,6 +919,8 @@ describe('approval controller', () => {
     });
 
     it('throws if accept wants to wait but request does not expect result', async () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({
         id: ID_MOCK,
         origin: ORIGIN_MOCK,
@@ -909,8 +935,12 @@ describe('approval controller', () => {
     });
 
     it('deletes entry', () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'type' });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept('foo');
 
       expect(
@@ -922,9 +952,15 @@ describe('approval controller', () => {
     });
 
     it('deletes one entry out of many without side-effects', () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'type1' });
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({ id: 'fizz', origin: 'bar.baz', type: 'type2' });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept('fizz');
 
       expect(
@@ -1034,6 +1070,8 @@ describe('approval controller', () => {
         type: 'myType4',
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept('foo2', 'success2');
 
       let result = await promise2;
@@ -1048,6 +1086,8 @@ describe('approval controller', () => {
       expect(approvalController.has({ origin: 'fizz.buzz' })).toBe(false);
       expect(approvalController.has({ origin: 'bar.baz' })).toBe(true);
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept('foo1', 'success1');
 
       result = await promise1;
@@ -1154,6 +1194,8 @@ describe('approval controller', () => {
         showApprovalRequest,
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       messenger.call(
         'ApprovalController:addRequest',
         { id: 'foo', origin: 'bar.baz', type: TYPE },
@@ -1178,6 +1220,8 @@ describe('approval controller', () => {
         showApprovalRequest,
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       messenger.call(
         'ApprovalController:addRequest',
         { id: 'foo', origin: 'bar.baz', type: TYPE },
@@ -1202,6 +1246,8 @@ describe('approval controller', () => {
         showApprovalRequest,
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.add({
         id: 'foo',
         origin: 'bar.baz',
@@ -1375,6 +1421,8 @@ describe('approval controller', () => {
         approvalController.state[PENDING_APPROVALS_STORE_KEY],
       )[0].id;
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept(resultRequestId);
       await promise;
 
@@ -1391,9 +1439,13 @@ describe('approval controller', () => {
     async function doesNotThrowIfAddingRequestFails(
       methodCallback: () => Promise<unknown>,
     ) {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       methodCallback();
 
       // Second call will fail as mocked nanoid will generate the same ID.
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       methodCallback();
 
       expect(console.info).toHaveBeenCalledTimes(1);
@@ -1419,6 +1471,8 @@ describe('approval controller', () => {
         approvalController.state[PENDING_APPROVALS_STORE_KEY],
       )[0].id;
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept(resultRequestId);
       await promise;
 
@@ -1431,11 +1485,15 @@ describe('approval controller', () => {
 
     describe('success', () => {
       it('adds request with result success approval type', async () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         approvalController.success(SUCCESS_OPTIONS_MOCK);
         expectRequestAdded(APPROVAL_TYPE_RESULT_SUCCESS, SUCCESS_OPTIONS_MOCK);
       });
 
       it('adds request with no options', async () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         approvalController.success();
 
         expectRequestAdded(APPROVAL_TYPE_RESULT_SUCCESS, {
@@ -1447,6 +1505,8 @@ describe('approval controller', () => {
       });
 
       it('only includes relevant options in request data', async () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         approvalController.success({
           ...SUCCESS_OPTIONS_MOCK,
           extra: 'testValue',
@@ -1460,6 +1520,8 @@ describe('approval controller', () => {
       });
 
       it('shows approval request', async () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         approvalController.success(SUCCESS_OPTIONS_MOCK);
         expect(showApprovalRequest).toHaveBeenCalledTimes(1);
       });
@@ -1474,6 +1536,8 @@ describe('approval controller', () => {
       });
 
       it('does not throw if adding request fails', async () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         doesNotThrowIfAddingRequestFails(() =>
           approvalController.success(SUCCESS_OPTIONS_MOCK),
         );
@@ -1491,11 +1555,15 @@ describe('approval controller', () => {
 
     describe('error', () => {
       it('adds request with result error approval type', async () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         approvalController.error(ERROR_OPTIONS_MOCK);
         expectRequestAdded(APPROVAL_TYPE_RESULT_ERROR, ERROR_OPTIONS_MOCK);
       });
 
       it('adds request with no options', async () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         approvalController.error();
 
         expectRequestAdded(APPROVAL_TYPE_RESULT_ERROR, {
@@ -1507,6 +1575,8 @@ describe('approval controller', () => {
       });
 
       it('only includes relevant options in request data', async () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         approvalController.error({
           ...ERROR_OPTIONS_MOCK,
           extra: 'testValue',
@@ -1520,6 +1590,8 @@ describe('approval controller', () => {
       });
 
       it('shows approval request', async () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         approvalController.error(ERROR_OPTIONS_MOCK);
         expect(showApprovalRequest).toHaveBeenCalledTimes(1);
       });
@@ -1534,6 +1606,8 @@ describe('approval controller', () => {
       });
 
       it('does not throw if adding request fails', async () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         doesNotThrowIfAddingRequestFails(() =>
           approvalController.error(ERROR_OPTIONS_MOCK),
         );

--- a/packages/approval-controller/src/ApprovalController.ts
+++ b/packages/approval-controller/src/ApprovalController.ts
@@ -379,6 +379,8 @@ export class ApprovalController extends BaseController<
 
     this.#approvals = new Map();
     this.#origins = new Map();
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.#showApprovalRequest = showApprovalRequest;
     this.#typesExcludedFromRateLimiting = typesExcludedFromRateLimiting;
     this.registerMessageHandlers();
@@ -590,6 +592,8 @@ export class ApprovalController extends BaseController<
     if (origin) {
       return Array.from(
         (this.#origins.get(origin) || new Map()).values(),
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
       ).reduce((total, value) => total + value, 0);
     }
 

--- a/packages/assets-controllers/src/AccountTrackerController.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.ts
@@ -176,8 +176,12 @@ export class AccountTrackerController extends StaticIntervalPollingControllerV1<
     this.getCurrentChainId = getCurrentChainId;
     this.getNetworkClientById = getNetworkClientById;
     onPreferencesStateChange(() => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.refresh();
     });
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.poll();
   }
 
@@ -232,6 +236,8 @@ export class AccountTrackerController extends StaticIntervalPollingControllerV1<
     this.handle && clearTimeout(this.handle);
     await this.refresh();
     this.handle = setTimeout(() => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.poll(this.config.interval);
     }, this.config.interval);
   }
@@ -242,6 +248,8 @@ export class AccountTrackerController extends StaticIntervalPollingControllerV1<
    * @param networkClientId - The network client ID used to get balances.
    */
   async _executePoll(networkClientId: string): Promise<void> {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.refresh(networkClientId);
   }
 

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -145,6 +145,8 @@ export class CurrencyRateController extends StaticIntervalPollingController<
     } finally {
       releaseLock();
     }
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     nativeCurrencies.forEach(this.updateExchangeRate.bind(this));
   }
 

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -379,6 +379,8 @@ describe('NftController', () => {
       // @ts-ignore-next-line
       const erc721Result = nftController.watchNft(ERC721_NFT, ERC20);
       await expect(erc721Result).rejects.toThrow(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Non NFT asset type ${ERC20} not supported by watchNft`,
       );
 
@@ -386,6 +388,8 @@ describe('NftController', () => {
       // @ts-ignore-next-line
       const erc1155Result = nftController.watchNft(ERC1155_NFT, ERC20);
       await expect(erc1155Result).rejects.toThrow(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Non NFT asset type ${ERC20} not supported by watchNft`,
       );
     });
@@ -414,6 +418,8 @@ describe('NftController', () => {
       // @ts-ignore-next-line
       const erc721Result = nftController.watchNft(ERC721_NFT, ERC1155);
       await expect(erc721Result).rejects.toThrow(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Suggested NFT of type ${ERC721} does not match received type ${ERC1155}`,
       );
     });

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -889,6 +889,8 @@ describe('NftController', () => {
       });
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.goerli });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       nftController.watchNft(ERC721_NFT, ERC721, 'https://etherscan.io', {
         userAddress: SECOND_OWNER_ADDRESS,
       });
@@ -896,6 +898,8 @@ describe('NftController', () => {
       await pendingRequest;
 
       // now accept the request
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept(requestId);
       await acceptedRequest;
 
@@ -987,6 +991,8 @@ describe('NftController', () => {
         selectedAddress: OWNER_ADDRESS,
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       nftController.watchNft(ERC721_NFT, ERC721, 'https://etherscan.io', {
         networkClientId: 'goerli',
       });
@@ -1001,6 +1007,8 @@ describe('NftController', () => {
       });
       changeNetwork({ selectedNetworkClientId: InfuraNetworkType.sepolia });
       // now accept the request
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       approvalController.accept(requestId);
       await acceptedRequest;
 
@@ -1425,8 +1433,12 @@ describe('NftController', () => {
         .reply(200, {
           name: 'name (directly from tokenURI)',
           description: 'description (directly from tokenURI)',
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           external_link: null,
           image: 'image (directly from tokenURI)',
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           animation_url: null,
         });
 

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -378,6 +378,8 @@ export class NftController extends BaseController<
 
     this.messagingSystem.subscribe(
       'PreferencesController:stateChange',
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       this.#onPreferencesControllerStateChange.bind(this),
     );
 
@@ -794,9 +796,13 @@ export class NftController extends BaseController<
       return {
         address: contractAddress,
         ...blockchainContractData,
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         schema_name: nftMetadataFromApi?.standard ?? null,
         collection: {
           name: null,
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           image_url:
             nftMetadataFromApi?.collection?.image ??
             nftMetadataFromApi?.collection?.imageUrl ??
@@ -811,13 +817,25 @@ export class NftController extends BaseController<
     /* istanbul ignore next */
     return {
       address: contractAddress,
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       asset_contract_type: null,
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       created_date: null,
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       schema_name: null,
       symbol: null,
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       total_supply: null,
       description: null,
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       external_link: null,
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       collection: { name: null, image_url: null },
     };
   }
@@ -961,12 +979,22 @@ export class NftController extends BaseController<
         networkClientId,
       );
       const {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         asset_contract_type,
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         created_date,
         symbol,
         description,
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         external_link,
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         schema_name,
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         collection: { name, image_url, tokenCount },
       } = contractInformation;
 
@@ -1141,6 +1169,8 @@ export class NftController extends BaseController<
 
     if (type !== ERC721 && type !== ERC1155) {
       throw rpcErrors.invalidParams(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Non NFT asset type ${type} not supported by watchNft`,
       );
     }

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -468,6 +468,8 @@ export class NftController extends BaseController<
   }
 
   getNftApi() {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     return `${NFT_API_BASE_URL}/tokens`;
   }
 

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -157,6 +157,8 @@ describe('NftDetectionController', () => {
               isSpam: false,
             },
             blockaidResult: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               result_type: BlockaidResultType.Benign,
             },
           },
@@ -176,6 +178,8 @@ describe('NftDetectionController', () => {
               isSpam: false,
             },
             blockaidResult: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               result_type: BlockaidResultType.Benign,
             },
           },
@@ -202,6 +206,8 @@ describe('NftDetectionController', () => {
               isSpam: false,
             },
             blockaidResult: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               result_type: BlockaidResultType.Benign,
             },
           },
@@ -237,6 +243,8 @@ describe('NftDetectionController', () => {
               isSpam: false,
             },
             blockaidResult: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               result_type: BlockaidResultType.Malicious,
             },
           },
@@ -256,6 +264,8 @@ describe('NftDetectionController', () => {
               isSpam: true,
             },
             blockaidResult: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               result_type: BlockaidResultType.Benign,
             },
           },
@@ -275,6 +285,8 @@ describe('NftDetectionController', () => {
               isSpam: true,
             },
             blockaidResult: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               result_type: BlockaidResultType.Malicious,
             },
           },

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -544,6 +544,8 @@ export class NftDetectionController extends StaticIntervalPollingController<
   }
 
   #getOwnerNftApi({ address, next }: { address: string; next?: string }) {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     return `${NFT_API_BASE_URL}/users/${address}/tokens?chainIds=1&limit=50&includeTopBid=true&continuation=${
       next ?? ''
     }`;

--- a/packages/assets-controllers/src/NftDetectionController.ts
+++ b/packages/assets-controllers/src/NftDetectionController.ts
@@ -72,20 +72,44 @@ export type NftDetectionControllerMessenger = RestrictedControllerMessenger<
  * @property lastSale - When this item was last sold
  */
 export type ApiNft = {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   token_id: string;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   num_sales: number | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   background_color: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   image_url: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   image_preview_url: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   image_thumbnail_url: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   image_original_url: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   animation_url: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   animation_original_url: string | null;
   name: string | null;
   description: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   external_link: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   asset_contract: ApiNftContract;
   creator: ApiNftCreator;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   last_sale: ApiNftLastSale | null;
 };
 
@@ -105,15 +129,27 @@ export type ApiNft = {
  */
 export type ApiNftContract = {
   address: string;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   asset_contract_type: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   created_date: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   schema_name: string | null;
   symbol: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   total_supply: string | null;
   description: string | null;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   external_link: string | null;
   collection: {
     name: string | null;
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     image_url?: string | null;
     tokenCount?: string | null;
   };
@@ -128,8 +164,14 @@ export type ApiNftContract = {
  * @property transaction - Object containing transaction_hash and block_hash
  */
 export type ApiNftLastSale = {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   event_timestamp: string;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   total_price: string;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   transaction: { transaction_hash: string; block_hash: string };
 };
 
@@ -143,6 +185,8 @@ export type ApiNftLastSale = {
  */
 export type ApiNftCreator = {
   user: { username: string };
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   profile_img_url: string;
   address: string;
 };
@@ -169,8 +213,14 @@ export enum BlockaidResultType {
 export type Blockaid = {
   contract: string;
   chainId: number;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   result_type: BlockaidResultType;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   malicious_score: string;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   attack_types: object;
 };
 
@@ -444,6 +494,8 @@ export class NftDetectionController extends StaticIntervalPollingController<
   async #startPolling(): Promise<void> {
     this.#stopPolling();
     await this.detectNfts();
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.#intervalId = setInterval(async () => {
       await this.detectNfts();
     }, this.#interval);
@@ -480,6 +532,8 @@ export class NftDetectionController extends StaticIntervalPollingController<
     if (!useNftDetection !== this.#disabled) {
       this.#disabled = !useNftDetection;
       if (useNftDetection) {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.start();
       } else {
         this.stop();
@@ -556,11 +610,19 @@ export class NftDetectionController extends StaticIntervalPollingController<
     const apiNfts = await this.#getOwnerNfts(userAddress);
     const addNftPromises = apiNfts.map(async (nft) => {
       const {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         tokenId: token_id,
         contract,
         kind,
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         image: image_url,
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         imageSmall: image_thumbnail_url,
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         metadata: { imageOriginal: image_original_url } = {},
         name,
         description,

--- a/packages/assets-controllers/src/RatesController/RatesController.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.ts
@@ -92,6 +92,8 @@ export class RatesController extends BaseController<
    * // Execute criticalLogic within a lock.
    * const result = await this.#withLock(criticalLogic);
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   async #withLock<R>(callback: () => R) {
     const releaseLock = await this.#mutex.acquire();
     try {

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -144,12 +144,16 @@ export class TokenBalancesController extends BaseController<
       'TokensController:stateChange',
       ({ tokens: newTokens, detectedTokens }) => {
         this.#tokens = [...newTokens, ...detectedTokens];
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.updateBalances();
       },
     );
 
     this.#getERC20BalanceOf = getERC20BalanceOf;
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.poll();
   }
 
@@ -184,6 +188,8 @@ export class TokenBalancesController extends BaseController<
     await safelyExecute(() => this.updateBalances());
 
     this.#handle = setTimeout(() => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.poll(this.#interval);
     }, this.#interval);
   }

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -171,12 +171,16 @@ describe('TokenDetectionController', () => {
       .get(getTokensPath(ChainId.mainnet))
       .reply(200, sampleTokenList)
       .get(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `/token/${convertHexToDecimal(ChainId.mainnet)}?address=${
           tokenAFromList.address
         }`,
       )
       .reply(200, tokenAFromList)
       .get(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `/token/${convertHexToDecimal(ChainId.mainnet)}?address=${
           tokenBFromList.address
         }`,
@@ -1977,6 +1981,8 @@ describe('TokenDetectionController', () => {
  * @returns The constructed path.
  */
 function getTokensPath(chainId: Hex) {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   return `/tokens/${convertHexToDecimal(
     chainId,
   )}?occurrenceFloor=3&includeNativeAssets=false&includeDuplicateSymbolAssets=false&includeTokenFees=false&includeAssetType=false`;

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -1956,7 +1956,11 @@ describe('TokenDetectionController', () => {
             category: 'Wallet',
             properties: {
               tokens: [`${sampleTokenA.symbol} - ${sampleTokenA.address}`],
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               token_standard: 'ERC20',
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               asset_type: 'TOKEN',
             },
           });

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -174,7 +174,11 @@ export class TokenDetectionController extends StaticIntervalPollingController<
     category: string;
     properties: {
       tokens: string[];
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       token_standard: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       asset_type: string;
     };
   }) => void;
@@ -207,7 +211,11 @@ export class TokenDetectionController extends StaticIntervalPollingController<
       category: string;
       properties: {
         tokens: string[];
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         token_standard: string;
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         asset_type: string;
       };
     }) => void;
@@ -254,6 +262,8 @@ export class TokenDetectionController extends StaticIntervalPollingController<
    * Constructor helper for registering this controller's messaging system subscriptions to controller events.
    */
   #registerEventListeners() {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.messagingSystem.subscribe('KeyringController:unlock', async () => {
       this.#isUnlocked = true;
       await this.#restartTokenDetection();
@@ -266,6 +276,8 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
     this.messagingSystem.subscribe(
       'TokenListController:stateChange',
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async ({ tokenList }) => {
         const hasTokens = Object.keys(tokenList).length;
 
@@ -277,6 +289,8 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
     this.messagingSystem.subscribe(
       'PreferencesController:stateChange',
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async ({ selectedAddress: newSelectedAddress, useTokenDetection }) => {
         const isSelectedAddressChanged =
           this.#selectedAddress !== newSelectedAddress;
@@ -296,6 +310,8 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
     this.messagingSystem.subscribe(
       'AccountsController:selectedAccountChange',
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async ({ address: newSelectedAddress }) => {
         const isSelectedAddressChanged =
           this.#selectedAddress !== newSelectedAddress;
@@ -310,6 +326,8 @@ export class TokenDetectionController extends StaticIntervalPollingController<
 
     this.messagingSystem.subscribe(
       'NetworkController:networkDidChange',
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async ({ selectedNetworkClientId }) => {
         const isNetworkClientIdChanged =
           this.#networkClientId !== selectedNetworkClientId;
@@ -382,6 +400,8 @@ export class TokenDetectionController extends StaticIntervalPollingController<
     }
     this.#stopPolling();
     await this.detectTokens();
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.#intervalId = setInterval(async () => {
       await this.detectTokens();
     }, this.getIntervalLength());
@@ -597,7 +617,11 @@ export class TokenDetectionController extends StaticIntervalPollingController<
           category: 'Wallet',
           properties: {
             tokens: eventTokensDetails,
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             token_standard: 'ERC20',
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             asset_type: 'TOKEN',
           },
         });

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -1360,6 +1360,8 @@ describe('TokenListController', () => {
  * @returns The constructed path.
  */
 function getTokensPath(chainId: Hex) {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   return `/tokens/${convertHexToDecimal(
     chainId,
   )}?occurrenceFloor=3&includeNativeAssets=false&includeDuplicateSymbolAssets=false&includeTokenFees=false&includeAssetType=false&includeERC20Permit=false&includeStorage=false`;

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -650,6 +650,8 @@ describe('TokenListController', () => {
       interval: 100,
       messenger,
     });
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     controller.start();
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 150));
     expect(controller.state.tokenList).toStrictEqual(

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -155,12 +155,16 @@ export class TokenListController extends StaticIntervalPollingController<
     this.updatePreventPollingOnNetworkRestart(preventPollingOnNetworkRestart);
     this.abortController = new AbortController();
     if (onNetworkStateChange) {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       onNetworkStateChange(async (networkControllerState) => {
         await this.#onNetworkControllerStateChange(networkControllerState);
       });
     } else {
       this.messagingSystem.subscribe(
         'NetworkController:stateChange',
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         async (networkControllerState) => {
           await this.#onNetworkControllerStateChange(networkControllerState);
         },
@@ -246,6 +250,8 @@ export class TokenListController extends StaticIntervalPollingController<
    */
   private async startPolling(): Promise<void> {
     await safelyExecute(() => this.fetchTokenList());
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.intervalId = setInterval(async () => {
       await safelyExecute(() => this.fetchTokenList());
     }, this.intervalDelay);

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -249,6 +249,8 @@ export class TokenRatesController extends StaticIntervalPollingControllerV1<
       this.configure({ disabled: true }, false, false);
     }
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     onPreferencesStateChange(async ({ selectedAddress }) => {
       if (this.config.selectedAddress !== selectedAddress) {
         this.configure({ selectedAddress });
@@ -258,6 +260,8 @@ export class TokenRatesController extends StaticIntervalPollingControllerV1<
       }
     });
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     onTokensStateChange(async ({ allTokens, allDetectedTokens }) => {
       const previousTokenAddresses = this.#getTokenAddresses(
         this.config.chainId,
@@ -272,6 +276,8 @@ export class TokenRatesController extends StaticIntervalPollingControllerV1<
       }
     });
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     onNetworkStateChange(async ({ selectedNetworkClientId }) => {
       const selectedNetworkClient = getNetworkClientById(
         selectedNetworkClientId,
@@ -347,6 +353,8 @@ export class TokenRatesController extends StaticIntervalPollingControllerV1<
     // Poll using recursive `setTimeout` instead of `setInterval` so that
     // requests don't stack if they take longer than the polling interval
     this.handle = setTimeout(() => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.#poll();
     }, this.config.interval);
   }

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -914,6 +914,8 @@ describe('TokensController', () => {
           const fullErrorMessage = `TokenService Error: ${error}`;
           nock(TOKEN_END_POINT_API)
             .get(
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               `/token/${convertHexToDecimal(
                 chainId,
               )}?address=${dummyTokenAddress}`,

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -810,6 +810,8 @@ export class TokensController extends BaseController<
 
     if (await this.#detectIsERC721(asset.address, networkClientId)) {
       throw rpcErrors.invalidParams(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Contract ${asset.address} must match type ${type}, but was detected as ${ERC721}`,
       );
     }
@@ -822,6 +824,8 @@ export class TokensController extends BaseController<
     );
     if (isErc1155) {
       throw rpcErrors.invalidParams(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Contract ${asset.address} must match type ${type}, but was detected as ${ERC1155}`,
       );
     }
@@ -849,6 +853,8 @@ export class TokensController extends BaseController<
       asset.symbol.toUpperCase() !== contractSymbol.toUpperCase()
     ) {
       throw rpcErrors.invalidParams(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `The symbol in the request (${asset.symbol}) does not match the symbol in the contract (${contractSymbol})`,
       );
     }
@@ -878,6 +884,8 @@ export class TokensController extends BaseController<
       String(asset.decimals) !== contractDecimals
     ) {
       throw rpcErrors.invalidParams(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `The decimals in the request (${asset.decimals}) do not match the decimals in the contract (${contractDecimals})`,
       );
     }
@@ -886,6 +894,8 @@ export class TokensController extends BaseController<
     const decimalsNum = parseInt(decimalsStr as unknown as string, 10);
     if (!Number.isInteger(decimalsNum) || decimalsNum > 36 || decimalsNum < 0) {
       throw rpcErrors.invalidParams(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Invalid decimals "${decimalsStr}": must be an integer 0 <= 36`,
       );
     }

--- a/packages/assets-controllers/src/assetsUtil.test.ts
+++ b/packages/assets-controllers/src/assetsUtil.test.ts
@@ -152,6 +152,8 @@ describe('assetsUtil', () => {
         chainId: ChainId.mainnet,
         tokenAddress: linkTokenAddress,
       });
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       const expectedValue = `https://static.cx.metamask.io/api/v1/tokenIcons/${convertHexToDecimal(
         ChainId.mainnet,
       )}/${linkTokenAddress}.png`;

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -107,6 +107,8 @@ export const formatIconUrlWithProxy = ({
   tokenAddress: string;
 }) => {
   const chainIdDecimal = convertHexToDecimal(chainId).toString();
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   return `https://static.cx.metamask.io/api/v1/tokenIcons/${chainIdDecimal}/${tokenAddress.toLowerCase()}.png`;
 };
 

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -114,23 +114,59 @@ export const formatIconUrlWithProxy = ({
  * Networks where token detection is supported - Values are in hex format
  */
 export enum SupportedTokenDetectionNetworks {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   mainnet = '0x1', // decimal: 1
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   bsc = '0x38', // decimal: 56
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   polygon = '0x89', // decimal: 137
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   avax = '0xa86a', // decimal: 43114
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   aurora = '0x4e454152', // decimal: 1313161554
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   linea_goerli = '0xe704', // decimal: 59140
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   linea_mainnet = '0xe708', // decimal: 59144
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   arbitrum = '0xa4b1', // decimal: 42161
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   optimism = '0xa', // decimal: 10
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   base = '0x2105', // decimal: 8453
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   zksync = '0x144', // decimal: 324
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   cronos = '0x19', // decimal: 25
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   celo = '0xa4ec', // decimal: 42220
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   gnosis = '0x64', // decimal: 100
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   fantom = '0xfa', // decimal: 250
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   polygon_zkevm = '0x44d', // decimal: 1101
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   moonbeam = '0x504', // decimal: 1284
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   moonriver = '0x505', // decimal: 1285
 }
 

--- a/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
+++ b/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
@@ -70,6 +70,8 @@ function getMultiPricingURL(
  * @param json.Response - The response status.
  * @param json.Message - The error message.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 function handleErrorResponse(json: { Response?: string; Message?: string }) {
   if (json.Response === 'Error') {
     throw new Error(json.Message);
@@ -103,12 +105,16 @@ export async function fetchExchangeRate(
   if (!Number.isFinite(conversionRate)) {
     throw new Error(
       `Invalid response for ${currency.toUpperCase()}: ${
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         json[currency.toUpperCase()]
       }`,
     );
   }
 
   if (includeUSDRate && !Number.isFinite(usdConversionRate)) {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Invalid response for usdConversionRate: ${json.USD}`);
   }
 

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -19,6 +19,8 @@ export const TOKEN_METADATA_NO_SUPPORT_ERROR =
  */
 function getTokensURL(chainId: Hex) {
   const occurrenceFloor = chainId === ChainId['linea-mainnet'] ? 1 : 3;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   return `${TOKEN_END_POINT_API}/tokens/${convertHexToDecimal(
     chainId,
   )}?occurrenceFloor=${occurrenceFloor}&includeNativeAssets=false&includeDuplicateSymbolAssets=false&includeTokenFees=false&includeAssetType=false&includeERC20Permit=false&includeStorage=false`;
@@ -32,6 +34,8 @@ function getTokensURL(chainId: Hex) {
  * @returns The token metadata URL.
  */
 function getTokenMetadataURL(chainId: Hex, tokenAddress: string) {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   return `${TOKEN_END_POINT_API}/token/${convertHexToDecimal(
     chainId,
   )}?address=${tokenAddress}`;

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -84,6 +84,8 @@ export async function fetchTokenListByChainId(
  * @param options.timeout - The fetch timeout.
  * @returns The token metadata, or `undefined` if the request was either aborted or failed.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export async function fetchTokenMetadata<T>(
   chainId: Hex,
   tokenAddress: string,
@@ -145,6 +147,8 @@ async function parseJsonResponse(apiResponse: Response): Promise<unknown> {
   const responseObj = await apiResponse.json();
   // api may return errors as json without setting an error http status code
   if (responseObj?.error) {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`TokenService Error: ${responseObj.error}`);
   }
   return responseObj;

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -1,6 +1,8 @@
 /**
  * State change callbacks
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type Listener<T> = (state: T) => void;
 
 /**
@@ -38,6 +40,8 @@ export interface BaseState {
  * called "state". Each controller is responsible for its own state, and all global wallet state
  * is tracked in a controller as state.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export class BaseControllerV1<C extends BaseConfig, S extends BaseState> {
   /**
    * Default options used to configure this controller

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -25,6 +25,8 @@ export type StateConstraint = Record<string, Json>;
  * @param patches - A list of patches describing any changes (see here for more
  * information: https://immerjs.github.io/immer/docs/patches)
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type Listener<T> = (state: T, patches: Patch[]) => void;
 
 /**
@@ -36,6 +38,8 @@ export type Listener<T> = (state: T, patches: Patch[]) => void;
  * @param value - A piece of controller state.
  * @returns Something derived from controller state.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type StateDeriver<T extends Json> = (value: T) => Json;
 
 /**
@@ -44,6 +48,8 @@ export type StateDeriver<T extends Json> = (value: T) => Json;
  * This metadata describes which parts of state should be persisted, and how to
  * get an anonymized representation of the state.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type StateMetadata<T extends StateConstraint> = {
   [P in keyof T]: StatePropertyMetadata<T[P]>;
 };
@@ -59,6 +65,8 @@ export type StateMetadata<T extends StateConstraint> = {
  * identifiable), or is set to a function that returns an anonymized
  * representation of this state.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type StatePropertyMetadata<T extends Json> = {
   persist: boolean | StateDeriver<T>;
   anonymous: boolean | StateDeriver<T>;
@@ -96,6 +104,8 @@ export type ControllerEvents<
 export class BaseController<
   ControllerName extends string,
   ControllerState extends StateConstraint,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   messenger extends RestrictedControllerMessenger<
     ControllerName,
     ActionConstraint | ControllerActions<ControllerName, ControllerState>,

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -152,7 +152,11 @@ describe('ComposableController', () => {
   describe('BaseControllerV1', () => {
     it('should compose controller state', () => {
       type ComposableControllerState = {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         BarController: BarControllerState;
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         BazController: BazControllerState;
       };
       const composableMessenger = new ControllerMessenger<
@@ -176,6 +180,8 @@ describe('ComposableController', () => {
 
     it('should notify listeners of nested state change', () => {
       type ComposableControllerState = {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         BarController: BarControllerState;
       };
       const controllerMessenger = new ControllerMessenger<
@@ -211,7 +217,11 @@ describe('ComposableController', () => {
   describe('BaseControllerV2', () => {
     it('should compose controller state', () => {
       type ComposableControllerState = {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         QuzController: QuzControllerState;
       };
       const controllerMessenger = new ControllerMessenger<
@@ -258,6 +268,8 @@ describe('ComposableController', () => {
 
     it('should notify listeners of nested state change', () => {
       type ComposableControllerState = {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
       };
       const controllerMessenger = new ControllerMessenger<
@@ -300,7 +312,11 @@ describe('ComposableController', () => {
   describe('Mixed BaseControllerV1 and BaseControllerV2', () => {
     it('should compose controller state', () => {
       type ComposableControllerState = {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         BarController: BarControllerState;
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
       };
       const barController = new BarController();
@@ -333,7 +349,11 @@ describe('ComposableController', () => {
 
     it('should notify listeners of BaseControllerV1 state change', () => {
       type ComposableControllerState = {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         BarController: BarControllerState;
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
       };
       const barController = new BarController();
@@ -377,7 +397,11 @@ describe('ComposableController', () => {
 
     it('should notify listeners of BaseControllerV2 state change', () => {
       type ComposableControllerState = {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         BarController: BarControllerState;
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
       };
       const barController = new BarController();
@@ -443,6 +467,8 @@ describe('ComposableController', () => {
 
     it('should throw if composing a controller that does not extend from BaseController', () => {
       type ComposableControllerState = {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
       };
       const notController = new JsonRpcEngine();

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -271,6 +271,8 @@ export class ComposableController<
       isBaseController(controller)
     ) {
       this.messagingSystem.subscribe(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `${name}:stateChange`,
         (childState: Record<string, unknown>) => {
           this.update((state) => {

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -79,11 +79,19 @@ export const ChainId = {
 export type ChainId = (typeof ChainId)[keyof typeof ChainId];
 
 export enum NetworksTicker {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   mainnet = 'ETH',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   goerli = 'GoerliETH',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   sepolia = 'SepoliaETH',
   'linea-goerli' = 'LineaETH',
   'linea-sepolia' = 'LineaETH',
   'linea-mainnet' = 'ETH',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   rpc = '',
 }

--- a/packages/controller-utils/src/util.test.ts
+++ b/packages/controller-utils/src/util.test.ts
@@ -507,6 +507,8 @@ describe('util', () => {
             if (method === 'eth_getBlockByHash') {
               return cb(null, { id: params[0] });
             }
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             throw new Error(`Unsupported method ${method}`);
           }
         }

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -64,6 +64,8 @@ export function isSafeChainId(chainId: Hex): boolean {
  * @param inputBn - BN instance to convert to a hex string.
  * @returns A '0x'-prefixed hex string.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export function BNToHex(inputBn: BN) {
   return add0x(inputBn.toString(16));
 }
@@ -148,6 +150,8 @@ export function getBuyURL(
 ): string | undefined {
   switch (networkCode) {
     case '1':
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       return `https://buy.coinbase.com/?code=9ec56d01-7e81-5017-930c-513daa27bb6a&amount=${amount}&address=${address}&crypto_currency=ETH`;
     case '5':
       return 'https://goerli-faucet.slock.it/';
@@ -289,6 +293,8 @@ export function toChecksumHexAddress(address: string): string;
  * and is only present for backward compatibility. It may be removed in a future
  * major version. Please pass a string to `toChecksumHexAddress` instead.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export function toChecksumHexAddress<T>(address: T): T;
 
 // Tools only see JSDocs for overloads and ignore them for the implementation.
@@ -551,6 +557,8 @@ export function isPlainObject(value: unknown): value is PlainObject {
  *
  * @template T - The non-empty array member type.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type NonEmptyArray<T> = [T, ...T[]];
 
 /**
@@ -560,6 +568,8 @@ export type NonEmptyArray<T> = [T, ...T[]];
  * @param value - The value to check.
  * @returns Whether the value is a non-empty array.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export function isNonEmptyArray<T>(value: T[]): value is NonEmptyArray<T> {
   return Array.isArray(value) && value.length > 0;
 }

--- a/packages/ens-controller/src/EnsController.test.ts
+++ b/packages/ens-controller/src/EnsController.test.ts
@@ -42,6 +42,8 @@ jest.mock('@ethersproject/providers', () => {
   const originalModule = jest.requireActual('@ethersproject/providers');
 
   return {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     __esModule: true,
     ...originalModule,
   };

--- a/packages/ens-controller/src/EnsController.ts
+++ b/packages/ens-controller/src/EnsController.ts
@@ -258,6 +258,8 @@ export class EnsController extends BaseController<
       (address && !isValidHexAddress(address))
     ) {
       throw new Error(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Invalid ENS entry: { chainId:${chainId}, ensName:${ensName}, address:${address}}`,
       );
     }

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -86,6 +86,8 @@ const setupNetworkController = async ({
   if (initializeProvider) {
     // Call this without awaiting to simulate what the extension or mobile app
     // might do
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     networkController.initializeProvider();
     // Ensure that the request for eth_getBlockByNumber made by the PollingBlockTracker
     // inside the NetworkController goes through
@@ -292,6 +294,8 @@ describe('GasFeeController', () => {
   afterEach(() => {
     gasFeeController.destroy();
     const { blockTracker } = networkController.getProviderAndBlockTracker();
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     blockTracker?.destroy();
     sinon.restore();
     jest.clearAllMocks();
@@ -541,6 +545,8 @@ describe('GasFeeController', () => {
         },
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await gasFeeController.enableNonRPCGasFeeApis();
 
       expect(gasFeeController.state.nonRPCGasFeeApisDisabled).toBe(false);
@@ -556,6 +562,8 @@ describe('GasFeeController', () => {
         },
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await gasFeeController.disableNonRPCGasFeeApis();
 
       expect(gasFeeController.state.nonRPCGasFeeApisDisabled).toBe(true);

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -1026,10 +1026,14 @@ describe('GasFeeController', () => {
           isEIP1559Compatible: true,
           isLegacyGasAPICompatible: false,
           fetchGasEstimates,
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           fetchGasEstimatesUrl: `${GAS_API_BASE_URL}/networks/${convertHexToDecimal(
             ChainId.goerli,
           )}/suggestedGasFees`,
           fetchLegacyGasPriceEstimates,
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           fetchLegacyGasPriceEstimatesUrl: `${GAS_API_BASE_URL}/networks/${convertHexToDecimal(
             ChainId.goerli,
           )}/gasPrices`,
@@ -1133,6 +1137,8 @@ describe('GasFeeController', () => {
 
         expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
           expect.objectContaining({
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             fetchGasEstimatesUrl: `${GAS_API_BASE_URL}/networks/${convertHexToDecimal(
               ChainId.sepolia,
             )}/suggestedGasFees`,
@@ -1175,6 +1181,8 @@ describe('GasFeeController', () => {
       expect(mockedDetermineGasFeeCalculations).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           fetchGasEstimatesUrl: `${GAS_API_BASE_URL}/networks/${convertHexToDecimal(
             ChainId.goerli,
           )}/suggestedGasFees`,
@@ -1186,6 +1194,8 @@ describe('GasFeeController', () => {
       expect(mockedDetermineGasFeeCalculations).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           fetchGasEstimatesUrl: `${GAS_API_BASE_URL}/networks/${convertHexToDecimal(
             ChainId.goerli,
           )}/suggestedGasFees`,
@@ -1199,6 +1209,8 @@ describe('GasFeeController', () => {
       await clock.tickAsync(pollingInterval);
       expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
         expect.objectContaining({
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           fetchGasEstimatesUrl: `${GAS_API_BASE_URL}/networks/${convertHexToDecimal(
             ChainId.sepolia,
           )}/suggestedGasFees`,

--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -32,6 +32,8 @@ import {
 
 export const GAS_API_BASE_URL = 'https://gas.api.infura.io';
 
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type unknownString = 'unknown';
 
 // Fee Market describes the way gas is set after the london hardfork, and was
@@ -270,6 +272,8 @@ export class GasFeeController extends StaticIntervalPollingController<
 
   private readonly legacyAPIEndpoint: string;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   private readonly EIP1559APIEndpoint: string;
 
   private readonly getCurrentNetworkEIP1559Compatibility;
@@ -359,6 +363,8 @@ export class GasFeeController extends StaticIntervalPollingController<
 
     if (onNetworkDidChange && getChainId) {
       this.currentChainId = getChainId();
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       onNetworkDidChange(async (networkControllerState) => {
         await this.#onNetworkControllerDidChange(networkControllerState);
       });
@@ -372,6 +378,8 @@ export class GasFeeController extends StaticIntervalPollingController<
       ).configuration.chainId;
       this.messagingSystem.subscribe(
         'NetworkController:networkDidChange',
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         async (networkControllerState) => {
           await this.#onNetworkControllerDidChange(networkControllerState);
         },
@@ -540,6 +548,8 @@ export class GasFeeController extends StaticIntervalPollingController<
       clearInterval(this.intervalId);
     }
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.intervalId = setInterval(async () => {
       await safelyExecute(() => this._fetchGasFeeEstimateData());
     }, this.intervalDelay);

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -476,6 +476,8 @@ describe('KeyringController', () => {
 
         cacheEncryptionKey &&
           it('should set encryptionKey and encryptionSalt in state', async () => {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             withController({ cacheEncryptionKey }, async ({ controller }) => {
               await controller.createNewVaultAndRestore(
                 password,
@@ -588,6 +590,8 @@ describe('KeyringController', () => {
 
         cacheEncryptionKey &&
           it('should set encryptionKey and encryptionSalt in state', async () => {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             withController({ cacheEncryptionKey }, async ({ initialState }) => {
               expect(initialState.encryptionKey).toBeDefined();
               expect(initialState.encryptionSalt).toBeDefined();
@@ -981,6 +985,8 @@ describe('KeyringController', () => {
           });
         });
 
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line jest/expect-expect
         it('should not select imported account', async () => {
           await withController(async ({ controller }) => {
             await controller.importAccountWithStrategy(
@@ -1052,6 +1058,8 @@ describe('KeyringController', () => {
           });
         });
 
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line jest/expect-expect
         it('should not select imported account', async () => {
           await withController(async ({ controller }) => {
             const somePassword = 'holachao123';
@@ -2124,6 +2132,8 @@ describe('KeyringController', () => {
 
         cacheEncryptionKey &&
           it('should set encryptionKey and encryptionSalt in state', async () => {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             withController({ cacheEncryptionKey }, async ({ controller }) => {
               await controller.submitPassword(password);
               expect(controller.state.encryptionKey).toBeDefined();
@@ -3425,6 +3435,8 @@ describe('KeyringController', () => {
             await controller.persistAllKeyrings();
           }
         });
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         messenger.subscribe('KeyringController:stateChange', listener);
 
         await controller.submitPassword(password);

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1069,7 +1069,7 @@ export class KeyringController extends BaseController<
       // FIXME: We do cast to `Hex` to makes the type checker happy here, and
       // because `Keyring<State>.removeAccount` requires address to be `Hex`. Those
       // type would need to be updated for a full non-EVM support.
-      await keyring.removeAccount(address as Hex);
+      keyring.removeAccount(address as Hex);
 
       const accounts = await keyring.getAccounts();
       // Check if this was the last/only account

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -52,12 +52,26 @@ const name = 'KeyringController';
  * Available keyring types
  */
 export enum KeyringTypes {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   simple = 'Simple Key Pair',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   hd = 'HD Key Tree',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   qr = 'QR Hardware Wallet Device',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   trezor = 'Trezor Hardware',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   ledger = 'Ledger Hardware',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   lattice = 'Lattice Hardware',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   snap = 'Snap Keyring',
 }
 
@@ -246,7 +260,11 @@ export type KeyringObject = {
  * A strategy for importing an account
  */
 export enum AccountImportStrategy {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   privateKey = 'privateKey',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   json = 'json',
 }
 
@@ -380,6 +398,8 @@ export type KeyringSelector =
  *
  * @param releaseLock - A function to release the lock.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type MutuallyExclusiveCallback<T> = ({
   releaseLock,
 }: {
@@ -1166,6 +1186,8 @@ export class KeyringController extends BaseController<
         { version },
       );
     } catch (error) {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       throw new Error(`Keyring Controller signTypedMessage: ${error}`);
     }
   }
@@ -1586,6 +1608,8 @@ export class KeyringController extends BaseController<
       } catch (e) {
         // TODO: Add test case for when keyring throws
         /* istanbul ignore next */
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         throw new Error(`Unspecified error when connect QR Hardware, ${e}`);
       }
     });
@@ -2239,6 +2263,8 @@ export class KeyringController extends BaseController<
    * @param fn - The function to execute.
    * @returns The result of the function.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   async #persistOrRollback<T>(fn: MutuallyExclusiveCallback<T>): Promise<T> {
     return this.#withRollback(async ({ releaseLock }) => {
       const callbackResult = await fn({ releaseLock });
@@ -2256,6 +2282,8 @@ export class KeyringController extends BaseController<
    * @param fn - The function to execute atomically.
    * @returns The result of the function.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   async #withRollback<T>(fn: MutuallyExclusiveCallback<T>): Promise<T> {
     return this.#withControllerLock(async ({ releaseLock }) => {
       const currentSerializedKeyrings = await this.#getSerializedKeyrings();
@@ -2296,6 +2324,8 @@ export class KeyringController extends BaseController<
    * @param fn - The function to execute while the controller mutex is locked.
    * @returns The result of the function.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   async #withControllerLock<T>(fn: MutuallyExclusiveCallback<T>): Promise<T> {
     return withLock(this.#controllerOperationMutex, fn);
   }
@@ -2311,6 +2341,8 @@ export class KeyringController extends BaseController<
    * @param fn - The function to execute while the vault mutex is locked.
    * @returns The result of the function.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   async #withVaultLock<T>(fn: MutuallyExclusiveCallback<T>): Promise<T> {
     this.#assertControllerMutexIsLocked();
 
@@ -2327,6 +2359,8 @@ export class KeyringController extends BaseController<
  * @param fn - The function to execute while the mutex is locked.
  * @returns The result of the function.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 async function withLock<T>(
   mutex: Mutex,
   fn: MutuallyExclusiveCallback<T>,

--- a/packages/logging-controller/src/LoggingController.test.ts
+++ b/packages/logging-controller/src/LoggingController.test.ts
@@ -54,6 +54,8 @@ describe('LoggingController', () => {
     });
 
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('LoggingController:add', {
         type: LogType.GenericLog,
         data: `Generic log`,
@@ -80,6 +82,8 @@ describe('LoggingController', () => {
     });
 
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('LoggingController:add', {
         type: LogType.EthSignLog,
         data: {
@@ -114,6 +118,8 @@ describe('LoggingController', () => {
     });
 
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('LoggingController:add', {
         type: LogType.GenericLog,
         data: `Generic log`,
@@ -127,6 +133,8 @@ describe('LoggingController', () => {
     }
 
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('LoggingController:add', {
         type: LogType.GenericLog,
         data: `Generic log 2`,
@@ -164,6 +172,8 @@ describe('LoggingController', () => {
     });
 
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('LoggingController:add', {
         type: LogType.EthSignLog,
         data: {

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -85,7 +85,8 @@ export interface AbstractMessageParamsMetamask extends AbstractMessageParams {
  */
 // This interface was created before this ESLint rule was added.
 // Convert to a `type` in a future major version.
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention
 export interface MessageManagerState<M extends AbstractMessage>
   extends BaseState {
   unapprovedMessages: { [key: string]: M };
@@ -100,14 +101,22 @@ export type SecurityProviderRequest = (
   messageType: string,
 ) => Promise<Json>;
 
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type getCurrentChainId = () => Hex;
 
 /**
  * Controller in charge of managing - storing, adding, removing, updating - Messages.
  */
 export abstract class AbstractMessageManager<
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   M extends AbstractMessage,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   P extends AbstractMessageParams,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   PM extends AbstractMessageParamsMetamask,
 > extends BaseControllerV1<BaseConfig, MessageManagerState<M>> {
   protected messages: M[];
@@ -422,6 +431,8 @@ export abstract class AbstractMessageManager<
   ): Promise<string> {
     const { metamaskId: messageId, ...messageParams } = messageParamsWithId;
     return new Promise((resolve, reject) => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       this.hub.once(`${messageId}:finished`, (data: AbstractMessage) => {
         switch (data.status) {
           case 'signed':
@@ -434,6 +445,8 @@ export abstract class AbstractMessageManager<
             );
           case 'errored':
             return reject(
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               new Error(`MetaMask ${messageName} Signature: ${data.error}`),
             );
           default:

--- a/packages/message-manager/src/PersonalMessageManager.test.ts
+++ b/packages/message-manager/src/PersonalMessageManager.test.ts
@@ -80,6 +80,8 @@ describe('PersonalMessageManager', () => {
     };
     const originalRequest = {
       origin: 'origin',
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       securityAlertResponse: { result_type: 'result_type', reason: 'reason' },
     };
     const messageId = await controller.addUnapprovedMessage(

--- a/packages/message-manager/src/TypedMessageManager.test.ts
+++ b/packages/message-manager/src/TypedMessageManager.test.ts
@@ -127,6 +127,8 @@ describe('TypedMessageManager', () => {
     };
     const originalRequest = {
       origin: 'origin',
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       securityAlertResponse: { result_type: 'result_type', reason: 'reason' },
     };
     const messageId = await controller.addUnapprovedMessage(
@@ -308,6 +310,8 @@ describe('TypedMessageManager', () => {
     const messageData = typedMessage;
     const firstMessage = { from: fromMock, data: messageData };
     const version = 'V1';
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     const messageId = await await controller.addUnapprovedMessage(
       firstMessage,
       undefined,

--- a/packages/message-manager/src/utils.test.ts
+++ b/packages/message-manager/src/utils.test.ts
@@ -256,6 +256,8 @@ describe('utils', () => {
           unexpectedChainId,
         ),
       ).toThrow(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Cannot sign messages for chainId "${convertHexToDecimal(
           mockedCurrentChainId,
         )}", because MetaMask is switching networks.`,
@@ -275,8 +277,12 @@ describe('utils', () => {
           chainId,
         ),
       ).toThrow(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Provided chainId "${convertHexToDecimal(
           mockedCurrentChainId,
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         )}" must match the active chainId "${convertHexToDecimal(chainId)}"`,
       );
     });

--- a/packages/message-manager/src/utils.ts
+++ b/packages/message-manager/src/utils.ts
@@ -74,6 +74,8 @@ export function validateTypedSignMessageDataV1(
 
   if (!messageData.data || !Array.isArray(messageData.data)) {
     throw new Error(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `Invalid message "data": ${messageData.data} must be a valid array.`,
     );
   }
@@ -143,12 +145,16 @@ export function validateTypedSignMessageDataV3V4(
     const activeChainId = parseInt(currentChainId, 16);
     if (Number.isNaN(activeChainId)) {
       throw new Error(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Cannot sign messages for chainId "${chainId}", because MetaMask is switching networks.`,
       );
     }
 
     if (chainId !== activeChainId) {
       throw new Error(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `Provided chainId "${chainId}" must match the active chainId "${activeChainId}"`,
       );
     }

--- a/packages/name-controller/src/NameController.ts
+++ b/packages/name-controller/src/NameController.ts
@@ -22,8 +22,12 @@ export const PROPOSED_NAME_EXPIRE_DURATION = 60 * 60 * 24; // 24 hours
  */
 export enum NameOrigin {
   // Originated from an account identity.
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   ACCOUNT_IDENTITY = 'account-identity',
   // Originated from an address book entry.
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   ADDRESS_BOOK = 'address-book',
   // Originated from the API (NameController.setName). This is the default.
   API = 'api',

--- a/packages/name-controller/src/providers/etherscan.ts
+++ b/packages/name-controller/src/providers/etherscan.ts
@@ -23,17 +23,41 @@ type EtherscanGetSourceCodeResponse = {
   message: string;
   result: [
     {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       SourceCode: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       ABI: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       ContractName: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       CompilerVersion: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       OptimizationUsed: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       Runs: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       ConstructorArguments: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       Library: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       LicenseType: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       Proxy: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       Implementation: string;
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       SwarmSource: string;
     },
   ];
@@ -168,6 +192,8 @@ export class EtherscanNameProvider implements NameProvider {
 
     Object.keys(params).forEach((key, index) => {
       const value = params[key];
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       url += `${index === 0 ? '?' : '&'}${key}=${value}`;
     });
 

--- a/packages/name-controller/src/types.ts
+++ b/packages/name-controller/src/types.ts
@@ -1,6 +1,8 @@
 /** The name types supported by the NameController. */
 export enum NameType {
   /** The address of an Ethereum account. */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   ETHEREUM_ADDRESS = 'ethereumAddress',
 }
 

--- a/packages/name-controller/src/util.ts
+++ b/packages/name-controller/src/util.ts
@@ -5,6 +5,8 @@
  * @param query - GraphQL query.
  * @param variables - GraphQL variables.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export async function graphQL<T>(
   url: string,
   query: string,

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -76,6 +76,8 @@ export type NetworkMetadata = {
   /**
    * EIPs supported by the network.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   EIPS: {
     [eipNumber: number]: boolean;
   };
@@ -125,6 +127,8 @@ type NetworkConfigurations = Record<
  * @returns The keys of an object, typed according to the type of the object
  * itself.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export function knownKeysOf<K extends PropertyKey>(
   // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1308,6 +1312,8 @@ export class NetworkController extends BaseController<
           url: referrer,
         },
         properties: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           chain_id: chainId,
           symbol: ticker,
           source,

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -601,6 +601,8 @@ export class NetworkController extends BaseController<
     this.#infuraProjectId = infuraProjectId;
     this.#trackMetaMetricsEvent = trackMetaMetricsEvent;
     this.messagingSystem.registerActionHandler(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:getProviderConfig`,
       () => {
         return this.state.providerConfig;
@@ -608,6 +610,8 @@ export class NetworkController extends BaseController<
     );
 
     this.messagingSystem.registerActionHandler(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:getEthQuery`,
       () => {
         return this.#ethQuery;
@@ -615,36 +619,50 @@ export class NetworkController extends BaseController<
     );
 
     this.messagingSystem.registerActionHandler(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:getNetworkClientById`,
       this.getNetworkClientById.bind(this),
     );
 
     this.messagingSystem.registerActionHandler(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:getEIP1559Compatibility`,
       this.getEIP1559Compatibility.bind(this),
     );
 
     this.messagingSystem.registerActionHandler(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:setActiveNetwork`,
       this.setActiveNetwork.bind(this),
     );
 
     this.messagingSystem.registerActionHandler(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:setProviderType`,
       this.setProviderType.bind(this),
     );
 
     this.messagingSystem.registerActionHandler(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:findNetworkClientIdByChainId`,
       this.findNetworkClientIdByChainId.bind(this),
     );
 
     this.messagingSystem.registerActionHandler(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:getNetworkConfigurationByNetworkClientId`,
       this.getNetworkConfigurationByNetworkClientId.bind(this),
     );
 
     this.messagingSystem.registerActionHandler(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:getSelectedNetworkClient`,
       this.getSelectedNetworkClient.bind(this),
     );
@@ -748,6 +766,8 @@ export class NetworkController extends BaseController<
         ];
       if (!infuraNetworkClient) {
         throw new Error(
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `No Infura network client was found with the ID "${networkClientId}".`,
         );
       }
@@ -760,6 +780,8 @@ export class NetworkController extends BaseController<
       ];
     if (!customNetworkClient) {
       throw new Error(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `No custom network client was found with the ID "${networkClientId}".`,
       );
     }
@@ -993,10 +1015,14 @@ export class NetworkController extends BaseController<
     assert.notStrictEqual(
       type,
       NetworkType.rpc,
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `NetworkController - cannot call "setProviderType" with type "${NetworkType.rpc}". Use "setActiveNetwork"`,
     );
     assert.ok(
       isInfuraNetworkType(type),
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `Unknown Infura provider type "${type}".`,
     );
 
@@ -1173,6 +1199,8 @@ export class NetworkController extends BaseController<
     networkClientId: NetworkClientId,
   ): NetworkConfiguration | undefined {
     if (isInfuraNetworkType(networkClientId)) {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       const rpcUrl = `https://${networkClientId}.infura.io/v3/${
         this.#infuraProjectId
       }`;
@@ -1580,6 +1608,8 @@ export class NetworkController extends BaseController<
       return [];
     }
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Unrecognized network type: '${providerConfig.type}'`);
   }
 
@@ -1613,6 +1643,8 @@ export class NetworkController extends BaseController<
         builtInNetworkClientRegistry[networkClientId as BuiltInNetworkClientId];
       if (!autoManagedNetworkClient) {
         throw new Error(
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `Could not find custom network matching ${networkClientId}`,
         );
       }
@@ -1628,6 +1660,8 @@ export class NetworkController extends BaseController<
       autoManagedNetworkClient = customNetworkClientRegistry[networkClientId];
       if (!autoManagedNetworkClient) {
         throw new Error(
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `Could not find built-in network matching ${networkClientId}`,
         );
       }

--- a/packages/network-controller/src/create-auto-managed-network-client.ts
+++ b/packages/network-controller/src/create-auto-managed-network-client.ts
@@ -45,6 +45,8 @@ export type AutoManagedNetworkClient<
  * This is impossible when using the Proxy API, as the target object has to be
  * something, so this object represents that "something".
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const UNINITIALIZED_TARGET = { __UNINITIALIZED__: true };
 
 /**

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -101,6 +101,8 @@ export function createNetworkClient(
   const provider = providerFromEngine(engine);
 
   const destroy = () => {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     blockTracker.destroy();
   };
 
@@ -152,6 +154,8 @@ function createNetworkAndChainIdMiddleware({
   network: InfuraNetworkType;
 }) {
   return createScaffoldMiddleware({
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     eth_chainId: ChainId[network],
   });
 }

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -289,7 +289,11 @@ describe('NetworkController', () => {
     });
 
     for (const { networkType } of INFURA_NETWORKS) {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       describe(`when the type in the provider config is "${networkType}"`, () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         it(`does not create another network client for the ${networkType} Infura network, since it is built in`, async () => {
           await withController(
             {
@@ -929,7 +933,11 @@ describe('NetworkController', () => {
     });
 
     for (const { networkType } of INFURA_NETWORKS) {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       describe(`when the type in the provider configuration is changed to "${networkType}"`, () => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         it(`returns a provider object that was pointed to another network before the switch and is pointed to "${networkType}" afterward`, async () => {
           await withController(
             {
@@ -2193,6 +2201,8 @@ describe('NetworkController', () => {
 
     [NetworkType.mainnet, NetworkType.goerli, NetworkType.sepolia].forEach(
       (networkType) => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         describe(`when the provider config in state contains a network type of "${networkType}"`, () => {
           describe('if the network was switched after the eth_getBlockByNumber request started but before it completed', () => {
             it('stores the network status of the second network, not the first', async () => {
@@ -2818,6 +2828,8 @@ describe('NetworkController', () => {
       ticker,
       blockExplorerUrl,
     } of INFURA_NETWORKS) {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       describe(`given a network type of "${networkType}"`, () => {
         refreshNetworkTests({
           expectedProviderConfig: buildProviderConfig({
@@ -2829,6 +2841,8 @@ describe('NetworkController', () => {
         });
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       it(`overwrites the provider configuration using a predetermined chainId, ticker, and blockExplorerUrl for "${networkType}", clearing id, rpcUrl, and nickname`, async () => {
         await withController(
           {
@@ -2865,6 +2879,8 @@ describe('NetworkController', () => {
         );
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       it(`updates state.selectedNetworkClientId, setting it to ${networkType}`, async () => {
         await withController({}, async ({ controller }) => {
           const fakeProvider = buildFakeProvider();
@@ -3254,6 +3270,8 @@ describe('NetworkController', () => {
       ticker,
       blockExplorerUrl,
     } of INFURA_NETWORKS) {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       describe(`given a network type of "${networkType}"`, () => {
         refreshNetworkTests({
           expectedProviderConfig: buildProviderConfig({
@@ -3265,6 +3283,8 @@ describe('NetworkController', () => {
         });
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       it(`overwrites the provider configuration using a predetermined chainId, ticker, and blockExplorerUrl for "${networkType}", clearing id, rpcUrl, and nickname`, async () => {
         await withController(
           {
@@ -3301,6 +3321,8 @@ describe('NetworkController', () => {
         );
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       it(`updates state.selectedNetworkClientId, setting it to ${networkType}`, async () => {
         await withController({}, async ({ controller }) => {
           const fakeProvider = buildFakeProvider();
@@ -3734,6 +3756,8 @@ describe('NetworkController', () => {
   describe('resetConnection', () => {
     [NetworkType.mainnet, NetworkType.goerli, NetworkType.sepolia].forEach(
       (networkType) => {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         describe(`when the type in the provider configuration is "${networkType}"`, () => {
           refreshNetworkTests({
             expectedProviderConfig: buildProviderConfig({ type: networkType }),
@@ -4884,6 +4908,8 @@ describe('NetworkController', () => {
           controller.upsertNetworkConfiguration(
             {
               rpcUrl: 'https://test.network',
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
               chainId: toHex(MAX_SAFE_CHAIN_ID + 1),
               ticker: 'TICKER',
             },
@@ -5210,6 +5236,8 @@ describe('NetworkController', () => {
     describe('if a provider has not been set', () => {
       [NetworkType.mainnet, NetworkType.goerli, NetworkType.sepolia].forEach(
         (networkType) => {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           describe(`when the type in the provider configuration is "${networkType}"`, () => {
             refreshNetworkTests({
               expectedProviderConfig: buildProviderConfig({
@@ -5243,6 +5271,8 @@ describe('NetworkController', () => {
 
     describe('if a provider has been set', () => {
       for (const { networkType } of INFURA_NETWORKS) {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         describe(`if the previous provider configuration had a type of "${networkType}"`, () => {
           it('emits networkWillChange with state payload', async () => {
             await withController(
@@ -5487,6 +5517,8 @@ describe('NetworkController', () => {
             );
           });
 
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           it(`initializes a provider pointed to the "${networkType}" Infura network`, async () => {
             await withController(
               {
@@ -6608,6 +6640,8 @@ function refreshNetworkTests({
       );
     });
   } else {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     it(`sets the provider to an Infura provider pointed to ${expectedProviderConfig.type}`, async () => {
       await withController(
         {
@@ -7796,6 +7830,8 @@ async function waitForPublishedEvents<E extends NetworkControllerEvents>({
             // Using a string instead of an Error leads to better backtraces.
             /* eslint-disable-next-line prefer-promise-reject-errors */
             reject(
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               `Expected to receive ${expectedNumberOfEvents} ${eventType} event(s), but received ${
                 interestingEventPayloads.length
               } after ${timeBeforeAssumingNoMoreEvents}ms.\n\nAll payloads:\n\n${inspect(

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -2228,6 +2228,8 @@ describe('NetworkController', () => {
                         },
                         response: SUCCESSFUL_ETH_GET_BLOCK_BY_NUMBER_RESPONSE,
                         beforeCompleting: () => {
+                          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                          // eslint-disable-next-line @typescript-eslint/no-floating-promises
                           controller.setActiveNetwork(
                             'testNetworkConfigurationId',
                           );
@@ -2327,6 +2329,8 @@ describe('NetworkController', () => {
                           result: POST_1559_BLOCK,
                         },
                         beforeCompleting: () => {
+                          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                          // eslint-disable-next-line @typescript-eslint/no-floating-promises
                           controller.setActiveNetwork(
                             'testNetworkConfigurationId',
                           );
@@ -2423,6 +2427,8 @@ describe('NetworkController', () => {
                         },
                         error: BLOCKED_INFURA_JSON_RPC_ERROR,
                         beforeCompleting: () => {
+                          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                          // eslint-disable-next-line @typescript-eslint/no-floating-promises
                           controller.setActiveNetwork(
                             'testNetworkConfigurationId',
                           );
@@ -2539,6 +2545,8 @@ describe('NetworkController', () => {
                     },
                     response: SUCCESSFUL_ETH_GET_BLOCK_BY_NUMBER_RESPONSE,
                     beforeCompleting: () => {
+                      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                      // eslint-disable-next-line @typescript-eslint/no-floating-promises
                       controller.setProviderType(NetworkType.goerli);
                     },
                   },
@@ -2631,6 +2639,8 @@ describe('NetworkController', () => {
                       result: POST_1559_BLOCK,
                     },
                     beforeCompleting: () => {
+                      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                      // eslint-disable-next-line @typescript-eslint/no-floating-promises
                       controller.setProviderType(NetworkType.goerli);
                     },
                   },
@@ -2722,6 +2732,8 @@ describe('NetworkController', () => {
                     },
                     response: SUCCESSFUL_ETH_GET_BLOCK_BY_NUMBER_RESPONSE,
                     beforeCompleting: () => {
+                      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                      // eslint-disable-next-line @typescript-eslint/no-floating-promises
                       controller.setProviderType(NetworkType.goerli);
                     },
                   },
@@ -3471,6 +3483,8 @@ describe('NetworkController', () => {
             },
           },
           async ({ controller, messenger }) => {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             setFakeProvider(controller, {
               stubLookupNetworkWhileSetting: true,
             });
@@ -3502,6 +3516,8 @@ describe('NetworkController', () => {
             },
           },
           async ({ controller }) => {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             setFakeProvider(controller, {
               stubLookupNetworkWhileSetting: true,
             });
@@ -3520,6 +3536,8 @@ describe('NetworkController', () => {
         describe('if the latest block has a "baseFeePerGas" property', () => {
           it('sets the "1559" property to true', async () => {
             await withController(async ({ controller }) => {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               setFakeProvider(controller, {
                 stubs: [
                   {
@@ -3547,6 +3565,8 @@ describe('NetworkController', () => {
 
           it('returns true', async () => {
             await withController(async ({ controller }) => {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               setFakeProvider(controller, {
                 stubs: [
                   {
@@ -3573,6 +3593,8 @@ describe('NetworkController', () => {
         describe('if the latest block does not have a "baseFeePerGas" property', () => {
           it('sets the "1559" property to false', async () => {
             await withController(async ({ controller }) => {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               setFakeProvider(controller, {
                 stubs: [
                   {
@@ -3600,6 +3622,8 @@ describe('NetworkController', () => {
 
           it('returns false', async () => {
             await withController(async ({ controller }) => {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               setFakeProvider(controller, {
                 stubs: [
                   {
@@ -3635,6 +3659,8 @@ describe('NetworkController', () => {
           };
           it('keeps the "1559" property as undefined', async () => {
             await withController(async ({ controller }) => {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               setFakeProvider(controller, {
                 stubs: [latestBlockRespondsNull],
                 stubLookupNetworkWhileSetting: true,
@@ -3652,6 +3678,8 @@ describe('NetworkController', () => {
 
           it('returns undefined', async () => {
             await withController(async ({ controller }) => {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               setFakeProvider(controller, {
                 stubs: [latestBlockRespondsNull],
                 stubLookupNetworkWhileSetting: true,
@@ -3669,6 +3697,8 @@ describe('NetworkController', () => {
       describe('if the request for the latest block is unsuccessful', () => {
         it('does not make any state changes', async () => {
           await withController(async ({ controller, messenger }) => {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             setFakeProvider(controller, {
               stubs: [
                 {
@@ -3743,6 +3773,8 @@ describe('NetworkController', () => {
           },
         },
         async ({ messenger }) => {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/await-thenable
           const providerConfig = await messenger.call(
             'NetworkController:getProviderConfig',
           );
@@ -4484,6 +4516,8 @@ describe('NetworkController', () => {
                 url: 'https://test-dapp.com',
               },
               properties: {
+                // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 chain_id: toHex(111),
                 symbol: 'TICKER',
                 source: 'dapp',
@@ -5244,6 +5278,8 @@ describe('NetworkController', () => {
                   operation: () => {
                     // Intentionally not awaited because we're capturing an event
                     // emitted partway through the operation
+                    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
                     controller.rollbackToPreviousProvider();
                   },
                 });
@@ -5287,6 +5323,8 @@ describe('NetworkController', () => {
                   operation: () => {
                     // Intentionally not awaited because we're capturing an event
                     // emitted partway through the operation
+                    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
                     controller.rollbackToPreviousProvider();
                   },
                 });
@@ -5433,6 +5471,8 @@ describe('NetworkController', () => {
                   operation: () => {
                     // Intentionally not awaited because we want to check state
                     // while this operation is in-progress
+                    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
                     controller.rollbackToPreviousProvider();
                   },
                   beforeResolving: () => {
@@ -5836,6 +5876,8 @@ describe('NetworkController', () => {
                 operation: () => {
                   // Intentionally not awaited because we're capturing an event
                   // emitted partway through the operation
+                  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                  // eslint-disable-next-line @typescript-eslint/no-floating-promises
                   controller.rollbackToPreviousProvider();
                 },
               });
@@ -5867,6 +5909,8 @@ describe('NetworkController', () => {
                 operation: () => {
                   // Intentionally not awaited because we're capturing an event
                   // emitted partway through the operation
+                  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                  // eslint-disable-next-line @typescript-eslint/no-floating-promises
                   controller.rollbackToPreviousProvider();
                 },
               });
@@ -6009,6 +6053,8 @@ describe('NetworkController', () => {
                 operation: () => {
                   // Intentionally not awaited because we want to check state
                   // while this operation is in-progress
+                  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                  // eslint-disable-next-line @typescript-eslint/no-floating-promises
                   controller.rollbackToPreviousProvider();
                 },
                 beforeResolving: () => {
@@ -6478,6 +6524,8 @@ function refreshNetworkTests({
           operation: () => {
             // Intentionally not awaited because we're capturing an event
             // emitted partway through the operation
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             operation(controller);
           },
         });
@@ -6504,6 +6552,8 @@ function refreshNetworkTests({
           operation: () => {
             // Intentionally not awaited because we're capturing an event
             // emitted partway through the operation
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             operation(controller);
           },
         });
@@ -7524,6 +7574,8 @@ async function withController<ReturnValue>(
     return await fn({ controller, messenger });
   } finally {
     const { blockTracker } = controller.getProviderAndBlockTracker();
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     blockTracker?.destroy();
   }
 }
@@ -7674,6 +7726,8 @@ async function setFakeProvider(
  * @returns A promise that resolves to the list of payloads for the set of
  * events, optionally filtered, when a specific number of them have occurred.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 async function waitForPublishedEvents<E extends NetworkControllerEvents>({
   messenger,
   eventType,
@@ -7718,6 +7772,8 @@ async function waitForPublishedEvents<E extends NetworkControllerEvents>({
           interestingEventPayloads.push(payload);
           if (interestingEventPayloads.length === expectedNumberOfEvents) {
             stopTimer();
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             end();
           } else {
             resetTimer();
@@ -7767,6 +7823,8 @@ async function waitForPublishedEvents<E extends NetworkControllerEvents>({
       function resetTimer() {
         stopTimer();
         timer = setTimeout(() => {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           end();
         }, timeBeforeAssumingNoMoreEvents);
       }

--- a/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
@@ -180,6 +180,8 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
   });
 
   for (const emptyValue of [null, undefined, '\u003cnil\u003e']) {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     it(`does not retry an empty response of "${emptyValue}"`, async () => {
       const request = { method };
       const mockResult = emptyValue;
@@ -203,6 +205,8 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
       });
     });
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     it(`does not reuse the result of a previous request if it was "${emptyValue}"`, async () => {
       const requests = [{ method }, { method }];
       const mockResults = [emptyValue, { blockHash: '0x100' }];

--- a/packages/network-controller/tests/provider-api-tests/block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-param.ts
@@ -194,6 +194,8 @@ export function testsForRpcMethodSupportingBlockParam(
     });
 
     for (const emptyValue of [null, undefined, '\u003cnil\u003e']) {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       it(`does not retry an empty response of "${emptyValue}"`, async () => {
         const request = {
           method,
@@ -230,6 +232,8 @@ export function testsForRpcMethodSupportingBlockParam(
         });
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       it(`does not reuse the result of a previous request if it was "${emptyValue}"`, async () => {
         const requests = [
           { method, params: buildMockParams({ blockParamIndex, blockParam }) },
@@ -1625,6 +1629,8 @@ export function testsForRpcMethodSupportingBlockParam(
       });
 
       for (const emptyValue of [null, undefined, '\u003cnil\u003e']) {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         it(`does not retry an empty response of "${emptyValue}"`, async () => {
           const request = {
             method,
@@ -1651,6 +1657,8 @@ export function testsForRpcMethodSupportingBlockParam(
           });
         });
 
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         it(`does not reuse the result of a previous request if it was "${emptyValue}"`, async () => {
           const requests = [
             {
@@ -1759,6 +1767,8 @@ export function testsForRpcMethodSupportingBlockParam(
 
           for (const emptyValue of [null, undefined, '\u003cnil\u003e']) {
             if (providerType === 'infura') {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               it(`retries up to 10 times if a "${emptyValue}" response is returned, returning successful non-empty response if there is one on the 10th try`, async () => {
                 const request = {
                   method,
@@ -1798,6 +1808,8 @@ export function testsForRpcMethodSupportingBlockParam(
                 );
               });
 
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               it(`retries up to 10 times if a "${emptyValue}" response is returned, failing after the 10th try`, async () => {
                 const request = {
                   method,
@@ -1836,6 +1848,8 @@ export function testsForRpcMethodSupportingBlockParam(
                 );
               });
             } else {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               it(`does not retry an empty response of "${emptyValue}"`, async () => {
                 const request = {
                   method,
@@ -1871,6 +1885,8 @@ export function testsForRpcMethodSupportingBlockParam(
                 );
               });
 
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               it(`does not reuse the result of a previous request if it was "${emptyValue}"`, async () => {
                 const requests = [
                   {
@@ -1953,6 +1969,8 @@ export function testsForRpcMethodSupportingBlockParam(
         });
 
         for (const emptyValue of [null, undefined, '\u003cnil\u003e']) {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           it(`does not retry an empty response of "${emptyValue}"`, async () => {
             const request = {
               method,
@@ -1983,6 +2001,8 @@ export function testsForRpcMethodSupportingBlockParam(
             });
           });
 
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           it(`does not reuse the result of a previous request if it was "${emptyValue}"`, async () => {
             const requests = [
               {

--- a/packages/network-controller/tests/provider-api-tests/helpers.ts
+++ b/packages/network-controller/tests/provider-api-tests/helpers.ts
@@ -337,7 +337,9 @@ export async function withMockedCommunications(
 ) {
   const rpcUrl =
     providerType === 'infura'
-      ? `https://${infuraNetwork}.infura.io`
+      ? // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        `https://${infuraNetwork}.infura.io`
       : customRpcUrl;
   const nockScope = buildScopeForMockingRequests(rpcUrl);
   // TODO: Replace `any` with type

--- a/packages/network-controller/tests/provider-api-tests/helpers.ts
+++ b/packages/network-controller/tests/provider-api-tests/helpers.ts
@@ -254,6 +254,8 @@ async function mockAllBlockTrackerRequests({
   nockScope,
   blockNumber = DEFAULT_LATEST_BLOCK_NUMBER,
 }: MockBlockTrackerRequestOptions) {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/await-thenable
   const result = await mockRpcCall({
     nockScope,
     request: { method: 'eth_blockNumber', params: [] },

--- a/packages/network-controller/tests/provider-api-tests/no-block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/no-block-param.ts
@@ -135,6 +135,8 @@ export function testsForRpcMethodAssumingNoBlockParam(
   });
 
   for (const emptyValue of [null, undefined, '\u003cnil\u003e']) {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     it(`does not retry an empty response of "${emptyValue}"`, async () => {
       const request = { method };
       const mockResult = emptyValue;
@@ -158,6 +160,8 @@ export function testsForRpcMethodAssumingNoBlockParam(
       });
     });
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     it(`does not reuse the result of a previous request if it was "${emptyValue}"`, async () => {
       const requests = [{ method }, { method }];
       const mockResults = [emptyValue, 'some result'];

--- a/packages/notification-controller/src/NotificationController.test.ts
+++ b/packages/notification-controller/src/NotificationController.test.ts
@@ -49,6 +49,8 @@ describe('NotificationController', () => {
     });
 
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('NotificationController:show', origin, message),
     ).toBeUndefined();
     const notifications = Object.values(controller.state.notifications);
@@ -71,11 +73,15 @@ describe('NotificationController', () => {
     });
 
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('NotificationController:show', origin, message),
     ).toBeUndefined();
     const notifications = Object.values(controller.state.notifications);
     expect(notifications).toHaveLength(1);
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('NotificationController:markRead', [
         notifications[0].id,
         'foo',
@@ -100,11 +106,15 @@ describe('NotificationController', () => {
     });
 
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('NotificationController:show', origin, message),
     ).toBeUndefined();
     const notifications = Object.values(controller.state.notifications);
     expect(notifications).toHaveLength(1);
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('NotificationController:dismiss', [
         notifications[0].id,
         'foo',
@@ -123,11 +133,15 @@ describe('NotificationController', () => {
     });
 
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('NotificationController:show', origin, message),
     ).toBeUndefined();
     const notifications = Object.values(controller.state.notifications);
     expect(notifications).toHaveLength(1);
     expect(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await unrestricted.call('NotificationController:clear'),
     ).toBeUndefined();
 

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -67,6 +67,8 @@ type FilterObjectCaveat = Caveat<
 type NoopCaveat = Caveat<typeof CaveatTypes.noopCaveat, null>;
 
 // A caveat value merger for any caveat whose value is an array of JSON primitives.
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const primitiveArrayMerger = <T extends string | null | number>(
   a: T[],
   b: T[],
@@ -203,19 +205,43 @@ type DefaultCaveatSpecifications = ExtractSpecifications<
  * Permission key constants.
  */
 const PermissionKeys = {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_doubleNumber: 'wallet_doubleNumber',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_getSecretArray: 'wallet_getSecretArray',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_getSecretObject: 'wallet_getSecretObject',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noop: 'wallet_noop',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedAndFailureSideEffects:
     'wallet_noopWithPermittedAndFailureSideEffects',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedAndFailureSideEffects2:
     'wallet_noopWithPermittedAndFailureSideEffects2',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedSideEffects: 'wallet_noopWithPermittedSideEffects',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithValidator: 'wallet_noopWithValidator',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithRequiredCaveat: 'wallet_noopWithRequiredCaveat',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithFactory: 'wallet_noopWithFactory',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithManyCaveats: 'wallet_noopWithManyCaveats',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   snap_foo: 'snap_foo',
   endowmentAnySubject: 'endowmentAnySubject',
   endowmentSnapsOnly: 'endowmentSnapsOnly',
@@ -235,20 +261,44 @@ type NoopWithFactoryPermission = ValidPermission<
  * Permission name (as opposed to keys) constants and getters.
  */
 const PermissionNames = {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_doubleNumber: PermissionKeys.wallet_doubleNumber,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_getSecretArray: PermissionKeys.wallet_getSecretArray,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_getSecretObject: PermissionKeys.wallet_getSecretObject,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noop: PermissionKeys.wallet_noop,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithValidator: PermissionKeys.wallet_noopWithValidator,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedAndFailureSideEffects:
     PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedAndFailureSideEffects2:
     PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects2,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedSideEffects:
     PermissionKeys.wallet_noopWithPermittedSideEffects,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithRequiredCaveat: PermissionKeys.wallet_noopWithRequiredCaveat,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithFactory: PermissionKeys.wallet_noopWithFactory,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithManyCaveats: PermissionKeys.wallet_noopWithManyCaveats,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   snap_foo: PermissionKeys.snap_foo,
   endowmentAnySubject: PermissionKeys.endowmentAnySubject,
   endowmentSnapsOnly: PermissionKeys.endowmentSnapsOnly,
@@ -624,6 +674,8 @@ function getExistingPermissionState() {
       'metamask.io': {
         origin: 'metamask.io',
         permissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {
             id: 'escwEx9JrOxGZKZk3RkL4',
             parentCapability: 'wallet_getSecretArray',
@@ -758,6 +810,8 @@ describe('PermissionController', () => {
                 },
               }),
             ),
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         ).toThrow(`Invalid permission type: "${invalidPermissionType}"`);
       });
     });
@@ -924,6 +978,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -933,6 +989,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'bar' },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -1490,6 +1548,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: [
@@ -1523,6 +1583,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
                 caveats: [
@@ -1547,6 +1609,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
                 caveats: [
@@ -1664,6 +1728,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: [
@@ -1688,6 +1754,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: [
@@ -1792,6 +1860,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: [
@@ -1815,6 +1885,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: null,
@@ -1847,6 +1919,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
                 caveats: [
@@ -1871,6 +1945,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
                 caveats: [
@@ -1974,8 +2050,14 @@ describe('PermissionController', () => {
 
   describe('updatePermissionsByCaveat', () => {
     enum MultiCaveatOrigins {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       a = 'a.com',
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       b = 'b.io',
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       c = 'c.biz',
     }
 
@@ -2352,6 +2434,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -2361,6 +2445,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
@@ -2377,7 +2463,11 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretObject: {
             parentCapability: 'wallet_getSecretObject',
           },
@@ -2389,9 +2479,13 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
               }),
@@ -2409,6 +2503,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: origin1 },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretObject: {},
         },
       });
@@ -2416,6 +2512,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: origin2 },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -2425,6 +2523,8 @@ describe('PermissionController', () => {
           [origin1]: {
             origin: origin1,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
                 caveats: null,
@@ -2435,6 +2535,8 @@ describe('PermissionController', () => {
           [origin2]: {
             origin: origin2,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: null,
@@ -2521,6 +2623,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
@@ -2532,6 +2636,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretObject: {},
         },
         // preserveExistingPermissions is true by default
@@ -2542,9 +2648,13 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
               }),
@@ -2563,6 +2673,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
@@ -2574,6 +2686,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretObject: {},
         },
         preserveExistingPermissions: false,
@@ -2584,6 +2698,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
               }),
@@ -2600,6 +2716,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin: '' },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {},
           },
         }),
@@ -2610,6 +2728,8 @@ describe('PermissionController', () => {
           // @ts-expect-error Intentional destructive testing
           subject: { origin: 2 },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {},
           },
         }),
@@ -2623,6 +2743,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin: 'metamask.io' },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretFalafel: {},
           },
         }),
@@ -2637,6 +2759,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               // This must match the key
               parentCapability: 'wallet_getSecretObject',
@@ -2655,9 +2779,13 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               parentCapability: 'wallet_getSecretArray',
             },
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretObject: {
               // This must match the key
               parentCapability: 'wallet_getSecretArray',
@@ -2681,6 +2809,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               parentCapability: 'wallet_getSecretArray',
               caveats: [
@@ -2707,6 +2837,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               // @ts-expect-error Intentional destructive testing
               caveats: [[]],
@@ -2725,6 +2857,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               // @ts-expect-error Intentional destructive testing
               caveats: ['foo'],
@@ -2748,6 +2882,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               caveats: [
                 {
@@ -2779,6 +2915,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               caveats: [
                 {
@@ -2810,6 +2948,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               caveats: [{ type: 'fooType', value: 'bar' }],
             },
@@ -2832,6 +2972,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               caveats: [
                 {
@@ -2869,6 +3011,8 @@ describe('PermissionController', () => {
             controller.grantPermissions({
               subject: { origin },
               approvedPermissions: {
+                // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 wallet_getSecretArray: {
                   caveats: [
                     {
@@ -2923,6 +3067,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretObject: {
               caveats: [
                 {
@@ -2950,6 +3096,8 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_doubleNumber: {
               caveats: [
                 {
@@ -2999,6 +3147,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
@@ -3010,6 +3160,8 @@ describe('PermissionController', () => {
       controller.grantPermissionsIncremental({
         subject: { origin },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretObject: {},
         },
       });
@@ -3019,9 +3171,13 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
               }),
@@ -3043,6 +3199,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_noopWithManyCaveats: {
             caveats: [{ ...caveat1 }],
           },
@@ -3052,6 +3210,8 @@ describe('PermissionController', () => {
       controller.grantPermissionsIncremental({
         subject: { origin },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_noopWithManyCaveats: {
             caveats: [{ ...caveat2 }],
           },
@@ -3063,6 +3223,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_noopWithManyCaveats: getPermissionMatcher({
                 parentCapability: 'wallet_noopWithManyCaveats',
                 caveats: [{ ...caveat1 }, { ...caveat2 }],
@@ -3084,6 +3246,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_noopWithManyCaveats: {
             caveats: [getCaveat('foo')],
           },
@@ -3093,6 +3257,8 @@ describe('PermissionController', () => {
       controller.grantPermissionsIncremental({
         subject: { origin },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_noopWithManyCaveats: {
             caveats: [getCaveat('foo', 'bar')],
           },
@@ -3104,6 +3270,8 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_noopWithManyCaveats: getPermissionMatcher({
                 parentCapability: 'wallet_noopWithManyCaveats',
                 caveats: [getCaveat('foo', 'bar')],
@@ -4179,6 +4347,8 @@ describe('PermissionController', () => {
               { origin },
               {
                 [PermissionNames.wallet_getSecretArray]: {},
+                // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 wallet_getSecretKabob: {},
               },
             ),
@@ -4188,6 +4358,8 @@ describe('PermissionController', () => {
             requestedPermissions: {
               [PermissionNames.wallet_getSecretArray]: {
                 [PermissionNames.wallet_getSecretArray]: {},
+                // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 wallet_getSecretKabob: {},
               },
             },
@@ -5587,6 +5759,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -5689,6 +5863,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -5779,6 +5955,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -5809,6 +5987,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -5838,6 +6018,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -5872,6 +6054,8 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -5911,6 +6095,8 @@ describe('PermissionController', () => {
 
       const result = messenger.call('PermissionController:grantPermissions', {
         subject: { origin: 'foo' },
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         approvedPermissions: { wallet_getSecretArray: {} },
       });
 
@@ -5934,6 +6120,8 @@ describe('PermissionController', () => {
         'PermissionController:grantPermissionsIncremental',
         {
           subject: { origin: 'foo' },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           approvedPermissions: { wallet_getSecretArray: {} },
         },
       );
@@ -5964,6 +6152,8 @@ describe('PermissionController', () => {
         'PermissionController:requestPermissions',
         { origin: 'foo' },
         {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       );
@@ -5991,6 +6181,8 @@ describe('PermissionController', () => {
         'PermissionController:requestPermissionsIncremental',
         { origin: 'foo' },
         {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       );
@@ -6005,6 +6197,8 @@ describe('PermissionController', () => {
           'metamask.io': {
             origin: 'metamask.io',
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: {
                 id: 'escwEx9JrOxGZKZk3RkL4',
                 parentCapability: 'wallet_getSecretArray',
@@ -6030,6 +6224,8 @@ describe('PermissionController', () => {
 
       const updateCaveatSpy = jest.spyOn(controller, 'updateCaveat');
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await messenger.call(
         'PermissionController:updateCaveat',
         'metamask.io',
@@ -6044,6 +6240,8 @@ describe('PermissionController', () => {
           'metamask.io': {
             origin: 'metamask.io',
             permissions: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: {
                 id: 'escwEx9JrOxGZKZk3RkL4',
                 parentCapability: 'wallet_getSecretArray',
@@ -6199,6 +6397,8 @@ describe('PermissionController', () => {
           'Unauthorized to perform action. Try requesting the required permission(s) first. For more information, see: https://docs.metamask.io/guide/rpc-api.html#permissions',
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);
       expect(response.error).toMatchObject(
@@ -6221,6 +6421,8 @@ describe('PermissionController', () => {
 
       const expectedError = errors.methodNotFound('wallet_foo', { origin });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);
       const { error } = response;
@@ -6270,6 +6472,8 @@ describe('PermissionController', () => {
         { request: { ...request } },
       );
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);
       const { error } = response;

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -429,9 +429,17 @@ export type GenericPermissionController = PermissionController<
  * Describes the possible results of a {@link CaveatMutator} function.
  */
 export enum CaveatMutatorOperation {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   noop,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   updateValue,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   deleteCaveat,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   revokePermission,
 }
 
@@ -461,6 +469,8 @@ type CaveatMutatorResult =
       >;
     }>;
 
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type MergeCaveatResult<T extends CaveatConstraint | undefined> =
   T extends undefined
     ? [CaveatConstraint, CaveatConstraint['value']]
@@ -2314,6 +2324,8 @@ export class PermissionController<
    * @returns The merged permission.
    */
   #mergePermission<
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     T extends Partial<PermissionConstraint> | PermissionConstraint,
   >(
     leftPermission: T | undefined,
@@ -2370,6 +2382,8 @@ export class PermissionController<
    * @param rightCaveat - The right-hand caveat to merge.
    * @returns The merged caveat and the diff between the two caveats.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   #mergeCaveat<T extends CaveatConstraint, U extends T | undefined>(
     leftCaveat: U,
     rightCaveat: T,
@@ -2658,6 +2672,8 @@ export class PermissionController<
     }
 
     try {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.messagingSystem.call(
         'ApprovalController:acceptRequest',
         id,

--- a/packages/permission-controller/src/SubjectMetadataController.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.ts
@@ -142,11 +142,15 @@ export class SubjectMetadataController extends BaseController<
     this.subjectsWithoutPermissionsEncounteredSinceStartup = new Set();
 
     this.messagingSystem.registerActionHandler(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:getSubjectMetadata`,
       this.getSubjectMetadata.bind(this),
     );
 
     this.messagingSystem.registerActionHandler(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:addSubjectMetadata`,
       this.addSubjectMetadata.bind(this),
     );

--- a/packages/permission-controller/src/errors.ts
+++ b/packages/permission-controller/src/errors.ts
@@ -160,6 +160,8 @@ export class EndowmentPermissionDoesNotExistError extends Error {
   public data?: { origin: string };
 
   constructor(target: string, origin?: string) {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     super(`Subject "${origin}" has no permission for "${target}".`);
     if (origin) {
       this.data = { origin };

--- a/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
@@ -14,6 +14,8 @@ describe('getPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       (
         req: JsonRpcRequest<[]>,
         res: PendingJsonRpcResponse<PermissionConstraint[]>,
@@ -43,6 +45,8 @@ describe('getPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       (
         req: JsonRpcRequest<[]>,
         res: PendingJsonRpcResponse<PermissionConstraint[]>,

--- a/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
@@ -32,6 +32,8 @@ describe('requestPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<[RequestedPermissions], PermissionConstraint[]>(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       (req, res, next, end) =>
         implementation(req, res, next, end, {
           requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
@@ -66,6 +68,8 @@ describe('requestPermissions RPC method', () => {
     // is catched.
     engine.push<[RequestedPermissions], PermissionConstraint[]>(
       createAsyncMiddleware(async (req, res, next) =>
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         implementation(req, res, next, end, {
           requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
         }),
@@ -99,6 +103,8 @@ describe('requestPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<[RequestedPermissions], PermissionConstraint[]>(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) => {
         await implementation(req, res, next, end, {
           requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
@@ -122,6 +128,8 @@ describe('requestPermissions RPC method', () => {
       delete expectedError.stack;
 
       // @ts-expect-error Intentional destructive testing
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);
       delete response.error.stack;

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -28,6 +28,8 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<RevokePermissionArgs, null>(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) =>
         await implementation(req, res, next, end, {
           revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
@@ -40,6 +42,8 @@ describe('revokePermissions RPC method', () => {
       method: 'wallet_revokePermissions',
       params: [
         {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           snap_dialog: {},
         },
       ],
@@ -59,6 +63,8 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<RevokePermissionArgs, null>(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) =>
         await implementation(req, res, next, end, {
           revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
@@ -79,6 +85,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);
     delete response.error.stack;
@@ -92,6 +100,8 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<RevokePermissionArgs, null>(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) =>
         await implementation(req, res, next, end, {
           revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
@@ -112,6 +122,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);
     delete response.error.stack;
@@ -125,6 +137,8 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<RevokePermissionArgs, null>(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) =>
         await implementation(req, res, next, end, {
           revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
@@ -144,6 +158,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);
     delete response.error.stack;
@@ -157,6 +173,8 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<RevokePermissionArgs, null>(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) =>
         await implementation(req, res, next, end, {
           revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
@@ -177,6 +195,8 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);
     delete response.error.stack;

--- a/packages/permission-controller/src/utils.ts
+++ b/packages/permission-controller/src/utils.ts
@@ -21,8 +21,14 @@ import type {
 } from './Permission';
 
 export enum MethodNames {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   requestPermissions = 'wallet_requestPermissions',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   getPermissions = 'wallet_getPermissions',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   revokePermissions = 'wallet_revokePermissions',
 }
 
@@ -44,8 +50,14 @@ export type ExtractSpecifications<
  * A middleware function for handling a permitted method.
  */
 export type HandlerMiddlewareFunction<
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   T,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   U extends JsonRpcParams,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   V extends Json,
 > = (
   req: JsonRpcRequest<U>,
@@ -61,6 +73,8 @@ export type HandlerMiddlewareFunction<
  * This can then be used to select only the necessary hooks whenever a method
  * is called for purposes of POLA.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type HookNames<T> = {
   [Property in keyof T]: true;
 };
@@ -69,8 +83,14 @@ export type HookNames<T> = {
  * A handler for a permitted method.
  */
 export type PermittedHandlerExport<
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   T,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   U extends JsonRpcParams,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   V extends Json,
 > = {
   implementation: HandlerMiddlewareFunction<T, U, V>;

--- a/packages/permission-log-controller/src/PermissionLogController.ts
+++ b/packages/permission-log-controller/src/PermissionLogController.ts
@@ -133,6 +133,8 @@ export class PermissionLogController extends BaseController<
       return;
     }
     const newEntries = {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       eth_accounts: {
         accounts: this.#getAccountToTimeMap(accounts, Date.now()),
       },
@@ -299,6 +301,8 @@ export class PermissionLogController extends BaseController<
       // a set of accounts if the RPC method is "eth_requestAccounts".
       const accounts = result as string[];
       newEntries = {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         eth_accounts: {
           accounts: this.#getAccountToTimeMap(accounts, time),
           lastApproved: time,

--- a/packages/permission-log-controller/src/enums.ts
+++ b/packages/permission-log-controller/src/enums.ts
@@ -9,8 +9,14 @@ export const LOG_IGNORE_METHODS = [
   'wallet_watchAsset',
 ];
 
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export enum LOG_METHOD_TYPES {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   restricted = 'restricted',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   internal = 'internal',
 }
 

--- a/packages/permission-log-controller/tests/helpers.ts
+++ b/packages/permission-log-controller/tests/helpers.ts
@@ -23,8 +23,14 @@ const SUBJECTS = {
 };
 
 const PERM_NAMES = Object.freeze({
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   eth_accounts: 'eth_accounts',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   test_method: 'test_method',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   does_not_exist: 'does_not_exist',
 });
 
@@ -53,6 +59,8 @@ const CAVEATS = {
    * @param accounts - The accounts for the caveat
    * @returns An eth_accounts restrictReturnedAccounts caveats
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   eth_accounts: (accounts: string[]) => {
     return [
       {
@@ -77,7 +85,11 @@ const PERMS = {
      *
      * @returns A permissions request object with eth_accounts
      */
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     eth_accounts: () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       return { eth_accounts: {} };
     },
 
@@ -86,7 +98,11 @@ const PERMS = {
      *
      * @returns A permissions request object with test_method
      */
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     test_method: () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       return { test_method: {} };
     },
 
@@ -95,7 +111,11 @@ const PERMS = {
      *
      * @returns A permissions request object with does_not_exist
      */
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     does_not_exist: () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       return { does_not_exist: {} };
     },
   },
@@ -112,6 +132,8 @@ const PERMS = {
      * @param accounts - The accounts for the eth_accounts permission caveat
      * @returns A granted permissions object with eth_accounts and its caveat
      */
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     eth_accounts: (accounts: string[]) => {
       return {
         parentCapability: PERM_NAMES.eth_accounts,
@@ -124,6 +146,8 @@ const PERMS = {
      *
      * @returns A granted permissions object with test_method
      */
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     test_method: () => {
       return {
         parentCapability: PERM_NAMES.test_method,
@@ -169,6 +193,8 @@ export const getters = deepFreeze({
      * @param origin - The origin of the request
      * @returns An RPC request object
      */
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     eth_accounts: (origin: string) => {
       return {
         ...JsonRpcRequestStruct.TYPE,
@@ -185,6 +211,8 @@ export const getters = deepFreeze({
      * @param param - The request param
      * @returns An RPC request object
      */
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     test_method: (origin: string, param = false) => {
       return {
         ...JsonRpcRequestStruct.TYPE,
@@ -200,6 +228,8 @@ export const getters = deepFreeze({
      * @param origin - The origin of the request
      * @returns An RPC request object
      */
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     eth_requestAccounts: (origin: string) => {
       return {
         ...JsonRpcRequestStruct.TYPE,
@@ -254,6 +284,8 @@ export const getters = deepFreeze({
      * @param args - Any other data for the request's subjectMetadata
      * @returns An RPC request object
      */
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     metamask_sendDomainMetadata: (
       origin: string,
       name: string,

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -67,11 +67,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             blocklist: [],
             fuzzylist: [],
             allowlist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -130,11 +134,15 @@ describe('PhishingController', () => {
         .get(METAMASK_STALELIST_FILE)
         .reply(200, {
           data: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             eth_phishing_detect_config: {
               blocklist: ['this-should-not-be-in-default-blocklist.com'],
               fuzzylist: [],
               allowlist: ['this-should-not-be-in-default-allowlist.com'],
             },
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             phishfort_hotlist: {
               blocklist: [],
             },
@@ -450,11 +458,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: ['metamask.io'],
             blocklist: [],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -479,11 +491,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: [],
             blocklist: [],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -508,11 +524,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: [],
             blocklist: [],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -537,11 +557,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: [],
             blocklist: ['etnerscan.io'],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -567,11 +591,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             blocklist: ['xn--myetherallet-4k5fwn.com'],
             allowlist: [],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -596,11 +624,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: [],
             blocklist: ['xn--myetherallet-4k5fwn.com'],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -626,11 +658,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: [],
             blocklist: [],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -666,11 +702,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: [],
             blocklist: [],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -697,11 +737,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: ['opensea.io'],
             blocklist: [],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -726,11 +770,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: ['opensea.io'],
             blocklist: [],
             fuzzylist: ['opensea.io'],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -755,11 +803,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: ['opensea.io'],
             blocklist: [],
             fuzzylist: ['opensea.io'],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -785,11 +837,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: [],
             blocklist: ['electrum.mx'],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -820,11 +876,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: [],
             blocklist: ['electrum.mx'],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -856,11 +916,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: [],
             blocklist: ['xn--myetherallet-4k5fwn.com'],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -891,11 +955,15 @@ describe('PhishingController', () => {
       .get(METAMASK_STALELIST_FILE)
       .reply(200, {
         data: {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           eth_phishing_detect_config: {
             allowlist: [],
             blocklist: ['xn--myetherallet-4k5fwn.com'],
             fuzzylist: [],
           },
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           phishfort_hotlist: {
             blocklist: [],
           },
@@ -931,11 +999,15 @@ describe('PhishingController', () => {
         .get(METAMASK_STALELIST_FILE)
         .reply(200, {
           data: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             eth_phishing_detect_config: {
               allowlist: [],
               blocklist: [exampleBlockedUrl],
               fuzzylist: [],
             },
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             phishfort_hotlist: {
               blocklist: [],
             },
@@ -989,11 +1061,15 @@ describe('PhishingController', () => {
         .get(METAMASK_STALELIST_FILE)
         .reply(200, {
           data: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             eth_phishing_detect_config: {
               allowlist: [],
               blocklist: [exampleBlockedUrl],
               fuzzylist: [],
             },
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             phishfort_hotlist: {
               blocklist: [],
             },
@@ -1138,11 +1214,15 @@ describe('PhishingController', () => {
           .delay(100)
           .reply(200, {
             data: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               eth_phishing_detect_config: {
                 allowlist: [],
                 blocklist: [],
                 fuzzylist: [],
               },
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               phishfort_hotlist: {
                 blocklist: [],
               },
@@ -1176,11 +1256,15 @@ describe('PhishingController', () => {
           .delay(100)
           .reply(200, {
             data: {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               eth_phishing_detect_config: {
                 allowlist: [],
                 blocklist: [],
                 fuzzylist: [],
               },
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               phishfort_hotlist: {
                 blocklist: [],
               },

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -56,7 +56,11 @@ export type EthPhishingResponse = {
  * @property version - Stalelist data structure iteration.
  */
 export type PhishingStalelist = {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   eth_phishing_detect_config: Record<ListTypes, string[]>;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   phishfort_hotlist: Record<ListTypes, string[]>;
   tolerance: number;
   version: number;
@@ -119,6 +123,8 @@ export type HotlistDiff = {
   isRemoval?: boolean;
 };
 
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export type DataResultWrapper<T> = {
   data: T;
 };
@@ -489,6 +495,8 @@ export class PhishingController extends BaseController<
       return;
     }
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { phishfort_hotlist, eth_phishing_detect_config, ...partialState } =
       stalelistResponse.data;
 

--- a/packages/polling-controller/src/AbstractPollingController.ts
+++ b/packages/polling-controller/src/AbstractPollingController.ts
@@ -20,6 +20,8 @@ export const getKey = (
  * @param Base - The base class to mix onto.
  * @returns The composed class.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export function AbstractPollingControllerBaseMixin<TBase extends Constructor>(
   Base: TBase,
 ) {

--- a/packages/polling-controller/src/AbstractPollingController.ts
+++ b/packages/polling-controller/src/AbstractPollingController.ts
@@ -12,6 +12,8 @@ import type {
 export const getKey = (
   networkClientId: NetworkClientId,
   options: Json,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 ): PollingTokenSetId => `${networkClientId}:${stringify(options)}`;
 
 /**

--- a/packages/polling-controller/src/BlockTrackerPollingController.ts
+++ b/packages/polling-controller/src/BlockTrackerPollingController.ts
@@ -18,6 +18,8 @@ import type { Constructor, PollingTokenSetId } from './types';
  * @param Base - The base class to mix onto.
  * @returns The composed class.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 function BlockTrackerPollingControllerMixin<TBase extends Constructor>(
   Base: TBase,
 ) {
@@ -47,6 +49,8 @@ function BlockTrackerPollingControllerMixin<TBase extends Constructor>(
           networkClientId,
           options,
         );
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         networkClient.blockTracker.addListener('latest', updateOnNewBlock);
         this.#activeListeners[key] = updateOnNewBlock;
       } else {
@@ -65,6 +69,8 @@ function BlockTrackerPollingControllerMixin<TBase extends Constructor>(
       if (networkClient && this.#activeListeners[key]) {
         const listener = this.#activeListeners[key];
         if (listener) {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/no-misused-promises
           networkClient.blockTracker.removeListener('latest', listener);
           delete this.#activeListeners[key];
         }

--- a/packages/polling-controller/src/BlockTrackerPollingController.ts
+++ b/packages/polling-controller/src/BlockTrackerPollingController.ts
@@ -55,6 +55,8 @@ function BlockTrackerPollingControllerMixin<TBase extends Constructor>(
         this.#activeListeners[key] = updateOnNewBlock;
       } else {
         throw new Error(
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `Unable to retrieve blockTracker for networkClientId ${networkClientId}`,
         );
       }

--- a/packages/polling-controller/src/StaticIntervalPollingController.ts
+++ b/packages/polling-controller/src/StaticIntervalPollingController.ts
@@ -19,6 +19,8 @@ import type {
  * @param Base - The base class to mix onto.
  * @returns The composed class.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 function StaticIntervalPollingControllerMixin<TBase extends Constructor>(
   Base: TBase,
 ) {
@@ -52,6 +54,8 @@ function StaticIntervalPollingControllerMixin<TBase extends Constructor>(
 
       // eslint-disable-next-line no-multi-assign
       const intervalId = (this.#intervalIds[key] = setTimeout(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         async () => {
           try {
             await this._executePoll(networkClientId, options);

--- a/packages/profile-sync-controller/src/sdk/__fixtures__/mock-auth.ts
+++ b/packages/profile-sync-controller/src/sdk/__fixtures__/mock-auth.ts
@@ -29,37 +29,67 @@ export const MOCK_ACCESS_JWT =
 const MOCK_NONCE_RESPONSE = {
   nonce: 'xGMm9SoihEKeAEfV',
   identifier: '0xd8641601Cb79a94FD872fE42d5b4a067A44a7e88',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   expires_in: 300,
 };
 
 const MOCK_SIWE_LOGIN_RESPONSE = {
   token: MOCK_JWT,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   expires_in: 3600,
   profile: {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     profile_id: 'fa2bbf82-bd9a-4e6b-aabc-9ca0d0319b6e',
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     metametrics_id: 'de742679-4960-4977-a415-4718b5f8e86c',
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     identifier_id:
       'ec9a4e9906836497efad2fd4d4290b34d2c6a2c0d93eb174aa3cd88a133adbaf',
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     identifier_type: 'SIWE',
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     encrypted_storage_key: '2c6a2c0d93eb174aa3cd88a133adbaf',
   },
 };
 
 export const MOCK_SRP_LOGIN_RESPONSE = {
   token: MOCK_JWT,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   expires_in: 3600,
   profile: {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     profile_id: 'f88227bd-b615-41a3-b0be-467dd781a4ad',
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     metametrics_id: '561ec651-a844-4b36-a451-04d6eac35740',
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     identifier_id:
       'da9a9fc7b09edde9cc23cec9b7e11a71fb0ab4d2ddd8af8af905306f3e1456fb',
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     identifier_type: 'SRP',
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     encrypted_storage_key: 'd2ddd8af8af905306f3e1456fb',
   },
 };
 
 export const MOCK_OIDC_TOKEN_RESPONSE = {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   access_token: MOCK_ACCESS_JWT,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   expires_in: 3600,
 };
 

--- a/packages/profile-sync-controller/src/sdk/__fixtures__/mock-userstorage.ts
+++ b/packages/profile-sync-controller/src/sdk/__fixtures__/mock-userstorage.ts
@@ -13,6 +13,8 @@ type MockReply = {
 const MOCK_STORAGE_URL = STORAGE_URL(Env.DEV, 'notifications', '');
 
 export const MOCK_STORAGE_KEY = 'MOCK_STORAGE_KEY';
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const MOCK_NOTIFICATIONS_DATA = { is_compact: false };
 export const MOCK_NOTIFICATIONS_DATA_ENCRYPTED = encryption.encryptString(
   JSON.stringify(MOCK_NOTIFICATIONS_DATA),

--- a/packages/profile-sync-controller/src/sdk/__fixtures__/test-utils.ts
+++ b/packages/profile-sync-controller/src/sdk/__fixtures__/test-utils.ts
@@ -11,7 +11,8 @@ import { Env, Platform } from '../env';
 export type MockVariable = any;
 
 // Utility for mocking, the generics will constrain values
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/naming-convention
 export const typedMockFn = <Fn extends (...args: any[]) => any>() =>
   jest.fn<ReturnType<Fn>, Parameters<Fn>>();
 

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-siwe.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-siwe.ts
@@ -16,10 +16,14 @@ import type {
   UserProfile,
 } from './types';
 
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type JwtBearerAuth_SIWE_Options = {
   storage: AuthStorageOptions;
 };
 
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type JwtBearerAuth_SIWE_Signer = {
   address: string;
   chainId: number;

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.ts
@@ -12,6 +12,8 @@ import type {
   UserProfile,
 } from './types';
 
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type JwtBearerAuth_SRP_Options = {
   storage: AuthStorageOptions;
   signing?: AuthSigningOptions;

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/services.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/services.ts
@@ -46,8 +46,14 @@ type NonceResponse = {
 
 type PairRequest = {
   signature: string;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   raw_message: string;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   encrypted_storage_key: string;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   identifier_type: 'SIWE' | 'SRP';
 };
 
@@ -161,6 +167,8 @@ export async function authorizeOIDC(
 
     if (!response.ok) {
       const responseBody = (await response.json()) as {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         error_description: string;
         error: string;
       };
@@ -213,6 +221,8 @@ export async function authenticate(
       },
       body: JSON.stringify({
         signature,
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         raw_message: rawMessage,
       }),
     });

--- a/packages/profile-sync-controller/src/sdk/authentication.test.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication.test.ts
@@ -223,6 +223,8 @@ describe('Authentication - SRP Flow - getAccessToken() & getUserProfile()', () =
         mockOAuth2TokenUrl: {
           status: 400,
           body: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             error_description: 'invalid JWT token',
             error: 'invalid_request',
           },
@@ -398,6 +400,8 @@ describe('Authentication - SIWE Flow - getAccessToken(), getUserProfile(), signM
         mockOAuth2TokenUrl: {
           status: 400,
           body: {
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             error_description: 'invalid JWT token',
             error: 'invalid_request',
           },

--- a/packages/profile-sync-controller/src/sdk/authentication.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication.ts
@@ -10,6 +10,8 @@ import type { Env } from './env';
 import { PairError, UnsupportedAuthTypeError } from './errors';
 
 // Computing the Classes, so we only get back the public methods for the interface.
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type Compute<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
 type SIWEInterface = Compute<SIWEJwtBearerAuth>;
 type SRPInterface = Compute<SRPJwtBearerAuth>;
@@ -69,8 +71,14 @@ export class JwtBearerAuth implements SIWEInterface, SRPInterface {
           const sig = await p.signMessage(raw);
           return {
             signature: sig,
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             raw_message: raw,
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             encrypted_storage_key: p.encryptedStorageKey,
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             identifier_type: p.identifierType,
           };
         } catch (e) {

--- a/packages/profile-sync-controller/src/sdk/encryption.ts
+++ b/packages/profile-sync-controller/src/sdk/encryption.ts
@@ -41,12 +41,20 @@ function bytesToUtf8(byteArray: Uint8Array): string {
 }
 
 class EncryptorDecryptor {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   #ALGORITHM_NONCE_SIZE = 12; // 12 bytes
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   #ALGORITHM_KEY_SIZE = 16; // 16 bytes
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   #PBKDF2_SALT_SIZE = 16; // 16 bytes
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   #PBKDF2_ITERATIONS = 900_000;
 
   encryptString(plaintext: string, password: string): string {

--- a/packages/profile-sync-controller/src/sdk/user-storage.ts
+++ b/packages/profile-sync-controller/src/sdk/user-storage.ts
@@ -159,6 +159,8 @@ export class UserStorage {
     return hashedKey;
   }
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   async #getAuthorizationHeader(): Promise<{ Authorization: string }> {
     const accessToken = await this.config.auth.getAccessToken();
     return { Authorization: `Bearer ${accessToken}` };

--- a/packages/rate-limit-controller/src/RateLimitController.ts
+++ b/packages/rate-limit-controller/src/RateLimitController.ts
@@ -205,6 +205,8 @@ export class RateLimitController<
       Object.assign(state, {
         requests: {
           ...(state.requests as RateLimitedRequests<RateLimitedApis>),
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
           [api]: { [origin]: previous + 1 },
         },
       });

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -102,7 +102,8 @@ const waitForFinishStatusMock = jest.fn();
 const approveMessageMock = jest.fn();
 
 // TODO: Replace `any` with type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/naming-convention
 const createMessageManagerMock = <T>(prototype?: any): jest.Mocked<T> => {
   const messageManagerMock = Object.create(prototype);
 
@@ -783,6 +784,8 @@ describe('SignatureController', () => {
     });
 
     it('updates state on message manager state change', async () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await personalMessageManagerMock.subscribe.mock.calls[0][0]({
         // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -790,6 +793,8 @@ describe('SignatureController', () => {
         unapprovedMessagesCount: 3,
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       expect(await signatureController.state).toStrictEqual({
         // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -801,6 +806,8 @@ describe('SignatureController', () => {
     });
 
     it('updates state on personal message manager state change', async () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await personalMessageManagerMock.subscribe.mock.calls[0][0]({
         // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -808,6 +815,8 @@ describe('SignatureController', () => {
         unapprovedMessagesCount: 4,
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       expect(await signatureController.state).toStrictEqual({
         // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -819,6 +828,8 @@ describe('SignatureController', () => {
     });
 
     it('updates state on typed message manager state change', async () => {
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await typedMessageManagerMock.subscribe.mock.calls[0][0]({
         // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -826,6 +837,8 @@ describe('SignatureController', () => {
         unapprovedMessagesCount: 5,
       });
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       expect(await signatureController.state).toStrictEqual({
         unapprovedPersonalMsgs: {},
         // TODO: Replace `any` with type

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -288,6 +288,8 @@ export class SignatureController extends BaseController<
       ApprovalType.PersonalSign,
       SigningMethod.PersonalSign,
       'Personal Message',
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       this.#signPersonalMessage.bind(this),
       messageParams,
       req,
@@ -316,6 +318,8 @@ export class SignatureController extends BaseController<
       ApprovalType.EthSignTypedData,
       signTypeForLogger,
       'Typed Message',
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       this.#signTypedMessage.bind(this),
       messageParams,
       req,
@@ -372,9 +376,17 @@ export class SignatureController extends BaseController<
   }
 
   async #newUnsignedAbstractMessage<
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     M extends AbstractMessage,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     P extends AbstractMessageParams,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     PM extends AbstractMessageParamsMetamask,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     SO,
   >(
     messageManager: AbstractMessageManager<M, P, PM>,
@@ -432,6 +444,8 @@ export class SignatureController extends BaseController<
         throw providerErrors.userRejectedRequest('User rejected the request.');
       }
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await signMessage(messageParamsWithId, signingOpts);
 
       const signatureResult = await signaturePromise;
@@ -577,8 +591,14 @@ export class SignatureController extends BaseController<
   }
 
   #rejectUnapproved<
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     M extends AbstractMessage,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     P extends AbstractMessageParams,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     PM extends AbstractMessageParamsMetamask,
   >(messageManager: AbstractMessageManager<M, P, PM>, reason?: string) {
     Object.keys(messageManager.getUnapprovedMessages()).forEach((messageId) => {
@@ -587,8 +607,14 @@ export class SignatureController extends BaseController<
   }
 
   #clearUnapproved<
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     M extends AbstractMessage,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     P extends AbstractMessageParams,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     PM extends AbstractMessageParamsMetamask,
   >(messageManager: AbstractMessageManager<M, P, PM>) {
     messageManager.update({
@@ -598,8 +624,14 @@ export class SignatureController extends BaseController<
   }
 
   async #signAbstractMessage<
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     M extends AbstractMessage,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     P extends AbstractMessageParams,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     PM extends AbstractMessageParamsMetamask,
   >(
     messageManager: AbstractMessageManager<M, P, PM>,
@@ -640,8 +672,14 @@ export class SignatureController extends BaseController<
   }
 
   #errorMessage<
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     M extends AbstractMessage,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     P extends AbstractMessageParams,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     PM extends AbstractMessageParamsMetamask,
   >(
     messageManager: AbstractMessageManager<M, P, PM>,
@@ -656,8 +694,14 @@ export class SignatureController extends BaseController<
   }
 
   #cancelAbstractMessage<
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     M extends AbstractMessage,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     P extends AbstractMessageParams,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     PM extends AbstractMessageParamsMetamask,
   >(
     messageManager: AbstractMessageManager<M, P, PM>,
@@ -672,8 +716,14 @@ export class SignatureController extends BaseController<
   }
 
   #handleMessageManagerEvents<
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     M extends AbstractMessage,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     P extends AbstractMessageParams,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     PM extends AbstractMessageParamsMetamask,
   >(messageManager: AbstractMessageManager<M, P, PM>, eventName: string) {
     messageManager.hub.on('updateBadge', () => {
@@ -689,8 +739,14 @@ export class SignatureController extends BaseController<
   }
 
   #subscribeToMessageState<
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     M extends AbstractMessage,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     P extends AbstractMessageParams,
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     PM extends AbstractMessageParamsMetamask,
   >(
     messageManager: AbstractMessageManager<M, P, PM>,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1287,6 +1287,8 @@ describe('TransactionController', () => {
       const mockDeviceConfirmedOn = WalletDevice.OTHER;
       const mockOrigin = 'origin';
       const mockSecurityAlertResponse = {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         result_type: 'Malicious',
         reason: 'blur_farming',
         description:
@@ -4062,18 +4064,24 @@ describe('TransactionController', () => {
           txParams: { ...TRANSACTION_META_MOCK.txParams, nonce: '0x1' },
         };
 
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         const duplicate_1 = {
           ...confirmed,
           id: 'testId2',
           status: TransactionStatus.submitted,
         };
 
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         const duplicate_2 = {
           ...duplicate_1,
           id: 'testId3',
           status: TransactionStatus.approved,
         };
 
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         const duplicate_3 = {
           ...duplicate_1,
           id: 'testId4',
@@ -4302,6 +4310,8 @@ describe('TransactionController', () => {
       };
 
       // Send the transaction to put it in the process of being signed
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       controller.approveTransactionsWithSameNonce([mockTransactionParam]);
 
       // Now send it one more time to test that it doesn't get signed again
@@ -4681,6 +4691,8 @@ describe('TransactionController', () => {
 
       controller.updateSecurityAlertResponse(transactionMeta.id, {
         reason: 'NA',
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         result_type: 'Benign',
       });
 
@@ -4702,6 +4714,8 @@ describe('TransactionController', () => {
         // @ts-expect-error Intentionally passing invalid input
         controller.updateSecurityAlertResponse(undefined, {
           reason: 'NA',
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           result_type: 'Benign',
         }),
       ).toThrow(
@@ -4767,6 +4781,8 @@ describe('TransactionController', () => {
       expect(() =>
         controller.updateSecurityAlertResponse('456', {
           reason: 'NA',
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           result_type: 'Benign',
         }),
       ).toThrow(

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -2807,6 +2807,8 @@ export class TransactionController extends BaseController<
       updatedTransactionMeta,
     );
     this.#internalEvents.emit(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${transactionMeta.id}:finished`,
       updatedTransactionMeta,
     );
@@ -2842,6 +2844,8 @@ export class TransactionController extends BaseController<
         const { chainId, status, txParams, time } = tx;
 
         if (txParams) {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           const key = `${String(txParams.nonce)}-${convertHexToDecimal(
             chainId,
           )}-${new Date(time).toDateString()}`;

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -1559,6 +1559,8 @@ describe('TransactionController Integration', () => {
             )
             .reply(200, ETHERSCAN_TRANSACTION_RESPONSE_MOCK);
 
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           transactionController.updateIncomingTransactions([networkClientId]);
 
           expectedLastFetchedBlockNumbers[
@@ -1617,6 +1619,8 @@ describe('TransactionController Integration', () => {
         )
         .reply(200, ETHERSCAN_TRANSACTION_RESPONSE_MOCK);
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       transactionController.updateIncomingTransactions();
 
       // we have to wait for the mutex to be released after the 5 second API rate limit timer
@@ -1725,6 +1729,8 @@ describe('TransactionController Integration', () => {
             networkClientId,
           );
           const delay = () =>
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             new Promise<null>(async (resolve) => {
               await advanceTime({ clock, duration: 100 });
               resolve(null);
@@ -1736,6 +1742,8 @@ describe('TransactionController Integration', () => {
           ]);
           expect(secondNonceLockIfAcquired).toBeNull();
 
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/await-thenable
           await firstNonceLock.releaseLock();
           await advanceTime({ clock, duration: 1 });
 
@@ -1794,6 +1802,8 @@ describe('TransactionController Integration', () => {
         otherNetworkClientIdOnGoerli,
       );
       const delay = () =>
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         new Promise<null>(async (resolve) => {
           await advanceTime({ clock, duration: 100 });
           resolve(null);
@@ -1805,6 +1815,8 @@ describe('TransactionController Integration', () => {
       ]);
       expect(secondNonceLockIfAcquired).toBeNull();
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await firstNonceLock.releaseLock();
       await advanceTime({ clock, duration: 1 });
 
@@ -1961,6 +1973,8 @@ describe('TransactionController Integration', () => {
       const secondNonceLockPromise =
         transactionController.getNonceLock(ACCOUNT_MOCK);
       const delay = () =>
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         new Promise<null>(async (resolve) => {
           await advanceTime({ clock, duration: 100 });
           resolve(null);
@@ -1972,6 +1986,8 @@ describe('TransactionController Integration', () => {
       ]);
       expect(secondNonceLockIfAcquired).toBeNull();
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await firstNonceLock.releaseLock();
 
       secondNonceLockIfAcquired = await Promise.race([

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -1241,6 +1241,8 @@ describe('TransactionController Integration', () => {
           ]);
 
           expectedLastFetchedBlockNumbers[
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             `${config.chainId}#${selectedAddress}#normal`
           ] = parseInt(ETHERSCAN_TRANSACTION_BASE_MOCK.blockNumber, 10);
           expectedTransactions.push({
@@ -1652,6 +1654,8 @@ describe('TransactionController Integration', () => {
           transactionController.updateIncomingTransactions([networkClientId]);
 
           expectedLastFetchedBlockNumbers[
+            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             `${config.chainId}#${selectedAddress}#normal`
           ] = parseInt(ETHERSCAN_TRANSACTION_BASE_MOCK.blockNumber, 10);
           expectedTransactions.push({

--- a/packages/transaction-controller/src/gas-flows/DefaultGasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/DefaultGasFeeFlow.ts
@@ -56,6 +56,8 @@ export class DefaultGasFeeFlow implements GasFeeFlow {
         );
         break;
       default:
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         throw new Error(`Unsupported gas estimate type: ${gasEstimateType}`);
     }
 

--- a/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.ts
@@ -122,6 +122,8 @@ export class EtherscanRemoteTransactionSource
     );
   };
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   #getResponseTransactions<T extends EtherscanTransactionMetaBase>(
     response: EtherscanTransactionResponse<T>,
   ): T[] {

--- a/packages/transaction-controller/src/helpers/IncomingTransactionHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/IncomingTransactionHelper.test.ts
@@ -99,6 +99,8 @@ async function emitBlockTrackerLatestEvent(
     helper.start();
   }
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/await-thenable
   await BLOCK_TRACKER_MOCK.addListener.mock.calls[0]?.[1]?.(
     FROM_BLOCK_HEX_MOCK,
   );

--- a/packages/transaction-controller/src/helpers/IncomingTransactionHelper.ts
+++ b/packages/transaction-controller/src/helpers/IncomingTransactionHelper.ts
@@ -116,11 +116,15 @@ export class IncomingTransactionHelper {
       return;
     }
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.#blockTracker.addListener('latest', this.#onLatestBlock);
     this.#isRunning = true;
   }
 
   stop() {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.#blockTracker.removeListener('latest', this.#onLatestBlock);
     this.#isRunning = false;
   }

--- a/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
@@ -93,6 +93,8 @@ function newMultichainTrackingHelper(
             provider: MOCK_PROVIDERS['customNetworkClientId-1'],
           };
         default:
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           throw new Error(`Invalid network client id ${networkClientId}`);
       }
     });
@@ -461,6 +463,8 @@ describe('MultichainTrackingHelper', () => {
 
       helper.initialize();
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       helper.updateIncomingTransactions(['mainnet', 'goerli']);
       expect(mockIncomingTransactionHelpers['0x1'].update).toHaveBeenCalled();
       expect(
@@ -671,6 +675,8 @@ describe('MultichainTrackingHelper', () => {
   });
 
   describe('acquireNonceLockForChainIdKey', () => {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line jest/expect-expect
     it('returns a unqiue mutex for each chainId and key combination', async () => {
       const { helper } = newMultichainTrackingHelper();
 
@@ -699,6 +705,8 @@ describe('MultichainTrackingHelper', () => {
       });
 
       const delay = () =>
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         new Promise<null>(async (resolve) => {
           await advanceTime({ clock, duration: 100 });
           resolve(null);
@@ -710,6 +718,8 @@ describe('MultichainTrackingHelper', () => {
       ]);
       expect(secondReleaseLockIfAcquired).toBeNull();
 
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await firstReleaseLock();
       await advanceTime({ clock, duration: 1 });
 

--- a/packages/transaction-controller/src/helpers/PendingTransactionTracker.test.ts
+++ b/packages/transaction-controller/src/helpers/PendingTransactionTracker.test.ts
@@ -79,6 +79,8 @@ describe('PendingTransactionTracker', () => {
       );
     }
 
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     await blockTracker.on.mock.calls[0][1](latestBlockNumber);
   }
 

--- a/packages/transaction-controller/src/helpers/PendingTransactionTracker.ts
+++ b/packages/transaction-controller/src/helpers/PendingTransactionTracker.ts
@@ -48,11 +48,15 @@ type Events = {
 // Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface PendingTransactionTrackerEventEmitter extends EventEmitter {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   on<T extends keyof Events>(
     eventName: T,
     listener: (...args: Events[T]) => void,
   ): this;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   emit<T extends keyof Events>(eventName: T, ...args: Events[T]): boolean;
 }
 

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -8,6 +8,8 @@ import type { Operation } from 'fast-json-patch';
 /**
  * Given a record, ensures that each property matches the `Json` type.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type MakeJsonCompatible<T> = T extends Json
   ? T
   : {
@@ -453,15 +455,33 @@ export type SendFlowHistoryEntry = {
  * some are wallet-specific.
  */
 export enum TransactionStatus {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   approved = 'approved',
   /** @deprecated Determined by the clients using the transaction type. No longer used. */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   cancelled = 'cancelled',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   confirmed = 'confirmed',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   dropped = 'dropped',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   failed = 'failed',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   rejected = 'rejected',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   signed = 'signed',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   submitted = 'submitted',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   unapproved = 'unapproved',
 }
 
@@ -469,7 +489,11 @@ export enum TransactionStatus {
  * Options for wallet device.
  */
 export enum WalletDevice {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   MM_MOBILE = 'metamask_mobile',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   MM_EXTENSION = 'metamask_extension',
   OTHER = 'other_device',
 }
@@ -481,6 +505,8 @@ export enum TransactionType {
   /**
    * A transaction sending a network's native asset to a recipient.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   cancel = 'cancel',
 
   /**
@@ -488,31 +514,43 @@ export enum TransactionType {
    * have not treated as a special case, such as approve, transfer, and
    * transferfrom.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   contractInteraction = 'contractInteraction',
 
   /**
    * A transaction that deployed a smart contract.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   deployContract = 'contractDeployment',
 
   /**
    * A transaction for Ethereum decryption.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   ethDecrypt = 'eth_decrypt',
 
   /**
    * A transaction for getting an encryption public key.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   ethGetEncryptionPublicKey = 'eth_getEncryptionPublicKey',
 
   /**
    * An incoming (deposit) transaction.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   incoming = 'incoming',
 
   /**
    * A transaction for personal sign.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   personalSign = 'personal_sign',
 
   /**
@@ -521,31 +559,43 @@ export enum TransactionType {
    * to speed up pending transactions. This is accomplished by creating a new tx with
    * the same nonce and higher gas fees.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   retry = 'retry',
 
   /**
    * A transaction sending a network's native asset to a recipient.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   simpleSend = 'simpleSend',
 
   /**
    * A transaction that is signing typed data.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   signTypedData = 'eth_signTypedData',
 
   /**
    * A transaction sending a network's native asset to a recipient.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   smart = 'smart',
 
   /**
    * A transaction swapping one token for another through MetaMask Swaps.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   swap = 'swap',
 
   /**
    * A transaction swapping one token for another through MetaMask Swaps, then sending the swapped token to a recipient.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   swapAndSend = 'swapAndSend',
 
   /**
@@ -554,12 +604,16 @@ export enum TransactionType {
    * of the user for the MetaMask Swaps contract. The first swap for any token
    * will have an accompanying swapApproval transaction.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   swapApproval = 'swapApproval',
 
   /**
    * A token transaction requesting an allowance of the token to spend on
    * behalf of the user.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   tokenMethodApprove = 'approve',
 
   /**
@@ -568,12 +622,16 @@ export enum TransactionType {
    * this method the contract checks to ensure that the receiver is an address
    * capable of handling the token being sent.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   tokenMethodSafeTransferFrom = 'safetransferfrom',
 
   /**
    * A token transaction where the user is sending tokens that they own to
    * another address.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   tokenMethodTransfer = 'transfer',
 
   /**
@@ -581,17 +639,23 @@ export enum TransactionType {
    * has an allowance of. For more information on allowances, see the approve
    * type.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   tokenMethodTransferFrom = 'transferfrom',
 
   /**
    * A token transaction requesting an allowance of all of a user's tokens to
    * spend on behalf of the user.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   tokenMethodSetApprovalForAll = 'setapprovalforall',
 
   /**
    * Increase the allowance by a given increment
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   tokenMethodIncreaseAllowance = 'increaseAllowance',
 }
 
@@ -886,6 +950,8 @@ export enum TransactionEnvelopeType {
   /**
    * A legacy transaction, the very first type.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   legacy = '0x0',
 
   /**
@@ -893,6 +959,8 @@ export enum TransactionEnvelopeType {
    * specifying the state that a transaction would act upon in advance and
    * theoretically save on gas fees.
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   accessList = '0x1',
 
   /**
@@ -903,6 +971,8 @@ export enum TransactionEnvelopeType {
    * the maxPriorityFeePerGas (maximum amount of gwei per gas from the
    * transaction fee to distribute to miner).
    */
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   feeMarket = '0x2',
 }
 
@@ -911,6 +981,8 @@ export enum TransactionEnvelopeType {
  */
 export enum UserFeeLevel {
   CUSTOM = 'custom',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   DAPP_SUGGESTED = 'dappSuggested',
   MEDIUM = 'medium',
 }
@@ -986,6 +1058,8 @@ export type TransactionError = {
 export type SecurityAlertResponse = {
   reason: string;
   features?: string[];
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   result_type: string;
   providerRequestsCount?: Record<string, number>;
 };
@@ -1127,8 +1201,14 @@ export type SimulationBalanceChange = {
 
 /** Token standards supported by simulation. */
 export enum SimulationTokenStandard {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   erc20 = 'erc20',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   erc721 = 'erc721',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   erc1155 = 'erc1155',
 }
 

--- a/packages/transaction-controller/src/utils/etherscan.test.ts
+++ b/packages/transaction-controller/src/utils/etherscan.test.ts
@@ -81,7 +81,11 @@ describe('Etherscan', () => {
         }/api?` +
           `module=account` +
           `&address=${REQUEST_MOCK.address}` +
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `&startBlock=${REQUEST_MOCK.fromBlock}` +
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `&offset=${REQUEST_MOCK.limit}` +
           `&sort=desc` +
           `&action=${action}` +
@@ -107,7 +111,11 @@ describe('Etherscan', () => {
         }/api?` +
           `module=account` +
           `&address=${REQUEST_MOCK.address}` +
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `&startBlock=${REQUEST_MOCK.fromBlock}` +
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `&offset=${REQUEST_MOCK.limit}` +
           `&sort=desc` +
           `&action=${action}` +

--- a/packages/transaction-controller/src/utils/etherscan.ts
+++ b/packages/transaction-controller/src/utils/etherscan.ts
@@ -33,6 +33,8 @@ export interface EtherscanTransactionMeta extends EtherscanTransactionMetaBase {
   input: string;
   isError: string;
   methodId: string;
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   txreceipt_status: string;
 }
 
@@ -50,6 +52,8 @@ export interface EtherscanTokenTransactionMeta
 // Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface EtherscanTransactionResponse<
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   T extends EtherscanTransactionMetaBase,
 > {
   status: '0' | '1';
@@ -130,6 +134,8 @@ export async function fetchEtherscanTokenTransactions({
  * @param options.limit - Number of transactions to retrieve.
  * @returns An object containing the request status and an array of transaction data.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 async function fetchTransactions<T extends EtherscanTransactionMetaBase>(
   action: string,
   {
@@ -209,5 +215,7 @@ export function getEtherscanApiHost(chainId: Hex) {
     throw new Error(`Etherscan does not support chain with ID: ${chainId}`);
   }
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   return `https://${networkInfo.subdomain}.${networkInfo.domain}`;
 }

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -320,6 +320,8 @@ async function getSuggestedGasFees(
         return { gasPrice: response.estimates.gasPrice };
       default:
         throw new Error(
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `Unsupported gas fee estimate type returned from flow: ${gasFeeEstimateType}`,
         );
     }

--- a/packages/transaction-controller/src/utils/simulation.ts
+++ b/packages/transaction-controller/src/utils/simulation.ts
@@ -34,7 +34,11 @@ export enum SupportedToken {
   ERC20 = 'erc20',
   ERC721 = 'erc721',
   ERC1155 = 'erc1155',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   ERC20_WRAPPED = 'erc20Wrapped',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   ERC721_LEGACY = 'erc721Legacy',
 }
 

--- a/packages/transaction-controller/src/utils/swaps.test.ts
+++ b/packages/transaction-controller/src/utils/swaps.test.ts
@@ -484,7 +484,8 @@ describe('updatePostTransactionBalance', () => {
       .spyOn(request, 'getTransaction')
       .mockImplementation(() => transactionMeta);
 
-    // eslint-disable-next-line jest/valid-expect-in-promise
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line jest/valid-expect-in-promise, @typescript-eslint/no-floating-promises
     updatePostTransactionBalance(transactionMeta, request).then(
       ({ updatedTransactionMeta }) => {
         expect(updatedTransactionMeta?.postTxBalance).toBe(mockPostTxBalance);

--- a/packages/transaction-controller/src/utils/utils.ts
+++ b/packages/transaction-controller/src/utils/utils.ts
@@ -147,7 +147,7 @@ export function validateIfTransactionUnapproved(
     throw new Error(
       // TODO: Either fix this lint violation or explain why it's necessary to ignore.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      `TransactionsController: Can only call ${fnName} on an unapproved transaction.\nCurrent tx status: ${transactionMeta?.status}`,
+      `TransactionsController: Can only call ${fnName} on an unapproved transaction.\n      Current tx status: ${transactionMeta?.status}`,
     );
   }
 }

--- a/packages/transaction-controller/src/utils/utils.ts
+++ b/packages/transaction-controller/src/utils/utils.ts
@@ -128,6 +128,8 @@ export function validateMinimumIncrease(proposed: string, min: string) {
   if (proposedDecimal >= minDecimal) {
     return proposed;
   }
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   const errorMsg = `The proposed value: ${proposedDecimal} should meet or exceed the minimum value: ${minDecimal}`;
   throw new Error(errorMsg);
 }

--- a/packages/transaction-controller/src/utils/utils.ts
+++ b/packages/transaction-controller/src/utils/utils.ts
@@ -85,6 +85,8 @@ export const validateGasValues = (
     const value = (gasValues as any)[key];
     if (typeof value !== 'string' || !isStrictHexString(value)) {
       throw new TypeError(
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `expected hex string for ${key} but received: ${value}`,
       );
     }
@@ -143,8 +145,9 @@ export function validateIfTransactionUnapproved(
 ) {
   if (transactionMeta?.status !== TransactionStatus.unapproved) {
     throw new Error(
-      `TransactionsController: Can only call ${fnName} on an unapproved transaction.
-      Current tx status: ${transactionMeta?.status}`,
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      `TransactionsController: Can only call ${fnName} on an unapproved transaction.\nCurrent tx status: ${transactionMeta?.status}`,
     );
   }
 }

--- a/packages/transaction-controller/src/utils/validation.ts
+++ b/packages/transaction-controller/src/utils/validation.ts
@@ -196,6 +196,8 @@ function validateParamChainId(chainId: number | string | undefined) {
     typeof chainId !== 'string'
   ) {
     throw rpcErrors.invalidParams(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `Invalid transaction params: chainId is not a Number or hex string. got: (${chainId})`,
     );
   }
@@ -321,6 +323,8 @@ function ensureFieldIsString(
 ) {
   if (typeof txParams[field] !== 'string') {
     throw rpcErrors.invalidParams(
+      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `Invalid transaction params: ${field} is not a string. got: (${txParams[field]})`,
     );
   }

--- a/packages/transaction-controller/tests/EtherscanMocks.ts
+++ b/packages/transaction-controller/tests/EtherscanMocks.ts
@@ -32,6 +32,8 @@ export const ETHERSCAN_TRANSACTION_SUCCESS_MOCK: EtherscanTransactionMeta = {
   input: '0x',
   isError: '0',
   methodId: 'testId',
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   txreceipt_status: '1',
 };
 

--- a/packages/user-operation-controller/src/UserOperationController.test.ts
+++ b/packages/user-operation-controller/src/UserOperationController.test.ts
@@ -238,6 +238,8 @@ describe('UserOperationController', () => {
           return approvalControllerAddRequestMock();
         }
 
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         throw new Error(`Unexpected mock messenger action: ${action}`);
       },
     );

--- a/packages/user-operation-controller/src/UserOperationController.ts
+++ b/packages/user-operation-controller/src/UserOperationController.ts
@@ -72,16 +72,22 @@ type Events = {
 };
 
 export type UserOperationControllerEventEmitter = EventEmitter & {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   on<T extends keyof Events>(
     eventName: T,
     listener: (...args: Events[T]) => void,
   ): UserOperationControllerEventEmitter;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   once<T extends keyof Events>(
     eventName: T,
     listener: (...args: Events[T]) => void,
   ): UserOperationControllerEventEmitter;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   emit<T extends keyof Events>(eventName: T, ...args: Events[T]): boolean;
 };
 
@@ -697,6 +703,8 @@ export class UserOperationController extends BaseController<
       (metadata) => {
         log('In listener...');
         this.hub.emit('user-operation-confirmed', metadata);
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         this.hub.emit(`${metadata.id}:confirmed`, metadata);
       },
     );
@@ -705,6 +713,8 @@ export class UserOperationController extends BaseController<
       'user-operation-failed',
       (metadata, error) => {
         this.hub.emit('user-operation-failed', metadata, error);
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         this.hub.emit(`${metadata.id}:failed`, metadata, error);
       },
     );

--- a/packages/user-operation-controller/src/helpers/Bundler.ts
+++ b/packages/user-operation-controller/src/helpers/Bundler.ts
@@ -98,6 +98,8 @@ export class Bundler {
     return hash;
   }
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   async #query<T>(method: string, params: unknown[]): Promise<T> {
     const request = {
       method: 'POST',

--- a/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.ts
+++ b/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.ts
@@ -21,16 +21,22 @@ type Events = {
 };
 
 export type PendingUserOperationTrackerEventEmitter = EventEmitter & {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   on<T extends keyof Events>(
     eventName: T,
     listener: (...args: Events[T]) => void,
   ): PendingUserOperationTrackerEventEmitter;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   once<T extends keyof Events>(
     eventName: T,
     listener: (...args: Events[T]) => void,
   ): PendingUserOperationTrackerEventEmitter;
 
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   emit<T extends keyof Events>(eventName: T, ...args: Events[T]): boolean;
 };
 

--- a/packages/user-operation-controller/src/utils/validation.test.ts
+++ b/packages/user-operation-controller/src/utils/validation.test.ts
@@ -69,6 +69,8 @@ const SIGN_USER_OPERATION_RESPONSE_MOCK: SignUserOperationResponse = {
  * @param value - The value to set.
  * @returns The copied object with the property path set to the given value.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 function setPropertyPath<T>(object: T, pathString: string, value: unknown): T {
   const copy = cloneDeep(object);
   const path = pathString.split('.');
@@ -94,6 +96,8 @@ function setPropertyPath<T>(object: T, pathString: string, value: unknown): T {
  * @param expectedInternalError - The specific validation error.
  * @param rootPropertyName - The name of the root input.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 function expectValidationError<T>(
   validateFunction: (request: T) => void,
   input: T,

--- a/packages/user-operation-controller/src/utils/validation.ts
+++ b/packages/user-operation-controller/src/utils/validation.ts
@@ -182,6 +182,8 @@ export function validateSignUserOperationResponse(
  * @param struct - The struct to validate against.
  * @param message - The message to throw if validation fails.
  */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
 function validate<T>(data: unknown, struct: Struct<T>, message: string) {
   try {
     assert(data, struct, message);

--- a/scripts/create-package/cli.test.ts
+++ b/scripts/create-package/cli.test.ts
@@ -25,6 +25,8 @@ function getMockArgv(...args: string[]) {
  */
 function getParsedArgv(name: string, description: string) {
   return {
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     _: [],
     $0: 'create-package',
     name: `@metamask/${name}`,

--- a/scripts/create-package/commands.test.ts
+++ b/scripts/create-package/commands.test.ts
@@ -30,6 +30,8 @@ describe('create-package/commands', () => {
       });
 
       const args: Arguments<CreatePackageOptions> = {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         _: [],
         $0: 'create-package',
         name: '@metamask/new-package',

--- a/tests/fake-provider.ts
+++ b/tests/fake-provider.ts
@@ -173,9 +173,13 @@ export class FakeProvider extends SafeEventEmitterProvider {
 
       if (stub.delay) {
         originalSetTimeout(() => {
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           this.#handleRequest(stub, callback);
         }, stub.delay);
       } else {
+        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.#handleRequest(stub, callback);
       }
 

--- a/tests/mock-network.ts
+++ b/tests/mock-network.ts
@@ -108,7 +108,9 @@ class MockedNetwork {
     this.#requestMocks = mocks;
     const rpcUrl =
       networkClientConfiguration.type === 'infura'
-        ? `https://${networkClientConfiguration.network}.infura.io`
+        ? // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          `https://${networkClientConfiguration.network}.infura.io`
         : networkClientConfiguration.rpcUrl;
     this.#nockScope = nock(rpcUrl);
   }

--- a/tests/setupAfterEnv/matchers.ts
+++ b/tests/setupAfterEnv/matchers.ts
@@ -51,6 +51,8 @@ expect.extend({
     if (rejectionValue !== UNRESOLVED) {
       return {
         message: () =>
+          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `Expected promise to be fulfilled, but it was rejected with ${rejectionValue}.`,
         pass: false,
       };
@@ -108,9 +110,12 @@ expect.extend({
       : {
           message: () => {
             return `Expected promise to never resolve after ${TIME_TO_WAIT_UNTIL_UNRESOLVED}ms, but it ${
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              /* eslint-disable @typescript-eslint/restrict-template-expressions */
               rejectionValue
                 ? `was rejected with ${rejectionValue}`
                 : `resolved with ${resolutionValue}`
+              /* eslint-enable @typescript-eslint/restrict-template-expressions */
             }`;
           },
           pass: false,

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -6,7 +6,8 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
     // We're using `interface` here so that we can extend and not override it.
-    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention
     interface Matchers<R> {
       toBeFulfilled(): Promise<R>;
       toNeverResolve(): Promise<R>;


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Currently, `yarn lint` produces a bunch of warnings from ESLint. These warnings were added in a previous commit that upgraded ESLint packages as a way to avoid fixing lint violations created by the upgrade. However, this causes two problems:

1. They produce a lot of noise that makes it very difficult to find true errors, especially when looking at a CI run.
2. They allow new instances of these violations to show up (because warnings don't cause `eslint` to fail).

This commit removes the overrides from the ESLint config for these rules so that they go back to being errors and adds `eslint-disable` directives above the lines that cause the violations. Note that this is not intended to be a long-term solution, and in the future, we should dedicate time to either fixing the violations or explaining why ignoring them is necessary.


## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes #4381.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

(There are no changes to functionality.)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
