### PR TITLE
fix: fix RatesController.setCryptoCurrencyList invalid internal field

### DIFF
--- a/packages/assets-controllers/src/RatesController/RatesController.test.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.test.ts
@@ -315,7 +315,7 @@ describe('RatesController', () => {
   describe('setCryptocurrencyList', () => {
     it('updates the cryptocurrency list', async () => {
       const fetchExchangeRateStub = jest.fn().mockResolvedValue({});
-      const mockCryptocurrencyList: Cryptocurrency[] = [];
+      const mockCryptocurrencyList: Cryptocurrency[] = []; // Different from default list
       const ratesController = setupRatesController({
         interval: 150,
         initialState: {},
@@ -327,6 +327,10 @@ describe('RatesController', () => {
       const cryptocurrencyListPreUpdate =
         ratesController.getCryptocurrencyList();
       expect(cryptocurrencyListPreUpdate).toStrictEqual([Cryptocurrency.Btc]);
+      // Just to make sure we're updating to something else than the default list
+      expect(cryptocurrencyListPreUpdate).not.toStrictEqual(
+        mockCryptocurrencyList,
+      );
 
       await ratesController.setCryptocurrencyList(mockCryptocurrencyList);
       const cryptocurrencyListPostUpdate =

--- a/packages/assets-controllers/src/RatesController/RatesController.test.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.test.ts
@@ -315,7 +315,7 @@ describe('RatesController', () => {
   describe('setCryptocurrencyList', () => {
     it('updates the cryptocurrency list', async () => {
       const fetchExchangeRateStub = jest.fn().mockResolvedValue({});
-      const mockCryptocurrencyList = [Cryptocurrency.Btc];
+      const mockCryptocurrencyList: Cryptocurrency[] = [];
       const ratesController = setupRatesController({
         interval: 150,
         initialState: {},

--- a/packages/assets-controllers/src/RatesController/RatesController.test.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.test.ts
@@ -100,8 +100,8 @@ describe('RatesController', () => {
       const { fiatCurrency, rates, cryptocurrencies } = ratesController.state;
       expect(ratesController).toBeDefined();
       expect(fiatCurrency).toBe('usd');
-      expect(Object.keys(rates)).toStrictEqual(['btc']);
-      expect(cryptocurrencies).toStrictEqual(['btc']);
+      expect(Object.keys(rates)).toStrictEqual([Cryptocurrency.Btc]);
+      expect(cryptocurrencies).toStrictEqual([Cryptocurrency.Btc]);
     });
   });
 
@@ -326,7 +326,7 @@ describe('RatesController', () => {
 
       const cryptocurrencyListPreUpdate =
         ratesController.getCryptocurrencyList();
-      expect(cryptocurrencyListPreUpdate).toStrictEqual(['btc']);
+      expect(cryptocurrencyListPreUpdate).toStrictEqual([Cryptocurrency.Btc]);
 
       await ratesController.setCryptocurrencyList(mockCryptocurrencyList);
       const cryptocurrencyListPostUpdate =

--- a/packages/assets-controllers/src/RatesController/RatesController.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.ts
@@ -182,14 +182,16 @@ export class RatesController extends BaseController<
 
   /**
    * Sets the list of supported cryptocurrencies.
-   * @param list - The list of supported cryptocurrencies.
+   * @param cryptocurrencies - The list of supported cryptocurrencies.
    */
-  async setCryptocurrencyList(list: Cryptocurrency[]): Promise<void> {
+  async setCryptocurrencyList(
+    cryptocurrencies: Cryptocurrency[],
+  ): Promise<void> {
     await this.#withLock(() => {
       this.update(() => {
         return {
           ...this.state,
-          fromCurrencies: list,
+          cryptocurrencies,
         };
       });
     });

--- a/packages/assets-controllers/src/RatesController/RatesController.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.ts
@@ -8,6 +8,7 @@ import type {
   RatesControllerOptions,
   RatesControllerMessenger,
 } from './types';
+import { Draft } from 'immer';
 
 export const name = 'RatesController';
 
@@ -134,9 +135,9 @@ export class RatesController extends BaseController<
         };
       }
 
-      this.update(() => {
+      this.update((state: Draft<RatesControllerState>): RatesControllerState => {
         return {
-          ...this.state,
+          ...state,
           rates: updatedRates,
         };
       });
@@ -188,9 +189,9 @@ export class RatesController extends BaseController<
     cryptocurrencies: Cryptocurrency[],
   ): Promise<void> {
     await this.#withLock(() => {
-      this.update(() => {
+      this.update((state: Draft<RatesControllerState>): RatesControllerState => {
         return {
-          ...this.state,
+          ...state,
           cryptocurrencies,
         };
       });
@@ -207,9 +208,9 @@ export class RatesController extends BaseController<
     }
 
     await this.#withLock(() => {
-      this.update(() => {
+      this.update((state: Draft<RatesControllerState>): RatesControllerState => {
         return {
-          ...defaultState,
+          ...state,
           fiatCurrency,
         };
       });

--- a/packages/assets-controllers/src/RatesController/RatesController.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.ts
@@ -1,5 +1,6 @@
 import { BaseController } from '@metamask/base-controller';
 import { Mutex } from 'async-mutex';
+import type { Draft } from 'immer';
 
 import { fetchMultiExchangeRate as defaultFetchExchangeRate } from '../crypto-compare-service';
 import type {
@@ -8,7 +9,6 @@ import type {
   RatesControllerOptions,
   RatesControllerMessenger,
 } from './types';
-import { Draft } from 'immer';
 
 export const name = 'RatesController';
 
@@ -135,12 +135,14 @@ export class RatesController extends BaseController<
         };
       }
 
-      this.update((state: Draft<RatesControllerState>): RatesControllerState => {
-        return {
-          ...state,
-          rates: updatedRates,
-        };
-      });
+      this.update(
+        (state: Draft<RatesControllerState>): RatesControllerState => {
+          return {
+            ...state,
+            rates: updatedRates,
+          };
+        },
+      );
     });
   }
 
@@ -189,12 +191,14 @@ export class RatesController extends BaseController<
     cryptocurrencies: Cryptocurrency[],
   ): Promise<void> {
     await this.#withLock(() => {
-      this.update((state: Draft<RatesControllerState>): RatesControllerState => {
-        return {
-          ...state,
-          cryptocurrencies,
-        };
-      });
+      this.update(
+        (state: Draft<RatesControllerState>): RatesControllerState => {
+          return {
+            ...state,
+            cryptocurrencies,
+          };
+        },
+      );
     });
   }
 
@@ -208,12 +212,14 @@ export class RatesController extends BaseController<
     }
 
     await this.#withLock(() => {
-      this.update((state: Draft<RatesControllerState>): RatesControllerState => {
-        return {
-          ...state,
-          fiatCurrency,
-        };
-      });
+      this.update(
+        (state: Draft<RatesControllerState>): RatesControllerState => {
+          return {
+            ...state,
+            fiatCurrency,
+          };
+        },
+      );
     });
     await this.#updateRates();
   }


### PR DESCRIPTION
## Explanation

We missed to rename that field in that PR: https://github.com/MetaMask/core/pull/4242

## References

N/A

## Changelog

### `@metamask/assets-controllers`

- FIXED: Fix `RatesController.setCryptocurrencyList`
  - It was not using the correct field when updating the internal state (`fromCurrencies` -> `cryptocurrencies`)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
