### PR TITLE
Loosen get adapter param types

### DIFF
--- a/packages/multichain/src/adapters/caip-permission-adapter-eth-accounts.test.ts
+++ b/packages/multichain/src/adapters/caip-permission-adapter-eth-accounts.test.ts
@@ -49,7 +49,6 @@ describe('CAIP-25 eth_accounts adapters', () => {
             accounts: ['wallet:eip155:0x5'],
           },
         },
-        isMultichainOrigin: false,
       });
 
       expect(ethAccounts).toStrictEqual([

--- a/packages/multichain/src/adapters/caip-permission-adapter-eth-accounts.ts
+++ b/packages/multichain/src/adapters/caip-permission-adapter-eth-accounts.ts
@@ -19,7 +19,12 @@ const isEip155ScopeString = (scopeString: ScopeString) => {
   );
 };
 
-export const getEthAccounts = (caip25CaveatValue: Caip25CaveatValue) => {
+export const getEthAccounts = (
+  caip25CaveatValue: Pick<
+    Caip25CaveatValue,
+    'requiredScopes' | 'optionalScopes'
+  >,
+) => {
   const ethAccounts: string[] = [];
   const sessionScopes = mergeScopes(
     caip25CaveatValue.requiredScopes,

--- a/packages/multichain/src/adapters/caip-permission-adapter-permittedChains.test.ts
+++ b/packages/multichain/src/adapters/caip-permission-adapter-permittedChains.test.ts
@@ -46,7 +46,6 @@ describe('CAIP-25 permittedChains adapters', () => {
             accounts: ['eip155:100:0x100'],
           },
         },
-        isMultichainOrigin: false,
       });
 
       expect(ethChainIds).toStrictEqual(['0x1', '0x5', '0xa', '0x64']);

--- a/packages/multichain/src/adapters/caip-permission-adapter-permittedChains.ts
+++ b/packages/multichain/src/adapters/caip-permission-adapter-permittedChains.ts
@@ -13,7 +13,10 @@ import {
 } from '../scope/types';
 
 export const getPermittedEthChainIds = (
-  caip25CaveatValue: Caip25CaveatValue,
+  caip25CaveatValue: Pick<
+    Caip25CaveatValue,
+    'requiredScopes' | 'optionalScopes'
+  >,
 ) => {
   const ethChainIds: Hex[] = [];
   const sessionScopes = mergeScopes(


### PR DESCRIPTION
## Explanation

Loosen `getEthAccounts` and `getPermittedEthChainIds` param type

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
