### PR TITLE
refactor: move logic from `setAccountName` to `updateAccountMetadata`

### DIFF
--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -419,7 +419,7 @@ export class AccountsController extends BaseController<
    */
   setAccountName(accountId: string, accountName: string): void {
     // This will check for name uniqueness and fire the `accountRenamed` event
-    // if the account has been renamed
+    // if the account has been renamed.
     this.updateAccountMetadata(accountId, { name: accountName });
   }
 


### PR DESCRIPTION
## Explanation

This PR moves the name uniqueness check & the firing of the `accountRenamed` logic from `setAccountName` to `updateAccountMetadata`.

## References

## Changelog

### `@metamask/accounts-controller`

- **CHANGED**: move logic from `setAccountName` to `updateAccountMetadata`


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
