### PR TITLE
fix: updateAccountMetadata action type name and export

### DIFF
--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -106,7 +106,7 @@ export type AccountsControllerGetAccountAction = {
   handler: AccountsController['getAccount'];
 };
 
-export type AccountsControllerUpdateAccountMetadata = {
+export type AccountsControllerUpdateAccountMetadataAction = {
   type: `${typeof controllerName}:updateAccountMetadata`;
   handler: AccountsController['updateAccountMetadata'];
 };
@@ -128,7 +128,7 @@ export type AccountsControllerActions =
   | AccountsControllerGetNextAvailableAccountNameAction
   | AccountsControllerGetAccountAction
   | AccountsControllerGetSelectedMultichainAccountAction
-  | AccountsControllerUpdateAccountMetadata;
+  | AccountsControllerUpdateAccountMetadataAction;
 
 export type AccountsControllerChangeEvent = ControllerStateChangeEvent<
   typeof controllerName,

--- a/packages/accounts-controller/src/index.ts
+++ b/packages/accounts-controller/src/index.ts
@@ -11,6 +11,7 @@ export type {
   AccountsControllerGetAccountByAddressAction,
   AccountsControllerGetAccountAction,
   AccountsControllerGetNextAvailableAccountNameAction,
+  AccountsControllerUpdateAccountMetadataAction,
   AccountsControllerActions,
   AccountsControllerChangeEvent,
   AccountsControllerSelectedAccountChangeEvent,


### PR DESCRIPTION
## Explanation

This PR fixes the `updateAccountMetadata` action type name, and exports it correctly.

## References

## Changelog

### `@metamask/accounts-controller`

- **FIXED**: `AccountsControllerUpdateAccountMetadataAction` type name
- **ADDED**: `AccountsControllerUpdateAccountMetadataAction` export

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
