### PR TITLE
refactor: Authentication Controller - add mobile OIDC support

### DIFF
--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -132,6 +132,10 @@ export default class AuthenticationController extends BaseController<
       state: { ...defaultState, ...state },
     });
 
+    if (!metametrics) {
+      throw new Error('`metametrics` field is required');
+    }
+
     this.#metametrics = metametrics;
 
     this.#registerMessageHandlers();
@@ -251,7 +255,10 @@ export default class AuthenticationController extends BaseController<
       };
 
       // 3. Trade for Access Token
-      const accessToken = await getAccessToken(loginResponse.token);
+      const accessToken = await getAccessToken(
+        loginResponse.token,
+        this.#metametrics.agent,
+      );
       if (!accessToken) {
         throw new Error(`Unable to get Access Token`);
       }

--- a/packages/profile-sync-controller/src/controllers/authentication/services.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/services.test.ts
@@ -85,7 +85,7 @@ describe('authentication/services.ts - login() tests', () => {
 describe('authentication/services.ts - getAccessToken() tests', () => {
   it('returns access token jwt if successful OIDC token request', async () => {
     const mockLoginEndpoint = mockEndpointAccessToken();
-    const response = await getAccessToken('mock single-use jwt');
+    const response = await getAccessToken('mock single-use jwt', 'extension');
 
     mockLoginEndpoint.done();
     expect(response).toBe(MOCK_ACCESS_TOKEN);
@@ -97,7 +97,7 @@ describe('authentication/services.ts - getAccessToken() tests', () => {
       body: Record<string, unknown>,
     ) => {
       const mockLoginEndpoint = mockEndpointAccessToken({ status, body });
-      const response = await getAccessToken('mock single-use jwt');
+      const response = await getAccessToken('mock single-use jwt', 'extension');
 
       mockLoginEndpoint.done();
       expect(response).toBeNull();


### PR DESCRIPTION
## Explanation

mobile uses a different OIDC than extension, which generates different access tokens.

## References

## Changelog

### `@metamask/profile-sync-controller`

- **Added**: AuthenticationController - platform field when logging in
- **Added**: AuthenticationController - metametrics validation check on constructor

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
