### PR TITLE
feat: update notifications controllers from extension fixes.

### DIFF
--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -210,11 +210,27 @@ export type AllowedActions =
   | NotificationServicesPushControllerUpdateTriggerPushNotifications;
 
 // Events
-export type NotificationServicesControllerMessengerEvents =
+export type NotificationServicesControllerChangeEvent =
   ControllerStateChangeEvent<
     typeof controllerName,
     NotificationServicesControllerState
   >;
+
+export type MetamaskNotificationsControllerNotificationsListUpdatedEvent = {
+  type: `${typeof controllerName}:notificationsListUpdated`;
+  payload: [INotification[]];
+};
+
+export type MetamaskNotificationsControllerMarkNotificationsAsRead = {
+  type: `${typeof controllerName}:markNotificationsAsRead`;
+  payload: [INotification[]];
+};
+
+// Events
+export type Events =
+  | NotificationServicesControllerChangeEvent
+  | MetamaskNotificationsControllerNotificationsListUpdatedEvent
+  | MetamaskNotificationsControllerMarkNotificationsAsRead;
 
 // Allowed Events
 export type AllowedEvents =
@@ -230,7 +246,7 @@ export type NotificationServicesControllerMessenger =
   RestrictedControllerMessenger<
     typeof controllerName,
     Actions | AllowedActions,
-    AllowedEvents,
+    Events | AllowedEvents,
     AllowedActions['type'],
     AllowedEvents['type']
   >;
@@ -1066,6 +1082,11 @@ export default class NotificationServicesController extends BaseController<
         state.metamaskNotificationsList = metamaskNotifications;
       });
 
+      this.messagingSystem.publish(
+        `${controllerName}:notificationsListUpdated`,
+        this.state.metamaskNotificationsList,
+      );
+
       this.#setIsFetchingMetamaskNotifications(false);
       return metamaskNotifications;
     } catch (err) {
@@ -1150,6 +1171,11 @@ export default class NotificationServicesController extends BaseController<
         },
       );
     });
+
+    this.messagingSystem.publish(
+      `${controllerName}:markNotificationsAsRead`,
+      this.state.metamaskNotificationsList,
+    );
   }
 
   /**
@@ -1181,6 +1207,10 @@ export default class NotificationServicesController extends BaseController<
             notification,
             ...state.metamaskNotificationsList,
           ];
+          this.messagingSystem.publish(
+            `${controllerName}:notificationsListUpdated`,
+            state.metamaskNotificationsList,
+          );
         }
       });
     }

--- a/packages/notification-services-controller/src/NotificationServicesController/types/on-chain-notification/on-chain-notification.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/types/on-chain-notification/on-chain-notification.ts
@@ -45,6 +45,8 @@ export type OnChainRawNotification = {
   >;
 }[NotificationDataKinds];
 
+export type UnprocessedOnChainRawNotification = Notification;
+
 export type OnChainRawNotificationsWithNetworkFields = Extract<
   OnChainRawNotification,
   { data: { network_fee: unknown } }

--- a/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
@@ -213,7 +213,7 @@ export default class NotificationServicesPushController extends BaseController<
         return;
       }
 
-      this.#pushListenerUnsubscribe = await listenToPushNotifications({
+      this.#pushListenerUnsubscribe ??= await listenToPushNotifications({
         env: this.#env,
         listenToPushReceived: async (n) => {
           this.messagingSystem.publish(

--- a/packages/notification-services-controller/src/NotificationServicesPushController/services/push/push-web.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/services/push/push-web.ts
@@ -10,6 +10,7 @@ import log from 'loglevel';
 
 import type { Types } from '../../../NotificationServicesController';
 import { Processors } from '../../../NotificationServicesController';
+import { toRawOnChainNotification } from '../../../shared/to-raw-notification';
 import type { PushNotificationEnv } from '../../types/firebase';
 
 declare const self: ServiceWorkerGlobalScope;
@@ -95,14 +96,14 @@ export async function listenToPushNotificationsReceived(
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     async (payload: MessagePayload) => {
       try {
-        const notificationData: Types.NotificationUnion = payload?.data?.data
-          ? JSON.parse(payload?.data?.data)
-          : undefined;
+        const data: Types.UnprocessedOnChainRawNotification | undefined =
+          payload?.data?.data ? JSON.parse(payload?.data?.data) : undefined;
 
-        if (!notificationData) {
+        if (!data) {
           return;
         }
 
+        const notificationData = toRawOnChainNotification(data);
         const notification = Processors.processNotification(notificationData);
         await handler(notification);
       } catch (error) {

--- a/packages/notification-services-controller/src/shared/to-raw-notification.ts
+++ b/packages/notification-services-controller/src/shared/to-raw-notification.ts
@@ -1,0 +1,21 @@
+import type {
+  OnChainRawNotification,
+  UnprocessedOnChainRawNotification,
+} from 'src/NotificationServicesController/types';
+
+/**
+ * A true "raw notification" does not have some fields that exist on this type. E.g. the `type` field.
+ * This is retro-actively added when we fetch notifications to be able to easily type-discriminate notifications.
+ * We use this to ensure that the correct missing fields are added to the raw shapes
+ *
+ * @param data - raw onchain notification
+ * @returns a complete raw onchain notification
+ */
+export function toRawOnChainNotification(
+  data: UnprocessedOnChainRawNotification,
+): OnChainRawNotification {
+  return {
+    ...data,
+    type: data?.data?.kind,
+  } as OnChainRawNotification;
+}


### PR DESCRIPTION
## Explanation

There were a set of additional extension fixes that also need to be ported over to the shared libraries.
We are actively working on replacing the extension controllers with the shared libraries (this way we don't need to do this weird back and forth syncing).

## References

N/A

## Changelog

### `@metamask/notification-services-controller`

- **ADDED**: New events when notifications list is updated or when notifications are marked as read.
- **ADDED**: shared function `toRawOnChainNotification` that is used to polyfill and complete raw on chain notifications (before they get processed).
- **FIXED**: update push notifications to correctly use polyfilled/complete raw notifications.
- **ADDED**: new type `UnprocessedOnChainRawNotification` to signify the actual raw data we receive from servers.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
