### PR TITLE
feat: add new method `updateAccountMetadata`

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -2331,7 +2331,7 @@ describe('AccountsController', () => {
     });
   });
 
-  describe('setAccountMetadata', () => {
+  describe('updateAccountMetadata', () => {
     it('updates the metadata of an existing account', () => {
       const { accountsController } = setupAccountsController({
         initialState: {
@@ -2341,7 +2341,7 @@ describe('AccountsController', () => {
           },
         },
       });
-      accountsController.setAccountMetadata(mockAccount.id, {
+      accountsController.updateAccountMetadata(mockAccount.id, {
         name: 'new name',
       });
 

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -2331,6 +2331,26 @@ describe('AccountsController', () => {
     });
   });
 
+  describe('setAccountMetadata', () => {
+    it('updates the metadata of an existing account', () => {
+      const { accountsController } = setupAccountsController({
+        initialState: {
+          internalAccounts: {
+            accounts: { [mockAccount.id]: mockAccount },
+            selectedAccount: mockAccount.id,
+          },
+        },
+      });
+      accountsController.setAccountMetadata(mockAccount.id, {
+        name: 'new name',
+      });
+
+      expect(
+        accountsController.getAccountExpect(mockAccount.id).metadata.name,
+      ).toBe('new name');
+    });
+  });
+
   describe('#getNextAccountNumber', () => {
     // Account names start at 2 since have 1 HD account + 2 simple keypair accounts (and both
     // those keyring types are "grouped" together)

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -2342,12 +2342,13 @@ describe('AccountsController', () => {
         },
       });
       accountsController.updateAccountMetadata(mockAccount.id, {
-        name: 'new name',
+        lastSelected: 1,
       });
 
       expect(
-        accountsController.getAccountExpect(mockAccount.id).metadata.name,
-      ).toBe('new name');
+        accountsController.getAccountExpect(mockAccount.id).metadata
+          .lastSelected,
+      ).toBe(1);
     });
   });
 

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -430,7 +430,7 @@ export class AccountsController extends BaseController<
         metadata: { ...account.metadata, name: accountName },
       };
       // Do not remove this comment - This error is flaky: Comment out or restore the `ts-expect-error` directive below as needed.
-      // @ts-expect-error Known issue - `Json` causes recursive error in immer `Draft`/`WritableDraft` types
+      // // @ts-expect-error Known issue - `Json` causes recursive error in immer `Draft`/`WritableDraft` types
       currentState.internalAccounts.accounts[accountId] = internalAccount;
     });
   }

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -106,9 +106,9 @@ export type AccountsControllerGetAccountAction = {
   handler: AccountsController['getAccount'];
 };
 
-export type AccountsControllerSetAccountMetadata = {
-  type: `${typeof controllerName}:setAccountMetadata`;
-  handler: AccountsController['setAccountMetadata'];
+export type AccountsControllerUpdateAccountMetadata = {
+  type: `${typeof controllerName}:updateAccountMetadata`;
+  handler: AccountsController['updateAccountMetadata'];
 };
 
 export type AllowedActions =
@@ -128,7 +128,7 @@ export type AccountsControllerActions =
   | AccountsControllerGetNextAvailableAccountNameAction
   | AccountsControllerGetAccountAction
   | AccountsControllerGetSelectedMultichainAccountAction
-  | AccountsControllerSetAccountMetadata;
+  | AccountsControllerUpdateAccountMetadata;
 
 export type AccountsControllerChangeEvent = ControllerStateChangeEvent<
   typeof controllerName,
@@ -441,7 +441,7 @@ export class AccountsController extends BaseController<
    * @param accountId - The ID of the account to set the name for.
    * @param metadata - The new metadata for the account.
    */
-  setAccountMetadata(
+  updateAccountMetadata(
     accountId: string,
     metadata: Partial<InternalAccount['metadata']>,
   ): void {
@@ -1124,8 +1124,8 @@ export class AccountsController extends BaseController<
     );
 
     this.messagingSystem.registerActionHandler(
-      `AccountsController:setAccountMetadata`,
-      this.setAccountMetadata.bind(this),
+      `AccountsController:updateAccountMetadata`,
+      this.updateAccountMetadata.bind(this),
     );
   }
 }

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -438,7 +438,7 @@ export class AccountsController extends BaseController<
   /**
    * Updates the metadata of the account with the given ID.
    *
-   * @param accountId - The ID of the account to set the name for.
+   * @param accountId - The ID of the account for which the metadata will be updated.
    * @param metadata - The new metadata for the account.
    */
   updateAccountMetadata(

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -412,8 +412,6 @@ export class AccountsController extends BaseController<
    * @throws An error if an account with the same name already exists.
    */
   setAccountName(accountId: string, accountName: string): void {
-    const account = this.getAccountExpect(accountId);
-
     if (
       this.listMultichainAccounts().find(
         (internalAccount) =>
@@ -424,19 +422,12 @@ export class AccountsController extends BaseController<
       throw new Error('Account name already exists');
     }
 
-    this.update((currentState: Draft<AccountsControllerState>) => {
-      const internalAccount = {
-        ...account,
-        metadata: { ...account.metadata, name: accountName },
-      };
-      // Do not remove this comment - This error is flaky: Comment out or restore the `ts-expect-error` directive below as needed.
-      // // @ts-expect-error Known issue - `Json` causes recursive error in immer `Draft`/`WritableDraft` types
-      currentState.internalAccounts.accounts[accountId] = internalAccount;
-    });
+    this.updateAccountMetadata(accountId, { name: accountName });
   }
 
   /**
    * Updates the metadata of the account with the given ID.
+   * Use {@link setAccountName} if you only need to update the name of the account.
    *
    * @param accountId - The ID of the account for which the metadata will be updated.
    * @param metadata - The new metadata for the account.
@@ -453,6 +444,7 @@ export class AccountsController extends BaseController<
         metadata: { ...account.metadata, ...metadata },
       };
       // Do not remove this comment - This error is flaky: Comment out or restore the `ts-expect-error` directive below as needed.
+      // See: https://github.com/MetaMask/utils/issues/168
       // // @ts-expect-error Known issue - `Json` causes recursive error in immer `Draft`/`WritableDraft` types
       currentState.internalAccounts.accounts[accountId] = internalAccount;
     });


### PR DESCRIPTION
## Explanation

This PR adds a new `updateAccountMetadata` method/action for the `AccountsController`.
This method will be needed for the Account syncing feature (from @MetaMask/notifications ), but can also come handy in the future if / when we decide to expand the contents of the metadata object for new features.

On the account syncing side, we're still deciding if we're going to manage conflicting names resolution, but in either scenario, this new `updateAccountMetadata` method is needed.

### For example: 

Scenario 1: we don't manage conflicting names

- We'll add a new `lastUpdated` metadata key to the `InternalAccount` type from `@metamask/keyring-api`
- We'll read this key when syncing accounts, and act accordingly (replace account name OR decide it's the SOT and keep the account name)
- If we replace the account name, we'll update this key with `updateAccountMetadata`

Scenario 2: we manage conflicting names

- We'll add a new `conflictingNames` metadata key to the `InternalAccount` type from `@metamask/keyring-api`
- We'll read this key when displaying conflicts in the UI
- When a user resolves a conflict in names from the UI, we'll update this key with `updateAccountMetadata`

Related to [this Epic](https://consensyssoftware.atlassian.net/jira/software/projects/NOTIFY/boards/616?assignee=712020%3A5843b7e2-a7fe-4c45-9fbd-e1f2b2eb58c2&selectedIssue=NOTIFY-851)
## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/accounts-controller`

- **ADDED**: Add `updateAccountMetadata` method and `AccountsController:updateAccountMetadata` controller action

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
