### PR TITLE
Fixed SafeEventEmitterProvider invalid default params

### DIFF
--- a/packages/eth-json-rpc-provider/src/safe-event-emitter-provider.test.ts
+++ b/packages/eth-json-rpc-provider/src/safe-event-emitter-provider.test.ts
@@ -511,7 +511,6 @@ describe('convertEip1193RequestToJsonRpcRequest', () => {
       id: 'mock-id',
       jsonrpc: '2.0',
       method: 'test',
-      params: [],
     });
   });
 });

--- a/packages/eth-json-rpc-provider/src/safe-event-emitter-provider.ts
+++ b/packages/eth-json-rpc-provider/src/safe-event-emitter-provider.ts
@@ -31,18 +31,19 @@ export function convertEip1193RequestToJsonRpcRequest<
 >(
   eip1193Request: Eip1193Request<Params>,
 ): JsonRpcRequest<Params | Record<never, never>> {
-  const {
-    id = uuidV4(),
-    jsonrpc = '2.0',
-    method,
-    params = [],
-  } = eip1193Request;
-  return {
-    id,
-    jsonrpc,
-    method,
-    params,
-  };
+  const { id = uuidV4(), jsonrpc = '2.0', method, params } = eip1193Request;
+  return params
+    ? {
+        id,
+        jsonrpc,
+        method,
+        params,
+      }
+    : {
+        id,
+        jsonrpc,
+        method,
+      };
 }
 
 /**


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
The SafeEventEmitterProvider is failing to send net_version requests correctly because it's using an empty object as the default params when none are provided.

While some methods do use an object for params, the vast majority use an array instead. Passing an empty object as the params for a method that has array parameters can result in failure (as is the case for net_version).

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->
* Fixes #4595 

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/eth-json-rpc-provider`

- **FIXED**: The default value for params in the request has been replaced from empty object to an empty array

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
