### PR TITLE
feat: fetch token rates across accounts

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -1581,7 +1581,7 @@ describe('TokenRatesController', () => {
         );
       });
 
-      it('does not update state if there are no tokens for the given chain and address', async () => {
+      it('does not update state if there are no tokens for the given chain', async () => {
         await withController(
           async ({
             controller,
@@ -1589,23 +1589,10 @@ describe('TokenRatesController', () => {
             triggerNetworkStateChange,
           }) => {
             const tokenAddress = '0x0000000000000000000000000000000000000001';
-            const differentAccount =
-              '0x1000000000000000000000000000000000000000';
             controller.enable();
             await callUpdateExchangeRatesMethod({
               allTokens: {
-                // These tokens are for the right chain but wrong account
-                [ChainId.mainnet]: {
-                  [differentAccount]: [
-                    {
-                      address: tokenAddress,
-                      decimals: 18,
-                      symbol: 'TST',
-                      aggregators: [],
-                    },
-                  ],
-                },
-                // These tokens are for the right account but wrong chain
+                // These tokens are on a different chain
                 [toHex(2)]: {
                   [defaultSelectedAddress]: [
                     {
@@ -1713,7 +1700,10 @@ describe('TokenRatesController', () => {
             await callUpdateExchangeRatesMethod({
               allTokens: {
                 [chainId]: {
-                  [defaultSelectedAddress]: tokens,
+                  [defaultSelectedAddress]: tokens.slice(0, 100),
+                  // Include tokens from non selected addresses
+                  '0x0000000000000000000000000000000000000123':
+                    tokens.slice(100),
                 },
               },
               chainId,
@@ -1748,6 +1738,7 @@ describe('TokenRatesController', () => {
         const tokenAddresses = [
           '0x0000000000000000000000000000000000000001',
           '0x0000000000000000000000000000000000000002',
+          '0x0000000000000000000000000000000000000003',
         ];
         const tokenPricesService = buildMockTokenPricesService({
           fetchTokenPrices: jest.fn().mockResolvedValue({
@@ -1760,6 +1751,11 @@ describe('TokenRatesController', () => {
               currency: 'ETH',
               tokenAddress: tokenAddresses[1],
               value: 0.002,
+            },
+            [tokenAddresses[2]]: {
+              currency: 'ETH',
+              tokenAddress: tokenAddresses[2],
+              value: 0.003,
             },
           }),
         });
@@ -1787,6 +1783,15 @@ describe('TokenRatesController', () => {
                       aggregators: [],
                     },
                   ],
+                  // Include tokens from non selected addresses
+                  '0x0000000000000000000000000000000000000123': [
+                    {
+                      address: tokenAddresses[2],
+                      decimals: 18,
+                      symbol: 'TST1',
+                      aggregators: [],
+                    },
+                  ],
                 },
               },
               chainId: ChainId.mainnet,
@@ -1811,6 +1816,11 @@ describe('TokenRatesController', () => {
                   "currency": "ETH",
                   "tokenAddress": "0x0000000000000000000000000000000000000002",
                   "value": 0.002,
+                },
+                "0x0000000000000000000000000000000000000003": Object {
+                  "currency": "ETH",
+                  "tokenAddress": "0x0000000000000000000000000000000000000003",
+                  "value": 0.003,
                 },
               },
             },

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -985,7 +985,7 @@ describe('TokenRatesController', () => {
     });
 
     describe('when polling is active', () => {
-      it('should update exchange rates when selected address changes', async () => {
+      it('should not update exchange rates when selected address changes', async () => {
         const alternateSelectedAddress =
           '0x0000000000000000000000000000000000000002';
         const alternateSelectedAccount = createMockInternalAccount({
@@ -1024,7 +1024,7 @@ describe('TokenRatesController', () => {
               .mockResolvedValue();
             triggerSelectedAccountChange(alternateSelectedAccount);
 
-            expect(updateExchangeRatesSpy).toHaveBeenCalledTimes(1);
+            expect(updateExchangeRatesSpy).not.toHaveBeenCalled();
           },
         );
       });

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -301,8 +301,6 @@ export class TokenRatesController extends StaticIntervalPollingController<
     this.#subscribeToTokensStateChange();
 
     this.#subscribeToNetworkStateChange();
-
-    this.#subscribeToAccountChange();
   }
 
   #subscribeToTokensStateChange() {
@@ -356,45 +354,22 @@ export class TokenRatesController extends StaticIntervalPollingController<
     );
   }
 
-  #subscribeToAccountChange() {
-    this.messagingSystem.subscribe(
-      'AccountsController:selectedEvmAccountChange',
-      // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      async (selectedAccount) => {
-        if (this.#selectedAccountId !== selectedAccount.id) {
-          this.#selectedAccountId = selectedAccount.id;
-          if (this.#pollState === PollState.Active) {
-            await this.updateExchangeRates();
-          }
-        }
-      },
-    );
-  }
-
   /**
-   * Get the user's tokens for the given chain.
+   * Get the tokens for the given chain.
    *
    * @param chainId - The chain ID.
    * @returns The list of tokens addresses for the current chain
    */
   #getTokenAddresses(chainId: Hex): Hex[] {
-    const selectedAccount = this.messagingSystem.call(
-      'AccountsController:getAccount',
-      this.#selectedAccountId,
-    );
-    const selectedAddress = selectedAccount?.address ?? '';
-    const tokens = this.#allTokens[chainId]?.[selectedAddress] || [];
-    const detectedTokens =
-      this.#allDetectedTokens[chainId]?.[selectedAddress] || [];
+    const getTokens = (allTokens: Record<Hex, { address: string }[]>) =>
+      Object.values(allTokens ?? {}).flatMap((tokens) =>
+        tokens.map(({ address }) => toHex(toChecksumHexAddress(address))),
+      );
 
-    return [
-      ...new Set(
-        [...tokens, ...detectedTokens].map((token) =>
-          toHex(toChecksumHexAddress(token.address)),
-        ),
-      ),
-    ].sort();
+    const tokenAddresses = getTokens(this.#allTokens[chainId]);
+    const detectedTokenAddresses = getTokens(this.#allDetectedTokens[chainId]);
+
+    return [...new Set([...tokenAddresses, ...detectedTokenAddresses])].sort();
   }
 
   /**


### PR DESCRIPTION
## Explanation

The `TokenRatesController` used to only fetch prices for tokens on the currently selected account.  With this change, it will fetch prices for tokens across all accounts.

This will power UI features like showing portfolio $ values in the account picker, and avoids needing to re-fetch prices when switching accounts which causes some UI lag.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **CHANGED**: `TokenRatesController` now fetches prices for tokens across all accounts

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
