### PR TITLE
fix: do not sync imported accounts

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -314,10 +314,7 @@ export default class UserStorageController extends BaseController<
       );
     },
     doesInternalAccountHaveCorrectKeyringType: (account: InternalAccount) => {
-      return (
-        account.metadata.keyring.type === KeyringTypes.hd ||
-        account.metadata.keyring.type === KeyringTypes.simple
-      );
+      return account.metadata.keyring.type === KeyringTypes.hd;
     },
     getInternalAccountsList: async (): Promise<InternalAccount[]> => {
       // eslint-disable-next-line @typescript-eslint/await-thenable


### PR DESCRIPTION
## Explanation

This PR fixed an unintended behavior where we were syncing imported accounts.

## References

https://consensyssoftware.atlassian.net/browse/NOTIFY-1215

## Changelog

### `@metamask/profile-sync-controller`

- **CHANGED**: Account syncing will not sync imported accounts anymore

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
