### PR TITLE
fix: Fix `update-readme-content` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,13 @@ linkStyle default opacity:0.5
   signature_controller --> keyring_controller;
   signature_controller --> logging_controller;
   signature_controller --> message_manager;
+  transaction_controller --> accounts_controller;
   transaction_controller --> approval_controller;
   transaction_controller --> base_controller;
   transaction_controller --> controller_utils;
   transaction_controller --> gas_fee_controller;
   transaction_controller --> network_controller;
+  transaction_controller --> eth_json_rpc_provider;
   user_operation_controller --> approval_controller;
   user_operation_controller --> base_controller;
   user_operation_controller --> controller_utils;

--- a/scripts/update-readme-content.ts
+++ b/scripts/update-readme-content.ts
@@ -56,10 +56,7 @@ async function retrieveWorkspaces(): Promise<Workspace[]> {
     '--verbose',
   ]);
 
-  return stdout
-    .split('\n')
-    .map((line) => JSON.parse(line))
-    .slice(1);
+  return stdout.split('\n').map((line) => JSON.parse(line));
 }
 
 /**


### PR DESCRIPTION
## Explanation

The `update-readme-content` script will automatically update the package graph in the README. This script was omitting the first package in the list, the `accounts-controller` package.

The script has been updated to stop removing this package, and the script was run to update the current README (one dependency between core packages was missing).

It's unclear why the first line was removed in the first place. It's possible that an earlier version of Yarn had one additional line in the output.

## References

None

## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
