### PR TITLE
feat: Focus approval request UI when a request is queued

### DIFF
--- a/packages/queued-request-controller/src/QueuedRequestController.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.ts
@@ -310,7 +310,6 @@ export class QueuedRequestController extends BaseController<
   async #waitForDequeue(
     origin: string
   ): Promise<void> {
-    this.#showApprovalRequest()
     const {
       promise,
       reject,
@@ -362,6 +361,7 @@ export class QueuedRequestController extends BaseController<
         this.state.queuedRequestCount > 0 ||
         this.#originOfCurrentBatch !== request.origin
       ) {
+        this.#showApprovalRequest()
         await this.#waitForDequeue(request.origin)
       } else if (this.#shouldRequestSwitchNetwork(request)) {
         // Process request immediately


### PR DESCRIPTION
## Explanation

Currently when a request is queued, it does not cause the existing confirmation window to be focused. This is because queued requests are withheld from the `ApprovalController` which is responsible for showing batched/scrubbable confirmations to the user. Since the `ApprovalController` never actually receives queued requests until they are ready to be shown to the user, it becomes the responsibility of the `QueuedRequestController` to determine when the confirmation window must be focused because a new confirmation has been enqueued.

This PR adds a new callback/hook to the `QueuedRequestController`, enabling it to trigger the notification window receiving focus.

## References

Fixes: https://github.com/MetaMask/metamask-extension/issues/25397

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/queued-request-controller`

- **BREAKING**: `QueuedRequestController` constructor params now requires a `showApprovalRequest` hook that is called when the approval request UI should be opened/focused as the result of a request with confirmation being enqueued.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
