### PR TITLE
feat(NOTIFY-1102): add account sync analytics callbacks

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -580,6 +580,59 @@ describe('user-storage/user-storage-controller - syncInternalAccountsWithUserSto
     );
   });
 
+  it('fires the onAccountAdded callback when adding an account', async () => {
+    const mockUserStorageAccountsResponse = async () => {
+      return {
+        status: 200,
+        body: await createMockUserStorageEntries(
+          MOCK_USER_STORAGE_ACCOUNTS.SAME_AS_INTERNAL_ALL,
+        ),
+      };
+    };
+
+    const arrangeMocksForAccounts = async () => {
+      return {
+        messengerMocks: mockUserStorageMessenger({
+          accounts: {
+            accountsList: MOCK_INTERNAL_ACCOUNTS.ONE as InternalAccount[],
+          },
+        }),
+        mockAPI: {
+          mockEndpointGetUserStorage:
+            await mockEndpointGetUserStorageAllFeatureEntries(
+              'accounts',
+              await mockUserStorageAccountsResponse(),
+            ),
+        },
+      };
+    };
+
+    const onAccountAdded = jest.fn();
+
+    const { messengerMocks, mockAPI } = await arrangeMocksForAccounts();
+    const controller = new UserStorageController({
+      messenger: messengerMocks.messenger,
+      config: {
+        accountSyncing: {
+          onAccountAdded,
+        },
+      },
+      env: {
+        isAccountSyncingEnabled: true,
+      },
+      getMetaMetricsState: () => true,
+    });
+
+    await controller.syncInternalAccountsWithUserStorage();
+
+    mockAPI.mockEndpointGetUserStorage.done();
+
+    expect(onAccountAdded).toHaveBeenCalledTimes(
+      MOCK_USER_STORAGE_ACCOUNTS.SAME_AS_INTERNAL_ALL.length -
+        MOCK_INTERNAL_ACCOUNTS.ONE.length,
+    );
+  });
+
   it('does not create internal accounts if user storage has less accounts', async () => {
     const mockUserStorageAccountsResponse = async () => {
       return {
@@ -892,6 +945,48 @@ describe('user-storage/user-storage-controller - syncInternalAccountsWithUserSto
       expect(
         messengerMocks.mockAccountsUpdateAccountMetadata,
       ).not.toHaveBeenCalled();
+    });
+
+    it('fires the onAccountNameUpdated callback when renaming an internal account', async () => {
+      const arrangeMocksForAccounts = async () => {
+        return {
+          messengerMocks: mockUserStorageMessenger({
+            accounts: {
+              accountsList:
+                MOCK_INTERNAL_ACCOUNTS.ONE_DEFAULT_NAME as InternalAccount[],
+            },
+          }),
+          mockAPI: {
+            mockEndpointGetUserStorage:
+              await mockEndpointGetUserStorageAllFeatureEntries(
+                'accounts',
+                await mockUserStorageAccountsResponse(),
+              ),
+          },
+        };
+      };
+
+      const onAccountNameUpdated = jest.fn();
+
+      const { messengerMocks, mockAPI } = await arrangeMocksForAccounts();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+        config: {
+          accountSyncing: {
+            onAccountNameUpdated,
+          },
+        },
+        env: {
+          isAccountSyncingEnabled: true,
+        },
+        getMetaMetricsState: () => true,
+      });
+
+      await controller.syncInternalAccountsWithUserStorage();
+
+      mockAPI.mockEndpointGetUserStorage.done();
+
+      expect(onAccountNameUpdated).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Explanation

This PR adds callbacks that will be used for analytics in the account sync context.

## References

[Notify-1102](https://consensyssoftware.atlassian.net/jira/software/projects/NOTIFY/boards/616?assignee=712020%3A5843b7e2-a7fe-4c45-9fbd-e1f2b2eb58c2&selectedIssue=NOTIFY-1102)

## Changelog

### `@metamask/profile-sync-controller`

- **ADDED**: `onAccountAdded` and `onAccountNameUpdated` account syncing big sync callbacks


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
