### PR TITLE
refactor: add back profile sync dependency

### DIFF
--- a/packages/notification-services-controller/package.json
+++ b/packages/notification-services-controller/package.json
@@ -45,6 +45,7 @@
     "@metamask/base-controller": "^6.0.0",
     "@metamask/controller-utils": "^11.0.0",
     "@metamask/keyring-controller": "^17.1.0",
+    "@metamask/profile-sync-controller": "^0.1.0",
     "bignumber.js": "^4.1.0",
     "contentful": "^10.3.6",
     "firebase": "^10.11.0",
@@ -66,7 +67,8 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@metamask/keyring-controller": "^17.0.0"
+    "@metamask/keyring-controller": "^17.0.0",
+    "@metamask/profile-sync-controller": "^0.1.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3254,6 +3254,7 @@ __metadata:
     "@metamask/base-controller": ^6.0.0
     "@metamask/controller-utils": ^11.0.0
     "@metamask/keyring-controller": ^17.1.0
+    "@metamask/profile-sync-controller": ^0.1.0
     "@types/jest": ^27.4.1
     "@types/readable-stream": ^2.3.0
     bignumber.js: ^4.1.0
@@ -3271,6 +3272,7 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/keyring-controller": ^17.0.0
+    "@metamask/profile-sync-controller": ^0.1.0
   languageName: unknown
   linkType: soft
 
@@ -3463,7 +3465,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/profile-sync-controller@workspace:packages/profile-sync-controller":
+"@metamask/profile-sync-controller@^0.1.0, @metamask/profile-sync-controller@workspace:packages/profile-sync-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/profile-sync-controller@workspace:packages/profile-sync-controller"
   dependencies:


### PR DESCRIPTION
## Explanation

This was removed as it was blocking publishing of profile sync controller. Adding here so it unblocks the next release for this controller: https://github.com/MetaMask/core/pull/4438


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
