### PR TITLE
Bump Snaps packages

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -46,8 +46,8 @@
     "@metamask/base-controller": "^7.0.0",
     "@metamask/eth-snap-keyring": "^4.3.3",
     "@metamask/keyring-api": "^8.1.0",
-    "@metamask/snaps-sdk": "^6.4.0",
-    "@metamask/snaps-utils": "^8.1.0",
+    "@metamask/snaps-sdk": "^6.5.0",
+    "@metamask/snaps-utils": "^8.1.1",
     "@metamask/utils": "^9.1.0",
     "deepmerge": "^4.2.2",
     "ethereum-cryptography": "^2.1.2",
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-controller": "^17.2.0",
-    "@metamask/snaps-controllers": "^9.6.0",
+    "@metamask/snaps-controllers": "^9.7.0",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",
     "jest": "^27.5.1",
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^17.0.0",
-    "@metamask/snaps-controllers": "^9.6.0"
+    "@metamask/snaps-controllers": "^9.7.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -44,10 +44,10 @@
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",
     "@metamask/base-controller": "^7.0.0",
-    "@metamask/eth-snap-keyring": "^4.3.1",
+    "@metamask/eth-snap-keyring": "^4.3.3",
     "@metamask/keyring-api": "^8.1.0",
-    "@metamask/snaps-sdk": "^6.1.1",
-    "@metamask/snaps-utils": "^7.8.1",
+    "@metamask/snaps-sdk": "^6.4.0",
+    "@metamask/snaps-utils": "^8.1.0",
     "@metamask/utils": "^9.1.0",
     "deepmerge": "^4.2.2",
     "ethereum-cryptography": "^2.1.2",
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-controller": "^17.2.0",
-    "@metamask/snaps-controllers": "^9.3.1",
+    "@metamask/snaps-controllers": "^9.6.0",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",
     "jest": "^27.5.1",
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^17.0.0",
-    "@metamask/snaps-controllers": "^9.3.0"
+    "@metamask/snaps-controllers": "^9.6.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/chain-controller/package.json
+++ b/packages/chain-controller/package.json
@@ -45,9 +45,9 @@
     "@metamask/base-controller": "^7.0.0",
     "@metamask/chain-api": "^0.1.0",
     "@metamask/keyring-api": "^8.1.0",
-    "@metamask/snaps-controllers": "^9.3.1",
-    "@metamask/snaps-sdk": "^6.1.1",
-    "@metamask/snaps-utils": "^7.8.1",
+    "@metamask/snaps-controllers": "^9.6.0",
+    "@metamask/snaps-sdk": "^6.4.0",
+    "@metamask/snaps-utils": "^8.1.0",
     "@metamask/utils": "^9.1.0",
     "uuid": "^8.3.2"
   },

--- a/packages/chain-controller/package.json
+++ b/packages/chain-controller/package.json
@@ -45,9 +45,9 @@
     "@metamask/base-controller": "^7.0.0",
     "@metamask/chain-api": "^0.1.0",
     "@metamask/keyring-api": "^8.1.0",
-    "@metamask/snaps-controllers": "^9.6.0",
-    "@metamask/snaps-sdk": "^6.4.0",
-    "@metamask/snaps-utils": "^8.1.0",
+    "@metamask/snaps-controllers": "^9.7.0",
+    "@metamask/snaps-sdk": "^6.5.0",
+    "@metamask/snaps-utils": "^8.1.1",
     "@metamask/utils": "^9.1.0",
     "uuid": "^8.3.2"
   },

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -70,8 +70,8 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^7.0.0",
-    "@metamask/snaps-sdk": "^6.4.0",
-    "@metamask/snaps-utils": "^8.1.0",
+    "@metamask/snaps-sdk": "^6.5.0",
+    "@metamask/snaps-utils": "^8.1.1",
     "@noble/ciphers": "^0.5.2",
     "@noble/hashes": "^1.4.0",
     "immer": "^9.0.6",
@@ -85,7 +85,7 @@
     "@metamask/keyring-api": "^8.1.0",
     "@metamask/keyring-controller": "^17.2.0",
     "@metamask/network-controller": "^21.0.0",
-    "@metamask/snaps-controllers": "^9.6.0",
+    "@metamask/snaps-controllers": "^9.7.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "ethers": "^6.12.0",
@@ -100,7 +100,7 @@
   "peerDependencies": {
     "@metamask/accounts-controller": "^18.1.1",
     "@metamask/keyring-controller": "^17.2.0",
-    "@metamask/snaps-controllers": "^9.6.0"
+    "@metamask/snaps-controllers": "^9.7.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -70,8 +70,8 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^7.0.0",
-    "@metamask/snaps-sdk": "^6.1.1",
-    "@metamask/snaps-utils": "^7.8.1",
+    "@metamask/snaps-sdk": "^6.4.0",
+    "@metamask/snaps-utils": "^8.1.0",
     "@noble/ciphers": "^0.5.2",
     "@noble/hashes": "^1.4.0",
     "immer": "^9.0.6",
@@ -85,7 +85,7 @@
     "@metamask/keyring-api": "^8.1.0",
     "@metamask/keyring-controller": "^17.2.0",
     "@metamask/network-controller": "^21.0.0",
-    "@metamask/snaps-controllers": "^9.3.1",
+    "@metamask/snaps-controllers": "^9.6.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "ethers": "^6.12.0",
@@ -100,7 +100,7 @@
   "peerDependencies": {
     "@metamask/accounts-controller": "^18.1.1",
     "@metamask/keyring-controller": "^17.2.0",
-    "@metamask/snaps-controllers": "^9.3.0"
+    "@metamask/snaps-controllers": "^9.6.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2198,9 +2198,9 @@ __metadata:
     "@metamask/eth-snap-keyring": "npm:^4.3.3"
     "@metamask/keyring-api": "npm:^8.1.0"
     "@metamask/keyring-controller": "npm:^17.2.0"
-    "@metamask/snaps-controllers": "npm:^9.6.0"
-    "@metamask/snaps-sdk": "npm:^6.4.0"
-    "@metamask/snaps-utils": "npm:^8.1.0"
+    "@metamask/snaps-controllers": "npm:^9.7.0"
+    "@metamask/snaps-sdk": "npm:^6.5.0"
+    "@metamask/snaps-utils": "npm:^8.1.1"
     "@metamask/utils": "npm:^9.1.0"
     "@types/jest": "npm:^27.4.1"
     "@types/readable-stream": "npm:^2.3.0"
@@ -2215,7 +2215,7 @@ __metadata:
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@metamask/keyring-controller": ^17.0.0
-    "@metamask/snaps-controllers": ^9.6.0
+    "@metamask/snaps-controllers": ^9.7.0
   languageName: unknown
   linkType: soft
 
@@ -2446,9 +2446,9 @@ __metadata:
     "@metamask/base-controller": "npm:^7.0.0"
     "@metamask/chain-api": "npm:^0.1.0"
     "@metamask/keyring-api": "npm:^8.1.0"
-    "@metamask/snaps-controllers": "npm:^9.6.0"
-    "@metamask/snaps-sdk": "npm:^6.4.0"
-    "@metamask/snaps-utils": "npm:^8.1.0"
+    "@metamask/snaps-controllers": "npm:^9.7.0"
+    "@metamask/snaps-sdk": "npm:^6.5.0"
+    "@metamask/snaps-utils": "npm:^8.1.1"
     "@metamask/utils": "npm:^9.1.0"
     "@types/jest": "npm:^27.4.1"
     "@types/readable-stream": "npm:^2.3.0"
@@ -3441,9 +3441,9 @@ __metadata:
     "@metamask/keyring-api": "npm:^8.1.0"
     "@metamask/keyring-controller": "npm:^17.2.0"
     "@metamask/network-controller": "npm:^21.0.0"
-    "@metamask/snaps-controllers": "npm:^9.6.0"
-    "@metamask/snaps-sdk": "npm:^6.4.0"
-    "@metamask/snaps-utils": "npm:^8.1.0"
+    "@metamask/snaps-controllers": "npm:^9.7.0"
+    "@metamask/snaps-sdk": "npm:^6.5.0"
+    "@metamask/snaps-utils": "npm:^8.1.1"
     "@noble/ciphers": "npm:^0.5.2"
     "@noble/hashes": "npm:^1.4.0"
     "@types/jest": "npm:^27.4.1"
@@ -3462,7 +3462,7 @@ __metadata:
   peerDependencies:
     "@metamask/accounts-controller": ^18.1.1
     "@metamask/keyring-controller": ^17.2.0
-    "@metamask/snaps-controllers": ^9.6.0
+    "@metamask/snaps-controllers": ^9.7.0
   languageName: unknown
   linkType: soft
 
@@ -3631,9 +3631,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^9.6.0":
-  version: 9.6.0
-  resolution: "@metamask/snaps-controllers@npm:9.6.0"
+"@metamask/snaps-controllers@npm:^9.6.0, @metamask/snaps-controllers@npm:^9.7.0":
+  version: 9.7.0
+  resolution: "@metamask/snaps-controllers@npm:9.7.0"
   dependencies:
     "@metamask/approval-controller": "npm:^7.0.2"
     "@metamask/base-controller": "npm:^6.0.2"
@@ -3645,9 +3645,9 @@ __metadata:
     "@metamask/post-message-stream": "npm:^8.1.1"
     "@metamask/rpc-errors": "npm:^6.3.1"
     "@metamask/snaps-registry": "npm:^3.2.1"
-    "@metamask/snaps-rpc-methods": "npm:^11.1.0"
-    "@metamask/snaps-sdk": "npm:^6.4.0"
-    "@metamask/snaps-utils": "npm:^8.1.0"
+    "@metamask/snaps-rpc-methods": "npm:^11.1.1"
+    "@metamask/snaps-sdk": "npm:^6.5.0"
+    "@metamask/snaps-utils": "npm:^8.1.1"
     "@metamask/utils": "npm:^9.2.1"
     "@xstate/fsm": "npm:^2.0.0"
     browserify-zlib: "npm:^0.2.0"
@@ -3660,11 +3660,11 @@ __metadata:
     readable-web-to-node-stream: "npm:^3.0.2"
     tar-stream: "npm:^3.1.7"
   peerDependencies:
-    "@metamask/snaps-execution-environments": ^6.7.0
+    "@metamask/snaps-execution-environments": ^6.7.1
   peerDependenciesMeta:
     "@metamask/snaps-execution-environments":
       optional: true
-  checksum: 10/c71fdfae9e403f505e6bb298c7b53173416d903a32a0ccd461d5f20b2d72b132245c3b9a6f33dca62f2cbc01839d8777eb11eec506dabb9ee55d22d5ef15791d
+  checksum: 10/8a353819e60330ef3e338a40b1115d4c830b92b1cc0c92afb2b34bf46fbc906e6da5f905654e1d486cacd40b7025ec74d3cd01cb935090035ce9f1021ce5469f
   languageName: node
   linkType: hard
 
@@ -3680,32 +3680,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^11.1.0":
-  version: 11.1.0
-  resolution: "@metamask/snaps-rpc-methods@npm:11.1.0"
+"@metamask/snaps-rpc-methods@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "@metamask/snaps-rpc-methods@npm:11.1.1"
   dependencies:
     "@metamask/key-tree": "npm:^9.1.2"
     "@metamask/permission-controller": "npm:^11.0.0"
     "@metamask/rpc-errors": "npm:^6.3.1"
-    "@metamask/snaps-sdk": "npm:^6.4.0"
-    "@metamask/snaps-utils": "npm:^8.1.0"
+    "@metamask/snaps-sdk": "npm:^6.5.0"
+    "@metamask/snaps-utils": "npm:^8.1.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.2.1"
     "@noble/hashes": "npm:^1.3.1"
-  checksum: 10/96c068ce171553b743287237fc5f382234ed1e00d028e16b7f9779a8681317145cf89bc88e5fec6e2ea7edb0dc5d2b76c415a3116b1a4254c0173cb65c149a09
+  checksum: 10/e23279dabc6f4ffe2c6c4a7003a624cd5e79b558d7981ec12c23e54a5da25cb7be9bc7bddfa8b2ce84af28a89b42076a2c14ab004b7a976a4426bf1e1de71b5b
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^6.1.0, @metamask/snaps-sdk@npm:^6.4.0":
-  version: 6.4.0
-  resolution: "@metamask/snaps-sdk@npm:6.4.0"
+"@metamask/snaps-sdk@npm:^6.1.0, @metamask/snaps-sdk@npm:^6.4.0, @metamask/snaps-sdk@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "@metamask/snaps-sdk@npm:6.5.0"
   dependencies:
     "@metamask/key-tree": "npm:^9.1.2"
     "@metamask/providers": "npm:^17.1.2"
     "@metamask/rpc-errors": "npm:^6.3.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.2.1"
-  checksum: 10/fbfa0d440c96eba3b0d19dfa87ab317a59203b65d5f30709fd2330c3f7fb6bd7460af389127369fa297eef178084e8b37e1950f00f8852bc6e50de0b2c0f2004
+  checksum: 10/e3da25d20d6adae2cd4845552fe973d0571303d1b9dffdce5d29202707278afac949293aec4470954620d852f30adebd1e54713f2b07c1c341dab09e908e0368
   languageName: node
   linkType: hard
 
@@ -3740,9 +3740,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "@metamask/snaps-utils@npm:8.1.0"
+"@metamask/snaps-utils@npm:^8.1.1":
+  version: 8.1.1
+  resolution: "@metamask/snaps-utils@npm:8.1.1"
   dependencies:
     "@babel/core": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
@@ -3752,7 +3752,7 @@ __metadata:
     "@metamask/rpc-errors": "npm:^6.3.1"
     "@metamask/slip44": "npm:^4.0.0"
     "@metamask/snaps-registry": "npm:^3.2.1"
-    "@metamask/snaps-sdk": "npm:^6.4.0"
+    "@metamask/snaps-sdk": "npm:^6.5.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.2.1"
     "@noble/hashes": "npm:^1.3.1"
@@ -3767,7 +3767,7 @@ __metadata:
     semver: "npm:^7.5.4"
     ses: "npm:^1.1.0"
     validate-npm-package-name: "npm:^5.0.0"
-  checksum: 10/15afed46be3ee826aa08730b01f1a13a432991582e1b7af525d4de1c8367342ccc508ec5060b1bebf747089398316281cd9b53e748002caf50036b89f24eb7c6
+  checksum: 10/f4ceb52a1f9578993c88c82a67f4f041309af51c83ff5caa3fed080f36b54d14ea7da807ce1cf19a13600dd0e77c51af70398e8c7bb78f0ba99a037f4d22610f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,12 +2195,12 @@ __metadata:
     "@ethereumjs/util": "npm:^8.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.0"
-    "@metamask/eth-snap-keyring": "npm:^4.3.1"
+    "@metamask/eth-snap-keyring": "npm:^4.3.3"
     "@metamask/keyring-api": "npm:^8.1.0"
     "@metamask/keyring-controller": "npm:^17.2.0"
-    "@metamask/snaps-controllers": "npm:^9.3.1"
-    "@metamask/snaps-sdk": "npm:^6.1.1"
-    "@metamask/snaps-utils": "npm:^7.8.1"
+    "@metamask/snaps-controllers": "npm:^9.6.0"
+    "@metamask/snaps-sdk": "npm:^6.4.0"
+    "@metamask/snaps-utils": "npm:^8.1.0"
     "@metamask/utils": "npm:^9.1.0"
     "@types/jest": "npm:^27.4.1"
     "@types/readable-stream": "npm:^2.3.0"
@@ -2215,7 +2215,7 @@ __metadata:
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@metamask/keyring-controller": ^17.0.0
-    "@metamask/snaps-controllers": ^9.3.0
+    "@metamask/snaps-controllers": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2446,9 +2446,9 @@ __metadata:
     "@metamask/base-controller": "npm:^7.0.0"
     "@metamask/chain-api": "npm:^0.1.0"
     "@metamask/keyring-api": "npm:^8.1.0"
-    "@metamask/snaps-controllers": "npm:^9.3.1"
-    "@metamask/snaps-sdk": "npm:^6.1.1"
-    "@metamask/snaps-utils": "npm:^7.8.1"
+    "@metamask/snaps-controllers": "npm:^9.6.0"
+    "@metamask/snaps-sdk": "npm:^6.4.0"
+    "@metamask/snaps-utils": "npm:^8.1.0"
     "@metamask/utils": "npm:^9.1.0"
     "@types/jest": "npm:^27.4.1"
     "@types/readable-stream": "npm:^2.3.0"
@@ -2488,7 +2488,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^11.0.2, @metamask/controller-utils@npm:^11.2.0, @metamask/controller-utils@workspace:packages/controller-utils":
+"@metamask/controller-utils@npm:^11.2.0, @metamask/controller-utils@workspace:packages/controller-utils":
   version: 0.0.0-use.local
   resolution: "@metamask/controller-utils@workspace:packages/controller-utils"
   dependencies:
@@ -2792,21 +2792,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-snap-keyring@npm:^4.3.1":
-  version: 4.3.2
-  resolution: "@metamask/eth-snap-keyring@npm:4.3.2"
+"@metamask/eth-snap-keyring@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "@metamask/eth-snap-keyring@npm:4.3.3"
   dependencies:
     "@ethereumjs/tx": "npm:^4.2.0"
     "@metamask/eth-sig-util": "npm:^7.0.3"
-    "@metamask/keyring-api": "npm:^8.0.1"
-    "@metamask/snaps-controllers": "npm:^9.3.0"
-    "@metamask/snaps-sdk": "npm:^6.1.0"
+    "@metamask/keyring-api": "npm:^8.1.0"
+    "@metamask/snaps-controllers": "npm:^9.6.0"
+    "@metamask/snaps-sdk": "npm:^6.4.0"
     "@metamask/snaps-utils": "npm:^7.8.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^9.1.0"
+    "@metamask/utils": "npm:^9.2.1"
     "@types/uuid": "npm:^9.0.1"
     uuid: "npm:^9.0.0"
-  checksum: 10/c6a38be757d31ef2d88568397dc59635ba993bae7e732f16d3c3584ae6d7bf76a3ef05998dc2c8ca1c9d8db79573b6bf2b85b0af68bc2906183cc806845d6677
+  checksum: 10/035c82afef82a4cee7bc63b5c4f152a132b683017ec90a4b614764a4bc7adcca8faccf78c25adcddca2d29eee2fed08706f07d72afb93640956b86e862d4f555
   languageName: node
   linkType: hard
 
@@ -3052,7 +3052,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^8.0.1, @metamask/keyring-api@npm:^8.1.0":
+"@metamask/keyring-api@npm:^8.1.0":
   version: 8.1.0
   resolution: "@metamask/keyring-api@npm:8.1.0"
   dependencies:
@@ -3349,21 +3349,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/phishing-controller@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "@metamask/phishing-controller@npm:10.1.1"
-  dependencies:
-    "@metamask/base-controller": "npm:^6.0.2"
-    "@metamask/controller-utils": "npm:^11.0.2"
-    "@types/punycode": "npm:^2.1.0"
-    eth-phishing-detect: "npm:^1.2.0"
-    fastest-levenshtein: "npm:^1.0.16"
-    punycode: "npm:^2.1.1"
-  checksum: 10/4c6723d62a3a0b071fbf4c2b227a2eef6daa5f742bce80677bdf96312393c427d0d3c183ffcc13e065464c6c644f2b556c56e79161757bbccb525d4b34ee46b0
-  languageName: node
-  linkType: hard
-
-"@metamask/phishing-controller@workspace:packages/phishing-controller":
+"@metamask/phishing-controller@npm:^12.0.2, @metamask/phishing-controller@workspace:packages/phishing-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/phishing-controller@workspace:packages/phishing-controller"
   dependencies:
@@ -3413,7 +3399,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/post-message-stream@npm:^8.1.0":
+"@metamask/post-message-stream@npm:^8.1.1":
   version: 8.1.1
   resolution: "@metamask/post-message-stream@npm:8.1.1"
   dependencies:
@@ -3455,9 +3441,9 @@ __metadata:
     "@metamask/keyring-api": "npm:^8.1.0"
     "@metamask/keyring-controller": "npm:^17.2.0"
     "@metamask/network-controller": "npm:^21.0.0"
-    "@metamask/snaps-controllers": "npm:^9.3.1"
-    "@metamask/snaps-sdk": "npm:^6.1.1"
-    "@metamask/snaps-utils": "npm:^7.8.1"
+    "@metamask/snaps-controllers": "npm:^9.6.0"
+    "@metamask/snaps-sdk": "npm:^6.4.0"
+    "@metamask/snaps-utils": "npm:^8.1.0"
     "@noble/ciphers": "npm:^0.5.2"
     "@noble/hashes": "npm:^1.4.0"
     "@types/jest": "npm:^27.4.1"
@@ -3476,7 +3462,7 @@ __metadata:
   peerDependencies:
     "@metamask/accounts-controller": ^18.1.1
     "@metamask/keyring-controller": ^17.2.0
-    "@metamask/snaps-controllers": ^9.3.0
+    "@metamask/snaps-controllers": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -3645,9 +3631,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^9.3.0, @metamask/snaps-controllers@npm:^9.3.1":
-  version: 9.4.0
-  resolution: "@metamask/snaps-controllers@npm:9.4.0"
+"@metamask/snaps-controllers@npm:^9.6.0":
+  version: 9.6.0
+  resolution: "@metamask/snaps-controllers@npm:9.6.0"
   dependencies:
     "@metamask/approval-controller": "npm:^7.0.2"
     "@metamask/base-controller": "npm:^6.0.2"
@@ -3655,14 +3641,14 @@ __metadata:
     "@metamask/json-rpc-middleware-stream": "npm:^8.0.2"
     "@metamask/object-multiplex": "npm:^2.0.0"
     "@metamask/permission-controller": "npm:^11.0.0"
-    "@metamask/phishing-controller": "npm:^10.1.1"
-    "@metamask/post-message-stream": "npm:^8.1.0"
+    "@metamask/phishing-controller": "npm:^12.0.2"
+    "@metamask/post-message-stream": "npm:^8.1.1"
     "@metamask/rpc-errors": "npm:^6.3.1"
     "@metamask/snaps-registry": "npm:^3.2.1"
-    "@metamask/snaps-rpc-methods": "npm:^11.0.0"
-    "@metamask/snaps-sdk": "npm:^6.2.0"
-    "@metamask/snaps-utils": "npm:^8.0.0"
-    "@metamask/utils": "npm:^9.1.0"
+    "@metamask/snaps-rpc-methods": "npm:^11.1.0"
+    "@metamask/snaps-sdk": "npm:^6.4.0"
+    "@metamask/snaps-utils": "npm:^8.1.0"
+    "@metamask/utils": "npm:^9.2.1"
     "@xstate/fsm": "npm:^2.0.0"
     browserify-zlib: "npm:^0.2.0"
     concat-stream: "npm:^2.0.0"
@@ -3674,11 +3660,11 @@ __metadata:
     readable-web-to-node-stream: "npm:^3.0.2"
     tar-stream: "npm:^3.1.7"
   peerDependencies:
-    "@metamask/snaps-execution-environments": ^6.6.2
+    "@metamask/snaps-execution-environments": ^6.7.0
   peerDependenciesMeta:
     "@metamask/snaps-execution-environments":
       optional: true
-  checksum: 10/36c9fb83c675443b1dd9f2bf9eccd1eda1648c5c451bb93e432a358377557f7953b96579d2b5d9605f39bfb96062968a8e612b9500c14fb1fb7bb15d176bd7a1
+  checksum: 10/c71fdfae9e403f505e6bb298c7b53173416d903a32a0ccd461d5f20b2d72b132245c3b9a6f33dca62f2cbc01839d8777eb11eec506dabb9ee55d22d5ef15791d
   languageName: node
   linkType: hard
 
@@ -3694,36 +3680,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "@metamask/snaps-rpc-methods@npm:11.0.0"
+"@metamask/snaps-rpc-methods@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "@metamask/snaps-rpc-methods@npm:11.1.0"
   dependencies:
     "@metamask/key-tree": "npm:^9.1.2"
     "@metamask/permission-controller": "npm:^11.0.0"
     "@metamask/rpc-errors": "npm:^6.3.1"
-    "@metamask/snaps-sdk": "npm:^6.2.0"
-    "@metamask/snaps-utils": "npm:^8.0.0"
+    "@metamask/snaps-sdk": "npm:^6.4.0"
+    "@metamask/snaps-utils": "npm:^8.1.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^9.1.0"
+    "@metamask/utils": "npm:^9.2.1"
     "@noble/hashes": "npm:^1.3.1"
-  checksum: 10/2e594d7f9fde910e87525a6ded9a162d2ea8631249b7868ca710df0d8d25c127674079956976c7443e30c96bedb84bf818748a01aad41cfe69f88524781b994f
+  checksum: 10/96c068ce171553b743287237fc5f382234ed1e00d028e16b7f9779a8681317145cf89bc88e5fec6e2ea7edb0dc5d2b76c415a3116b1a4254c0173cb65c149a09
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^6.1.0, @metamask/snaps-sdk@npm:^6.1.1, @metamask/snaps-sdk@npm:^6.2.0, @metamask/snaps-sdk@npm:^6.2.1":
-  version: 6.2.1
-  resolution: "@metamask/snaps-sdk@npm:6.2.1"
+"@metamask/snaps-sdk@npm:^6.1.0, @metamask/snaps-sdk@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@metamask/snaps-sdk@npm:6.4.0"
   dependencies:
     "@metamask/key-tree": "npm:^9.1.2"
     "@metamask/providers": "npm:^17.1.2"
     "@metamask/rpc-errors": "npm:^6.3.1"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^9.1.0"
-  checksum: 10/95728ff7cb5646d04221230c1368f84b1aef931a361ef79689d32426f9f86c6524345e3bd387221a8e7ee0d47e15d1797665bf244566b94cacc09bd643567f05
+    "@metamask/utils": "npm:^9.2.1"
+  checksum: 10/fbfa0d440c96eba3b0d19dfa87ab317a59203b65d5f30709fd2330c3f7fb6bd7460af389127369fa297eef178084e8b37e1950f00f8852bc6e50de0b2c0f2004
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^7.8.0, @metamask/snaps-utils@npm:^7.8.1":
+"@metamask/snaps-utils@npm:^7.8.0":
   version: 7.8.1
   resolution: "@metamask/snaps-utils@npm:7.8.1"
   dependencies:
@@ -3754,9 +3740,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^8.0.0":
-  version: 8.0.1
-  resolution: "@metamask/snaps-utils@npm:8.0.1"
+"@metamask/snaps-utils@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@metamask/snaps-utils@npm:8.1.0"
   dependencies:
     "@babel/core": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
@@ -3766,9 +3752,9 @@ __metadata:
     "@metamask/rpc-errors": "npm:^6.3.1"
     "@metamask/slip44": "npm:^4.0.0"
     "@metamask/snaps-registry": "npm:^3.2.1"
-    "@metamask/snaps-sdk": "npm:^6.2.1"
+    "@metamask/snaps-sdk": "npm:^6.4.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^9.1.0"
+    "@metamask/utils": "npm:^9.2.1"
     "@noble/hashes": "npm:^1.3.1"
     "@scure/base": "npm:^1.1.1"
     chalk: "npm:^4.1.2"
@@ -3781,7 +3767,7 @@ __metadata:
     semver: "npm:^7.5.4"
     ses: "npm:^1.1.0"
     validate-npm-package-name: "npm:^5.0.0"
-  checksum: 10/4c0d58ad04f1e4c625dd01aaf171de0f538afc2003ac928159deee5ebed6d490ccd50575ad585b4f6846aa8d00bccd8f1ea4b32f124e6427873fb985cae8513f
+  checksum: 10/15afed46be3ee826aa08730b01f1a13a432991582e1b7af525d4de1c8367342ccc508ec5060b1bebf747089398316281cd9b53e748002caf50036b89f24eb7c6
   languageName: node
   linkType: hard
 
@@ -3906,9 +3892,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^9.0.0, @metamask/utils@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "@metamask/utils@npm:9.1.0"
+"@metamask/utils@npm:^9.0.0, @metamask/utils@npm:^9.1.0, @metamask/utils@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "@metamask/utils@npm:9.2.1"
   dependencies:
     "@ethereumjs/tx": "npm:^4.2.0"
     "@metamask/superstruct": "npm:^3.1.0"
@@ -3919,7 +3905,7 @@ __metadata:
     pony-cause: "npm:^2.1.10"
     semver: "npm:^7.5.4"
     uuid: "npm:^9.0.1"
-  checksum: 10/7335e151a51be92e86868dc48b3ee78c376d4edd5d758d334176027247637ab22839d8f663bd02542c0a19b05ecec456bedab5f36436689cf3d953ca36d91781
+  checksum: 10/2192797afd91af19898e107afeaf63e89b61dc7285e0a75d0cc814b5b288e4cdfc856781b01904034c4d2c1efd9bdab512af24c7e4dfe7b77a03f1f3d9dec7e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

This bumps all Snaps packages used in the core repo to the latest version. This is necessary to unblock #4648.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
