### PR TITLE
add account support check in validator

### DIFF
--- a/packages/multichain/src/caip25Permission.test.ts
+++ b/packages/multichain/src/caip25Permission.test.ts
@@ -44,6 +44,7 @@ describe('endowment:caip25', () => {
     const specification = caip25EndowmentBuilder.specificationBuilder({
       methodHooks: {
         findNetworkClientIdByChainId: jest.fn(),
+        listAccounts: jest.fn(),
       },
     });
     expect(specification).toStrictEqual({
@@ -227,9 +228,11 @@ describe('endowment:caip25', () => {
 
   describe('permission validator', () => {
     const findNetworkClientIdByChainId = jest.fn();
+    const listAccounts = jest.fn();
     const { validator } = caip25EndowmentBuilder.specificationBuilder({
       methodHooks: {
         findNetworkClientIdByChainId,
+        listAccounts,
       },
     });
 
@@ -493,7 +496,7 @@ describe('endowment:caip25', () => {
           },
         },
         normalizedOptionalScopes: {
-          'eip155:1': {
+          'eip155:5': {
             methods: ['normalized_optional'],
             notifications: [],
             accounts: [],
@@ -534,7 +537,7 @@ describe('endowment:caip25', () => {
       }
       expect(MockScopeAssert.assertScopesSupported).toHaveBeenCalledWith(
         {
-          'eip155:1': {
+          'eip155:5': {
             methods: ['normalized_optional'],
             notifications: [],
             accounts: [],
@@ -549,6 +552,61 @@ describe('endowment:caip25', () => {
       expect(isChainIdSupportedBody).toContain('findNetworkClientIdByChainId');
     });
 
+    it('throws if the eth accounts specified in the normalized scopeObjects are not all supported', () => {
+      MockScopeAuthorization.validateAndNormalizeScopes.mockReturnValue({
+        normalizedRequiredScopes: {
+          'eip155:1': {
+            methods: ['eth_chainId'],
+            notifications: [],
+            accounts: ['eip155:1:0xdead'],
+          },
+        },
+        normalizedOptionalScopes: {
+          'eip155:5': {
+            methods: [],
+            notifications: [],
+            accounts: ['eip155:5:0xbeef'],
+          },
+        },
+      });
+      listAccounts.mockReturnValue([{ address: '0xdead' }]); // missing '0xbeef'
+
+      expect(() => {
+        validator({
+          caveats: [
+            {
+              type: Caip25CaveatType,
+              value: {
+                requiredScopes: {
+                  'eip155:1': {
+                    methods: ['eth_chainId'],
+                    notifications: [],
+                    accounts: ['eip155:1:0xdead'],
+                  },
+                },
+                optionalScopes: {
+                  'eip155:5': {
+                    methods: [],
+                    notifications: [],
+                    accounts: ['eip155:5:0xbeef'],
+                  },
+                },
+                isMultichainOrigin: true,
+              },
+            },
+          ],
+          date: 1234,
+          id: '1',
+          invoker: 'test.com',
+          parentCapability: Caip25EndowmentPermissionName,
+        });
+      }).toThrow(
+        new Error(
+          `${Caip25EndowmentPermissionName} error: Received invalid eip155 account values for caveat of type "${Caip25CaveatType}".`,
+        ),
+      );
+    });
+
     it('throws if the input requiredScopes does not match the output of validateAndNormalizeScopes', () => {
       MockScopeAuthorization.validateAndNormalizeScopes.mockReturnValue({
         normalizedRequiredScopes: {},
@@ -560,6 +618,8 @@ describe('endowment:caip25', () => {
           },
         },
       });
+      listAccounts.mockReturnValue([{ address: '0xbeef' }]);
+
       expect(() => {
         validator({
           caveats: [
@@ -603,6 +663,8 @@ describe('endowment:caip25', () => {
         },
         normalizedOptionalScopes: {},
       });
+      listAccounts.mockReturnValue([{ address: '0xdead' }]);
+
       expect(() => {
         validator({
           caveats: [
@@ -652,6 +714,11 @@ describe('endowment:caip25', () => {
           },
         },
       });
+      listAccounts.mockReturnValue([
+        { address: '0xdead' },
+        { address: '0xbeef' },
+      ]);
+
       expect(
         validator({
           caveats: [

--- a/packages/multichain/src/caip25Permission.test.ts
+++ b/packages/multichain/src/caip25Permission.test.ts
@@ -602,7 +602,7 @@ describe('endowment:caip25', () => {
         });
       }).toThrow(
         new Error(
-          `${Caip25EndowmentPermissionName} error: Received invalid eip155 account values for caveat of type "${Caip25CaveatType}".`,
+          `${Caip25EndowmentPermissionName} error: Received eip155 account value(s) for caveat of type "${Caip25CaveatType}" that were not found in the wallet keyring.`,
         ),
       );
     });

--- a/packages/multichain/src/caip25Permission.test.ts
+++ b/packages/multichain/src/caip25Permission.test.ts
@@ -552,7 +552,7 @@ describe('endowment:caip25', () => {
       expect(isChainIdSupportedBody).toContain('findNetworkClientIdByChainId');
     });
 
-    it('throws if the eth accounts specified in the normalized scopeObjects are not all supported', () => {
+    it('throws if the eth accounts specified in the normalized scopeObjects are not found in the wallet keyring', () => {
       MockScopeAuthorization.validateAndNormalizeScopes.mockReturnValue({
         normalizedRequiredScopes: {
           'eip155:1': {

--- a/packages/multichain/src/caip25Permission.ts
+++ b/packages/multichain/src/caip25Permission.ts
@@ -138,7 +138,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
       );
       if (!allEthAccountsSupported) {
         throw new Error(
-          `${Caip25EndowmentPermissionName} error: Received eip155 account value(s) for caveat of type "${Caip25CaveatType}" that were not found in the wallet keyring`,
+          `${Caip25EndowmentPermissionName} error: Received eip155 account value(s) for caveat of type "${Caip25CaveatType}" that were not found in the wallet keyring.`,
         );
       }
 

--- a/packages/multichain/src/caip25Permission.ts
+++ b/packages/multichain/src/caip25Permission.ts
@@ -138,7 +138,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
       );
       if (!allEthAccountsSupported) {
         throw new Error(
-          `${Caip25EndowmentPermissionName} error: Received invalid eip155 account values for caveat of type "${Caip25CaveatType}".`,
+          `${Caip25EndowmentPermissionName} error: Received eip155 account value(s) for caveat of type "${Caip25CaveatType}" that were not found in the wallet keyring`,
         );
       }
 

--- a/packages/multichain/src/caip25Permission.ts
+++ b/packages/multichain/src/caip25Permission.ts
@@ -122,7 +122,7 @@ const specificationBuilder: PermissionSpecificationBuilder<
         isChainIdSupported,
       });
 
-      // These should be EVM accounts already although the name does not necessary imply that
+      // Fetch EVM accounts from native wallet keyring
       // These addresses are lowercased already
       const existingEvmAddresses = methodHooks
         .listAccounts()

--- a/packages/multichain/src/caip25Permission.ts
+++ b/packages/multichain/src/caip25Permission.ts
@@ -19,6 +19,7 @@ import {
 import { strict as assert } from 'assert';
 import { cloneDeep, isEqual } from 'lodash';
 
+import { getEthAccounts } from './adapters/caip-permission-adapter-eth-accounts';
 import { assertScopesSupported } from './scope/assert';
 import { validateAndNormalizeScopes } from './scope/authorization';
 import type {
@@ -56,6 +57,7 @@ type Caip25EndowmentSpecification = ValidPermissionSpecification<{
 type Caip25EndowmentSpecificationBuilderOptions = {
   methodHooks: {
     findNetworkClientIdByChainId: (chainId: Hex) => NetworkClientId;
+    listAccounts: () => { address: Hex }[];
   };
 };
 
@@ -119,6 +121,26 @@ const specificationBuilder: PermissionSpecificationBuilder<
       assertScopesSupported(normalizedOptionalScopes, {
         isChainIdSupported,
       });
+
+      // These should be EVM accounts already although the name does not necessary imply that
+      // These addresses are lowercased already
+      const existingEvmAddresses = methodHooks
+        .listAccounts()
+        .map((account) => account.address);
+      const ethAccounts = getEthAccounts({
+        requiredScopes: normalizedRequiredScopes,
+        optionalScopes: normalizedOptionalScopes,
+        isMultichainOrigin,
+      }).map((address) => address.toLowerCase() as Hex);
+
+      const allEthAccountsSupported = ethAccounts.every((address) =>
+        existingEvmAddresses.includes(address),
+      );
+      if (!allEthAccountsSupported) {
+        throw new Error(
+          `${Caip25EndowmentPermissionName} error: Received invalid eip155 account values for caveat of type "${Caip25CaveatType}".`,
+        );
+      }
 
       assert.deepEqual(requiredScopes, normalizedRequiredScopes);
       assert.deepEqual(optionalScopes, normalizedOptionalScopes);


### PR DESCRIPTION
## Explanation

Mirrors the [wallet_createSession handler
](https://github.com/MetaMask/metamask-extension/pull/27782/files#diff-107459889087f2776c6db636bd45498bef6749302f9d2dc633b4de17fede40a3R96-R108) in how eth account support is checked/asserted. Opted to do this rather than modify `assertScopeSupported` because the `bucketScopes` helper also relies on `assertScopedSupported` but doesn't care about accounts (which is why eth accounts are checked outside of assertScopeSupported in the wallet_createSession handler currently)

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
