### PR TITLE
fix: update subpath exports to use new .d.cts definition files.

### DIFF
--- a/packages/notification-services-controller/notification-services/mocks/package.json
+++ b/packages/notification-services-controller/notification-services/mocks/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "license": "MIT",
   "sideEffects": false,
-  "main": "../../dist/NotificationServicesController/__fixtures__/index.js",
-  "types": "../../dist/types/NotificationServicesController/__fixtures__/index.d.ts"
+  "main": "../../dist/NotificationServicesController/__fixtures__/index.cjs",
+  "types": "../../dist/NotificationServicesController/__fixtures__/index.d.cts"
 }

--- a/packages/notification-services-controller/notification-services/package.json
+++ b/packages/notification-services-controller/notification-services/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "license": "MIT",
   "sideEffects": false,
-  "main": "../dist/NotificationServicesController/index.js",
-  "types": "../dist/types/NotificationServicesController/index.d.ts"
+  "main": "../dist/NotificationServicesController/index.cjs",
+  "types": "../dist/NotificationServicesController/index.d.cts"
 }

--- a/packages/notification-services-controller/notification-services/ui/package.json
+++ b/packages/notification-services-controller/notification-services/ui/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "license": "MIT",
   "sideEffects": false,
-  "main": "../../dist/NotificationServicesController/ui/index.js",
-  "types": "../../dist/types/NotificationServicesController/ui/index.d.ts"
+  "main": "../../dist/NotificationServicesController/ui/index.cjs",
+  "types": "../../dist/NotificationServicesController/ui/index.d.cts"
 }

--- a/packages/notification-services-controller/package.json
+++ b/packages/notification-services-controller/package.json
@@ -28,29 +28,54 @@
       }
     },
     "./notification-services": {
-      "import": "./dist/NotificationServicesController/index.mjs",
-      "require": "./dist/NotificationServicesController/index.js",
-      "types": "./dist/types/NotificationServicesController/index.d.ts"
+      "import": {
+        "types": "./dist/NotificationServicesController/index.d.mts",
+        "default": "./dist/NotificationServicesController/index.mjs"
+      },
+      "require": {
+        "types": "./dist/NotificationServicesController/index.d.cts",
+        "default": "./dist/NotificationServicesController/index.cjs"
+      }
     },
     "./notification-services/ui": {
-      "import": "./dist/NotificationServicesController/ui/index.mjs",
-      "require": "./dist/NotificationServicesController/ui/index.js",
-      "types": "./dist/types/NotificationServicesController/ui/index.d.ts"
+      "import": {
+        "types": "./dist/NotificationServicesController/ui/index.d.mts",
+        "default": "./dist/NotificationServicesController/ui/index.mjs"
+      },
+      "require": {
+        "types": "./dist/NotificationServicesController/ui/index.d.cts",
+        "default": "./dist/NotificationServicesController/ui/index.cjs"
+      }
     },
     "./notification-services/mocks": {
-      "import": "./dist/NotificationServicesController/__fixtures__/index.mjs",
-      "require": "./dist/NotificationServicesController/__fixtures__/index.js",
-      "types": "./dist/types/NotificationServicesController/__fixtures__/index.d.ts"
+      "import": {
+        "types": "./dist/NotificationServicesController/__fixtures__/index.d.mts",
+        "default": "./dist/NotificationServicesController/__fixtures__/index.mjs"
+      },
+      "require": {
+        "types": "./dist/NotificationServicesController/__fixtures__/index.d.cts",
+        "default": "./dist/NotificationServicesController/__fixtures__/index.cjs"
+      }
     },
     "./push-services": {
-      "import": "./dist/NotificationServicesPushController/index.mjs",
-      "require": "./dist/NotificationServicesPushController/index.js",
-      "types": "./dist/types/NotificationServicesPushController/index.d.ts"
+      "import": {
+        "types": "./dist/NotificationServicesPushController/index.d.mts",
+        "default": "./dist/NotificationServicesPushController/index.mjs"
+      },
+      "require": {
+        "types": "./dist/NotificationServicesPushController/index.d.cts",
+        "default": "./dist/NotificationServicesPushController/index.cjs"
+      }
     },
     "./push-services/mocks": {
-      "import": "./dist/NotificationServicesPushController/__fixtures__/index.mjs",
-      "require": "./dist/NotificationServicesPushController/__fixtures__/index.js",
-      "types": "./dist/types/NotificationServicesPushController/__fixtures__/index.d.ts"
+      "import": {
+        "types": "./dist/NotificationServicesPushController/__fixtures__/index.d.mts",
+        "default": "./dist/NotificationServicesPushController/__fixtures__/index.mjs"
+      },
+      "require": {
+        "types": "./dist/NotificationServicesPushController/__fixtures__/index.d.cts",
+        "default": "./dist/NotificationServicesPushController/__fixtures__/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/notification-services-controller/push-services/mocks/package.json
+++ b/packages/notification-services-controller/push-services/mocks/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "license": "MIT",
   "sideEffects": false,
-  "main": "../../dist/NotificationServicesPushController/__fixtures__/index.js",
-  "types": "../../dist/types/NotificationServicesPushController/__fixtures__/index.d.ts"
+  "main": "../../dist/NotificationServicesPushController/__fixtures__/index.cjs",
+  "types": "../../dist/NotificationServicesPushController/__fixtures__/index.d.cts"
 }

--- a/packages/notification-services-controller/push-services/package.json
+++ b/packages/notification-services-controller/push-services/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "license": "MIT",
   "sideEffects": false,
-  "main": "../dist/NotificationServicesPushController/index.js",
-  "types": "../dist/types/NotificationServicesPushController/index.d.ts"
+  "main": "../dist/NotificationServicesPushController/index.cjs",
+  "types": "../dist/NotificationServicesPushController/index.d.cts"
 }

--- a/packages/profile-sync-controller/auth/mocks/package.json
+++ b/packages/profile-sync-controller/auth/mocks/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "license": "MIT",
   "sideEffects": false,
-  "main": "../../dist/controllers/authentication/__fixtures__/index.js",
-  "types": "../../dist/types/controllers/authentication/__fixtures__/index.d.ts"
+  "main": "../../dist/controllers/authentication/__fixtures__/index.cjs",
+  "types": "../../dist/controllers/authentication/__fixtures__/index.d.cts"
 }

--- a/packages/profile-sync-controller/auth/package.json
+++ b/packages/profile-sync-controller/auth/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "license": "MIT",
   "sideEffects": false,
-  "main": "../dist/controllers/authentication/index.js",
-  "types": "../dist/types/controllers/authentication/index.d.ts"
+  "main": "../dist/controllers/authentication/index.cjs",
+  "types": "../dist/controllers/authentication/index.d.cts"
 }

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -28,29 +28,54 @@
       }
     },
     "./sdk": {
-      "import": "./dist/sdk/index.mjs",
-      "require": "./dist/sdk/index.js",
-      "types": "./dist/types/sdk/index.d.ts"
+      "import": {
+        "types": "./dist/sdk/index.d.mts",
+        "default": "./dist/sdk/index.mjs"
+      },
+      "require": {
+        "types": "./dist/sdk/index.d.cts",
+        "default": "./dist/sdk/index.cjs"
+      }
     },
     "./auth": {
-      "import": "./dist/controllers/authentication/index.mjs",
-      "require": "./dist/controllers/authentication/index.js",
-      "types": "./dist/types/controllers/authentication/index.d.ts"
+      "import": {
+        "types": "./dist/controllers/authentication/index.d.mts",
+        "default": "./dist/controllers/authentication/index.mjs"
+      },
+      "require": {
+        "types": "./dist/controllers/authentication/index.d.cts",
+        "default": "./dist/controllers/authentication/index.cjs"
+      }
     },
     "./auth/mocks": {
-      "import": "./dist/controllers/authentication/__fixtures__/index.mjs",
-      "require": "./dist/controllers/authentication/__fixtures__/index.js",
-      "types": "./dist/types/controllers/authentication/__fixtures__/index.d.ts"
+      "import": {
+        "types": "./dist/controllers/authentication/__fixtures__/index.d.mts",
+        "default": "./dist/controllers/authentication/__fixtures__/index.mjs"
+      },
+      "require": {
+        "types": "./dist/controllers/authentication/__fixtures__/index.d.cts",
+        "default": "./dist/controllers/authentication/__fixtures__/index.cjs"
+      }
     },
     "./user-storage": {
-      "import": "./dist/controllers/user-storage/index.mjs",
-      "require": "./dist/controllers/user-storage/index.js",
-      "types": "./dist/types/controllers/user-storage/index.d.ts"
+      "import": {
+        "types": "./dist/controllers/user-storage/index.d.mts",
+        "default": "./dist/controllers/user-storage/index.mjs"
+      },
+      "require": {
+        "types": "./dist/controllers/user-storage/index.d.cts",
+        "default": "./dist/controllers/user-storage/index.cjs"
+      }
     },
     "./user-storage/mocks": {
-      "import": "./dist/controllers/user-storage/__fixtures__/index.mjs",
-      "require": "./dist/controllers/user-storage/__fixtures__/index.js",
-      "types": "./dist/types/controllers/user-storage/__fixtures__/index.d.ts"
+      "import": {
+        "types": "./dist/controllers/user-storage/__fixtures__/index.d.mts",
+        "default": "./dist/controllers/user-storage/__fixtures__/index.mjs"
+      },
+      "require": {
+        "types": "./dist/controllers/user-storage/__fixtures__/index.d.cts",
+        "default": "./dist/controllers/user-storage/__fixtures__/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -59,7 +59,8 @@
   "files": [
     "dist/",
     "auth/",
-    "user-storage/"
+    "user-storage/",
+    "sdk/"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/profile-sync-controller/sdk/package.json
+++ b/packages/profile-sync-controller/sdk/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "license": "MIT",
   "sideEffects": false,
-  "main": "../dist/sdk/index.js",
-  "types": "../dist/types/sdk/index.d.ts"
+  "main": "../dist/sdk/index.cjs",
+  "types": "../dist/sdk/index.d.cts"
 }

--- a/packages/profile-sync-controller/user-storage/mocks/package.json
+++ b/packages/profile-sync-controller/user-storage/mocks/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "license": "MIT",
   "sideEffects": false,
-  "main": "../../dist/controllers/user-storage/__fixtures__/index.js",
-  "types": "../../dist/types/controllers/user-storage/__fixtures__/index.d.ts"
+  "main": "../../dist/controllers/user-storage/__fixtures__/index.cjs",
+  "types": "../../dist/types/controllers/user-storage/__fixtures__/index.d.cts"
 }

--- a/packages/profile-sync-controller/user-storage/package.json
+++ b/packages/profile-sync-controller/user-storage/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "license": "MIT",
   "sideEffects": false,
-  "main": "../dist/controllers/user-storage/index.js",
-  "types": "../dist/types/controllers/user-storage/index.d.ts"
+  "main": "../dist/controllers/user-storage/index.cjs",
+  "types": "../dist/controllers/user-storage/index.d.cts"
 }


### PR DESCRIPTION
## Explanation

We have moved from tsup to ts-bridge, which generates a different path/file for typescript definition files.

This updates the notifications team packages that use subpath exports:
- `@metamask/profile-sync-controller`
- `@metamask/notification-services-controller`

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to? Are there other links that reviewers should consult to understand these changes better?

For example:

* Fixes #12345
* Related to #67890
-->

https://consensyssoftware.atlassian.net/browse/NOTIFY-1108

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/profile-sync-controller`

- **CHANGED**: Subpath exports `"types"` files.
- **ADDED**: SDK to supported `"files"` in package.json

### `@metamask/notification-services-controller`

- **CHANGED**: Subpath exports `"types"` files.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
