### PR TITLE
feat: added utility function to check if snap is connected

### DIFF
--- a/packages/profile-sync-controller/src/sdk/authentication.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication.ts
@@ -9,7 +9,10 @@ import { AuthType } from './authentication-jwt-bearer/types';
 import type { Env } from './env';
 import { PairError, UnsupportedAuthTypeError } from './errors';
 import { getMetaMaskProviderEIP6963 } from './utils/eip-6963-metamask-provider';
-import { connectSnap } from './utils/messaging-signing-snap-requests';
+import {
+  connectSnap,
+  isSnapConnected,
+} from './utils/messaging-signing-snap-requests';
 
 // Computing the Classes, so we only get back the public methods for the interface.
 // TODO: Either fix this lint violation or explain why it's necessary to ignore.
@@ -57,6 +60,16 @@ export class JwtBearerAuth implements SIWEInterface, SRPInterface {
     }
     const res = await connectSnap(provider);
     return res;
+  }
+
+  async isSnapConnected(): Promise<boolean> {
+    const provider = await getMetaMaskProviderEIP6963();
+    if (!provider) {
+      return false;
+    }
+
+    const isConnected = await isSnapConnected(provider);
+    return isConnected;
   }
 
   async getUserProfile(): Promise<UserProfile> {

--- a/packages/profile-sync-controller/src/sdk/utils/messaging-signing-snap-requests.test.ts
+++ b/packages/profile-sync-controller/src/sdk/utils/messaging-signing-snap-requests.test.ts
@@ -8,6 +8,7 @@ import {
   connectSnap,
   getSnap,
   getSnaps,
+  isSnapConnected,
 } from './messaging-signing-snap-requests';
 
 /**
@@ -30,6 +31,38 @@ describe('getSnaps() tests', () => {
     await getSnaps(mockProvider);
 
     expect(mockRequest).toHaveBeenCalled();
+  });
+});
+
+describe('isSnapConnected() tests', () => {
+  it('return true if snap is connected', async () => {
+    const { mockProvider, mockRequest } = arrangeMockProvider();
+    const mockSnap: Snap = { id: SNAP_ORIGIN } as MockVariable;
+    mockRequest.mockResolvedValue({ [SNAP_ORIGIN]: mockSnap });
+
+    const isConnected = await isSnapConnected(mockProvider);
+    expect(mockRequest).toHaveBeenCalled();
+    expect(isConnected).toBe(true);
+  });
+
+  it('return false if snap is NOT connected', async () => {
+    const { mockProvider, mockRequest } = arrangeMockProvider();
+
+    const mockSnap: Snap = { id: 'A differentSnap' } as MockVariable;
+    mockRequest.mockResolvedValue({ diffSnap: mockSnap });
+
+    const isConnected = await isSnapConnected(mockProvider);
+    expect(mockRequest).toHaveBeenCalled();
+    expect(isConnected).toBe(false);
+  });
+
+  it('return false if an error is thrown when making provider request', async () => {
+    const { mockProvider, mockRequest } = arrangeMockProvider();
+    mockRequest.mockRejectedValue(new Error('MOCK ERROR'));
+
+    const isConnected = await isSnapConnected(mockProvider);
+    expect(mockRequest).toHaveBeenCalled();
+    expect(isConnected).toBe(false);
   });
 });
 

--- a/packages/profile-sync-controller/src/sdk/utils/messaging-signing-snap-requests.ts
+++ b/packages/profile-sync-controller/src/sdk/utils/messaging-signing-snap-requests.ts
@@ -46,6 +46,27 @@ export async function getSnaps(
 }
 
 /**
+ * Check if snap is connected
+ *
+ * @param provider - MetaMask Wallet Provider
+ * @returns if snap is connected
+ */
+export async function isSnapConnected(
+  provider: Eip1193Provider,
+): Promise<boolean> {
+  try {
+    const snaps = await getSnaps(provider);
+    if (!snaps) {
+      return false;
+    }
+    return Object.keys(snaps).includes(SNAP_ORIGIN);
+  } catch (e) {
+    console.error('Failed to determine if snap is connected', e);
+    return false;
+  }
+}
+
+/**
  * Will return the message signing snap if installed
  * @param provider - MetaMask Wallet Provider
  */


### PR DESCRIPTION
## Explanation

Exposing utility function to check if message signing snap is connected

Reference:
- https://consensyssoftware.atlassian.net/browse/NOTIFY-1062

## Changelog

**@metamask/profile-sync-controller**

```md
### Added

- isSnapConnected method to the Authentication SDK

```