### PR TITLE
fix: add `SelectedNetworkController` setNetworkClientId useRequestQueuePreference guard

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -172,11 +172,7 @@ export class SelectedNetworkController extends BaseController<
             path[0] === 'subjects' && path[1] !== undefined;
           if (isChangingSubject && typeof path[1] === 'string') {
             const domain = path[1];
-            if (
-              op === 'add' &&
-              this.state.domains[domain] === undefined &&
-              this.#useRequestQueuePreference
-            ) {
+            if (op === 'add' && this.state.domains[domain] === undefined) {
               this.setNetworkClientIdForDomain(
                 domain,
                 this.messagingSystem.call('NetworkController:getState')

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -311,6 +311,10 @@ export class SelectedNetworkController extends BaseController<
     domain: Domain,
     networkClientId: NetworkClientId,
   ) {
+    if (!this.#useRequestQueuePreference) {
+      return;
+    }
+
     if (domain === METAMASK_DOMAIN) {
       throw new Error(
         `NetworkClientId for domain "${METAMASK_DOMAIN}" cannot be set on the SelectedNetworkController`,

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -306,29 +306,27 @@ describe('SelectedNetworkController', () => {
     });
 
     describe('when the useRequestQueue is false', () => {
-      describe('when the requesting domain is not metamask', () => {
-        it('skips setting the networkClientId for the passed in domain', () => {
-          const { controller } = setup({
-            state: {
-              domains: {
-                '1.com': 'mainnet',
-                '2.com': 'mainnet',
-                '3.com': 'mainnet',
-              },
+      it('skips setting the networkClientId for the passed in domain', () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              '1.com': 'mainnet',
+              '2.com': 'mainnet',
+              '3.com': 'mainnet',
             },
-          });
-          const domains = ['1.com', '2.com', '3.com'];
-          const networkClientIds = ['1', '2', '3'];
+          },
+        });
+        const domains = ['1.com', '2.com', '3.com'];
+        const networkClientIds = ['1', '2', '3'];
 
-          domains.forEach((domain, i) =>
-            controller.setNetworkClientIdForDomain(domain, networkClientIds[i]),
-          );
+        domains.forEach((domain, i) =>
+          controller.setNetworkClientIdForDomain(domain, networkClientIds[i]),
+        );
 
-          expect(controller.state.domains).toStrictEqual({
-            '1.com': 'mainnet',
-            '2.com': 'mainnet',
-            '3.com': 'mainnet',
-          });
+        expect(controller.state.domains).toStrictEqual({
+          '1.com': 'mainnet',
+          '2.com': 'mainnet',
+          '3.com': 'mainnet',
         });
       });
     });
@@ -786,32 +784,71 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('Constructor checks for domains in permissions', () => {
-    it('should set networkClientId for domains not already in state when useRequestQueuePreference is true', async () => {
-      const getSubjectNamesMock = ['newdomain.com'];
-      const { controller } = setup({
-        state: { domains: {} },
-        getSubjectNames: getSubjectNamesMock,
-        useRequestQueuePreference: true,
+    describe('when useRequestQueuePreference is true', () => {
+      it('should set networkClientId for domains not already in state', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
+            },
+          },
+          getSubjectNames: ['newdomain.com'],
+          useRequestQueuePreference: true,
+        });
+
+        expect(controller.state.domains).toStrictEqual({
+          'newdomain.com': 'mainnet',
+          'existingdomain.com': 'initialNetworkId',
+        });
       });
 
-      // Now, 'newdomain.com' should have the selectedNetworkClientId set
-      expect(controller.state.domains['newdomain.com']).toBe('mainnet');
+      it('should not modify domains already in state', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
+            },
+          },
+          getSubjectNames: ['existingdomain.com'],
+          useRequestQueuePreference: true,
+        });
+
+        expect(controller.state.domains).toStrictEqual({
+          'existingdomain.com': 'initialNetworkId',
+        });
+      });
     });
 
-    it('should not modify domains already in state', async () => {
-      const { controller } = setup({
-        state: {
-          domains: {
-            'existingdomain.com': 'initialNetworkId',
+    describe('when useRequestQueuePreference is false', () => {
+      it('should set networkClientId for domains not already in state', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
+            },
           },
-        },
-        getSubjectNames: ['existingdomain.com'],
+          getSubjectNames: ['newdomain.com'],
+        });
+
+        expect(controller.state.domains).toStrictEqual({
+          'existingdomain.com': 'initialNetworkId',
+        });
       });
 
-      // The 'existingdomain.com' should retain its initial networkClientId
-      expect(controller.state.domains['existingdomain.com']).toBe(
-        'initialNetworkId',
-      );
+      it('should not modify domains already in state', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
+            },
+          },
+          getSubjectNames: ['existingdomain.com'],
+        });
+
+        expect(controller.state.domains).toStrictEqual({
+          'existingdomain.com': 'initialNetworkId',
+        });
+      });
     });
   });
 

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -225,37 +225,77 @@ describe('SelectedNetworkController', () => {
     });
   });
 
-  describe('networkController:stateChange and useRequestQueuePreference is true', () => {
-    describe('when a networkClient is deleted from the network controller state', () => {
-      it('updates the networkClientId for domains which were previously set to the deleted networkClientId', () => {
-        const { controller, messenger } = setup({
-          state: {
-            domains: {
-              metamask: 'goerli',
-              'example.com': 'test-network-client-id',
-              'test.com': 'test-network-client-id',
+  describe('networkController:stateChange', () => {
+    describe('when useRequestQueuePreference is false', () => {
+      describe('when a networkClient is deleted from the network controller state', () => {
+        it('does not update the networkClientId for domains which were previously set to the deleted networkClientId', () => {
+          const { controller, messenger } = setup({
+            state: {
+              // normally there would not be any domains in state if useRequestQueuePreference is false
+              domains: {
+                metamask: 'goerli',
+                'example.com': 'test-network-client-id',
+                'test.com': 'test-network-client-id',
+              },
             },
-          },
-          useRequestQueuePreference: true,
-        });
+          });
 
-        messenger.publish(
-          'NetworkController:stateChange',
-          {
-            providerConfig: { chainId: '0x5', ticker: 'ETH', type: 'goerli' },
-            selectedNetworkClientId: 'goerli',
-            networkConfigurations: {},
-            networksMetadata: {},
-          },
-          [
+          messenger.publish(
+            'NetworkController:stateChange',
             {
-              op: 'remove',
-              path: ['networkConfigurations', 'test-network-client-id'],
+              providerConfig: { chainId: '0x5', ticker: 'ETH', type: 'goerli' },
+              selectedNetworkClientId: 'goerli',
+              networkConfigurations: {},
+              networksMetadata: {},
             },
-          ],
-        );
-        expect(controller.state.domains['example.com']).toBe('goerli');
-        expect(controller.state.domains['test.com']).toBe('goerli');
+            [
+              {
+                op: 'remove',
+                path: ['networkConfigurations', 'test-network-client-id'],
+              },
+            ],
+          );
+          expect(controller.state.domains).toStrictEqual({
+            metamask: 'goerli',
+            'example.com': 'test-network-client-id',
+            'test.com': 'test-network-client-id',
+          });
+        });
+      });
+    });
+
+    describe('when useRequestQueuePreference is true', () => {
+      describe('when a networkClient is deleted from the network controller state', () => {
+        it('updates the networkClientId for domains which were previously set to the deleted networkClientId', () => {
+          const { controller, messenger } = setup({
+            state: {
+              domains: {
+                metamask: 'goerli',
+                'example.com': 'test-network-client-id',
+                'test.com': 'test-network-client-id',
+              },
+            },
+            useRequestQueuePreference: true,
+          });
+
+          messenger.publish(
+            'NetworkController:stateChange',
+            {
+              providerConfig: { chainId: '0x5', ticker: 'ETH', type: 'goerli' },
+              selectedNetworkClientId: 'goerli',
+              networkConfigurations: {},
+              networksMetadata: {},
+            },
+            [
+              {
+                op: 'remove',
+                path: ['networkConfigurations', 'test-network-client-id'],
+              },
+            ],
+          );
+          expect(controller.state.domains['example.com']).toBe('goerli');
+          expect(controller.state.domains['test.com']).toBe('goerli');
+        });
       });
     });
   });

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -820,7 +820,7 @@ describe('SelectedNetworkController', () => {
     });
 
     describe('when useRequestQueuePreference is false', () => {
-      it('should set networkClientId for domains not already in state', async () => {
+      it('should not set networkClientId for new domains', async () => {
         const { controller } = setup({
           state: {
             domains: {


### PR DESCRIPTION
## Explanation

Our previous SelectedNetworkController fix that [added a guard to permission state changes](https://github.com/MetaMask/core/pull/4368) was not sufficient. This PR properly addresses the underlying issue of setting networkClientId for domains when the `useRequestQueuePreference` flag is false by moving the guard into the `setNetworkClientId()` method itself

## References

* Fixes: https://github.com/MetaMask/metamask-extension/issues/25097

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/selected-network-controller`

- **FIXED**: `setNetworkClientId()` will now result in a noop if `useRequestQueuePreference` is false


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
