### PR TITLE
chore(keyring-controller): Improve `createNewVaultAndKeychain` tests and docs

### DIFF
--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -497,28 +497,18 @@ describe('KeyringController', () => {
         describe('when there is no existing vault', () => {
           it('should create new vault, mnemonic and keychain', async () => {
             await withController(
-              { cacheEncryptionKey },
-              async ({ controller, initialState, encryptor }) => {
-                const cleanKeyringController = new KeyringController({
-                  messenger: buildKeyringControllerMessenger(),
-                  cacheEncryptionKey,
-                  encryptor,
-                });
-                const initialSeedWord = await controller.exportSeedPhrase(
+              { cacheEncryptionKey, skipVaultCreation: true },
+              async ({ controller }) => {
+                await controller.createNewVaultAndKeychain(password);
+
+                const currentSeedPhrase = await controller.exportSeedPhrase(
                   password,
                 );
-                await cleanKeyringController.createNewVaultAndKeychain(
-                  password,
-                );
-                const currentSeedWord =
-                  await cleanKeyringController.exportSeedPhrase(password);
-                expect(initialSeedWord).toBeDefined();
-                expect(initialState).not.toBe(cleanKeyringController.state);
-                expect(currentSeedWord).toBeDefined();
-                expect(initialSeedWord).not.toBe(currentSeedWord);
+
+                expect(currentSeedPhrase.length).toBeGreaterThan(0);
                 expect(
                   isValidHexAddress(
-                    cleanKeyringController.state.keyrings[0].accounts[0] as Hex,
+                    controller.state.keyrings[0].accounts[0] as Hex,
                   ),
                 ).toBe(true);
                 expect(controller.state.vault).toBeDefined();
@@ -526,19 +516,37 @@ describe('KeyringController', () => {
             );
           });
 
-          it('should set default state', async () => {
-            await withController(async ({ controller }) => {
-              expect(controller.state.keyrings).not.toStrictEqual([]);
-              const keyring = controller.state.keyrings[0];
-              expect(keyring.accounts).not.toStrictEqual([]);
-              expect(keyring.type).toBe('HD Key Tree');
-              expect(controller.state.vault).toBeDefined();
+          cacheEncryptionKey &&
+            it('should set encryptionKey and encryptionSalt in state', async () => {
+              await withController(
+                { cacheEncryptionKey, skipVaultCreation: true },
+                async ({ controller }) => {
+                  await controller.createNewVaultAndKeychain(password);
+
+                  expect(controller.state.encryptionKey).toBeDefined();
+                  expect(controller.state.encryptionSalt).toBeDefined();
+                },
+              );
             });
+
+          it('should set default state', async () => {
+            await withController(
+              { cacheEncryptionKey, skipVaultCreation: true },
+              async ({ controller }) => {
+                await controller.createNewVaultAndKeychain(password);
+
+                expect(controller.state.keyrings).not.toStrictEqual([]);
+                const keyring = controller.state.keyrings[0];
+                expect(keyring.accounts).not.toStrictEqual([]);
+                expect(keyring.type).toBe('HD Key Tree');
+                expect(controller.state.vault).toBeDefined();
+              },
+            );
           });
 
           it('should throw error if password is of wrong type', async () => {
             await withController(
-              { skipVaultCreation: true },
+              { cacheEncryptionKey, skipVaultCreation: true },
               async ({ controller }) => {
                 await expect(
                   controller.createNewVaultAndKeychain(
@@ -555,7 +563,7 @@ describe('KeyringController', () => {
               .spyOn(HDKeyring.prototype, 'getAccounts')
               .mockResolvedValue([]);
             await withController(
-              { skipVaultCreation: true },
+              { cacheEncryptionKey, skipVaultCreation: true },
               async ({ controller }) => {
                 await expect(
                   controller.createNewVaultAndKeychain(password),
@@ -566,37 +574,47 @@ describe('KeyringController', () => {
         });
 
         describe('when there is an existing vault', () => {
-          it('should return existing vault', async () => {
+          it('should not create a new vault or keychain', async () => {
             await withController(
               { cacheEncryptionKey },
               async ({ controller, initialState }) => {
                 const initialSeedWord = await controller.exportSeedPhrase(
                   password,
                 );
+                expect(initialSeedWord).toBeDefined();
                 const initialVault = controller.state.vault;
+
                 await controller.createNewVaultAndKeychain(password);
+
                 const currentSeedWord = await controller.exportSeedPhrase(
                   password,
                 );
-                expect(initialSeedWord).toBeDefined();
                 expect(initialState).toStrictEqual(controller.state);
-                expect(currentSeedWord).toBeDefined();
                 expect(initialSeedWord).toBe(currentSeedWord);
                 expect(initialVault).toStrictEqual(controller.state.vault);
               },
             );
           });
-        });
 
-        cacheEncryptionKey &&
-          it('should set encryptionKey and encryptionSalt in state', async () => {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            withController({ cacheEncryptionKey }, async ({ initialState }) => {
-              expect(initialState.encryptionKey).toBeDefined();
-              expect(initialState.encryptionSalt).toBeDefined();
+          cacheEncryptionKey &&
+            // TODO: Re-enable this after we properly clear the key and salt from state upon lock
+            // eslint-disable-next-line jest/no-disabled-tests
+            it.skip('should set encryptionKey and encryptionSalt in state', async () => {
+              await withController(
+                { cacheEncryptionKey },
+                async ({ controller }) => {
+                  await controller.setLocked();
+                  expect(controller.state.encryptionKey).toBeUndefined();
+                  expect(controller.state.encryptionSalt).toBeUndefined();
+
+                  await controller.createNewVaultAndKeychain(password);
+
+                  expect(controller.state.encryptionKey).toBeDefined();
+                  expect(controller.state.encryptionSalt).toBeDefined();
+                },
+              );
             });
-          });
+        });
       }),
     );
   });

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -772,10 +772,12 @@ export class KeyringController extends BaseController<
   }
 
   /**
-   * Create a new primary keychain and wipe any previous keychains.
+   * Create a new vault and primary keyring.
+   *
+   * This only works if keyrings are empty. If there is a pre-existing unlocked vault, calling this will have no effect.
+   * If there is a pre-existing locked vault, it will be replaced.
    *
    * @param password - Password to unlock the new vault.
-   * @returns Promise resolving when the operation ends successfully.
    */
   async createNewVaultAndKeychain(password: string) {
     return this.#persistOrRollback(async () => {


### PR DESCRIPTION
## Explanation

The tests for `createNewVaultAndKeychain` have been improved. Many of them did not call the function-under-test at all, or they called it in the wrong circumstances.

The inline comment for the function was updated to be more accurate. It implied that an existing vault would be wiped out, but that's not necessarily true.


## References

N/A

## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
