### PR TITLE
fix: Fix `create-package` changes to `tsconfig.build.json`

### DIFF
--- a/scripts/create-package/utils.test.ts
+++ b/scripts/create-package/utils.test.ts
@@ -131,7 +131,10 @@ describe('create-package/utils', () => {
       expect(fs.promises.writeFile).toHaveBeenCalledWith(
         expect.stringMatching(/tsconfig\.build\.json$/u),
         JSON.stringify({
-          references: [{ path: './packages/bar' }, { path: './packages/foo' }],
+          references: [
+            { path: './packages/bar' },
+            { path: './packages/foo/tsconfig.build.json' },
+          ],
         }),
       );
 

--- a/scripts/create-package/utils.ts
+++ b/scripts/create-package/utils.ts
@@ -150,15 +150,19 @@ function updateTsConfigs(
   packageData: PackageData,
   monorepoFileData: MonorepoFileData,
 ): void {
-  [monorepoFileData.tsConfig, monorepoFileData.tsConfigBuild].forEach(
-    (config) => {
-      config.references.push({
-        path: `./${path.basename(PACKAGES_PATH)}/${packageData.directoryName}`,
-      });
+  const { tsConfig, tsConfigBuild } = monorepoFileData;
 
-      config.references.sort((a, b) => a.path.localeCompare(b.path));
-    },
-  );
+  tsConfig.references.push({
+    path: `./${path.basename(PACKAGES_PATH)}/${packageData.directoryName}`,
+  });
+  tsConfig.references.sort((a, b) => a.path.localeCompare(b.path));
+
+  tsConfigBuild.references.push({
+    path: `./${path.basename(PACKAGES_PATH)}/${
+      packageData.directoryName
+    }/tsconfig.build.json`,
+  });
+  tsConfigBuild.references.sort((a, b) => a.path.localeCompare(b.path));
 }
 
 /**


### PR DESCRIPTION
## Explanation

The `create-package` tool automatically updates `tsconfig.build.json` with an entry for the new package, but this entry is invalid. It should reference the package-level `tsconfig.build.json` file, but instead it just references the package directory (so the `tsconfig.json` file is used instead.

This mistake resulted in very confusing build errors when I recently created a new package.

This has been corrected, and tests have been updated accordingly.

## References

None

## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
