### PR TITLE
Add type annotation to `EventEmitter`

### DIFF
--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -204,7 +204,7 @@ export abstract class AbstractMessageManager<
   /**
    * EventEmitter instance used to listen to specific message events
    */
-  hub = new EventEmitter();
+  hub: EventEmitter = new EventEmitter();
 
   /**
    * Name of this controller used during composition


### PR DESCRIPTION
## Explanation

Adds a type annotation for the `EventEmitter` in `AbstractMessageMessenger`.

Without this, TypeScript would infer `EventEmitter` to be generic and break types in packages consuming this package.

```
    hub: EventEmitter<[never]>;
```

Following this change, the EventEmitter is no longer inferred as generic.

```
    hub: EventEmitter;
```


## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/message-manager`

- **Fixed**: Fix `EventEmitter` inferred type

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
