### PR TITLE
testfix(transaction-controller): Refactor provider setup to provide correct providers and tracker

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -302,11 +302,10 @@ const INFURA_PROJECT_ID = '341eacb578dd44a1a049cbc5f6fd4035';
 const HTTP_PROVIDERS = {
   goerli: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
   mainnet: new HttpProvider(`https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
-  palm: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
-  /*
   linea: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
   linea_goerli: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
-  */
+  custom: new HttpProvider(`http://127.0.0.123:456/ethrpc?apiKey=foobar`),
+  palm: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
 }
 
 type MockNetwork = {
@@ -376,8 +375,8 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
 };
 
 const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
-  provider: HTTP_PROVIDERS.palm,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
+  provider: HTTP_PROVIDERS.linea,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.linea),
   state: {
     selectedNetworkClientId: NetworkType['linea-mainnet'],
     networksMetadata: {
@@ -397,8 +396,8 @@ const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
 };
 
 const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
-  provider: HTTP_PROVIDERS.palm,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
+  provider: HTTP_PROVIDERS.linea_goerli,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.linea_goerli),
   state: {
     selectedNetworkClientId: NetworkType['linea-goerli'],
     networksMetadata: {
@@ -418,8 +417,8 @@ const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
 };
 
 const MOCK_CUSTOM_NETWORK: MockNetwork = {
-  provider: HTTP_PROVIDERS.palm,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
+  provider: HTTP_PROVIDERS.custom,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.custom),
   state: {
     selectedNetworkClientId: 'uuid-1',
     networksMetadata: {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -299,15 +299,15 @@ function waitForTransactionFinished(
 
 const MOCK_PREFERENCES = { state: { selectedAddress: 'foo' } };
 const INFURA_PROJECT_ID = '341eacb578dd44a1a049cbc5f6fd4035';
-const GOERLI_PROVIDER = new HttpProvider(
-  `https://goerli.infura.io/v3/${INFURA_PROJECT_ID}`,
-);
-const MAINNET_PROVIDER = new HttpProvider(
-  `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
-);
-const PALM_PROVIDER = new HttpProvider(
-  `https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
-);
+const HTTP_PROVIDERS = {
+  goerli: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
+  mainnet: new HttpProvider(`https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
+  palm: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
+  /*
+  linea: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
+  linea_goerli: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
+  */
+}
 
 type MockNetwork = {
   provider: Provider;
@@ -317,8 +317,8 @@ type MockNetwork = {
 };
 
 const MOCK_NETWORK: MockNetwork = {
-  provider: MAINNET_PROVIDER,
-  blockTracker: buildMockBlockTracker('0x102833C', MAINNET_PROVIDER),
+  provider: HTTP_PROVIDERS.mainnet,
+  blockTracker: buildMockBlockTracker('0x102833C', HTTP_PROVIDERS.mainnet),
   state: {
     selectedNetworkClientId: NetworkType.goerli,
     networksMetadata: {
@@ -337,8 +337,8 @@ const MOCK_NETWORK: MockNetwork = {
   subscribe: () => undefined,
 };
 const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
-  provider: GOERLI_PROVIDER,
-  blockTracker: buildMockBlockTracker('0x102833C', GOERLI_PROVIDER),
+  provider: HTTP_PROVIDERS.palm,
+  blockTracker: buildMockBlockTracker('0x102833C', HTTP_PROVIDERS.goerli),
   state: {
     selectedNetworkClientId: NetworkType.goerli,
     networksMetadata: {
@@ -355,8 +355,8 @@ const MOCK_NETWORK_WITHOUT_CHAIN_ID: MockNetwork = {
   subscribe: () => undefined,
 };
 const MOCK_MAINNET_NETWORK: MockNetwork = {
-  provider: MAINNET_PROVIDER,
-  blockTracker: buildMockBlockTracker('0x102833C', MAINNET_PROVIDER),
+  provider: HTTP_PROVIDERS.mainnet,
+  blockTracker: buildMockBlockTracker('0x102833C', HTTP_PROVIDERS.mainnet),
   state: {
     selectedNetworkClientId: NetworkType.mainnet,
     networksMetadata: {
@@ -376,8 +376,8 @@ const MOCK_MAINNET_NETWORK: MockNetwork = {
 };
 
 const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
-  provider: PALM_PROVIDER,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', PALM_PROVIDER),
+  provider: HTTP_PROVIDERS.palm,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
   state: {
     selectedNetworkClientId: NetworkType['linea-mainnet'],
     networksMetadata: {
@@ -397,8 +397,8 @@ const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
 };
 
 const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
-  provider: PALM_PROVIDER,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', PALM_PROVIDER),
+  provider: HTTP_PROVIDERS.palm,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
   state: {
     selectedNetworkClientId: NetworkType['linea-goerli'],
     networksMetadata: {
@@ -418,8 +418,8 @@ const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
 };
 
 const MOCK_CUSTOM_NETWORK: MockNetwork = {
-  provider: PALM_PROVIDER,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', PALM_PROVIDER),
+  provider: HTTP_PROVIDERS.palm,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.palm),
   state: {
     selectedNetworkClientId: 'uuid-1',
     networksMetadata: {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -300,13 +300,23 @@ function waitForTransactionFinished(
 const MOCK_PREFERENCES = { state: { selectedAddress: 'foo' } };
 const INFURA_PROJECT_ID = '341eacb578dd44a1a049cbc5f6fd4035';
 const HTTP_PROVIDERS = {
-  goerli: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
-  mainnet: new HttpProvider(`https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
-  linea: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
-  linea_goerli: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
+  goerli: new HttpProvider(
+    `https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
+  ),
+  mainnet: new HttpProvider(
+    `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
+  ),
+  linea: new HttpProvider(
+    `https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
+  ),
+  linea_goerli: new HttpProvider(
+    `https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
+  ),
   custom: new HttpProvider(`http://127.0.0.123:456/ethrpc?apiKey=foobar`),
-  palm: new HttpProvider(`https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`),
-}
+  palm: new HttpProvider(
+    `https://palm-mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
+  ),
+};
 
 type MockNetwork = {
   provider: Provider;


### PR DESCRIPTION
## Explanation

Refactors tests so that providers are injected appropriately in the `MockMultichainTransaction`.

This is expected to fail without #4390 .

## References


## Changelog

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
