### PR TITLE
fix: use `listMultichainAccounts` and set `lastSelected` for initial account

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -451,16 +451,6 @@ describe('AccountsController', () => {
         .mockReturnValueOnce('mock-id') // call to check if its a new account
         .mockReturnValueOnce('mock-id2'); // call to add account
 
-      const mockNewKeyringState = {
-        isUnlocked: true,
-        keyrings: [
-          {
-            type: KeyringTypes.hd,
-            accounts: [mockAccount.address],
-          },
-        ],
-      };
-
       const { accountsController } = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -475,6 +465,16 @@ describe('AccountsController', () => {
         accountsController,
         'listMultichainAccounts',
       );
+
+      const mockNewKeyringState = {
+        isUnlocked: true,
+        keyrings: [
+          {
+            type: KeyringTypes.hd,
+            accounts: [mockAccount.address],
+          },
+        ],
+      };
 
       messenger.publish(
         'KeyringController:stateChange',

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -445,7 +445,7 @@ describe('AccountsController', () => {
   });
 
   describe('onKeyringStateChange', () => {
-    it('uses listMultichainAccount', async () => {
+    it('uses listMultichainAccounts', async () => {
       const messenger = buildMessenger();
       mockUUID
         .mockReturnValueOnce('mock-id') // call to check if its a new account

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -853,9 +853,6 @@ export class AccountsController extends BaseController<
       keyringType,
       accounts,
     );
-    console.log('accounts', accounts);
-    console.log('keyringType', keyringType);
-    console.log('keyringAccounts', keyringAccounts);
     const lastDefaultIndexUsedForKeyringType = keyringAccounts.reduce(
       (maxInternalAccountIndex, internalAccount) => {
         // We **DO NOT USE** `\d+` here to only consider valid "human"
@@ -958,9 +955,6 @@ export class AccountsController extends BaseController<
   }
 
   #publishAccountChangeEvent(account: InternalAccount) {
-    console.log('publishing new account');
-    console.log('previosu', this.state.internalAccounts.selectedAccount);
-    console.log('new', account);
     if (isEvmAccountType(account.type)) {
       this.messagingSystem.publish(
         'AccountsController:selectedEvmAccountChange',

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -381,17 +381,7 @@ export class AccountsController extends BaseController<
       currentState.internalAccounts.selectedAccount = account.id;
     });
 
-    if (isEvmAccountType(account.type)) {
-      this.messagingSystem.publish(
-        'AccountsController:selectedEvmAccountChange',
-        account,
-      );
-    }
-
-    this.messagingSystem.publish(
-      'AccountsController:selectedAccountChange',
-      account,
-    );
+    this.#publishAccountChangeEvent(account);
   }
 
   /**
@@ -759,6 +749,8 @@ export class AccountsController extends BaseController<
             },
           );
           currentState.internalAccounts.selectedAccount = accountToSelect.id;
+
+          this.#publishAccountChangeEvent(accountToSelect);
         }
       });
     }
@@ -952,6 +944,19 @@ export class AccountsController extends BaseController<
     };
 
     return accountsState;
+  }
+
+  #publishAccountChangeEvent(account: InternalAccount) {
+    if (isEvmAccountType(account.type)) {
+      this.messagingSystem.publish(
+        'AccountsController:selectedEvmAccountChange',
+        account,
+      );
+    }
+    this.messagingSystem.publish(
+      'AccountsController:selectedAccountChange',
+      account,
+    );
   }
 
   /**

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -409,7 +409,6 @@ export class AccountsController extends BaseController<
         ...account,
         metadata: { ...account.metadata, name: accountName },
       };
-      // @ts-ignore
       currentState.internalAccounts.accounts[accountId] = internalAccount;
     });
   }

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -749,6 +749,9 @@ export class AccountsController extends BaseController<
             },
           );
           currentState.internalAccounts.selectedAccount = accountToSelect.id;
+          currentState.internalAccounts.accounts[
+            accountToSelect.id
+          ].metadata.lastSelected = Date.now();
 
           this.#publishAccountChangeEvent(accountToSelect);
         }
@@ -926,6 +929,8 @@ export class AccountsController extends BaseController<
         return accountsState;
       }
     }
+
+    const isFirstAccount = Object.keys(accountsState).length === 0;
 
     // Get next account name available for this given keyring
     const accountName = this.getNextAvailableAccountName(

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -751,7 +751,7 @@ export class AccountsController extends BaseController<
           currentState.internalAccounts.selectedAccount = accountToSelect.id;
           currentState.internalAccounts.accounts[
             accountToSelect.id
-          ].metadata.lastSelected = Date.now();
+          ].metadata.lastSelected = this.#getLastSelectedIndex();
 
           this.#publishAccountChangeEvent(accountToSelect);
         }
@@ -899,6 +899,17 @@ export class AccountsController extends BaseController<
   }
 
   /**
+   * Retrieves the index value for `metadata.lastSelected`.
+   *
+   * @returns The index value.
+   */
+  #getLastSelectedIndex() {
+    // NOTE: For now we use the current date, since we know this value
+    // will always be higher than any already selected account index.
+    return Date.now();
+  }
+
+  /**
    * Handles the addition of a new account to the controller.
    * If the account is not a Snap Keyring account, generates an internal account for it and adds it to the controller.
    * If the account is a Snap Keyring account, retrieves the account from the keyring and adds it to the controller.
@@ -946,7 +957,7 @@ export class AccountsController extends BaseController<
         ...newAccount.metadata,
         name: accountName,
         importTime: Date.now(),
-        lastSelected: isFirstAccount ? Date.now() : 0,
+        lastSelected: isFirstAccount ? this.#getLastSelectedIndex() : 0,
       },
     };
 


### PR DESCRIPTION
## Explanation

This PR fixes the following:

1. Emits `selectedAccountChange` for initial account
2. Updates `lastSelected` for initial account
3. Uses `listMultichainAccounts` instead of `listAccounts` for multichain methods

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes https://github.com/MetaMask/accounts-planning/issues/507

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/accounts-controller`

- **FIXED**: Emits `selectedAccountChange` and updates last selected for initial account.
- **FIXED**: Uses `listMultichainAccounts` instead of `listAccounts` for multichain methods

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
