### PR TITLE
docs: Fix typos contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -153,8 +153,8 @@ To use a preview build for a package within a project, you need to override the 
 > If you're migrating an existing package to the monorepo, please see [the package migration documentation](./package-migration-process-guide.md).
 > You may be able to make use of `create-package` when migrating your package, but there's a lot more to it.
 
-Manually a new monorepo package can be a tedious, even frustrating process. To spare us from that
-suffering, we have created a CLI that automates most of the job for us, creatively titled
+Manually creating a new monorepo package can be a tedious, even frustrating process. To alleviate that
+problem, we have created a CLI that automates most of the job for us, creatively titled
 [`create-package`](../scripts/create-package/). To create a new monorepo package, follow these steps:
 
 1. Create a new package using `yarn create-package`.

--- a/scripts/create-package/cli.ts
+++ b/scripts/create-package/cli.ts
@@ -20,11 +20,9 @@ export default async function cli(
     // Disable --version. This is an internal tool and it doesn't have a version.
     .version(false)
     .usage('$0 [args]')
-    // Typecast: the CommandModule<T, U>[] signature does in fact exist, but it is
-    // missing from our yargs types.
-    // TODO: Replace `any` with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .command(commands as any)
+    // @ts-expect-error: The CommandModule<T, U>[] signature does in fact exist,
+    // but it is missing from our yargs types.
+    .command(commands)
     .strict()
     .check((args) => {
       // Trim all strings and ensure they are not empty.

--- a/scripts/create-package/commands.ts
+++ b/scripts/create-package/commands.ts
@@ -66,8 +66,6 @@ const defaultCommand: CommandModule = {
     await createPackageHandler(args),
 };
 
-// export type CommandKeys = 'default';
-
 export const commands = [defaultCommand];
 export const commandMap = {
   $0: defaultCommand,


### PR DESCRIPTION
Fixes a typo in `./contributing.md`.