### PR TITLE
[composable-controller] Fix incorrect behavior and improve type-level safeguards

### DIFF
--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/json-rpc-engine": "^9.0.2",
+    "@metamask/utils": "^9.1.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -12,6 +12,15 @@ import type {
 import type { Patch } from 'immer';
 
 export const controllerName = 'ComposableController';
+/**
+ * A universal supertype for the `BaseControllerV1` state object.
+ */
+type ConfigConstraintV1 = BaseConfig & object;
+
+/**
+ * A universal supertype for the `BaseControllerV1` state object.
+ */
+type StateConstraintV1 = BaseState & object;
 
 /**
  * A universal subtype of all controller instances that extend from `BaseControllerV1`.

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -10,7 +10,7 @@ import type {
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
-import type { PublicInterface } from '@metamask/utils';
+import type { Json, PublicInterface } from '@metamask/utils';
 import type { Patch } from 'immer';
 
 export const controllerName = 'ComposableController';
@@ -40,6 +40,23 @@ type BaseControllerV1Instance = PublicInterface<
 >;
 
 /**
+ * A universal supertype of functions that accept a piece of controller state and return some derivation of that state.
+ */
+type StateDeriverConstraint = (value: never) => Json;
+
+/**
+ * A universal supertype of metadata objects for individual state properties.
+ */
+type StatePropertyMetadataConstraint = {
+  [P in 'anonymous' | 'persist']: boolean | StateDeriverConstraint;
+};
+
+/**
+ * A universal supertype of state metadata objects.
+ */
+type StateMetadataConstraint = Record<string, StatePropertyMetadataConstraint>;
+
+/**
  * A universal subtype of all controller instances that extend from `BaseController` (formerly `BaseControllerV2`).
  * Any `BaseController` instance can be assigned to this type.
  *
@@ -57,7 +74,9 @@ type BaseControllerInstance = Omit<
     >
   >,
   'metadata'
-> & { metadata: Record<string, unknown> };
+> & {
+  metadata: StateMetadataConstraint;
+};
 
 /**
  * A universal subtype of all controller instances that extend from `BaseController` (formerly `BaseControllerV2`) or `BaseControllerV1`.

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -1,4 +1,3 @@
-import { BaseController, BaseControllerV1 } from '@metamask/base-controller';
 import type {
   ActionConstraint,
   BaseConfig,
@@ -9,6 +8,7 @@ import type {
   StateMetadata,
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
+import { BaseController, BaseControllerV1 } from '@metamask/base-controller';
 import type { PublicInterface } from '@metamask/utils';
 import type { Patch } from 'immer';
 
@@ -60,9 +60,7 @@ type BaseControllerInstance = {
  * Note that this type is not the widest subtype or narrowest supertype of all `BaseController` and `BaseControllerV1` instances.
  * This type is therefore unsuitable for general use as a type constraint, and is only intended for use within the ComposableController.
  */
-export type ControllerInstance =
-  | BaseControllerV1Instance
-  | BaseControllerInstance;
+type ControllerInstance = BaseControllerV1Instance | BaseControllerInstance;
 
 /**
  * The narrowest supertype of all `RestrictedControllerMessenger` instances.

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -1,6 +1,7 @@
 import type {
   ActionConstraint,
   BaseConfig,
+  BaseControllerV1,
   BaseState,
   EventConstraint,
   RestrictedControllerMessenger,
@@ -8,7 +9,7 @@ import type {
   StateMetadata,
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
-import { BaseController, BaseControllerV1 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import type { PublicInterface } from '@metamask/utils';
 import type { Patch } from 'immer';
 
@@ -105,8 +106,7 @@ export function isBaseControllerV1(
     'disabled' in controller &&
     typeof controller.disabled === 'boolean' &&
     'subscribe' in controller &&
-    typeof controller.subscribe === 'function' &&
-    controller instanceof BaseControllerV1
+    typeof controller.subscribe === 'function'
   );
 }
 
@@ -124,8 +124,7 @@ export function isBaseController(
     'state' in controller &&
     typeof controller.state === 'object' &&
     'metadata' in controller &&
-    typeof controller.metadata === 'object' &&
-    controller instanceof BaseController
+    typeof controller.metadata === 'object'
   );
 }
 

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -9,6 +9,7 @@ import type {
   StateMetadata,
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
+import type { PublicInterface } from '@metamask/utils';
 import type { Patch } from 'immer';
 
 export const controllerName = 'ComposableController';
@@ -29,10 +30,9 @@ type StateConstraintV1 = BaseState & object;
  * Note that this type is not the widest subtype or narrowest supertype of all `BaseControllerV1` instances.
  * This type is therefore unsuitable for general use as a type constraint, and is only intended for use within the ComposableController.
  */
-export type BaseControllerV1Instance =
-  // `any` is used so that all `BaseControllerV1` instances are assignable to this type.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  BaseControllerV1<any, any>;
+type BaseControllerV1Instance = PublicInterface<
+  BaseControllerV1<ConfigConstraintV1, StateConstraintV1>
+>;
 
 /**
  * A universal subtype of all controller instances that extend from `BaseController` (formerly `BaseControllerV2`).

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -325,7 +325,9 @@ export class ComposableController<
         });
       });
     } else {
-      throw new Error(INVALID_CONTROLLER_ERROR);
+      // False negative. `name` is a string type.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      throw new Error(`${name} - ${INVALID_CONTROLLER_ERROR}`);
     }
   }
 }

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -43,9 +43,10 @@ type BaseControllerV1Instance = PublicInterface<
  *
  * For this reason, we only look for `BaseController` properties that we use in the ComposableController (name and state).
  */
-export type BaseControllerInstance = {
+type BaseControllerInstance = {
   name: string;
   state: StateConstraint;
+  metadata: Record<string, unknown>;
 };
 
 /**

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -66,14 +66,15 @@ export type ControllerInstance =
  * @template ControllerName - Name of the controller.
  * Optionally can be used to narrow the type to a specific controller.
  */
-export type RestrictedControllerMessengerConstraint =
-  RestrictedControllerMessenger<
-    string,
-    ActionConstraint,
-    EventConstraint,
-    string,
-    string
-  >;
+export type RestrictedControllerMessengerConstraint<
+  ControllerName extends string = string,
+> = RestrictedControllerMessenger<
+  ControllerName,
+  ActionConstraint,
+  EventConstraint,
+  string,
+  string
+>;
 
 /**
  * Determines if the given controller is an instance of `BaseControllerV1`

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -235,11 +235,12 @@ export type ComposableControllerMessenger<
 /**
  * Controller that composes multiple child controllers and maintains up-to-date composed state.
  *
- * @template ChildControllerState - A type object containing the names and state types of the child controllers are being used to instantiate the {@link ComposableController}.
+ * @template ComposableControllerState - A type object containing the names and state types of the child controllers.
+ * @template ChildControllers - A union type of the child controllers being used to instantiate the {@link ComposableController}.
  */
 export class ComposableController<
   ComposableControllerState extends LegacyComposableControllerStateConstraint,
-  ChildControllers extends ControllerInstance = GetChildControllers<ComposableControllerState>,
+  ChildControllers extends ControllerInstance,
 > extends BaseController<
   typeof controllerName,
   ComposableControllerState,

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -47,11 +47,16 @@ type BaseControllerV1Instance = PublicInterface<
  *
  * For this reason, we only look for `BaseController` properties that we use in the ComposableController (name and state).
  */
-type BaseControllerInstance = {
-  name: string;
-  state: StateConstraint;
-  metadata: Record<string, unknown>;
-};
+type BaseControllerInstance = Omit<
+  PublicInterface<
+    BaseController<
+      string,
+      StateConstraint,
+      RestrictedControllerMessengerConstraint
+    >
+  >,
+  'metadata'
+> & { metadata: Record<string, unknown> };
 
 /**
  * A universal subtype of all controller instances that extend from `BaseController` (formerly `BaseControllerV2`) or `BaseControllerV1`.

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -125,7 +125,9 @@ export function isBaseController(
 /**
  * A universal supertype for the controller state object, encompassing both `BaseControllerV1` and `BaseControllerV2` state.
  */
-export type LegacyControllerStateConstraint = BaseState | StateConstraint;
+export type LegacyControllerStateConstraint =
+  | StateConstraintV1
+  | StateConstraint;
 
 /**
  * A universal supertype for the composable controller state object.
@@ -156,7 +158,7 @@ export type ComposableControllerStateConstraint = {
 // TODO: Replace all instances with `ControllerStateChangeEvent` once `BaseControllerV2` migrations are completed for all controllers.
 type LegacyControllerStateChangeEvent<
   ControllerName extends string,
-  ControllerState extends LegacyControllerStateConstraint,
+  ControllerState extends StateConstraintV1,
 > = {
   type: `${ControllerName}:stateChange`;
   payload: [ControllerState, Patch[]];
@@ -191,6 +193,7 @@ export type ComposableControllerEvents<
  *
  * @template ComposableControllerState - A type object that maps controller names to their state types.
  */
+export type ChildControllerStateChangeEvents<
   ComposableControllerState extends ComposableControllerStateConstraint,
 > = ComposableControllerState extends Record<
   infer ControllerName extends string,
@@ -198,7 +201,8 @@ export type ComposableControllerEvents<
 >
   ? ControllerState extends StateConstraint
     ? ControllerStateChangeEvent<ControllerName, ControllerState>
-    : ControllerState extends Record<string, unknown>
+    : // TODO: Remove this conditional branch once `BaseControllerV2` migrations are completed for all controllers.
+    ControllerState extends StateConstraintV1
     ? LegacyControllerStateChangeEvent<ControllerName, ControllerState>
     : never
   : never;

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -304,10 +304,12 @@ export class ComposableController<
    */
   #updateChildController(controller: ControllerInstance): void {
     const { name } = controller;
-    if (
-      isBaseController(controller) ||
-      (isBaseControllerV1(controller) && 'messagingSystem' in controller)
-    ) {
+    if (!isBaseController(controller) && !isBaseControllerV1(controller)) {
+      // False negative. `name` is a string type.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      throw new Error(`${name} - ${INVALID_CONTROLLER_ERROR}`);
+    }
+    try {
       this.messagingSystem.subscribe(
         // False negative. `name` is a string type.
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
@@ -318,16 +320,17 @@ export class ComposableController<
           });
         },
       );
-    } else if (isBaseControllerV1(controller)) {
+    } catch (error: unknown) {
+      // False negative. `name` is a string type.
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      console.error(`${name} - ${String(error)}`);
+    }
+    if (isBaseControllerV1(controller)) {
       controller.subscribe((childState: StateConstraintV1) => {
         this.update((state) => {
           Object.assign(state, { [name]: childState });
         });
       });
-    } else {
-      // False negative. `name` is a string type.
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      throw new Error(`${name} - ${INVALID_CONTROLLER_ERROR}`);
     }
   }
 }

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -83,19 +83,22 @@ export type RestrictedControllerMessengerConstraint<
  */
 export function isBaseControllerV1(
   controller: ControllerInstance,
-): controller is BaseControllerV1<
-  BaseConfig & Record<string, unknown>,
-  BaseState & Record<string, unknown>
-> {
+): controller is BaseControllerV1Instance {
   return (
     'name' in controller &&
     typeof controller.name === 'string' &&
+    'config' in controller &&
+    typeof controller.config === 'object' &&
     'defaultConfig' in controller &&
     typeof controller.defaultConfig === 'object' &&
+    'state' in controller &&
+    typeof controller.state === 'object' &&
     'defaultState' in controller &&
     typeof controller.defaultState === 'object' &&
     'disabled' in controller &&
     typeof controller.disabled === 'boolean' &&
+    'subscribe' in controller &&
+    typeof controller.subscribe === 'function' &&
     controller instanceof BaseControllerV1
   );
 }
@@ -107,16 +110,14 @@ export function isBaseControllerV1(
  */
 export function isBaseController(
   controller: ControllerInstance,
-): controller is BaseController<
-  string,
-  StateConstraint,
-  RestrictedControllerMessengerConstraint
-> {
+): controller is BaseControllerInstance {
   return (
     'name' in controller &&
     typeof controller.name === 'string' &&
     'state' in controller &&
     typeof controller.state === 'object' &&
+    'metadata' in controller &&
+    typeof controller.metadata === 'object' &&
     controller instanceof BaseController
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4081,21 +4081,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.4.2, @noble/curves@npm:~1.4.0":
+"@noble/curves@npm:1.4.2, @noble/curves@npm:^1.2.0, @noble/curves@npm:~1.4.0":
   version: 1.4.2
   resolution: "@noble/curves@npm:1.4.2"
   dependencies:
     "@noble/hashes": "npm:1.4.0"
   checksum: 10/f433a2e8811ae345109388eadfa18ef2b0004c1f79417553241db4f0ad0d59550be6298a4f43d989c627e9f7551ffae6e402a4edf0173981e6da95fc7cab5123
-  languageName: node
-  linkType: hard
-
-"@noble/curves@npm:^1.2.0":
-  version: 1.4.0
-  resolution: "@noble/curves@npm:1.4.0"
-  dependencies:
-    "@noble/hashes": "npm:1.4.0"
-  checksum: 10/b21b30a36ff02bfcc0f5e6163d245cdbaf7f640511fff97ccf83fc207ee79cfd91584b4d97977374de04cb118a55eb63a7964c82596a64162bbc42bc685ae6d9
   languageName: node
   linkType: hard
 
@@ -5207,21 +5198,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0":
+"acorn@npm:^8.11.0, acorn@npm:^8.2.4, acorn@npm:^8.4.1, acorn@npm:^8.9.0":
   version: 8.12.1
   resolution: "acorn@npm:8.12.1"
   bin:
     acorn: bin/acorn
   checksum: 10/d08c2d122bba32d0861e0aa840b2ee25946c286d5dc5990abca991baf8cdbfbe199b05aacb221b979411a2fea36f83e26b5ac4f6b4e0ce49038c62316c1848f0
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.2.4, acorn@npm:^8.4.1, acorn@npm:^8.9.0":
-  version: 8.11.3
-  resolution: "acorn@npm:8.11.3"
-  bin:
-    acorn: bin/acorn
-  checksum: 10/b688e7e3c64d9bfb17b596e1b35e4da9d50553713b3b3630cf5690f2b023a84eac90c56851e6912b483fe60e8b4ea28b254c07e92f17ef83d72d78745a8352dd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2487,6 +2487,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^6.0.2"
     "@metamask/json-rpc-engine": "npm:^9.0.2"
+    "@metamask/utils": "npm:^9.1.0"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"
     immer: "npm:^9.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4080,12 +4080,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.4.2, @noble/curves@npm:^1.2.0, @noble/curves@npm:~1.4.0":
+"@noble/curves@npm:1.4.2, @noble/curves@npm:~1.4.0":
   version: 1.4.2
   resolution: "@noble/curves@npm:1.4.2"
   dependencies:
     "@noble/hashes": "npm:1.4.0"
   checksum: 10/f433a2e8811ae345109388eadfa18ef2b0004c1f79417553241db4f0ad0d59550be6298a4f43d989c627e9f7551ffae6e402a4edf0173981e6da95fc7cab5123
+  languageName: node
+  linkType: hard
+
+"@noble/curves@npm:^1.2.0":
+  version: 1.4.0
+  resolution: "@noble/curves@npm:1.4.0"
+  dependencies:
+    "@noble/hashes": "npm:1.4.0"
+  checksum: 10/b21b30a36ff02bfcc0f5e6163d245cdbaf7f640511fff97ccf83fc207ee79cfd91584b4d97977374de04cb118a55eb63a7964c82596a64162bbc42bc685ae6d9
   languageName: node
   linkType: hard
 
@@ -5197,12 +5206,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0, acorn@npm:^8.2.4, acorn@npm:^8.4.1, acorn@npm:^8.9.0":
+"acorn@npm:^8.11.0":
   version: 8.12.1
   resolution: "acorn@npm:8.12.1"
   bin:
     acorn: bin/acorn
   checksum: 10/d08c2d122bba32d0861e0aa840b2ee25946c286d5dc5990abca991baf8cdbfbe199b05aacb221b979411a2fea36f83e26b5ac4f6b4e0ce49038c62316c1848f0
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.2.4, acorn@npm:^8.4.1, acorn@npm:^8.9.0":
+  version: 8.11.3
+  resolution: "acorn@npm:8.11.3"
+  bin:
+    acorn: bin/acorn
+  checksum: 10/b688e7e3c64d9bfb17b596e1b35e4da9d50553713b3b3630cf5690f2b023a84eac90c56851e6912b483fe60e8b4ea28b254c07e92f17ef83d72d78745a8352dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Overview

This commit fixes issues with the `ComposableController` class's interface, and its logic for validating V1 and V2 controllers.

These changes will enable `ComposableController` to function correctly downstream in the Mobile Engine, and eventually the Wallet Framework POC.

## Explanation

The previous approach of generating mock controller classes from the `ComposableControllerState` input using the `GetChildControllers` was flawed, because the mock controllers would always be incomplete, complicating attempts at validation. 

Instead, we now rely on the downstream consumer to provide both a composed type of state schemas (`ComposableControllerState`) and a type union of the child controller instances (`ChildControllers`). For example, in mobile, we can use (with some adjustments) `EngineState` for the former, and `Controllers[keyof Controllers]` for the latter.

The validation logic for V1 controllers has also been updated. Due to breaking changes made to the private properties of `BaseControllerV1` (https://github.com/MetaMask/core/pull/3959), mobile V1 controllers relying on versions prior to these changes were introduced were incompatible with the up-to-date `BaseControllerV1` version that the composable-controller package references. 

In this commit, the validator type `BaseControllerV1Instance` filters out the problematic private properties by using the `PublicInterface` type. Because the public API of `BaseControllerV1` has been relatively constant, this removes the type errors that previously occurred in mobile when passing V1 controllers into `ComposableController`. 

## References

- Closes https://github.com/MetaMask/core/issues/4448
- Contributes to https://github.com/MetaMask/core/issues/4213
- Next steps https://github.com/MetaMask/metamask-mobile/issues/10073
  - See https://github.com/MetaMask/metamask-mobile/pull/10011

## Changelog

### `@metamask/composable-controller` (major)

### Changed

- **BREAKING:** Add two required generic parameters to the `ComposableController` class: `ComposedControllerState` (constrained by `LegacyComposableControllerStateConstraint`) and `ChildControllers` (constrained by `ControllerInstance`) ([#4467](https://github.com/MetaMask/core/pull/4467)).
- **BREAKING:** The type guard `isBaseController` now validates that the input has an object-type property named `metadata` in addition to its existing checks.
- **BREAKING:** The type guard `isBaseControllerV1` now validates that the input has object-type properties `config`, `state`, and function-type property `subscribe`, in addition to its existing checks.
- **BREAKING:** Narrow `LegacyControllerStateConstraint` type from `BaseState | StateConstraint` to `BaseState & object | StateConstraint`.
- Add an optional generic parameter `ControllerName` to the `RestrictedControllerMessengerConstraint` type, which extends `string` and defaults to `string`.
 
### Fixed

- **BREAKING:** The `ComposableController` class raises a type error if a non-controller with no `state` property is passed into the `ChildControllers` generic parameter or the `controllers` constructor option.
  - Previously, a runtime error was thrown at class instantiation with no type-level enforcement.
- When the `ComposableController` class is instantiated, its messenger now attempts to subscribe to all child controller `stateChange` events that are included in the messenger's events allowlist.
  - This was always the expected behavior, but a bug introduced in `@metamask/composable-controller@6.0.0` caused `stateChange` event subscriptions to fail.
- `isBaseController` and `isBaseControllerV1` no longer return false negatives.
  - The `instanceof` operator is no longer used to validate that the input is a subclass of `BaseController` or `BaseControllerV1`.
- The `ChildControllerStateChangeEvents` type checks that the child controller's state extends from the `StateConstraintV1` type instead of from `Record<string, unknown>`. ([#4467](https://github.com/MetaMask/core/pull/4467))
  - V1 controllers define their state types using the `interface` keyword, which are incompatible with `Record<string, unknown>` by default. This resulted in `ChildControllerStateChangeEvents` failing to generate `stateChange` events for V1 controllers and returning `never`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
