### PR TITLE
testing Tx nonce tracker 6 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
-    "@metamask/eth-block-tracker": "^9.0.2",
+    "@metamask/eth-block-tracker": "^9.0.3",
     "@metamask/eth-json-rpc-provider": "^4.0.0",
     "@metamask/json-rpc-engine": "^9.0.0",
     "@metamask/utils": "^8.3.0",

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@metamask/base-controller": "^6.0.0",
     "@metamask/controller-utils": "^11.0.0",
-    "@metamask/eth-block-tracker": "^9.0.2",
+    "@metamask/eth-block-tracker": "^9.0.3",
     "@metamask/eth-json-rpc-infura": "^9.1.0",
     "@metamask/eth-json-rpc-middleware": "^12.1.1",
     "@metamask/eth-json-rpc-provider": "^4.0.0",

--- a/packages/permission-controller/src/SubjectMetadataController.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.ts
@@ -209,6 +209,8 @@ export class SubjectMetadataController extends BaseController<
     this.subjectsWithoutPermissionsEncounteredSinceStartup.add(origin);
 
     this.update((draftState) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore something about string-indexing
       draftState.subjectMetadata[origin] = newMetadata;
       if (typeof originToForget === 'string') {
         delete draftState.subjectMetadata[originToForget];
@@ -231,7 +233,8 @@ export class SubjectMetadataController extends BaseController<
    */
   trimMetadataState(): void {
     this.update((draftState) => {
-      // @ts-expect-error ts(2589)
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore infinite type-resursion srsly
       return SubjectMetadataController.getTrimmedState(
         draftState,
         this.subjectHasPermissions,

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -54,7 +54,7 @@
     "@metamask/gas-fee-controller": "^17.0.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/network-controller": "^19.0.0",
-    "@metamask/nonce-tracker": "^5.0.0",
+    "@metamask/nonce-tracker": "^6.0.0",
     "@metamask/rpc-errors": "^6.2.1",
     "@metamask/utils": "^8.3.0",
     "async-mutex": "^0.5.0",

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -300,12 +300,10 @@ const MOCK_PREFERENCES = { state: { selectedAddress: 'foo' } };
 const INFURA_PROJECT_ID = '341eacb578dd44a1a049cbc5f6fd4035';
 const HTTP_PROVIDERS = {
   mainnet: new HttpProvider(`https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
-  palm: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
-  /*
   goerli: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
   linea: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
   linea_goerli: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
-  */
+  custom: new HttpProvider(`http://127.0.0.123:456/ethrpc?apiKey=foobar`),
 }
 
 type MockNetwork = {
@@ -357,8 +355,8 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
 };
 
 const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
-  provider: HTTP_PROVIDERS.palm,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
+  provider: HTTP_PROVIDERS.linea,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.linea),
   state: {
     selectedNetworkClientId: NetworkType['linea-mainnet'],
     networksMetadata: {
@@ -378,8 +376,8 @@ const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
 };
 
 const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
-  provider: HTTP_PROVIDERS.palm,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
+  provider: HTTP_PROVIDERS.linea_goerli,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.linea_goerli),
   state: {
     selectedNetworkClientId: NetworkType['linea-goerli'],
     networksMetadata: {
@@ -399,8 +397,8 @@ const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
 };
 
 const MOCK_CUSTOM_NETWORK: MockNetwork = {
-  provider: HTTP_PROVIDERS.palm,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
+  provider: HTTP_PROVIDERS.custom,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.custom),
   state: {
     selectedNetworkClientId: 'uuid-1',
     networksMetadata: {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -335,24 +335,6 @@ const MOCK_NETWORK: MockNetwork = {
   },
   subscribe: () => undefined,
 };
-const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
-  provider: HTTP_PROVIDERS.palm,
-  blockTracker: buildMockBlockTracker('0x102833C', HTTP_PROVIDERS.palm),
-  state: {
-    selectedNetworkClientId: NetworkType.goerli,
-    networksMetadata: {
-      [NetworkType.goerli]: {
-        EIPS: { 1559: false },
-        status: NetworkStatus.Available,
-      },
-    },
-    providerConfig: {
-      type: NetworkType.goerli,
-    } as NetworkState['providerConfig'],
-    networkConfigurations: {},
-  },
-  subscribe: () => undefined,
-};
 const MOCK_MAINNET_NETWORK: MockNetwork = {
   provider: HTTP_PROVIDERS.mainnet,
   blockTracker: buildMockBlockTracker('0x102833C', HTTP_PROVIDERS.mainnet),

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -298,12 +298,15 @@ function waitForTransactionFinished(
 
 const MOCK_PREFERENCES = { state: { selectedAddress: 'foo' } };
 const INFURA_PROJECT_ID = '341eacb578dd44a1a049cbc5f6fd4035';
-const MAINNET_PROVIDER = new HttpProvider(
-  `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
-);
-const PALM_PROVIDER = new HttpProvider(
-  `https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
-);
+const HTTP_PROVIDERS = {
+  mainnet: new HttpProvider(`https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
+  palm: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
+  /*
+  goerli: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
+  linea: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
+  linea_goerli: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
+  */
+}
 
 type MockNetwork = {
   provider: Provider;
@@ -313,8 +316,8 @@ type MockNetwork = {
 };
 
 const MOCK_NETWORK: MockNetwork = {
-  provider: MAINNET_PROVIDER,
-  blockTracker: buildMockBlockTracker('0x102833C', MAINNET_PROVIDER),
+  provider: HTTP_PROVIDERS.mainnet,
+  blockTracker: buildMockBlockTracker('0x102833C', HTTP_PROVIDERS.mainnet),
   state: {
     selectedNetworkClientId: NetworkType.goerli,
     networksMetadata: {
@@ -333,8 +336,8 @@ const MOCK_NETWORK: MockNetwork = {
   subscribe: () => undefined,
 };
 const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
-  provider: PALM_PROVIDER,
-  blockTracker: buildMockBlockTracker('0x102833C', PALM_PROVIDER),
+  provider: HTTP_PROVIDERS.palm,
+  blockTracker: buildMockBlockTracker('0x102833C', HTTP_PROVIDERS.palm),
   state: {
     selectedNetworkClientId: NetworkType.goerli,
     networksMetadata: {
@@ -351,8 +354,8 @@ const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
   subscribe: () => undefined,
 };
 const MOCK_MAINNET_NETWORK: MockNetwork = {
-  provider: MAINNET_PROVIDER,
-  blockTracker: buildMockBlockTracker('0x102833C', MAINNET_PROVIDER),
+  provider: HTTP_PROVIDERS.mainnet,
+  blockTracker: buildMockBlockTracker('0x102833C', HTTP_PROVIDERS.mainnet),
   state: {
     selectedNetworkClientId: NetworkType.mainnet,
     networksMetadata: {
@@ -372,8 +375,8 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
 };
 
 const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
-  provider: PALM_PROVIDER,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', PALM_PROVIDER),
+  provider: HTTP_PROVIDERS.palm,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
   state: {
     selectedNetworkClientId: NetworkType['linea-mainnet'],
     networksMetadata: {
@@ -393,8 +396,8 @@ const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
 };
 
 const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
-  provider: PALM_PROVIDER,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', PALM_PROVIDER),
+  provider: HTTP_PROVIDERS.palm,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
   state: {
     selectedNetworkClientId: NetworkType['linea-goerli'],
     networksMetadata: {
@@ -414,8 +417,8 @@ const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
 };
 
 const MOCK_CUSTOM_NETWORK: MockNetwork = {
-  provider: PALM_PROVIDER,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', PALM_PROVIDER),
+  provider: HTTP_PROVIDERS.palm,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
   state: {
     selectedNetworkClientId: 'uuid-1',
     networksMetadata: {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -3405,7 +3405,6 @@ export class TransactionController extends BaseController<
       // TODO: Fix types
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       provider: provider as any,
-      // @ts-expect-error TODO: Fix types
       blockTracker,
       getPendingTransactions: this.#getNonceTrackerPendingTransactions.bind(
         this,

--- a/packages/transaction-controller/src/helpers/IncomingTransactionHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/IncomingTransactionHelper.test.ts
@@ -31,7 +31,7 @@ const BLOCK_TRACKER_MOCK = {
 } as unknown as jest.Mocked<BlockTracker>;
 
 const CONTROLLER_ARGS_MOCK = {
-  blockTracker: BLOCK_TRACKER_MOCK,
+  getBlockTracker: () => BLOCK_TRACKER_MOCK,
   getCurrentAccount: () => ADDRESS_MOCK,
   getLastFetchedBlockNumbers: () => ({}),
   getChainId: () => CHAIN_ID_MOCK,
@@ -589,7 +589,7 @@ describe('IncomingTransactionHelper', () => {
       helper.start();
 
       expect(
-        CONTROLLER_ARGS_MOCK.blockTracker.addListener,
+        CONTROLLER_ARGS_MOCK.getBlockTracker().addListener,
       ).toHaveBeenCalledTimes(1);
     });
 
@@ -603,7 +603,7 @@ describe('IncomingTransactionHelper', () => {
       helper.start();
 
       expect(
-        CONTROLLER_ARGS_MOCK.blockTracker.addListener,
+        CONTROLLER_ARGS_MOCK.getBlockTracker().addListener,
       ).toHaveBeenCalledTimes(1);
     });
 
@@ -617,7 +617,7 @@ describe('IncomingTransactionHelper', () => {
       helper.start();
 
       expect(
-        CONTROLLER_ARGS_MOCK.blockTracker.addListener,
+        CONTROLLER_ARGS_MOCK.getBlockTracker().addListener,
       ).not.toHaveBeenCalled();
     });
 
@@ -632,7 +632,7 @@ describe('IncomingTransactionHelper', () => {
       helper.start();
 
       expect(
-        CONTROLLER_ARGS_MOCK.blockTracker.addListener,
+        CONTROLLER_ARGS_MOCK.getBlockTracker().addListener,
       ).not.toHaveBeenCalled();
     });
   });
@@ -648,7 +648,7 @@ describe('IncomingTransactionHelper', () => {
       helper.stop();
 
       expect(
-        CONTROLLER_ARGS_MOCK.blockTracker.removeListener,
+        CONTROLLER_ARGS_MOCK.getBlockTracker().removeListener,
       ).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
@@ -220,6 +220,16 @@ function newMultichainTrackingHelper(
 describe('MultichainTrackingHelper', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+
+    for (const network of [
+      'mainnet',
+      'goerli',
+      'sepolia',
+      'customNetworkClientId-1',
+    ] as const) {
+      MOCK_BLOCK_TRACKERS[network] = buildMockBlockTracker(network);
+      MOCK_PROVIDERS[network] = buildMockProvider(network);
+    }
   });
 
   describe('onNetworkStateChange', () => {

--- a/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
@@ -220,16 +220,6 @@ function newMultichainTrackingHelper(
 describe('MultichainTrackingHelper', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-
-    for (const network of [
-      'mainnet',
-      'goerli',
-      'sepolia',
-      'customNetworkClientId-1',
-    ] as const) {
-      MOCK_BLOCK_TRACKERS[network] = buildMockBlockTracker(network);
-      MOCK_PROVIDERS[network] = buildMockProvider(network);
-    }
   });
 
   describe('onNetworkStateChange', () => {

--- a/packages/transaction-controller/src/helpers/MultichainTrackingHelper.ts
+++ b/packages/transaction-controller/src/helpers/MultichainTrackingHelper.ts
@@ -11,13 +11,15 @@ import type { NonceLock, NonceTracker } from '@metamask/nonce-tracker';
 import type { Hex } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 
-import { incomingTransactionsLogger as log } from '../logger';
+import { createModuleLogger, projectLogger } from '../logger';
 import { EtherscanRemoteTransactionSource } from './EtherscanRemoteTransactionSource';
 import type {
   IncomingTransactionHelper,
   IncomingTransactionOptions,
 } from './IncomingTransactionHelper';
 import type { PendingTransactionTracker } from './PendingTransactionTracker';
+
+const log = createModuleLogger(projectLogger, 'multichain');
 
 /**
  * Registry of network clients provided by the NetworkController
@@ -28,11 +30,12 @@ type NetworkClientRegistry = ReturnType<
 
 export type MultichainTrackingHelperOptions = {
   isMultichainEnabled: boolean;
-  provider: Provider;
-  nonceTracker: NonceTracker;
   incomingTransactionOptions: IncomingTransactionOptions;
 
   findNetworkClientIdByChainId: NetworkController['findNetworkClientIdByChainId'];
+  getGlobalProviderAndBlockTracker: () =>
+    | { provider: Provider; blockTracker: BlockTracker }
+    | undefined;
   getNetworkClientById: NetworkController['getNetworkClientById'];
   getNetworkClientRegistry: NetworkController['getNetworkClientRegistry'];
 
@@ -48,14 +51,14 @@ export type MultichainTrackingHelperOptions = {
     chainId?: Hex;
   }) => NonceTracker;
   createIncomingTransactionHelper: (opts: {
-    blockTracker: BlockTracker;
+    getBlockTracker: () => BlockTracker | undefined;
+    getChainId: () => Hex | undefined;
     etherscanRemoteTransactionSource: EtherscanRemoteTransactionSource;
-    chainId?: Hex;
   }) => IncomingTransactionHelper;
   createPendingTransactionTracker: (opts: {
-    provider: Provider;
-    blockTracker: BlockTracker;
-    chainId?: Hex;
+    getBlockTracker: () => BlockTracker | undefined;
+    getChainId: () => Hex | undefined;
+    getEthQuery: () => EthQuery | undefined;
   }) => PendingTransactionTracker;
   onNetworkStateChange: (
     listener: (
@@ -67,13 +70,15 @@ export type MultichainTrackingHelperOptions = {
 export class MultichainTrackingHelper {
   #isMultichainEnabled: boolean;
 
-  readonly #provider: Provider;
-
-  readonly #nonceTracker: NonceTracker;
+  #globalNonceTracker: NonceTracker | undefined;
 
   readonly #incomingTransactionOptions: IncomingTransactionOptions;
 
   readonly #findNetworkClientIdByChainId: NetworkController['findNetworkClientIdByChainId'];
+
+  readonly #getGlobalProviderAndBlockTracker: () =>
+    | { provider: Provider; blockTracker: BlockTracker }
+    | undefined;
 
   readonly #getNetworkClientById: NetworkController['getNetworkClientById'];
 
@@ -94,15 +99,15 @@ export class MultichainTrackingHelper {
   }) => NonceTracker;
 
   readonly #createIncomingTransactionHelper: (opts: {
-    blockTracker: BlockTracker;
-    chainId?: Hex;
+    getBlockTracker: () => BlockTracker | undefined;
+    getChainId: () => Hex | undefined;
     etherscanRemoteTransactionSource: EtherscanRemoteTransactionSource;
   }) => IncomingTransactionHelper;
 
   readonly #createPendingTransactionTracker: (opts: {
-    provider: Provider;
-    blockTracker: BlockTracker;
-    chainId?: Hex;
+    getBlockTracker: () => BlockTracker | undefined;
+    getChainId: () => Hex | undefined;
+    getEthQuery: () => EthQuery | undefined;
   }) => PendingTransactionTracker;
 
   readonly #nonceMutexesByChainId = new Map<Hex, Map<string, Mutex>>();
@@ -123,10 +128,9 @@ export class MultichainTrackingHelper {
 
   constructor({
     isMultichainEnabled,
-    provider,
-    nonceTracker,
     incomingTransactionOptions,
     findNetworkClientIdByChainId,
+    getGlobalProviderAndBlockTracker,
     getNetworkClientById,
     getNetworkClientRegistry,
     removeIncomingTransactionHelperListeners,
@@ -137,11 +141,10 @@ export class MultichainTrackingHelper {
     onNetworkStateChange,
   }: MultichainTrackingHelperOptions) {
     this.#isMultichainEnabled = isMultichainEnabled;
-    this.#provider = provider;
-    this.#nonceTracker = nonceTracker;
     this.#incomingTransactionOptions = incomingTransactionOptions;
 
     this.#findNetworkClientIdByChainId = findNetworkClientIdByChainId;
+    this.#getGlobalProviderAndBlockTracker = getGlobalProviderAndBlockTracker;
     this.#getNetworkClientById = getNetworkClientById;
     this.#getNetworkClientRegistry = getNetworkClientRegistry;
 
@@ -186,8 +189,36 @@ export class MultichainTrackingHelper {
   }: {
     networkClientId?: NetworkClientId;
     chainId?: Hex;
-  } = {}): EthQuery {
-    return new EthQuery(this.getProvider({ networkClientId, chainId }));
+  } = {}): EthQuery | undefined {
+    if (!networkClientId && !chainId) {
+      const globalProvider = this.#getGlobalProviderAndBlockTracker()?.provider;
+      return globalProvider ? new EthQuery(globalProvider) : undefined;
+    }
+    let networkClient: NetworkClient | undefined;
+
+    if (networkClientId) {
+      try {
+        networkClient = this.#getNetworkClientById(networkClientId);
+      } catch (err) {
+        log('Failed to get network client by networkClientId', networkClientId);
+      }
+    }
+
+    if (!networkClient && chainId) {
+      try {
+        networkClientId = this.#findNetworkClientIdByChainId(chainId);
+        networkClient = this.#getNetworkClientById(networkClientId);
+      } catch (err) {
+        log('Failed to get network client by chainId', chainId);
+      }
+    }
+    if (networkClient) {
+      const provider = this.getProvider({ networkClientId, chainId });
+      if (provider) {
+        return new EthQuery(provider);
+      }
+    }
+    return undefined;
   }
 
   getProvider({
@@ -196,17 +227,16 @@ export class MultichainTrackingHelper {
   }: {
     networkClientId?: NetworkClientId;
     chainId?: Hex;
-  } = {}): Provider {
-    if (!this.#isMultichainEnabled) {
-      return this.#provider;
-    }
-
+  } = {}): Provider | undefined {
     const networkClient = this.#getNetworkClient({
       networkClientId,
       chainId,
     });
 
-    return networkClient?.provider || this.#provider;
+    return (
+      networkClient?.provider ||
+      this.#getGlobalProviderAndBlockTracker()?.provider
+    );
   }
 
   /**
@@ -249,9 +279,15 @@ export class MultichainTrackingHelper {
   async getNonceLock(
     address: string,
     networkClientId?: NetworkClientId,
-  ): Promise<NonceLock> {
+  ): Promise<NonceLock | undefined> {
     let releaseLockForChainIdKey: (() => void) | undefined;
-    let nonceTracker = this.#nonceTracker;
+    let nonceTracker: NonceTracker | undefined;
+
+    if (!networkClientId || !this.#isMultichainEnabled) {
+      this.#globalNonceTracker ??= this.#getGlobalNonceTracker();
+      nonceTracker = this.#globalNonceTracker;
+    }
+
     if (networkClientId && this.#isMultichainEnabled) {
       const networkClient = this.#getNetworkClientById(networkClientId);
       releaseLockForChainIdKey = await this.acquireNonceLockForChainIdKey({
@@ -263,6 +299,10 @@ export class MultichainTrackingHelper {
         throw new Error('missing nonceTracker for networkClientId');
       }
       nonceTracker = trackers.nonceTracker;
+    }
+
+    if (!nonceTracker) {
+      return undefined;
     }
 
     // Acquires the lock for the chainId + address and the nonceLock from the nonceTracker, then
@@ -377,11 +417,9 @@ export class MultichainTrackingHelper {
       return;
     }
 
-    const {
-      provider,
-      blockTracker,
-      configuration: { chainId },
-    } = this.#getNetworkClientById(networkClientId);
+    const networkClient = this.#getNetworkClientById(networkClientId);
+    const { provider, blockTracker, configuration } = networkClient;
+    const { chainId } = configuration;
 
     let etherscanRemoteTransactionSource =
       this.#etherscanRemoteTransactionSourcesMap.get(chainId);
@@ -403,15 +441,15 @@ export class MultichainTrackingHelper {
     });
 
     const incomingTransactionHelper = this.#createIncomingTransactionHelper({
-      blockTracker,
+      getBlockTracker: () => blockTracker,
+      getChainId: () => chainId,
       etherscanRemoteTransactionSource,
-      chainId,
     });
 
     const pendingTransactionTracker = this.#createPendingTransactionTracker({
-      provider,
-      blockTracker,
-      chainId,
+      getBlockTracker: () => blockTracker,
+      getChainId: () => chainId,
+      getEthQuery: () => new EthQuery(provider),
     });
 
     this.#trackingMap.set(networkClientId, {
@@ -442,6 +480,23 @@ export class MultichainTrackingHelper {
       this.#etherscanRemoteTransactionSourcesMap.delete(chainId);
     });
   };
+
+  #getGlobalNonceTracker(): NonceTracker | undefined {
+    const globalProvider = this.#getGlobalProviderAndBlockTracker()?.provider;
+
+    const globalBlockTracker =
+      this.#getGlobalProviderAndBlockTracker()?.blockTracker;
+
+    if (!globalProvider || !globalBlockTracker) {
+      log('Cannot get nonce lock as selected network is not available');
+      return undefined;
+    }
+
+    return this.#createNonceTracker({
+      provider: globalProvider,
+      blockTracker: globalBlockTracker,
+    });
+  }
 
   #getNetworkClient({
     networkClientId,

--- a/packages/transaction-controller/src/helpers/PendingTransactionTracker.test.ts
+++ b/packages/transaction-controller/src/helpers/PendingTransactionTracker.test.ts
@@ -90,7 +90,7 @@ describe('PendingTransactionTracker', () => {
 
     options = {
       approveTransaction: jest.fn(),
-      blockTracker,
+      getBlockTracker: () => blockTracker,
       failTransaction,
       getChainId: () => CHAIN_ID_MOCK,
       getEthQuery: () => ETH_QUERY_MOCK,

--- a/packages/transaction-controller/src/helpers/PendingTransactionTracker.ts
+++ b/packages/transaction-controller/src/helpers/PendingTransactionTracker.ts
@@ -1,13 +1,12 @@
 import { query } from '@metamask/controller-utils';
 import type EthQuery from '@metamask/eth-query';
-import type {
-  BlockTracker,
-  NetworkClientId,
-} from '@metamask/network-controller';
+import type { BlockTracker } from '@metamask/network-controller';
+import type { Hex } from '@metamask/utils';
+import { createModuleLogger } from '@metamask/utils';
 import EventEmitter from 'events';
 import { cloneDeep, merge } from 'lodash';
 
-import { createModuleLogger, projectLogger } from '../logger';
+import { projectLogger } from '../logger';
 import type { TransactionMeta, TransactionReceipt } from '../types';
 import { TransactionStatus, TransactionType } from '../types';
 
@@ -61,13 +60,21 @@ export class PendingTransactionTracker {
 
   #approveTransaction: (transactionId: string) => Promise<void>;
 
-  #blockTracker: BlockTracker;
+  #beforeCheckPendingTransaction: (transactionMeta: TransactionMeta) => boolean;
+
+  #beforePublish: (transactionMeta: TransactionMeta) => boolean;
+
+  #currentBlockTracker?: BlockTracker;
 
   #droppedBlockCountByHash: Map<string, number>;
 
-  #getChainId: () => string;
+  #getBlockTracker: () => BlockTracker | undefined;
 
-  #getEthQuery: (networkClientId?: NetworkClientId) => EthQuery;
+  #getChainId: () => Hex | undefined;
+
+  #getEthQuery: () => EthQuery | undefined;
+
+  #getGlobalLock: (chainId: Hex) => Promise<() => void>;
 
   #getTransactions: () => TransactionMeta[];
 
@@ -77,19 +84,13 @@ export class PendingTransactionTracker {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   #listener: any;
 
-  #getGlobalLock: () => Promise<() => void>;
-
   #publishTransaction: (ethQuery: EthQuery, rawTx: string) => Promise<string>;
 
   #running: boolean;
 
-  #beforeCheckPendingTransaction: (transactionMeta: TransactionMeta) => boolean;
-
-  #beforePublish: (transactionMeta: TransactionMeta) => boolean;
-
   constructor({
     approveTransaction,
-    blockTracker,
+    getBlockTracker,
     getChainId,
     getEthQuery,
     getTransactions,
@@ -99,12 +100,12 @@ export class PendingTransactionTracker {
     hooks,
   }: {
     approveTransaction: (transactionId: string) => Promise<void>;
-    blockTracker: BlockTracker;
-    getChainId: () => string;
-    getEthQuery: (networkClientId?: NetworkClientId) => EthQuery;
+    getBlockTracker: () => BlockTracker | undefined;
+    getChainId: () => Hex | undefined;
+    getEthQuery: () => EthQuery | undefined;
     getTransactions: () => TransactionMeta[];
     isResubmitEnabled?: () => boolean;
-    getGlobalLock: () => Promise<() => void>;
+    getGlobalLock: (chainId: Hex) => Promise<() => void>;
     publishTransaction: (ethQuery: EthQuery, rawTx: string) => Promise<string>;
     hooks?: {
       beforeCheckPendingTransaction?: (
@@ -116,8 +117,8 @@ export class PendingTransactionTracker {
     this.hub = new EventEmitter() as PendingTransactionTrackerEventEmitter;
 
     this.#approveTransaction = approveTransaction;
-    this.#blockTracker = blockTracker;
     this.#droppedBlockCountByHash = new Map();
+    this.#getBlockTracker = getBlockTracker;
     this.#getChainId = getChainId;
     this.#getEthQuery = getEthQuery;
     this.#getTransactions = getTransactions;
@@ -132,39 +133,60 @@ export class PendingTransactionTracker {
   }
 
   startIfPendingTransactions = () => {
-    const pendingTransactions = this.#getPendingTransactions();
+    const { blockTracker, chainId } = this.#getNetworkObjects();
+
+    if (!blockTracker || !chainId) {
+      log('Unable to start as network is not available');
+      return;
+    }
+
+    this.#currentBlockTracker = blockTracker;
+
+    const pendingTransactions = this.#getPendingTransactions(chainId);
 
     if (pendingTransactions.length) {
-      this.#start();
+      this.#start(blockTracker);
     } else {
       this.stop();
     }
   };
 
   /**
-   * Force checks the network if the given transaction is confirmed and updates it's status.
+   * Force checks the network if the given transaction is confirmed and updates its status.
    *
    * @param txMeta - The transaction to check
    */
   async forceCheckTransaction(txMeta: TransactionMeta) {
-    const releaseLock = await this.#getGlobalLock();
+    let releaseLock: (() => void) | undefined;
 
     try {
-      await this.#checkTransaction(txMeta);
+      const { blockTracker, chainId, ethQuery } = this.#getNetworkObjects();
+
+      if (!blockTracker || !chainId || !ethQuery) {
+        log(
+          'Cannot force check transaction as network not available',
+          txMeta.id,
+        );
+        return;
+      }
+
+      releaseLock = await this.#getGlobalLock(chainId);
+
+      await this.#checkTransaction(txMeta, ethQuery, chainId);
     } catch (error) {
       /* istanbul ignore next */
-      log('Failed to check transaction', error);
+      log('Failed to force check transaction', error);
     } finally {
-      releaseLock();
+      releaseLock?.();
     }
   }
 
-  #start() {
+  #start(blockTracker: BlockTracker) {
     if (this.#running) {
       return;
     }
 
-    this.#blockTracker.on('latest', this.#listener);
+    blockTracker.on('latest', this.#listener);
     this.#running = true;
 
     log('Started polling');
@@ -175,36 +197,48 @@ export class PendingTransactionTracker {
       return;
     }
 
-    this.#blockTracker.removeListener('latest', this.#listener);
+    this.#currentBlockTracker?.removeListener('latest', this.#listener);
+    this.#currentBlockTracker = undefined;
     this.#running = false;
 
     log('Stopped polling');
   }
 
   async #onLatestBlock(latestBlockNumber: string) {
-    const releaseLock = await this.#getGlobalLock();
-
     try {
-      await this.#checkTransactions();
-    } catch (error) {
-      /* istanbul ignore next */
-      log('Failed to check transactions', error);
-    } finally {
-      releaseLock();
-    }
+      const { blockTracker, chainId, ethQuery } = this.#getNetworkObjects();
 
-    try {
-      await this.#resubmitTransactions(latestBlockNumber);
+      if (!blockTracker || !chainId || !ethQuery) {
+        log('Cannot process latest block as network not available');
+        return;
+      }
+
+      const releaseLock = await this.#getGlobalLock(chainId);
+
+      try {
+        await this.#checkTransactions(chainId, ethQuery);
+      } catch (error) {
+        /* istanbul ignore next */
+        log('Failed to check transactions', error);
+      } finally {
+        releaseLock();
+      }
+
+      try {
+        await this.#resubmitTransactions(latestBlockNumber, chainId, ethQuery);
+      } catch (error) {
+        /* istanbul ignore next */
+        log('Failed to resubmit transactions', error);
+      }
     } catch (error) {
-      /* istanbul ignore next */
-      log('Failed to resubmit transactions', error);
+      log('Failed to process latest block', error);
     }
   }
 
-  async #checkTransactions() {
+  async #checkTransactions(chainId: Hex, ethQuery: EthQuery) {
     log('Checking transactions');
 
-    const pendingTransactions = this.#getPendingTransactions();
+    const pendingTransactions = this.#getPendingTransactions(chainId);
 
     if (!pendingTransactions.length) {
       log('No pending transactions to check');
@@ -217,18 +251,24 @@ export class PendingTransactionTracker {
     });
 
     await Promise.all(
-      pendingTransactions.map((tx) => this.#checkTransaction(tx)),
+      pendingTransactions.map((tx) =>
+        this.#checkTransaction(tx, ethQuery, chainId),
+      ),
     );
   }
 
-  async #resubmitTransactions(latestBlockNumber: string) {
+  async #resubmitTransactions(
+    latestBlockNumber: string,
+    chainId: Hex,
+    ethQuery: EthQuery,
+  ) {
     if (!this.#isResubmitEnabled() || !this.#running) {
       return;
     }
 
     log('Resubmitting transactions');
 
-    const pendingTransactions = this.#getPendingTransactions();
+    const pendingTransactions = this.#getPendingTransactions(chainId);
 
     if (!pendingTransactions.length) {
       log('No pending transactions to resubmit');
@@ -242,7 +282,7 @@ export class PendingTransactionTracker {
 
     for (const txMeta of pendingTransactions) {
       try {
-        await this.#resubmitTransaction(txMeta, latestBlockNumber);
+        await this.#resubmitTransaction(txMeta, latestBlockNumber, ethQuery);
         // TODO: Replace `any` with type
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
@@ -273,10 +313,13 @@ export class PendingTransactionTracker {
   async #resubmitTransaction(
     txMeta: TransactionMeta,
     latestBlockNumber: string,
+    ethQuery: EthQuery,
   ) {
     if (!this.#isResubmitDue(txMeta, latestBlockNumber)) {
       return;
     }
+
+    log('Resubmitting transaction', txMeta.id);
 
     const { rawTx } = txMeta;
 
@@ -290,7 +333,6 @@ export class PendingTransactionTracker {
       return;
     }
 
-    const ethQuery = this.#getEthQuery(txMeta.networkClientId);
     await this.#publishTransaction(ethQuery, rawTx);
 
     const retryCount = (txMeta.retryCount ?? 0) + 1;
@@ -331,7 +373,11 @@ export class PendingTransactionTracker {
     return blocksSinceFirstRetry >= requiredBlocksSinceFirstRetry;
   }
 
-  async #checkTransaction(txMeta: TransactionMeta) {
+  async #checkTransaction(
+    txMeta: TransactionMeta,
+    ethQuery: EthQuery,
+    chainId: Hex,
+  ) {
     const { hash, id } = txMeta;
 
     if (!hash && this.#beforeCheckPendingTransaction(txMeta)) {
@@ -346,14 +392,14 @@ export class PendingTransactionTracker {
       return;
     }
 
-    if (this.#isNonceTaken(txMeta)) {
+    if (this.#isNonceTaken(txMeta, chainId)) {
       log('Nonce already taken', id);
       this.#dropTransaction(txMeta);
       return;
     }
 
     try {
-      const receipt = await this.#getTransactionReceipt(hash);
+      const receipt = await this.#getTransactionReceipt(ethQuery, hash);
       const isSuccess = receipt?.status === RECEIPT_STATUS_SUCCESS;
       const isFailure = receipt?.status === RECEIPT_STATUS_FAILURE;
 
@@ -371,11 +417,15 @@ export class PendingTransactionTracker {
       const { blockNumber, blockHash } = receipt || {};
 
       if (isSuccess && blockNumber && blockHash) {
-        await this.#onTransactionConfirmed(txMeta, {
-          ...receipt,
-          blockNumber,
-          blockHash,
-        });
+        await this.#onTransactionConfirmed(
+          txMeta,
+          {
+            ...receipt,
+            blockNumber,
+            blockHash,
+          },
+          ethQuery,
+        );
 
         return;
       }
@@ -393,7 +443,7 @@ export class PendingTransactionTracker {
       return;
     }
 
-    if (await this.#isTransactionDropped(txMeta)) {
+    if (await this.#isTransactionDropped(txMeta, ethQuery)) {
       this.#dropTransaction(txMeta);
     }
   }
@@ -401,6 +451,7 @@ export class PendingTransactionTracker {
   async #onTransactionConfirmed(
     txMeta: TransactionMeta,
     receipt: SuccessfulTransactionReceipt,
+    ethQuery: EthQuery,
   ) {
     const { id } = txMeta;
     const { blockHash } = receipt;
@@ -408,7 +459,7 @@ export class PendingTransactionTracker {
     log('Transaction confirmed', id);
 
     const { baseFeePerGas, timestamp: blockTimestamp } =
-      await this.#getBlockByHash(blockHash, false);
+      await this.#getBlockByHash(blockHash, false, ethQuery);
 
     const updatedTxMeta = cloneDeep(txMeta);
     updatedTxMeta.baseFeePerGas = baseFeePerGas;
@@ -429,7 +480,7 @@ export class PendingTransactionTracker {
     this.hub.emit('transaction-confirmed', updatedTxMeta);
   }
 
-  async #isTransactionDropped(txMeta: TransactionMeta) {
+  async #isTransactionDropped(txMeta: TransactionMeta, ethQuery: EthQuery) {
     const {
       hash,
       id,
@@ -441,7 +492,11 @@ export class PendingTransactionTracker {
       return false;
     }
 
-    const networkNextNonceHex = await this.#getNetworkTransactionCount(from);
+    const networkNextNonceHex = await this.#getNetworkTransactionCount(
+      from,
+      ethQuery,
+    );
+
     const networkNextNonceNumber = parseInt(networkNextNonceHex, 16);
     const nonceNumber = parseInt(nonce, 16);
 
@@ -468,10 +523,10 @@ export class PendingTransactionTracker {
     return true;
   }
 
-  #isNonceTaken(txMeta: TransactionMeta): boolean {
+  #isNonceTaken(txMeta: TransactionMeta, chainId: Hex): boolean {
     const { id, txParams } = txMeta;
 
-    return this.#getCurrentChainTransactions().some(
+    return this.#getCurrentChainTransactions(chainId).some(
       (tx) =>
         tx.id !== id &&
         tx.txParams.from === txParams.from &&
@@ -481,8 +536,8 @@ export class PendingTransactionTracker {
     );
   }
 
-  #getPendingTransactions(): TransactionMeta[] {
-    return this.#getCurrentChainTransactions().filter(
+  #getPendingTransactions(chainId: Hex): TransactionMeta[] {
+    return this.#getCurrentChainTransactions(chainId).filter(
       (tx) =>
         tx.status === TransactionStatus.submitted &&
         !tx.verifiedOnBlockchain &&
@@ -515,32 +570,43 @@ export class PendingTransactionTracker {
   }
 
   async #getTransactionReceipt(
+    ethQuery: EthQuery,
     txHash?: string,
   ): Promise<TransactionReceipt | undefined> {
-    return await query(this.#getEthQuery(), 'getTransactionReceipt', [txHash]);
+    return await query(ethQuery, 'getTransactionReceipt', [txHash]);
   }
 
   async #getBlockByHash(
     blockHash: string,
     includeTransactionDetails: boolean,
+    ethQuery: EthQuery,
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
-    return await query(this.#getEthQuery(), 'getBlockByHash', [
+    return await query(ethQuery, 'getBlockByHash', [
       blockHash,
       includeTransactionDetails,
     ]);
   }
 
-  async #getNetworkTransactionCount(address: string): Promise<string> {
-    return await query(this.#getEthQuery(), 'getTransactionCount', [address]);
+  async #getNetworkTransactionCount(
+    address: string,
+    ethQuery: EthQuery,
+  ): Promise<string> {
+    return await query(ethQuery, 'getTransactionCount', [address]);
   }
 
-  #getCurrentChainTransactions(): TransactionMeta[] {
-    const currentChainId = this.#getChainId();
-
+  #getCurrentChainTransactions(currentChainId: Hex): TransactionMeta[] {
     return this.#getTransactions().filter(
       (tx) => tx.chainId === currentChainId,
     );
+  }
+
+  #getNetworkObjects() {
+    const blockTracker = this.#getBlockTracker();
+    const chainId = this.#getChainId();
+    const ethQuery = this.#getEthQuery();
+
+    return { blockTracker, chainId, ethQuery };
   }
 }

--- a/packages/transaction-controller/src/helpers/\
+++ b/packages/transaction-controller/src/helpers/\
@@ -37,10 +37,7 @@ export class GasFeePoller {
     options: FetchGasFeeEstimateOptions,
   ) => Promise<GasFeeState>;
 
-  #getProvider: (
-    chainId: Hex,
-    networkClientId?: NetworkClientId,
-  ) => Provider | undefined;
+  #getProvider: (chainId: Hex, networkClientId?: NetworkClientId) => Provider;
 
   #getTransactions: () => TransactionMeta[];
 
@@ -75,10 +72,7 @@ export class GasFeePoller {
     getGasFeeControllerEstimates: (
       options: FetchGasFeeEstimateOptions,
     ) => Promise<GasFeeState>;
-    getProvider: (
-      chainId: Hex,
-      networkClientId?: NetworkClientId,
-    ) => Provider | undefined;
+    getProvider: (chainId: Hex, networkClientId?: NetworkClientId) => Provider;
     getTransactions: () => TransactionMeta[];
     layer1GasFeeFlows: Layer1GasFeeFlow[];
     onStateChange: (listener: () => void) => void;
@@ -198,18 +192,7 @@ export class GasFeePoller {
   > {
     const { chainId, networkClientId } = transactionMeta;
 
-    const provider = this.#getProvider(chainId, networkClientId);
-    if (!provider) {
-      log('Provider not available', transactionMeta.id);
-      return undefined;
-    }
-
-    const ethQuery = new EthQuery(provider);
-    if (!ethQuery) {
-      log('Provider not available', transactionMeta.id);
-      return undefined;
-    }
-
+    const ethQuery = new EthQuery(this.#getProvider(chainId, networkClientId));
     const gasFeeFlow = getGasFeeFlow(transactionMeta, this.#gasFeeFlows);
 
     if (gasFeeFlow) {
@@ -218,6 +201,11 @@ export class GasFeePoller {
         gasFeeFlow.constructor.name,
         transactionMeta.id,
       );
+    }
+
+    if (!ethQuery) {
+      log('Provider not available', transactionMeta.id);
+      return;
     }
 
     const request: GasFeeFlowRequest = {
@@ -253,12 +241,7 @@ export class GasFeePoller {
     transactionMeta: TransactionMeta,
   ): Promise<Hex | undefined> {
     const { chainId, networkClientId } = transactionMeta;
-
     const provider = this.#getProvider(chainId, networkClientId);
-    if (!provider) {
-      log('Provider not available', transactionMeta.id);
-      throw new Error('provider not available');
-    }
 
     const layer1GasFee = await getTransactionLayer1GasFee({
       layer1GasFeeFlows: this.#layer1GasFeeFlows,

--- a/packages/transaction-controller/src/utils/nonce.ts
+++ b/packages/transaction-controller/src/utils/nonce.ts
@@ -3,6 +3,7 @@ import type {
   NonceLock,
   Transaction as NonceTrackerTransaction,
 } from '@metamask/nonce-tracker';
+import { providerErrors } from '@metamask/rpc-errors';
 
 import { createModuleLogger, projectLogger } from '../logger';
 import type { TransactionMeta, TransactionStatus } from '../types';
@@ -18,7 +19,7 @@ const log = createModuleLogger(projectLogger, 'nonce');
  */
 export async function getNextNonce(
   txMeta: TransactionMeta,
-  getNonceLock: (address: string) => Promise<NonceLock>,
+  getNonceLock: (address: string) => Promise<NonceLock | undefined>,
 ): Promise<[string, (() => void) | undefined]> {
   const {
     customNonceValue,
@@ -38,6 +39,11 @@ export async function getNextNonce(
   }
 
   const nonceLock = await getNonceLock(from);
+
+  if (!nonceLock) {
+    throw providerErrors.chainDisconnected();
+  }
+
   const nonce = toHex(nonceLock.nextNonce);
   const releaseLock = nonceLock.releaseLock.bind(nonceLock);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,7 +1974,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/eth-block-tracker": ^9.0.2
+    "@metamask/eth-block-tracker": ^9.0.3
     "@metamask/eth-json-rpc-provider": ^4.0.0
     "@metamask/json-rpc-engine": ^9.0.0
     "@metamask/utils": ^8.3.0
@@ -2104,16 +2104,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-block-tracker@npm:^9.0.2":
-  version: 9.0.2
-  resolution: "@metamask/eth-block-tracker@npm:9.0.2"
+"@metamask/eth-block-tracker@npm:^9.0.2, @metamask/eth-block-tracker@npm:^9.0.3":
+  version: 9.0.3
+  resolution: "@metamask/eth-block-tracker@npm:9.0.3"
   dependencies:
-    "@metamask/eth-json-rpc-provider": ^2.3.1
+    "@metamask/eth-json-rpc-provider": ^3.0.2
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.1.0
     json-rpc-random-id: ^1.0.1
     pify: ^5.0.0
-  checksum: ec66cb100b011cafb2052bf0ab6935336ea4c8afd1f6c48326faf362a387d36112b5fffe296f3c75edfb09b29516182015c6f31ee6cb615c0ef4d2aa4ddb9c88
+  checksum: edd3d59a0416752d90c8e2d8c10c31635dbe3eb323fcb054c401528afe4cbbb6a5a85aedd6ffee4a504d9779656bfab027f2274fd95981c90bf56b6f565dbca2
   languageName: node
   linkType: hard
 
@@ -2178,7 +2178,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/eth-json-rpc-provider@npm:^2.1.0, @metamask/eth-json-rpc-provider@npm:^2.3.1":
+"@metamask/eth-json-rpc-provider@npm:^2.1.0":
   version: 2.3.2
   resolution: "@metamask/eth-json-rpc-provider@npm:2.3.2"
   dependencies:
@@ -2186,6 +2186,17 @@ __metadata:
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.3.0
   checksum: e6731271aad3b972d85b9230c26d35a9b88722f3bd3024675ad2f568e634e9fdfef4717ef2892f3cc512d381cf17a4e20dbd5eb808ced765082bea3379ad6ddc
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-json-rpc-provider@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@metamask/eth-json-rpc-provider@npm:3.0.2"
+  dependencies:
+    "@metamask/json-rpc-engine": ^8.0.2
+    "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^8.3.0
+  checksum: 0321eaad6fa205a9d3ddcfaf28e63c05291614893cb2e116151185a4acbd6bb6a508d6e556b3cb8bc4d3caef4bf0a638202d9b6bdc127fbcb81715eb2660a809
   languageName: node
   linkType: hard
 
@@ -2589,7 +2600,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.4.4
     "@metamask/base-controller": ^6.0.0
     "@metamask/controller-utils": ^11.0.0
-    "@metamask/eth-block-tracker": ^9.0.2
+    "@metamask/eth-block-tracker": ^9.0.3
     "@metamask/eth-json-rpc-infura": ^9.1.0
     "@metamask/eth-json-rpc-middleware": ^12.1.1
     "@metamask/eth-json-rpc-provider": ^4.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2617,15 +2617,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/nonce-tracker@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@metamask/nonce-tracker@npm:5.0.0"
+"@metamask/nonce-tracker@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/nonce-tracker@npm:6.0.0"
   dependencies:
     "@ethersproject/providers": ^5.7.2
     async-mutex: ^0.3.1
   peerDependencies:
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 31de9d62f2aec52688a4b7ec1fab877d1f2f4e6b2b395abef2790ddee63b3511f312c07c29d1c191f900231dbd4cdde8e969b210462f78253a177cacee72688c
+  checksum: d24cdf8eedc892673c3fe4ee1eff87356810840d5d3abb59c3e8adc5fbf21a1a9498bc1df50a7a6a61e7ebe9f3a3f45df4dd4b5b4269e7a52e5d8121d68f83ef
   languageName: node
   linkType: hard
 
@@ -3152,7 +3152,7 @@ __metadata:
     "@metamask/gas-fee-controller": ^17.0.0
     "@metamask/metamask-eth-abis": ^3.1.1
     "@metamask/network-controller": ^19.0.0
-    "@metamask/nonce-tracker": ^5.0.0
+    "@metamask/nonce-tracker": ^6.0.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
     "@types/bn.js": ^5.1.5


### PR DESCRIPTION
combination of:

- #4327 
- #4359
- changing `TransactionController` tests to use separate providers per network instead of "palm mainnet" for everything but eth-mainnet.