### PR TITLE
Adapt to eip 1193 provider changes

### DIFF
--- a/packages/network-controller/src/create-auto-managed-network-client.test.ts
+++ b/packages/network-controller/src/create-auto-managed-network-client.test.ts
@@ -1,5 +1,4 @@
 import { BUILT_IN_NETWORKS, NetworkType } from '@metamask/controller-utils';
-import { promisify } from 'util';
 
 import { mockNetwork } from '../../../tests/mock-network';
 import { createAutoManagedNetworkClient } from './create-auto-managed-network-client';
@@ -69,6 +68,7 @@ describe('createAutoManagedNetworkClient', () => {
         expect('eventNames' in provider).toBe(true);
         expect('send' in provider).toBe(true);
         expect('sendAsync' in provider).toBe(true);
+        expect('request' in provider).toBe(true);
       });
 
       it('returns a provider proxy that acts like a provider, forwarding requests to the network', async () => {
@@ -91,7 +91,7 @@ describe('createAutoManagedNetworkClient', () => {
           networkClientConfiguration,
         );
 
-        const { result } = await promisify(provider.sendAsync).call(provider, {
+        const result = await provider.request({
           id: 1,
           jsonrpc: '2.0',
           method: 'test_method',
@@ -125,13 +125,13 @@ describe('createAutoManagedNetworkClient', () => {
           networkClientConfiguration,
         );
 
-        await promisify(provider.sendAsync).call(provider, {
+        await provider.request({
           id: 1,
           jsonrpc: '2.0',
           method: 'test_method',
           params: [],
         });
-        await promisify(provider.sendAsync).call(provider, {
+        await provider.request({
           id: 2,
           jsonrpc: '2.0',
           method: 'test_method',

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -308,15 +308,12 @@ describe('NetworkController', () => {
 
               const { provider } = controller.getProviderAndBlockTracker();
               assert(provider, 'Provider is not set');
-              const { result } = await promisify(provider.sendAsync).call(
-                provider,
-                {
-                  id: 1,
-                  jsonrpc: '2.0',
-                  method: 'test_method',
-                  params: [],
-                },
-              );
+              const result = await provider.request({
+                id: 1,
+                jsonrpc: '2.0',
+                method: 'test_method',
+                params: [],
+              });
               expect(result).toBe('test response');
             },
           );
@@ -413,15 +410,12 @@ describe('NetworkController', () => {
 
             const { provider } = controller.getProviderAndBlockTracker();
             assert(provider, 'Provider is not set');
-            const { result } = await promisify(provider.sendAsync).call(
-              provider,
-              {
-                id: 1,
-                jsonrpc: '2.0',
-                method: 'test_method',
-                params: [],
-              },
-            );
+            const result = await provider.request({
+              id: 1,
+              jsonrpc: '2.0',
+              method: 'test_method',
+              params: [],
+            });
             expect(result).toBe('test response');
           },
         );
@@ -440,7 +434,7 @@ describe('NetworkController', () => {
         const { provider, blockTracker } =
           controller.getProviderAndBlockTracker();
 
-        expect(provider).toHaveProperty('sendAsync');
+        expect(provider).toHaveProperty('request');
         expect(blockTracker).toHaveProperty('checkForLatestBlock');
       });
     });
@@ -524,26 +518,20 @@ describe('NetworkController', () => {
               const { provider } = controller.getProviderAndBlockTracker();
               assert(provider, 'Provider is somehow unset');
 
-              const promisifiedSendAsync1 = promisify(provider.sendAsync).bind(
-                provider,
-              );
-              const response1 = await promisifiedSendAsync1({
+              const result1 = await provider.request({
                 id: '1',
                 jsonrpc: '2.0',
                 method: 'test',
               });
-              expect(response1.result).toBe('test response 1');
+              expect(result1).toBe('test response 1');
 
               await controller.setProviderType(networkType);
-              const promisifiedSendAsync2 = promisify(provider.sendAsync).bind(
-                provider,
-              );
-              const response2 = await promisifiedSendAsync2({
+              const result2 = await provider.request({
                 id: '2',
                 jsonrpc: '2.0',
                 method: 'test',
               });
-              expect(response2.result).toBe('test response 2');
+              expect(result2).toBe('test response 2');
             },
           );
         });
@@ -614,26 +602,20 @@ describe('NetworkController', () => {
             const { provider } = controller.getProviderAndBlockTracker();
             assert(provider, 'Provider is somehow unset');
 
-            const promisifiedSendAsync1 = promisify(provider.sendAsync).bind(
-              provider,
-            );
-            const response1 = await promisifiedSendAsync1({
+            const result1 = await provider.request({
               id: '1',
               jsonrpc: '2.0',
               method: 'test',
             });
-            expect(response1.result).toBe('test response 1');
+            expect(result1).toBe('test response 1');
 
             await controller.setActiveNetwork('testNetworkConfigurationId');
-            const promisifiedSendAsync2 = promisify(provider.sendAsync).bind(
-              provider,
-            );
-            const response2 = await promisifiedSendAsync2({
+            const result2 = await provider.request({
               id: '2',
               jsonrpc: '2.0',
               method: 'test',
             });
-            expect(response2.result).toBe('test response 2');
+            expect(result2).toBe('test response 2');
           },
         );
       });
@@ -1017,7 +999,7 @@ describe('NetworkController', () => {
               ],
             ]);
             for (const networkClient of Object.values(networkClients)) {
-              expect(networkClient.provider).toHaveProperty('sendAsync');
+              expect(networkClient.provider).toHaveProperty('request');
               expect(networkClient.blockTracker).toHaveProperty(
                 'checkForLatestBlock',
               );
@@ -2909,15 +2891,12 @@ describe('NetworkController', () => {
 
               const { provider } = controller.getProviderAndBlockTracker();
               assert(provider, 'Provider is not set');
-              const { result } = await promisify(provider.sendAsync).call(
-                provider,
-                {
-                  id: 1,
-                  jsonrpc: '2.0',
-                  method: 'test_method',
-                  params: [],
-                },
-              );
+              const result = await provider.request({
+                id: 1,
+                jsonrpc: '2.0',
+                method: 'test_method',
+                params: [],
+              });
               expect(result).toBe('test response from built-in network');
             },
           );
@@ -3013,15 +2992,12 @@ describe('NetworkController', () => {
 
               const { provider } = controller.getProviderAndBlockTracker();
               assert(provider, 'Provider is not set');
-              const { result } = await promisify(provider.sendAsync).call(
-                provider,
-                {
-                  id: 1,
-                  jsonrpc: '2.0',
-                  method: 'test_method',
-                  params: [],
-                },
-              );
+              const result = await provider.request({
+                id: 1,
+                jsonrpc: '2.0',
+                method: 'test_method',
+                params: [],
+              });
               expect(result).toBe('test response from built-in network');
             },
           );
@@ -4153,15 +4129,12 @@ describe('NetworkController', () => {
 
               const { provider } = controller.getProviderAndBlockTracker();
               assert(provider, 'Provider is somehow unset');
-              const promisifiedSendAsync = promisify(provider.sendAsync).bind(
-                provider,
-              );
-              const response = await promisifiedSendAsync({
+              const result = await provider.request({
                 id: '1',
                 jsonrpc: '2.0',
                 method: 'test',
               });
-              expect(response.result).toBe('test response');
+              expect(result).toBe('test response');
             },
           );
         });
@@ -4713,15 +4686,12 @@ describe('NetworkController', () => {
 
             const { provider } = controller.getProviderAndBlockTracker();
             assert(provider, 'Provider is somehow unset');
-            const promisifiedSendAsync = promisify(provider.sendAsync).bind(
-              provider,
-            );
-            const response = await promisifiedSendAsync({
+            const result = await provider.request({
               id: '1',
               jsonrpc: '2.0',
               method: 'test',
             });
-            expect(response.result).toBe('test response');
+            expect(result).toBe('test response');
           },
         );
       });
@@ -5201,16 +5171,13 @@ function refreshNetworkTests({
           });
           const { provider } = controller.getProviderAndBlockTracker();
           assert(provider);
-          const promisifiedSendAsync = promisify(provider.sendAsync).bind(
-            provider,
-          );
-          const chainIdResult = await promisifiedSendAsync({
+          const chainIdResult = await provider.request({
             id: 1,
             jsonrpc: '2.0',
             method: 'eth_chainId',
             params: [],
           });
-          expect(chainIdResult.result).toBe(toHex(111));
+          expect(chainIdResult).toBe(toHex(111));
         },
       );
     });
@@ -5245,16 +5212,13 @@ function refreshNetworkTests({
           });
           const { provider } = controller.getProviderAndBlockTracker();
           assert(provider);
-          const promisifiedSendAsync = promisify(provider.sendAsync).bind(
-            provider,
-          );
-          const chainIdResult = await promisifiedSendAsync({
+          const chainIdResult = await provider.request({
             id: 1,
             jsonrpc: '2.0',
             method: 'eth_chainId',
             params: [],
           });
-          expect(chainIdResult.result).toBe(toHex(1337));
+          expect(chainIdResult).toBe(toHex(1337));
         },
       );
     });

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -54,7 +54,7 @@ export function buildSelectedNetworkControllerMessenger({
   getSubjectNames?: string[];
 } = {}) {
   const mockGetNetworkClientById = jest.fn().mockReturnValue({
-    provider: { sendAsync: jest.fn() },
+    provider: { request: jest.fn() },
     blockTracker: { getLatestBlock: jest.fn() },
   });
   messenger.registerActionHandler(
@@ -62,7 +62,7 @@ export function buildSelectedNetworkControllerMessenger({
     mockGetNetworkClientById,
   );
   const mockGetSelectedNetworkClient = jest.fn().mockReturnValue({
-    provider: { sendAsync: jest.fn() },
+    provider: { request: jest.fn() },
     blockTracker: { getLatestBlock: jest.fn() },
   });
   messenger.registerActionHandler(
@@ -154,7 +154,7 @@ const setup = ({
   const createEventEmitterProxyMock = jest.mocked(createEventEmitterProxy);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createEventEmitterProxyMock.mockImplementation((initialTarget: any) => {
-    if (initialTarget?.sendAsync !== undefined) {
+    if (initialTarget?.request !== undefined) {
       return mockProviderProxy;
     }
     if (initialTarget?.getLatestBlock !== undefined) {
@@ -440,7 +440,7 @@ describe('SelectedNetworkController', () => {
 
           expect(mockProviderProxy.setTarget).toHaveBeenNthCalledWith(
             2,
-            expect.objectContaining({ sendAsync: expect.any(Function) }),
+            expect.objectContaining({ request: expect.any(Function) }),
           );
           expect(mockProviderProxy.setTarget).toHaveBeenCalledTimes(2);
         });
@@ -785,7 +785,7 @@ describe('SelectedNetworkController', () => {
         );
 
         expect(mockProviderProxy.setTarget).toHaveBeenCalledWith(
-          expect.objectContaining({ sendAsync: expect.any(Function) }),
+          expect.objectContaining({ request: expect.any(Function) }),
         );
         expect(mockProviderProxy.setTarget).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## Explanation

After updating the [`SafeEventEmitterProvider` to support EIP-1193](https://github.com/MetaMask/core/issues/4095), I have made the following changes:

- Deprecated the use of `sendAsync` and replaced it with the `request` method.
  - Updated instances in the `core` repository:
    - `NetworkController` tests
  - Modified areas where we previously expected the provider returned by NetworkController to have a `sendAsync` method. These now use the `request` method with the correct method signature:
    - `SelectedNetworkController` tests
    - `createAutoManagedNetworkClient` tests

## References

* Fixes #4100

## Changelog

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
