### PR TITLE
fix: profile-sync-controller - make fixture constants lazy

### DIFF
--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -210,27 +210,27 @@ export type AllowedActions =
   | NotificationServicesPushControllerUpdateTriggerPushNotifications;
 
 // Events
-export type NotificationServicesControllerChangeEvent =
+export type NotificationServicesControllerStateChangeEvent =
   ControllerStateChangeEvent<
     typeof controllerName,
     NotificationServicesControllerState
   >;
 
-export type MetamaskNotificationsControllerNotificationsListUpdatedEvent = {
+export type NotificationListUpdatedEvent = {
   type: `${typeof controllerName}:notificationsListUpdated`;
   payload: [INotification[]];
 };
 
-export type MetamaskNotificationsControllerMarkNotificationsAsRead = {
+export type MarkNotificationsAsReadEvent = {
   type: `${typeof controllerName}:markNotificationsAsRead`;
   payload: [INotification[]];
 };
 
 // Events
 export type Events =
-  | NotificationServicesControllerChangeEvent
-  | MetamaskNotificationsControllerNotificationsListUpdatedEvent
-  | MetamaskNotificationsControllerMarkNotificationsAsRead;
+  | NotificationServicesControllerStateChangeEvent
+  | NotificationListUpdatedEvent
+  | MarkNotificationsAsReadEvent;
 
 // Allowed Events
 export type AllowedEvents =

--- a/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockResponses.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockResponses.ts
@@ -14,16 +14,16 @@ export const MOCK_USER_STORAGE_NOTIFICATIONS_ENDPOINT = `${USER_STORAGE_ENDPOINT
   MOCK_STORAGE_KEY,
 )}`;
 
-const MOCK_GET_USER_STORAGE_RESPONSE: GetUserStorageResponse = {
+const MOCK_GET_USER_STORAGE_RESPONSE = (): GetUserStorageResponse => ({
   HashedKey: 'HASHED_KEY',
-  Data: MOCK_ENCRYPTED_STORAGE_DATA,
-};
+  Data: MOCK_ENCRYPTED_STORAGE_DATA(),
+});
 
 export const getMockUserStorageGetResponse = () => {
   return {
     url: MOCK_USER_STORAGE_NOTIFICATIONS_ENDPOINT,
     requestMethod: 'GET',
-    response: MOCK_GET_USER_STORAGE_RESPONSE,
+    response: MOCK_GET_USER_STORAGE_RESPONSE(),
   } satisfies MockResponse;
 };
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockStorage.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockStorage.ts
@@ -4,7 +4,7 @@ export const MOCK_STORAGE_KEY_SIGNATURE = 'mockStorageKey';
 export const MOCK_STORAGE_KEY = createSHA256Hash(MOCK_STORAGE_KEY_SIGNATURE);
 export const MOCK_STORAGE_DATA = JSON.stringify({ hello: 'world' });
 
-// NOTE - bug on mobile that does not work well with encryption.encryptString on start time.
+// NOTE - using encryption.encryptString directly in fixtures causes issues on mobile.
 // This is because this fixture is getting added in at run time. Will be improved once we support multiple exports
 export const MOCK_ENCRYPTED_STORAGE_DATA = () =>
   encryption.encryptString(MOCK_STORAGE_DATA, MOCK_STORAGE_KEY);

--- a/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockStorage.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockStorage.ts
@@ -3,7 +3,8 @@ import encryption, { createSHA256Hash } from '../encryption';
 export const MOCK_STORAGE_KEY_SIGNATURE = 'mockStorageKey';
 export const MOCK_STORAGE_KEY = createSHA256Hash(MOCK_STORAGE_KEY_SIGNATURE);
 export const MOCK_STORAGE_DATA = JSON.stringify({ hello: 'world' });
-export const MOCK_ENCRYPTED_STORAGE_DATA = encryption.encryptString(
-  MOCK_STORAGE_DATA,
-  MOCK_STORAGE_KEY,
-);
+
+// NOTE - bug on mobile that does not work well with encryption.encryptString on start time.
+// This is because this fixture is getting added in at run time. Will be improved once we support multiple exports
+export const MOCK_ENCRYPTED_STORAGE_DATA = () =>
+  encryption.encryptString(MOCK_STORAGE_DATA, MOCK_STORAGE_KEY);

--- a/packages/profile-sync-controller/src/controllers/user-storage/services.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/services.test.ts
@@ -60,8 +60,9 @@ describe('user-storage/services.ts - getUserStorage() tests', () => {
 });
 
 describe('user-storage/services.ts - upsertUserStorage() tests', () => {
+  const encryptedData = MOCK_ENCRYPTED_STORAGE_DATA();
   const actCallUpsertUserStorage = () => {
-    return upsertUserStorage(MOCK_ENCRYPTED_STORAGE_DATA, {
+    return upsertUserStorage(encryptedData, {
       bearerToken: 'MOCK_BEARER_TOKEN',
       path: 'notifications.notificationSettings',
       storageKey: MOCK_STORAGE_KEY,


### PR DESCRIPTION
## Explanation

this is a temp fix so that mobile does not compute these fixtures are runtime. we do need to support multiple exports to ensure that these are not called.

## References

https://consensyssoftware.atlassian.net/browse/NOTIFY-958

## Changelog


### `@metamask/profile-sync-controller`

- **CHANGED**: profile sync fixture mocks to be evaluated lazily (by making them functions)
- **CHANGED**: Update notification services controller event type names.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
