### PR TITLE
fix: throw error when removing selected network

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1248,6 +1248,10 @@ export class NetworkController extends BaseController<
       );
     }
 
+    if (networkConfigurationId === this.state.selectedNetworkClientId) {
+      throw new Error(`The selected network configuration cannot be removed`);
+    }
+
     const autoManagedNetworkClientRegistry =
       this.#ensureAutoManagedNetworkClientRegistryPopulated();
     const networkClientId = networkConfigurationId;

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -3766,6 +3766,29 @@ describe('NetworkController', () => {
           },
         );
       });
+
+      it('throws an error if the given ID corresponds to the selected network', async () => {
+        await withController(
+          {
+            state: {
+              networkConfigurations: {
+                'AAAA-AAAA-AAAA-AAAA': {
+                  rpcUrl: 'https://test.network',
+                  ticker: 'TICKER',
+                  chainId: toHex(111),
+                  id: 'AAAA-AAAA-AAAA-AAAA',
+                },
+              },
+              selectedNetworkClientId: 'AAAA-AAAA-AAAA-AAAA',
+            },
+          },
+          async ({ controller }) => {
+            expect(() =>
+              controller.removeNetworkConfiguration('AAAA-AAAA-AAAA-AAAA'),
+            ).toThrow('The selected network configuration cannot be removed');
+          },
+        );
+      });
     });
 
     describe('given an ID that does not identify a network configuration in state', () => {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Currently, deleting a network configuration which is also the current selected network will corrupt the state, since the selected ID will not point to any valid config.

With this PR, `removeNetworkConfiguration` throws an error if the caller tries to remove the selected network.

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes #4563 

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/network-controller`

- **FIXED**: Selected network client configuration cannot be removed

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
