### PR TITLE
fix: Return error as sent from the UI instead of throwing a new one

### DIFF
--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -44,7 +44,6 @@
     "@metamask/base-controller": "^6.0.2",
     "@metamask/controller-utils": "^11.0.2",
     "@metamask/message-manager": "^10.0.2",
-    "@metamask/rpc-errors": "^6.3.1",
     "@metamask/utils": "^9.1.0",
     "lodash": "^4.17.21"
   },

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -12,7 +12,6 @@ import {
   PersonalMessageManager,
   TypedMessageManager,
 } from '@metamask/message-manager';
-import { EthereumProviderError } from '@metamask/rpc-errors';
 
 import type {
   SignatureControllerMessenger,

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -18,7 +18,6 @@ import type {
   SignatureControllerOptions,
 } from './SignatureController';
 import { SignatureController } from './SignatureController';
-import exp from 'constants';
 
 jest.mock('@metamask/message-manager', () => ({
   PersonalMessageManager: jest.fn(),

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -18,6 +18,7 @@ import type {
   SignatureControllerOptions,
 } from './SignatureController';
 import { SignatureController } from './SignatureController';
+import exp from 'constants';
 
 jest.mock('@metamask/message-manager', () => ({
   PersonalMessageManager: jest.fn(),
@@ -367,7 +368,12 @@ describe('SignatureController', () => {
     it('throws if approval rejected', async () => {
       messengerMock.call
         .mockResolvedValueOnce({}) // LoggerController:add
-        .mockRejectedValueOnce({ message: 'User rejected the request.' }); // ApprovalController:addRequest
+        .mockRejectedValueOnce({
+          message: 'User rejected the request.',
+          data: {
+            source: 'MetaMask',
+          },
+        }); // ApprovalController:addRequest
       // TODO: Replace `any` with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const error: any = await getError<Error>(
@@ -378,6 +384,7 @@ describe('SignatureController', () => {
           ),
       );
       expect(error.message).toBe('User rejected the request.');
+      expect(error.data).toStrictEqual({ source: 'MetaMask' });
     });
 
     it('throws if cannot get signature', async () => {
@@ -519,7 +526,10 @@ describe('SignatureController', () => {
     it('throws if approval rejected', async () => {
       messengerMock.call
         .mockResolvedValueOnce({}) // LoggerController:add
-        .mockRejectedValueOnce({ message: 'User rejected the request.' }); // ApprovalController:addRequest
+        .mockRejectedValueOnce({
+          message: 'User rejected the request.',
+          data: { source: 'Metamask' },
+        }); // ApprovalController:addRequest
       // TODO: Replace `any` with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const error: any = await getError<Error>(
@@ -532,6 +542,7 @@ describe('SignatureController', () => {
           ),
       );
       expect(error.message).toBe('User rejected the request.');
+      expect(error.data).toStrictEqual({ source: 'Metamask' });
     });
 
     it('throws if cannot get signature', async () => {

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -378,7 +378,6 @@ describe('SignatureController', () => {
             requestMock,
           ),
       );
-      expect(error instanceof EthereumProviderError).toBe(true);
       expect(error.message).toBe('User rejected the request.');
     });
 
@@ -533,7 +532,6 @@ describe('SignatureController', () => {
             { parseJsonData: true },
           ),
       );
-      expect(error instanceof EthereumProviderError).toBe(true);
       expect(error.message).toBe('User rejected the request.');
     });
 

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -367,10 +367,10 @@ describe('SignatureController', () => {
     it('throws if approval rejected', async () => {
       messengerMock.call
         .mockResolvedValueOnce({}) // LoggerController:add
-        .mockRejectedValueOnce({}); // ApprovalController:addRequest
+        .mockRejectedValueOnce({ message: 'User rejected the request.' }); // ApprovalController:addRequest
       // TODO: Replace `any` with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const error: any = await getError(
+      const error: any = await getError<Error>(
         async () =>
           await signatureController.newUnsignedPersonalMessage(
             messageParamsMock,
@@ -519,10 +519,10 @@ describe('SignatureController', () => {
     it('throws if approval rejected', async () => {
       messengerMock.call
         .mockResolvedValueOnce({}) // LoggerController:add
-        .mockRejectedValueOnce({}); // ApprovalController:addRequest
+        .mockRejectedValueOnce({ message: 'User rejected the request.' }); // ApprovalController:addRequest
       // TODO: Replace `any` with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const error: any = await getError(
+      const error: any = await getError<Error>(
         async () =>
           await signatureController.newUnsignedTypedMessage(
             messageParamsMock,

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -40,7 +40,6 @@ import {
   PersonalMessageManager,
   TypedMessageManager,
 } from '@metamask/message-manager';
-import { providerErrors } from '@metamask/rpc-errors';
 import type { Hex, Json } from '@metamask/utils';
 import EventEmitter from 'events';
 import { cloneDeep } from 'lodash';
@@ -432,7 +431,7 @@ export class SignatureController extends BaseController<
         );
 
         resultCallbacks = acceptResult.resultCallbacks;
-      } catch {
+      } catch (e) {
         // User rejected the signature request
         this.#addLog(
           signTypeForLogger,
@@ -441,7 +440,7 @@ export class SignatureController extends BaseController<
         );
 
         this.#cancelAbstractMessage(messageManager, messageId);
-        throw providerErrors.userRejectedRequest('User rejected the request.');
+        throw e;
       }
 
       // TODO: Either fix this lint violation or explain why it's necessary to ignore.

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -431,7 +431,7 @@ export class SignatureController extends BaseController<
         );
 
         resultCallbacks = acceptResult.resultCallbacks;
-      } catch (e) {
+      } catch (error) {
         // User rejected the signature request
         this.#addLog(
           signTypeForLogger,
@@ -440,7 +440,7 @@ export class SignatureController extends BaseController<
         );
 
         this.#cancelAbstractMessage(messageManager, messageId);
-        throw e;
+        throw error;
       }
 
       // TODO: Either fix this lint violation or explain why it's necessary to ignore.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3711,7 +3711,6 @@ __metadata:
     "@metamask/keyring-controller": "npm:^17.1.2"
     "@metamask/logging-controller": "npm:^5.0.0"
     "@metamask/message-manager": "npm:^10.0.2"
-    "@metamask/rpc-errors": "npm:^6.3.1"
     "@metamask/utils": "npm:^9.1.0"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"


### PR DESCRIPTION
## Explanation

When signatures are rejected the UI sends some extra information in the error data property. This information is stripped off when the error is re-thrown in the controller. This change aims as throwing the error back to the UI as received.

Removes the @metamask/rpc-errors package from the Signature controller as this is not used anymore.
## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to [#2703](https://github.com/MetaMask/MetaMask-planning/issues/2703)
-->

## Changelog

None


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
