### PR TITLE
fix: Compress transaction history upon update

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `DISPLAYED_TRANSACTION_HISTORY_PATHS` constant, representing the transaction history paths that may be used for display ([#4555](https://github.com/MetaMask/core/pull/4555))
   - This was exported so that it might be used to ensure display logic and internal history logic remains in-sync.
   - Any paths listed here will have their timestamps preserved. Unlisted paths may be compressed by the controller to minimize history size, losing the timestamp.
+- Add `MAX_TRANSACTION_HISTORY_LENGTH` constant, representing the expected maximum size of the `history` property for a given transaction ([#4555](https://github.com/MetaMask/core/pull/4555))
+  - Note that this is not strictly enforced, the length may exceed this number of all entries are "displayed" entries, but we expect this to be extremely improbable in practice.
 
 ### Fixed
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ACTIVITY_LOG_HISTORY_PATHS` constant, representing the transaction history paths used in displaying the transaction activity log ([#4555](https://github.com/MetaMask/core/pull/4555))
+  - This can be used to ensure display logic and internal history logic remains in-sync.
+
+### Fixed
+
+- Prevent transaction history from growing endlessly in size ([#4555](https://github.com/MetaMask/core/pull/4555))
+
 ## [35.0.1]
 
 ### Changed

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `ACTIVITY_LOG_HISTORY_PATHS` constant, representing the transaction history paths used in displaying the transaction activity log ([#4555](https://github.com/MetaMask/core/pull/4555))
-  - This can be used to ensure display logic and internal history logic remains in-sync.
+- Add `DISPLAYED_TRANSACTION_HISTORY_PATHS` constant, representing the transaction history paths that may be used for display ([#4555](https://github.com/MetaMask/core/pull/4555))
+  - This was exported so that it might be used to ensure display logic and internal history logic remains in-sync.
+  - Any paths listed here will have their timestamps preserved. Unlisted paths may be compressed by the controller to minimize history size, losing the timestamp.
 
 ### Fixed
 

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -70,7 +70,7 @@ export {
   WalletDevice,
 } from './types';
 export type { EtherscanTransactionMeta } from './utils/etherscan';
-export { ACTIVITY_LOG_HISTORY_PATHS } from './utils/history';
+export { DISPLAYED_TRANSACTION_HISTORY_PATHS } from './utils/history';
 export { determineTransactionType } from './utils/transaction-type';
 export { mergeGasFeeEstimates } from './utils/gas-flow';
 export {

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -70,6 +70,7 @@ export {
   WalletDevice,
 } from './types';
 export type { EtherscanTransactionMeta } from './utils/etherscan';
+export { ACTIVITY_LOG_HISTORY_PATHS } from './utils/history';
 export { determineTransactionType } from './utils/transaction-type';
 export { mergeGasFeeEstimates } from './utils/gas-flow';
 export {

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -70,7 +70,10 @@ export {
   WalletDevice,
 } from './types';
 export type { EtherscanTransactionMeta } from './utils/etherscan';
-export { DISPLAYED_TRANSACTION_HISTORY_PATHS } from './utils/history';
+export {
+  DISPLAYED_TRANSACTION_HISTORY_PATHS,
+  MAX_TRANSACTION_HISTORY_LENGTH,
+} from './utils/history';
 export { determineTransactionType } from './utils/transaction-type';
 export { mergeGasFeeEstimates } from './utils/gas-flow';
 export {

--- a/packages/transaction-controller/src/utils/history.test.ts
+++ b/packages/transaction-controller/src/utils/history.test.ts
@@ -86,9 +86,7 @@ describe('History', () => {
           },
         });
         // Validate that last history entry is correct
-        // Assertion used because we know the history is set here.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const mockHistoryLength = mockTransaction.history!.length;
+        const mockHistoryLength = mockTransaction.history.length;
         expect(mockTransaction.history?.[mockHistoryLength - 1]).toStrictEqual([
           {
             note: 'Mock non-displayed change',
@@ -119,9 +117,7 @@ describe('History', () => {
                 value: generateAddress(2),
               },
             ],
-            // We know that the history was generated with a history.
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            ...mockTransaction.history!.slice(3),
+            ...mockTransaction.history.slice(3),
             // This is the new entry:
             [
               {
@@ -159,9 +155,7 @@ describe('History', () => {
           },
         });
         // Validate that last history entry is correct
-        // Assertion used because we know the history is set here.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const mockHistoryLength = mockTransaction.history!.length;
+        const mockHistoryLength = mockTransaction.history.length;
         expect(mockTransaction.history?.[mockHistoryLength - 1]).toStrictEqual([
           {
             note: 'Mock displayed change',
@@ -182,9 +176,7 @@ describe('History', () => {
         expect(updatedTransaction).toStrictEqual({
           ...mockTransaction,
           history: [
-            // We know that the history was generated with a history.
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            ...mockTransactionClone.history!.slice(0, MAX_HISTORY_LENGTH - 1),
+            ...mockTransactionClone.history.slice(0, MAX_HISTORY_LENGTH - 1),
             // This is the new merged entry:
             [
               {
@@ -224,9 +216,7 @@ describe('History', () => {
           },
         });
         // Validate that last history entry is correct
-        // Assertion used because we know the history is set here.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const mockHistoryLength = mockTransaction.history!.length;
+        const mockHistoryLength = mockTransaction.history.length;
         expect(mockTransaction.history?.[mockHistoryLength - 1]).toStrictEqual([
           {
             note: 'Mock displayed change',
@@ -246,9 +236,7 @@ describe('History', () => {
         expect(updatedTransaction).toStrictEqual({
           ...mockTransaction,
           history: [
-            // We know that the history was generated with a history.
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            ...mockTransaction.history!,
+            ...mockTransaction.history,
             // This is the new entry:
             [
               {
@@ -288,7 +276,7 @@ function createMockTransaction({
 }: {
   partialTransaction?: Omit<Partial<TransactionMeta>, 'status'>;
   originalTransaction?: TransactionMeta;
-} = {}): TransactionMeta {
+} = {}): TransactionMeta & Required<Pick<TransactionMeta, 'history'>> {
   const minimalTransaction: TransactionMeta = {
     chainId: toHex(1337),
     id: 'mock-id',
@@ -303,10 +291,14 @@ function createMockTransaction({
     minimalTransaction.history = originalTransaction.history || [
       originalTransaction,
     ];
+  } else {
+    minimalTransaction.history = [{ ...minimalTransaction }];
   }
 
   return {
-    ...minimalTransaction,
+    // Cast used here because TypeScript wasn't able to infer that `history` was guaranteed to be set
+    ...(minimalTransaction as TransactionMeta &
+      Required<Pick<TransactionMeta, 'history'>>),
     ...partialTransaction,
   };
 }

--- a/packages/transaction-controller/src/utils/history.test.ts
+++ b/packages/transaction-controller/src/utils/history.test.ts
@@ -1,0 +1,372 @@
+import { toHex } from '@metamask/controller-utils';
+import { add0x } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+
+import {
+  type TransactionHistory,
+  TransactionStatus,
+  type TransactionMeta,
+  type TransactionHistoryEntry,
+} from '../types';
+import { MAX_HISTORY_LENGTH, updateTransactionHistory } from './history';
+
+describe('History', () => {
+  describe('updateTransactionHistory', () => {
+    it('does nothing if the history property is missing', () => {
+      const mockTransaction = createMockTransaction();
+      const originalInputTransaction = cloneDeep(mockTransaction);
+
+      const updatedTransaction = updateTransactionHistory(
+        mockTransaction,
+        'test update',
+      );
+
+      expect(updatedTransaction).toBe(mockTransaction);
+      expect(updatedTransaction).toStrictEqual(originalInputTransaction);
+    });
+
+    it('does nothing if there have been no changes', () => {
+      const originalTransaction = createMockTransaction();
+      const mockTransaction = createMockTransaction({ originalTransaction });
+      const mockTransactionClone = cloneDeep(mockTransaction);
+
+      const updatedTransaction = updateTransactionHistory(
+        mockTransaction,
+        'test update',
+      );
+
+      expect(updatedTransaction).toBe(mockTransaction);
+      expect(updatedTransaction).toStrictEqual(mockTransactionClone);
+    });
+
+    it('adds a new history entry', () => {
+      const originalTransaction = createMockTransaction();
+      const mockTransaction = createMockTransaction({
+        originalTransaction,
+        partialTransaction: {
+          history: [originalTransaction],
+          txParams: { from: generateAddress(123) },
+        },
+      });
+
+      const updatedTransaction = updateTransactionHistory(
+        mockTransaction,
+        'test update',
+      );
+
+      expect(updatedTransaction).not.toBe(mockTransaction);
+      expect(updatedTransaction).toStrictEqual({
+        ...mockTransaction,
+        history: [
+          originalTransaction,
+          [
+            {
+              note: 'test update',
+              op: 'replace',
+              path: '/txParams/from',
+              timestamp: expect.any(Number),
+              value: generateAddress(123),
+            },
+          ],
+        ],
+      });
+    });
+
+    describe('when history is past max size with non-displayed entries', () => {
+      it('merges a non-displayed entry when adding a new entry after max history size is reached', () => {
+        const originalTransaction = createMockTransaction();
+        const mockTransaction = createMockTransaction({
+          partialTransaction: {
+            history: generateMockHistory({
+              originalTransaction,
+              length: MAX_HISTORY_LENGTH,
+            }),
+            // This is the changed value
+            txParams: { from: generateAddress(123) },
+          },
+        });
+        // Validate that last history entry is correct
+        // Assertion used because we know the history is set here.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const mockHistoryLength = mockTransaction.history!.length;
+        expect(mockTransaction.history?.[mockHistoryLength - 1]).toStrictEqual([
+          {
+            note: 'Mock non-displayed change',
+            op: 'replace',
+            path: '/txParams/from',
+            value: generateAddress(MAX_HISTORY_LENGTH - 1),
+          },
+        ]);
+        expect(mockTransaction.history).toHaveLength(MAX_HISTORY_LENGTH);
+
+        const updatedTransaction = updateTransactionHistory(
+          mockTransaction,
+          'test update',
+        );
+
+        expect(updatedTransaction).not.toBe(mockTransaction);
+        expect(updatedTransaction).toStrictEqual({
+          ...mockTransaction,
+          history: [
+            originalTransaction,
+            // This is the merged entry of mockTransaction.history[1] and mockTransaction.history[2]
+            [
+              {
+                note: 'Mock non-displayed change, Mock non-displayed change',
+                op: 'replace',
+                path: '/txParams/from',
+                timestamp: expect.any(Number),
+                value: generateAddress(2),
+              },
+            ],
+            // We know that the history was generated with a history.
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            ...mockTransaction.history!.slice(3),
+            // This is the new entry:
+            [
+              {
+                note: 'test update',
+                op: 'replace',
+                path: '/txParams/from',
+                timestamp: expect.any(Number),
+                value: generateAddress(123),
+              },
+            ],
+          ],
+        });
+        expect(updatedTransaction.history).toHaveLength(MAX_HISTORY_LENGTH);
+      });
+    });
+
+    describe('when history is past max size with a single non-displayed entry at the end', () => {
+      it('merges a non-displayed entry when adding a new entry after max history size is reached', () => {
+        const originalTransaction = createMockTransaction();
+        // This matches the last gas price change in the mock history
+        const mockTransactionGasPrice = toHex(MAX_HISTORY_LENGTH - 1);
+        const mockTransaction = createMockTransaction({
+          partialTransaction: {
+            history: generateMockHistory({
+              numberOfDisplayEntries: MAX_HISTORY_LENGTH - 1,
+              originalTransaction,
+              length: MAX_HISTORY_LENGTH,
+            }),
+            txParams: {
+              // This is the changed value
+              from: generateAddress(123),
+              // This matches the last gas price change in the mock history
+              gasPrice: mockTransactionGasPrice,
+            },
+          },
+        });
+        // Validate that last history entry is correct
+        // Assertion used because we know the history is set here.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const mockHistoryLength = mockTransaction.history!.length;
+        expect(mockTransaction.history?.[mockHistoryLength - 1]).toStrictEqual([
+          {
+            note: 'Mock displayed change',
+            op: 'replace',
+            path: '/txParams/gasPrice',
+            value: mockTransactionGasPrice,
+          },
+        ]);
+        const mockTransactionClone = cloneDeep(mockTransaction);
+        expect(mockTransaction.history).toHaveLength(MAX_HISTORY_LENGTH);
+
+        const updatedTransaction = updateTransactionHistory(
+          mockTransaction,
+          'test update',
+        );
+
+        expect(updatedTransaction).not.toBe(mockTransaction);
+        expect(updatedTransaction).toStrictEqual({
+          ...mockTransaction,
+          history: [
+            // We know that the history was generated with a history.
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            ...mockTransactionClone.history!.slice(0, MAX_HISTORY_LENGTH - 1),
+            // This is the new merged entry:
+            [
+              {
+                note: 'Mock displayed change, test update',
+                op: 'replace',
+                path: '/txParams/gasPrice',
+                timestamp: expect.any(Number),
+                value: mockTransactionGasPrice,
+              },
+              {
+                op: 'replace',
+                path: '/txParams/from',
+                value: generateAddress(123),
+              },
+            ],
+          ],
+        });
+        expect(updatedTransaction.history).toHaveLength(MAX_HISTORY_LENGTH);
+      });
+    });
+
+    describe('when history is past max size with only displayed entries', () => {
+      it('adds a new history entry, exceeding max size', () => {
+        const originalTransaction = createMockTransaction();
+        const mockTransaction = createMockTransaction({
+          partialTransaction: {
+            history: generateMockHistory({
+              numberOfDisplayEntries: MAX_HISTORY_LENGTH - 1,
+              originalTransaction,
+              length: MAX_HISTORY_LENGTH,
+            }),
+            txParams: {
+              from: originalTransaction.txParams.from,
+              // This is the changed value
+              gasPrice: toHex(1337),
+            },
+          },
+        });
+        // Validate that last history entry is correct
+        // Assertion used because we know the history is set here.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const mockHistoryLength = mockTransaction.history!.length;
+        expect(mockTransaction.history?.[mockHistoryLength - 1]).toStrictEqual([
+          {
+            note: 'Mock displayed change',
+            op: 'replace',
+            path: '/txParams/gasPrice',
+            value: toHex(MAX_HISTORY_LENGTH - 1),
+          },
+        ]);
+        expect(mockTransaction.history).toHaveLength(MAX_HISTORY_LENGTH);
+
+        const updatedTransaction = updateTransactionHistory(
+          mockTransaction,
+          'test update',
+        );
+
+        expect(updatedTransaction).not.toBe(mockTransaction);
+        expect(updatedTransaction).toStrictEqual({
+          ...mockTransaction,
+          history: [
+            // We know that the history was generated with a history.
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            ...mockTransaction.history!,
+            // This is the new entry:
+            [
+              {
+                note: 'test update',
+                op: 'replace',
+                path: '/txParams/gasPrice',
+                timestamp: expect.any(Number),
+                value: toHex(1337),
+              },
+            ],
+          ],
+        });
+        expect(updatedTransaction.history).toHaveLength(MAX_HISTORY_LENGTH + 1);
+      });
+    });
+  });
+});
+
+/**
+ * Create a mock transaction.
+ *
+ * Optionally an incomplete transaction can be passed in, and any missing required proeprties will
+ * be filled out. The 'status' property is not allowed as input only because it was complicated to
+ * get the types to be correct if it was provided.
+ *
+ * A `history` property is included only if an original transaction is passed in.
+ *
+ * @param options - Options.
+ * @param options.partialTransaction - A partial transaction, without a 'status' property.
+ * @param options.originalTransaction - The original transaction object to include in the transaction
+ * history.
+ * @returns A mock transaction.
+ */
+function createMockTransaction({
+  partialTransaction,
+  originalTransaction,
+}: {
+  partialTransaction?: Omit<Partial<TransactionMeta>, 'status'>;
+  originalTransaction?: TransactionMeta;
+} = {}): TransactionMeta {
+  const minimalTransaction: TransactionMeta = {
+    chainId: toHex(1337),
+    id: 'mock-id',
+    time: 0,
+    status: TransactionStatus.submitted as const,
+    txParams: {
+      from: '',
+    },
+  };
+
+  if (originalTransaction) {
+    minimalTransaction.history = originalTransaction.history || [
+      originalTransaction,
+    ];
+  }
+
+  return {
+    ...minimalTransaction,
+    ...partialTransaction,
+  };
+}
+
+/**
+ * Generate a mock transaction history.
+ *
+ * @param args - Arguments.
+ * @param args.numberOfDisplayEntries - The number of displayed history entries to generate.
+ * @param args.originalTransaction - The original transaction, before any history changes.
+ * @param args.length - The total length of history to generate.
+ * @returns Mock transaction history.
+ */
+function generateMockHistory({
+  numberOfDisplayEntries = 0,
+  originalTransaction,
+  length,
+}: {
+  numberOfDisplayEntries?: number;
+  originalTransaction: TransactionMeta;
+  length: number;
+}): TransactionHistory {
+  if (length < 1) {
+    throw new Error('Invalid length');
+  } else if (numberOfDisplayEntries >= length) {
+    throw new Error('Length must exceed number of displayed entries');
+  }
+
+  const historyEntries: TransactionHistoryEntry[] = [
+    ...Array(length - 1).keys(),
+  ].map((index: number) => {
+    // Use index of this entry in history array, for better readability/debugging of mock values
+    const historyIndex = index + 1;
+
+    return [
+      numberOfDisplayEntries < historyIndex
+        ? {
+            note: 'Mock non-displayed change',
+            op: 'replace',
+            path: '/txParams/from',
+            value: generateAddress(historyIndex),
+          }
+        : {
+            note: 'Mock displayed change',
+            op: index === 0 ? 'add' : 'replace',
+            path: '/txParams/gasPrice',
+            value: toHex(historyIndex),
+          },
+    ];
+  });
+
+  return [originalTransaction, ...historyEntries];
+}
+
+/**
+ * Generate a mock lowercase Ethereum address.
+ *
+ * @param number - The address as a decimal number.
+ * @returns The mock address
+ */
+function generateAddress(number: number) {
+  return add0x(number.toString(16).padStart(40, '0'));
+}

--- a/packages/transaction-controller/src/utils/history.test.ts
+++ b/packages/transaction-controller/src/utils/history.test.ts
@@ -8,7 +8,10 @@ import {
   type TransactionMeta,
   type TransactionHistoryEntry,
 } from '../types';
-import { MAX_HISTORY_LENGTH, updateTransactionHistory } from './history';
+import {
+  MAX_TRANSACTION_HISTORY_LENGTH,
+  updateTransactionHistory,
+} from './history';
 
 describe('History', () => {
   describe('updateTransactionHistory', () => {
@@ -80,7 +83,7 @@ describe('History', () => {
           partialTransaction: {
             history: generateMockHistory({
               originalTransaction,
-              length: MAX_HISTORY_LENGTH,
+              length: MAX_TRANSACTION_HISTORY_LENGTH,
             }),
             // This is the changed value
             txParams: { from: generateAddress(123) },
@@ -94,10 +97,12 @@ describe('History', () => {
             note: 'Mock non-displayed change',
             op: 'replace',
             path: '/txParams/from',
-            value: generateAddress(MAX_HISTORY_LENGTH - 1),
+            value: generateAddress(MAX_TRANSACTION_HISTORY_LENGTH - 1),
           },
         ]);
-        expect(mockTransaction.history).toHaveLength(MAX_HISTORY_LENGTH);
+        expect(mockTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH,
+        );
 
         const updatedTransaction = updateTransactionHistory(
           mockTransaction,
@@ -132,7 +137,9 @@ describe('History', () => {
             ],
           ],
         });
-        expect(updatedTransaction.history).toHaveLength(MAX_HISTORY_LENGTH);
+        expect(updatedTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH,
+        );
       });
     });
 
@@ -140,13 +147,15 @@ describe('History', () => {
       it('merges a non-displayed entry when adding a new entry after max history size is reached', () => {
         const originalTransaction = createMinimalMockTransaction();
         // This matches the last gas price change in the mock history
-        const mockTransactionGasPrice = toHex(MAX_HISTORY_LENGTH - 1);
+        const mockTransactionGasPrice = toHex(
+          MAX_TRANSACTION_HISTORY_LENGTH - 1,
+        );
         const mockTransaction = createMockTransaction({
           partialTransaction: {
             history: generateMockHistory({
-              numberOfDisplayEntries: MAX_HISTORY_LENGTH - 1,
+              numberOfDisplayEntries: MAX_TRANSACTION_HISTORY_LENGTH - 1,
               originalTransaction,
-              length: MAX_HISTORY_LENGTH,
+              length: MAX_TRANSACTION_HISTORY_LENGTH,
             }),
             txParams: {
               // This is the changed value
@@ -168,7 +177,9 @@ describe('History', () => {
           },
         ]);
         const mockTransactionClone = cloneDeep(mockTransaction);
-        expect(mockTransaction.history).toHaveLength(MAX_HISTORY_LENGTH);
+        expect(mockTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH,
+        );
 
         const updatedTransaction = updateTransactionHistory(
           mockTransaction,
@@ -179,7 +190,10 @@ describe('History', () => {
         expect(updatedTransaction).toStrictEqual({
           ...mockTransaction,
           history: [
-            ...mockTransactionClone.history.slice(0, MAX_HISTORY_LENGTH - 1),
+            ...mockTransactionClone.history.slice(
+              0,
+              MAX_TRANSACTION_HISTORY_LENGTH - 1,
+            ),
             // This is the new merged entry:
             [
               {
@@ -197,7 +211,9 @@ describe('History', () => {
             ],
           ],
         });
-        expect(updatedTransaction.history).toHaveLength(MAX_HISTORY_LENGTH);
+        expect(updatedTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH,
+        );
       });
     });
 
@@ -207,9 +223,9 @@ describe('History', () => {
         const mockTransaction = createMockTransaction({
           partialTransaction: {
             history: generateMockHistory({
-              numberOfDisplayEntries: MAX_HISTORY_LENGTH - 1,
+              numberOfDisplayEntries: MAX_TRANSACTION_HISTORY_LENGTH - 1,
               originalTransaction,
-              length: MAX_HISTORY_LENGTH,
+              length: MAX_TRANSACTION_HISTORY_LENGTH,
             }),
             txParams: {
               from: originalTransaction.txParams.from,
@@ -226,10 +242,12 @@ describe('History', () => {
             note: 'Mock displayed change',
             op: 'replace',
             path: '/txParams/gasPrice',
-            value: toHex(MAX_HISTORY_LENGTH - 1),
+            value: toHex(MAX_TRANSACTION_HISTORY_LENGTH - 1),
           },
         ]);
-        expect(mockTransaction.history).toHaveLength(MAX_HISTORY_LENGTH);
+        expect(mockTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH,
+        );
 
         const updatedTransaction = updateTransactionHistory(
           mockTransaction,
@@ -253,7 +271,9 @@ describe('History', () => {
             ],
           ],
         });
-        expect(updatedTransaction.history).toHaveLength(MAX_HISTORY_LENGTH + 1);
+        expect(updatedTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH + 1,
+        );
       });
     });
   });

--- a/packages/transaction-controller/src/utils/history.test.ts
+++ b/packages/transaction-controller/src/utils/history.test.ts
@@ -86,8 +86,9 @@ describe('History', () => {
           },
         });
         // Validate that last history entry is correct
-        const mockHistoryLength = mockTransaction.history.length;
-        expect(mockTransaction.history?.[mockHistoryLength - 1]).toStrictEqual([
+        expect(
+          mockTransaction.history?.[mockTransaction.history.length - 1],
+        ).toStrictEqual([
           {
             note: 'Mock non-displayed change',
             op: 'replace',
@@ -155,8 +156,9 @@ describe('History', () => {
           },
         });
         // Validate that last history entry is correct
-        const mockHistoryLength = mockTransaction.history.length;
-        expect(mockTransaction.history?.[mockHistoryLength - 1]).toStrictEqual([
+        expect(
+          mockTransaction.history?.[mockTransaction.history.length - 1],
+        ).toStrictEqual([
           {
             note: 'Mock displayed change',
             op: 'replace',
@@ -216,8 +218,9 @@ describe('History', () => {
           },
         });
         // Validate that last history entry is correct
-        const mockHistoryLength = mockTransaction.history.length;
-        expect(mockTransaction.history?.[mockHistoryLength - 1]).toStrictEqual([
+        expect(
+          mockTransaction.history?.[mockTransaction.history.length - 1],
+        ).toStrictEqual([
           {
             note: 'Mock displayed change',
             op: 'replace',

--- a/packages/transaction-controller/src/utils/history.ts
+++ b/packages/transaction-controller/src/utils/history.ts
@@ -130,6 +130,8 @@ function compressTransactionHistory(
     firstNonDisplayedEntryIndex,
     mergeTargetEntryIndex,
   );
+  const firstEntryToMerge = historyEntries[firstIndexToMerge];
+  const secondEntryToMerge = historyEntries[firstIndexToMerge + 1];
 
   const beforeMergeState = replayHistory([
     initialEntry,
@@ -137,14 +139,14 @@ function compressTransactionHistory(
   ]);
   const afterMergeState = replayHistory([
     beforeMergeState,
-    historyEntries[firstIndexToMerge],
-    historyEntries[firstIndexToMerge + 1],
+    firstEntryToMerge,
+    secondEntryToMerge,
   ]);
   const mergedHistoryEntry = generateHistoryEntry(
     beforeMergeState,
     afterMergeState,
-    `${String(historyEntries[firstIndexToMerge][0].note)}, ${String(
-      historyEntries[firstIndexToMerge + 1][0].note,
+    `${String(firstEntryToMerge[0].note)}, ${String(
+      secondEntryToMerge[0].note,
     )}`,
   );
 

--- a/packages/transaction-controller/src/utils/history.ts
+++ b/packages/transaction-controller/src/utils/history.ts
@@ -69,8 +69,10 @@ export function updateTransactionHistory(
   // Casts required here because this list has two separate types of entries:
   // TransactionMeta and TransactionHistoryEntry. The only TransactionMeta is the first
   // entry, but TypeScript loses that type information when `slice` is called for some reason.
-  let updatedHistory = transactionMeta.history.slice() as TransactionHistory;
-  updatedHistory.push(newHistoryEntry);
+  let updatedHistory = [
+    ...transactionMeta.history,
+    newHistoryEntry,
+  ] as TransactionHistory;
 
   if (updatedHistory.length > MAX_HISTORY_LENGTH) {
     updatedHistory = compressTransactionHistory(updatedHistory);

--- a/packages/transaction-controller/src/utils/history.ts
+++ b/packages/transaction-controller/src/utils/history.ts
@@ -10,7 +10,7 @@ import type {
 /**
  * The maximum allowed length of the `transaction.history` property.
  */
-export const MAX_HISTORY_LENGTH = 100;
+export const MAX_TRANSACTION_HISTORY_LENGTH = 100;
 
 /**
  * A list of trarnsaction history paths that may be used for display. These entries will not be
@@ -75,7 +75,7 @@ export function updateTransactionHistory(
     newHistoryEntry,
   ] as TransactionHistory;
 
-  if (updatedHistory.length > MAX_HISTORY_LENGTH) {
+  if (updatedHistory.length > MAX_TRANSACTION_HISTORY_LENGTH) {
     updatedHistory = compressTransactionHistory(updatedHistory);
   }
 

--- a/packages/transaction-controller/src/utils/history.ts
+++ b/packages/transaction-controller/src/utils/history.ts
@@ -13,9 +13,10 @@ import type {
 export const MAX_HISTORY_LENGTH = 100;
 
 /**
- * A list of the paths used in the display of a transaction activity log.
+ * A list of trarnsaction history paths that may be used for display. These entries will not be
+ * compressed.
  */
-export const ACTIVITY_LOG_HISTORY_PATHS = [
+export const DISPLAYED_TRANSACTION_HISTORY_PATHS = [
   '/status',
   '/txParams/gasPrice',
   '/txParams/gas',
@@ -104,7 +105,7 @@ function compressTransactionHistory(
   const firstNonDisplayedEntryIndex = historyEntries.findIndex(
     (historyEntry) => {
       return !historyEntry.some(({ path }) =>
-        ACTIVITY_LOG_HISTORY_PATHS.includes(path),
+        DISPLAYED_TRANSACTION_HISTORY_PATHS.includes(path),
       );
     },
   );

--- a/packages/transaction-controller/src/utils/history.ts
+++ b/packages/transaction-controller/src/utils/history.ts
@@ -62,22 +62,23 @@ export function updateTransactionHistory(
     note,
   );
 
-  if (newHistoryEntry.length > 0) {
-    // Casts required here because this list has two separate types of entries:
-    // TransactionMeta and TransactionHistoryEntry. The only TransactionMeta is the first
-    // entry, but TypeScript loses that type information when `slice` is called for some reason.
-    let updatedHistory = transactionMeta.history.slice() as TransactionHistory;
-    updatedHistory.push(newHistoryEntry);
-
-    if (updatedHistory.length > MAX_HISTORY_LENGTH) {
-      updatedHistory = compressTransactionHistory(updatedHistory);
-    }
-
-    return merge({}, transactionMeta, {
-      history: updatedHistory,
-    });
+  if (newHistoryEntry.length === 0) {
+    return transactionMeta;
   }
-  return transactionMeta;
+
+  // Casts required here because this list has two separate types of entries:
+  // TransactionMeta and TransactionHistoryEntry. The only TransactionMeta is the first
+  // entry, but TypeScript loses that type information when `slice` is called for some reason.
+  let updatedHistory = transactionMeta.history.slice() as TransactionHistory;
+  updatedHistory.push(newHistoryEntry);
+
+  if (updatedHistory.length > MAX_HISTORY_LENGTH) {
+    updatedHistory = compressTransactionHistory(updatedHistory);
+  }
+
+  return merge({}, transactionMeta, {
+    history: updatedHistory,
+  });
 }
 
 /**

--- a/packages/transaction-controller/src/utils/history.ts
+++ b/packages/transaction-controller/src/utils/history.ts
@@ -109,7 +109,7 @@ function compressTransactionHistory(
     },
   );
 
-  // If no non-diplayed entry is found, let history exceed max size.
+  // If no non-displayed entry is found, let history exceed max size.
   // TODO: Move data used for display to another property, so that we can more reliably limit
   // history size or remove it altogether.
   if (firstNonDisplayedEntryIndex === -1) {


### PR DESCRIPTION
## Explanation

The TransactionController has been updated to compress transaction history if it exceeds the max transaction history size, which for now has been set to 100. Each time a new entry is added to a transaction history already at max size, we merge two entries to make room for the new one.

Note that we never compress entries used for display in the transaction activity log, because compressing those entries might hide events that we want to display. If there are no non-displayed entries to compress, history is allowed to exceed the max size.

This is a temporary solution to prevent unbounded growth of the transaction history. While technically it is still unbounded at this level because we don't strictly limit displayed history entries, we don't know of any cases where displayed entries can be repeated a significant number of times, so this will solve that problem in practice.

## References

Fixes #4549

## Changelog

For the `@metamask/transaction-controller` package:
```markdown
### Added

- Add `DISPLAYED_TRANSACTION_HISTORY_PATHS` constant, representing the transaction history paths that may be used for display ([#4555](https://github.com/MetaMask/core/pull/4555))
  - This was exported so that it might be used to ensure display logic and internal history logic remains in-sync.
  - Any paths listed here will have their timestamps preserved. Unlisted paths may be compressed by the controller to minimize history size, losing the timestamp.
- Add `MAX_TRANSACTION_HISTORY_LENGTH` constant, representing the expected maximum size of the `history` property for a given transaction ([#4555](https://github.com/MetaMask/core/pull/4555))
  - Note that this is not strictly enforced, the length may exceed this number of all entries are "displayed" entries, but we expect this to be extremely improbable in practice.

### Fixed

- Prevent transaction history from growing endlessly in size ([#4555](https://github.com/MetaMask/core/pull/4555))
```
## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
