### PR TITLE
fix: handle undefined selectedAccount in updateAccounts

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1828,6 +1828,97 @@ describe('AccountsController', () => {
         'Unknown keyring unknown',
       );
     });
+
+    it.each([
+      {
+        lastSelectedForAccount1: 1111,
+        lastSelectedForAccount2: 9999,
+        expectedSelectedId: 'mock-id2',
+      },
+      {
+        lastSelectedForAccount1: undefined,
+        lastSelectedForAccount2: 9999,
+        expectedSelectedId: 'mock-id2',
+      },
+      {
+        lastSelectedForAccount1: 1111,
+        lastSelectedForAccount2: undefined,
+        expectedSelectedId: 'mock-id',
+      },
+      {
+        lastSelectedForAccount1: 1111,
+        lastSelectedForAccount2: 0,
+        expectedSelectedId: 'mock-id',
+      },
+    ])(
+      'handle missing selected account. Account 1 lastSelected $lastSelectedForAccount1, Account 2 lastSelected $lastSelectedForAccount2. Expected selected account: $expectedSelectedId',
+      async ({
+        lastSelectedForAccount1,
+        lastSelectedForAccount2,
+        expectedSelectedId,
+      }) => {
+        const messenger = buildMessenger();
+        const mockExistingAccount1 = createExpectedInternalAccount({
+          id: 'mock-id',
+          name: 'Account 1',
+          address: '0x123',
+          keyringType: KeyringTypes.hd,
+        });
+        mockExistingAccount1.metadata.lastSelected = lastSelectedForAccount1;
+        const mockExistingAccount2 = createExpectedInternalAccount({
+          id: 'mock-id2',
+          name: 'Account 2',
+          address: '0x456',
+          keyringType: KeyringTypes.hd,
+        });
+        mockExistingAccount2.metadata.lastSelected = lastSelectedForAccount2;
+
+        mockUUID
+          .mockReturnValueOnce('mock-id') // call to check if its a new account
+          .mockReturnValueOnce('mock-id2'); // call to check if its a new account
+
+        messenger.registerActionHandler(
+          'KeyringController:getKeyringsByType',
+          mockGetKeyringByType.mockReturnValueOnce([
+            {
+              type: KeyringTypes.snap,
+              listAccounts: async () => [mockSnapAccount2],
+            },
+          ]),
+        );
+
+        // first account will be normal, second will be a snap account
+        messenger.registerActionHandler(
+          'KeyringController:getAccounts',
+          mockGetAccounts.mockResolvedValue(['0x1234', mockAddress1]),
+        );
+        messenger.registerActionHandler(
+          'KeyringController:getKeyringForAccount',
+          mockGetKeyringForAccount
+            .mockResolvedValueOnce({ type: KeyringTypes.snap })
+            .mockResolvedValueOnce({ type: KeyringTypes.hd }),
+        );
+
+        const { accountsController } = setupAccountsController({
+          initialState: {
+            internalAccounts: {
+              accounts: {
+                [mockExistingAccount1.id]: mockExistingAccount1,
+                [mockExistingAccount2.id]: mockExistingAccount2,
+              },
+              selectedAccount: 'unknown',
+            },
+          },
+          messenger,
+        });
+
+        await accountsController.updateAccounts();
+
+        const selectedAccount = accountsController.getSelectedAccount();
+
+        expect(selectedAccount.id).toStrictEqual(expectedSelectedId);
+      },
+    );
   });
 
   describe('loadBackup', () => {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -789,9 +789,8 @@ export class AccountsController extends BaseController<
             this.state.internalAccounts.selectedAccount
           ]
         ) {
-          const lastSelectedAccount = this.#getLastSelectedAccount(
-            Object.values(existingAccounts),
-          );
+          const lastSelectedAccount =
+            this.#getLastSelectedAccount(existingAccounts);
 
           if (lastSelectedAccount) {
             currentState.internalAccounts.selectedAccount =

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -504,6 +504,28 @@ export class AccountsController extends BaseController<
 
     this.update((currentState: Draft<AccountsControllerState>) => {
       currentState.internalAccounts.accounts = accounts;
+
+      if (
+        !currentState.internalAccounts.accounts[
+          currentState.internalAccounts.selectedAccount
+        ]
+      ) {
+        const lastSelectedAccount = this.#getLastSelectedAccount(
+          Object.values(accounts),
+        );
+
+        if (lastSelectedAccount) {
+          currentState.internalAccounts.selectedAccount =
+            lastSelectedAccount.id;
+          currentState.internalAccounts.accounts[
+            lastSelectedAccount.id
+          ].metadata.lastSelected = this.#getLastSelectedIndex();
+          this.#publishAccountChangeEvent(lastSelectedAccount);
+        } else {
+          // It will be undefined if there are no accounts
+          currentState.internalAccounts.selectedAccount = '';
+        }
+      }
     });
   }
 
@@ -767,30 +789,21 @@ export class AccountsController extends BaseController<
             this.state.internalAccounts.selectedAccount
           ]
         ) {
-          // if currently selected account is undefined and there are no accounts
-          // it mean the keyring was reinitialized.
-          if (existingAccounts.length === 0) {
-            currentState.internalAccounts.selectedAccount = '';
-            return;
-          }
-
-          // at this point, we know that `existingAccounts.length` is > 0, so
-          // `accountToSelect` won't be `undefined`!
-          const [accountToSelect] = existingAccounts.sort(
-            (accountA, accountB) => {
-              // sort by lastSelected descending
-              return (
-                (accountB.metadata.lastSelected ?? 0) -
-                (accountA.metadata.lastSelected ?? 0)
-              );
-            },
+          const lastSelectedAccount = this.#getLastSelectedAccount(
+            Object.values(existingAccounts),
           );
-          currentState.internalAccounts.selectedAccount = accountToSelect.id;
-          currentState.internalAccounts.accounts[
-            accountToSelect.id
-          ].metadata.lastSelected = this.#getLastSelectedIndex();
 
-          this.#publishAccountChangeEvent(accountToSelect);
+          if (lastSelectedAccount) {
+            currentState.internalAccounts.selectedAccount =
+              lastSelectedAccount.id;
+            currentState.internalAccounts.accounts[
+              lastSelectedAccount.id
+            ].metadata.lastSelected = this.#getLastSelectedIndex();
+            this.#publishAccountChangeEvent(lastSelectedAccount);
+          } else {
+            // It will be undefined if there are no accounts
+            currentState.internalAccounts.selectedAccount = '';
+          }
         }
       });
     }
@@ -859,19 +872,15 @@ export class AccountsController extends BaseController<
   #getLastSelectedAccount(
     accounts: InternalAccount[],
   ): InternalAccount | undefined {
-    return accounts.reduce((prevAccount, currentAccount) => {
-      if (
-        // When the account is added, lastSelected will be set
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        currentAccount.metadata.lastSelected! >
-        // When the account is added, lastSelected will be set
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        prevAccount.metadata.lastSelected!
-      ) {
-        return currentAccount;
-      }
-      return prevAccount;
-    }, accounts[0]);
+    const [accountToSelect] = accounts.sort((accountA, accountB) => {
+      // sort by lastSelected descending
+      return (
+        (accountB.metadata.lastSelected ?? 0) -
+        (accountA.metadata.lastSelected ?? 0)
+      );
+    });
+
+    return accountToSelect;
   }
 
   /**


### PR DESCRIPTION
## Explanation

This PR fixes `updateAccounts` in the `AccountsController` to handle the edge case where the selected account is undefined. This follows the same logic used in `onKeyringStateChange` 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

Fixes: https://github.com/MetaMask/metamask-extension/issues/26377

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:



* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/accounts-controller`

- **FIXED**: `updateAccounts` logic to handle when the selectedAccount is undefined.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
