### PR TITLE
refactor: AuthenticationController - Add Async MetaMetrics Id support

### DIFF
--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -37,7 +37,7 @@ type SessionData = {
 };
 
 type MetaMetricsAuth = {
-  getMetaMetricsId: () => string;
+  getMetaMetricsId: () => string | Promise<string>;
   agent: 'extension' | 'mobile';
 };
 
@@ -238,7 +238,7 @@ export default class AuthenticationController extends BaseController<
       const rawMessage = createLoginRawMessage(nonce, publicKey);
       const signature = await this.#snapSignMessage(rawMessage);
       const loginResponse = await login(rawMessage, signature, {
-        metametricsId: this.#metametrics.getMetaMetricsId(),
+        metametricsId: await this.#metametrics.getMetaMetricsId(),
         agent: this.#metametrics.agent,
       });
       if (!loginResponse?.token) {


### PR DESCRIPTION
## Explanation

This is for mobile integration support. Allows developers to provide an async metametrics ID (if this needs to be computed async).

## References

## Changelog

### `@metamask/profile-sync-controller`

- **CHANGED**: `getMetaMetricsId` interface to support async.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
