### PR TITLE
fix: Add useMultiRpcMigration to PreferencesController

### DIFF
--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -28,6 +28,7 @@ describe('PreferencesController', () => {
       showTestNetworks: false,
       isIpfsGatewayEnabled: true,
       useTransactionSimulations: true,
+      useMultiRpcMigration: true,
       showIncomingTransactions: Object.values(
         ETHERSCAN_SUPPORTED_CHAIN_IDS,
       ).reduce((acc, curr) => {
@@ -366,6 +367,12 @@ describe('PreferencesController', () => {
     expect(() => controller.setUseNftDetection(true)).toThrow(
       'useNftDetection cannot be enabled if openSeaEnabled is false',
     );
+  });
+
+  it('should set useMultiRpcMigration', () => {
+    const controller = setupPreferencesController();
+    controller.setUseMultiRpcMigration(true);
+    expect(controller.state.useMultiRpcMigration).toBe(true);
   });
 
   it('should set featureFlags', () => {

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -110,6 +110,10 @@ export type PreferencesState = {
    * Controls whether transaction simulations are enabled
    */
   useTransactionSimulations: boolean;
+  /**
+   * Controls whether Multi rpc modal is displayed or not
+   */
+  useMultiRpcMigration: boolean;
 };
 
 const metadata = {
@@ -128,6 +132,7 @@ const metadata = {
   useTokenDetection: { persist: true, anonymous: true },
   smartTransactionsOptInStatus: { persist: true, anonymous: false },
   useTransactionSimulations: { persist: true, anonymous: true },
+  useMultiRpcMigration: { persist: true, anonymous: true },
 };
 
 const name = 'PreferencesController';
@@ -197,6 +202,7 @@ export function getDefaultPreferencesState() {
     showTestNetworks: false,
     useNftDetection: false,
     useTokenDetection: true,
+    useMultiRpcMigration: true,
     smartTransactionsOptInStatus: false,
     useTransactionSimulations: true,
   };
@@ -481,6 +487,20 @@ export class PreferencesController extends BaseController<
         };
       });
     }
+  }
+
+  /**
+   * Toggle multi rpc migration modal.
+   *
+   * @param useMultiRpcMigration - Boolean indicating if the multi rpc modal will be displayed or not.
+   */
+  setUseMultiRpcMigration(useMultiRpcMigration: boolean) {
+    this.update((state) => {
+      state.useMultiRpcMigration = useMultiRpcMigration;
+      if (!useMultiRpcMigration) {
+        state.useMultiRpcMigration = false;
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
## Explanation

**Current state:**
The `PreferencesController` does not include support for two new features related to network validation and multi-RPC migration behavior. Specifically, there is no existing functionality to:
1. Control the display of the multi-RPC migration modal (`useMultiRpcMigration`).

**Solution:**
This PR adds two new properties to the `PreferencesController` state: 
- `useMultiRpcMigration`: Controls whether the multi-RPC migration modal is displayed.

Along with these additions, corresponding setter methods ( `setUseMultiRpcMigration`) have been implemented. These methods allow for toggling the state of the new properties.

**Additional details:**
- Test cases have been added to ensure that the new properties are correctly updated in the state when their respective setter methods are invoked.
- The default values for these properties have been set to `true` to maintain expected functionality for users.

There were no additional package updates or dependency changes required in this PR.

## References

- No specific issues or pull requests tied to this change.

## Changelog

### `@metamask/preferences-controller`

- **ADDED**: Added `useMultiRpcMigration` property to the `PreferencesController` state, controlling the display of the multi-RPC migration modal.
- **ADDED**: Implemented `setUseMultiRpcMigration` method to toggle the `useMultiRpcMigration` property.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes (N/A)
