### PR TITLE
fix: fetch correct price for $OMNI

### DIFF
--- a/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
+++ b/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
@@ -4,7 +4,10 @@ import { handleFetch } from '@metamask/controller-utils';
  * A map from native currency symbol to CryptoCompare identifier.
  * This is only needed when the values don't match.
  */
-const nativeSymbolOverrides = new Map([['MNT', 'MANTLE']]);
+const nativeSymbolOverrides = new Map([
+  ['MNT', 'MANTLE'],
+  ['OMNI', 'OMNINET']
+]);
 
 const CRYPTO_COMPARE_DOMAIN = 'https://min-api.cryptocompare.com';
 

--- a/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
+++ b/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
@@ -6,7 +6,7 @@ import { handleFetch } from '@metamask/controller-utils';
  */
 const nativeSymbolOverrides = new Map([
   ['MNT', 'MANTLE'],
-  ['OMNI', 'OMNINET']
+  ['OMNI', 'OMNINET'],
 ]);
 
 const CRYPTO_COMPARE_DOMAIN = 'https://min-api.cryptocompare.com';


### PR DESCRIPTION
## Explanation

Redirects the native currency $OMNI to the correct token price

- Wrong: https://www.cryptocompare.com/coins/omni
- Correct: https://www.cryptocompare.com/coins/omninet

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **FIXED**: Fetch correct price for the $OMNI native currency

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
