### PR TITLE
fix: remove boot cleanup on network switch

### DIFF
--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -940,7 +940,6 @@ export class TransactionController extends BaseController<
     onNetworkStateChange(() => {
       log('Detected network change', this.getChainId());
       this.pendingTransactionTracker.startIfPendingTransactions();
-      this.onBootCleanup();
     });
 
     this.onBootCleanup();


### PR DESCRIPTION
## Explanation

Ensure boot cleanup only occurs when initialising the controller and not when the network is changed.

Boot cleanup involves clearing unapproved transactions and failing approved and signed transactions.

## References

Fixes [#27499](https://github.com/MetaMask/metamask-extension/issues/27499)

## Changelog

### `@metamask/transaction-controller`

- **FIXED**: Cleanup transactions only during initialisation. 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
