### PR TITLE
Switch ethers to a devDependency

### DIFF
--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -47,7 +47,6 @@
     "@metamask/snaps-utils": "^7.4.0",
     "@noble/ciphers": "^0.5.2",
     "@noble/hashes": "^1.4.0",
-    "ethers": "^6.12.0",
     "immer": "^9.0.6",
     "loglevel": "^1.8.1",
     "siwe": "^2.3.2"
@@ -57,6 +56,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
+    "ethers": "^6.12.0",
     "jest": "^27.5.1",
     "jest-environment-jsdom": "^27.5.1",
     "nock": "^13.3.1",


### PR DESCRIPTION
## Explanation

This change fixes build errors on the extension that the ethers dependency introduced.
We were not aware of these build errors before because this package has not been used yet in the extension (but migration is in progress!).
Ethers is eventually only needed as a devDependency so I'm moving it here.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/profile-sync-controller`

- **CHANGED**: Switch ethers to a devDependency

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
