### PR TITLE
feat: add allowlist to c2 domain detection

### DIFF
--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -477,7 +477,7 @@ export class PhishingController extends BaseController<
   isBlockedRequest(origin: string): PhishingDetectorResult {
     const punycodeOrigin = toASCII(origin);
 
-    return this.#detector.isMaliciousRequestDomain(punycodeOrigin);
+    return this.#detector.isMaliciousC2Domain(punycodeOrigin);
   }
 
   /**

--- a/packages/phishing-controller/src/PhishingDetector.test.ts
+++ b/packages/phishing-controller/src/PhishingDetector.test.ts
@@ -1335,10 +1335,12 @@ describe('PhishingDetector', () => {
       await withPhishingDetector(
         [
           {
-            allowlist: ['example.com'],
+            allowlist: ['develop.d3bkcslj57l47p.amplifyapp.com'],
             blocklist: [],
             fuzzylist: [],
-            c2DomainBlocklist: [],
+            c2DomainBlocklist: [
+              '0415f1f12f07ddc4ef7e229da747c6c53a6a6474fbaf295a35d984ec0ece9455',
+            ],
             name: 'first-config',
             version: 1,
             tolerance: 2,
@@ -1346,10 +1348,10 @@ describe('PhishingDetector', () => {
         ],
         async ({ detector }) => {
           const result = detector.isMaliciousRequestDomain(
-            'https://example.com',
+            'https://develop.d3bkcslj57l47p.amplifyapp.com',
           );
           expect(result).toStrictEqual({
-            match: 'example.com',
+            match: 'develop.d3bkcslj57l47p.amplifyapp.com',
             name: 'first-config',
             result: false,
             type: PhishingDetectorResultType.Allowlist,

--- a/packages/phishing-controller/src/PhishingDetector.test.ts
+++ b/packages/phishing-controller/src/PhishingDetector.test.ts
@@ -1139,7 +1139,7 @@ describe('PhishingDetector', () => {
     });
   });
 
-  describe('isMaliciousRequestDomain', () => {
+  describe('isMaliciousC2Domain', () => {
     it('should return false if c2DomainBlocklist is not defined or empty', async () => {
       await withPhishingDetector(
         [
@@ -1153,9 +1153,7 @@ describe('PhishingDetector', () => {
           },
         ],
         async ({ detector }) => {
-          const result = detector.isMaliciousRequestDomain(
-            'https://example.com',
-          );
+          const result = detector.isMaliciousC2Domain('https://example.com');
           expect(result).toStrictEqual({
             result: false,
             type: PhishingDetectorResultType.C2DomainBlocklist,
@@ -1171,7 +1169,7 @@ describe('PhishingDetector', () => {
             blocklist: [],
             fuzzylist: [],
             c2DomainBlocklist: [
-              '0415f1f12f07ddc4ef7e229da747c6c53a6a6474fbaf295a35d984ec0ece9455',
+              'a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947',
             ],
             name: 'test-config',
             version: 1,
@@ -1179,9 +1177,7 @@ describe('PhishingDetector', () => {
           },
         ],
         async ({ detector }) => {
-          const result = detector.isMaliciousRequestDomain(
-            'https://develop.d3bkcslj57l47p.amplifyapp.com',
-          );
+          const result = detector.isMaliciousC2Domain('https://example.com');
           expect(result).toStrictEqual({
             name: 'test-config',
             result: true,
@@ -1199,16 +1195,14 @@ describe('PhishingDetector', () => {
             blocklist: [],
             fuzzylist: [],
             c2DomainBlocklist: [
-              '0415f1f12f07ddc4ef7e229da747c6c53a6a6474fbaf295a35d984ec0ece9455',
+              'a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947',
             ],
             name: 'test-config',
             tolerance: 2,
           },
         ],
         async ({ detector }) => {
-          const result = detector.isMaliciousRequestDomain(
-            'https://develop.d3bkcslj57l47p.amplifyapp.com',
-          );
+          const result = detector.isMaliciousC2Domain('https://example.com');
           expect(result).toStrictEqual({
             name: 'test-config',
             result: true,
@@ -1226,7 +1220,7 @@ describe('PhishingDetector', () => {
             blocklist: [],
             fuzzylist: [],
             c2DomainBlocklist: [
-              '0415f1f12f07ddc4ef7e229da747c6c53a6a6474fbaf295a35d984ec0ece9455',
+              'a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947',
             ],
             name: 'test-config',
             version: 1,
@@ -1234,7 +1228,7 @@ describe('PhishingDetector', () => {
           },
         ],
         async ({ detector }) => {
-          const result = detector.isMaliciousRequestDomain('#$@(%&@#$(%');
+          const result = detector.isMaliciousC2Domain('#$@(%&@#$(%');
           expect(result).toStrictEqual({
             result: false,
             type: PhishingDetectorResultType.C2DomainBlocklist,
@@ -1250,7 +1244,7 @@ describe('PhishingDetector', () => {
             blocklist: [],
             fuzzylist: [],
             c2DomainBlocklist: [
-              '0415f1f12f07ddc4ef7e229da747c6c53a6a6474fbaf295a35d984ec0ece9455',
+              'a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947',
             ],
             name: 'test-config',
             version: 1,
@@ -1258,9 +1252,7 @@ describe('PhishingDetector', () => {
           },
         ],
         async ({ detector }) => {
-          const result = detector.isMaliciousRequestDomain(
-            'https://develop.d3bkcslj57l47p.amplifyapp.com',
-          );
+          const result = detector.isMaliciousC2Domain('https://example.com');
           expect(result).toStrictEqual({
             name: 'test-config',
             result: true,
@@ -1284,9 +1276,7 @@ describe('PhishingDetector', () => {
           },
         ],
         async ({ detector }) => {
-          const result = detector.isMaliciousRequestDomain(
-            'https://example.com',
-          );
+          const result = detector.isMaliciousC2Domain('https://example.com');
           expect(result).toStrictEqual({
             result: false,
             type: PhishingDetectorResultType.C2DomainBlocklist,
@@ -1302,7 +1292,7 @@ describe('PhishingDetector', () => {
             blocklist: [],
             fuzzylist: [],
             c2DomainBlocklist: [
-              '0415f1f12f07ddc4ef7e229da747c6c53a6a6474fbaf295a35d984ec0ece9455',
+              'a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947',
             ],
             name: 'first-config',
             version: 1,
@@ -1318,9 +1308,7 @@ describe('PhishingDetector', () => {
           },
         ],
         async ({ detector }) => {
-          const result = detector.isMaliciousRequestDomain(
-            'https://develop.d3bkcslj57l47p.amplifyapp.com',
-          );
+          const result = detector.isMaliciousC2Domain('https://example.com');
           expect(result).toStrictEqual({
             name: 'first-config',
             result: true,
@@ -1331,15 +1319,15 @@ describe('PhishingDetector', () => {
       );
     });
 
-    it('should return allowlist if URL is in the allowlist', async () => {
+    it('should return allowlist if URL is in the allowlist with something on the blocklist', async () => {
       await withPhishingDetector(
         [
           {
-            allowlist: ['develop.d3bkcslj57l47p.amplifyapp.com'],
+            allowlist: ['example.com'],
             blocklist: [],
             fuzzylist: [],
             c2DomainBlocklist: [
-              '0415f1f12f07ddc4ef7e229da747c6c53a6a6474fbaf295a35d984ec0ece9455',
+              'a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947',
             ],
             name: 'first-config',
             version: 1,
@@ -1347,11 +1335,35 @@ describe('PhishingDetector', () => {
           },
         ],
         async ({ detector }) => {
-          const result = detector.isMaliciousRequestDomain(
-            'https://develop.d3bkcslj57l47p.amplifyapp.com',
-          );
+          const result = detector.isMaliciousC2Domain('https://example.com');
           expect(result).toStrictEqual({
-            match: 'develop.d3bkcslj57l47p.amplifyapp.com',
+            match: 'example.com',
+            name: 'first-config',
+            result: false,
+            type: PhishingDetectorResultType.Allowlist,
+            version: '1',
+          });
+        },
+      );
+    });
+
+    it('should return allowlist if URL is in the allowlist', async () => {
+      await withPhishingDetector(
+        [
+          {
+            allowlist: ['example.com'],
+            blocklist: [],
+            fuzzylist: [],
+            c2DomainBlocklist: [],
+            name: 'first-config',
+            version: 1,
+            tolerance: 2,
+          },
+        ],
+        async ({ detector }) => {
+          const result = detector.isMaliciousC2Domain('https://example.com');
+          expect(result).toStrictEqual({
+            match: 'example.com',
             name: 'first-config',
             result: false,
             type: PhishingDetectorResultType.Allowlist,
@@ -1374,9 +1386,7 @@ describe('PhishingDetector', () => {
           },
         ],
         async ({ detector }) => {
-          const result = detector.isMaliciousRequestDomain(
-            'https://example.com',
-          );
+          const result = detector.isMaliciousC2Domain('https://example.com');
           expect(result).toStrictEqual({
             match: 'example.com',
             name: 'first-config',
@@ -1401,7 +1411,7 @@ describe('PhishingDetector', () => {
           },
         ],
         async ({ detector }) => {
-          const result = detector.isMaliciousRequestDomain(
+          const result = detector.isMaliciousC2Domain(
             'https://example.com.', // URL with trailing dot
           );
           expect(result).toStrictEqual({
@@ -1434,9 +1444,7 @@ describe('PhishingDetector', () => {
           },
         ],
         async ({ detector }) => {
-          const result = detector.isMaliciousRequestDomain(
-            'https://example.com',
-          );
+          const result = detector.isMaliciousC2Domain('https://example.com');
           expect(result).toStrictEqual({
             result: false,
             type: PhishingDetectorResultType.C2DomainBlocklist,

--- a/packages/phishing-controller/src/PhishingDetector.test.ts
+++ b/packages/phishing-controller/src/PhishingDetector.test.ts
@@ -1331,6 +1331,88 @@ describe('PhishingDetector', () => {
       );
     });
 
+    it('should return allowlist if URL is in the allowlist', async () => {
+      await withPhishingDetector(
+        [
+          {
+            allowlist: ['example.com'],
+            blocklist: [],
+            fuzzylist: [],
+            c2DomainBlocklist: [],
+            name: 'first-config',
+            version: 1,
+            tolerance: 2,
+          },
+        ],
+        async ({ detector }) => {
+          const result = detector.isMaliciousRequestDomain(
+            'https://example.com',
+          );
+          expect(result).toStrictEqual({
+            match: 'example.com',
+            name: 'first-config',
+            result: false,
+            type: PhishingDetectorResultType.Allowlist,
+            version: '1',
+          });
+        },
+      );
+    });
+
+    it('should return allowlist if URL is in the allowlist without a version', async () => {
+      await withPhishingDetector(
+        [
+          {
+            allowlist: ['example.com'],
+            blocklist: [],
+            fuzzylist: [],
+            c2DomainBlocklist: [],
+            name: 'first-config',
+            tolerance: 2,
+          },
+        ],
+        async ({ detector }) => {
+          const result = detector.isMaliciousRequestDomain(
+            'https://example.com',
+          );
+          expect(result).toStrictEqual({
+            match: 'example.com',
+            name: 'first-config',
+            result: false,
+            type: PhishingDetectorResultType.Allowlist,
+            version: undefined,
+          });
+        },
+      );
+    });
+
+    it('should correctly normalize the hostname by removing the trailing dot', async () => {
+      await withPhishingDetector(
+        [
+          {
+            allowlist: ['example.com'],
+            blocklist: [],
+            fuzzylist: [],
+            c2DomainBlocklist: [],
+            name: 'first-config',
+            tolerance: 2,
+          },
+        ],
+        async ({ detector }) => {
+          const result = detector.isMaliciousRequestDomain(
+            'https://example.com.', // URL with trailing dot
+          );
+          expect(result).toStrictEqual({
+            match: 'example.com', // Expectation is that the trailing dot is removed
+            name: 'first-config',
+            result: false,
+            type: PhishingDetectorResultType.Allowlist,
+            version: undefined,
+          });
+        },
+      );
+    });
+
     it('should return false with type "c2DomainBlocklist" if no configs have a valid c2DomainBlocklist', async () => {
       await withPhishingDetector(
         [

--- a/packages/phishing-controller/src/PhishingDetector.ts
+++ b/packages/phishing-controller/src/PhishingDetector.ts
@@ -222,7 +222,7 @@ export class PhishingDetector {
    * @param urlString - The URL to check.
    * @returns An object indicating if the URL is blocked and relevant metadata.
    */
-  isMaliciousRequestDomain(urlString: string): PhishingDetectorResult {
+  isMaliciousC2Domain(urlString: string): PhishingDetectorResult {
     let hostname;
     try {
       hostname = new URL(urlString).hostname;

--- a/packages/phishing-controller/src/PhishingDetector.ts
+++ b/packages/phishing-controller/src/PhishingDetector.ts
@@ -116,6 +116,7 @@ export class PhishingDetector {
   }
 
   #check(url: string): PhishingDetectorResult {
+    console.log('Checking URL', url);
     const ipfsCidMatch = url.match(ipfsCidRegex());
 
     // Check for IPFS CID related blocklist entries
@@ -146,11 +147,14 @@ export class PhishingDetector {
     try {
       domain = new URL(url).hostname;
     } catch (error) {
+      console.error('Error parsing URL', error);
       return {
         result: false,
         type: PhishingDetectorResultType.All,
       };
     }
+
+    console.log('Checking domain', domain);
 
     const fqdn = domain.endsWith('.') ? domain.slice(0, -1) : domain;
 
@@ -223,29 +227,48 @@ export class PhishingDetector {
    * @returns An object indicating if the URL is blocked and relevant metadata.
    */
   isMaliciousRequestDomain(urlString: string): PhishingDetectorResult {
-    for (const { c2DomainBlocklist, name, version } of this.#configs) {
-      try {
-        const url = new URL(urlString);
+    let hostname;
+    try {
+      hostname = new URL(urlString).hostname;
+    } catch (error) {
+      return {
+        result: false,
+        type: PhishingDetectorResultType.C2DomainBlocklist,
+      };
+    }
 
-        const hash = sha256Hash(url.hostname.toLowerCase());
-        const blocked = c2DomainBlocklist?.includes(hash) ?? false;
+    const fqdn = hostname.endsWith('.') ? hostname.slice(0, -1) : hostname;
 
-        if (blocked) {
-          return {
-            name,
-            result: true,
-            type: PhishingDetectorResultType.C2DomainBlocklist,
-            version: version === undefined ? version : String(version),
-          };
-        }
-      } catch (error) {
+    const source = domainToParts(fqdn);
+
+    for (const { allowlist, name, version } of this.#configs) {
+      // if source matches allowlist hostname (or subdomain thereof), PASS
+      const allowlistMatch = matchPartsAgainstList(source, allowlist);
+      if (allowlistMatch) {
+        const match = domainPartsToDomain(allowlistMatch);
         return {
+          match,
+          name,
           result: false,
-          type: PhishingDetectorResultType.C2DomainBlocklist,
+          type: PhishingDetectorResultType.Allowlist,
+          version: version === undefined ? version : String(version),
         };
       }
     }
 
+    for (const { c2DomainBlocklist, name, version } of this.#configs) {
+      const hash = sha256Hash(hostname.toLowerCase());
+      const blocked = c2DomainBlocklist?.includes(hash) ?? false;
+
+      if (blocked) {
+        return {
+          name,
+          result: true,
+          type: PhishingDetectorResultType.C2DomainBlocklist,
+          version: version === undefined ? version : String(version),
+        };
+      }
+    }
     // did not match, PASS
     return {
       result: false,

--- a/packages/phishing-controller/src/PhishingDetector.ts
+++ b/packages/phishing-controller/src/PhishingDetector.ts
@@ -116,7 +116,6 @@ export class PhishingDetector {
   }
 
   #check(url: string): PhishingDetectorResult {
-    console.log('Checking URL', url);
     const ipfsCidMatch = url.match(ipfsCidRegex());
 
     // Check for IPFS CID related blocklist entries
@@ -153,8 +152,6 @@ export class PhishingDetector {
         type: PhishingDetectorResultType.All,
       };
     }
-
-    console.log('Checking domain', domain);
 
     const fqdn = domain.endsWith('.') ? domain.slice(0, -1) : domain;
 

--- a/packages/phishing-controller/src/PhishingDetector.ts
+++ b/packages/phishing-controller/src/PhishingDetector.ts
@@ -146,7 +146,6 @@ export class PhishingDetector {
     try {
       domain = new URL(url).hostname;
     } catch (error) {
-      console.error('Error parsing URL', error);
       return {
         result: false,
         type: PhishingDetectorResultType.All,


### PR DESCRIPTION
## Explanation

### Changes Introduced:
The existing phishing detection system in the `PhishingDetector` class did not include functionality for handling an allowlist when checking C2 domain blocklists. This meant that you were not able to continue to the website when a c2 was detected

### Dependency Updates:
No dependencies were updated in this PR.

## Changelog

### `@metamask/phishing-controller`

- **ADDED**: Allowlist functionality to the C2 domain detection system.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
