### PR TITLE
feat: scaffolding - update storage schema

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/schema.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/schema.ts
@@ -11,7 +11,8 @@ const ALLOW_ARBITRARY_KEYS = 'ALLOW_ARBITRARY_KEYS' as const;
 
 export const USER_STORAGE_SCHEMA = {
   notifications: ['notificationSettings'],
-  accounts: [ALLOW_ARBITRARY_KEYS],
+  accounts: [ALLOW_ARBITRARY_KEYS], // keyed by account addresses
+  networks: [ALLOW_ARBITRARY_KEYS], // keyed by chains/networks
 } as const;
 
 type UserStorageSchema = typeof USER_STORAGE_SCHEMA;

--- a/packages/profile-sync-controller/src/controllers/user-storage/services.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/services.ts
@@ -34,16 +34,15 @@ export type GetUserStorageAllFeatureEntriesResponse = {
 export type UserStorageBaseOptions = {
   bearerToken: string;
   storageKey: string;
+  nativeScryptCrypto?: NativeScrypt;
 };
 
 export type UserStorageOptions = UserStorageBaseOptions & {
   path: UserStoragePathWithFeatureAndKey;
-  nativeScryptCrypto?: NativeScrypt;
 };
 
 export type UserStorageAllFeatureEntriesOptions = UserStorageBaseOptions & {
   path: UserStoragePathWithFeatureOnly;
-  nativeScryptCrypto?: NativeScrypt;
 };
 
 /**


### PR DESCRIPTION
## Explanation

Scaffolding - adds a new supported storage schema. This will unlock network syncing.

## References

https://consensyssoftware.atlassian.net/browse/NOTIFY-1032

## Changelog

### `@metamask/profile-sync-controller`

- **Added**: `networks` to the User Storage Schema.
- **CHANGED**: moved `nativeScryptCrypto` into the `UserStorageBaseOptions`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
