### PR TITLE
Revert "Release 208.0.0 (#4731)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "208.0.0",
+  "version": "207.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [18.2.2]
-
-### Changed
-
-- Bump accounts related packages ([#4713](https://github.com/MetaMask/core/pull/4713)), ([#4728](https://github.com/MetaMask/core/pull/4728))
-  - Those packages are now built slightly differently and are part of the [accounts monorepo](https://github.com/MetaMask/accounts).
-  - Bump `@metamask/keyring-api` from `^8.1.0` to `^8.1.4`
-  - Bump `@metamask/eth-snap-keyring` from `^4.3.3` to `^4.3.6`
-
 ## [18.2.1]
 
 ### Changed
@@ -329,8 +320,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#1637](https://github.com/MetaMask/core/pull/1637))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@18.2.2...HEAD
-[18.2.2]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@18.2.1...@metamask/accounts-controller@18.2.2
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@18.2.1...HEAD
 [18.2.1]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@18.2.0...@metamask/accounts-controller@18.2.1
 [18.2.0]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@18.1.1...@metamask/accounts-controller@18.2.0
 [18.1.1]: https://github.com/MetaMask/core/compare/@metamask/accounts-controller@18.1.0...@metamask/accounts-controller@18.1.1

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/accounts-controller",
-  "version": "18.2.2",
+  "version": "18.2.1",
   "description": "Manages internal accounts",
   "keywords": [
     "MetaMask",
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-controller": "^17.2.2",
+    "@metamask/keyring-controller": "^17.2.1",
     "@metamask/snaps-controllers": "^9.7.0",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.1.0]
-
-### Added
-
-- Add `deleteAfterResult` option to accept method to delay removal of approval request from state ([#4715](https://github.com/MetaMask/core/pull/4715))
-
 ## [7.0.4]
 
 ### Fixed
@@ -247,8 +241,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@7.1.0...HEAD
-[7.1.0]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@7.0.4...@metamask/approval-controller@7.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@7.0.4...HEAD
 [7.0.4]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@7.0.3...@metamask/approval-controller@7.0.4
 [7.0.3]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@7.0.2...@metamask/approval-controller@7.0.3
 [7.0.2]: https://github.com/MetaMask/core/compare/@metamask/approval-controller@7.0.1...@metamask/approval-controller@7.0.2

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/approval-controller",
-  "version": "7.1.0",
+  "version": "7.0.4",
   "description": "Manages requests that require user approval",
   "keywords": [
     "MetaMask",

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [38.1.0]
-
-### Changed
-
-- Parallelization of detected tokens with balance ([#4697](https://github.com/MetaMask/core/pull/4697))
-- Bump accounts related packages ([#4713](https://github.com/MetaMask/core/pull/4713)), ([#4728](https://github.com/MetaMask/core/pull/4728))
-  - Those packages are now built slightly differently and are part of the [accounts monorepo](https://github.com/MetaMask/accounts).
-  - Bump `@metamask/keyring-api` from `^8.1.0` to `^8.1.4`
-
 ## [38.0.1]
 
 ### Fixed
@@ -1130,8 +1121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use Ethers for AssetsContractController ([#845](https://github.com/MetaMask/core/pull/845))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@38.1.0...HEAD
-[38.1.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@38.0.1...@metamask/assets-controllers@38.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@38.0.1...HEAD
 [38.0.1]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@38.0.0...@metamask/assets-controllers@38.0.1
 [38.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@37.0.0...@metamask/assets-controllers@38.0.0
 [37.0.0]: https://github.com/MetaMask/core/compare/@metamask/assets-controllers@36.0.0...@metamask/assets-controllers@37.0.0

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/assets-controllers",
-  "version": "38.0.2",
+  "version": "38.0.1",
   "description": "Controllers which manage interactions involving ERC-20, ERC-721, and ERC-1155 tokens (including NFTs)",
   "keywords": [
     "MetaMask",
@@ -73,12 +73,12 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/accounts-controller": "^18.2.2",
-    "@metamask/approval-controller": "^7.1.0",
+    "@metamask/accounts-controller": "^18.2.1",
+    "@metamask/approval-controller": "^7.0.4",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/ethjs-provider-http": "^0.3.0",
     "@metamask/keyring-api": "^8.1.3",
-    "@metamask/keyring-controller": "^17.2.2",
+    "@metamask/keyring-controller": "^17.2.1",
     "@metamask/network-controller": "^21.0.1",
     "@metamask/preferences-controller": "^13.0.3",
     "@types/jest": "^27.4.1",

--- a/packages/chain-controller/CHANGELOG.md
+++ b/packages/chain-controller/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3]
-
-### Changed
-
-- Bump accounts related packages ([#4713](https://github.com/MetaMask/core/pull/4713)), ([#4728](https://github.com/MetaMask/core/pull/4728))
-  - Those packages are now built slightly differently and are part of the [accounts monorepo](https://github.com/MetaMask/accounts).
-  - Bump `@metamask/keyring-api` from `^8.1.0` to `^8.1.4`
-
 ## [0.1.2]
 
 ### Changed
@@ -57,8 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/chain-controller@0.1.3...HEAD
-[0.1.3]: https://github.com/MetaMask/core/compare/@metamask/chain-controller@0.1.2...@metamask/chain-controller@0.1.3
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/chain-controller@0.1.2...HEAD
 [0.1.2]: https://github.com/MetaMask/core/compare/@metamask/chain-controller@0.1.1...@metamask/chain-controller@0.1.2
 [0.1.1]: https://github.com/MetaMask/core/compare/@metamask/chain-controller@0.1.0...@metamask/chain-controller@0.1.1
 [0.1.0]: https://github.com/MetaMask/core/releases/tag/@metamask/chain-controller@0.1.0

--- a/packages/chain-controller/package.json
+++ b/packages/chain-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/chain-controller",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "description": "Manages chain-agnostic providers",
   "keywords": [
     "MetaMask",

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [17.2.2]
-
-### Changed
-
-- Bump accounts related packages ([#4713](https://github.com/MetaMask/core/pull/4713)), ([#4728](https://github.com/MetaMask/core/pull/4728))
-  - Those packages are now built slightly differently and are part of the [accounts monorepo](https://github.com/MetaMask/accounts).
-  - Bump `@metamask/keyring-api` from `^8.1.0` to `^8.1.4`
-  - Bump `@metamask/eth-hd-keyring` from `^7.0.1` to `^7.0.4`
-  - Bump `@metamask/eth-simple-keyring` from `^6.0.1` to `^6.0.5`
-
 ## [17.2.1]
 
 ### Fixed
@@ -561,8 +551,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@17.2.2...HEAD
-[17.2.2]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@17.2.1...@metamask/keyring-controller@17.2.2
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@17.2.1...HEAD
 [17.2.1]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@17.2.0...@metamask/keyring-controller@17.2.1
 [17.2.0]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@17.1.2...@metamask/keyring-controller@17.2.0
 [17.1.2]: https://github.com/MetaMask/core/compare/@metamask/keyring-controller@17.1.1...@metamask/keyring-controller@17.1.2

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-controller",
-  "version": "17.2.2",
+  "version": "17.2.1",
   "description": "Stores identities seen in the wallet and manages interactions such as signing",
   "keywords": [
     "MetaMask",

--- a/packages/notification-controller/CHANGELOG.md
+++ b/packages/notification-controller/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.0]
-
-### Changed
-
-- **BREAKING**: The `show` function now uses an option bag rather than a single `string` ([#4682](https://github.com/MetaMask/core/pull/4682))
-  - This will be used to persist the extra properties needed to show JSX content in Snap notifications.
-
 ## [6.0.1]
 
 ### Changed
@@ -154,8 +147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@7.0.0...HEAD
-[7.0.0]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@6.0.1...@metamask/notification-controller@7.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@6.0.1...HEAD
 [6.0.1]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@6.0.0...@metamask/notification-controller@6.0.1
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@5.0.2...@metamask/notification-controller@6.0.0
 [5.0.2]: https://github.com/MetaMask/core/compare/@metamask/notification-controller@5.0.1...@metamask/notification-controller@5.0.2

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/notification-controller",
-  "version": "7.0.0",
+  "version": "6.0.1",
   "description": "Manages display of notifications within MetaMask",
   "keywords": [
     "MetaMask",

--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.1]
-
-### Changed
-
-- Bump `@metamask/keyring-controller` from `^17.2.1` to `^17.2.2`. ([#4731](https://github.com/MetaMask/core/pull/4731))
-- Bump `@metamask/profile-sync-controller` from `^0.9.1` to `^0.9.2`. ([#4731](https://github.com/MetaMask/core/pull/4731))
-
 ## [0.8.0]
 
 ### Changed
@@ -173,8 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@0.8.1...HEAD
-[0.8.1]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@0.8.0...@metamask/notification-services-controller@0.8.1
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@0.8.0...HEAD
 [0.8.0]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@0.7.0...@metamask/notification-services-controller@0.8.0
 [0.7.0]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@0.6.0...@metamask/notification-services-controller@0.7.0
 [0.6.0]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@0.5.1...@metamask/notification-services-controller@0.6.0

--- a/packages/notification-services-controller/package.json
+++ b/packages/notification-services-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/notification-services-controller",
-  "version": "0.8.1",
+  "version": "0.8.0",
   "description": "Manages New MetaMask decentralized Notification system",
   "keywords": [
     "MetaMask",
@@ -110,8 +110,8 @@
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-controller": "^17.2.2",
-    "@metamask/profile-sync-controller": "^0.9.2",
+    "@metamask/keyring-controller": "^17.2.1",
+    "@metamask/profile-sync-controller": "^0.9.1",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",
     "contentful": "^10.15.0",

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -58,7 +58,7 @@
     "nanoid": "^3.1.31"
   },
   "devDependencies": {
-    "@metamask/approval-controller": "^7.1.0",
+    "@metamask/approval-controller": "^7.0.4",
     "@metamask/auto-changelog": "^3.4.4",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-controller": "^17.2.2",
+    "@metamask/keyring-controller": "^17.2.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.2]
-
-### Changed
-
-- Bump accounts related packages ([#4713](https://github.com/MetaMask/core/pull/4713)), ([#4728](https://github.com/MetaMask/core/pull/4728))
-  - Those packages are now built slightly differently and are part of the [accounts monorepo](https://github.com/MetaMask/accounts).
-  - Bump `@metamask/keyring-api` from `^8.1.0` to `^8.1.4`
-
 ## [0.9.1]
 
 ### Changed
@@ -240,8 +232,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/profile-sync-controller@0.9.2...HEAD
-[0.9.2]: https://github.com/MetaMask/core/compare/@metamask/profile-sync-controller@0.9.1...@metamask/profile-sync-controller@0.9.2
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/profile-sync-controller@0.9.1...HEAD
 [0.9.1]: https://github.com/MetaMask/core/compare/@metamask/profile-sync-controller@0.9.0...@metamask/profile-sync-controller@0.9.1
 [0.9.0]: https://github.com/MetaMask/core/compare/@metamask/profile-sync-controller@0.8.1...@metamask/profile-sync-controller@0.9.0
 [0.8.1]: https://github.com/MetaMask/core/compare/@metamask/profile-sync-controller@0.8.0...@metamask/profile-sync-controller@0.8.1

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/profile-sync-controller",
-  "version": "0.9.2",
+  "version": "0.9.1",
   "description": "The profile sync helps developers synchronize data across multiple clients and devices in a privacy-preserving way. All data saved in the user storage database is encrypted client-side to preserve privacy. The user storage provides a modular design, giving developers the flexibility to construct and manage their storage spaces in a way that best suits their needs",
   "keywords": [
     "MetaMask",
@@ -102,7 +102,7 @@
   "dependencies": {
     "@metamask/base-controller": "^7.0.1",
     "@metamask/keyring-api": "^8.1.3",
-    "@metamask/keyring-controller": "^17.2.2",
+    "@metamask/keyring-controller": "^17.2.1",
     "@metamask/snaps-sdk": "^6.5.0",
     "@metamask/snaps-utils": "^8.1.1",
     "@noble/ciphers": "^0.5.2",
@@ -113,7 +113,7 @@
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",
-    "@metamask/accounts-controller": "^18.2.2",
+    "@metamask/accounts-controller": "^18.2.1",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/network-controller": "^21.0.1",
     "@metamask/snaps-controllers": "^9.7.0",

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -54,9 +54,9 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@metamask/approval-controller": "^7.1.0",
+    "@metamask/approval-controller": "^7.0.4",
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-controller": "^17.2.2",
+    "@metamask/keyring-controller": "^17.2.1",
     "@metamask/logging-controller": "^6.0.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [37.1.0]
-
-### Added
-
-- Populate `submitHistory` in state when submitting transactions to network ([#4706](https://github.com/MetaMask/core/pull/4706))
-- Export `CHAIN_IDS`, `ETHERSCAN_SUPPORTED_NETWORKS` and `SPEED_UP_RATE` constants ([#4706](https://github.com/MetaMask/core/pull/4706))
-
-### Changed
-
-- Make `getPermittedAccounts` constructor callback optional ([#4706](https://github.com/MetaMask/core/pull/4706))
-- Bump accounts related packages ([#4713](https://github.com/MetaMask/core/pull/4713)), ([#4728](https://github.com/MetaMask/core/pull/4728))
-  - Those packages are now built slightly differently and are part of the [accounts monorepo](https://github.com/MetaMask/accounts).
-  - Bump `@metamask/keyring-api` from `^8.1.0` to `^8.1.4`
-
 ## [37.0.0]
 
 ### Changed
@@ -1037,8 +1023,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@37.1.0...HEAD
-[37.1.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@37.0.0...@metamask/transaction-controller@37.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@37.0.0...HEAD
 [37.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@36.1.0...@metamask/transaction-controller@37.0.0
 [36.1.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@36.0.0...@metamask/transaction-controller@36.1.0
 [36.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@35.2.0...@metamask/transaction-controller@36.0.0

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "37.1.0",
+  "version": "37.0.0",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",
@@ -69,8 +69,8 @@
   },
   "devDependencies": {
     "@babel/runtime": "^7.23.9",
-    "@metamask/accounts-controller": "^18.2.2",
-    "@metamask/approval-controller": "^7.1.0",
+    "@metamask/accounts-controller": "^18.2.1",
+    "@metamask/approval-controller": "^7.0.4",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/eth-json-rpc-provider": "^4.1.4",
     "@metamask/ethjs-provider-http": "^0.3.0",

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -61,12 +61,12 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/approval-controller": "^7.1.0",
+    "@metamask/approval-controller": "^7.0.4",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/gas-fee-controller": "^20.0.1",
-    "@metamask/keyring-controller": "^17.2.2",
+    "@metamask/keyring-controller": "^17.2.1",
     "@metamask/network-controller": "^21.0.1",
-    "@metamask/transaction-controller": "^37.1.0",
+    "@metamask/transaction-controller": "^37.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,7 +2027,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/accounts-controller@npm:^18.2.2, @metamask/accounts-controller@workspace:packages/accounts-controller":
+"@metamask/accounts-controller@npm:^18.2.1, @metamask/accounts-controller@workspace:packages/accounts-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/accounts-controller@workspace:packages/accounts-controller"
   dependencies:
@@ -2036,7 +2036,7 @@ __metadata:
     "@metamask/base-controller": "npm:^7.0.1"
     "@metamask/eth-snap-keyring": "npm:^4.3.6"
     "@metamask/keyring-api": "npm:^8.1.3"
-    "@metamask/keyring-controller": "npm:^17.2.2"
+    "@metamask/keyring-controller": "npm:^17.2.1"
     "@metamask/snaps-controllers": "npm:^9.7.0"
     "@metamask/snaps-sdk": "npm:^6.5.0"
     "@metamask/snaps-utils": "npm:^8.1.1"
@@ -2103,7 +2103,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/approval-controller@npm:^7.0.2, @metamask/approval-controller@npm:^7.1.0, @metamask/approval-controller@workspace:packages/approval-controller":
+"@metamask/approval-controller@npm:^7.0.2, @metamask/approval-controller@npm:^7.0.4, @metamask/approval-controller@workspace:packages/approval-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/approval-controller@workspace:packages/approval-controller"
   dependencies:
@@ -2133,8 +2133,8 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/accounts-controller": "npm:^18.2.2"
-    "@metamask/approval-controller": "npm:^7.1.0"
+    "@metamask/accounts-controller": "npm:^18.2.1"
+    "@metamask/approval-controller": "npm:^7.0.4"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.1"
     "@metamask/contract-metadata": "npm:^2.4.0"
@@ -2142,7 +2142,7 @@ __metadata:
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-provider-http": "npm:^0.3.0"
     "@metamask/keyring-api": "npm:^8.1.3"
-    "@metamask/keyring-controller": "npm:^17.2.2"
+    "@metamask/keyring-controller": "npm:^17.2.1"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^21.0.1"
     "@metamask/polling-controller": "npm:^10.0.1"
@@ -2908,7 +2908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-controller@npm:^17.2.2, @metamask/keyring-controller@workspace:packages/keyring-controller":
+"@metamask/keyring-controller@npm:^17.2.1, @metamask/keyring-controller@workspace:packages/keyring-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-controller@workspace:packages/keyring-controller"
   dependencies:
@@ -3088,8 +3088,8 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.1"
     "@metamask/controller-utils": "npm:^11.3.0"
-    "@metamask/keyring-controller": "npm:^17.2.2"
-    "@metamask/profile-sync-controller": "npm:^0.9.2"
+    "@metamask/keyring-controller": "npm:^17.2.1"
+    "@metamask/profile-sync-controller": "npm:^0.9.1"
     "@types/jest": "npm:^27.4.1"
     "@types/readable-stream": "npm:^2.3.0"
     bignumber.js: "npm:^4.1.0"
@@ -3145,7 +3145,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/permission-controller@workspace:packages/permission-controller"
   dependencies:
-    "@metamask/approval-controller": "npm:^7.1.0"
+    "@metamask/approval-controller": "npm:^7.0.4"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.1"
     "@metamask/controller-utils": "npm:^11.3.0"
@@ -3256,7 +3256,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.1"
     "@metamask/controller-utils": "npm:^11.3.0"
-    "@metamask/keyring-controller": "npm:^17.2.2"
+    "@metamask/keyring-controller": "npm:^17.2.1"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"
     jest: "npm:^27.5.1"
@@ -3270,16 +3270,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/profile-sync-controller@npm:^0.9.2, @metamask/profile-sync-controller@workspace:packages/profile-sync-controller":
+"@metamask/profile-sync-controller@npm:^0.9.1, @metamask/profile-sync-controller@workspace:packages/profile-sync-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/profile-sync-controller@workspace:packages/profile-sync-controller"
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
-    "@metamask/accounts-controller": "npm:^18.2.2"
+    "@metamask/accounts-controller": "npm:^18.2.1"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.1"
     "@metamask/keyring-api": "npm:^8.1.3"
-    "@metamask/keyring-controller": "npm:^17.2.2"
+    "@metamask/keyring-controller": "npm:^17.2.1"
     "@metamask/network-controller": "npm:^21.0.1"
     "@metamask/snaps-controllers": "npm:^9.7.0"
     "@metamask/snaps-sdk": "npm:^6.5.0"
@@ -3434,11 +3434,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/signature-controller@workspace:packages/signature-controller"
   dependencies:
-    "@metamask/approval-controller": "npm:^7.1.0"
+    "@metamask/approval-controller": "npm:^7.0.4"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.1"
     "@metamask/controller-utils": "npm:^11.3.0"
-    "@metamask/keyring-controller": "npm:^17.2.2"
+    "@metamask/keyring-controller": "npm:^17.2.1"
     "@metamask/logging-controller": "npm:^6.0.1"
     "@metamask/message-manager": "npm:^10.1.1"
     "@metamask/utils": "npm:^9.1.0"
@@ -3625,7 +3625,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^37.1.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
+"@metamask/transaction-controller@npm:^37.0.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/transaction-controller@workspace:packages/transaction-controller"
   dependencies:
@@ -3636,8 +3636,8 @@ __metadata:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^18.2.2"
-    "@metamask/approval-controller": "npm:^7.1.0"
+    "@metamask/accounts-controller": "npm:^18.2.1"
+    "@metamask/approval-controller": "npm:^7.0.4"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.1"
     "@metamask/controller-utils": "npm:^11.3.0"
@@ -3682,18 +3682,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/user-operation-controller@workspace:packages/user-operation-controller"
   dependencies:
-    "@metamask/approval-controller": "npm:^7.1.0"
+    "@metamask/approval-controller": "npm:^7.0.4"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.1"
     "@metamask/controller-utils": "npm:^11.3.0"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/gas-fee-controller": "npm:^20.0.1"
-    "@metamask/keyring-controller": "npm:^17.2.2"
+    "@metamask/keyring-controller": "npm:^17.2.1"
     "@metamask/network-controller": "npm:^21.0.1"
     "@metamask/polling-controller": "npm:^10.0.1"
     "@metamask/rpc-errors": "npm:^6.3.1"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^37.1.0"
+    "@metamask/transaction-controller": "npm:^37.0.0"
     "@metamask/utils": "npm:^9.1.0"
     "@types/jest": "npm:^27.4.1"
     bn.js: "npm:^5.2.1"


### PR DESCRIPTION
## Explanation

This reverts commit 9949c81f5d6cf06e28d6dac36f26760d8be95e2c.

The `assets-controllers` version was wrong for the last RC. So we have to revert this RC and re-create it while fixing the `assets-controllers` bad version.

Version during that release [was `38.0.2`](https://github.com/MetaMask/core/blob/eb656db1704c6dcfa9474086434b267b15e62c97/packages/assets-controllers/package.json#L3) but it should have been `38.1.0`.

## References

- https://github.com/MetaMask/core/pull/4731

## Changelog

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
