### PR TITLE
refactor(permission-controller)!: Fix various lint rule violations

### DIFF
--- a/packages/permission-controller/.eslintrc.js
+++ b/packages/permission-controller/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
             selector: 'objectLiteralMethod',
             format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
           },
+          // This option is modified.
           {
             selector: 'objectLiteralProperty',
             format: ['camelCase', 'PascalCase', 'UPPER_CASE'],

--- a/packages/permission-controller/.eslintrc.js
+++ b/packages/permission-controller/.eslintrc.js
@@ -1,0 +1,31 @@
+module.exports = {
+  extends: ['../../.eslintrc.js'],
+
+  overrides: [
+    {
+      files: [
+        'src/PermissionController.test.ts',
+        'src/rpc-methods/revokePermissions.test.ts',
+      ],
+      rules: {
+        '@typescript-eslint/naming-convention': [
+          'error',
+          {
+            selector: 'objectLiteralProperty',
+            format: ['camelCase', 'UPPER_CASE'],
+            leadingUnderscore: 'allow',
+            filter: {
+              regex: '^[a-z][a-zA-Z0-9]*_w+$',
+              match: true,
+            },
+          },
+          {
+            selector: 'objectLiteralProperty',
+            format: null,
+            modifiers: ['requiresQuotes'],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/permission-controller/.eslintrc.js
+++ b/packages/permission-controller/.eslintrc.js
@@ -11,7 +11,8 @@ module.exports = {
         // This is taken directly from @metamask/eslint-config-typescript@12.1.0
         '@typescript-eslint/naming-convention': [
           'error',
-          // We have to disable the default selector, or it doesn't work.
+          // We have to disable the default selector for our objectLiteralProperty
+          // filter to work.
           // {
           //   selector: 'default',
           //   format: ['camelCase'],
@@ -34,7 +35,7 @@ module.exports = {
             selector: 'objectLiteralMethod',
             format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
           },
-          // This option is modified.
+          // This option is modified by the addition of a filter.
           {
             selector: 'objectLiteralProperty',
             format: ['camelCase', 'PascalCase', 'UPPER_CASE'],

--- a/packages/permission-controller/.eslintrc.js
+++ b/packages/permission-controller/.eslintrc.js
@@ -8,19 +8,74 @@ module.exports = {
         'src/rpc-methods/revokePermissions.test.ts',
       ],
       rules: {
+        // This is taken directly from @metamask/eslint-config-typescript@12.1.0
         '@typescript-eslint/naming-convention': [
           'error',
+          // We have to disable the default selector, or it doesn't work.
+          // {
+          //   selector: 'default',
+          //   format: ['camelCase'],
+          //   leadingUnderscore: 'allow',
+          //   trailingUnderscore: 'forbid',
+          // },
+          {
+            selector: 'enumMember',
+            format: ['PascalCase'],
+          },
+          {
+            selector: 'interface',
+            format: ['PascalCase'],
+            custom: {
+              regex: '^I[A-Z]',
+              match: false,
+            },
+          },
+          {
+            selector: 'objectLiteralMethod',
+            format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+          },
           {
             selector: 'objectLiteralProperty',
-            format: ['camelCase', 'UPPER_CASE'],
-            leadingUnderscore: 'allow',
+            format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
             filter: {
-              regex: '^[a-z][a-zA-Z0-9]*_w+$',
+              // Match RPC method names like foo_bar, foo_barBaz, etc., and metamask.io
+              regex: '(^[a-z]+_[a-z]+[a-zA-Z0-9]*)|metamask\\.io$',
+              match: false,
+            },
+          },
+          {
+            selector: 'typeLike',
+            format: ['PascalCase'],
+          },
+          {
+            selector: 'typeParameter',
+            format: ['PascalCase'],
+            custom: {
+              regex: '^.{3,}',
               match: true,
             },
           },
           {
-            selector: 'objectLiteralProperty',
+            selector: 'variable',
+            format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+            leadingUnderscore: 'allow',
+          },
+          {
+            selector: 'parameter',
+            format: ['camelCase', 'PascalCase'],
+            leadingUnderscore: 'allow',
+          },
+          {
+            selector: [
+              'classProperty',
+              'objectLiteralProperty',
+              'typeProperty',
+              'classMethod',
+              'objectLiteralMethod',
+              'typeMethod',
+              'accessor',
+              'enumMember',
+            ],
             format: null,
             modifiers: ['requiresQuotes'],
           },

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -754,9 +754,9 @@ describe('PermissionController', () => {
                 },
               }),
             ),
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        ).toThrow(`Invalid permission type: "${invalidPermissionType}"`);
+        ).toThrow(
+          `Invalid permission type: "${String(invalidPermissionType)}"`,
+        );
       });
     });
 
@@ -6028,9 +6028,7 @@ describe('PermissionController', () => {
 
       const updateCaveatSpy = jest.spyOn(controller, 'updateCaveat');
 
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-      // eslint-disable-next-line @typescript-eslint/await-thenable
-      await messenger.call(
+      messenger.call(
         'PermissionController:updateCaveat',
         'metamask.io',
         'wallet_getSecretArray',
@@ -6199,7 +6197,7 @@ describe('PermissionController', () => {
           'Unauthorized to perform action. Try requesting the required permission(s) first. For more information, see: https://docs.metamask.io/guide/rpc-api.html#permissions',
       });
 
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // TypeScript is confused; this signature is async.
       // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);
@@ -6223,7 +6221,7 @@ describe('PermissionController', () => {
 
       const expectedError = errors.methodNotFound('wallet_foo', { origin });
 
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // TypeScript is confused; this signature is async.
       // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);
@@ -6274,7 +6272,7 @@ describe('PermissionController', () => {
         { request: { ...request } },
       );
 
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // TypeScript is confused; this signature is async.
       // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -6197,7 +6197,7 @@ describe('PermissionController', () => {
           'Unauthorized to perform action. Try requesting the required permission(s) first. For more information, see: https://docs.metamask.io/guide/rpc-api.html#permissions',
       });
 
-      // TypeScript is confused; this signature is async.
+      // ESLint is confused; this signature is async.
       // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);
@@ -6221,7 +6221,7 @@ describe('PermissionController', () => {
 
       const expectedError = errors.methodNotFound('wallet_foo', { origin });
 
-      // TypeScript is confused; this signature is async.
+      // ESLint is confused; this signature is async.
       // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);
@@ -6272,7 +6272,7 @@ describe('PermissionController', () => {
         { request: { ...request } },
       );
 
-      // TypeScript is confused; this signature is async.
+      // ESLint is confused; this signature is async.
       // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -610,7 +610,7 @@ type AddPermissionRequestParams = {
   id: string;
   origin: string;
   requestData: PermissionsRequest;
-  type: MethodNames.requestPermissions;
+  type: MethodNames.RequestPermissions;
 };
 
 type AddPermissionRequestArgs = [string, AddPermissionRequestParams];
@@ -2206,7 +2206,7 @@ describe('PermissionController', () => {
         CaveatTypes.filterArrayResponse,
         () => {
           return {
-            operation: CaveatMutatorOperation.updateValue,
+            operation: CaveatMutatorOperation.UpdateValue,
             value: ['a', 'b'],
           };
         },
@@ -2222,7 +2222,7 @@ describe('PermissionController', () => {
       controller.updatePermissionsByCaveat(
         CaveatTypes.filterArrayResponse,
         () => {
-          return { operation: CaveatMutatorOperation.noop };
+          return { operation: CaveatMutatorOperation.Noop };
         },
       );
       expect(controller.state).toStrictEqual(getMultiCaveatStateMatcher());
@@ -2235,7 +2235,7 @@ describe('PermissionController', () => {
         CaveatTypes.filterArrayResponse,
         () => {
           return {
-            operation: CaveatMutatorOperation.updateValue,
+            operation: CaveatMutatorOperation.UpdateValue,
             value: ['a', 'b'],
           };
         },
@@ -2273,9 +2273,9 @@ describe('PermissionController', () => {
       const mutator = () => {
         counter += 1;
         return counter === 1
-          ? { operation: CaveatMutatorOperation.noop as const }
+          ? { operation: CaveatMutatorOperation.Noop as const }
           : {
-              operation: CaveatMutatorOperation.updateValue as const,
+              operation: CaveatMutatorOperation.UpdateValue as const,
               value: ['a', 'b'],
             };
       };
@@ -2307,7 +2307,7 @@ describe('PermissionController', () => {
       controller.updatePermissionsByCaveat(
         CaveatTypes.filterArrayResponse,
         () => {
-          return { operation: CaveatMutatorOperation.deleteCaveat };
+          return { operation: CaveatMutatorOperation.DeleteCaveat };
         },
       );
 
@@ -2339,7 +2339,7 @@ describe('PermissionController', () => {
       controller.updatePermissionsByCaveat(
         CaveatTypes.filterObjectResponse,
         () => {
-          return { operation: CaveatMutatorOperation.revokePermission };
+          return { operation: CaveatMutatorOperation.RevokePermission };
         },
       );
 
@@ -2364,8 +2364,8 @@ describe('PermissionController', () => {
         return {
           operation:
             counter === 1
-              ? CaveatMutatorOperation.revokePermission
-              : CaveatMutatorOperation.noop,
+              ? CaveatMutatorOperation.RevokePermission
+              : CaveatMutatorOperation.Noop,
         };
       };
 
@@ -2389,7 +2389,7 @@ describe('PermissionController', () => {
           CaveatTypes.filterArrayResponse,
           () => {
             return {
-              operation: CaveatMutatorOperation.updateValue,
+              operation: CaveatMutatorOperation.UpdateValue,
               value: 'foo',
             };
           },
@@ -2402,7 +2402,7 @@ describe('PermissionController', () => {
 
       expect(() =>
         controller.updatePermissionsByCaveat(CaveatTypes.noopCaveat, () => {
-          return { operation: CaveatMutatorOperation.deleteCaveat };
+          return { operation: CaveatMutatorOperation.DeleteCaveat };
         }),
       ).toThrow('noopWithRequiredCaveat permission validation failed');
     });
@@ -3340,7 +3340,7 @@ describe('PermissionController', () => {
               permissions: { [PermissionNames.wallet_getSecretArray]: {} },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -3392,7 +3392,7 @@ describe('PermissionController', () => {
               permissions: { [PermissionNames.wallet_getSecretArray]: {} },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -3463,7 +3463,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -3543,7 +3543,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -3639,7 +3639,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -3728,7 +3728,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -3787,7 +3787,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -3861,7 +3861,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -3917,7 +3917,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -3987,7 +3987,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -4066,7 +4066,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -4141,7 +4141,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -4225,7 +4225,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -4502,7 +4502,7 @@ describe('PermissionController', () => {
               permissions: { [PermissionNames.snap_foo]: {} },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -4617,7 +4617,7 @@ describe('PermissionController', () => {
                 permissions: { [PermissionNames.wallet_getSecretArray]: {} },
                 ...getRequestDataDiffProperty(),
               },
-              type: MethodNames.requestPermissions,
+              type: MethodNames.RequestPermissions,
             },
             true,
           );
@@ -4669,7 +4669,7 @@ describe('PermissionController', () => {
               permissions: { [PermissionNames.wallet_getSecretArray]: {} },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -4720,7 +4720,7 @@ describe('PermissionController', () => {
               permissions: { [PermissionNames.wallet_getSecretArray]: {} },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -4770,7 +4770,7 @@ describe('PermissionController', () => {
               permissions: { [PermissionNames.wallet_getSecretArray]: {} },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -4832,7 +4832,7 @@ describe('PermissionController', () => {
                 permissions: { [PermissionNames.wallet_getSecretArray]: {} },
                 ...getRequestDataDiffProperty(),
               },
-              type: MethodNames.requestPermissions,
+              type: MethodNames.RequestPermissions,
             },
             true,
           );
@@ -4907,7 +4907,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -4968,7 +4968,7 @@ describe('PermissionController', () => {
               },
               ...getRequestDataDiffProperty(),
             },
-            type: MethodNames.requestPermissions,
+            type: MethodNames.RequestPermissions,
           },
           true,
         );
@@ -5198,7 +5198,7 @@ describe('PermissionController', () => {
                 },
                 diff: getPermissionDiffMatcher(leftCaveats, caveatsDiff),
               },
-              type: MethodNames.requestPermissions,
+              type: MethodNames.RequestPermissions,
             },
             true,
           );

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -67,16 +67,14 @@ type FilterObjectCaveat = Caveat<
 type NoopCaveat = Caveat<typeof CaveatTypes.noopCaveat, null>;
 
 // A caveat value merger for any caveat whose value is an array of JSON primitives.
-// TODO: Either fix this lint violation or explain why it's necessary to ignore.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const primitiveArrayMerger = <T extends string | null | number>(
-  a: T[],
-  b: T[],
+const primitiveArrayMerger = <Element extends string | null | number>(
+  a: Element[],
+  b: Element[],
 ) => {
   const diff = b.filter((element) => !a.includes(element));
 
   if (diff.length > 0) {
-    return [[...(a ?? []), ...diff], diff] as [T[], T[]];
+    return [[...(a ?? []), ...diff], diff] as [Element[], Element[]];
   }
   return [] as [];
 };
@@ -205,43 +203,19 @@ type DefaultCaveatSpecifications = ExtractSpecifications<
  * Permission key constants.
  */
 const PermissionKeys = {
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_doubleNumber: 'wallet_doubleNumber',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_getSecretArray: 'wallet_getSecretArray',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_getSecretObject: 'wallet_getSecretObject',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noop: 'wallet_noop',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedAndFailureSideEffects:
     'wallet_noopWithPermittedAndFailureSideEffects',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedAndFailureSideEffects2:
     'wallet_noopWithPermittedAndFailureSideEffects2',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedSideEffects: 'wallet_noopWithPermittedSideEffects',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithValidator: 'wallet_noopWithValidator',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithRequiredCaveat: 'wallet_noopWithRequiredCaveat',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithFactory: 'wallet_noopWithFactory',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithManyCaveats: 'wallet_noopWithManyCaveats',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   snap_foo: 'snap_foo',
   endowmentAnySubject: 'endowmentAnySubject',
   endowmentSnapsOnly: 'endowmentSnapsOnly',
@@ -261,44 +235,20 @@ type NoopWithFactoryPermission = ValidPermission<
  * Permission name (as opposed to keys) constants and getters.
  */
 const PermissionNames = {
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_doubleNumber: PermissionKeys.wallet_doubleNumber,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_getSecretArray: PermissionKeys.wallet_getSecretArray,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_getSecretObject: PermissionKeys.wallet_getSecretObject,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noop: PermissionKeys.wallet_noop,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithValidator: PermissionKeys.wallet_noopWithValidator,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedAndFailureSideEffects:
     PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedAndFailureSideEffects2:
     PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects2,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithPermittedSideEffects:
     PermissionKeys.wallet_noopWithPermittedSideEffects,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithRequiredCaveat: PermissionKeys.wallet_noopWithRequiredCaveat,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithFactory: PermissionKeys.wallet_noopWithFactory,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   wallet_noopWithManyCaveats: PermissionKeys.wallet_noopWithManyCaveats,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   snap_foo: PermissionKeys.snap_foo,
   endowmentAnySubject: PermissionKeys.endowmentAnySubject,
   endowmentSnapsOnly: PermissionKeys.endowmentSnapsOnly,
@@ -674,8 +624,6 @@ function getExistingPermissionState() {
       'metamask.io': {
         origin: 'metamask.io',
         permissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {
             id: 'escwEx9JrOxGZKZk3RkL4',
             parentCapability: 'wallet_getSecretArray',
@@ -974,8 +922,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -985,8 +931,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'bar' },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -1544,8 +1488,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: [
@@ -1579,8 +1521,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
                 caveats: [
@@ -1605,8 +1545,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
                 caveats: [
@@ -1724,8 +1662,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: [
@@ -1750,8 +1686,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: [
@@ -1856,8 +1790,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: [
@@ -1881,8 +1813,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: null,
@@ -1915,8 +1845,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
                 caveats: [
@@ -1941,8 +1869,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
                 caveats: [
@@ -2046,15 +1972,9 @@ describe('PermissionController', () => {
 
   describe('updatePermissionsByCaveat', () => {
     enum MultiCaveatOrigins {
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      a = 'a.com',
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      b = 'b.io',
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      c = 'c.biz',
+      A = 'a.com',
+      B = 'b.io',
+      C = 'c.biz',
     }
 
     /**
@@ -2066,7 +1986,7 @@ describe('PermissionController', () => {
       const controller = getDefaultPermissionController();
 
       controller.grantPermissions({
-        subject: { origin: MultiCaveatOrigins.a },
+        subject: { origin: MultiCaveatOrigins.A },
         approvedPermissions: {
           [PermissionNames.wallet_getSecretArray]: {
             caveats: [{ type: CaveatTypes.filterArrayResponse, value: ['a'] }],
@@ -2075,7 +1995,7 @@ describe('PermissionController', () => {
       });
 
       controller.grantPermissions({
-        subject: { origin: MultiCaveatOrigins.b },
+        subject: { origin: MultiCaveatOrigins.B },
         approvedPermissions: {
           [PermissionNames.wallet_getSecretArray]: {
             caveats: [
@@ -2097,7 +2017,7 @@ describe('PermissionController', () => {
       });
 
       controller.grantPermissions({
-        subject: { origin: MultiCaveatOrigins.c },
+        subject: { origin: MultiCaveatOrigins.C },
         approvedPermissions: {
           [PermissionNames.wallet_getSecretObject]: {
             caveats: [{ type: CaveatTypes.filterObjectResponse, value: ['c'] }],
@@ -2118,22 +2038,22 @@ describe('PermissionController', () => {
     ) => {
       return {
         subjects: {
-          [MultiCaveatOrigins.a]: {
-            origin: MultiCaveatOrigins.a,
+          [MultiCaveatOrigins.A]: {
+            origin: MultiCaveatOrigins.A,
             permissions: {
               [PermissionNames.wallet_getSecretArray]: getPermissionMatcher({
                 parentCapability: PermissionNames.wallet_getSecretArray,
                 caveats: [
                   { type: CaveatTypes.filterArrayResponse, value: ['a'] },
                 ],
-                invoker: MultiCaveatOrigins.a,
+                invoker: MultiCaveatOrigins.A,
               }),
-              ...overrides[MultiCaveatOrigins.a],
+              ...overrides[MultiCaveatOrigins.A],
             },
           },
 
-          [MultiCaveatOrigins.b]: {
-            origin: MultiCaveatOrigins.b,
+          [MultiCaveatOrigins.B]: {
+            origin: MultiCaveatOrigins.B,
             permissions: {
               [PermissionNames.wallet_getSecretArray]: getPermissionMatcher({
                 parentCapability: PermissionNames.wallet_getSecretArray,
@@ -2141,7 +2061,7 @@ describe('PermissionController', () => {
                   { type: CaveatTypes.filterArrayResponse, value: ['b'] },
                   { type: CaveatTypes.reverseArrayResponse, value: null },
                 ],
-                invoker: MultiCaveatOrigins.b,
+                invoker: MultiCaveatOrigins.B,
               }),
               [PermissionNames.wallet_getSecretObject]: getPermissionMatcher({
                 parentCapability: PermissionNames.wallet_getSecretObject,
@@ -2149,42 +2069,42 @@ describe('PermissionController', () => {
                   { type: CaveatTypes.filterObjectResponse, value: ['b'] },
                   { type: CaveatTypes.noopCaveat, value: null },
                 ],
-                invoker: MultiCaveatOrigins.b,
+                invoker: MultiCaveatOrigins.B,
               }),
               [PermissionNames.wallet_noopWithRequiredCaveat]:
                 getPermissionMatcher({
                   parentCapability:
                     PermissionNames.wallet_noopWithRequiredCaveat,
                   caveats: [{ type: CaveatTypes.noopCaveat, value: null }],
-                  invoker: MultiCaveatOrigins.b,
+                  invoker: MultiCaveatOrigins.B,
                 }),
               [PermissionNames.wallet_doubleNumber]: getPermissionMatcher({
                 parentCapability: PermissionNames.wallet_doubleNumber,
                 caveats: null,
-                invoker: MultiCaveatOrigins.b,
+                invoker: MultiCaveatOrigins.B,
               }),
-              ...overrides[MultiCaveatOrigins.b],
+              ...overrides[MultiCaveatOrigins.B],
             },
           },
 
-          [MultiCaveatOrigins.c]: {
-            origin: MultiCaveatOrigins.c,
+          [MultiCaveatOrigins.C]: {
+            origin: MultiCaveatOrigins.C,
             permissions: {
               [PermissionNames.wallet_getSecretObject]: getPermissionMatcher({
                 parentCapability: PermissionNames.wallet_getSecretObject,
                 caveats: [
                   { type: CaveatTypes.filterObjectResponse, value: ['c'] },
                 ],
-                invoker: MultiCaveatOrigins.c,
+                invoker: MultiCaveatOrigins.C,
               }),
               [PermissionNames.wallet_noopWithRequiredCaveat]:
                 getPermissionMatcher({
                   parentCapability:
                     PermissionNames.wallet_noopWithRequiredCaveat,
                   caveats: [{ type: CaveatTypes.noopCaveat, value: null }],
-                  invoker: MultiCaveatOrigins.c,
+                  invoker: MultiCaveatOrigins.C,
                 }),
-              ...overrides[MultiCaveatOrigins.c],
+              ...overrides[MultiCaveatOrigins.C],
             },
           },
         },
@@ -2243,23 +2163,23 @@ describe('PermissionController', () => {
 
       expect(controller.state).toStrictEqual(
         getMultiCaveatStateMatcher({
-          [MultiCaveatOrigins.a]: {
+          [MultiCaveatOrigins.A]: {
             [PermissionNames.wallet_getSecretArray]: getPermissionMatcher({
               parentCapability: PermissionNames.wallet_getSecretArray,
               caveats: [
                 { type: CaveatTypes.filterArrayResponse, value: ['a', 'b'] },
               ],
-              invoker: MultiCaveatOrigins.a,
+              invoker: MultiCaveatOrigins.A,
             }),
           },
-          [MultiCaveatOrigins.b]: {
+          [MultiCaveatOrigins.B]: {
             [PermissionNames.wallet_getSecretArray]: getPermissionMatcher({
               parentCapability: PermissionNames.wallet_getSecretArray,
               caveats: [
                 { type: CaveatTypes.filterArrayResponse, value: ['a', 'b'] },
                 { type: CaveatTypes.reverseArrayResponse, value: null },
               ],
-              invoker: MultiCaveatOrigins.b,
+              invoker: MultiCaveatOrigins.B,
             }),
           },
         }),
@@ -2287,14 +2207,14 @@ describe('PermissionController', () => {
 
       expect(controller.state).toStrictEqual(
         getMultiCaveatStateMatcher({
-          [MultiCaveatOrigins.b]: {
+          [MultiCaveatOrigins.B]: {
             [PermissionNames.wallet_getSecretArray]: getPermissionMatcher({
               parentCapability: PermissionNames.wallet_getSecretArray,
               caveats: [
                 { type: CaveatTypes.filterArrayResponse, value: ['a', 'b'] },
                 { type: CaveatTypes.reverseArrayResponse, value: null },
               ],
-              invoker: MultiCaveatOrigins.b,
+              invoker: MultiCaveatOrigins.B,
             }),
           },
         }),
@@ -2313,20 +2233,20 @@ describe('PermissionController', () => {
 
       expect(controller.state).toStrictEqual(
         getMultiCaveatStateMatcher({
-          [MultiCaveatOrigins.a]: {
+          [MultiCaveatOrigins.A]: {
             [PermissionNames.wallet_getSecretArray]: getPermissionMatcher({
               parentCapability: PermissionNames.wallet_getSecretArray,
               caveats: null,
-              invoker: MultiCaveatOrigins.a,
+              invoker: MultiCaveatOrigins.A,
             }),
           },
-          [MultiCaveatOrigins.b]: {
+          [MultiCaveatOrigins.B]: {
             [PermissionNames.wallet_getSecretArray]: getPermissionMatcher({
               parentCapability: PermissionNames.wallet_getSecretArray,
               caveats: [
                 { type: CaveatTypes.reverseArrayResponse, value: null },
               ],
-              invoker: MultiCaveatOrigins.b,
+              invoker: MultiCaveatOrigins.B,
             }),
           },
         }),
@@ -2344,11 +2264,11 @@ describe('PermissionController', () => {
       );
 
       const matcher = getMultiCaveatStateMatcher();
-      delete matcher.subjects[MultiCaveatOrigins.b].permissions[
+      delete matcher.subjects[MultiCaveatOrigins.B].permissions[
         PermissionNames.wallet_getSecretObject
       ];
 
-      delete matcher.subjects[MultiCaveatOrigins.c].permissions[
+      delete matcher.subjects[MultiCaveatOrigins.C].permissions[
         PermissionNames.wallet_getSecretObject
       ];
 
@@ -2376,7 +2296,7 @@ describe('PermissionController', () => {
 
       const matcher = getMultiCaveatStateMatcher();
       // @ts-expect-error Intentional destructive testing
-      delete matcher.subjects[MultiCaveatOrigins.a];
+      delete matcher.subjects[MultiCaveatOrigins.A];
 
       expect(controller.state).toStrictEqual(matcher);
     });
@@ -2430,8 +2350,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -2441,8 +2359,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
@@ -2459,11 +2375,7 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretObject: {
             parentCapability: 'wallet_getSecretObject',
           },
@@ -2475,13 +2387,9 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
               }),
@@ -2499,8 +2407,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: origin1 },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretObject: {},
         },
       });
@@ -2508,8 +2414,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: origin2 },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -2519,8 +2423,6 @@ describe('PermissionController', () => {
           [origin1]: {
             origin: origin1,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
                 caveats: null,
@@ -2531,8 +2433,6 @@ describe('PermissionController', () => {
           [origin2]: {
             origin: origin2,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
                 caveats: null,
@@ -2619,8 +2519,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
@@ -2632,8 +2530,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretObject: {},
         },
         // preserveExistingPermissions is true by default
@@ -2644,13 +2540,9 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
               }),
@@ -2669,8 +2561,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
@@ -2682,8 +2572,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretObject: {},
         },
         preserveExistingPermissions: false,
@@ -2694,8 +2582,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
               }),
@@ -2712,8 +2598,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin: '' },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {},
           },
         }),
@@ -2724,8 +2608,6 @@ describe('PermissionController', () => {
           // @ts-expect-error Intentional destructive testing
           subject: { origin: 2 },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {},
           },
         }),
@@ -2739,8 +2621,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin: 'metamask.io' },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretFalafel: {},
           },
         }),
@@ -2755,8 +2635,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               // This must match the key
               parentCapability: 'wallet_getSecretObject',
@@ -2775,13 +2653,9 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               parentCapability: 'wallet_getSecretArray',
             },
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretObject: {
               // This must match the key
               parentCapability: 'wallet_getSecretArray',
@@ -2805,8 +2679,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               parentCapability: 'wallet_getSecretArray',
               caveats: [
@@ -2833,8 +2705,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               // @ts-expect-error Intentional destructive testing
               caveats: [[]],
@@ -2853,8 +2723,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               // @ts-expect-error Intentional destructive testing
               caveats: ['foo'],
@@ -2878,8 +2746,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               caveats: [
                 {
@@ -2911,8 +2777,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               caveats: [
                 {
@@ -2944,8 +2808,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               caveats: [{ type: 'fooType', value: 'bar' }],
             },
@@ -2968,8 +2830,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretArray: {
               caveats: [
                 {
@@ -3007,8 +2867,6 @@ describe('PermissionController', () => {
             controller.grantPermissions({
               subject: { origin },
               approvedPermissions: {
-                // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-                // eslint-disable-next-line @typescript-eslint/naming-convention
                 wallet_getSecretArray: {
                   caveats: [
                     {
@@ -3063,8 +2921,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_getSecretObject: {
               caveats: [
                 {
@@ -3092,8 +2948,6 @@ describe('PermissionController', () => {
         controller.grantPermissions({
           subject: { origin },
           approvedPermissions: {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             wallet_doubleNumber: {
               caveats: [
                 {
@@ -3143,8 +2997,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
@@ -3156,8 +3008,6 @@ describe('PermissionController', () => {
       controller.grantPermissionsIncremental({
         subject: { origin },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretObject: {},
         },
       });
@@ -3167,13 +3017,9 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretArray',
               }),
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretObject: getPermissionMatcher({
                 parentCapability: 'wallet_getSecretObject',
               }),
@@ -3195,8 +3041,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_noopWithManyCaveats: {
             caveats: [{ ...caveat1 }],
           },
@@ -3206,8 +3050,6 @@ describe('PermissionController', () => {
       controller.grantPermissionsIncremental({
         subject: { origin },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_noopWithManyCaveats: {
             caveats: [{ ...caveat2 }],
           },
@@ -3219,8 +3061,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_noopWithManyCaveats: getPermissionMatcher({
                 parentCapability: 'wallet_noopWithManyCaveats',
                 caveats: [{ ...caveat1 }, { ...caveat2 }],
@@ -3242,8 +3082,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_noopWithManyCaveats: {
             caveats: [getCaveat('foo')],
           },
@@ -3253,8 +3091,6 @@ describe('PermissionController', () => {
       controller.grantPermissionsIncremental({
         subject: { origin },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_noopWithManyCaveats: {
             caveats: [getCaveat('foo', 'bar')],
           },
@@ -3266,8 +3102,6 @@ describe('PermissionController', () => {
           [origin]: {
             origin,
             permissions: expect.objectContaining({
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_noopWithManyCaveats: getPermissionMatcher({
                 parentCapability: 'wallet_noopWithManyCaveats',
                 caveats: [getCaveat('foo', 'bar')],
@@ -4343,8 +4177,6 @@ describe('PermissionController', () => {
               { origin },
               {
                 [PermissionNames.wallet_getSecretArray]: {},
-                // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-                // eslint-disable-next-line @typescript-eslint/naming-convention
                 wallet_getSecretKabob: {},
               },
             ),
@@ -4354,8 +4186,6 @@ describe('PermissionController', () => {
             requestedPermissions: {
               [PermissionNames.wallet_getSecretArray]: {
                 [PermissionNames.wallet_getSecretArray]: {},
-                // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-                // eslint-disable-next-line @typescript-eslint/naming-convention
                 wallet_getSecretKabob: {},
               },
             },
@@ -5755,8 +5585,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -5859,8 +5687,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -5951,8 +5777,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -5983,8 +5807,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -6014,8 +5836,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -6050,8 +5870,6 @@ describe('PermissionController', () => {
       controller.grantPermissions({
         subject: { origin: 'foo' },
         approvedPermissions: {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       });
@@ -6091,8 +5909,6 @@ describe('PermissionController', () => {
 
       const result = messenger.call('PermissionController:grantPermissions', {
         subject: { origin: 'foo' },
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         approvedPermissions: { wallet_getSecretArray: {} },
       });
 
@@ -6116,8 +5932,6 @@ describe('PermissionController', () => {
         'PermissionController:grantPermissionsIncremental',
         {
           subject: { origin: 'foo' },
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           approvedPermissions: { wallet_getSecretArray: {} },
         },
       );
@@ -6148,8 +5962,6 @@ describe('PermissionController', () => {
         'PermissionController:requestPermissions',
         { origin: 'foo' },
         {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       );
@@ -6177,8 +5989,6 @@ describe('PermissionController', () => {
         'PermissionController:requestPermissionsIncremental',
         { origin: 'foo' },
         {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getSecretArray: {},
         },
       );
@@ -6193,8 +6003,6 @@ describe('PermissionController', () => {
           'metamask.io': {
             origin: 'metamask.io',
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: {
                 id: 'escwEx9JrOxGZKZk3RkL4',
                 parentCapability: 'wallet_getSecretArray',
@@ -6236,8 +6044,6 @@ describe('PermissionController', () => {
           'metamask.io': {
             origin: 'metamask.io',
             permissions: {
-              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               wallet_getSecretArray: {
                 id: 'escwEx9JrOxGZKZk3RkL4',
                 parentCapability: 'wallet_getSecretArray',

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -429,18 +429,10 @@ export type GenericPermissionController = PermissionController<
  * Describes the possible results of a {@link CaveatMutator} function.
  */
 export enum CaveatMutatorOperation {
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  noop,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  updateValue,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  deleteCaveat,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  revokePermission,
+  Noop,
+  UpdateValue,
+  DeleteCaveat,
+  RevokePermission,
 }
 
 /**
@@ -459,20 +451,18 @@ export type CaveatMutator<TargetCaveat extends CaveatConstraint> = (
 
 type CaveatMutatorResult =
   | Readonly<{
-      operation: CaveatMutatorOperation.updateValue;
+      operation: CaveatMutatorOperation.UpdateValue;
       value: CaveatConstraint['value'];
     }>
   | Readonly<{
       operation: Exclude<
         CaveatMutatorOperation,
-        CaveatMutatorOperation.updateValue
+        CaveatMutatorOperation.UpdateValue
       >;
     }>;
 
-// TODO: Either fix this lint violation or explain why it's necessary to ignore.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-type MergeCaveatResult<T extends CaveatConstraint | undefined> =
-  T extends undefined
+type MergeCaveatResult<CaveatType extends CaveatConstraint | undefined> =
+  CaveatType extends undefined
     ? [CaveatConstraint, CaveatConstraint['value']]
     : [CaveatConstraint, CaveatConstraint['value']] | [];
 
@@ -1408,10 +1398,10 @@ export class PermissionController<
    * value to update the existing caveat with.
    *
    * For each caveat, depending on the mutator result, this method will:
-   * - Do nothing ({@link CaveatMutatorOperation.noop})
-   * - Update the value of the caveat ({@link CaveatMutatorOperation.updateValue}). The caveat specification validator, if any, will be called after updating the value.
-   * - Delete the caveat ({@link CaveatMutatorOperation.deleteCaveat}). The permission specification validator, if any, will be called after deleting the caveat.
-   * - Revoke the parent permission ({@link CaveatMutatorOperation.revokePermission})
+   * - Do nothing ({@link CaveatMutatorOperation.Noop})
+   * - Update the value of the caveat ({@link CaveatMutatorOperation.UpdateValue}). The caveat specification validator, if any, will be called after updating the value.
+   * - Delete the caveat ({@link CaveatMutatorOperation.DeleteCaveat}). The permission specification validator, if any, will be called after deleting the caveat.
+   * - Revoke the parent permission ({@link CaveatMutatorOperation.RevokePermission})
    *
    * This method throws if the validation of any caveat or permission fails.
    *
@@ -1446,10 +1436,10 @@ export class PermissionController<
           const mutatorResult = mutator(targetCaveat.value);
           const { operation } = mutatorResult;
           switch (operation) {
-            case CaveatMutatorOperation.noop:
+            case CaveatMutatorOperation.Noop:
               break;
 
-            case CaveatMutatorOperation.updateValue:
+            case CaveatMutatorOperation.UpdateValue:
               // Typecast: `Mutable` is used here to assign to a readonly
               // property. `targetConstraint` should already be mutable because
               // it's part of a draft, but for some reason it's not. We can't
@@ -1465,11 +1455,11 @@ export class PermissionController<
               );
               break;
 
-            case CaveatMutatorOperation.deleteCaveat:
+            case CaveatMutatorOperation.DeleteCaveat:
               this.deleteCaveat(permission, targetCaveatType, subject.origin);
               break;
 
-            case CaveatMutatorOperation.revokePermission:
+            case CaveatMutatorOperation.RevokePermission:
               this.deletePermission(
                 draftState.subjects,
                 subject.origin,
@@ -2324,13 +2314,11 @@ export class PermissionController<
    * @returns The merged permission.
    */
   #mergePermission<
-    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    T extends Partial<PermissionConstraint> | PermissionConstraint,
+    PermissionType extends Partial<PermissionConstraint> | PermissionConstraint,
   >(
-    leftPermission: T | undefined,
-    rightPermission: T,
-  ): [T, CaveatDiffMap<CaveatConstraint>] {
+    leftPermission: PermissionType | undefined,
+    rightPermission: PermissionType,
+  ): [PermissionType, CaveatDiffMap<CaveatConstraint>] {
     const { caveatPairs, leftUniqueCaveats, rightUniqueCaveats } =
       collectUniqueAndPairedCaveats(leftPermission, rightPermission);
 
@@ -2382,12 +2370,13 @@ export class PermissionController<
    * @param rightCaveat - The right-hand caveat to merge.
    * @returns The merged caveat and the diff between the two caveats.
    */
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  #mergeCaveat<T extends CaveatConstraint, U extends T | undefined>(
-    leftCaveat: U,
-    rightCaveat: T,
-  ): MergeCaveatResult<U> {
+  #mergeCaveat<
+    RightCaveat extends CaveatConstraint,
+    LeftCaveat extends RightCaveat | undefined,
+  >(
+    leftCaveat: LeftCaveat,
+    rightCaveat: RightCaveat,
+  ): MergeCaveatResult<LeftCaveat> {
     /* istanbul ignore if: This should be impossible */
     if (leftCaveat !== undefined && leftCaveat.type !== rightCaveat.type) {
       throw new CaveatMergeTypeMismatchError(leftCaveat.type, rightCaveat.type);
@@ -2414,7 +2403,7 @@ export class PermissionController<
           },
           diff,
         ]
-      : ([] as MergeCaveatResult<U>);
+      : ([] as MergeCaveatResult<LeftCaveat>);
   }
 
   /**
@@ -2433,7 +2422,7 @@ export class PermissionController<
         id,
         origin,
         requestData: permissionsRequest,
-        type: MethodNames.requestPermissions,
+        type: MethodNames.RequestPermissions,
       },
       true,
     );

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -2661,9 +2661,7 @@ export class PermissionController<
     }
 
     try {
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.messagingSystem.call(
+      await this.messagingSystem.call(
         'ApprovalController:acceptRequest',
         id,
         request,

--- a/packages/permission-controller/src/SubjectMetadataController.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.ts
@@ -142,14 +142,14 @@ export class SubjectMetadataController extends BaseController<
     this.subjectsWithoutPermissionsEncounteredSinceStartup = new Set();
 
     this.messagingSystem.registerActionHandler(
-      // @typescript-eslint is confused by the string literal type.
+      // ESLint is confused by the string literal type.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:getSubjectMetadata`,
       this.getSubjectMetadata.bind(this),
     );
 
     this.messagingSystem.registerActionHandler(
-      // @typescript-eslint is confused by the string literal type.
+      // ESLint is confused by the string literal type.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:addSubjectMetadata`,
       this.addSubjectMetadata.bind(this),

--- a/packages/permission-controller/src/SubjectMetadataController.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.ts
@@ -142,14 +142,14 @@ export class SubjectMetadataController extends BaseController<
     this.subjectsWithoutPermissionsEncounteredSinceStartup = new Set();
 
     this.messagingSystem.registerActionHandler(
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // @typescript-eslint is confused by the string literal type.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:getSubjectMetadata`,
       this.getSubjectMetadata.bind(this),
     );
 
     this.messagingSystem.registerActionHandler(
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // @typescript-eslint is confused by the string literal type.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `${this.name}:addSubjectMetadata`,
       this.addSubjectMetadata.bind(this),

--- a/packages/permission-controller/src/errors.ts
+++ b/packages/permission-controller/src/errors.ts
@@ -160,9 +160,11 @@ export class EndowmentPermissionDoesNotExistError extends Error {
   public data?: { origin: string };
 
   constructor(target: string, origin?: string) {
-    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    super(`Subject "${origin}" has no permission for "${target}".`);
+    super(
+      `${
+        origin ? `Subject "${origin}"` : 'Unknown subject'
+      } has no permission for "${target}".`,
+    );
     if (origin) {
       this.data = { origin };
     }

--- a/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
@@ -14,17 +14,16 @@ describe('getPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push(
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      (
+      async (
         req: JsonRpcRequest<[]>,
         res: PendingJsonRpcResponse<PermissionConstraint[]>,
         next,
         end,
-      ) =>
-        implementation(req, res, next, end, {
+      ) => {
+        await implementation(req, res, next, end, {
           getPermissionsForOrigin: mockGetPermissionsForOrigin,
-        }),
+        });
+      },
     );
 
     const response = await engine.handle({
@@ -45,17 +44,16 @@ describe('getPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push(
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      (
+      async (
         req: JsonRpcRequest<[]>,
         res: PendingJsonRpcResponse<PermissionConstraint[]>,
         next,
         end,
-      ) =>
-        implementation(req, res, next, end, {
+      ) => {
+        await implementation(req, res, next, end, {
           getPermissionsForOrigin: mockGetPermissionsForOrigin,
-        }),
+        });
+      },
     );
 
     const response = await engine.handle({

--- a/packages/permission-controller/src/rpc-methods/getPermissions.ts
+++ b/packages/permission-controller/src/rpc-methods/getPermissions.ts
@@ -11,7 +11,7 @@ export const getPermissionsHandler: PermittedHandlerExport<
   [],
   PermissionConstraint[]
 > = {
-  methodNames: [MethodNames.getPermissions],
+  methodNames: [MethodNames.GetPermissions],
   implementation: getPermissionsImplementation,
   hookNames: {
     getPermissionsForOrigin: true,

--- a/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
@@ -32,12 +32,11 @@ describe('requestPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<[RequestedPermissions], PermissionConstraint[]>(
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      (req, res, next, end) =>
-        implementation(req, res, next, end, {
+      async (req, res, next, end) => {
+        await implementation(req, res, next, end, {
           requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
-        }),
+        });
+      },
     );
 
     const response = await engine.handle({
@@ -68,7 +67,7 @@ describe('requestPermissions RPC method', () => {
     // is catched.
     engine.push<[RequestedPermissions], PermissionConstraint[]>(
       createAsyncMiddleware(async (req, res, next) =>
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+        // This promise will be awaited by the createAsyncMiddleware wrapper.
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         implementation(req, res, next, end, {
           requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
@@ -103,8 +102,6 @@ describe('requestPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<[RequestedPermissions], PermissionConstraint[]>(
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) => {
         await implementation(req, res, next, end, {
           requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
@@ -128,7 +125,7 @@ describe('requestPermissions RPC method', () => {
       delete expectedError.stack;
 
       // @ts-expect-error Intentional destructive testing
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // TypeScript is confused; this signature is async.
       // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);

--- a/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
@@ -125,7 +125,7 @@ describe('requestPermissions RPC method', () => {
       delete expectedError.stack;
 
       // @ts-expect-error Intentional destructive testing
-      // TypeScript is confused; this signature is async.
+      // ESLint is confused; this signature is async.
       // eslint-disable-next-line @typescript-eslint/await-thenable
       const response = await engine.handle(request);
       assertIsJsonRpcFailure(response);

--- a/packages/permission-controller/src/rpc-methods/requestPermissions.ts
+++ b/packages/permission-controller/src/rpc-methods/requestPermissions.ts
@@ -12,7 +12,7 @@ export const requestPermissionsHandler: PermittedHandlerExport<
   [RequestedPermissions],
   PermissionConstraint[]
 > = {
-  methodNames: [MethodNames.requestPermissions],
+  methodNames: [MethodNames.RequestPermissions],
   implementation: requestPermissionsImplementation,
   hookNames: {
     requestPermissionsForOrigin: true,

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -83,7 +83,7 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TypeScript is confused; this signature is async.
+    // ESLint is confused; this signature is async.
     // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);
@@ -120,7 +120,7 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TypeScript is confused; this signature is async.
+    // ESLint is confused; this signature is async.
     // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);
@@ -156,7 +156,7 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TypeScript is confused; this signature is async.
+    // ESLint is confused; this signature is async.
     // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);
@@ -193,7 +193,7 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TypeScript is confused; this signature is async.
+    // ESLint is confused; this signature is async.
     // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -27,14 +27,11 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push<RevokePermissionArgs, null>(
-      // ESLint is confused; this expression evaluates to an async function.
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      async (req, res, next, end) =>
-        await implementation(req, res, next, end, {
-          revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
-        }),
-    );
+    engine.push<RevokePermissionArgs, null>(async (req, res, next, end) => {
+      await implementation(req, res, next, end, {
+        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+      });
+    });
 
     const response = await engine.handle({
       jsonrpc: '2.0',
@@ -60,14 +57,11 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push<RevokePermissionArgs, null>(
-      // ESLint is confused; this expression evaluates to an async function.
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      async (req, res, next, end) =>
-        await implementation(req, res, next, end, {
-          revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
-        }),
-    );
+    engine.push<RevokePermissionArgs, null>(async (req, res, next, end) => {
+      await implementation(req, res, next, end, {
+        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+      });
+    });
 
     const req: JsonRpcRequest<Record<string, Json>> = {
       jsonrpc: '2.0',
@@ -97,14 +91,11 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push<RevokePermissionArgs, null>(
-      // ESLint is confused; this expression evaluates to an async function.
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      async (req, res, next, end) =>
-        await implementation(req, res, next, end, {
-          revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
-        }),
-    );
+    engine.push<RevokePermissionArgs, null>(async (req, res, next, end) => {
+      await implementation(req, res, next, end, {
+        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+      });
+    });
 
     const req: JsonRpcRequest<[Record<string, Json>]> = {
       jsonrpc: '2.0',
@@ -134,14 +125,11 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push<RevokePermissionArgs, null>(
-      // ESLint is confused; this expression evaluates to an async function.
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      async (req, res, next, end) =>
-        await implementation(req, res, next, end, {
-          revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
-        }),
-    );
+    engine.push<RevokePermissionArgs, null>(async (req, res, next, end) => {
+      await implementation(req, res, next, end, {
+        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+      });
+    });
 
     const req: JsonRpcRequest<[]> = {
       jsonrpc: '2.0',
@@ -170,14 +158,11 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push<RevokePermissionArgs, null>(
-      // ESLint is confused; this expression evaluates to an async function.
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      async (req, res, next, end) =>
-        await implementation(req, res, next, end, {
-          revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
-        }),
-    );
+    engine.push<RevokePermissionArgs, null>(async (req, res, next, end) => {
+      await implementation(req, res, next, end, {
+        revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
+      });
+    });
 
     const req: JsonRpcRequest<Json[]> = {
       jsonrpc: '2.0',

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -42,7 +42,6 @@ describe('revokePermissions RPC method', () => {
       method: 'wallet_revokePermissions',
       params: [
         {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           snap_dialog: {},
         },
       ],

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -83,7 +83,7 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // TypeScript is confused; this signature is async.
     // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);
@@ -120,7 +120,7 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // TypeScript is confused; this signature is async.
     // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);
@@ -156,7 +156,7 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // TypeScript is confused; this signature is async.
     // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);
@@ -193,7 +193,7 @@ describe('revokePermissions RPC method', () => {
       .serialize();
     delete expectedError.stack;
 
-    // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+    // TypeScript is confused; this signature is async.
     // eslint-disable-next-line @typescript-eslint/await-thenable
     const response = await engine.handle(req);
     assertIsJsonRpcFailure(response);

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -28,7 +28,7 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<RevokePermissionArgs, null>(
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // ESLint is confused; this expression evaluates to an async function.
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) =>
         await implementation(req, res, next, end, {
@@ -42,7 +42,6 @@ describe('revokePermissions RPC method', () => {
       method: 'wallet_revokePermissions',
       params: [
         {
-          // TODO: Either fix this lint violation or explain why it's necessary to ignore.
           // eslint-disable-next-line @typescript-eslint/naming-convention
           snap_dialog: {},
         },
@@ -63,7 +62,7 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<RevokePermissionArgs, null>(
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // ESLint is confused; this expression evaluates to an async function.
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) =>
         await implementation(req, res, next, end, {
@@ -100,7 +99,7 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<RevokePermissionArgs, null>(
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // ESLint is confused; this expression evaluates to an async function.
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) =>
         await implementation(req, res, next, end, {
@@ -137,7 +136,7 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<RevokePermissionArgs, null>(
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // ESLint is confused; this expression evaluates to an async function.
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) =>
         await implementation(req, res, next, end, {
@@ -173,7 +172,7 @@ describe('revokePermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<RevokePermissionArgs, null>(
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+      // ESLint is confused; this expression evaluates to an async function.
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async (req, res, next, end) =>
         await implementation(req, res, next, end, {

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.ts
@@ -17,7 +17,7 @@ export const revokePermissionsHandler: PermittedHandlerExport<
   RevokePermissionArgs,
   null
 > = {
-  methodNames: [MethodNames.revokePermissions],
+  methodNames: [MethodNames.RevokePermissions],
   implementation: revokePermissionsImplementation,
   hookNames: {
     revokePermissionsForOrigin: true,

--- a/packages/permission-controller/src/utils.ts
+++ b/packages/permission-controller/src/utils.ts
@@ -21,15 +21,9 @@ import type {
 } from './Permission';
 
 export enum MethodNames {
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  requestPermissions = 'wallet_requestPermissions',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  getPermissions = 'wallet_getPermissions',
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  revokePermissions = 'wallet_revokePermissions',
+  RequestPermissions = 'wallet_requestPermissions',
+  GetPermissions = 'wallet_getPermissions',
+  RevokePermissions = 'wallet_revokePermissions',
 }
 
 /**
@@ -50,21 +44,15 @@ export type ExtractSpecifications<
  * A middleware function for handling a permitted method.
  */
 export type HandlerMiddlewareFunction<
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  T,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  U extends JsonRpcParams,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  V extends Json,
+  Hooks,
+  Params extends JsonRpcParams,
+  Result extends Json,
 > = (
-  req: JsonRpcRequest<U>,
-  res: PendingJsonRpcResponse<V>,
+  req: JsonRpcRequest<Params>,
+  res: PendingJsonRpcResponse<Result>,
   next: JsonRpcEngineNextCallback,
   end: JsonRpcEngineEndCallback,
-  hooks: T,
+  hooks: Hooks,
 ) => void | Promise<void>;
 
 /**
@@ -73,28 +61,20 @@ export type HandlerMiddlewareFunction<
  * This can then be used to select only the necessary hooks whenever a method
  * is called for purposes of POLA.
  */
-// TODO: Either fix this lint violation or explain why it's necessary to ignore.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export type HookNames<T> = {
-  [Property in keyof T]: true;
+export type HookNames<HookMap> = {
+  [Property in keyof HookMap]: true;
 };
 
 /**
  * A handler for a permitted method.
  */
 export type PermittedHandlerExport<
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  T,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  U extends JsonRpcParams,
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  V extends Json,
+  Hooks,
+  Params extends JsonRpcParams,
+  Result extends Json,
 > = {
-  implementation: HandlerMiddlewareFunction<T, U, V>;
-  hookNames: HookNames<T>;
+  implementation: HandlerMiddlewareFunction<Hooks, Params, Result>;
+  hookNames: HookNames<Hooks>;
   methodNames: string[];
 };
 


### PR DESCRIPTION
## Explanation

Fixes various `@typescript-eslint` violations in the permission controller. Due to the prevalence of RPC method names as object literal keys in a couple of files, an `.eslintrc.js` has been added to the permission controller workspace to accommodate this exception to our naming convention.

## References

n/a

## Changelog

### `@metamask/permission-controller`

- **BREAKING**: Rename enum property names to follow PascalCase instead of camelCase
  - The affected enums are:
    - `CaveatMutatorOperations`
    - `MethodNames`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
