### PR TITLE
Revert "Release/168.0.0"

### DIFF
--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -7,28 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.1]
-
-### Added
-
-- export `defaultState` for `NotificationServicesController` and `NotificationServicesPushController`. ([#4441](https://github.com/MetaMask/core/pull/4441))
-
-- export `NOTIFICATION_CHAINS_ID` which is a const-asserted version of `NOTIFICATION_CHAINS` ([#4441](https://github.com/MetaMask/core/pull/4441))
-
-- export `NOTIFICATION_NETWORK_CURRENCY_NAME` and `NOTIFICATION_NETWORK_CURRENCY_SYMBOL`. Allows consistent currency names and symbols for supported notification services ([#4441](https://github.com/MetaMask/core/pull/4441))
-
-- add `isPushIntegrated` as an optional env property in the `NotificationServicesController` constructor (defaults to true) ([#4441](https://github.com/MetaMask/core/pull/4441))
-
-### Fixed
-
-- `NotificationServicesPushController` - removed global `self` calls for mobile compatibility ([#4441](https://github.com/MetaMask/core/pull/4441))
-
 ## [0.1.0]
 
 ### Added
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@0.1.1...HEAD
-[0.1.1]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@0.1.0...@metamask/notification-services-controller@0.1.1
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@0.1.0...HEAD
 [0.1.0]: https://github.com/MetaMask/core/releases/tag/@metamask/notification-services-controller@0.1.0

--- a/packages/notification-services-controller/package.json
+++ b/packages/notification-services-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/notification-services-controller",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "Manages New MetaMask decentralized Notification system",
   "keywords": [
     "MetaMask",
@@ -45,7 +45,7 @@
     "@metamask/base-controller": "^6.0.0",
     "@metamask/controller-utils": "^11.0.0",
     "@metamask/keyring-controller": "^17.1.0",
-    "@metamask/profile-sync-controller": "^0.1.1",
+    "@metamask/profile-sync-controller": "^0.1.0",
     "bignumber.js": "^4.1.0",
     "contentful": "^10.3.6",
     "firebase": "^10.11.0",
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^17.0.0",
-    "@metamask/profile-sync-controller": "^0.1.1"
+    "@metamask/profile-sync-controller": "^0.1.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -7,22 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.1]
-
-### Added
-
-- export `defaultState` for `AuthenticationController` and `UserStorageController`. ([#4441](https://github.com/MetaMask/core/pull/4441))
-
-### Changed
-
-- `AuthType`, `Env`, `Platform` are changed from const enums to enums ([#4441](https://github.com/MetaMask/core/pull/4441))
-
 ## [0.1.0]
 
 ### Added
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/profile-sync-controller@0.1.1...HEAD
-[0.1.1]: https://github.com/MetaMask/core/compare/@metamask/profile-sync-controller@0.1.0...@metamask/profile-sync-controller@0.1.1
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/profile-sync-controller@0.1.0...HEAD
 [0.1.0]: https://github.com/MetaMask/core/releases/tag/@metamask/profile-sync-controller@0.1.0

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/profile-sync-controller",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "The profile sync helps developers synchronize data across multiple clients and devices in a privacy-preserving way. All data saved in the user storage database is encrypted client-side to preserve privacy. The user storage provides a modular design, giving developers the flexibility to construct and manage their storage spaces in a way that best suits their needs",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3255,7 +3255,7 @@ __metadata:
     "@metamask/base-controller": ^6.0.0
     "@metamask/controller-utils": ^11.0.0
     "@metamask/keyring-controller": ^17.1.0
-    "@metamask/profile-sync-controller": ^0.1.1
+    "@metamask/profile-sync-controller": ^0.1.0
     "@types/jest": ^27.4.1
     "@types/readable-stream": ^2.3.0
     bignumber.js: ^4.1.0
@@ -3273,7 +3273,7 @@ __metadata:
     uuid: ^8.3.2
   peerDependencies:
     "@metamask/keyring-controller": ^17.0.0
-    "@metamask/profile-sync-controller": ^0.1.1
+    "@metamask/profile-sync-controller": ^0.1.0
   languageName: unknown
   linkType: soft
 
@@ -3466,7 +3466,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/profile-sync-controller@^0.1.1, @metamask/profile-sync-controller@workspace:packages/profile-sync-controller":
+"@metamask/profile-sync-controller@^0.1.0, @metamask/profile-sync-controller@workspace:packages/profile-sync-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/profile-sync-controller@workspace:packages/profile-sync-controller"
   dependencies:


### PR DESCRIPTION
Reverts MetaMask/core#4469

We need to redo this release because the version was not set on the `package.json` and did not go out 🤦🏾 , apologies!