### PR TITLE
feat(NOTIFY-1214): add support for DELETE ONE endpoint

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -45,6 +45,7 @@ import {
 import { startNetworkSyncing } from './network-syncing/controller-integration';
 import {
   batchUpsertUserStorage,
+  deleteUserStorage,
   deleteUserStorageAllFeatureEntries,
   getUserStorage,
   getUserStorageAllFeatureEntries,
@@ -671,6 +672,28 @@ export default class UserStorageController extends BaseController<
       await this.#getStorageKeyAndBearerToken();
 
     await batchUpsertUserStorage(values, {
+      path,
+      bearerToken,
+      storageKey,
+      nativeScryptCrypto: this.#nativeScryptCrypto,
+    });
+  }
+
+  /**
+   * Allows deletion of user data. Developers can extend the entry path and entry name through the `schema.ts` file.
+   *
+   * @param path - string in the form of `${feature}.${key}` that matches schema
+   * @returns nothing. NOTE that an error is thrown if fails to delete data.
+   */
+  public async performDeleteStorage(
+    path: UserStoragePathWithFeatureAndKey,
+  ): Promise<void> {
+    this.#assertProfileSyncingEnabled();
+
+    const { bearerToken, storageKey } =
+      await this.#getStorageKeyAndBearerToken();
+
+    await deleteUserStorage({
       path,
       bearerToken,
       storageKey,

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -697,7 +697,6 @@ export default class UserStorageController extends BaseController<
       path,
       bearerToken,
       storageKey,
-      nativeScryptCrypto: this.#nativeScryptCrypto,
     });
   }
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockResponses.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockResponses.ts
@@ -118,6 +118,16 @@ export const getMockUserStorageBatchPutResponse = (
   } satisfies MockResponse;
 };
 
+export const deleteMockUserStorageResponse = (
+  path: UserStoragePathWithFeatureAndKey = 'notifications.notification_settings',
+) => {
+  return {
+    url: getMockUserStorageEndpoint(path),
+    requestMethod: 'DELETE',
+    response: null,
+  } satisfies MockResponse;
+};
+
 export const deleteMockUserStorageAllFeatureEntriesResponse = (
   path: UserStoragePathWithFeatureOnly = 'notifications',
 ) => {

--- a/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockServices.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockServices.ts
@@ -10,6 +10,7 @@ import {
   getMockUserStorageAllFeatureEntriesResponse,
   getMockUserStorageBatchPutResponse,
   deleteMockUserStorageAllFeatureEntriesResponse,
+  deleteMockUserStorageResponse,
 } from './mockResponses';
 
 type MockReply = {
@@ -76,6 +77,20 @@ export const mockEndpointBatchUpsertUserStorage = (
     .reply(mockReply?.status ?? 204, async (uri, requestBody) => {
       return await callback?.(uri, requestBody);
     });
+  return mockEndpoint;
+};
+
+export const mockEndpointDeleteUserStorage = (
+  path: UserStoragePathWithFeatureAndKey = 'notifications.notification_settings',
+  mockReply?: MockReply,
+) => {
+  const mockResponse = deleteMockUserStorageResponse(path);
+  const reply = mockReply ?? {
+    status: 200,
+  };
+
+  const mockEndpoint = nock(mockResponse.url).delete('').reply(reply.status);
+
   return mockEndpoint;
 };
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/services.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/services.test.ts
@@ -7,6 +7,7 @@ import {
   mockEndpointGetUserStorageAllFeatureEntries,
   mockEndpointBatchUpsertUserStorage,
   mockEndpointDeleteUserStorageAllFeatureEntries,
+  mockEndpointDeleteUserStorage,
 } from './__fixtures__/mockServices';
 import {
   MOCK_STORAGE_DATA,
@@ -19,6 +20,7 @@ import {
   getUserStorageAllFeatureEntries,
   upsertUserStorage,
   deleteUserStorageAllFeatureEntries,
+  deleteUserStorage,
 } from './services';
 
 describe('user-storage/services.ts - getUserStorage() tests', () => {
@@ -241,6 +243,60 @@ describe('user-storage/services.ts - batchUpsertUserStorage() tests', () => {
       expect.any(Error),
     );
     mockUpsertUserStorage.done();
+  });
+});
+
+describe('user-storage/services.ts - deleteUserStorage() tests', () => {
+  const actCallDeleteUserStorage = async () => {
+    return await deleteUserStorage({
+      path: 'notifications.notification_settings',
+      bearerToken: 'MOCK_BEARER_TOKEN',
+      storageKey: MOCK_STORAGE_KEY,
+    });
+  };
+
+  it('invokes delete endpoint with no errors', async () => {
+    const mockDeleteUserStorage = mockEndpointDeleteUserStorage(
+      'notifications.notification_settings',
+    );
+
+    await actCallDeleteUserStorage();
+
+    expect(mockDeleteUserStorage.isDone()).toBe(true);
+  });
+
+  it('throws error if unable to delete user storage', async () => {
+    const mockDeleteUserStorage = mockEndpointDeleteUserStorage(
+      'notifications.notification_settings',
+      { status: 500 },
+    );
+
+    await expect(actCallDeleteUserStorage()).rejects.toThrow(expect.any(Error));
+    mockDeleteUserStorage.done();
+  });
+
+  it('throws error if feature not found', async () => {
+    const mockDeleteUserStorage = mockEndpointDeleteUserStorage(
+      'notifications.notification_settings',
+      { status: 404 },
+    );
+
+    await expect(actCallDeleteUserStorage()).rejects.toThrow(
+      'user-storage - feature/entry not found',
+    );
+    mockDeleteUserStorage.done();
+  });
+
+  it('throws error if unable to get user storage', async () => {
+    const mockDeleteUserStorage = mockEndpointDeleteUserStorage(
+      'notifications.notification_settings',
+      { status: 400 },
+    );
+
+    await expect(actCallDeleteUserStorage()).rejects.toThrow(
+      'user-storage - unable to delete data',
+    );
+    mockDeleteUserStorage.done();
   });
 });
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/services.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/services.ts
@@ -264,7 +264,7 @@ export async function deleteUserStorage(
     throw new Error('user-storage - feature/entry not found');
   }
 
-  if (userStorageResponse.status !== 200 || !userStorageResponse.ok) {
+  if (!userStorageResponse.ok) {
     throw new Error('user-storage - unable to delete data');
   }
 }
@@ -292,7 +292,7 @@ export async function deleteUserStorageAllFeatureEntries(
     throw new Error('user-storage - feature not found');
   }
 
-  if (userStorageResponse.status !== 200 || !userStorageResponse.ok) {
+  if (!userStorageResponse.ok) {
     throw new Error('user-storage - unable to delete data');
   }
 }

--- a/packages/profile-sync-controller/src/controllers/user-storage/services.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/services.ts
@@ -241,6 +241,35 @@ export async function batchUpsertUserStorage(
 }
 
 /**
+ * User Storage Service - Delete Storage Entry.
+ *
+ * @param opts - User Storage Options
+ */
+export async function deleteUserStorage(
+  opts: UserStorageOptions,
+): Promise<void> {
+  const { bearerToken, path, storageKey } = opts;
+  const encryptedPath = createEntryPath(path, storageKey);
+  const url = new URL(`${USER_STORAGE_ENDPOINT}/${encryptedPath}`);
+
+  const userStorageResponse = await fetch(url.toString(), {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${bearerToken}`,
+    },
+  });
+
+  if (userStorageResponse.status === 404) {
+    throw new Error('user-storage - feature/entry not found');
+  }
+
+  if (userStorageResponse.status !== 200 || !userStorageResponse.ok) {
+    throw new Error('user-storage - unable to delete data');
+  }
+}
+
+/**
  * User Storage Service - Delete all storage entries for a specific feature.
  *
  * @param opts - User Storage Options
@@ -259,7 +288,6 @@ export async function deleteUserStorageAllFeatureEntries(
     },
   });
 
-  // Acceptable error - since indicates feature does not exist.
   if (userStorageResponse.status === 404) {
     throw new Error('user-storage - feature not found');
   }

--- a/packages/profile-sync-controller/src/sdk/__fixtures__/mock-userstorage.ts
+++ b/packages/profile-sync-controller/src/sdk/__fixtures__/mock-userstorage.ts
@@ -77,6 +77,16 @@ export const handleMockUserStoragePut = (
   return mockEndpoint;
 };
 
+export const handleMockUserStorageDelete = async (mockReply?: MockReply) => {
+  const reply = mockReply ?? { status: 204 };
+  const mockEndpoint = nock(MOCK_STORAGE_URL)
+    .persist()
+    .delete(/.*/u)
+    .reply(reply.status);
+
+  return mockEndpoint;
+};
+
 export const handleMockUserStorageDeleteAllFeatureEntries = async (
   mockReply?: MockReply,
 ) => {

--- a/packages/profile-sync-controller/src/sdk/user-storage.test.ts
+++ b/packages/profile-sync-controller/src/sdk/user-storage.test.ts
@@ -10,6 +10,7 @@ import {
   handleMockUserStoragePut,
   handleMockUserStorageGetAllFeatureEntries,
   handleMockUserStorageDeleteAllFeatureEntries,
+  handleMockUserStorageDelete,
 } from './__fixtures__/mock-userstorage';
 import { arrangeAuth, typedMockFn } from './__fixtures__/test-utils';
 import type { IBaseAuth } from './authentication-jwt-bearer/types';
@@ -131,6 +132,33 @@ describe('User Storage', () => {
 
     await userStorage.batchSetItems('accounts', dataToStore);
     expect(mockPut.isDone()).toBe(true);
+  });
+
+  it('user storage: delete one feature entry', async () => {
+    const { auth } = arrangeAuth('SRP', MOCK_SRP);
+    const { userStorage } = arrangeUserStorage(auth);
+
+    const mockDelete = await handleMockUserStorageDelete();
+
+    await userStorage.deleteItem('notifications.notification_settings');
+    expect(mockDelete.isDone()).toBe(true);
+  });
+
+  it('user storage: failed to delete one feature entry', async () => {
+    const { auth } = arrangeAuth('SRP', MOCK_SRP);
+    const { userStorage } = arrangeUserStorage(auth);
+
+    await handleMockUserStorageDelete({
+      status: 401,
+      body: {
+        message: 'failed to delete storage entry',
+        error: 'generic-error',
+      },
+    });
+
+    await expect(
+      userStorage.deleteItem('notifications.notification_settings'),
+    ).rejects.toThrow(UserStorageError);
   });
 
   it('user storage: delete all feature entries', async () => {


### PR DESCRIPTION
## Explanation

This PR adds profile-sync SDK and `UserStorageController` support for the DELETE endpoint.
This exposes new methods that permit deleting one user entry for a specific feature.

## References

https://consensyssoftware.atlassian.net/browse/NOTIFY-1214

## Changelog

### `@metamask/profile-sync-controller`

- **ADDED**: `UserStorageController` and profile-sync SDK support for the `DELETE` one feature entry endpoint


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
