### PR TITLE
Use selected network controller for Snaps

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -26,12 +26,6 @@ const stateMetadata = {
 
 const getDefaultState = () => ({ domains: {} });
 
-// npm and local are currently the only valid prefixes for snap domains
-// TODO: eventually we maybe want to pull this in from snaps-utils to ensure it stays in sync
-// For now it seems like overkill to add a dependency for this one constant
-// https://github.com/MetaMask/snaps/blob/2beee7803bfe9e540788a3558b546b9f55dc3cb4/packages/snaps-utils/src/types.ts#L120
-const snapsPrefixes = ['npm:', 'local:'] as const;
-
 export type Domain = string;
 
 export const METAMASK_DOMAIN = 'metamask' as const;
@@ -357,10 +351,6 @@ export class SelectedNetworkController extends BaseController<
       );
     }
 
-    if (snapsPrefixes.some((prefix) => domain.startsWith(prefix))) {
-      return;
-    }
-
     if (!this.#domainHasPermissions(domain)) {
       throw new Error(
         'NetworkClientId for domain cannot be called with a domain that has not yet been granted permissions',
@@ -386,11 +376,8 @@ export class SelectedNetworkController extends BaseController<
    * @returns The proxy and block tracker proxies.
    */
   getProviderAndBlockTracker(domain: Domain): NetworkProxy {
-    // If the domain is 'metamask' or a snap, return the NetworkController's globally selected network client proxy
-    if (
-      domain === METAMASK_DOMAIN ||
-      snapsPrefixes.some((prefix) => domain.startsWith(prefix))
-    ) {
+    // If the domain is 'metamask', return the NetworkController's globally selected network client proxy
+    if (domain === METAMASK_DOMAIN) {
       const networkClient = this.messagingSystem.call(
         'NetworkController:getSelectedNetworkClient',
       );

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -789,23 +789,22 @@ describe('SelectedNetworkController', () => {
 
     // TODO - improve these tests by using a full NetworkController and doing more robust behavioral testing
     describe('when the domain is a snap (starts with "npm:" or "local:")', () => {
-      it('returns a proxied globally selected networkClient and does not create a new proxy in the domainProxyMap', () => {
-        const { controller, domainProxyMap, messenger } = setup({
+      it('calls to NetworkController:getSelectedNetworkClient and creates a new proxy provider and block tracker with the proxied globally selected network client', () => {
+        const { controller, messenger } = setup({
           state: {
             domains: {},
           },
-          useRequestQueuePreference: true,
+          useRequestQueuePreference: false,
         });
         jest.spyOn(messenger, 'call');
-        const snapDomain = 'npm:@metamask/bip32-example-snap';
 
-        const result = controller.getProviderAndBlockTracker(snapDomain);
-
-        expect(domainProxyMap.get(snapDomain)).toBeUndefined();
+        const result = controller.getProviderAndBlockTracker('npm:foo-snap');
+        expect(result).toBeDefined();
+        // unfortunately checking which networkController method is called is the best
+        // proxy (no pun intended) for checking that the correct instance of the networkClient is used
         expect(messenger.call).toHaveBeenCalledWith(
           'NetworkController:getSelectedNetworkClient',
         );
-        expect(result).toBeDefined();
       });
 
       it('throws an error if the globally selected network client is not initialized', () => {


### PR DESCRIPTION
## Explanation

This removes some checks in the `SelectedNetworkController` which disallow a Snap from using their own network, and default to the globally selected network. After this change, Snaps will be able to select their own network just like websites.

## References

Related to MetaMask/MetaMask-planning#2938.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/selected-network-controller`

- **CHANGED**: Allow Snaps to change own network

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
