### PR TITLE
fix: remove gasPrice property from linea_estimateGas request

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove `gasPrice` from requests to `linea_estimateGas` ([#4737](https://github.com/MetaMask/core/pull/4737))
+
 ## [37.0.0]
 
 ### Changed

--- a/packages/transaction-controller/src/gas-flows/LineaGasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/LineaGasFeeFlow.ts
@@ -116,8 +116,6 @@ export class LineaGasFeeFlow implements GasFeeFlow {
         to: transactionMeta.txParams.to,
         value: transactionMeta.txParams.value,
         input: transactionMeta.txParams.data,
-        // Required in request but no impact on response.
-        gasPrice: '0x100000000',
       },
     ]);
   }


### PR DESCRIPTION
## Explanation

The `LineaGasFeeFlow` in the `TransactionController` aims to provide more accurate gas fee estimates derived from a specific transaction, rather than just at the network level.

This is achieved via a request to the custom `linea_estimateGas` RPC method on the provider.

Originally, the `gasPrice` property was necessary to prevent a bug, but now that issue has been fixed remotely, it is itself causing an alternate bug that returns the following error mesage:

`transaction up-front cost 0x16e360000000000 exceeds transaction sender account balance 0x7b2c1918e11642`

This PR simply removes the `gasPrice` property from the request. 

## References

## Changelog

```
### Fixed

- Remove `gasPrice` from requests to `linea_estimateGas` ([#4737](https://github.com/MetaMask/core/pull/4737))
```

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
