### PR TITLE
chore: add codeowner entries for confirmations team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,9 @@
 /packages/permission-controller      @MetaMask/snaps-devs
 /packages/notification-controller    @MetaMask/snaps-devs
 /packages/rate-limit-controller      @MetaMask/snaps-devs
+
+/packages/gas-fee-controller         @MetaMask/confirmations
+/packages/name-controller            @MetaMask/confirmations
+/packages/signature-controller       @MetaMask/confirmations
+/packages/transaction-controller     @MetaMask/confirmations
+/packages/user-operation-controller  @MetaMask/confirmations


### PR DESCRIPTION
## Explanation

Add entries for the Confirmations team to `CODEOWNERS`.

As with any code ownership, PRs from any team are encouraged, this is primarily a mechanism to ensure any changes are visible to the team, and consistent with the broader architecture and design patterns.

## References

## Changelog

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
