### PR TITLE
feat(controller-utils): support bn.js v4 input to BN functions

### DIFF
--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -53,7 +53,9 @@
     "@metamask/utils": "^10.0.0",
     "@spruceid/siwe-parser": "2.1.0",
     "@types/bn.js": "^5.1.5",
+    "@types/bnjs4": "npm:@types/bn.js@^4.11.6",
     "bn.js": "^5.2.1",
+    "bnjs4": "npm:bn.js@^4.12.0",
     "eth-ens-namehash": "^2.0.8",
     "fast-deep-equal": "^3.1.3"
   },

--- a/packages/controller-utils/src/util.test.ts
+++ b/packages/controller-utils/src/util.test.ts
@@ -1,6 +1,7 @@
 import EthQuery from '@metamask/eth-query';
 import BigNumber from 'bignumber.js';
 import BN from 'bn.js';
+import BN4 from 'bnjs4';
 import nock from 'nock';
 
 import { FakeProvider } from '../../../tests/fake-provider';
@@ -32,11 +33,27 @@ describe('util', () => {
 
   it('bNToHex', () => {
     expect(util.BNToHex(new BN('1337'))).toBe('0x539');
+    expect(util.BNToHex(new BN4('1337'))).toBe('0x539');
     expect(util.BNToHex(new BigNumber('1337'))).toBe('0x539');
   });
 
   it('fractionBN', () => {
     expect(util.fractionBN(new BN('1337'), 9, 10).toNumber()).toBe(1203);
+    expect(util.fractionBN(new BN4('1337'), 9, 10).toNumber()).toBe(1203);
+    // Ensure return values use the same bn.js implementation as input by detection using non-typed API
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    expect(
+      (util.fractionBN(new BN4('1337'), 9, 10) as any)._strip,
+    ).toBeUndefined();
+    expect(
+      (util.fractionBN(new BN4('1337'), 9, 10) as any).strip,
+    ).toBeDefined();
+    expect(
+      (util.fractionBN(new BN('1337'), 9, 10) as any)._strip,
+    ).toBeDefined();
+    expect(
+      (util.fractionBN(new BN('1337'), 9, 10) as any).strip,
+    ).toBeUndefined();
   });
 
   it('getBuyURL', () => {

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -70,10 +70,12 @@ export function isSafeChainId(chainId: Hex): boolean {
  */
 // TODO: Either fix this lint violation or explain why it's necessary to ignore.
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function BNToHex(inputBn: BN | BN4 | BigNumber) {
+export function BNToHex(inputBn: BN | BN4 | BigNumber): string {
   return add0x(inputBn.toString(16));
 }
 
+function getBNImplementation(targetBN: BN4): typeof BN4;
+function getBNImplementation(targetBN: BN): typeof BN;
 /**
  * Return the bn.js library responsible for the BN in question
  * @param targetBN - A BN instance
@@ -83,6 +85,16 @@ function getBNImplementation(targetBN: BN | BN4): typeof BN4 | typeof BN {
   return Object.keys(targetBN).includes('_strip') ? BN4 : BN;
 }
 
+export function fractionBN(
+  targetBN: BN,
+  numerator: number | string,
+  denominator: number | string,
+): BN;
+export function fractionBN(
+  targetBN: BN4,
+  numerator: number | string,
+  denominator: number | string,
+): BN4;
 /**
  * Used to multiply a BN by a fraction.
  *
@@ -95,13 +107,13 @@ export function fractionBN(
   targetBN: BN | BN4,
   numerator: number | string,
   denominator: number | string,
-) {
+): BN | BN4 {
+  // @ts-expect-error - Signature overload confusion
   const BNImplementation = getBNImplementation(targetBN);
 
-  // @ts-expect-error - Incompatible constructor signatures are actually compatible here
   const numBN = new BNImplementation(numerator);
-  // @ts-expect-error - Incompatible constructor signatures are actually compatible here
   const denomBN = new BNImplementation(denominator);
+  // @ts-expect-error - BNImplementation gets unexpected typed
   return targetBN.mul(numBN).div(denomBN);
 }
 
@@ -206,6 +218,8 @@ export function hexToText(hex: string) {
   }
 }
 
+export function fromHex(value: string | BN): BN;
+export function fromHex(value: BN4): BN4;
 /**
  * Parses a hex string and converts it into a number that can be operated on in a bignum-safe,
  * base-10 way.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2338,9 +2338,11 @@ __metadata:
     "@metamask/utils": "npm:^10.0.0"
     "@spruceid/siwe-parser": "npm:2.1.0"
     "@types/bn.js": "npm:^5.1.5"
+    "@types/bnjs4": "npm:@types/bn.js@^4.11.6"
     "@types/jest": "npm:^27.4.1"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
+    bnjs4: "npm:bn.js@^4.12.0"
     deepmerge: "npm:^4.2.2"
     eth-ens-namehash: "npm:^2.0.8"
     fast-deep-equal: "npm:^3.1.3"
@@ -4331,6 +4333,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/bnjs4@npm:@types/bn.js@^4.11.6":
+  version: 4.11.6
+  resolution: "@types/bn.js@npm:4.11.6"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/9ff3e7a1539a953c381c0d30ea2049162e3cab894cda91ee10f3a84d603f9afa2b2bc2a38fe9b427de94b6e2b7b77aefd217c1c7b07a10ae8d7499f9d6697a41
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.1.7":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
@@ -5419,7 +5430,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.11.9":
+"bn.js@npm:^4.11.9, bnjs4@npm:bn.js@^4.12.0":
   version: 4.12.0
   resolution: "bn.js@npm:4.12.0"
   checksum: 10/10f8db196d3da5adfc3207d35d0a42aa29033eb33685f20ba2c36cadfe2de63dad05df0a20ab5aae01b418d1c4b3d4d205273085262fa020d17e93ff32b67527


### PR DESCRIPTION
## Explanation

- Extend types to indicate support for passing in bn.js v4 instances to BN.js utility functions
  - Affected functions:
    - `BNToHex`
    - `fractionBN`
    - `fromHex`
    - `toHex`
  - If input is v4 instance, return as v4. Otherwise use v5, as previously.
  - `fractionBN` now uses the original BN implementation when passed a v4 BN instance
- Use [overload signatures](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) to more specifically type BN-related util functions


## References

- Context: https://github.com/MetaMask/metamask-mobile/pull/11972
  - Note that these functions are _already_ used with v4 input but this was not caught due to the way `bn.js` is imported downstream. Making this support explicit facilitates resolving the type issue without requiring a prior full migration off bn.js v4 or resorting to peppering ts-expect-errors all over.
- #4827
- https://github.com/ethereumjs/ethereumjs-util/issues/250

## Changelog

### `@metamask/controller-utils`

- **CHANGED**: The following functions now accept input from `bn.js` v4 library:
    - `BNToHex`
    - `fractionBN`
    - `fromHex`
    - `toHex`
- **FIXED**: `fractionToBN` now returns output using the same `bn.js` library version that created the input


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
