### PR TITLE
feat: update currency rate controller polling input

### DIFF
--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -155,7 +155,7 @@ describe('CurrencyRateController', () => {
       messenger,
     });
 
-    controller.startPolling({ networkClientId: 'mainnet' });
+    controller.startPolling({ nativeCurrency: 'ETH' });
     await advanceTime({ clock, duration: 0 });
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
     expect(controller.state.currencyRates).toStrictEqual({
@@ -192,7 +192,7 @@ describe('CurrencyRateController', () => {
       messenger,
     });
 
-    controller.startPolling({ networkClientId: 'sepolia' });
+    controller.startPolling({ nativeCurrency: 'ETH' });
 
     await advanceTime({ clock, duration: 0 });
 
@@ -217,7 +217,7 @@ describe('CurrencyRateController', () => {
       fetchExchangeRate: fetchExchangeRateStub,
       messenger,
     });
-    controller.startPolling({ networkClientId: 'sepolia' });
+    controller.startPolling({ nativeCurrency: 'ETH' });
     await advanceTime({ clock, duration: 0 });
 
     controller.stopAllPolling();
@@ -225,7 +225,7 @@ describe('CurrencyRateController', () => {
     // called once upon initial start
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
 
-    controller.startPolling({ networkClientId: 'sepolia' });
+    controller.startPolling({ nativeCurrency: 'ETH' });
     await advanceTime({ clock, duration: 0 });
 
     expect(fetchExchangeRateStub).toHaveBeenCalledTimes(2);

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -7,10 +7,7 @@ import {
   TESTNET_TICKER_SYMBOLS,
   FALL_BACK_VS_CURRENCY,
 } from '@metamask/controller-utils';
-import type {
-  NetworkClientId,
-  NetworkControllerGetNetworkClientByIdAction,
-} from '@metamask/network-controller';
+import type { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
 import { StaticIntervalPollingController } from '@metamask/polling-controller';
 import { Mutex } from 'async-mutex';
 
@@ -80,7 +77,7 @@ const defaultState = {
 
 /** The input to start polling for the {@link CurrencyRateController} */
 type CurrencyRatePollingInput = {
-  networkClientId: NetworkClientId;
+  nativeCurrency: string;
 };
 
 /**
@@ -243,16 +240,12 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
    * Updates exchange rate for the current currency.
    *
    * @param input - The input for the poll.
-   * @param input.networkClientId - The network client ID used to get a ticker value.
+   * @param input.nativeCurrency - The native currency symbol to poll prices for.
    */
   async _executePoll({
-    networkClientId,
+    nativeCurrency,
   }: CurrencyRatePollingInput): Promise<void> {
-    const networkClient = this.messagingSystem.call(
-      'NetworkController:getNetworkClientById',
-      networkClientId,
-    );
-    await this.updateExchangeRate(networkClient.configuration.ticker);
+    await this.updateExchangeRate(nativeCurrency);
   }
 }
 


### PR DESCRIPTION
## Explanation

Prepares the currency rate controller to be polled across chains.  We want a unique polling loop for each unique native currency (e.g. ETH, BNB).  Rather than for each network client id.  So this PR updates the polling input.

## References

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **BREAKING**: The `CurrencyRateController` polling input is now `{nativeCurrency: string}` instead of a network client id.

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
