### PR TITLE
add `caip-stream` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This repository contains the following packages [^fn1]:
 
 <!-- start package list -->
 
-- [`@metamask/accounts-controller`](packages/accounts-controller)
 - [`@metamask/address-book-controller`](packages/address-book-controller)
 - [`@metamask/announcement-controller`](packages/announcement-controller)
 - [`@metamask/approval-controller`](packages/approval-controller)
 - [`@metamask/assets-controllers`](packages/assets-controllers)
 - [`@metamask/base-controller`](packages/base-controller)
 - [`@metamask/build-utils`](packages/build-utils)
+- [`@metamask/caip-stream`](packages/caip-stream)
 - [`@metamask/chain-controller`](packages/chain-controller)
 - [`@metamask/composable-controller`](packages/composable-controller)
 - [`@metamask/controller-utils`](packages/controller-utils)
@@ -52,13 +52,13 @@ Or, in graph form [^fn1]:
 %%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
 graph LR;
 linkStyle default opacity:0.5
-  accounts_controller(["@metamask/accounts-controller"]);
   address_book_controller(["@metamask/address-book-controller"]);
   announcement_controller(["@metamask/announcement-controller"]);
   approval_controller(["@metamask/approval-controller"]);
   assets_controllers(["@metamask/assets-controllers"]);
   base_controller(["@metamask/base-controller"]);
   build_utils(["@metamask/build-utils"]);
+  caip_stream(["@metamask/caip-stream"]);
   chain_controller(["@metamask/chain-controller"]);
   composable_controller(["@metamask/composable-controller"]);
   controller_utils(["@metamask/controller-utils"]);
@@ -85,8 +85,6 @@ linkStyle default opacity:0.5
   signature_controller(["@metamask/signature-controller"]);
   transaction_controller(["@metamask/transaction-controller"]);
   user_operation_controller(["@metamask/user-operation-controller"]);
-  accounts_controller --> base_controller;
-  accounts_controller --> keyring_controller;
   address_book_controller --> base_controller;
   address_book_controller --> controller_utils;
   announcement_controller --> base_controller;
@@ -154,11 +152,13 @@ linkStyle default opacity:0.5
   signature_controller --> keyring_controller;
   signature_controller --> logging_controller;
   signature_controller --> message_manager;
+  transaction_controller --> accounts_controller;
   transaction_controller --> approval_controller;
   transaction_controller --> base_controller;
   transaction_controller --> controller_utils;
   transaction_controller --> gas_fee_controller;
   transaction_controller --> network_controller;
+  transaction_controller --> eth_json_rpc_provider;
   user_operation_controller --> approval_controller;
   user_operation_controller --> base_controller;
   user_operation_controller --> controller_utils;

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains the following packages [^fn1]:
 
 <!-- start package list -->
 
+- [`@metamask/accounts-controller`](packages/accounts-controller)
 - [`@metamask/address-book-controller`](packages/address-book-controller)
 - [`@metamask/announcement-controller`](packages/announcement-controller)
 - [`@metamask/approval-controller`](packages/approval-controller)
@@ -52,6 +53,7 @@ Or, in graph form [^fn1]:
 %%{ init: { 'flowchart': { 'curve': 'bumpX' } } }%%
 graph LR;
 linkStyle default opacity:0.5
+  accounts_controller(["@metamask/accounts-controller"]);
   address_book_controller(["@metamask/address-book-controller"]);
   announcement_controller(["@metamask/announcement-controller"]);
   approval_controller(["@metamask/approval-controller"]);
@@ -85,6 +87,8 @@ linkStyle default opacity:0.5
   signature_controller(["@metamask/signature-controller"]);
   transaction_controller(["@metamask/transaction-controller"]);
   user_operation_controller(["@metamask/user-operation-controller"]);
+  accounts_controller --> base_controller;
+  accounts_controller --> keyring_controller;
   address_book_controller --> base_controller;
   address_book_controller --> controller_utils;
   announcement_controller --> base_controller;
@@ -152,13 +156,11 @@ linkStyle default opacity:0.5
   signature_controller --> keyring_controller;
   signature_controller --> logging_controller;
   signature_controller --> message_manager;
-  transaction_controller --> accounts_controller;
   transaction_controller --> approval_controller;
   transaction_controller --> base_controller;
   transaction_controller --> controller_utils;
   transaction_controller --> gas_fee_controller;
   transaction_controller --> network_controller;
-  transaction_controller --> eth_json_rpc_provider;
   user_operation_controller --> approval_controller;
   user_operation_controller --> base_controller;
   user_operation_controller --> controller_utils;

--- a/packages/caip-stream/CHANGELOG.md
+++ b/packages/caip-stream/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/core/

--- a/packages/caip-stream/LICENSE
+++ b/packages/caip-stream/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2024 MetaMask
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE

--- a/packages/caip-stream/README.md
+++ b/packages/caip-stream/README.md
@@ -1,0 +1,15 @@
+# `@metamask/caip-stream`
+
+A helper that enables CAIP enveloped message support from MetaMask multiplexed streams
+
+## Installation
+
+`yarn add @metamask/caip-stream`
+
+or
+
+`npm install @metamask/caip-stream`
+
+## Contributing
+
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).

--- a/packages/caip-stream/jest.config.js
+++ b/packages/caip-stream/jest.config.js
@@ -1,0 +1,26 @@
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+const merge = require('deepmerge');
+const path = require('path');
+
+const baseConfig = require('../../jest.config.packages');
+
+const displayName = path.basename(__dirname);
+
+module.exports = merge(baseConfig, {
+  // The display name when running multiple projects
+  displayName,
+
+  // An object that configures minimum threshold enforcement for coverage results
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+});

--- a/packages/caip-stream/package.json
+++ b/packages/caip-stream/package.json
@@ -30,14 +30,14 @@
     "dist/"
   ],
   "scripts": {
+    "build": "tsup --config ../../tsup.config.ts --tsconfig ./tsconfig.build.json --clean",
     "build:docs": "typedoc",
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/caip-stream",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest --reporters=jest-silent-reporter",
     "test:clean": "jest --clearCache",
     "test:verbose": "jest --verbose",
-    "test:watch": "jest --watch",
-    "build": "tsup --config ../../tsup.config.ts --tsconfig ./tsconfig.build.json --clean"
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@metamask/utils": "^8.3.0",

--- a/packages/caip-stream/package.json
+++ b/packages/caip-stream/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@metamask/caip-stream",
+  "version": "0.0.0",
+  "description": "A helper that enables CAIP enveloped message support from MetaMask multiplexed streams",
+  "keywords": [
+    "MetaMask",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/core/tree/main/packages/caip-stream#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/core/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/core.git"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/types/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/types/index.d.ts",
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build:docs": "typedoc",
+    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/caip-stream",
+    "publish:preview": "yarn npm publish --tag preview",
+    "test": "jest --reporters=jest-silent-reporter",
+    "test:clean": "jest --clearCache",
+    "test:verbose": "jest --verbose",
+    "test:watch": "jest --watch",
+    "build": "tsup --config ../../tsup.config.ts --tsconfig ./tsconfig.build.json --clean"
+  },
+  "dependencies": {
+    "@metamask/utils": "^8.3.0",
+    "readable-stream": "^3.6.2"
+  },
+  "devDependencies": {
+    "@metamask/auto-changelog": "^3.4.4",
+    "@types/jest": "^27.4.1",
+    "@types/readable-stream": "4.0.4",
+    "deepmerge": "^4.2.2",
+    "jest": "^27.5.1",
+    "ts-jest": "^27.1.4",
+    "typedoc": "^0.24.8",
+    "typedoc-plugin-missing-exports": "^2.0.0",
+    "typescript": "~4.9.5"
+  },
+  "engines": {
+    "node": "^18.18 || >=20"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/caip-stream/src/createCaipStream.test.ts
+++ b/packages/caip-stream/src/createCaipStream.test.ts
@@ -1,0 +1,72 @@
+import { createDeferredPromise } from '@metamask/utils';
+import { PassThrough } from 'readable-stream';
+
+import { createCaipStream } from './createCaipStream';
+import { SplitStream } from './streams/SplitStream';
+import { onData, writeToStream } from './tests/streams';
+
+describe('createCaipStream', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('pipes a caip-x message from source stream to the substream as a multiplexed `metamask-provider` message', async () => {
+    const sourceStream = new PassThrough({ objectMode: true });
+
+    const sourceStreamChunks = onData(sourceStream);
+
+    const providerStream = createCaipStream(sourceStream);
+    const providerStreamChunks = onData(providerStream);
+
+    await writeToStream(sourceStream, {
+      type: 'caip-x',
+      data: { foo: 'bar' },
+    });
+
+    expect(sourceStreamChunks).toStrictEqual([
+      { type: 'caip-x', data: { foo: 'bar' } },
+    ]);
+    expect(providerStreamChunks).toStrictEqual([
+      { name: 'metamask-provider', data: { foo: 'bar' } },
+    ]);
+  });
+
+  it('pipes a multiplexed `metamask-provider` message from the substream to the source stream as a caip-x message', async () => {
+    // using a SplitStream here instead of PassThrough to prevent a loop
+    // when sourceStream gets written to at the end of the CAIP pipeline
+    const sourceStream = new SplitStream();
+    const innerStreamChunks = onData(sourceStream.substream);
+
+    const providerStream = createCaipStream(sourceStream);
+
+    await writeToStream(providerStream, {
+      name: 'metamask-provider',
+      data: { foo: 'bar' },
+    });
+
+    // Note that it's not possible to verify the output side of the internal SplitStream
+    // instantiated inside createCaipStream as only the substream is actually exported
+    expect(innerStreamChunks).toStrictEqual([
+      { type: 'caip-x', data: { foo: 'bar' } },
+    ]);
+  });
+
+  it('calls the logger with an error when the pipeline ends', async () => {
+    const { promise: isFinished, resolve: loggerCallback } =
+      createDeferredPromise();
+    const logger = jest.fn().mockImplementation(() => {
+      loggerCallback();
+    });
+
+    const sourceStream = new SplitStream();
+    createCaipStream(sourceStream, logger);
+    sourceStream.destroy();
+
+    await isFinished;
+
+    expect(logger).toHaveBeenCalledWith(
+      'MetaMask CAIP stream',
+      expect.any(Error),
+    );
+  });
+});

--- a/packages/caip-stream/src/createCaipStream.ts
+++ b/packages/caip-stream/src/createCaipStream.ts
@@ -1,0 +1,41 @@
+import type { Duplex } from 'readable-stream';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error pipeline() isn't defined as part of @types/readable-stream
+import { pipeline } from 'readable-stream';
+
+import { CaipToMultiplexTransform } from './streams/CaipToMultiplexTransform';
+import { MultiplexToCaipTransform } from './streams/MultiplexToCaipTransform';
+import { SplitStream } from './streams/SplitStream';
+
+/**
+ * Creates a pipeline using a port stream meant to be consumed by the JSON-RPC engine:
+ * - accepts only incoming CAIP messages intended for evm providers from the port stream
+ * - translates those incoming messages into the internal multiplexed format for 'metamask-provider'
+ * - writes these messages to a new stream that the JSON-RPC engine should operate off
+ * - accepts only outgoing messages in the internal multiplexed format for 'metamask-provider' from this new stream
+ * - translates those outgoing messages back to the CAIP message format
+ * - writes these messages back to the port stream
+ *
+ * @param portStream - The source and sink duplex stream
+ * @param logger - An optional function called when the internal pipeline ends
+ * @returns a new duplex stream that should be operated on instead of the original portStream
+ */
+export const createCaipStream = (
+  portStream: Duplex,
+  logger: (...data: unknown[]) => void = console.log,
+): Duplex => {
+  const splitStream = new SplitStream();
+  const caipToMultiplexTransform = new CaipToMultiplexTransform();
+  const multiplexToCaipTransform = new MultiplexToCaipTransform();
+
+  pipeline(
+    portStream,
+    caipToMultiplexTransform,
+    splitStream,
+    multiplexToCaipTransform,
+    portStream,
+    (err: Error) => logger('MetaMask CAIP stream', err),
+  );
+
+  return splitStream.substream;
+};

--- a/packages/caip-stream/src/index.ts
+++ b/packages/caip-stream/src/index.ts
@@ -1,0 +1,1 @@
+export * from './createCaipStream';

--- a/packages/caip-stream/src/streams/CaipToMultiplexTransform.test.ts
+++ b/packages/caip-stream/src/streams/CaipToMultiplexTransform.test.ts
@@ -1,0 +1,36 @@
+import { onData, writeToStream } from '../tests/streams';
+import { CaipToMultiplexTransform } from './CaipToMultiplexTransform';
+
+describe('CaipToMultiplexTransform', () => {
+  it('drops non caip-x messages', async () => {
+    const caipToMultiplexTransform = new CaipToMultiplexTransform();
+
+    const streamChunks = onData(caipToMultiplexTransform);
+
+    await writeToStream(caipToMultiplexTransform, { foo: 'bar' });
+    await writeToStream(caipToMultiplexTransform, {
+      type: 'caip-wrong',
+      data: { foo: 'bar' },
+    });
+
+    expect(streamChunks).toStrictEqual([]);
+  });
+
+  it('rewraps caip-x messages into multiplexed `metamask-provider` messages', async () => {
+    const caipToMultiplexTransform = new CaipToMultiplexTransform();
+
+    const streamChunks = onData(caipToMultiplexTransform);
+
+    await writeToStream(caipToMultiplexTransform, {
+      type: 'caip-x',
+      data: { foo: 'bar' },
+    });
+
+    expect(streamChunks).toStrictEqual([
+      {
+        name: 'metamask-provider',
+        data: { foo: 'bar' },
+      },
+    ]);
+  });
+});

--- a/packages/caip-stream/src/streams/CaipToMultiplexTransform.ts
+++ b/packages/caip-stream/src/streams/CaipToMultiplexTransform.ts
@@ -1,0 +1,22 @@
+import { isObject } from '@metamask/utils';
+import { Transform } from 'readable-stream';
+
+export class CaipToMultiplexTransform extends Transform {
+  constructor() {
+    super({ objectMode: true });
+  }
+
+  _write(
+    value: unknown,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    if (isObject(value) && value.type === 'caip-x') {
+      this.push({
+        name: 'metamask-provider',
+        data: value.data,
+      });
+    }
+    callback();
+  }
+}

--- a/packages/caip-stream/src/streams/MultiplexToCaipTransform.test.ts
+++ b/packages/caip-stream/src/streams/MultiplexToCaipTransform.test.ts
@@ -1,0 +1,36 @@
+import { onData, writeToStream } from '../tests/streams';
+import { MultiplexToCaipTransform } from './MultiplexToCaipTransform';
+
+describe('multiplexToCaipTransform', () => {
+  it('drops non multiplexed `metamask-provider` messages', async () => {
+    const multiplexToCaipTransform = new MultiplexToCaipTransform();
+
+    const streamChunks = onData(multiplexToCaipTransform);
+
+    await writeToStream(multiplexToCaipTransform, { foo: 'bar' });
+    await writeToStream(multiplexToCaipTransform, {
+      name: 'wrong-multiplex',
+      data: { foo: 'bar' },
+    });
+
+    expect(streamChunks).toStrictEqual([]);
+  });
+
+  it('rewraps multiplexed `metamask-provider` messages into caip-x messages', async () => {
+    const multiplexToCaipTransform = new MultiplexToCaipTransform();
+
+    const streamChunks = onData(multiplexToCaipTransform);
+
+    await writeToStream(multiplexToCaipTransform, {
+      name: 'metamask-provider',
+      data: { foo: 'bar' },
+    });
+
+    expect(streamChunks).toStrictEqual([
+      {
+        type: 'caip-x',
+        data: { foo: 'bar' },
+      },
+    ]);
+  });
+});

--- a/packages/caip-stream/src/streams/MultiplexToCaipTransform.ts
+++ b/packages/caip-stream/src/streams/MultiplexToCaipTransform.ts
@@ -1,0 +1,22 @@
+import { isObject } from '@metamask/utils';
+import { Transform } from 'readable-stream';
+
+export class MultiplexToCaipTransform extends Transform {
+  constructor() {
+    super({ objectMode: true });
+  }
+
+  _write(
+    value: unknown,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    if (isObject(value) && value.name === 'metamask-provider') {
+      this.push({
+        type: 'caip-x',
+        data: value.data,
+      });
+    }
+    callback();
+  }
+}

--- a/packages/caip-stream/src/streams/SplitStream.test.ts
+++ b/packages/caip-stream/src/streams/SplitStream.test.ts
@@ -1,0 +1,28 @@
+import { onData, writeToStream } from '../tests/streams';
+import { SplitStream } from './SplitStream';
+
+describe('SplitStream', () => {
+  it('redirects writes from the main stream to the substream', async () => {
+    const splitStream = new SplitStream();
+
+    const outerStreamChunks = onData(splitStream);
+    const innerStreamChunks = onData(splitStream.substream);
+
+    await writeToStream(splitStream, { foo: 'bar' });
+
+    expect(outerStreamChunks).toStrictEqual([]);
+    expect(innerStreamChunks).toStrictEqual([{ foo: 'bar' }]);
+  });
+
+  it('redirects writes from the substream to the main stream', async () => {
+    const splitStream = new SplitStream();
+
+    const outerStreamChunks = onData(splitStream);
+    const innerStreamChunks = onData(splitStream.substream);
+
+    await writeToStream(splitStream.substream, { foo: 'bar' });
+
+    expect(outerStreamChunks).toStrictEqual([{ foo: 'bar' }]);
+    expect(innerStreamChunks).toStrictEqual([]);
+  });
+});

--- a/packages/caip-stream/src/streams/SplitStream.ts
+++ b/packages/caip-stream/src/streams/SplitStream.ts
@@ -1,0 +1,23 @@
+import { Duplex } from 'readable-stream';
+
+export class SplitStream extends Duplex {
+  substream: Duplex;
+
+  constructor(substream?: SplitStream) {
+    super({ objectMode: true });
+    this.substream = substream ?? new SplitStream(this);
+  }
+
+  _read() {
+    return undefined;
+  }
+
+  _write(
+    value: unknown,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.substream.push(value);
+    callback();
+  }
+}

--- a/packages/caip-stream/src/tests/streams.ts
+++ b/packages/caip-stream/src/tests/streams.ts
@@ -1,0 +1,19 @@
+import { createDeferredPromise } from '@metamask/utils';
+import type { Duplex } from 'readable-stream';
+
+export const writeToStream = async (stream: Duplex, message: unknown) => {
+  const { promise: isWritten, resolve: writeCallback } =
+    createDeferredPromise();
+
+  stream.write(message, () => writeCallback());
+  await isWritten;
+};
+
+export const onData = (stream: Duplex): unknown[] => {
+  const chunks: unknown[] = [];
+  stream.on('data', (chunk: unknown) => {
+    chunks.push(chunk);
+  });
+
+  return chunks;
+};

--- a/packages/caip-stream/tsconfig.build.json
+++ b/packages/caip-stream/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.packages.build.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/types",
+    "rootDir": "./src"
+  },
+  "references": [],
+  "include": ["../../types", "./src"]
+}

--- a/packages/caip-stream/tsconfig.json
+++ b/packages/caip-stream/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  },
+  "references": [],
+  "include": ["../../types", "./src"]
+}

--- a/packages/caip-stream/typedoc.json
+++ b/packages/caip-stream/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "out": "docs",
+  "tsconfig": "./tsconfig.build.json"
+}

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -172,7 +172,11 @@ export class SelectedNetworkController extends BaseController<
             path[0] === 'subjects' && path[1] !== undefined;
           if (isChangingSubject && typeof path[1] === 'string') {
             const domain = path[1];
-            if (op === 'add' && this.state.domains[domain] === undefined) {
+            if (
+              op === 'add' &&
+              this.state.domains[domain] === undefined &&
+              this.#useRequestQueuePreference
+            ) {
               this.setNetworkClientIdForDomain(
                 domain,
                 this.messagingSystem.call('NetworkController:getState')
@@ -307,10 +311,6 @@ export class SelectedNetworkController extends BaseController<
     domain: Domain,
     networkClientId: NetworkClientId,
   ) {
-    if (!this.#useRequestQueuePreference) {
-      return;
-    }
-
     if (domain === METAMASK_DOMAIN) {
       throw new Error(
         `NetworkClientId for domain "${METAMASK_DOMAIN}" cannot be set on the SelectedNetworkController`,

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -172,11 +172,7 @@ export class SelectedNetworkController extends BaseController<
             path[0] === 'subjects' && path[1] !== undefined;
           if (isChangingSubject && typeof path[1] === 'string') {
             const domain = path[1];
-            if (
-              op === 'add' &&
-              this.state.domains[domain] === undefined &&
-              this.#useRequestQueuePreference
-            ) {
+            if (op === 'add' && this.state.domains[domain] === undefined) {
               this.setNetworkClientIdForDomain(
                 domain,
                 this.messagingSystem.call('NetworkController:getState')
@@ -311,6 +307,10 @@ export class SelectedNetworkController extends BaseController<
     domain: Domain,
     networkClientId: NetworkClientId,
   ) {
+    if (!this.#useRequestQueuePreference) {
+      return;
+    }
+
     if (domain === METAMASK_DOMAIN) {
       throw new Error(
         `NetworkClientId for domain "${METAMASK_DOMAIN}" cannot be set on the SelectedNetworkController`,

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -225,36 +225,77 @@ describe('SelectedNetworkController', () => {
     });
   });
 
-  describe('It updates domain state when the network controller state changes', () => {
-    describe('when a networkClient is deleted from the network controller state', () => {
-      it('updates the networkClientId for domains which were previously set to the deleted networkClientId', () => {
-        const { controller, messenger } = setup({
-          state: {
-            domains: {
-              metamask: 'goerli',
-              'example.com': 'test-network-client-id',
-              'test.com': 'test-network-client-id',
+  describe('networkController:stateChange', () => {
+    describe('when useRequestQueuePreference is false', () => {
+      describe('when a networkClient is deleted from the network controller state', () => {
+        it('does not update the networkClientId for domains which were previously set to the deleted networkClientId', () => {
+          const { controller, messenger } = setup({
+            state: {
+              // normally there would not be any domains in state if useRequestQueuePreference is false
+              domains: {
+                metamask: 'goerli',
+                'example.com': 'test-network-client-id',
+                'test.com': 'test-network-client-id',
+              },
             },
-          },
-        });
+          });
 
-        messenger.publish(
-          'NetworkController:stateChange',
-          {
-            providerConfig: { chainId: '0x5', ticker: 'ETH', type: 'goerli' },
-            selectedNetworkClientId: 'goerli',
-            networkConfigurations: {},
-            networksMetadata: {},
-          },
-          [
+          messenger.publish(
+            'NetworkController:stateChange',
             {
-              op: 'remove',
-              path: ['networkConfigurations', 'test-network-client-id'],
+              providerConfig: { chainId: '0x5', ticker: 'ETH', type: 'goerli' },
+              selectedNetworkClientId: 'goerli',
+              networkConfigurations: {},
+              networksMetadata: {},
             },
-          ],
-        );
-        expect(controller.state.domains['example.com']).toBe('goerli');
-        expect(controller.state.domains['test.com']).toBe('goerli');
+            [
+              {
+                op: 'remove',
+                path: ['networkConfigurations', 'test-network-client-id'],
+              },
+            ],
+          );
+          expect(controller.state.domains).toStrictEqual({
+            metamask: 'goerli',
+            'example.com': 'test-network-client-id',
+            'test.com': 'test-network-client-id',
+          });
+        });
+      });
+    });
+
+    describe('when useRequestQueuePreference is true', () => {
+      describe('when a networkClient is deleted from the network controller state', () => {
+        it('updates the networkClientId for domains which were previously set to the deleted networkClientId', () => {
+          const { controller, messenger } = setup({
+            state: {
+              domains: {
+                metamask: 'goerli',
+                'example.com': 'test-network-client-id',
+                'test.com': 'test-network-client-id',
+              },
+            },
+            useRequestQueuePreference: true,
+          });
+
+          messenger.publish(
+            'NetworkController:stateChange',
+            {
+              providerConfig: { chainId: '0x5', ticker: 'ETH', type: 'goerli' },
+              selectedNetworkClientId: 'goerli',
+              networkConfigurations: {},
+              networksMetadata: {},
+            },
+            [
+              {
+                op: 'remove',
+                path: ['networkConfigurations', 'test-network-client-id'],
+              },
+            ],
+          );
+          expect(controller.state.domains['example.com']).toBe('goerli');
+          expect(controller.state.domains['test.com']).toBe('goerli');
+        });
       });
     });
   });
@@ -263,42 +304,42 @@ describe('SelectedNetworkController', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
-    it('should throw an error when passed "metamask" as domain arg', () => {
-      const { controller } = setup();
-      expect(() => {
-        controller.setNetworkClientIdForDomain('metamask', 'mainnet');
-      }).toThrow(
-        'NetworkClientId for domain "metamask" cannot be set on the SelectedNetworkController',
-      );
-      expect(controller.state.domains.metamask).toBeUndefined();
-    });
+
     describe('when the useRequestQueue is false', () => {
-      describe('when the requesting domain is not metamask', () => {
-        it('updates the networkClientId for domain in state', () => {
-          const { controller } = setup({
-            state: {
-              domains: {
-                '1.com': 'mainnet',
-                '2.com': 'mainnet',
-                '3.com': 'mainnet',
-              },
+      it('skips setting the networkClientId for the passed in domain', () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              '1.com': 'mainnet',
+              '2.com': 'mainnet',
+              '3.com': 'mainnet',
             },
-          });
-          const domains = ['1.com', '2.com', '3.com'];
-          const networkClientIds = ['1', '2', '3'];
+          },
+        });
+        const domains = ['1.com', '2.com', '3.com'];
+        const networkClientIds = ['1', '2', '3'];
 
-          domains.forEach((domain, i) =>
-            controller.setNetworkClientIdForDomain(domain, networkClientIds[i]),
-          );
+        domains.forEach((domain, i) =>
+          controller.setNetworkClientIdForDomain(domain, networkClientIds[i]),
+        );
 
-          expect(controller.state.domains['1.com']).toBe('1');
-          expect(controller.state.domains['2.com']).toBe('2');
-          expect(controller.state.domains['3.com']).toBe('3');
+        expect(controller.state.domains).toStrictEqual({
+          '1.com': 'mainnet',
+          '2.com': 'mainnet',
+          '3.com': 'mainnet',
         });
       });
     });
-
     describe('when the useRequestQueue is true', () => {
+      it('should throw an error when passed "metamask" as domain arg', () => {
+        const { controller } = setup({ useRequestQueuePreference: true });
+        expect(() => {
+          controller.setNetworkClientIdForDomain('metamask', 'mainnet');
+        }).toThrow(
+          'NetworkClientId for domain "metamask" cannot be set on the SelectedNetworkController',
+        );
+        expect(controller.state.domains.metamask).toBeUndefined();
+      });
       describe('when the requesting domain is a snap (starts with "npm:" or "local:"', () => {
         it('skips setting the networkClientId for the passed in domain', () => {
           const { controller, mockHasPermissions } = setup({
@@ -377,6 +418,7 @@ describe('SelectedNetworkController', () => {
         it('throw an error and does not set the networkClientId for the passed in domain', () => {
           const { controller, mockHasPermissions } = setup({
             state: { domains: {} },
+            useRequestQueuePreference: true,
           });
           mockHasPermissions.mockReturnValue(false);
 
@@ -742,31 +784,71 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('Constructor checks for domains in permissions', () => {
-    it('should set networkClientId for domains not already in state', async () => {
-      const getSubjectNamesMock = ['newdomain.com'];
-      const { controller } = setup({
-        state: { domains: {} },
-        getSubjectNames: getSubjectNamesMock,
+    describe('when useRequestQueuePreference is true', () => {
+      it('should set networkClientId for domains not already in state', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
+            },
+          },
+          getSubjectNames: ['newdomain.com'],
+          useRequestQueuePreference: true,
+        });
+
+        expect(controller.state.domains).toStrictEqual({
+          'newdomain.com': 'mainnet',
+          'existingdomain.com': 'initialNetworkId',
+        });
       });
 
-      // Now, 'newdomain.com' should have the selectedNetworkClientId set
-      expect(controller.state.domains['newdomain.com']).toBe('mainnet');
+      it('should not modify domains already in state', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
+            },
+          },
+          getSubjectNames: ['existingdomain.com'],
+          useRequestQueuePreference: true,
+        });
+
+        expect(controller.state.domains).toStrictEqual({
+          'existingdomain.com': 'initialNetworkId',
+        });
+      });
     });
 
-    it('should not modify domains already in state', async () => {
-      const { controller } = setup({
-        state: {
-          domains: {
-            'existingdomain.com': 'initialNetworkId',
+    describe('when useRequestQueuePreference is false', () => {
+      it('should set networkClientId for domains not already in state', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
+            },
           },
-        },
-        getSubjectNames: ['existingdomain.com'],
+          getSubjectNames: ['newdomain.com'],
+        });
+
+        expect(controller.state.domains).toStrictEqual({
+          'existingdomain.com': 'initialNetworkId',
+        });
       });
 
-      // The 'existingdomain.com' should retain its initial networkClientId
-      expect(controller.state.domains['existingdomain.com']).toBe(
-        'initialNetworkId',
-      );
+      it('should not modify domains already in state', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
+            },
+          },
+          getSubjectNames: ['existingdomain.com'],
+        });
+
+        expect(controller.state.domains).toStrictEqual({
+          'existingdomain.com': 'initialNetworkId',
+        });
+      });
     });
   });
 

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -225,77 +225,36 @@ describe('SelectedNetworkController', () => {
     });
   });
 
-  describe('networkController:stateChange', () => {
-    describe('when useRequestQueuePreference is false', () => {
-      describe('when a networkClient is deleted from the network controller state', () => {
-        it('does not update the networkClientId for domains which were previously set to the deleted networkClientId', () => {
-          const { controller, messenger } = setup({
-            state: {
-              // normally there would not be any domains in state if useRequestQueuePreference is false
-              domains: {
-                metamask: 'goerli',
-                'example.com': 'test-network-client-id',
-                'test.com': 'test-network-client-id',
-              },
+  describe('It updates domain state when the network controller state changes', () => {
+    describe('when a networkClient is deleted from the network controller state', () => {
+      it('updates the networkClientId for domains which were previously set to the deleted networkClientId', () => {
+        const { controller, messenger } = setup({
+          state: {
+            domains: {
+              metamask: 'goerli',
+              'example.com': 'test-network-client-id',
+              'test.com': 'test-network-client-id',
             },
-          });
-
-          messenger.publish(
-            'NetworkController:stateChange',
-            {
-              providerConfig: { chainId: '0x5', ticker: 'ETH', type: 'goerli' },
-              selectedNetworkClientId: 'goerli',
-              networkConfigurations: {},
-              networksMetadata: {},
-            },
-            [
-              {
-                op: 'remove',
-                path: ['networkConfigurations', 'test-network-client-id'],
-              },
-            ],
-          );
-          expect(controller.state.domains).toStrictEqual({
-            metamask: 'goerli',
-            'example.com': 'test-network-client-id',
-            'test.com': 'test-network-client-id',
-          });
+          },
         });
-      });
-    });
 
-    describe('when useRequestQueuePreference is true', () => {
-      describe('when a networkClient is deleted from the network controller state', () => {
-        it('updates the networkClientId for domains which were previously set to the deleted networkClientId', () => {
-          const { controller, messenger } = setup({
-            state: {
-              domains: {
-                metamask: 'goerli',
-                'example.com': 'test-network-client-id',
-                'test.com': 'test-network-client-id',
-              },
-            },
-            useRequestQueuePreference: true,
-          });
-
-          messenger.publish(
-            'NetworkController:stateChange',
+        messenger.publish(
+          'NetworkController:stateChange',
+          {
+            providerConfig: { chainId: '0x5', ticker: 'ETH', type: 'goerli' },
+            selectedNetworkClientId: 'goerli',
+            networkConfigurations: {},
+            networksMetadata: {},
+          },
+          [
             {
-              providerConfig: { chainId: '0x5', ticker: 'ETH', type: 'goerli' },
-              selectedNetworkClientId: 'goerli',
-              networkConfigurations: {},
-              networksMetadata: {},
+              op: 'remove',
+              path: ['networkConfigurations', 'test-network-client-id'],
             },
-            [
-              {
-                op: 'remove',
-                path: ['networkConfigurations', 'test-network-client-id'],
-              },
-            ],
-          );
-          expect(controller.state.domains['example.com']).toBe('goerli');
-          expect(controller.state.domains['test.com']).toBe('goerli');
-        });
+          ],
+        );
+        expect(controller.state.domains['example.com']).toBe('goerli');
+        expect(controller.state.domains['test.com']).toBe('goerli');
       });
     });
   });
@@ -304,42 +263,42 @@ describe('SelectedNetworkController', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
-
+    it('should throw an error when passed "metamask" as domain arg', () => {
+      const { controller } = setup();
+      expect(() => {
+        controller.setNetworkClientIdForDomain('metamask', 'mainnet');
+      }).toThrow(
+        'NetworkClientId for domain "metamask" cannot be set on the SelectedNetworkController',
+      );
+      expect(controller.state.domains.metamask).toBeUndefined();
+    });
     describe('when the useRequestQueue is false', () => {
-      it('skips setting the networkClientId for the passed in domain', () => {
-        const { controller } = setup({
-          state: {
-            domains: {
-              '1.com': 'mainnet',
-              '2.com': 'mainnet',
-              '3.com': 'mainnet',
+      describe('when the requesting domain is not metamask', () => {
+        it('updates the networkClientId for domain in state', () => {
+          const { controller } = setup({
+            state: {
+              domains: {
+                '1.com': 'mainnet',
+                '2.com': 'mainnet',
+                '3.com': 'mainnet',
+              },
             },
-          },
-        });
-        const domains = ['1.com', '2.com', '3.com'];
-        const networkClientIds = ['1', '2', '3'];
+          });
+          const domains = ['1.com', '2.com', '3.com'];
+          const networkClientIds = ['1', '2', '3'];
 
-        domains.forEach((domain, i) =>
-          controller.setNetworkClientIdForDomain(domain, networkClientIds[i]),
-        );
+          domains.forEach((domain, i) =>
+            controller.setNetworkClientIdForDomain(domain, networkClientIds[i]),
+          );
 
-        expect(controller.state.domains).toStrictEqual({
-          '1.com': 'mainnet',
-          '2.com': 'mainnet',
-          '3.com': 'mainnet',
+          expect(controller.state.domains['1.com']).toBe('1');
+          expect(controller.state.domains['2.com']).toBe('2');
+          expect(controller.state.domains['3.com']).toBe('3');
         });
       });
     });
+
     describe('when the useRequestQueue is true', () => {
-      it('should throw an error when passed "metamask" as domain arg', () => {
-        const { controller } = setup({ useRequestQueuePreference: true });
-        expect(() => {
-          controller.setNetworkClientIdForDomain('metamask', 'mainnet');
-        }).toThrow(
-          'NetworkClientId for domain "metamask" cannot be set on the SelectedNetworkController',
-        );
-        expect(controller.state.domains.metamask).toBeUndefined();
-      });
       describe('when the requesting domain is a snap (starts with "npm:" or "local:"', () => {
         it('skips setting the networkClientId for the passed in domain', () => {
           const { controller, mockHasPermissions } = setup({
@@ -418,7 +377,6 @@ describe('SelectedNetworkController', () => {
         it('throw an error and does not set the networkClientId for the passed in domain', () => {
           const { controller, mockHasPermissions } = setup({
             state: { domains: {} },
-            useRequestQueuePreference: true,
           });
           mockHasPermissions.mockReturnValue(false);
 
@@ -784,71 +742,31 @@ describe('SelectedNetworkController', () => {
   });
 
   describe('Constructor checks for domains in permissions', () => {
-    describe('when useRequestQueuePreference is true', () => {
-      it('should set networkClientId for domains not already in state', async () => {
-        const { controller } = setup({
-          state: {
-            domains: {
-              'existingdomain.com': 'initialNetworkId',
-            },
-          },
-          getSubjectNames: ['newdomain.com'],
-          useRequestQueuePreference: true,
-        });
-
-        expect(controller.state.domains).toStrictEqual({
-          'newdomain.com': 'mainnet',
-          'existingdomain.com': 'initialNetworkId',
-        });
+    it('should set networkClientId for domains not already in state', async () => {
+      const getSubjectNamesMock = ['newdomain.com'];
+      const { controller } = setup({
+        state: { domains: {} },
+        getSubjectNames: getSubjectNamesMock,
       });
 
-      it('should not modify domains already in state', async () => {
-        const { controller } = setup({
-          state: {
-            domains: {
-              'existingdomain.com': 'initialNetworkId',
-            },
-          },
-          getSubjectNames: ['existingdomain.com'],
-          useRequestQueuePreference: true,
-        });
-
-        expect(controller.state.domains).toStrictEqual({
-          'existingdomain.com': 'initialNetworkId',
-        });
-      });
+      // Now, 'newdomain.com' should have the selectedNetworkClientId set
+      expect(controller.state.domains['newdomain.com']).toBe('mainnet');
     });
 
-    describe('when useRequestQueuePreference is false', () => {
-      it('should set networkClientId for domains not already in state', async () => {
-        const { controller } = setup({
-          state: {
-            domains: {
-              'existingdomain.com': 'initialNetworkId',
-            },
+    it('should not modify domains already in state', async () => {
+      const { controller } = setup({
+        state: {
+          domains: {
+            'existingdomain.com': 'initialNetworkId',
           },
-          getSubjectNames: ['newdomain.com'],
-        });
-
-        expect(controller.state.domains).toStrictEqual({
-          'existingdomain.com': 'initialNetworkId',
-        });
+        },
+        getSubjectNames: ['existingdomain.com'],
       });
 
-      it('should not modify domains already in state', async () => {
-        const { controller } = setup({
-          state: {
-            domains: {
-              'existingdomain.com': 'initialNetworkId',
-            },
-          },
-          getSubjectNames: ['existingdomain.com'],
-        });
-
-        expect(controller.state.domains).toStrictEqual({
-          'existingdomain.com': 'initialNetworkId',
-        });
-      });
+      // The 'existingdomain.com' should retain its initial networkClientId
+      expect(controller.state.domains['existingdomain.com']).toBe(
+        'initialNetworkId',
+      );
     });
   });
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,7 @@
     { "path": "./packages/assets-controllers/tsconfig.build.json" },
     { "path": "./packages/base-controller/tsconfig.build.json" },
     { "path": "./packages/build-utils/tsconfig.build.json" },
+    { "path": "./packages/caip-stream" },
     { "path": "./packages/chain-controller/tsconfig.build.json" },
     { "path": "./packages/composable-controller/tsconfig.build.json" },
     { "path": "./packages/controller-utils/tsconfig.build.json" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     { "path": "./packages/assets-controllers" },
     { "path": "./packages/base-controller" },
     { "path": "./packages/build-utils" },
+    { "path": "./packages/caip-stream" },
     { "path": "./packages/composable-controller" },
     { "path": "./packages/controller-utils" },
     { "path": "./packages/ens-controller" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,6 +1859,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/caip-stream@workspace:packages/caip-stream":
+  version: 0.0.0-use.local
+  resolution: "@metamask/caip-stream@workspace:packages/caip-stream"
+  dependencies:
+    "@metamask/auto-changelog": ^3.4.4
+    "@metamask/utils": ^8.3.0
+    "@types/jest": ^27.4.1
+    "@types/readable-stream": 4.0.4
+    deepmerge: ^4.2.2
+    jest: ^27.5.1
+    readable-stream: ^3.6.2
+    ts-jest: ^27.1.4
+    typedoc: ^0.24.8
+    typedoc-plugin-missing-exports: ^2.0.0
+    typescript: ~4.9.5
+  languageName: unknown
+  linkType: soft
+
 "@metamask/chain-api@npm:^0.0.1":
   version: 0.0.1
   resolution: "@metamask/chain-api@npm:0.0.1"
@@ -3947,6 +3965,16 @@ __metadata:
   version: 2.1.4
   resolution: "@types/punycode@npm:2.1.4"
   checksum: 16637bdd8e4f830243072668125f83b93b728085a05140ccc3e7801528d78c62cce5426b07d5cdc75e4f797e1644807c762777f651d1cd071ad0128835cdce5e
+  languageName: node
+  linkType: hard
+
+"@types/readable-stream@npm:4.0.4":
+  version: 4.0.4
+  resolution: "@types/readable-stream@npm:4.0.4"
+  dependencies:
+    "@types/node": "*"
+    safe-buffer: ~5.1.1
+  checksum: 02ab682ed65a6848c06d5c80d835f49a38913e5526f45f00a9275efc16e950a3b28b871720d79b9f9ad78e5384963fdad329938e953e4ff55014e0bb95bc9797
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

This PR introduces the `caip-stream` package, a library meant to be consumed by extension and test-dapp that helps enable the [CAIP envelope message interface](https://github.com/jiexi/CAIPs/pull/1) by transforming messages to and from the internal multiplex `metamask-provider` format

## References


Fixes: https://github.com/MetaMask/MetaMask-planning/issues/2528
See: https://github.com/jiexi/CAIPs/pull/1
See: https://github.com/MetaMask/metamask-extension/pull/25075
See: https://github.com/MetaMask/test-dapp/pull/342

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/caip-stream`

- **ADDED**: Initial implementation

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
