### PR TITLE
chore(constraints): respect ALLOWED_INCONSISTENT_DEPENDENCIES for workspace packages; simplify logic

### DIFF
--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -13,6 +13,15 @@ const semver = require('semver');
 const { inspect } = require('util');
 
 /**
+ * These packages and ranges are allowed to mismatch expected consistency checks
+ * Only intended as temporary measures to faciliate upgrades and releases.
+ * This should trend towards empty.
+ */
+const ALLOWED_INCONSISTENT_DEPENDENCIES = {
+  '@metamask/rpc-errors': ['^7.0.0'],
+};
+
+/**
  * Aliases for the Yarn type definitions, to make the code more readable.
  *
  * @typedef {import('@yarnpkg/types').Yarn.Constraints.Yarn} Yarn
@@ -594,6 +603,11 @@ function expectUpToDateWorkspaceDependenciesAndDevDependencies(
       dependencyWorkspace !== null &&
       dependency.type !== 'peerDependencies'
     ) {
+      const ignoredRanges = ALLOWED_INCONSISTENT_DEPENDENCIES[dependency.ident];
+      if (ignoredRanges?.includes(dependency.range)) {
+        continue;
+      }
+
       dependency.update(`^${dependencyWorkspace.manifest.version}`);
     }
   }
@@ -714,10 +728,6 @@ function expectControllerDependenciesListedAsPeerDependencies(
   }
 }
 
-const ALLOWED_INCONSISTENT_DEPENDENCIES = Object.entries({
-  '@metamask/rpc-errors': ['^7.0.0'],
-});
-
 /**
  * Filter out dependency ranges which are not to be considered in `expectConsistentDependenciesAndDevDependencies`.
  *
@@ -729,19 +739,15 @@ function getInconsistentDependenciesAndDevDependencies(
   dependencyIdent,
   dependenciesByRange,
 ) {
-  for (const [
-    allowedPackage,
-    ignoredRange,
-  ] of ALLOWED_INCONSISTENT_DEPENDENCIES) {
-    if (allowedPackage === dependencyIdent) {
-      return new Map(
-        Object.entries(dependenciesByRange).filter(
-          ([range]) => !ignoredRange.includes(range),
-        ),
-      );
-    }
+  const ignoredRanges = ALLOWED_INCONSISTENT_DEPENDENCIES[dependencyIdent];
+  if (!ignoredRanges) {
+    return dependenciesByRange;
   }
-  return dependenciesByRange;
+  return new Map(
+    Object.entries(dependenciesByRange).filter(
+      ([range]) => !ignoredRanges.includes(range),
+    ),
+  );
 }
 
 /**


### PR DESCRIPTION
## Explanation

Allow configuring yarn constraints to allow exceptions for dependency range consistency checks for workspace dependencies and devDependencies.

## References

- Follow-up to #4772
- #4798

## Changelog

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
