### PR TITLE
fix: add notification on push notification click callback

### DIFF
--- a/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
@@ -230,7 +230,7 @@ export default class NotificationServicesPushController extends BaseController<
             );
           }
 
-          this.#config.onPushNotificationClicked(e);
+          this.#config.onPushNotificationClicked(e, n);
         },
       });
 


### PR DESCRIPTION
## Explanation

Fix an issue where we don't pass the notification on the click callback. Clients can still function by introspecting the event to get the notification.

## References

N/A

## Changelog

### `@metamask/notification-services-controller`

- **ADDED**: notification parameter to the push notification click callback.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
