### PR TITLE
test: fix transaction controller integration tests with nonce tracker 6

### DIFF
--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -51,7 +51,7 @@
     "@metamask/controller-utils": "^11.0.2",
     "@metamask/eth-query": "^4.0.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
-    "@metamask/nonce-tracker": "^5.0.0",
+    "@metamask/nonce-tracker": "^6.0.0",
     "@metamask/rpc-errors": "^6.3.1",
     "@metamask/utils": "^9.1.0",
     "async-mutex": "^0.5.0",

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -3405,7 +3405,7 @@ export class TransactionController extends BaseController<
       // TODO: Fix types
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       provider: provider as any,
-      // @ts-expect-error TODO: Fix types
+      // TODO: Fix types
       blockTracker,
       getPendingTransactions: this.#getNonceTrackerPendingTransactions.bind(
         this,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3274,15 +3274,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/nonce-tracker@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@metamask/nonce-tracker@npm:5.0.0"
+"@metamask/nonce-tracker@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/nonce-tracker@npm:6.0.0"
   dependencies:
     "@ethersproject/providers": "npm:^5.7.2"
     async-mutex: "npm:^0.3.1"
   peerDependencies:
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/72bce31702c5575b6dd583dd772312994103ff25389643526284d0e4320588cb0c7b389739fbdb1828f3e6ab387deddfc8cf2b674aa65bf3054db089cafce1db
+  checksum: 10/e62edd38eeaba6d917bc3aed38017294f2bfdb59120a9fb4f093fe96a46d8d9214453a802fe782faaf4a007f4cd5f393607c70a2ff8479ecd7ef18827cad067a
   languageName: node
   linkType: hard
 
@@ -3948,7 +3948,7 @@ __metadata:
     "@metamask/keyring-api": "npm:^8.0.1"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^20.1.0"
-    "@metamask/nonce-tracker": "npm:^5.0.0"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
     "@metamask/rpc-errors": "npm:^6.3.1"
     "@metamask/utils": "npm:^9.1.0"
     "@types/bn.js": "npm:^5.1.5"


### PR DESCRIPTION
## Explanation

Fix the `TransactionController` integration tests with version `6.0.0` of `@metamask/nonce-tracker`.

This version of the nonce tracker constructs a new `Web3Provider` instance every time a `eth_getTransactionCount` call is required, this is needed in order to support the proxy provider which can dynamically point to different networks.

This `Web3Provider` extends the `JsonRpcProvider` whose constructor has the side effect of creating a timeout to determine the chain ID, if not provided in the constructor. When calling `getTransactionCount` on this provider, it first awaits the network being identified as a result of the timeout.

https://github.com/ethers-io/ethers.js/blob/v5.7.2/packages/providers/src.ts/json-rpc-provider.ts#L416

https://github.com/ethers-io/ethers.js/blob/v5.7.2/packages/providers/src.ts/base-provider.ts#L1461

Since the integration tests use fake timers, some of them were hanging when generating a nonce since an additional tick was required to process this constructor network timeout.

## References

Related to [#2668](https://github.com/MetaMask/MetaMask-planning/issues/2668)

## Changelog

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
