### PR TITLE
fix(notification-services-push-controller): Add missing messenger action/events

### DIFF
--- a/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
@@ -1,6 +1,7 @@
 import type {
   RestrictedControllerMessenger,
   ControllerGetStateAction,
+  ControllerStateChangeEvent,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
 import type { AuthenticationController } from '@metamask/profile-sync-controller';
@@ -22,6 +23,12 @@ export type NotificationServicesPushControllerState = {
   fcmToken: string;
 };
 
+export type NotificationServicesPushControllerGetStateAction =
+  ControllerGetStateAction<
+    typeof controllerName,
+    NotificationServicesPushControllerState
+  >;
+
 export type NotificationServicesPushControllerEnablePushNotificationsAction = {
   type: `${typeof controllerName}:enablePushNotifications`;
   handler: NotificationServicesPushController['enablePushNotifications'];
@@ -38,13 +45,19 @@ export type NotificationServicesPushControllerUpdateTriggerPushNotificationsActi
   };
 
 export type Actions =
+  | NotificationServicesPushControllerGetStateAction
   | NotificationServicesPushControllerEnablePushNotificationsAction
   | NotificationServicesPushControllerDisablePushNotificationsAction
-  | NotificationServicesPushControllerUpdateTriggerPushNotificationsAction
-  | ControllerGetStateAction<'state', NotificationServicesPushControllerState>;
+  | NotificationServicesPushControllerUpdateTriggerPushNotificationsAction;
 
 export type AllowedActions =
   AuthenticationController.AuthenticationControllerGetBearerToken;
+
+export type NotificationServicesPushControllerStateChangeEvent =
+  ControllerStateChangeEvent<
+    typeof controllerName,
+    NotificationServicesPushControllerState
+  >;
 
 export type NotificationServicesPushControllerOnNewNotificationEvent = {
   type: `${typeof controllerName}:onNewNotifications`;

--- a/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
@@ -64,7 +64,7 @@ export type NotificationServicesPushControllerOnNewNotificationEvent = {
   payload: [Types.INotification];
 };
 
-export type NotificationServicesPushControllerPushNotificationClicked = {
+export type NotificationServicesPushControllerPushNotificationClickedEvent = {
   type: `${typeof controllerName}:pushNotificationClicked`;
   payload: [Types.INotification];
 };

--- a/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
@@ -69,15 +69,18 @@ export type NotificationServicesPushControllerPushNotificationClickedEvent = {
   payload: [Types.INotification];
 };
 
-export type AllowedEvents =
+export type Events =
+  | NotificationServicesPushControllerStateChangeEvent
   | NotificationServicesPushControllerOnNewNotificationEvent
-  | NotificationServicesPushControllerPushNotificationClicked;
+  | NotificationServicesPushControllerPushNotificationClickedEvent;
+
+export type AllowedEvents = never;
 
 export type NotificationServicesPushControllerMessenger =
   RestrictedControllerMessenger<
     typeof controllerName,
     Actions | AllowedActions,
-    AllowedEvents,
+    Events | AllowedEvents,
     AllowedActions['type'],
     AllowedEvents['type']
   >;

--- a/packages/notification-services-controller/src/index.ts
+++ b/packages/notification-services-controller/src/index.ts
@@ -1,2 +1,2 @@
 export * as NotificationServicesController from './NotificationServicesController';
-export * as NotificationsServicesPushController from './NotificationServicesPushController';
+export * as NotificationServicesPushController from './NotificationServicesPushController';


### PR DESCRIPTION
## Explanation

Fixes various errors in the `NotificationServicesPushController`:

- [Define the `*:getState` action using the `ControllerGetStateAction` utility type](https://github.com/MetaMask/core/blob/add-controller-guidelines/docs/writing-controllers.md#define-the-getstate-action-using-the-controllergetstateaction-utility-type)
- [Define the `*:stateChange` event using the `ControllerStateChangeEvent` utility type](https://github.com/MetaMask/core/blob/add-controller-guidelines/docs/writing-controllers.md#define-the-statechange-event-using-the-controllerstatechangeevent-utility-type)
- [Define and export a type union for internal action types](https://github.com/MetaMask/core/blob/add-controller-guidelines/docs/writing-controllers.md#define-and-export-a-type-union-for-internal-action-types)
- [Define and export a type union for internal event types](https://github.com/MetaMask/core/blob/add-controller-guidelines/docs/writing-controllers.md#define-and-export-a-type-union-for-internal-event-types)
- [Define and export a type for the controller's messenger](https://github.com/MetaMask/core/blob/add-controller-guidelines/docs/writing-controllers.md#define-and-export-a-type-for-the-controllers-messenger)

## References

- Fixes #4579
- See https://github.com/MetaMask/core/pull/4633

## Changelog

### `@metamask/notification-services-controller` (major)

### Added

- Add and export types `NotificationServicesPushControllerGetStateAction`, `NotificationServicesPushControllerStateChangeEvent` ([#4641](https://github.com/MetaMask/core/pull/4641))

### Changed

- **BREAKING:** Rename `NotificationServicesPushControllerPushNotificationClicked` type to `NotificationServicesPushControllerPushNotificationClickedEvent` ([#4641](https://github.com/MetaMask/core/pull/4641))
- **BREAKING:** Narrow `AllowedEvents` type for `NotificationServicesPushControllerMessenger` to `never` ([#4641](https://github.com/MetaMask/core/pull/4641))
- `NotificationServicesPushControllerMessenger` must allow internal event `NotificationServicesPushControllerStateChangeEvent` ([#4641](https://github.com/MetaMask/core/pull/4641))

### Fixed

- **BREAKING:** Fix package-level export for `NotificationServicesPushController` from "NotificationsServicesPushController" to "NotificationsServicesPushController" ([#4641](https://github.com/MetaMask/core/pull/4641))
- **BREAKING:** Replace incorrectly-defined `getState` action in the `Actions` type for `NotificationServicesPushControllerMessenger` with new `NotificationServicesPushControllerGetStateAction` type ([#4641](https://github.com/MetaMask/core/pull/4641))

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
