### PR TITLE
feat(NOTIFY-1046): attach account sync upwards sync to `AccountsController` events

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -1279,6 +1279,68 @@ describe('user-storage/user-storage-controller - saveInternalAccountToUserStorag
       ),
     ).rejects.toThrow(expect.any(Error));
   });
+
+  it('saves an internal account to user storage when the AccountsController:accountRenamed event is fired', async () => {
+    const arrangeMocks = async () => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+      };
+    };
+
+    const { messengerMocks } = await arrangeMocks();
+
+    const controller = new UserStorageController({
+      messenger: messengerMocks.messenger,
+      env: {
+        isAccountSyncingEnabled: true,
+      },
+      getMetaMetricsState: () => true,
+    });
+
+    const mockSaveInternalAccountToUserStorage = jest
+      .spyOn(controller, 'saveInternalAccountToUserStorage')
+      .mockImplementation();
+
+    messengerMocks.baseMessenger.publish(
+      'AccountsController:accountRenamed',
+      MOCK_INTERNAL_ACCOUNTS.ONE[0] as InternalAccount,
+    );
+
+    expect(mockSaveInternalAccountToUserStorage).toHaveBeenCalledWith(
+      MOCK_INTERNAL_ACCOUNTS.ONE[0].address,
+    );
+  });
+
+  it('saves an internal account to user storage when the AccountsController:accountAdded event is fired', async () => {
+    const arrangeMocks = async () => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+      };
+    };
+
+    const { messengerMocks } = await arrangeMocks();
+
+    const controller = new UserStorageController({
+      messenger: messengerMocks.messenger,
+      env: {
+        isAccountSyncingEnabled: true,
+      },
+      getMetaMetricsState: () => true,
+    });
+
+    const mockSaveInternalAccountToUserStorage = jest
+      .spyOn(controller, 'saveInternalAccountToUserStorage')
+      .mockImplementation();
+
+    messengerMocks.baseMessenger.publish(
+      'AccountsController:accountAdded',
+      MOCK_INTERNAL_ACCOUNTS.ONE[0] as InternalAccount,
+    );
+
+    expect(mockSaveInternalAccountToUserStorage).toHaveBeenCalledWith(
+      MOCK_INTERNAL_ACCOUNTS.ONE[0].address,
+    );
+  });
 });
 
 /**
@@ -1290,14 +1352,16 @@ describe('user-storage/user-storage-controller - saveInternalAccountToUserStorag
  * @returns Mock User Storage Messenger
  */
 function mockUserStorageMessenger(options?: {
-  accounts: {
+  accounts?: {
     accountsList?: InternalAccount[];
   };
 }) {
-  const messenger = new ControllerMessenger<
+  const baseMessenger = new ControllerMessenger<
     AllowedActions,
     AllowedEvents
-  >().getRestricted({
+  >();
+
+  const messenger = baseMessenger.getRestricted({
     name: 'UserStorageController',
     allowedActions: [
       'KeyringController:getState',
@@ -1314,7 +1378,12 @@ function mockUserStorageMessenger(options?: {
       'AccountsController:getAccountByAddress',
       'KeyringController:addNewAccount',
     ],
-    allowedEvents: ['KeyringController:lock', 'KeyringController:unlock'],
+    allowedEvents: [
+      'KeyringController:lock',
+      'KeyringController:unlock',
+      'AccountsController:accountAdded',
+      'AccountsController:accountRenamed',
+    ],
   });
 
   const mockSnapGetPublicKey = jest.fn().mockResolvedValue('MOCK_PUBLIC_KEY');
@@ -1369,14 +1438,9 @@ function mockUserStorageMessenger(options?: {
 
   const mockAccountsUpdateAccountMetadata = jest.fn().mockResolvedValue(true);
 
-  const mockAccountsGetAccountByAddress = jest.fn().mockResolvedValue({
-    address: '0x123',
-    id: '1',
-    metadata: {
-      name: 'test',
-      nameLastUpdatedAt: 1,
-    },
-  });
+  const mockAccountsGetAccountByAddress = jest
+    .fn()
+    .mockResolvedValue(MOCK_INTERNAL_ACCOUNTS.ONE[0]);
 
   jest.spyOn(messenger, 'call').mockImplementation((...args) => {
     // Creates the correct typed call params for mocks
@@ -1469,6 +1533,7 @@ function mockUserStorageMessenger(options?: {
   });
 
   return {
+    baseMessenger,
     messenger,
     mockSnapGetPublicKey,
     mockSnapSignMessage,

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -1281,16 +1281,10 @@ describe('user-storage/user-storage-controller - saveInternalAccountToUserStorag
   });
 
   it('saves an internal account to user storage when the AccountsController:accountRenamed event is fired', async () => {
-    const arrangeMocks = async () => {
-      return {
-        messengerMocks: mockUserStorageMessenger(),
-      };
-    };
-
-    const { messengerMocks } = await arrangeMocks();
+    const { baseMessenger, messenger } = mockUserStorageMessenger();
 
     const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+      messenger,
       env: {
         isAccountSyncingEnabled: true,
       },
@@ -1301,7 +1295,7 @@ describe('user-storage/user-storage-controller - saveInternalAccountToUserStorag
       .spyOn(controller, 'saveInternalAccountToUserStorage')
       .mockImplementation();
 
-    messengerMocks.baseMessenger.publish(
+    baseMessenger.publish(
       'AccountsController:accountRenamed',
       MOCK_INTERNAL_ACCOUNTS.ONE[0] as InternalAccount,
     );
@@ -1312,16 +1306,10 @@ describe('user-storage/user-storage-controller - saveInternalAccountToUserStorag
   });
 
   it('saves an internal account to user storage when the AccountsController:accountAdded event is fired', async () => {
-    const arrangeMocks = async () => {
-      return {
-        messengerMocks: mockUserStorageMessenger(),
-      };
-    };
-
-    const { messengerMocks } = await arrangeMocks();
+    const { baseMessenger, messenger } = mockUserStorageMessenger();
 
     const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+      messenger,
       env: {
         isAccountSyncingEnabled: true,
       },
@@ -1332,7 +1320,7 @@ describe('user-storage/user-storage-controller - saveInternalAccountToUserStorag
       .spyOn(controller, 'saveInternalAccountToUserStorage')
       .mockImplementation();
 
-    messengerMocks.baseMessenger.publish(
+    baseMessenger.publish(
       'AccountsController:accountAdded',
       MOCK_INTERNAL_ACCOUNTS.ONE[0] as InternalAccount,
     );

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -2,6 +2,8 @@ import type {
   AccountsControllerListAccountsAction,
   AccountsControllerUpdateAccountMetadataAction,
   AccountsControllerGetAccountByAddressAction,
+  AccountsControllerAccountRenamedEvent,
+  AccountsControllerAccountAddedEvent,
 } from '@metamask/accounts-controller';
 import type {
   ControllerGetStateAction,
@@ -181,7 +183,9 @@ export type AllowedEvents =
   | UserStorageControllerAccountSyncingInProgress
   | UserStorageControllerAccountSyncingComplete
   | KeyringControllerLockEvent
-  | KeyringControllerUnlockEvent;
+  | KeyringControllerUnlockEvent
+  | AccountsControllerAccountAddedEvent
+  | AccountsControllerAccountRenamedEvent;
 
 // Messenger
 export type UserStorageControllerMessenger = RestrictedControllerMessenger<
@@ -243,6 +247,23 @@ export default class UserStorageController extends BaseController<
       return (
         Date.now() - this.#accounts.lastSyncedAt >
         this.#accounts.maxSyncInterval
+      );
+    },
+    setupAccountSyncingSubscriptions: () => {
+      this.messagingSystem.subscribe(
+        'AccountsController:accountAdded',
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        async (account) => {
+          await this.saveInternalAccountToUserStorage(account.address);
+        },
+      );
+
+      this.messagingSystem.subscribe(
+        'AccountsController:accountRenamed',
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        async (account) => {
+          await this.saveInternalAccountToUserStorage(account.address);
+        },
       );
     },
     getInternalAccountByAddress: async (address: string) => {
@@ -328,15 +349,9 @@ export default class UserStorageController extends BaseController<
       );
       this.#isUnlocked = isUnlocked;
 
-      this.messagingSystem.subscribe(
-        'KeyringController:unlock',
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        async () => {
-          this.#isUnlocked = true;
-
-          await this.syncInternalAccountsWithUserStorage();
-        },
-      );
+      this.messagingSystem.subscribe('KeyringController:unlock', () => {
+        this.#isUnlocked = true;
+      });
 
       this.messagingSystem.subscribe('KeyringController:lock', () => {
         this.#isUnlocked = false;
@@ -381,6 +396,7 @@ export default class UserStorageController extends BaseController<
     this.#keyringController.setupLockedStateSubscriptions();
     this.#registerMessageHandlers();
     this.#nativeScryptCrypto = nativeScryptCrypto;
+    this.#accounts.setupAccountSyncingSubscriptions();
   }
 
   /**
@@ -812,6 +828,8 @@ export default class UserStorageController extends BaseController<
     }
 
     try {
+      this.#assertProfileSyncingEnabled();
+
       await this.#accounts.saveInternalAccountToUserStorage(address);
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : JSON.stringify(e);


### PR DESCRIPTION
## Explanation

This PR adds listeners for `AccountsController` events to `UserStorageController`: 
- `accountAdded`
- `accountRenamed`

`UserStorageController` will update the user storage whenever these events are received.

## References

[NOTIFY-1046](https://consensyssoftware.atlassian.net/jira/software/projects/NOTIFY/boards/616?assignee=712020%3A5843b7e2-a7fe-4c45-9fbd-e1f2b2eb58c2&selectedIssue=NOTIFY-1046)

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/profile-sync-controller`

- **ADDED**:  `accountAdded` and `accountRenamed` events will now trigger upwards account syncing


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate


[NOTIFY-1046]: https://consensyssoftware.atlassian.net/browse/NOTIFY-1046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ