### PR TITLE
deps(json-rpc-engine): @metamask/rpc-errors@^6.3.1->^7.0.0

### DIFF
--- a/packages/json-rpc-engine/package.json
+++ b/packages/json-rpc-engine/package.json
@@ -56,7 +56,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/rpc-errors": "^6.3.1",
+    "@metamask/rpc-errors": "^7.0.0",
     "@metamask/safe-event-emitter": "^3.0.0",
     "@metamask/utils": "^9.1.0"
   },

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -714,6 +714,10 @@ function expectControllerDependenciesListedAsPeerDependencies(
   }
 }
 
+const ALLOWED_INCONSISTENT_DEPENDENCIES = Object.entries({
+  '@metamask/rpc-errors': ['^7.0.0'],
+});
+
 /**
  * Filter out dependency ranges which are not to be considered in `expectConsistentDependenciesAndDevDependencies`.
  *
@@ -725,9 +729,6 @@ function getInconsistentDependenciesAndDevDependencies(
   dependencyIdent,
   dependenciesByRange,
 ) {
-  const ALLOWED_INCONSISTENT_DEPENDENCIES = Object.entries({
-    // '@metamask/foo': ['^1.0.0'],
-  });
   for (const [
     allowedPackage,
     ignoredRange,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,7 +2862,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/rpc-errors": "npm:^6.3.1"
+    "@metamask/rpc-errors": "npm:^7.0.0"
     "@metamask/safe-event-emitter": "npm:^3.0.0"
     "@metamask/utils": "npm:^9.1.0"
     "@types/jest": "npm:^27.4.1"
@@ -3400,6 +3400,16 @@ __metadata:
     "@metamask/utils": "npm:^9.0.0"
     fast-safe-stringify: "npm:^2.0.6"
   checksum: 10/f968fb490b13b632c2ad4770a144d67cecdff8d539cb8b489c732b08dab7a62fae65d7a2908ce8c5b77260317aa618948a52463f093fa8d9f84aee1c5f6f5daf
+  languageName: node
+  linkType: hard
+
+"@metamask/rpc-errors@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@metamask/rpc-errors@npm:7.0.0"
+  dependencies:
+    "@metamask/utils": "npm:^9.0.0"
+    fast-safe-stringify: "npm:^2.0.6"
+  checksum: 10/f25e2a5506d4d0d6193c88aef8f035ec189a1177f8aee8fa01c9a33d73b1536ca7b5eea2fb33a477768bbd2abaf16529e68f0b3cf714387e5d6c9178225354fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

Bump `@metamask/rpc-errors` to latest for `@metamask/json-rpc-engine`.

## References

- https://github.com/MetaMask/rpc-errors/releases/tag/v7.0.0
  - Relevant change: https://github.com/MetaMask/rpc-errors/pull/158
- Consistent upgrade across the monorepo: https://github.com/MetaMask/core/pull/4769

#### Blocked by
- [x] #4772

#### Blocking
- https://github.com/MetaMask/eth-json-rpc-middleware/pull/342
- https://github.com/MetaMask/metamask-extension/pull/22875

## Changelog

### `@metamask/json-rpc-engine`

- **CHANGED**: Bump `@metamask/rpc-errors` from `^6.3.1` to `^7.0.0`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
