### PR TITLE
chore(constraints): allow exceptions for dependency-range consistency

### DIFF
--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -761,23 +761,24 @@ function expectConsistentDependenciesAndDevDependencies(Yarn) {
     dependencyIdent,
     dependenciesByRange,
   ] of nonPeerDependenciesByIdent.entries()) {
+    if (dependenciesByRange.size <= 1) {
+      continue;
+    }
     const dependenciesToConsider =
       getInconsistentDependenciesAndDevDependencies(
         dependencyIdent,
         dependenciesByRange,
       );
     const dependencyRanges = [...dependenciesToConsider.keys()].sort();
-    if (dependenciesByRange.size > 1) {
-      for (const dependencies of dependenciesToConsider.values()) {
-        for (const dependency of dependencies) {
-          dependency.error(
-            `Expected version range for ${dependencyIdent} (in ${
-              dependency.type
-            }) to be consistent across monorepo. Pick one: ${inspect(
-              dependencyRanges,
-            )}`,
-          );
-        }
+    for (const dependencies of dependenciesToConsider.values()) {
+      for (const dependency of dependencies) {
+        dependency.error(
+          `Expected version range for ${dependencyIdent} (in ${
+            dependency.type
+          }) to be consistent across monorepo. Pick one: ${inspect(
+            dependencyRanges,
+          )}`,
+        );
       }
     }
   }

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -715,6 +715,35 @@ function expectControllerDependenciesListedAsPeerDependencies(
 }
 
 /**
+ * Filter out dependency ranges which are not to be considered in `expectConsistentDependenciesAndDevDependencies`.
+ *
+ * @param {string} dependencyIdent - The dependency being filtered for
+ * @param {Map<string, Dependency>} dependenciesByRange - Dependencies by range
+ * @returns {Map<string, Dependency>} The resulting map.
+ */
+function getInconsistentDependenciesAndDevDependencies(
+  dependencyIdent,
+  dependenciesByRange,
+) {
+  const ALLOWED_INCONSISTENT_DEPENDENCIES = Object.entries({
+    // '@metamask/foo': ['^1.0.0'],
+  });
+  for (const [
+    allowedPackage,
+    ignoredRange,
+  ] of ALLOWED_INCONSISTENT_DEPENDENCIES) {
+    if (allowedPackage === dependencyIdent) {
+      return new Map(
+        Object.entries(dependenciesByRange).filter(
+          ([range]) => !ignoredRange.includes(range),
+        ),
+      );
+    }
+  }
+  return dependenciesByRange;
+}
+
+/**
  * Expect that all version ranges in `dependencies` and `devDependencies` for
  * the same dependency across the entire monorepo are the same. As it is
  * impossible to compare NPM version ranges, let the user decide if there are
@@ -732,9 +761,14 @@ function expectConsistentDependenciesAndDevDependencies(Yarn) {
     dependencyIdent,
     dependenciesByRange,
   ] of nonPeerDependenciesByIdent.entries()) {
-    const dependencyRanges = [...dependenciesByRange.keys()].sort();
+    const dependenciesToConsider =
+      getInconsistentDependenciesAndDevDependencies(
+        dependencyIdent,
+        dependenciesByRange,
+      );
+    const dependencyRanges = [...dependenciesToConsider.keys()].sort();
     if (dependenciesByRange.size > 1) {
-      for (const dependencies of dependenciesByRange.values()) {
+      for (const dependencies of dependenciesToConsider.values()) {
         for (const dependency of dependencies) {
           dependency.error(
             `Expected version range for ${dependencyIdent} (in ${


### PR DESCRIPTION
## Explanation

This allows adding explicit exceptions for the Yarn constraint `expectConsistentDependenciesAndDevDependencies`.

An exception entry consists of a package name and a set of exact version ranges to be ignored in checking.

This is useful when we have "repo-circular" dependencies, where package A (in this repo) depends on package B (in another repo), which in its turn depends on package C (back again in this repo), finally depending on some package D.

In some cases, bumping D atomically in the monorepo makes things very heavy-handed. This change allows to slice it up in such situations.


## References

- Example of heavy-handed PR: #4769
  - `C = @metamask/json-rpc-engine`
  - `D = @metamask/rpc-errors`
- Blocking: #4773


## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
