### PR TITLE
feat: notification-services-controller - add shared notification block explorer domains

### DIFF
--- a/packages/notification-services-controller/src/NotificationServicesController/ui/constants.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/ui/constants.ts
@@ -20,4 +20,47 @@ export const NOTIFICATION_NETWORK_CURRENCY_SYMBOL = {
   [NOTIFICATION_CHAINS_ID.POLYGON]: 'MATIC',
 };
 
+export type BlockExplorerConfig = {
+  url: string;
+  name: string;
+};
+
+export const SUPPORTED_NOTIFICATION_BLOCK_EXPLORERS = {
+  // ETHEREUM
+  [NOTIFICATION_CHAINS_ID.ETHEREUM]: {
+    url: 'https://etherscan.io',
+    name: 'Etherscan',
+  },
+  // OPTIMISM
+  [NOTIFICATION_CHAINS_ID.OPTIMISM]: {
+    url: 'https://optimistic.etherscan.io',
+    name: 'Optimistic Etherscan',
+  },
+  // BSC
+  [NOTIFICATION_CHAINS_ID.BSC]: {
+    url: 'https://bscscan.com',
+    name: 'BscScan',
+  },
+  // POLYGON
+  [NOTIFICATION_CHAINS_ID.POLYGON]: {
+    url: 'https://polygonscan.com',
+    name: 'PolygonScan',
+  },
+  // ARBITRUM
+  [NOTIFICATION_CHAINS_ID.ARBITRUM]: {
+    url: 'https://arbiscan.io',
+    name: 'Arbiscan',
+  },
+  // AVALANCHE
+  [NOTIFICATION_CHAINS_ID.AVALANCHE]: {
+    url: 'https://snowtrace.io',
+    name: 'Snowtrace',
+  },
+  // LINEA
+  [NOTIFICATION_CHAINS_ID.LINEA]: {
+    url: 'https://lineascan.build',
+    name: 'LineaScan',
+  },
+} satisfies Record<string, BlockExplorerConfig>;
+
 export { NOTIFICATION_CHAINS_ID } from '../constants/notification-schema';


### PR DESCRIPTION
## Explanation

This is so we can easily reuse these block explorers for all platforms that consume notifications. We may start moving more shared logic to shared libraries for this same reason.

## References

https://consensyssoftware.atlassian.net/browse/NOTIFY-941

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/notification-services-controller`

- **ADDED**: New constant for the block explorers for chains we support notifications for.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
