### PR TITLE
fix(NOTIFY-1190): key generation bug for react native scrypt

### DIFF
--- a/packages/profile-sync-controller/src/shared/encryption/encryption.ts
+++ b/packages/profile-sync-controller/src/shared/encryption/encryption.ts
@@ -6,7 +6,12 @@ import { utf8ToBytes, concatBytes, bytesToHex } from '@noble/hashes/utils';
 
 import type { NativeScrypt } from '../types/encryption';
 import { getAnyCachedKey, getCachedKeyBySalt, setCachedKey } from './cache';
-import { base64ToByteArray, byteArrayToBase64, bytesToUtf8 } from './utils';
+import {
+  base64ToByteArray,
+  byteArrayToBase64,
+  bytesToUtf8,
+  stringToByteArray,
+} from './utils';
 
 export type EncryptedPayload = {
   // version
@@ -211,7 +216,7 @@ class EncryptorDecryptor {
 
     if (nativeScryptCrypto) {
       newKey = await nativeScryptCrypto(
-        password,
+        stringToByteArray(password),
         newSalt,
         o.N,
         o.r,

--- a/packages/profile-sync-controller/src/shared/encryption/utils.ts
+++ b/packages/profile-sync-controller/src/shared/encryption/utils.ts
@@ -10,3 +10,7 @@ export const bytesToUtf8 = (byteArray: Uint8Array) => {
   const decoder = new TextDecoder('utf-8');
   return decoder.decode(byteArray);
 };
+
+export const stringToByteArray = (str: string) => {
+  return new TextEncoder().encode(str);
+};

--- a/packages/profile-sync-controller/src/shared/types/encryption.ts
+++ b/packages/profile-sync-controller/src/shared/types/encryption.ts
@@ -1,5 +1,5 @@
 export declare type NativeScrypt = (
-  passwd: string,
+  passwd: Uint8Array,
   salt: Uint8Array,
   N: number,
   r: number,


### PR DESCRIPTION
## Explanation

This PR fixes a bug where we passed a `string` parameter instead of a `UInt8Array` to the react native `scrypt` function.
This resulted in faulty key generation, bugs in encryption / decryption, and inconsistencies between mobile and the other clients.

## References

https://consensyssoftware.atlassian.net/browse/NOTIFY-1190

## Changelog

### `@metamask/profile-sync-controller`

- **CHANGED (BREAKING**): use `UInt8Array` instead of `string` for the password argument of `nativeScryptCrypto`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
