### PR TITLE
feat(controller-utils): support BigNumber as input to BNToHex

### DIFF
--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@types/jest": "^27.4.1",
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^4.1.0",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "nock": "^13.3.1",

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@types/jest": "^27.4.1",
+    "bignumber.js": "^9.1.2",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "nock": "^13.3.1",

--- a/packages/controller-utils/src/util.test.ts
+++ b/packages/controller-utils/src/util.test.ts
@@ -1,4 +1,5 @@
 import EthQuery from '@metamask/eth-query';
+import BigNumber from 'bignumber.js';
 import BN from 'bn.js';
 import nock from 'nock';
 
@@ -31,6 +32,7 @@ describe('util', () => {
 
   it('bNToHex', () => {
     expect(util.BNToHex(new BN('1337'))).toBe('0x539');
+    expect(util.BNToHex(new BigNumber('1337'))).toBe('0x539');
   });
 
   it('fractionBN', () => {

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -10,11 +10,12 @@ import {
 } from '@metamask/utils';
 import type { BigNumber } from 'bignumber.js';
 import BN from 'bn.js';
-export type { BigNumber };
 import ensNamehash from 'eth-ens-namehash';
 import deepEqual from 'fast-deep-equal';
 
 import { MAX_SAFE_CHAIN_ID } from './constants';
+
+export type { BigNumber };
 
 const TIMEOUT_ERROR = new Error('timeout');
 

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -8,6 +8,7 @@ import {
   isHexString,
   remove0x,
 } from '@metamask/utils';
+export type { BigNumber } from 'bignumber.js';
 import BN from 'bn.js';
 import ensNamehash from 'eth-ens-namehash';
 import deepEqual from 'fast-deep-equal';
@@ -59,14 +60,14 @@ export function isSafeChainId(chainId: Hex): boolean {
   );
 }
 /**
- * Converts a BN object to a hex string with a '0x' prefix.
+ * Converts a BN or BigNumber object to a hex string with a '0x' prefix.
  *
- * @param inputBn - BN instance to convert to a hex string.
+ * @param inputBn - BN|BigNumber instance to convert to a hex string.
  * @returns A '0x'-prefixed hex string.
  */
 // TODO: Either fix this lint violation or explain why it's necessary to ignore.
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function BNToHex(inputBn: BN) {
+export function BNToHex(inputBn: BN | BigNumber) {
   return add0x(inputBn.toString(16));
 }
 

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -8,8 +8,9 @@ import {
   isHexString,
   remove0x,
 } from '@metamask/utils';
-export type { BigNumber } from 'bignumber.js';
+import type { BigNumber } from 'bignumber.js';
 import BN from 'bn.js';
+export type { BigNumber };
 import ensNamehash from 'eth-ens-namehash';
 import deepEqual from 'fast-deep-equal';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2339,7 +2339,7 @@ __metadata:
     "@spruceid/siwe-parser": "npm:2.1.0"
     "@types/bn.js": "npm:^5.1.5"
     "@types/jest": "npm:^27.4.1"
-    bignumber.js: "npm:^9.1.2"
+    bignumber.js: "npm:^4.1.0"
     bn.js: "npm:^5.2.1"
     deepmerge: "npm:^4.2.2"
     eth-ens-namehash: "npm:^2.0.8"
@@ -5356,7 +5356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^9.0.1, bignumber.js@npm:^9.1.2":
+"bignumber.js@npm:^9.0.1":
   version: 9.1.2
   resolution: "bignumber.js@npm:9.1.2"
   checksum: 10/d89b8800a987225d2c00dcbf8a69dc08e92aa0880157c851c287b307d31ceb2fc2acb0c62c3e3a3d42b6c5fcae9b004035f13eb4386e56d529d7edac18d5c9d8

--- a/yarn.lock
+++ b/yarn.lock
@@ -2339,6 +2339,7 @@ __metadata:
     "@spruceid/siwe-parser": "npm:2.1.0"
     "@types/bn.js": "npm:^5.1.5"
     "@types/jest": "npm:^27.4.1"
+    bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     deepmerge: "npm:^4.2.2"
     eth-ens-namehash: "npm:^2.0.8"
@@ -5355,7 +5356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^9.0.1":
+"bignumber.js@npm:^9.0.1, bignumber.js@npm:^9.1.2":
   version: 9.1.2
   resolution: "bignumber.js@npm:9.1.2"
   checksum: 10/d89b8800a987225d2c00dcbf8a69dc08e92aa0880157c851c287b307d31ceb2fc2acb0c62c3e3a3d42b6c5fcae9b004035f13eb4386e56d529d7edac18d5c9d8
@@ -6392,7 +6393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.5.4, elliptic@npm:^6.5.7":
+"elliptic@npm:^6.5.7":
   version: 6.5.7
   resolution: "elliptic@npm:6.5.7"
   dependencies:
@@ -10073,6 +10074,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-addon-api@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "node-addon-api@npm:5.1.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10/595f59ffb4630564f587c502119cbd980d302e482781021f3b479f5fc7e41cf8f2f7280fdc2795f32d148e4f3259bd15043c52d4a3442796aa6f1ae97b959636
+  languageName: node
+  linkType: hard
+
 "node-fetch@npm:^2.6.1":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
@@ -11199,14 +11209,14 @@ __metadata:
   linkType: hard
 
 "secp256k1@npm:^4.0.0, secp256k1@npm:^4.0.1":
-  version: 4.0.3
-  resolution: "secp256k1@npm:4.0.3"
+  version: 4.0.4
+  resolution: "secp256k1@npm:4.0.4"
   dependencies:
-    elliptic: "npm:^6.5.4"
-    node-addon-api: "npm:^2.0.0"
+    elliptic: "npm:^6.5.7"
+    node-addon-api: "npm:^5.0.0"
     node-gyp: "npm:latest"
     node-gyp-build: "npm:^4.2.0"
-  checksum: 10/8b45820cd90fd2f95cc8fdb9bf8a71e572de09f2311911ae461a951ffa9e30c99186a129d0f1afeb380dd67eca0c10493f8a7513c39063fda015e99995088e3b
+  checksum: 10/45000f348c853df7c1e2b67c48efb062ae78c0620ab1a5cfb02fa20d3aad39c641f4e7a18b3de3b54a7c0cc1e0addeb8ecd9d88bc332e92df17a92b60c36122a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

The API for this part is equivalent between the two libraries. Allowing both eases migrations.

## References

### Related
- https://github.com/MetaMask/metamask-mobile/pull/11932

## Changelog

### `@metamask/controller-utils`

- **ADDED**: Types indicate `bignumber.js` instances are valid input to `BNToHex`.


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
