### PR TITLE
chore: Update codeowners to match EM agreed ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,15 +3,146 @@
 
 *                                    @MetaMask/engineering
 
-/packages/permission-controller      @MetaMask/snaps-devs
-/packages/notification-controller    @MetaMask/snaps-devs
-/packages/rate-limit-controller      @MetaMask/snaps-devs
+## package /packages/accounts-controller
+/packages/accounts-controller                  @MetaMask/accounts-engineers
+/packages/accounts-controller/package.json     @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
+/packages/accounts-controller/changelog.md     @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
 
-/packages/approval-controller        @MetaMask/confirmations
-/packages/gas-fee-controller         @MetaMask/confirmations
-/packages/message-manager            @MetaMask/confirmations
-/packages/name-controller            @MetaMask/confirmations
-/packages/signature-controller       @MetaMask/confirmations
-/packages/transaction-controller     @MetaMask/confirmations
+## package /packages/address-book-controller
+/packages/address-book-controller              @MetaMask/confirmations
+/packages/address-book-controller/package.json @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/address-book-controller/changelog.md @MetaMask/confirmations @MetaMask/wallet-framework-engineers
 
-/packages/phishing-controller        @MetaMask/product-safety
+## package /packages/announcement-controller
+/packages/announcement-controller              @MetaMask/wallet-ux
+/packages/announcement-controller/package.json @MetaMask/wallet-ux @MetaMask/wallet-framework-engineers
+/packages/announcement-controller/changelog.md @MetaMask/wallet-ux @MetaMask/wallet-framework-engineers
+
+## package /packages/approval-controller
+/packages/approval-controller               @MetaMask/confirmations
+/packages/approval-controller/package.json  @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/approval-controller/changelog.md  @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+
+## package /packages/assets-controller
+/packages/assets-controller              @MetaMask/metamask-assets
+/packages/assets-controller/package.json @MetaMask/metamask-assets @MetaMask/wallet-framework-engineers
+/packages/assets-controller/changelog.md @MetaMask/metamask-assets @MetaMask/wallet-framework-engineers
+
+## package /packages/base-controller
+/packages/base-controller              @MetaMask/wallet-framework-engineers
+
+## package /packages/build-utils
+/packages/build-utils                  @MetaMask/wallet-framework-engineers
+
+## package /packages/chain-controller
+/packages/chain-controller               @MetaMask/accounts-engineers
+/packages/chain-controller/package.json  @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
+/packages/chain-controller/changelog.md  @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
+
+## package /packages/composable-controller
+/packages/composable-controller        @MetaMask/wallet-framework-engineers
+
+## package /packages/controller-utils
+/packages/controller-utils             @MetaMask/wallet-framework-engineers
+
+## package /packages/ens-controller
+/packages/ens-controller                    @MetaMask/confirmations
+/packages/ens-controller/package.json       @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/ens-controller/changelog.md       @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+
+## package /packages/eth-json-rpc-provider
+/packages/eth-json-rpc-provider        @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
+
+## package /packages/gas-fee-controller
+/packages/gas-fee-controller                @MetaMask/confirmations
+/packages/gas-fee-controller/package.json   @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/gas-fee-controller/changelog.md   @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+
+## package /packages/json-rpc-engine
+/packages/json-rpc-engine              @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
+
+## package /packages/json-rpc-middleware-stream
+/packages/json-rpc-middleware-stream   @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
+
+## package /packages/keyring-controller
+/packages/keyring-controller                     @MetaMask/accounts-engineers
+/packages/keyring-controller/package.json        @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
+/packages/keyring-controller/changelog.md        @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
+
+## package /packages/logging-controller
+/packages/logging-controller                @MetaMask/confirmations
+/packages/logging-controller/package.json   @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/logging-controller/changelog.md   @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+
+## package /packages/message-manager
+/packages/message-manager                   @MetaMask/confirmations
+/packages/message-manager/package.json      @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/message-manager/changelog.md      @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+
+## package /packages/name-controller
+/packages/name-controller                   @MetaMask/confirmations
+/packages/name-controller/package.json      @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/name-controller/changelog.md      @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+
+## package /packages/network-controller
+/packages/network-controller           @MetaMask/wallet-framework-engineers @MetaMask/metamask-assets
+
+## package /packages/notification-controller
+/packages/notification-controller              @MetaMask/notifications
+/packages/notification-controller/package.json @MetaMask/notifications @MetaMask/wallet-framework-engineers
+/packages/notification-controller/changelog.md @MetaMask/notifications @MetaMask/wallet-framework-engineers
+
+## package /packages/notification-services-controller
+/packages/notification-services-controller              @MetaMask/notifications
+/packages/notification-services-controller/package.json @MetaMask/notifications @MetaMask/wallet-framework-engineers
+/packages/notification-services-controller/changelog.md @MetaMask/notifications @MetaMask/wallet-framework-engineers
+
+## package /packages/permission-controller
+/packages/permission-controller        @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
+
+## package /packages/permission-log-controller
+/packages/permission-log-controller    @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
+
+## package /packages/phishing-controller
+/packages/phishing-controller              @MetaMask/product-safety
+/packages/phishing-controller/package.json @MetaMask/product-safety @MetaMask/wallet-framework-engineers
+/packages/phishing-controller/changelog.md @MetaMask/product-safety @MetaMask/wallet-framework-engineers
+
+## package /packages/polling-controller
+/packages/polling-controller           @MetaMask/wallet-framework-engineers
+
+## package /packages/preferences-controller
+/packages/preferences-controller       @MetaMask/wallet-framework-engineers
+
+## package /packages/profile-sync-controller
+/packages/profile-sync-controller              @MetaMask/notifications
+/packages/profile-sync-controller/package.json @MetaMask/notifications @MetaMask/wallet-framework-engineers
+/packages/profile-sync-controller/changelog.md @MetaMask/notifications @MetaMask/wallet-framework-engineers
+
+## package /packages/queued-request-controller
+/packages/queued-request-controller               @MetaMask/wallet-api-platform-engineers
+/packages/queued-request-controller/package.json  @MetaMask/wallet-framework-engineers
+/packages/queued-request-controller/changelog.md  @MetaMask/wallet-framework-engineers
+
+## package /packages/rate-limit-controller
+/packages/rate-limit-controller              @MetaMask/snaps-devs
+/packages/rate-limit-controller/package.json @MetaMask/snaps-devs @MetaMask/wallet-framework-engineers
+/packages/rate-limit-controller/changelog.md @MetaMask/snaps-devs @MetaMask/wallet-framework-engineers
+
+## package /packages/selected-network-controller
+/packages/selected-network-controller  @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers @MetaMask/metamask-assets
+
+## package /packages/signature-controller
+/packages/signature-controller              @MetaMask/confirmations
+/packages/signature-controller/package.json @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/signature-controller/changelog.md @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+
+## package /packages/transaction-controller
+/packages/transaction-controller              @MetaMask/confirmations
+/packages/transaction-controller/package.json @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/transaction-controller/changelog.md @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+
+## package /packages/user-operation-controller
+/packages/user-operation-controller              @MetaMask/confirmations
+/packages/user-operation-controller/package.json @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/user-operation-controller/changelog.md @MetaMask/confirmations @MetaMask/wallet-framework-engineers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,8 +81,8 @@
 /packages/message-manager/CHANGELOG.md            @MetaMask/confirmations @MetaMask/wallet-framework-engineers
 /packages/name-controller/package.json            @MetaMask/confirmations @MetaMask/wallet-framework-engineers
 /packages/name-controller/CHANGELOG.md            @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/notification-controller/package.json    @MetaMask/notifications @MetaMask/wallet-framework-engineers
-/packages/notification-controller/CHANGELOG.md    @MetaMask/notifications @MetaMask/wallet-framework-engineers
+/packages/notification-controller/package.json    @MetaMask/snaps-devs @MetaMask/wallet-framework-engineers
+/packages/notification-controller/CHANGELOG.md    @MetaMask/snaps-devs @MetaMask/wallet-framework-engineers
 /packages/notification-services-controller/package.json @MetaMask/notifications @MetaMask/wallet-framework-engineers
 /packages/notification-services-controller/CHANGELOG.md @MetaMask/notifications @MetaMask/wallet-framework-engineers
 /packages/profile-sync-controller/package.json    @MetaMask/notifications @MetaMask/wallet-framework-engineers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,8 +87,8 @@
 /packages/notification-services-controller/CHANGELOG.md @MetaMask/notifications @MetaMask/wallet-framework-engineers
 /packages/profile-sync-controller/package.json    @MetaMask/notifications @MetaMask/wallet-framework-engineers
 /packages/profile-sync-controller/CHANGELOG.md    @MetaMask/notifications @MetaMask/wallet-framework-engineers
-/packages/queued-request-controller/package.json  @MetaMask/wallet-framework-engineers
-/packages/queued-request-controller/CHANGELOG.md  @MetaMask/wallet-framework-engineers
+/packages/queued-request-controller/package.json  @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
+/packages/queued-request-controller/CHANGELOG.md  @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
 /packages/signature-controller/package.json       @MetaMask/confirmations @MetaMask/wallet-framework-engineers
 /packages/signature-controller/CHANGELOG.md       @MetaMask/confirmations @MetaMask/wallet-framework-engineers
 /packages/rate-limit-controller/package.json      @MetaMask/snaps-devs @MetaMask/wallet-framework-engineers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,147 +2,98 @@
 # Each line is a file pattern followed by one or more owners.
 
 *                                    @MetaMask/engineering
+/.github/                            @MetaMask/wallet-framework-engineers
 
-## package /packages/accounts-controller
-/packages/accounts-controller                  @MetaMask/accounts-engineers
-/packages/accounts-controller/package.json     @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
-/packages/accounts-controller/changelog.md     @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
+## Accounts Team
+/packages/accounts-controller        @MetaMask/accounts-engineers
+/packages/keyring-controller         @MetaMask/accounts-engineers
+/packages/chain-controller           @MetaMask/accounts-engineers
 
-## package /packages/address-book-controller
-/packages/address-book-controller              @MetaMask/confirmations
-/packages/address-book-controller/package.json @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/address-book-controller/changelog.md @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+## Assets Team
+/packages/assets-controller          @MetaMask/metamask-assets
 
-## package /packages/announcement-controller
-/packages/announcement-controller              @MetaMask/wallet-ux
-/packages/announcement-controller/package.json @MetaMask/wallet-ux @MetaMask/wallet-framework-engineers
-/packages/announcement-controller/changelog.md @MetaMask/wallet-ux @MetaMask/wallet-framework-engineers
-
-## package /packages/approval-controller
+## Confirmations Team
+/packages/address-book-controller           @MetaMask/confirmations
 /packages/approval-controller               @MetaMask/confirmations
-/packages/approval-controller/package.json  @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/approval-controller/changelog.md  @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-
-## package /packages/assets-controller
-/packages/assets-controller              @MetaMask/metamask-assets
-/packages/assets-controller/package.json @MetaMask/metamask-assets @MetaMask/wallet-framework-engineers
-/packages/assets-controller/changelog.md @MetaMask/metamask-assets @MetaMask/wallet-framework-engineers
-
-## package /packages/base-controller
-/packages/base-controller              @MetaMask/wallet-framework-engineers
-
-## package /packages/build-utils
-/packages/build-utils                  @MetaMask/wallet-framework-engineers
-
-## package /packages/chain-controller
-/packages/chain-controller               @MetaMask/accounts-engineers
-/packages/chain-controller/package.json  @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
-/packages/chain-controller/changelog.md  @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
-
-## package /packages/composable-controller
-/packages/composable-controller        @MetaMask/wallet-framework-engineers
-
-## package /packages/controller-utils
-/packages/controller-utils             @MetaMask/wallet-framework-engineers
-
-## package /packages/ens-controller
 /packages/ens-controller                    @MetaMask/confirmations
-/packages/ens-controller/package.json       @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/ens-controller/changelog.md       @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-
-## package /packages/eth-json-rpc-provider
-/packages/eth-json-rpc-provider        @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
-
-## package /packages/gas-fee-controller
 /packages/gas-fee-controller                @MetaMask/confirmations
-/packages/gas-fee-controller/package.json   @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/gas-fee-controller/changelog.md   @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-
-## package /packages/json-rpc-engine
-/packages/json-rpc-engine              @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
-
-## package /packages/json-rpc-middleware-stream
-/packages/json-rpc-middleware-stream   @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
-
-## package /packages/keyring-controller
-/packages/keyring-controller                     @MetaMask/accounts-engineers
-/packages/keyring-controller/package.json        @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
-/packages/keyring-controller/changelog.md        @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
-
-## package /packages/logging-controller
 /packages/logging-controller                @MetaMask/confirmations
-/packages/logging-controller/package.json   @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/logging-controller/changelog.md   @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-
-## package /packages/message-manager
 /packages/message-manager                   @MetaMask/confirmations
-/packages/message-manager/package.json      @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/message-manager/changelog.md      @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-
-## package /packages/name-controller
 /packages/name-controller                   @MetaMask/confirmations
-/packages/name-controller/package.json      @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/name-controller/changelog.md      @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/signature-controller              @MetaMask/confirmations
+/packages/transaction-controller            @MetaMask/confirmations
+/packages/user-operation-controller         @MetaMask/confirmations
 
-## package /packages/network-controller
-/packages/network-controller           @MetaMask/wallet-framework-engineers @MetaMask/metamask-assets
+## Notifications Team
+/packages/notification-services-controller     @MetaMask/notifications
+/packages/profile-sync-controller              @MetaMask/notifications
 
-## package /packages/notification-controller
-/packages/notification-controller              @MetaMask/notifications
-/packages/notification-controller/package.json @MetaMask/notifications @MetaMask/wallet-framework-engineers
-/packages/notification-controller/changelog.md @MetaMask/notifications @MetaMask/wallet-framework-engineers
-
-## package /packages/notification-services-controller
-/packages/notification-services-controller              @MetaMask/notifications
-/packages/notification-services-controller/package.json @MetaMask/notifications @MetaMask/wallet-framework-engineers
-/packages/notification-services-controller/changelog.md @MetaMask/notifications @MetaMask/wallet-framework-engineers
-
-## package /packages/permission-controller
-/packages/permission-controller        @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
-
-## package /packages/permission-log-controller
-/packages/permission-log-controller    @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
-
-## package /packages/phishing-controller
+## Product Safety Team
 /packages/phishing-controller              @MetaMask/product-safety
-/packages/phishing-controller/package.json @MetaMask/product-safety @MetaMask/wallet-framework-engineers
-/packages/phishing-controller/changelog.md @MetaMask/product-safety @MetaMask/wallet-framework-engineers
 
-## package /packages/polling-controller
+## Snaps Team
+/packages/notification-controller          @MetaMask/snaps-devs
+/packages/rate-limit-controller            @MetaMask/snaps-devs
+
+## Wallet API Platform Team
+/packages/queued-request-controller        @MetaMask/wallet-api-platform-engineers
+
+## Wallet Framework Team
+/packages/base-controller              @MetaMask/wallet-framework-engineers
+/packages/build-utils                  @MetaMask/wallet-framework-engineers
+/packages/composable-controller        @MetaMask/wallet-framework-engineers
+/packages/controller-utils             @MetaMask/wallet-framework-engineers
 /packages/polling-controller           @MetaMask/wallet-framework-engineers
-
-## package /packages/preferences-controller
 /packages/preferences-controller       @MetaMask/wallet-framework-engineers
 
-## package /packages/profile-sync-controller
-/packages/profile-sync-controller              @MetaMask/notifications
-/packages/profile-sync-controller/package.json @MetaMask/notifications @MetaMask/wallet-framework-engineers
-/packages/profile-sync-controller/changelog.md @MetaMask/notifications @MetaMask/wallet-framework-engineers
+## Wallet UX Team
+/packages/announcement-controller      @MetaMask/wallet-ux
 
-## package /packages/queued-request-controller
-/packages/queued-request-controller               @MetaMask/wallet-api-platform-engineers
-/packages/queued-request-controller/package.json  @MetaMask/wallet-framework-engineers
-/packages/queued-request-controller/changelog.md  @MetaMask/wallet-framework-engineers
-
-## package /packages/rate-limit-controller
-/packages/rate-limit-controller              @MetaMask/snaps-devs
-/packages/rate-limit-controller/package.json @MetaMask/snaps-devs @MetaMask/wallet-framework-engineers
-/packages/rate-limit-controller/changelog.md @MetaMask/snaps-devs @MetaMask/wallet-framework-engineers
-
-## package /packages/selected-network-controller
+## Joint team ownership
+/packages/eth-json-rpc-provider        @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
+/packages/json-rpc-engine              @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
+/packages/json-rpc-middleware-stream   @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
+/packages/network-controller           @MetaMask/wallet-framework-engineers @MetaMask/metamask-assets
+/packages/permission-controller        @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers @MetaMask/snaps-devs
+/packages/permission-log-controller    @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
 /packages/selected-network-controller  @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers @MetaMask/metamask-assets
 
-## package /packages/signature-controller
-/packages/signature-controller              @MetaMask/confirmations
-/packages/signature-controller/package.json @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/signature-controller/changelog.md @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-
-## package /packages/transaction-controller
-/packages/transaction-controller              @MetaMask/confirmations
-/packages/transaction-controller/package.json @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/transaction-controller/changelog.md @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-
-## package /packages/user-operation-controller
-/packages/user-operation-controller              @MetaMask/confirmations
-/packages/user-operation-controller/package.json @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/user-operation-controller/changelog.md @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+## Package Release related
+/packages/accounts-controller/package.json        @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
+/packages/accounts-controller/CHANGELOG.md        @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
+/packages/address-book-controller/package.json    @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/address-book-controller/CHANGELOG.md    @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/announcement-controller/package.json    @MetaMask/wallet-ux @MetaMask/wallet-framework-engineers
+/packages/announcement-controller/CHANGELOG.md    @MetaMask/wallet-ux @MetaMask/wallet-framework-engineers
+/packages/approval-controller/package.json        @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/approval-controller/CHANGELOG.md        @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/assets-controller/package.json          @MetaMask/metamask-assets @MetaMask/wallet-framework-engineers
+/packages/assets-controller/CHANGELOG.md          @MetaMask/metamask-assets @MetaMask/wallet-framework-engineers
+/packages/ens-controller/package.json             @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/ens-controller/CHANGELOG.md             @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/gas-fee-controller/package.json         @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/gas-fee-controller/CHANGELOG.md         @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/keyring-controller/package.json         @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
+/packages/keyring-controller/CHANGELOG.md         @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
+/packages/logging-controller/package.json         @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/logging-controller/CHANGELOG.md         @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/message-manager/package.json            @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/message-manager/CHANGELOG.md            @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/name-controller/package.json            @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/name-controller/CHANGELOG.md            @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/notification-controller/package.json    @MetaMask/notifications @MetaMask/wallet-framework-engineers
+/packages/notification-controller/CHANGELOG.md    @MetaMask/notifications @MetaMask/wallet-framework-engineers
+/packages/notification-services-controller/package.json @MetaMask/notifications @MetaMask/wallet-framework-engineers
+/packages/notification-services-controller/CHANGELOG.md @MetaMask/notifications @MetaMask/wallet-framework-engineers
+/packages/profile-sync-controller/package.json    @MetaMask/notifications @MetaMask/wallet-framework-engineers
+/packages/profile-sync-controller/CHANGELOG.md    @MetaMask/notifications @MetaMask/wallet-framework-engineers
+/packages/queued-request-controller/package.json  @MetaMask/wallet-framework-engineers
+/packages/queued-request-controller/CHANGELOG.md  @MetaMask/wallet-framework-engineers
+/packages/signature-controller/package.json       @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/signature-controller/CHANGELOG.md       @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/rate-limit-controller/package.json      @MetaMask/snaps-devs @MetaMask/wallet-framework-engineers
+/packages/rate-limit-controller/CHANGELOG.md      @MetaMask/snaps-devs @MetaMask/wallet-framework-engineers
+/packages/transaction-controller/package.json     @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/transaction-controller/CHANGELOG.md     @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/user-operation-controller/package.json  @MetaMask/confirmations @MetaMask/wallet-framework-engineers
+/packages/user-operation-controller/CHANGELOG.md  @MetaMask/confirmations @MetaMask/wallet-framework-engineers


### PR DESCRIPTION
## Explanation
We, the MetaMask team (holistically), have recently spent time discussing code ownership around the packages in core. As a team we have aligned on which teams own which packages/controllers within core. This PR is to reflect that alignment. Additionally, in order to not make releasing challenging for the Wallet Framework (who are the stewards of the core repo) we have added this team as codeowners of the manifest file and the changelog file for all packages. 

For a little context being code owners doesn’t mean you are the only ones who work in that code but rather that you will take responsibility for making sure that the code is maintained, healthy, up to date and that others contributing to it do so in a manner that is aligned with our guidelines, processes and principles.

## References
- [Internal google sheets doc](https://docs.google.com/spreadsheets/d/1fukzs7OBZBnswPTLysGaZO7I7uBOGYFpfXEK3Krkn5o/edit?usp=sharing) teams used to align can be found in the google drive
- Additional discussions were in the #mmig-engineering-mgmt channel on slack

## Checklist

- [ n/a ] I've updated the test suite for new or updated code as appropriate
- [ n/a ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ n/a  ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ n/a ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
