### PR TITLE
feat: removed node dependancy from profile-sync-sdk

### DIFF
--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -44,7 +44,6 @@
     "@metamask/base-controller": "^6.0.1",
     "@metamask/snaps-controllers": "^8.1.1",
     "@metamask/snaps-sdk": "^4.2.0",
-    "@metamask/snaps-utils": "^7.4.0",
     "@noble/ciphers": "^0.5.2",
     "@noble/hashes": "^1.4.0",
     "immer": "^9.0.6",

--- a/packages/profile-sync-controller/src/controllers/authentication/auth-snap-requests.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/auth-snap-requests.ts
@@ -1,6 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { HandleSnapRequest } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
-import { HandlerType } from '@metamask/snaps-utils';
 
 type SnapRPCRequest = Parameters<HandleSnapRequest['handler']>[0];
 
@@ -15,7 +15,7 @@ export function createSnapPublicKeyRequest(): SnapRPCRequest {
   return {
     snapId,
     origin: '',
-    handler: HandlerType.OnRpcRequest,
+    handler: 'onRpcRequest' as any,
     request: {
       method: 'getPublicKey',
     },
@@ -34,7 +34,7 @@ export function createSnapSignMessageRequest(
   return {
     snapId,
     origin: '',
-    handler: HandlerType.OnRpcRequest,
+    handler: 'onRpcRequest' as any,
     request: {
       method: 'signMessage',
       params: { message },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3527,7 +3527,6 @@ __metadata:
     "@metamask/base-controller": "npm:^6.0.1"
     "@metamask/snaps-controllers": "npm:^8.1.1"
     "@metamask/snaps-sdk": "npm:^4.2.0"
-    "@metamask/snaps-utils": "npm:^7.4.0"
     "@noble/ciphers": "npm:^0.5.2"
     "@noble/hashes": "npm:^1.4.0"
     "@types/jest": "npm:^27.4.1"


### PR DESCRIPTION
## Explanation

Removed NodeJs dependency that was breaking the SDK usage on the client

