### PR TITLE
chore: bump `@metamask/keyring-api` to version `8.1.0`

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -44,7 +44,7 @@
     "@ethereumjs/util": "^8.1.0",
     "@metamask/base-controller": "^6.0.2",
     "@metamask/eth-snap-keyring": "^4.3.1",
-    "@metamask/keyring-api": "^8.0.1",
+    "@metamask/keyring-api": "^8.1.0",
     "@metamask/snaps-sdk": "^6.1.1",
     "@metamask/snaps-utils": "^7.8.1",
     "@metamask/utils": "^9.1.0",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -71,7 +71,7 @@
     "@metamask/approval-controller": "^7.0.2",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/ethjs-provider-http": "^0.3.0",
-    "@metamask/keyring-api": "^8.0.1",
+    "@metamask/keyring-api": "^8.1.0",
     "@metamask/keyring-controller": "^17.1.2",
     "@metamask/network-controller": "^20.1.0",
     "@metamask/preferences-controller": "^13.0.1",

--- a/packages/chain-controller/package.json
+++ b/packages/chain-controller/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@metamask/base-controller": "^6.0.2",
     "@metamask/chain-api": "^0.1.0",
-    "@metamask/keyring-api": "^8.0.1",
+    "@metamask/keyring-api": "^8.1.0",
     "@metamask/snaps-controllers": "^9.3.1",
     "@metamask/snaps-sdk": "^6.1.1",
     "@metamask/snaps-utils": "^7.8.1",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -48,7 +48,7 @@
     "@metamask/eth-hd-keyring": "^7.0.1",
     "@metamask/eth-sig-util": "^7.0.1",
     "@metamask/eth-simple-keyring": "^6.0.1",
-    "@metamask/keyring-api": "^8.0.1",
+    "@metamask/keyring-api": "^8.1.0",
     "@metamask/message-manager": "^10.0.2",
     "@metamask/utils": "^9.1.0",
     "async-mutex": "^0.5.0",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -69,7 +69,7 @@
     "@metamask/eth-json-rpc-provider": "^4.1.2",
     "@metamask/ethjs-provider-http": "^0.3.0",
     "@metamask/gas-fee-controller": "^19.0.1",
-    "@metamask/keyring-api": "^8.0.1",
+    "@metamask/keyring-api": "^8.1.0",
     "@metamask/network-controller": "^20.1.0",
     "@types/bn.js": "^5.1.5",
     "@types/jest": "^27.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,7 +2203,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^6.0.2"
     "@metamask/eth-snap-keyring": "npm:^4.3.1"
-    "@metamask/keyring-api": "npm:^8.0.1"
+    "@metamask/keyring-api": "npm:^8.1.0"
     "@metamask/keyring-controller": "npm:^17.1.2"
     "@metamask/snaps-controllers": "npm:^9.3.1"
     "@metamask/snaps-sdk": "npm:^6.1.1"
@@ -2321,7 +2321,7 @@ __metadata:
     "@metamask/controller-utils": "npm:^11.0.2"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-provider-http": "npm:^0.3.0"
-    "@metamask/keyring-api": "npm:^8.0.1"
+    "@metamask/keyring-api": "npm:^8.1.0"
     "@metamask/keyring-controller": "npm:^17.1.2"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^20.1.0"
@@ -2463,7 +2463,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^6.0.2"
     "@metamask/chain-api": "npm:^0.1.0"
-    "@metamask/keyring-api": "npm:^8.0.1"
+    "@metamask/keyring-api": "npm:^8.1.0"
     "@metamask/snaps-controllers": "npm:^9.3.1"
     "@metamask/snaps-sdk": "npm:^6.1.1"
     "@metamask/snaps-utils": "npm:^7.8.1"
@@ -3119,7 +3119,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^8.0.0, @metamask/keyring-api@npm:^8.0.1":
+"@metamask/keyring-api@npm:^8.0.0":
   version: 8.0.1
   resolution: "@metamask/keyring-api@npm:8.0.1"
   dependencies:
@@ -3132,6 +3132,22 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ">=15 <18"
   checksum: 10/a54d78130a71b51eebcaff1aaf35e5f7c56e6032850453c155ef2085df541a8b4b231106aaf481d049ec0f95da9faca04ead56944b71b4602916e6cacdd96c7f
+  languageName: node
+  linkType: hard
+
+"@metamask/keyring-api@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@metamask/keyring-api@npm:8.1.0"
+  dependencies:
+    "@metamask/snaps-sdk": "npm:^6.1.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^9.1.0"
+    "@types/uuid": "npm:^9.0.8"
+    bech32: "npm:^2.0.0"
+    uuid: "npm:^9.0.1"
+  peerDependencies:
+    "@metamask/providers": ">=15 <18"
+  checksum: 10/15711ddaa0007794cc23f9c02f6cfbee85aa1cf79a46468a0398404c295eef1511555ce6bd60a691081d33864d288ea8b309ee9ac9c4d6f277ab22e4d97cb76e
   languageName: node
   linkType: hard
 
@@ -3151,7 +3167,7 @@ __metadata:
     "@metamask/eth-hd-keyring": "npm:^7.0.1"
     "@metamask/eth-sig-util": "npm:^7.0.1"
     "@metamask/eth-simple-keyring": "npm:^6.0.1"
-    "@metamask/keyring-api": "npm:^8.0.1"
+    "@metamask/keyring-api": "npm:^8.1.0"
     "@metamask/message-manager": "npm:^10.0.2"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/utils": "npm:^9.1.0"
@@ -3945,7 +3961,7 @@ __metadata:
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-provider-http": "npm:^0.3.0"
     "@metamask/gas-fee-controller": "npm:^19.0.1"
-    "@metamask/keyring-api": "npm:^8.0.1"
+    "@metamask/keyring-api": "npm:^8.1.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^20.1.0"
     "@metamask/nonce-tracker": "npm:^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3119,23 +3119,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^8.0.0":
-  version: 8.0.1
-  resolution: "@metamask/keyring-api@npm:8.0.1"
-  dependencies:
-    "@metamask/snaps-sdk": "npm:^6.0.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^9.1.0"
-    "@types/uuid": "npm:^9.0.8"
-    bech32: "npm:^2.0.0"
-    uuid: "npm:^9.0.1"
-  peerDependencies:
-    "@metamask/providers": ">=15 <18"
-  checksum: 10/a54d78130a71b51eebcaff1aaf35e5f7c56e6032850453c155ef2085df541a8b4b231106aaf481d049ec0f95da9faca04ead56944b71b4602916e6cacdd96c7f
-  languageName: node
-  linkType: hard
-
-"@metamask/keyring-api@npm:^8.1.0":
+"@metamask/keyring-api@npm:^8.0.0, @metamask/keyring-api@npm:^8.1.0":
   version: 8.1.0
   resolution: "@metamask/keyring-api@npm:8.1.0"
   dependencies:


### PR DESCRIPTION
## Explanation

This PR bumps the `@metamask/keyring-api` to version `8.1.0` in every core package that depends on it.

## References

## Changelog

### `@metamask/accounts-controller`

- **CHANGED**: bump `@metamask/keyring-api` to version `8.1.0`

### `@metamask/assets-controller`

- **CHANGED**: bump `@metamask/keyring-api` to version `8.1.0`

### `@metamask/chain-controller`

- **CHANGED**: bump `@metamask/keyring-api` to version `8.1.0`

### `@metamask/keyring-controller`

- **CHANGED**: bump `@metamask/keyring-api` to version `8.1.0`

### `@metamask/transaction-controller`

- **CHANGED**: bump `@metamask/keyring-api` to version `8.1.0`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
