### PR TITLE
Fix permission-controller lint violations

### DIFF
--- a/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
@@ -14,13 +14,16 @@ describe('getPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push(
-      async (
+      (
         req: JsonRpcRequest<[]>,
         res: PendingJsonRpcResponse<PermissionConstraint[]>,
         next,
         end,
       ) => {
-        await implementation(req, res, next, end, {
+        // We intentionally do not await this promise; JsonRpcEngine won't await
+        // middleware anyway.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        implementation(req, res, next, end, {
           getPermissionsForOrigin: mockGetPermissionsForOrigin,
         });
       },
@@ -44,13 +47,16 @@ describe('getPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push(
-      async (
+      (
         req: JsonRpcRequest<[]>,
         res: PendingJsonRpcResponse<PermissionConstraint[]>,
         next,
         end,
       ) => {
-        await implementation(req, res, next, end, {
+        // We intentionally do not await this promise; JsonRpcEngine won't await
+        // middleware anyway.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        implementation(req, res, next, end, {
           getPermissionsForOrigin: mockGetPermissionsForOrigin,
         });
       },

--- a/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
@@ -32,8 +32,11 @@ describe('requestPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<[RequestedPermissions], PermissionConstraint[]>(
-      async (req, res, next, end) => {
-        await implementation(req, res, next, end, {
+      (req, res, next, end) => {
+        // We intentionally do not await this promise; JsonRpcEngine won't await
+        // middleware anyway.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        implementation(req, res, next, end, {
           requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
         });
       },
@@ -102,8 +105,11 @@ describe('requestPermissions RPC method', () => {
 
     const engine = new JsonRpcEngine();
     engine.push<[RequestedPermissions], PermissionConstraint[]>(
-      async (req, res, next, end) => {
-        await implementation(req, res, next, end, {
+      (req, res, next, end) => {
+        // We intentionally do not await this promise; JsonRpcEngine won't await
+        // middleware anyway.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        implementation(req, res, next, end, {
           requestPermissionsForOrigin: mockRequestPermissionsForOrigin,
         });
       },

--- a/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/revokePermissions.test.ts
@@ -27,8 +27,11 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push<RevokePermissionArgs, null>(async (req, res, next, end) => {
-      await implementation(req, res, next, end, {
+    engine.push<RevokePermissionArgs, null>((req, res, next, end) => {
+      // We intentionally do not await this promise; JsonRpcEngine won't await
+      // middleware anyway.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      implementation(req, res, next, end, {
         revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
       });
     });
@@ -57,8 +60,11 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push<RevokePermissionArgs, null>(async (req, res, next, end) => {
-      await implementation(req, res, next, end, {
+    engine.push<RevokePermissionArgs, null>((req, res, next, end) => {
+      // We intentionally do not await this promise; JsonRpcEngine won't await
+      // middleware anyway.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      implementation(req, res, next, end, {
         revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
       });
     });
@@ -91,8 +97,11 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push<RevokePermissionArgs, null>(async (req, res, next, end) => {
-      await implementation(req, res, next, end, {
+    engine.push<RevokePermissionArgs, null>((req, res, next, end) => {
+      // We intentionally do not await this promise; JsonRpcEngine won't await
+      // middleware anyway.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      implementation(req, res, next, end, {
         revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
       });
     });
@@ -125,8 +134,11 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push<RevokePermissionArgs, null>(async (req, res, next, end) => {
-      await implementation(req, res, next, end, {
+    engine.push<RevokePermissionArgs, null>((req, res, next, end) => {
+      // We intentionally do not await this promise; JsonRpcEngine won't await
+      // middleware anyway.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      implementation(req, res, next, end, {
         revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
       });
     });
@@ -158,8 +170,11 @@ describe('revokePermissions RPC method', () => {
     const mockRevokePermissionsForOrigin = jest.fn();
 
     const engine = new JsonRpcEngine();
-    engine.push<RevokePermissionArgs, null>(async (req, res, next, end) => {
-      await implementation(req, res, next, end, {
+    engine.push<RevokePermissionArgs, null>((req, res, next, end) => {
+      // We intentionally do not await this promise; JsonRpcEngine won't await
+      // middleware anyway.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      implementation(req, res, next, end, {
         revokePermissionsForOrigin: mockRevokePermissionsForOrigin,
       });
     });


### PR DESCRIPTION

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

There are some `permission-controller` tests which attempt to push an async middleware function onto an engine. Although this works in practice, `@typescript-eslint` balks at this, because the type for `JsonRpcEngine.push` says it takes a `JsonRpcMiddleware`, and a `JsonRpcMiddleware` has a return type of `void`, not `Promise<void>`. We could change that return type to `void | Promise<void>` but that would cause other changes we may not want to make. So this commit merely ignores the lint violations. This should be safe because `JsonRpcEngine` doesn't await middleware anyway.

Interestingly, the lint violations caused by this discrepancy only appear locally and not on CI. I am not sure why this is.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

Also see: https://github.com/MetaMask/core/pull/4521

## Changelog

(No consumer-facing changes to log)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
