### PR TITLE
feat: Remove the Phishfort list from the PhishingController

### DIFF
--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -1060,15 +1060,6 @@ describe('PhishingController', () => {
           name: ListNames.MetaMask,
           version: 0,
         },
-        {
-          allowlist: [],
-          blocklist: [],
-          fuzzylist: [],
-          tolerance: 0,
-          lastUpdated: 1,
-          name: ListNames.Phishfort,
-          version: 0,
-        },
       ]);
     });
 
@@ -1126,15 +1117,6 @@ describe('PhishingController', () => {
           version: 0,
           lastUpdated: 2,
           name: ListNames.MetaMask,
-        },
-        {
-          blocklist: [],
-          allowlist: [],
-          fuzzylist: [],
-          tolerance: 0,
-          version: 0,
-          lastUpdated: 1,
-          name: ListNames.Phishfort,
         },
       ]);
     });

--- a/packages/phishing-controller/src/utils.test.ts
+++ b/packages/phishing-controller/src/utils.test.ts
@@ -119,11 +119,11 @@ describe('applyDiffs', () => {
     const result = applyDiffs(
       testExistingState,
       [exampleAddDiff],
-      ListKeys.PhishfortHotlist,
+      ListKeys.EthPhishingDetectConfig,
     );
     expect(result).toStrictEqual({
       ...testExistingState,
-      name: ListNames.Phishfort,
+      name: ListNames.MetaMask,
     });
   });
 
@@ -137,14 +137,14 @@ describe('applyDiffs', () => {
     const result = applyDiffs(
       testExistingState,
       [
-        { ...exampleAddDiff, timestamp: 1674773009 },
+        { ...exampleAddDiff, timestamp: 1674773005 },
         { ...exampleRemoveDiff, timestamp: 1674773004 },
       ],
-      ListKeys.PhishfortHotlist,
+      ListKeys.EthPhishingDetectConfig,
     );
     expect(result).toStrictEqual({
       ...testExistingState,
-      name: ListNames.Phishfort,
+      name: ListNames.MetaMask,
     });
   });
 });


### PR DESCRIPTION
## Explanation

This PR removes PhishFort from the core MetaMask repository due to the termination of our contract with them for phishing detection. The immediate goal is to eliminate the PhishFort list from the PhishingController to prevent any potential false positives they might introduce. Given the urgency, this PR focuses solely on removing PhishFort from the client-side. Subsequent updates will address the removal of PhishFort from the API and the related test cases.

## References

<!-- 
Link any related issues, discussions, or documents that provide additional context for these changes.
-->

## Changelog

### `@metamask/phishing-controller`

- **REMOVED**: PhishFort list and related references have been removed from the PhishingController.

## Checklist

- [x] I've updated the test suite to reflect the removal of PhishFort.
- [x] I've updated relevant documentation to ensure no references to PhishFort remain.
- [x] No breaking changes have been introduced.
