### PR TITLE
fix: clear encryption salt and key

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -425,8 +425,6 @@ describe('KeyringController', () => {
               expect(controller.state).not.toBe(initialState);
               expect(controller.state.vault).toBeDefined();
               expect(controller.state.vault).toStrictEqual(initialVault);
-              expect(controller.state.encryptionKey).toBeUndefined();
-              expect(controller.state.encryptionSalt).toBeUndefined();
             },
           );
         });
@@ -573,6 +571,19 @@ describe('KeyringController', () => {
               },
             );
           });
+
+          !cacheEncryptionKey &&
+            it('should not set encryptionKey and encryptionSalt in state', async () => {
+              await withController(
+                { skipVaultCreation: true },
+                async ({ controller }) => {
+                  await controller.createNewVaultAndKeychain(password);
+
+                  expect(controller.state).not.toHaveProperty('encryptionKey');
+                  expect(controller.state).not.toHaveProperty('encryptionSalt');
+                },
+              );
+            });
         });
 
         describe('when there is an existing vault', () => {
@@ -597,11 +608,8 @@ describe('KeyringController', () => {
               },
             );
           });
-
           cacheEncryptionKey &&
-            // TODO: Re-enable this after we properly clear the key and salt from state upon lock
-            // eslint-disable-next-line jest/no-disabled-tests
-            it.skip('should set encryptionKey and encryptionSalt in state', async () => {
+            it('should set encryptionKey and encryptionSalt in state', async () => {
               await withController(
                 { cacheEncryptionKey },
                 async ({ controller }) => {
@@ -613,6 +621,17 @@ describe('KeyringController', () => {
 
                   expect(controller.state.encryptionKey).toBeDefined();
                   expect(controller.state.encryptionSalt).toBeDefined();
+                },
+              );
+            });
+          !cacheEncryptionKey &&
+            it('should not set encryptionKey and encryptionSalt in state', async () => {
+              await withController(
+                { skipVaultCreation: false, cacheEncryptionKey },
+                async ({ controller }) => {
+                  await controller.createNewVaultAndKeychain(password);
+                  expect(controller.state).not.toHaveProperty('encryptionKey');
+                  expect(controller.state).not.toHaveProperty('encryptionSalt');
                 },
               );
             });
@@ -631,8 +650,8 @@ describe('KeyringController', () => {
 
         expect(controller.isUnlocked()).toBe(false);
         expect(controller.state.isUnlocked).toBe(false);
-        expect(controller.state.encryptionKey).toBeUndefined();
-        expect(controller.state.encryptionSalt).toBeUndefined();
+        expect(controller.state).not.toHaveProperty('encryptionKey');
+        expect(controller.state).not.toHaveProperty('encryptionSalt');
       });
     });
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -425,6 +425,8 @@ describe('KeyringController', () => {
               expect(controller.state).not.toBe(initialState);
               expect(controller.state.vault).toBeDefined();
               expect(controller.state.vault).toStrictEqual(initialVault);
+              expect(controller.state.encryptionKey).toBeUndefined();
+              expect(controller.state.encryptionSalt).toBeUndefined();
             },
           );
         });
@@ -629,6 +631,8 @@ describe('KeyringController', () => {
 
         expect(controller.isUnlocked()).toBe(false);
         expect(controller.state.isUnlocked).toBe(false);
+        expect(controller.state.encryptionKey).toBeUndefined();
+        expect(controller.state.encryptionSalt).toBeUndefined();
       });
     });
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -608,6 +608,7 @@ describe('KeyringController', () => {
               },
             );
           });
+
           cacheEncryptionKey &&
             it('should set encryptionKey and encryptionSalt in state', async () => {
               await withController(
@@ -624,12 +625,14 @@ describe('KeyringController', () => {
                 },
               );
             });
+
           !cacheEncryptionKey &&
             it('should not set encryptionKey and encryptionSalt in state', async () => {
               await withController(
                 { skipVaultCreation: false, cacheEncryptionKey },
                 async ({ controller }) => {
                   await controller.createNewVaultAndKeychain(password);
+
                   expect(controller.state).not.toHaveProperty('encryptionKey');
                   expect(controller.state).not.toHaveProperty('encryptionSalt');
                 },

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1098,6 +1098,8 @@ export class KeyringController extends BaseController<
       this.update((state) => {
         state.isUnlocked = false;
         state.keyrings = [];
+        delete state.encryptionKey;
+        delete state.encryptionSalt;
       });
 
       this.messagingSystem.publish(`${name}:lock`);
@@ -1876,6 +1878,12 @@ export class KeyringController extends BaseController<
     if (typeof password !== 'string') {
       throw new TypeError(KeyringControllerError.WrongPasswordType);
     }
+
+    this.update((state) => {
+      delete state.encryptionKey;
+      delete state.encryptionSalt;
+    });
+
     this.#password = password;
 
     await this.#clearKeyrings();


### PR DESCRIPTION
## Explanation
- Currently, when a user locks the app and then resets their password, they are not able to log in wth their new password. 
- This is because the encryption key was generated with the old password and not cleared.
- The solve this we will remove the encryption key from state when the user locks the wallet as well as when `#createNewVaultWithKeyring` is called.
- This allows for a new encryption key to be generated with the new password when the user logs in again and `submitPassword` is called.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

* Fixes https://github.com/MetaMask/metamask-extension/issues/25696
* Moves path from [this PR](https://github.com/MetaMask/metamask-extension/pull/25753) into the KeyringController

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/keyring-controller`

- **FIXED**: Reset encryption key when wallet is locked or when new vault is created to ensure that encryption key is always based on most recent password. 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
