### PR TITLE
Bump `typescript` from `~5.4.5` to `~5.5.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "simple-git-hooks": "^2.8.0",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.2",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "yargs": "^17.7.2"
   },
   "packageManager": "yarn@4.2.2",

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -63,7 +63,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^17.0.0",

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -51,7 +51,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -55,7 +55,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -86,7 +86,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/accounts-controller": "^18.0.0",

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/chain-controller/package.json
+++ b/packages/chain-controller/package.json
@@ -59,7 +59,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -60,7 +60,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -56,7 +56,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^20.0.0"

--- a/packages/eth-json-rpc-provider/package.json
+++ b/packages/eth-json-rpc-provider/package.json
@@ -64,7 +64,7 @@
     "jest-it-up": "^2.0.2",
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -65,7 +65,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^20.0.0"

--- a/packages/json-rpc-engine/package.json
+++ b/packages/json-rpc-engine/package.json
@@ -63,7 +63,7 @@
     "jest-it-up": "^2.0.2",
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/json-rpc-middleware-stream/package.json
+++ b/packages/json-rpc-middleware-stream/package.json
@@ -57,7 +57,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "webextension-polyfill-ts": "^0.26.0"
   },
   "engines": {

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -70,7 +70,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5",
+    "typescript": "~5.5.4",
     "uuid": "^8.3.2"
   },
   "engines": {

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -57,7 +57,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -55,7 +55,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -72,7 +72,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/notification-services-controller/package.json
+++ b/packages/notification-services-controller/package.json
@@ -64,7 +64,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^17.0.0",

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -60,7 +60,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^7.0.0"

--- a/packages/permission-log-controller/package.json
+++ b/packages/permission-log-controller/package.json
@@ -56,7 +56,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -58,7 +58,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -58,7 +58,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^20.0.0"

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^17.0.0"

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -64,7 +64,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^17.0.0",

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -62,7 +62,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^20.0.0",

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -60,7 +60,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/network-controller": "^20.0.0",

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -59,7 +59,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^7.0.0",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -82,7 +82,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@babel/runtime": "^7.23.9",

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -67,7 +67,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^7.0.0",

--- a/scripts/create-package/package-template/package.json
+++ b/scripts/create-package/package-template/package.json
@@ -47,7 +47,7 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.4.5"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": "NODE_VERSIONS"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2218,7 +2218,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@metamask/keyring-controller": ^17.0.0
@@ -2251,7 +2251,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -2267,7 +2267,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -2299,7 +2299,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -2349,7 +2349,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@metamask/accounts-controller": ^18.0.0
@@ -2415,7 +2415,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -2442,7 +2442,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -2475,7 +2475,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   languageName: unknown
   linkType: soft
@@ -2495,7 +2495,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -2544,7 +2544,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -2597,7 +2597,7 @@ __metadata:
     simple-git-hooks: "npm:^2.8.0"
     ts-node: "npm:^10.9.1"
     tsup: "npm:^8.0.2"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     yargs: "npm:^17.7.2"
   languageName: unknown
   linkType: soft
@@ -2641,7 +2641,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   peerDependencies:
     "@metamask/network-controller": ^20.0.0
   languageName: unknown
@@ -2794,7 +2794,7 @@ __metadata:
     jest-it-up: "npm:^2.0.2"
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   languageName: unknown
   linkType: soft
@@ -3023,7 +3023,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@metamask/network-controller": ^20.0.0
@@ -3067,7 +3067,7 @@ __metadata:
     jest-it-up: "npm:^2.0.2"
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -3101,7 +3101,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     webextension-polyfill-ts: "npm:^0.26.0"
   languageName: unknown
   linkType: soft
@@ -3166,7 +3166,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   languageName: unknown
   linkType: soft
@@ -3184,7 +3184,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   languageName: unknown
   linkType: soft
@@ -3206,7 +3206,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   languageName: unknown
   linkType: soft
@@ -3233,7 +3233,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -3269,7 +3269,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   languageName: unknown
   linkType: soft
@@ -3300,7 +3300,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -3328,7 +3328,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@metamask/keyring-controller": ^17.0.0
@@ -3406,7 +3406,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   peerDependencies:
     "@metamask/approval-controller": ^7.0.0
   languageName: unknown
@@ -3448,7 +3448,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -3471,7 +3471,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -3506,7 +3506,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@metamask/network-controller": ^20.0.0
@@ -3538,7 +3538,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   peerDependencies:
     "@metamask/keyring-controller": ^17.0.0
   languageName: unknown
@@ -3569,7 +3569,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   peerDependencies:
     "@metamask/keyring-controller": ^17.0.0
     "@metamask/snaps-controllers": ^9.3.0
@@ -3620,7 +3620,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   peerDependencies:
     "@metamask/network-controller": ^20.0.0
     "@metamask/selected-network-controller": ^17.0.0
@@ -3641,7 +3641,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -3693,7 +3693,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   peerDependencies:
     "@metamask/network-controller": ^20.0.0
     "@metamask/permission-controller": ^11.0.0
@@ -3720,7 +3720,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
   peerDependencies:
     "@metamask/approval-controller": ^7.0.0
     "@metamask/keyring-controller": ^17.0.0
@@ -3967,7 +3967,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@babel/runtime": ^7.23.9
@@ -4004,7 +4004,7 @@ __metadata:
     ts-jest: "npm:^27.1.4"
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.5.4"
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@metamask/approval-controller": ^7.0.0
@@ -12994,23 +12994,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.4.5":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
+"typescript@npm:~5.5.4":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/d04a9e27e6d83861f2126665aa8d84847e8ebabcea9125b9ebc30370b98cb38b5dff2508d74e2326a744938191a83a69aa9fddab41f193ffa43eabfdf3f190a5
+  checksum: 10/1689ccafef894825481fc3d856b4834ba3cc185a9c2878f3c76a9a1ef81af04194849840f3c69e7961e2312771471bb3b460ca92561e1d87599b26c37d0ffb6f
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.4.5#optional!builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
+"typescript@patch:typescript@npm%3A~5.5.4#optional!builtin<compat/typescript>":
+  version: 5.5.4
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/760f7d92fb383dbf7dee2443bf902f4365db2117f96f875cf809167f6103d55064de973db9f78fe8f31ec08fff52b2c969aee0d310939c0a3798ec75d0bca2e1
+  checksum: 10/2c065f0ef81855eac25c9b658a3c9da65ffc005260c12854c2286f40f3667e1b1ecf8bdbdd37b59aa0397920378ce7900bff8cb32e0f1c7af6fd86efc676718c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## References

- Closes #4587

## Changelog

```md
### Changed

- Upgrade TypeScript version to `~5.5.4` ([#4586](https://github.com/MetaMask/core/pull/4586))
```

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
