### PR TITLE
fix: waiting for encrypted string

### DIFF
--- a/packages/profile-sync-controller/src/sdk/user-storage.ts
+++ b/packages/profile-sync-controller/src/sdk/user-storage.ts
@@ -84,7 +84,7 @@ export class UserStorage {
     try {
       const headers = await this.#getAuthorizationHeader();
       const storageKey = await this.getStorageKey();
-      const encryptedData = encryption.encryptString(data, storageKey);
+      const encryptedData = await encryption.encryptString(data, storageKey);
       const encryptedPath = createEntryPath(path, storageKey);
 
       const url = new URL(STORAGE_URL(this.env, encryptedPath));


### PR DESCRIPTION
## Explanation

This PR solves the bug of not awaiting for encrypted string in the user storage

## References
## Changelog
### @metamask/profile-sync-controller 
- fixed awaiting for encryption to complete

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
