### PR TITLE
fix: handle edge case of undefined accountId during onboarding for getSelectedMultichainAccount

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -23,7 +23,7 @@ import type {
   AllowedActions,
   AllowedEvents,
 } from './AccountsController';
-import { AccountsController } from './AccountsController';
+import { AccountsController, EMPTY_ACCOUNT } from './AccountsController';
 import { createMockInternalAccount } from './tests/mocks';
 import {
   getUUIDOptionsFromAddressOfNormalAccount,
@@ -1855,20 +1855,9 @@ describe('AccountsController', () => {
         },
       });
 
-      expect(accountsController.getSelectedAccount()).toStrictEqual({
-        id: '',
-        address: '',
-        options: {},
-        methods: [],
-        type: EthAccountType.Eoa,
-        metadata: {
-          name: '',
-          keyring: {
-            type: '',
-          },
-          importTime: 0,
-        },
-      });
+      expect(accountsController.getSelectedAccount()).toStrictEqual(
+        EMPTY_ACCOUNT,
+      );
     });
   });
 
@@ -1976,20 +1965,9 @@ describe('AccountsController', () => {
         },
       });
 
-      expect(accountsController.getSelectedMultichainAccount()).toStrictEqual({
-        id: '',
-        address: '',
-        options: {},
-        methods: [],
-        type: EthAccountType.Eoa,
-        metadata: {
-          name: '',
-          keyring: {
-            type: '',
-          },
-          importTime: 0,
-        },
-      });
+      expect(accountsController.getSelectedMultichainAccount()).toStrictEqual(
+        EMPTY_ACCOUNT,
+      );
     });
   });
 

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1965,6 +1965,32 @@ describe('AccountsController', () => {
         ).toThrow(`Invalid CAIP-2 chain ID: ${chainId}`);
       },
     );
+
+    it('handle the edge case of undefined accountId during onboarding', () => {
+      const { accountsController } = setupAccountsController({
+        initialState: {
+          internalAccounts: {
+            accounts: {},
+            selectedAccount: '',
+          },
+        },
+      });
+
+      expect(accountsController.getSelectedMultichainAccount()).toStrictEqual({
+        id: '',
+        address: '',
+        options: {},
+        methods: [],
+        type: EthAccountType.Eoa,
+        metadata: {
+          name: '',
+          keyring: {
+            type: '',
+          },
+          importTime: 0,
+        },
+      });
+    });
   });
 
   describe('listAccounts', () => {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -171,6 +171,21 @@ const defaultState: AccountsControllerState = {
   },
 };
 
+export const EMPTY_ACCOUNT = {
+  id: '',
+  address: '',
+  options: {},
+  methods: [],
+  type: EthAccountType.Eoa,
+  metadata: {
+    name: '',
+    keyring: {
+      type: '',
+    },
+    importTime: 0,
+  },
+};
+
 /**
  * Controller that manages internal accounts.
  * The accounts controller is responsible for creating and managing internal accounts.
@@ -430,6 +445,7 @@ export class AccountsController extends BaseController<
         ...account,
         metadata: { ...account.metadata, name: accountName },
       };
+      // @ts-expect-error - ignoring Type instantiation is excessively deep and possibly infinite.
       currentState.internalAccounts.accounts[accountId] = internalAccount;
     });
   }

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -301,20 +301,7 @@ export class AccountsController extends BaseController<
     // Edge case where the extension is setup but the srp is not yet created
     // certain ui elements will query the selected address before any accounts are created.
     if (this.state.internalAccounts.selectedAccount === '') {
-      return {
-        id: '',
-        address: '',
-        options: {},
-        methods: [],
-        type: EthAccountType.Eoa,
-        metadata: {
-          name: '',
-          keyring: {
-            type: '',
-          },
-          importTime: 0,
-        },
-      };
+      return EMPTY_ACCOUNT;
     }
 
     const selectedAccount = this.getAccountExpect(
@@ -350,20 +337,7 @@ export class AccountsController extends BaseController<
     // Edge case where the extension is setup but the srp is not yet created
     // certain ui elements will query the selected address before any accounts are created.
     if (this.state.internalAccounts.selectedAccount === '') {
-      return {
-        id: '',
-        address: '',
-        options: {},
-        methods: [],
-        type: EthAccountType.Eoa,
-        metadata: {
-          name: '',
-          keyring: {
-            type: '',
-          },
-          importTime: 0,
-        },
-      };
+      return EMPTY_ACCOUNT;
     }
 
     if (!chainId) {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -445,7 +445,6 @@ export class AccountsController extends BaseController<
         ...account,
         metadata: { ...account.metadata, name: accountName },
       };
-      // @ts-expect-error - ignoring Type instantiation is excessively deep and possibly infinite.
       currentState.internalAccounts.accounts[accountId] = internalAccount;
     });
   }

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -332,6 +332,25 @@ export class AccountsController extends BaseController<
   getSelectedMultichainAccount(
     chainId?: CaipChainId,
   ): InternalAccount | undefined {
+    // Edge case where the extension is setup but the srp is not yet created
+    // certain ui elements will query the selected address before any accounts are created.
+    if (this.state.internalAccounts.selectedAccount === '') {
+      return {
+        id: '',
+        address: '',
+        options: {},
+        methods: [],
+        type: EthAccountType.Eoa,
+        metadata: {
+          name: '',
+          keyring: {
+            type: '',
+          },
+          importTime: 0,
+        },
+      };
+    }
+
     if (!chainId) {
       return this.getAccountExpect(this.state.internalAccounts.selectedAccount);
     }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This pull request enhances the robustness of our onboarding process by addressing an edge case where selectedAccount is undefined because there aren't any accounts. Specifically, it ensures that the `getSelectedMultichainAccount` function can be safely called during onboarding, even if the selectedAccount has not been set. 

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/accounts-controller`

- **FIXED**: Fixed an edge case where selectedAccount could be undefined, ensuring getSelectedMultichainAccount can be safely invoked during the onboarding phase.


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
