### PR TITLE
patch: Compress transaction history upon update (#4555)

### DIFF
--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -70,6 +70,10 @@ export {
   WalletDevice,
 } from './types';
 export type { EtherscanTransactionMeta } from './utils/etherscan';
+export {
+  DISPLAYED_TRANSACTION_HISTORY_PATHS,
+  MAX_TRANSACTION_HISTORY_LENGTH,
+} from './utils/history';
 export { determineTransactionType } from './utils/transaction-type';
 export { mergeGasFeeEstimates } from './utils/gas-flow';
 export {

--- a/packages/transaction-controller/src/utils/history.test.ts
+++ b/packages/transaction-controller/src/utils/history.test.ts
@@ -1,0 +1,400 @@
+import { toHex } from '@metamask/controller-utils';
+import { add0x } from '@metamask/utils';
+import { cloneDeep } from 'lodash';
+
+import {
+  type TransactionHistory,
+  TransactionStatus,
+  type TransactionMeta,
+  type TransactionHistoryEntry,
+} from '../types';
+import {
+  MAX_TRANSACTION_HISTORY_LENGTH,
+  updateTransactionHistory,
+} from './history';
+
+describe('History', () => {
+  describe('updateTransactionHistory', () => {
+    it('does nothing if the history property is missing', () => {
+      const mockTransaction = createMinimalMockTransaction();
+      expect(mockTransaction.history).toBeUndefined();
+      const originalInputTransaction = cloneDeep(mockTransaction);
+
+      const updatedTransaction = updateTransactionHistory(
+        mockTransaction,
+        'test update',
+      );
+
+      expect(updatedTransaction).toBe(mockTransaction);
+      expect(updatedTransaction).toStrictEqual(originalInputTransaction);
+    });
+
+    it('does nothing if there have been no changes', () => {
+      const originalTransaction = createMinimalMockTransaction();
+      const mockTransaction = createMockTransaction({ originalTransaction });
+      const mockTransactionClone = cloneDeep(mockTransaction);
+
+      const updatedTransaction = updateTransactionHistory(
+        mockTransaction,
+        'test update',
+      );
+
+      expect(updatedTransaction).toBe(mockTransaction);
+      expect(updatedTransaction).toStrictEqual(mockTransactionClone);
+    });
+
+    it('adds a new history entry', () => {
+      const originalTransaction = createMinimalMockTransaction();
+      const mockTransaction = createMockTransaction({
+        originalTransaction,
+        partialTransaction: {
+          history: [originalTransaction],
+          txParams: { from: generateAddress(123) },
+        },
+      });
+
+      const updatedTransaction = updateTransactionHistory(
+        mockTransaction,
+        'test update',
+      );
+
+      expect(updatedTransaction).not.toBe(mockTransaction);
+      expect(updatedTransaction).toStrictEqual({
+        ...mockTransaction,
+        history: [
+          originalTransaction,
+          [
+            {
+              note: 'test update',
+              op: 'replace',
+              path: '/txParams/from',
+              timestamp: expect.any(Number),
+              value: generateAddress(123),
+            },
+          ],
+        ],
+      });
+    });
+
+    describe('when history is past max size with non-displayed entries', () => {
+      it('merges a non-displayed entry when adding a new entry after max history size is reached', () => {
+        const originalTransaction = createMinimalMockTransaction();
+        const mockTransaction = createMockTransaction({
+          partialTransaction: {
+            history: generateMockHistory({
+              originalTransaction,
+              length: MAX_TRANSACTION_HISTORY_LENGTH,
+            }),
+            // This is the changed value
+            txParams: { from: generateAddress(123) },
+          },
+        });
+        // Validate that last history entry is correct
+        expect(
+          mockTransaction.history?.[mockTransaction.history.length - 1],
+        ).toStrictEqual([
+          {
+            note: 'Mock non-displayed change',
+            op: 'replace',
+            path: '/txParams/from',
+            value: generateAddress(MAX_TRANSACTION_HISTORY_LENGTH - 1),
+          },
+        ]);
+        expect(mockTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH,
+        );
+
+        const updatedTransaction = updateTransactionHistory(
+          mockTransaction,
+          'test update',
+        );
+
+        expect(updatedTransaction).not.toBe(mockTransaction);
+        expect(updatedTransaction).toStrictEqual({
+          ...mockTransaction,
+          history: [
+            originalTransaction,
+            // This is the merged entry of mockTransaction.history[1] and mockTransaction.history[2]
+            [
+              {
+                note: 'Mock non-displayed change, Mock non-displayed change',
+                op: 'replace',
+                path: '/txParams/from',
+                timestamp: expect.any(Number),
+                value: generateAddress(2),
+              },
+            ],
+            ...mockTransaction.history.slice(3),
+            // This is the new entry:
+            [
+              {
+                note: 'test update',
+                op: 'replace',
+                path: '/txParams/from',
+                timestamp: expect.any(Number),
+                value: generateAddress(123),
+              },
+            ],
+          ],
+        });
+        expect(updatedTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH,
+        );
+      });
+    });
+
+    describe('when history is past max size with a single non-displayed entry at the end', () => {
+      it('merges a non-displayed entry when adding a new entry after max history size is reached', () => {
+        const originalTransaction = createMinimalMockTransaction();
+        // This matches the last gas price change in the mock history
+        const mockTransactionGasPrice = toHex(
+          MAX_TRANSACTION_HISTORY_LENGTH - 1,
+        );
+        const mockTransaction = createMockTransaction({
+          partialTransaction: {
+            history: generateMockHistory({
+              numberOfDisplayEntries: MAX_TRANSACTION_HISTORY_LENGTH - 1,
+              originalTransaction,
+              length: MAX_TRANSACTION_HISTORY_LENGTH,
+            }),
+            txParams: {
+              // This is the changed value
+              from: generateAddress(123),
+              // This matches the last gas price change in the mock history
+              gasPrice: mockTransactionGasPrice,
+            },
+          },
+        });
+        // Validate that last history entry is correct
+        expect(
+          mockTransaction.history?.[mockTransaction.history.length - 1],
+        ).toStrictEqual([
+          {
+            note: 'Mock displayed change',
+            op: 'replace',
+            path: '/txParams/gasPrice',
+            value: mockTransactionGasPrice,
+          },
+        ]);
+        const mockTransactionClone = cloneDeep(mockTransaction);
+        expect(mockTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH,
+        );
+
+        const updatedTransaction = updateTransactionHistory(
+          mockTransaction,
+          'test update',
+        );
+
+        expect(updatedTransaction).not.toBe(mockTransaction);
+        expect(updatedTransaction).toStrictEqual({
+          ...mockTransaction,
+          history: [
+            ...mockTransactionClone.history.slice(
+              0,
+              MAX_TRANSACTION_HISTORY_LENGTH - 1,
+            ),
+            // This is the new merged entry:
+            [
+              {
+                note: 'Mock displayed change, test update',
+                op: 'replace',
+                path: '/txParams/gasPrice',
+                timestamp: expect.any(Number),
+                value: mockTransactionGasPrice,
+              },
+              {
+                op: 'replace',
+                path: '/txParams/from',
+                value: generateAddress(123),
+              },
+            ],
+          ],
+        });
+        expect(updatedTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH,
+        );
+      });
+    });
+
+    describe('when history is past max size with only displayed entries', () => {
+      it('adds a new history entry, exceeding max size', () => {
+        const originalTransaction = createMinimalMockTransaction();
+        const mockTransaction = createMockTransaction({
+          partialTransaction: {
+            history: generateMockHistory({
+              numberOfDisplayEntries: MAX_TRANSACTION_HISTORY_LENGTH - 1,
+              originalTransaction,
+              length: MAX_TRANSACTION_HISTORY_LENGTH,
+            }),
+            txParams: {
+              from: originalTransaction.txParams.from,
+              // This is the changed value
+              gasPrice: toHex(1337),
+            },
+          },
+        });
+        // Validate that last history entry is correct
+        expect(
+          mockTransaction.history?.[mockTransaction.history.length - 1],
+        ).toStrictEqual([
+          {
+            note: 'Mock displayed change',
+            op: 'replace',
+            path: '/txParams/gasPrice',
+            value: toHex(MAX_TRANSACTION_HISTORY_LENGTH - 1),
+          },
+        ]);
+        expect(mockTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH,
+        );
+
+        const updatedTransaction = updateTransactionHistory(
+          mockTransaction,
+          'test update',
+        );
+
+        expect(updatedTransaction).not.toBe(mockTransaction);
+        expect(updatedTransaction).toStrictEqual({
+          ...mockTransaction,
+          history: [
+            ...mockTransaction.history,
+            // This is the new entry:
+            [
+              {
+                note: 'test update',
+                op: 'replace',
+                path: '/txParams/gasPrice',
+                timestamp: expect.any(Number),
+                value: toHex(1337),
+              },
+            ],
+          ],
+        });
+        expect(updatedTransaction.history).toHaveLength(
+          MAX_TRANSACTION_HISTORY_LENGTH + 1,
+        );
+      });
+    });
+  });
+});
+
+/**
+ * Create a minimal mock transaction. It has just enough to satify the type.
+ *
+ * @returns A minimal transaction.
+ */
+function createMinimalMockTransaction(): TransactionMeta {
+  return {
+    chainId: toHex(1337),
+    id: 'mock-id',
+    time: 0,
+    status: TransactionStatus.submitted as const,
+    txParams: {
+      from: '',
+    },
+  };
+}
+
+/**
+ * Create a mock transaction.
+ *
+ * Optionally an incomplete transaction can be passed in, and any missing required proeprties will
+ * be filled out. The 'status' property is not allowed as input only because it was complicated to
+ * get the types to be correct if it was provided.
+ *
+ * A `history` property is included only if an original transaction is passed in.
+ *
+ * @param options - Options.
+ * @param options.partialTransaction - A partial transaction, without a 'status' property.
+ * @param options.originalTransaction - The original transaction object to include in the transaction
+ * history.
+ * @returns A mock transaction.
+ */
+function createMockTransaction({
+  partialTransaction,
+  originalTransaction,
+}: {
+  partialTransaction?: Omit<Partial<TransactionMeta>, 'status'>;
+  originalTransaction?: TransactionMeta;
+} = {}): TransactionMeta & Required<Pick<TransactionMeta, 'history'>> {
+  const minimalTransaction = createMinimalMockTransaction();
+
+  if (originalTransaction) {
+    if (originalTransaction.history) {
+      throw new Error(
+        'The original transaction should be an initial snapshot of the transaction, with no history property',
+      );
+    }
+    minimalTransaction.history = [originalTransaction];
+  } else {
+    minimalTransaction.history = [{ ...minimalTransaction }];
+  }
+
+  return {
+    // Cast used here because TypeScript wasn't able to infer that `history` was guaranteed to be set
+    ...(minimalTransaction as TransactionMeta &
+      Required<Pick<TransactionMeta, 'history'>>),
+    ...partialTransaction,
+  };
+}
+
+/**
+ * Generate a mock transaction history.
+ *
+ * @param args - Arguments.
+ * @param args.numberOfDisplayEntries - The number of displayed history entries to generate.
+ * @param args.originalTransaction - The original transaction, before any history changes.
+ * @param args.length - The total length of history to generate.
+ * @returns Mock transaction history.
+ */
+function generateMockHistory({
+  numberOfDisplayEntries = 0,
+  originalTransaction,
+  length,
+}: {
+  numberOfDisplayEntries?: number;
+  originalTransaction: TransactionMeta;
+  length: number;
+}): TransactionHistory {
+  if (length < 1) {
+    throw new Error('Invalid length');
+  } else if (numberOfDisplayEntries >= length) {
+    throw new Error('Length must exceed number of displayed entries');
+  }
+
+  const historyEntries: TransactionHistoryEntry[] = [
+    ...Array(length - 1).keys(),
+  ].map((index: number) => {
+    // Use index of this entry in history array, for better readability/debugging of mock values
+    const historyIndex = index + 1;
+
+    return [
+      numberOfDisplayEntries < historyIndex
+        ? {
+            note: 'Mock non-displayed change',
+            op: 'replace',
+            path: '/txParams/from',
+            value: generateAddress(historyIndex),
+          }
+        : {
+            note: 'Mock displayed change',
+            op: index === 0 ? 'add' : 'replace',
+            path: '/txParams/gasPrice',
+            value: toHex(historyIndex),
+          },
+    ];
+  });
+
+  return [originalTransaction, ...historyEntries];
+}
+
+/**
+ * Generate a mock lowercase Ethereum address.
+ *
+ * @param number - The address as a decimal number.
+ * @returns The mock address
+ */
+function generateAddress(number: number) {
+  return add0x(number.toString(16).padStart(40, '0'));
+}

--- a/packages/transaction-controller/src/utils/history.ts
+++ b/packages/transaction-controller/src/utils/history.ts
@@ -8,6 +8,23 @@ import type {
 } from '../types';
 
 /**
+ * The maximum allowed length of the `transaction.history` property.
+ */
+export const MAX_TRANSACTION_HISTORY_LENGTH = 100;
+
+/**
+ * A list of trarnsaction history paths that may be used for display. These entries will not be
+ * compressed.
+ */
+export const DISPLAYED_TRANSACTION_HISTORY_PATHS = [
+  '/status',
+  '/txParams/gasPrice',
+  '/txParams/gas',
+  '/estimatedBaseFee',
+  '/blockTimestamp',
+];
+
+/**
  * Build a new version of the provided transaction with an initial history
  * entry, which is just a snapshot of the transaction.
  *
@@ -40,14 +57,102 @@ export function updateTransactionHistory(
 
   const currentState = snapshotFromTransactionMeta(transactionMeta);
   const previousState = replayHistory(transactionMeta.history);
-  const historyEntry = generateHistoryEntry(previousState, currentState, note);
+  const newHistoryEntry = generateHistoryEntry(
+    previousState,
+    currentState,
+    note,
+  );
 
-  if (historyEntry.length > 0) {
-    return merge({}, transactionMeta, {
-      history: [...transactionMeta.history, historyEntry],
-    });
+  if (newHistoryEntry.length === 0) {
+    return transactionMeta;
   }
-  return transactionMeta;
+
+  // Casts required here because this list has two separate types of entries:
+  // TransactionMeta and TransactionHistoryEntry. The only TransactionMeta is the first
+  // entry, but TypeScript loses that type information when `slice` is called for some reason.
+  let updatedHistory = [
+    ...transactionMeta.history,
+    newHistoryEntry,
+  ] as TransactionHistory;
+
+  if (updatedHistory.length > MAX_TRANSACTION_HISTORY_LENGTH) {
+    updatedHistory = compressTransactionHistory(updatedHistory);
+  }
+
+  return merge({}, transactionMeta, {
+    history: updatedHistory,
+  });
+}
+
+/**
+ * Compress the transaction history, if it is possible to do so without compressing entries used
+ * for display. History entries are merged together to make room for a single new entry.
+ *
+ * @param transactionHistory - The transaction history to compress.
+ * @returns A compressed transaction history.
+ */
+function compressTransactionHistory(
+  transactionHistory: TransactionHistory,
+): TransactionHistory {
+  const initialEntry = transactionHistory[0];
+  // Casts required here because this list has two separate types of entries:
+  // TransactionMeta and TransactionHistoryEntry. The only TransactionMeta is the first
+  // entry, but TypeScript loses that type information when `slice` is called for some reason.
+  const historyEntries = transactionHistory.slice(
+    1,
+  ) as TransactionHistoryEntry[];
+
+  const firstNonDisplayedEntryIndex = historyEntries.findIndex(
+    (historyEntry) => {
+      return !historyEntry.some(({ path }) =>
+        DISPLAYED_TRANSACTION_HISTORY_PATHS.includes(path),
+      );
+    },
+  );
+
+  // If no non-displayed entry is found, let history exceed max size.
+  // TODO: Move data used for display to another property, so that we can more reliably limit
+  // history size or remove it altogether.
+  if (firstNonDisplayedEntryIndex === -1) {
+    return transactionHistory;
+  }
+
+  // If a non-displayed entry is found that we can remove, merge it with another entry.
+  // The entry we're merging with might be a "displayed" entry, but that's OK, merging more changes
+  // in does not break our display logic.
+  const mergeTargetEntryIndex =
+    // Merge with previous entry if there is no next entry.
+    // We default to merging with next because the next entry might also be non-displayed, so it
+    // might be removed in a future trim, saving more space.
+    firstNonDisplayedEntryIndex === historyEntries.length - 1
+      ? firstNonDisplayedEntryIndex - 1
+      : firstNonDisplayedEntryIndex + 1;
+  const firstIndexToMerge = Math.min(
+    firstNonDisplayedEntryIndex,
+    mergeTargetEntryIndex,
+  );
+  const firstEntryToMerge = historyEntries[firstIndexToMerge];
+  const secondEntryToMerge = historyEntries[firstIndexToMerge + 1];
+
+  const beforeMergeState = replayHistory([
+    initialEntry,
+    ...historyEntries.slice(0, firstIndexToMerge),
+  ]);
+  const afterMergeState = replayHistory([
+    beforeMergeState,
+    firstEntryToMerge,
+    secondEntryToMerge,
+  ]);
+  const mergedHistoryEntry = generateHistoryEntry(
+    beforeMergeState,
+    afterMergeState,
+    `${String(firstEntryToMerge[0].note)}, ${String(
+      secondEntryToMerge[0].note,
+    )}`,
+  );
+
+  historyEntries.splice(firstIndexToMerge, 2, mergedHistoryEntry);
+  return [initialEntry, ...historyEntries];
 }
 
 /**


### PR DESCRIPTION
This is a back port of #4555 for `@metamask/transaction-controller@32.0.0`  (intended for the extension v12.0.x release).

Original description:

The TransactionController has been updated to compress transaction history if it exceeds the max transaction history size, which for now has been set to 100. Each time a new entry is added to a transaction history already at max size, we merge two entries to make room for the new one.

Note that we never compress entries used for display in the transaction activity log, because compressing those entries might hide events that we want to display. If there are no non-displayed entries to compress, history is allowed to exceed the max size.

This is a temporary solution to prevent unbounded growth of the transaction history. While technically it is still unbounded at this level because we don't strictly limit displayed history entries, we don't know of any cases where displayed entries can be repeated a significant number of times, so this will solve that problem in practice.

Fixes #4549

For the `@metamask/transaction-controller` package:
```markdown

- Add `DISPLAYED_TRANSACTION_HISTORY_PATHS` constant, representing the transaction history paths that may be used for display ([#4555](https://github.com/MetaMask/core/pull/4555))
  - This was exported so that it might be used to ensure display logic and internal history logic remains in-sync.
  - Any paths listed here will have their timestamps preserved. Unlisted paths may be compressed by the controller to minimize history size, losing the timestamp.
- Add `MAX_TRANSACTION_HISTORY_LENGTH` constant, representing the expected maximum size of the `history` property for a given transaction ([#4555](https://github.com/MetaMask/core/pull/4555))
  - Note that this is not strictly enforced, the length may exceed this number of all entries are "displayed" entries, but we expect this to be extremely improbable in practice.

- Prevent transaction history from growing endlessly in size ([#4555](https://github.com/MetaMask/core/pull/4555))
```

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate

---------

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
