### PR TITLE
Export phishing detector result type

### DIFF
--- a/packages/phishing-controller/src/index.ts
+++ b/packages/phishing-controller/src/index.ts
@@ -7,3 +7,4 @@ export type {
   PhishingDetectorConfiguration,
 } from './PhishingDetector';
 export { PhishingDetector } from './PhishingDetector';
+export { PhishingDetectorResultType } from './types';


### PR DESCRIPTION
## Explanation

`PhishingDetectorResult` expects a `PhishingDetectorResultType` enum as `type` property, but the enum was previously not exported. Since it's an enum, we can't access it by using `PhishingDetectorResult['type']` either.

We need access to this to mock the result of the phishing controller in tests in the Snaps repo.

## Changelog

### `@metamask/phishing-controller`

- **FIXED**: Export `PhishingDetectorResultType` enum

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
