### PR TITLE
fix: Fix `create-package` tests that cause test command to fail

### DIFF
--- a/jest.config.scripts.js
+++ b/jest.config.scripts.js
@@ -59,6 +59,8 @@ module.exports = {
   // modules.
   restoreMocks: true,
 
+  setupFilesAfterEnv: ['./tests/scripts-setup.ts'],
+
   // The test environment that will be used for testing
   testEnvironment: 'node',
 

--- a/scripts/create-package/index.test.ts
+++ b/scripts/create-package/index.test.ts
@@ -4,6 +4,18 @@ import { commands } from './commands';
 jest.mock('./cli');
 
 describe('create-package/index', () => {
+  let originalProcess: typeof globalThis.process;
+  beforeEach(() => {
+    originalProcess = globalThis.process;
+    // @ts-expect-error This is a simple mock that does not match the type.
+    // TODO: Replace with `jest.replaceProperty` after Jest v29 update.
+    globalThis.process = {};
+  });
+
+  afterEach(() => {
+    globalThis.process = originalProcess;
+  });
+
   it('executes the CLI application', async () => {
     const mock = cli as jest.MockedFunction<typeof cli>;
     mock.mockRejectedValue('foo');

--- a/scripts/create-package/index.test.ts
+++ b/scripts/create-package/index.test.ts
@@ -7,9 +7,8 @@ describe('create-package/index', () => {
   let originalProcess: typeof globalThis.process;
   beforeEach(() => {
     originalProcess = globalThis.process;
-    // @ts-expect-error This is a simple mock that does not match the type.
     // TODO: Replace with `jest.replaceProperty` after Jest v29 update.
-    globalThis.process = {};
+    globalThis.process = { ...globalThis.process };
   });
 
   afterEach(() => {

--- a/tests/scripts-setup.ts
+++ b/tests/scripts-setup.ts
@@ -1,0 +1,12 @@
+// If the code-under-test sets `process.exitCode`, the test process can exit with that code without
+// any error messages.
+// This ensures that an error message is shown explaining the reason for the failure. We can unset
+// the exit code in each affected test as part of the cleanup steps.
+afterEach(() => {
+  if (process.exitCode !== undefined && process.exitCode !== 0) {
+    throw new Error(`Non-zero exit code: ${String(process.exitCode)}`);
+  }
+});
+
+// Signals that this is a module not a script
+export {};


### PR DESCRIPTION
## Explanation

The test for `create-package` was causing the test command to fail with a non-zero exit code even when tests passed. This was because the code under test was setting `process.exitCode`, and this causes Jest to exit with that same code.

The test was updated to mock `process` to ensure that the real `process.exitCode` was not changed. Additionally, an `afterEach` hook has been added for all script tests that will catch such issues in the future.

## References

Alternative to #4415 

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
