### PR TITLE
feat: add `accountRenamed` event to `AccountsController`

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -2387,7 +2387,7 @@ describe('AccountsController', () => {
   });
 
   describe('setAccountName', () => {
-    it('set the name of an existing account', () => {
+    it('sets the name of an existing account', () => {
       const { accountsController } = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -2401,6 +2401,26 @@ describe('AccountsController', () => {
       expect(
         accountsController.getAccountExpect(mockAccount.id).metadata.name,
       ).toBe('new name');
+    });
+
+    it('publishes the accountRenamed event', () => {
+      const { accountsController, messenger } = setupAccountsController({
+        initialState: {
+          internalAccounts: {
+            accounts: { [mockAccount.id]: mockAccount },
+            selectedAccount: mockAccount.id,
+          },
+        },
+      });
+
+      const messengerSpy = jest.spyOn(messenger, 'publish');
+
+      accountsController.setAccountName(mockAccount.id, 'new name');
+
+      expect(messengerSpy).toHaveBeenCalledWith(
+        'AccountsController:accountRenamed',
+        accountsController.getAccountExpect(mockAccount.id),
+      );
     });
 
     it('throw an error if the account name already exists', () => {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -155,6 +155,11 @@ export type AccountsControllerAccountRemovedEvent = {
   payload: [AccountId];
 };
 
+export type AccountsControllerAccountRenamedEvent = {
+  type: `${typeof controllerName}:accountRenamed`;
+  payload: [InternalAccount];
+};
+
 export type AllowedEvents = SnapStateChange | KeyringControllerStateChangeEvent;
 
 export type AccountsControllerEvents =
@@ -162,7 +167,8 @@ export type AccountsControllerEvents =
   | AccountsControllerSelectedAccountChangeEvent
   | AccountsControllerSelectedEvmAccountChangeEvent
   | AccountsControllerAccountAddedEvent
-  | AccountsControllerAccountRemovedEvent;
+  | AccountsControllerAccountRemovedEvent
+  | AccountsControllerAccountRenamedEvent;
 
 export type AccountsControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
@@ -423,6 +429,10 @@ export class AccountsController extends BaseController<
     }
 
     this.updateAccountMetadata(accountId, { name: accountName });
+
+    const account = this.getAccountExpect(accountId);
+
+    this.messagingSystem.publish('AccountsController:accountRenamed', account);
   }
 
   /**


### PR DESCRIPTION
## Explanation

This PR adds a new event `accountRenamed` to the `AccountsController`.
This event will be listened to by the `UserStorageController` in order to granularly upload the new account state to user storage whenever a user changes one of their account's name.

## References

[Account Syncing](https://www.figma.com/board/sx26FtZcQc0zs0z5hpdqBh/Account-Syncing-Solution?node-id=0-1&node-type=CANVAS&t=nutSwHmXAxcG869V-0)
[NOTIFY-1046](https://consensyssoftware.atlassian.net/jira/software/projects/NOTIFY/boards/616?assignee=712020%3A5843b7e2-a7fe-4c45-9fbd-e1f2b2eb58c2&selectedIssue=NOTIFY-1046)

## Changelog


### `@metamask/accounts-controller`

- **ADDED**: `accountRenamed` event

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate


[NOTIFY-1046]: https://consensyssoftware.atlassian.net/browse/NOTIFY-1046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ