### PR TITLE
fix: move `@metamask/keyring-controller` to dependency in `@metamask/accounts-controller`

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -45,6 +45,7 @@
     "@metamask/base-controller": "^6.0.0",
     "@metamask/eth-snap-keyring": "^4.3.1",
     "@metamask/keyring-api": "^8.0.0",
+    "@metamask/keyring-controller": "^17.1.0",
     "@metamask/snaps-sdk": "^4.2.0",
     "@metamask/snaps-utils": "^7.4.0",
     "@metamask/utils": "^8.3.0",
@@ -55,7 +56,6 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-controller": "^17.1.0",
     "@metamask/snaps-controllers": "^8.1.1",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",


### PR DESCRIPTION
## Explanation

This PR moves `@metamask/keyring-controller` to dependency from devDependency in `@metamask/accounts-controller`

## References

## Changelog

### `@metamask/accounts-controller`

- **CHANGED**: move `@metamask/keyring-controller` from `devDependencies` to `dependencies`


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
