### PR TITLE
fix(NOTIFY-1166): only fire callback when account name has changed

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -896,7 +896,12 @@ export default class UserStorageController extends BaseController<
             },
           );
 
-          this.#config?.accountSyncing?.onAccountNameUpdated?.(profileId);
+          const areInternalAndUserStorageAccountNamesEqual =
+            internalAccount.metadata.name === userStorageAccount.n;
+
+          if (!areInternalAndUserStorageAccountNamesEqual) {
+            this.#config?.accountSyncing?.onAccountNameUpdated?.(profileId);
+          }
 
           continue;
         } else if (internalAccount.metadata.nameLastUpdatedAt !== undefined) {


### PR DESCRIPTION
## Explanation

This PR ensures the `onAccountNameUpdated` callback only fires when the new name is different from the previous one

## References

[NOTIFY-1166](https://consensyssoftware.atlassian.net/browse/NOTIFY-1166)

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/profile-sync-controller`

- **FIXED**: `onAccountNameUpdated` will now fire only when the new name is different from the previous one

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes


[NOTIFY-1166]: https://consensyssoftware.atlassian.net/browse/NOTIFY-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ