### PR TITLE
refactor: move contentful as a dev dependency

### DIFF
--- a/packages/notification-services-controller/package.json
+++ b/packages/notification-services-controller/package.json
@@ -73,7 +73,6 @@
     "@metamask/base-controller": "^7.0.0",
     "@metamask/controller-utils": "^11.2.0",
     "bignumber.js": "^4.1.0",
-    "contentful": "^10.15.0",
     "firebase": "^10.11.0",
     "loglevel": "^1.8.1",
     "uuid": "^8.3.2"
@@ -85,6 +84,7 @@
     "@metamask/profile-sync-controller": "^0.4.0",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",
+    "contentful": "^10.15.0",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "jest-environment-jsdom": "^27.5.1",


### PR DESCRIPTION
## Explanation

Updates the `@metamask/notification-services-controller` `contentful` package to be a dev dependency.
We are only using contentful for its types. This also cleans up extension/mobile lavamoat policies.

## References

https://consensyssoftware.atlassian.net/browse/NOTIFY-1076

## Changelog

### `@metamask/notification-services-controller`

- **CHANGED**: Moved `Contentful` to `devDependencies`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
