### PR TITLE
fix: add publish event in `deleteNotificationsById` and export snap types

### DIFF
--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -1229,6 +1229,11 @@ export default class NotificationServicesController extends BaseController<
     for (const id of ids) {
       await this.deleteNotificationById(id);
     }
+
+    this.messagingSystem.publish(
+      `${controllerName}:notificationsListUpdated`,
+      this.state.metamaskNotificationsList,
+    );
   }
 
   /**

--- a/packages/notification-services-controller/src/NotificationServicesController/types/index.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/types/index.ts
@@ -2,3 +2,4 @@ export * from './feature-announcement';
 export * from './notification';
 export * from './on-chain-notification';
 export * from './user-storage';
+export * from './snaps/snaps';


### PR DESCRIPTION
## Explanation

* What is the current state of things and why does it need to change? The `deleteNotificationsById` doesn't fire an event with the updated list of notifications and thus, the `updateBadge` function inside the extension is not fired.
* What is the solution your changes offer and how does it work? Publish an event after notifications are deleted
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain? Adding export for snap types, not able to pull the type out directly otherwise.

### `@metamask/notification-services-controller`

- **FIX**: The `deleteNotificationsById` function did not fire an event with the updated notifications list, this was added after the function runs through all the notifications it needs to delete.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
