### PR TITLE
feat: support Etherscan API keys

### DIFF
--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -291,6 +291,7 @@ export type TransactionControllerOptions = {
   getPermittedAccounts?: (origin?: string) => Promise<string[]>;
   getSavedGasFees?: (chainId: Hex) => SavedGasFees | undefined;
   incomingTransactions?: IncomingTransactionOptions & {
+    /** API keys to be used for Etherscan requests to prevent rate limiting. */
     etherscanApiKeysByChainId?: Record<Hex, string>;
   };
   isMultichainEnabled: boolean;

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -290,7 +290,9 @@ export type TransactionControllerOptions = {
   getNetworkState: () => NetworkState;
   getPermittedAccounts?: (origin?: string) => Promise<string[]>;
   getSavedGasFees?: (chainId: Hex) => SavedGasFees | undefined;
-  incomingTransactions?: IncomingTransactionOptions;
+  incomingTransactions?: IncomingTransactionOptions & {
+    etherscanApiKeysByChainId?: Record<Hex, string>;
+  };
   isMultichainEnabled: boolean;
   isSimulationEnabled?: () => boolean;
   messenger: TransactionControllerMessenger;
@@ -884,6 +886,7 @@ export class TransactionController extends BaseController<
 
     const etherscanRemoteTransactionSource =
       new EtherscanRemoteTransactionSource({
+        apiKeysByChainId: incomingTransactions.etherscanApiKeysByChainId,
         includeTokenTransfers: incomingTransactions.includeTokenTransfers,
       });
 

--- a/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.test.ts
+++ b/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.test.ts
@@ -15,12 +15,12 @@ import {
   ETHERSCAN_TRANSACTION_RESPONSE_ERROR_MOCK,
 } from '../../tests/EtherscanMocks';
 import { CHAIN_IDS } from '../constants';
+import type { RemoteTransactionSourceRequest } from '../types';
 import {
   fetchEtherscanTokenTransactions,
   fetchEtherscanTransactions,
 } from '../utils/etherscan';
 import { EtherscanRemoteTransactionSource } from './EtherscanRemoteTransactionSource';
-import { current } from 'immer';
 
 jest.mock('../utils/etherscan', () => ({
   fetchEtherscanTransactions: jest.fn(),
@@ -253,13 +253,9 @@ describe('EtherscanRemoteTransactionSource', () => {
         apiKeysByChainId: {
           [CHAIN_IDS.MAINNET]: API_KEY_MOCK,
         },
-      }).fetchTransactions(
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        {
-          currentChainId: CHAIN_IDS.MAINNET,
-        } as any,
-      );
+      }).fetchTransactions({
+        currentChainId: CHAIN_IDS.MAINNET,
+      } as unknown as RemoteTransactionSourceRequest);
 
       expect(fetchEtherscanTransactionsMock).toHaveBeenCalledTimes(1);
       expect(fetchEtherscanTransactionsMock).toHaveBeenCalledWith(
@@ -278,13 +274,9 @@ describe('EtherscanRemoteTransactionSource', () => {
         apiKeysByChainId: {
           [CHAIN_IDS.MAINNET]: API_KEY_MOCK,
         },
-      }).fetchTransactions(
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        {
-          currentChainId: CHAIN_IDS.SEPOLIA,
-        } as any,
-      );
+      }).fetchTransactions({
+        currentChainId: CHAIN_IDS.SEPOLIA,
+      } as unknown as RemoteTransactionSourceRequest);
 
       expect(fetchEtherscanTransactionsMock).toHaveBeenCalledTimes(1);
       expect(fetchEtherscanTransactionsMock).toHaveBeenCalledWith(

--- a/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/helpers/EtherscanRemoteTransactionSource.ts
@@ -25,12 +25,15 @@ import type {
 } from '../utils/etherscan';
 
 const ETHERSCAN_RATE_LIMIT_INTERVAL = 5000;
+
 /**
  * A RemoteTransactionSource that fetches transaction data from Etherscan.
  */
 export class EtherscanRemoteTransactionSource
   implements RemoteTransactionSource
 {
+  #apiKeysByChainId?: Record<Hex, string>;
+
   #includeTokenTransfers: boolean;
 
   #isTokenRequestPending: boolean;
@@ -38,8 +41,13 @@ export class EtherscanRemoteTransactionSource
   #mutex = new Mutex();
 
   constructor({
+    apiKeysByChainId,
     includeTokenTransfers,
-  }: { includeTokenTransfers?: boolean } = {}) {
+  }: {
+    apiKeysByChainId?: Record<Hex, string>;
+    includeTokenTransfers?: boolean;
+  } = {}) {
+    this.#apiKeysByChainId = apiKeysByChainId;
     this.#includeTokenTransfers = includeTokenTransfers ?? true;
     this.#isTokenRequestPending = false;
   }
@@ -57,10 +65,17 @@ export class EtherscanRemoteTransactionSource
   ): Promise<TransactionMeta[]> {
     const releaseLock = await this.#mutex.acquire();
     const acquiredTime = Date.now();
+    const { currentChainId: chainId } = request;
+    const apiKey = this.#apiKeysByChainId?.[chainId];
+
+    if (apiKey) {
+      log('Etherscan API key found for chain', chainId);
+    }
 
     const etherscanRequest: EtherscanTransactionRequest = {
       ...request,
-      chainId: request.currentChainId,
+      apiKey,
+      chainId,
     };
 
     try {

--- a/packages/transaction-controller/src/utils/etherscan.test.ts
+++ b/packages/transaction-controller/src/utils/etherscan.test.ts
@@ -15,6 +15,7 @@ jest.mock('@metamask/controller-utils', () => ({
 }));
 
 const ADDERSS_MOCK = '0x2A2D72308838A6A46a0B5FDA3055FE915b5D99eD';
+const API_KEY_MOCK = 'TestApiKey';
 
 const REQUEST_MOCK: EtherscanTransactionRequest = {
   address: ADDERSS_MOCK,
@@ -155,6 +156,33 @@ describe('Etherscan', () => {
           `&address=${REQUEST_MOCK.address}` +
           `&sort=desc` +
           `&action=${action}` +
+          `&tag=latest` +
+          `&page=1`,
+      );
+    });
+
+    it('includes API key if provided', async () => {
+      handleFetchMock.mockResolvedValueOnce(RESPONSE_MOCK);
+
+      // TODO: Replace `any` with type
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (Etherscan as any)[method]({
+        ...REQUEST_MOCK,
+        apiKey: API_KEY_MOCK,
+        fromBlock: undefined,
+        limit: undefined,
+      });
+
+      expect(handleFetchMock).toHaveBeenCalledTimes(1);
+      expect(handleFetchMock).toHaveBeenCalledWith(
+        `https://${ETHERSCAN_SUPPORTED_NETWORKS[CHAIN_IDS.GOERLI].subdomain}.${
+          ETHERSCAN_SUPPORTED_NETWORKS[CHAIN_IDS.GOERLI].domain
+        }/api?` +
+          `module=account` +
+          `&address=${REQUEST_MOCK.address}` +
+          `&sort=desc` +
+          `&action=${action}` +
+          `&apikey=${API_KEY_MOCK}` +
           `&tag=latest` +
           `&page=1`,
       );

--- a/packages/transaction-controller/src/utils/etherscan.ts
+++ b/packages/transaction-controller/src/utils/etherscan.ts
@@ -77,7 +77,7 @@ export interface EtherscanTransactionRequest {
  *
  * @param request - Configuration required to fetch transactions.
  * @param request.address - Address to retrieve transactions for.
- * @param request.apiKey - Etherscan API key to prevent throttling.
+ * @param request.apiKey - Etherscan API key to prevent rate limiting.
  * @param request.chainId - Current chain ID used to determine subdomain and domain.
  * @param request.fromBlock - Block number to start fetching transactions from.
  * @param request.limit - Number of transactions to retrieve.
@@ -106,7 +106,7 @@ export async function fetchEtherscanTransactions({
  *
  * @param request - Configuration required to fetch token transactions.
  * @param request.address - Address to retrieve token transactions for.
- * @param request.apiKey - Etherscan API key to prevent throttling.
+ * @param request.apiKey - Etherscan API key to prevent rate limiting.
  * @param request.chainId - Current chain ID used to determine subdomain and domain.
  * @param request.fromBlock - Block number to start fetching token transactions from.
  * @param request.limit - Number of token transactions to retrieve.
@@ -136,7 +136,7 @@ export async function fetchEtherscanTokenTransactions({
  * @param action - The Etherscan endpoint to use.
  * @param options - Options bag.
  * @param options.address - Address to retrieve transactions for.
- * @param options.apiKey - Etherscan API key to prevent throttling.
+ * @param options.apiKey - Etherscan API key to prevent rate limiting.
  * @param options.chainId - Current chain ID used to determine subdomain and domain.
  * @param options.fromBlock - Block number to start fetching transactions from.
  * @param options.limit - Number of transactions to retrieve.

--- a/packages/transaction-controller/src/utils/etherscan.ts
+++ b/packages/transaction-controller/src/utils/etherscan.ts
@@ -66,6 +66,7 @@ export interface EtherscanTransactionResponse<
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface EtherscanTransactionRequest {
   address: string;
+  apiKey?: string;
   chainId: Hex;
   fromBlock?: number;
   limit?: number;
@@ -76,6 +77,7 @@ export interface EtherscanTransactionRequest {
  *
  * @param request - Configuration required to fetch transactions.
  * @param request.address - Address to retrieve transactions for.
+ * @param request.apiKey - Etherscan API key to prevent throttling.
  * @param request.chainId - Current chain ID used to determine subdomain and domain.
  * @param request.fromBlock - Block number to start fetching transactions from.
  * @param request.limit - Number of transactions to retrieve.
@@ -83,6 +85,7 @@ export interface EtherscanTransactionRequest {
  */
 export async function fetchEtherscanTransactions({
   address,
+  apiKey,
   chainId,
   fromBlock,
   limit,
@@ -91,6 +94,7 @@ export async function fetchEtherscanTransactions({
 > {
   return await fetchTransactions('txlist', {
     address,
+    apiKey,
     chainId,
     fromBlock,
     limit,
@@ -102,6 +106,7 @@ export async function fetchEtherscanTransactions({
  *
  * @param request - Configuration required to fetch token transactions.
  * @param request.address - Address to retrieve token transactions for.
+ * @param request.apiKey - Etherscan API key to prevent throttling.
  * @param request.chainId - Current chain ID used to determine subdomain and domain.
  * @param request.fromBlock - Block number to start fetching token transactions from.
  * @param request.limit - Number of token transactions to retrieve.
@@ -109,6 +114,7 @@ export async function fetchEtherscanTransactions({
  */
 export async function fetchEtherscanTokenTransactions({
   address,
+  apiKey,
   chainId,
   fromBlock,
   limit,
@@ -117,6 +123,7 @@ export async function fetchEtherscanTokenTransactions({
 > {
   return await fetchTransactions('tokentx', {
     address,
+    apiKey,
     chainId,
     fromBlock,
     limit,
@@ -129,27 +136,30 @@ export async function fetchEtherscanTokenTransactions({
  * @param action - The Etherscan endpoint to use.
  * @param options - Options bag.
  * @param options.address - Address to retrieve transactions for.
+ * @param options.apiKey - Etherscan API key to prevent throttling.
  * @param options.chainId - Current chain ID used to determine subdomain and domain.
  * @param options.fromBlock - Block number to start fetching transactions from.
  * @param options.limit - Number of transactions to retrieve.
  * @returns An object containing the request status and an array of transaction data.
  */
-// TODO: Either fix this lint violation or explain why it's necessary to ignore.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-async function fetchTransactions<T extends EtherscanTransactionMetaBase>(
+async function fetchTransactions<
+  ResponseData extends EtherscanTransactionMetaBase,
+>(
   action: string,
   {
     address,
+    apiKey,
     chainId,
     fromBlock,
     limit,
   }: {
     address: string;
+    apiKey?: string;
     chainId: Hex;
     fromBlock?: number;
     limit?: number;
   },
-): Promise<EtherscanTransactionResponse<T>> {
+): Promise<EtherscanTransactionResponse<ResponseData>> {
   const urlParams = {
     module: 'account',
     address,
@@ -161,13 +171,14 @@ async function fetchTransactions<T extends EtherscanTransactionMetaBase>(
   const etherscanTxUrl = getEtherscanApiUrl(chainId, {
     ...urlParams,
     action,
+    apikey: apiKey,
   });
 
   log('Sending Etherscan request', etherscanTxUrl);
 
   const response = (await handleFetch(
     etherscanTxUrl,
-  )) as EtherscanTransactionResponse<T>;
+  )) as EtherscanTransactionResponse<ResponseData>;
 
   return response;
 }


### PR DESCRIPTION
## Explanation

Support the use of API keys when polling for incoming transactions in the `TransactionController`.

Provided by the client via the optional `incomingTransactions.etherscanApiKeysByChainId` property, since API keys may be exclusive to specific chains, based on the Etherscan host / domain.

## References

## Changelog

### `@metamask/transaction-controller`

- **ADDED**: Add optional `incomingTransactions.etherscanApiKeysByChainId` constructor property to support API keys in requests to Etherscan.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
