### PR TITLE
fix: profile-sync-controller mobile compilation issues

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockResponses.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockResponses.ts
@@ -33,43 +33,70 @@ export const getMockUserStorageEndpoint = (
   )}`;
 };
 
-export const createMockGetStorageResponse = async (
+/**
+ * Temp
+ * @param data - foo
+ * @returns bar
+ */
+export async function createMockGetStorageResponse(
   data?: string,
-): Promise<GetUserStorageResponse> => ({
-  HashedKey: 'HASHED_KEY',
-  Data: await MOCK_ENCRYPTED_STORAGE_DATA(data),
-});
+): Promise<GetUserStorageResponse> {
+  return {
+    HashedKey: 'HASHED_KEY',
+    Data: await MOCK_ENCRYPTED_STORAGE_DATA(data),
+  };
+}
 
-export const createMockAllFeatureEntriesResponse = async (
+/**
+ * Temp
+ * @param dataArr - foo
+ * @returns bar
+ */
+export async function createMockAllFeatureEntriesResponse(
   dataArr: string[] = [MOCK_STORAGE_DATA],
-): Promise<GetUserStorageAllFeatureEntriesResponse> =>
-  Promise.all(
-    dataArr.map(async (d) => ({
-      HashedKey: 'HASHED_KEY',
-      Data: await MOCK_ENCRYPTED_STORAGE_DATA(d),
-    })),
+): Promise<GetUserStorageAllFeatureEntriesResponse> {
+  return await Promise.all(
+    dataArr.map(async function (d) {
+      const encryptedData = await MOCK_ENCRYPTED_STORAGE_DATA(d);
+      return {
+        HashedKey: 'HASHED_KEY',
+        Data: encryptedData,
+      };
+    }),
   );
+}
 
-export const getMockUserStorageGetResponse = async (
+/**
+ * Temp
+ * @param path - foo
+ * @returns bar
+ */
+export async function getMockUserStorageGetResponse(
   path: UserStoragePathWithFeatureAndKey = 'notifications.notification_settings',
-) => {
+) {
   return {
     url: getMockUserStorageEndpoint(path),
     requestMethod: 'GET',
     response: await createMockGetStorageResponse(),
   } satisfies MockResponse;
-};
+}
 
-export const getMockUserStorageAllFeatureEntriesResponse = async (
+/**
+ * Temp
+ * @param path - foo
+ * @param dataArr - bar
+ * @returns baz
+ */
+export async function getMockUserStorageAllFeatureEntriesResponse(
   path: UserStoragePathWithFeatureOnly = 'notifications',
   dataArr?: string[],
-) => {
+) {
   return {
     url: getMockUserStorageEndpoint(path),
     requestMethod: 'GET',
     response: await createMockAllFeatureEntriesResponse(dataArr),
   } satisfies MockResponse;
-};
+}
 
 export const getMockUserStoragePutResponse = (
   path: UserStoragePathWithFeatureAndKey = 'notifications.notification_settings',

--- a/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockResponses.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockResponses.ts
@@ -34,9 +34,9 @@ export const getMockUserStorageEndpoint = (
 };
 
 /**
- * Temp
- * @param data - foo
- * @returns bar
+ * Creates a mock GET user-storage response
+ * @param data - data to encrypt
+ * @returns a realistic GET Response Body
  */
 export async function createMockGetStorageResponse(
   data?: string,
@@ -48,9 +48,9 @@ export async function createMockGetStorageResponse(
 }
 
 /**
- * Temp
- * @param dataArr - foo
- * @returns bar
+ * Creates a mock GET ALL user-storage response
+ * @param dataArr - array of data to encrypt
+ * @returns a realistic GET ALL Response Body
  */
 export async function createMockAllFeatureEntriesResponse(
   dataArr: string[] = [MOCK_STORAGE_DATA],
@@ -67,9 +67,9 @@ export async function createMockAllFeatureEntriesResponse(
 }
 
 /**
- * Temp
- * @param path - foo
- * @returns bar
+ * Creates a mock user-storage api GET request
+ * @param path - path of the GET Url
+ * @returns mock GET API request. Can be used by e2e or unit mock servers
  */
 export async function getMockUserStorageGetResponse(
   path: UserStoragePathWithFeatureAndKey = 'notifications.notification_settings',
@@ -82,10 +82,10 @@ export async function getMockUserStorageGetResponse(
 }
 
 /**
- * Temp
- * @param path - foo
- * @param dataArr - bar
- * @returns baz
+ * Creates a mock user-storage api GET ALL request
+ * @param path - path of the GET url
+ * @param dataArr - data to encrypt
+ * @returns mock GET ALL API request. Can be used by e2e or unit mock servers
  */
 export async function getMockUserStorageAllFeatureEntriesResponse(
   path: UserStoragePathWithFeatureOnly = 'notifications',


### PR DESCRIPTION
## Explanation

Our package has exported async arrow functions, which cannot be compiled during the `detox build android` step on mobile.

<details><summary>See error logs</summary>

![Screenshot 2024-09-20 at 21 16 55](https://github.com/user-attachments/assets/08c49d3e-b448-40cf-ad23-715dbd10d185)
</details> 

It is most likely related to this hermes error: https://github.com/facebook/hermes/issues/1395

This removes the exported async arrow functions in the bundle for normal async functions.

Long term we should either:
- Add ESLint rules to prevent other devs or teams being burnt by this
- Or have a transpilation step to avoid async arrow functions.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

https://consensyssoftware.atlassian.net/browse/NOTIFY-1144

## Changelog

### `@metamask/profile-sync-controller`

- **CHANGED**: updated exported async arrow functions to normal async functions.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
