### PR TITLE
chore: Add export of MarketDataDetails type

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -65,7 +65,7 @@ export type ContractExchangeRates = {
   [address: string]: number | undefined;
 };
 
-type MarketDataDetails = {
+export type MarketDataDetails = {
   tokenAddress: `0x${string}`;
   currency: string;
   allTimeHigh: number;

--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -109,6 +109,7 @@ export type {
   TokenRatesControllerMessenger,
   TokenRatesControllerState,
   TokenRatesControllerStateChangeEvent,
+  MarketDataDetails,
 } from './TokenRatesController';
 export {
   getDefaultTokenRatesControllerState,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change? `metamask-mobile` uses the `MarketDataDetails` type, so it needs to be exported from this repository
* What is the solution your changes offer and how does it work? I made the `MarketDataDetails` get exported
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain? No
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so? n/a
* If you had to upgrade a dependency, why did you do so? n/a
-->

## References


For example:

Helps to fix: https://github.com/MetaMask/metamask-mobile/issues/10205

## Changelog

n/a

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
