### PR TITLE
chore: Remove unnecessary steps from prepare preview builds script

### DIFF
--- a/scripts/prepare-preview-builds.jq
+++ b/scripts/prepare-preview-builds.jq
@@ -6,47 +6,4 @@
 # of the version. Technically we'd want to bump the non-prerelease portion as
 # well if we wanted this to be SemVer-compliant, but it was simpler not to.
 # This is just for testing, it doesn't need to strictly follow SemVer.
-.version |= split("-")[0] + "-preview-\($hash)" |
-
-# The workspace dependencies are updated to point to the exact preview build
-# version, so that Yarn does not try to resolve a different version from the
-# registry.
-
-if has("devDependencies") then
-  .devDependencies |= with_entries(
-    if .value | startswith("workspace:") then
-      .key |= sub("@metamask/"; "@metamask-previews/") |
-      .value |= sub("workspace:\\^"; "workspace:*")
-    else
-      .
-    end
-  )
-else
-  .
-end |
-
-if has("peerDependencies") then
-  .peerDependencies |= with_entries(
-    if .value | startswith("workspace:") then
-      .key |= sub("@metamask/"; "@metamask-previews/") |
-      .value |= sub("workspace:\\^"; "workspace:*")
-    else
-      .
-    end
-  )
-else
-  .
-end |
-
-if has("dependencies") then
-  .dependencies |= with_entries(
-    if .value | startswith("workspace:") then
-      .key |= sub("@metamask/"; "@metamask-previews/") |
-      .value |= sub("workspace:\\^"; "workspace:*")
-    else
-      .
-    end
-  )
-else
-  .
-end
+.version |= split("-")[0] + "-preview-\($hash)"


### PR DESCRIPTION
## Explanation

These steps handled updating `workspace:` references, but we don't use those anymore (since #1623).

## References

Related to #1623

## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
