### PR TITLE
feat: use crypto compare multi api for currency rate controller

### DIFF
--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -118,46 +118,50 @@ describe('CurrencyRateController', () => {
   });
 
   it('should not poll before being started', async () => {
-    const fetchExchangeRateStub = jest.fn();
+    const fetchMultiExchangeRateStub = jest.fn();
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 100,
-      fetchExchangeRate: fetchExchangeRateStub,
+      fetchMultiExchangeRate: fetchMultiExchangeRateStub,
       messenger,
     });
 
     await advanceTime({ clock, duration: 200 });
 
-    expect(fetchExchangeRateStub).not.toHaveBeenCalled();
+    expect(fetchMultiExchangeRateStub).not.toHaveBeenCalled();
 
     controller.destroy();
   });
 
   it('should poll and update state in the right interval', async () => {
+    const currentCurrency = 'cad';
+
     jest
       .spyOn(global.Date, 'now')
       .mockReturnValueOnce(10000)
       .mockReturnValueOnce(20000);
-    const fetchExchangeRateStub = jest
+    const fetchMultiExchangeRateStub = jest
       .fn()
       .mockResolvedValueOnce({
-        conversionRate: 1,
-        usdConversionRate: 11,
+        eth: { [currentCurrency]: 1, usd: 11 },
       })
       .mockResolvedValueOnce({
-        conversionRate: 2,
-        usdConversionRate: 22,
+        eth: {
+          [currentCurrency]: 2,
+          usd: 22,
+        },
       });
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 100,
-      fetchExchangeRate: fetchExchangeRateStub,
+      fetchMultiExchangeRate: fetchMultiExchangeRateStub,
       messenger,
+      state: { currentCurrency },
     });
 
-    controller.startPolling({ nativeCurrency: 'ETH' });
+    controller.startPolling({ nativeCurrencies: ['ETH'] });
     await advanceTime({ clock, duration: 0 });
-    expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
+    expect(fetchMultiExchangeRateStub).toHaveBeenCalledTimes(1);
     expect(controller.state.currencyRates).toStrictEqual({
       ETH: {
         conversionDate: 10,
@@ -167,11 +171,11 @@ describe('CurrencyRateController', () => {
     });
     await advanceTime({ clock, duration: 99 });
 
-    expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
+    expect(fetchMultiExchangeRateStub).toHaveBeenCalledTimes(1);
 
     await advanceTime({ clock, duration: 1 });
 
-    expect(fetchExchangeRateStub).toHaveBeenCalledTimes(2);
+    expect(fetchMultiExchangeRateStub).toHaveBeenCalledTimes(2);
     expect(controller.state.currencyRates).toStrictEqual({
       ETH: {
         conversionDate: 20,
@@ -184,67 +188,70 @@ describe('CurrencyRateController', () => {
   });
 
   it('should not poll after being stopped', async () => {
-    const fetchExchangeRateStub = jest.fn();
+    const fetchMultiExchangeRateStub = jest.fn();
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 100,
-      fetchExchangeRate: fetchExchangeRateStub,
+      fetchMultiExchangeRate: fetchMultiExchangeRateStub,
       messenger,
     });
 
-    controller.startPolling({ nativeCurrency: 'ETH' });
+    controller.startPolling({ nativeCurrencies: ['ETH'] });
 
     await advanceTime({ clock, duration: 0 });
 
     controller.stopAllPolling();
 
     // called once upon initial start
-    expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
+    expect(fetchMultiExchangeRateStub).toHaveBeenCalledTimes(1);
 
     await advanceTime({ clock, duration: 150, stepSize: 50 });
 
-    expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
+    expect(fetchMultiExchangeRateStub).toHaveBeenCalledTimes(1);
 
     controller.destroy();
   });
 
   it('should poll correctly after being started, stopped, and started again', async () => {
-    const fetchExchangeRateStub = jest.fn();
+    const fetchMultiExchangeRateStub = jest.fn();
 
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 100,
-      fetchExchangeRate: fetchExchangeRateStub,
+      fetchMultiExchangeRate: fetchMultiExchangeRateStub,
       messenger,
     });
-    controller.startPolling({ nativeCurrency: 'ETH' });
+    controller.startPolling({ nativeCurrencies: ['ETH'] });
     await advanceTime({ clock, duration: 0 });
 
     controller.stopAllPolling();
 
     // called once upon initial start
-    expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
+    expect(fetchMultiExchangeRateStub).toHaveBeenCalledTimes(1);
 
-    controller.startPolling({ nativeCurrency: 'ETH' });
+    controller.startPolling({ nativeCurrencies: ['ETH'] });
     await advanceTime({ clock, duration: 0 });
 
-    expect(fetchExchangeRateStub).toHaveBeenCalledTimes(2);
+    expect(fetchMultiExchangeRateStub).toHaveBeenCalledTimes(2);
 
     await advanceTime({ clock, duration: 100 });
 
-    expect(fetchExchangeRateStub).toHaveBeenCalledTimes(3);
+    expect(fetchMultiExchangeRateStub).toHaveBeenCalledTimes(3);
   });
 
   it('should update exchange rate', async () => {
+    const currentCurrency = 'cad';
+
     jest.spyOn(global.Date, 'now').mockImplementation(() => getStubbedDate());
-    const fetchExchangeRateStub = jest
+    const fetchMultiExchangeRateStub = jest
       .fn()
-      .mockResolvedValue({ conversionRate: 10, usdConversionRate: 111 });
+      .mockResolvedValue({ eth: { [currentCurrency]: 10, usd: 111 } });
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 10,
-      fetchExchangeRate: fetchExchangeRateStub,
+      fetchMultiExchangeRate: fetchMultiExchangeRateStub,
       messenger,
+      state: { currentCurrency },
     });
 
     expect(controller.state.currencyRates).toStrictEqual({
@@ -255,7 +262,7 @@ describe('CurrencyRateController', () => {
       },
     });
 
-    await controller.updateExchangeRate('ETH');
+    await controller.updateExchangeRate(['ETH']);
 
     expect(controller.state.currencyRates).toStrictEqual({
       ETH: {
@@ -269,25 +276,33 @@ describe('CurrencyRateController', () => {
   });
 
   it('should use the exchange rate for ETH when native currency is testnet ETH', async () => {
+    const currentCurrency = 'cad';
+
     jest.spyOn(global.Date, 'now').mockImplementation(() => getStubbedDate());
-    const fetchExchangeRateStub = jest
+    const fetchMultiExchangeRateStub = jest
       .fn()
-      .mockImplementation((_, nativeCurrency) => {
+      .mockImplementation((_, cryptocurrencies) => {
+        const nativeCurrency = cryptocurrencies[0];
         if (nativeCurrency === 'ETH') {
           return {
-            conversionRate: 10,
-            usdConversionRate: 110,
+            [nativeCurrency.toLowerCase()]: {
+              [currentCurrency.toLowerCase()]: 10,
+              usd: 110,
+            },
           };
         }
         return {
-          conversionRate: 0,
-          usdConversionRate: 100,
+          [nativeCurrency.toLowerCase()]: {
+            [currentCurrency.toLowerCase()]: 0,
+            usd: 100,
+          },
         };
       });
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
-      fetchExchangeRate: fetchExchangeRateStub,
+      fetchMultiExchangeRate: fetchMultiExchangeRateStub,
       messenger,
+      state: { currentCurrency },
     });
 
     expect(controller.state.currencyRates).toStrictEqual({
@@ -298,7 +313,7 @@ describe('CurrencyRateController', () => {
       },
     });
 
-    await controller.updateExchangeRate('SepoliaETH');
+    await controller.updateExchangeRate(['SepoliaETH']);
 
     expect(controller.state.currencyRates).toStrictEqual({
       ETH: {
@@ -317,14 +332,16 @@ describe('CurrencyRateController', () => {
   });
 
   it('should update current currency then clear and refetch rates', async () => {
+    const currentCurrency = 'cad';
     jest.spyOn(global.Date, 'now').mockImplementation(() => getStubbedDate());
-    const fetchExchangeRateStub = jest
-      .fn()
-      .mockResolvedValue({ conversionRate: 10, usdConversionRate: 11 });
+    const fetchMultiExchangeRateStub = jest.fn().mockResolvedValue({
+      eth: { [currentCurrency]: 10, usd: 11 },
+      btc: { [currentCurrency]: 10, usd: 11 },
+    });
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 10,
-      fetchExchangeRate: fetchExchangeRateStub,
+      fetchMultiExchangeRate: fetchMultiExchangeRateStub,
       messenger,
       state: {
         currencyRates: {
@@ -342,10 +359,10 @@ describe('CurrencyRateController', () => {
       },
     });
 
-    await controller.setCurrentCurrency('CAD');
+    await controller.setCurrentCurrency(currentCurrency);
 
     expect(controller.state).toStrictEqual({
-      currentCurrency: 'CAD',
+      currentCurrency,
       currencyRates: {
         ETH: {
           conversionDate: 0,
@@ -358,7 +375,7 @@ describe('CurrencyRateController', () => {
     await advanceTime({ clock, duration: 0 });
 
     expect(controller.state).toStrictEqual({
-      currentCurrency: 'CAD',
+      currentCurrency,
       currencyRates: {
         ETH: {
           conversionDate: getStubbedDate() / 1000,
@@ -377,19 +394,19 @@ describe('CurrencyRateController', () => {
   });
 
   it('should add usd rate to state when includeUsdRate is configured true', async () => {
-    const fetchExchangeRateStub = jest.fn().mockResolvedValue({});
+    const fetchMultiExchangeRateStub = jest.fn().mockResolvedValue({});
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       includeUsdRate: true,
-      fetchExchangeRate: fetchExchangeRateStub,
+      fetchMultiExchangeRate: fetchMultiExchangeRateStub,
       messenger,
       state: { currentCurrency: 'xyz' },
     });
-    await controller.updateExchangeRate('SepoliaETH');
+    await controller.updateExchangeRate(['SepoliaETH']);
 
-    expect(fetchExchangeRateStub).toHaveBeenCalledTimes(1);
-    expect(fetchExchangeRateStub.mock.calls).toMatchObject([
-      ['xyz', 'ETH', true],
+    expect(fetchMultiExchangeRateStub).toHaveBeenCalledTimes(1);
+    expect(fetchMultiExchangeRateStub.mock.calls).toMatchObject([
+      ['xyz', ['ETH'], true],
     ]);
 
     controller.destroy();
@@ -399,8 +416,8 @@ describe('CurrencyRateController', () => {
     jest.spyOn(global.Date, 'now').mockImplementation(() => getStubbedDate());
     const cryptoCompareHost = 'https://min-api.cryptocompare.com';
     nock(cryptoCompareHost)
-      .get('/data/price?fsym=ETH&tsyms=XYZ')
-      .reply(200, { XYZ: 2000.42 })
+      .get('/data/pricemulti?fsyms=ETH&tsyms=xyz')
+      .reply(200, { ETH: { XYZ: 2000.42 } })
       .persist();
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
@@ -408,7 +425,7 @@ describe('CurrencyRateController', () => {
       state: { currentCurrency: 'xyz' },
     });
 
-    await controller.updateExchangeRate('ETH');
+    await controller.updateExchangeRate(['ETH']);
 
     expect(controller.state).toStrictEqual({
       currentCurrency: 'xyz',
@@ -416,7 +433,7 @@ describe('CurrencyRateController', () => {
         ETH: {
           conversionDate: getStubbedDate() / 1000,
           conversionRate: 2000.42,
-          usdConversionRate: NaN,
+          usdConversionRate: undefined,
         },
       },
     });
@@ -427,7 +444,7 @@ describe('CurrencyRateController', () => {
   it('should throw unexpected errors', async () => {
     const cryptoCompareHost = 'https://min-api.cryptocompare.com';
     nock(cryptoCompareHost)
-      .get('/data/price?fsym=ETH&tsyms=XYZ')
+      .get('/data/pricemulti?fsyms=ETH&tsyms=xyz')
       .reply(200, {
         Response: 'Error',
         Message: 'this method has been deprecated',
@@ -440,41 +457,9 @@ describe('CurrencyRateController', () => {
       state: { currentCurrency: 'xyz' },
     });
 
-    await expect(controller.updateExchangeRate('ETH')).rejects.toThrow(
+    await expect(controller.updateExchangeRate(['ETH'])).rejects.toThrow(
       'this method has been deprecated',
     );
-
-    controller.destroy();
-  });
-
-  it('should catch expected errors', async () => {
-    const cryptoCompareHost = 'https://min-api.cryptocompare.com';
-    nock(cryptoCompareHost)
-      .get('/data/price?fsym=ETH&tsyms=XYZ')
-      .reply(200, {
-        Response: 'Error',
-        Message: 'market does not exist for this coin pair',
-      })
-      .persist();
-
-    const messenger = getRestrictedMessenger();
-    const controller = new CurrencyRateController({
-      messenger,
-      state: { currentCurrency: 'xyz' },
-    });
-
-    await controller.updateExchangeRate('ETH');
-
-    expect(controller.state).toStrictEqual({
-      currentCurrency: 'xyz',
-      currencyRates: {
-        ETH: {
-          conversionDate: null,
-          conversionRate: null,
-          usdConversionRate: null,
-        },
-      },
-    });
 
     controller.destroy();
   });
@@ -482,7 +467,7 @@ describe('CurrencyRateController', () => {
   it('should not update state on unexpected / transient errors', async () => {
     const cryptoCompareHost = 'https://min-api.cryptocompare.com';
     nock(cryptoCompareHost)
-      .get('/data/price?fsym=ETH&tsyms=XYZ')
+      .get('/data/pricemulti?fsyms=ETH&tsyms=xyz')
       .reply(500) // HTTP 500 transient error
       .persist();
 
@@ -500,12 +485,56 @@ describe('CurrencyRateController', () => {
     const controller = new CurrencyRateController({ messenger, state });
 
     // Error should still be thrown
-    await expect(controller.updateExchangeRate('ETH')).rejects.toThrow(
-      `Fetch failed with status '500' for request 'https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=XYZ'`,
+    await expect(controller.updateExchangeRate(['ETH'])).rejects.toThrow(
+      `Fetch failed with status '500' for request 'https://min-api.cryptocompare.com/data/pricemulti?fsyms=ETH&tsyms=xyz'`,
     );
 
     // But state should not be changed
     expect(controller.state).toStrictEqual(state);
+
+    controller.destroy();
+  });
+
+  it('fetches exchange rates for multiple native currencies', async () => {
+    jest.spyOn(global.Date, 'now').mockImplementation(() => getStubbedDate());
+    const cryptoCompareHost = 'https://min-api.cryptocompare.com';
+    nock(cryptoCompareHost)
+      .get('/data/pricemulti?fsyms=ETH,POL,BNB&tsyms=xyz')
+      .reply(200, {
+        BNB: { XYZ: 500.1 },
+        ETH: { XYZ: 4000.42 },
+        POL: { XYZ: 0.3 },
+      })
+      .persist();
+    const messenger = getRestrictedMessenger();
+    const controller = new CurrencyRateController({
+      messenger,
+      state: { currentCurrency: 'xyz' },
+    });
+
+    await controller.updateExchangeRate(['ETH', 'POL', 'BNB']);
+
+    const conversionDate = getStubbedDate() / 1000;
+    expect(controller.state).toStrictEqual({
+      currentCurrency: 'xyz',
+      currencyRates: {
+        BNB: {
+          conversionDate,
+          conversionRate: 500.1,
+          usdConversionRate: undefined,
+        },
+        ETH: {
+          conversionDate,
+          conversionRate: 4000.42,
+          usdConversionRate: undefined,
+        },
+        POL: {
+          conversionDate,
+          conversionRate: 0.3,
+          usdConversionRate: undefined,
+        },
+      },
+    });
 
     controller.destroy();
   });

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -433,7 +433,7 @@ describe('CurrencyRateController', () => {
         ETH: {
           conversionDate: getStubbedDate() / 1000,
           conversionRate: 2000.42,
-          usdConversionRate: undefined,
+          usdConversionRate: null,
         },
       },
     });
@@ -521,17 +521,17 @@ describe('CurrencyRateController', () => {
         BNB: {
           conversionDate,
           conversionRate: 500.1,
-          usdConversionRate: undefined,
+          usdConversionRate: null,
         },
         ETH: {
           conversionDate,
           conversionRate: 4000.42,
-          usdConversionRate: undefined,
+          usdConversionRate: null,
         },
         POL: {
           conversionDate,
           conversionRate: 0.3,
-          usdConversionRate: undefined,
+          usdConversionRate: null,
         },
       },
     });

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -184,13 +184,11 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
       const rates = Object.entries(nativeCurrenciesToFetch).reduce(
         (acc, [nativeCurrency, fetchedCurrency]) => {
           const rate = fetchExchangeRateResponse[fetchedCurrency.toLowerCase()];
-          if (rate) {
-            acc[nativeCurrency] = {
-              conversionDate: Date.now() / 1000,
-              conversionRate: rate[currentCurrency.toLowerCase()],
-              usdConversionRate: rate.usd,
-            };
-          }
+          acc[nativeCurrency] = {
+            conversionDate: rate !== undefined ? Date.now() / 1000 : null,
+            conversionRate: rate?.[currentCurrency.toLowerCase()] ?? null,
+            usdConversionRate: rate?.usd ?? null,
+          };
           return acc;
         },
         {} as CurrencyRateState['currencyRates'],

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -165,7 +165,7 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
       // For preloaded testnets (Goerli, Sepolia) we want to fetch exchange rate for real ETH.
       // Map each native currency to the symbol we want to fetch for it.
       const testnetSymbols = Object.values(TESTNET_TICKER_SYMBOLS);
-      const nativeCurrenciesToFetch = [...new Set(nativeCurrencies)].reduce(
+      const nativeCurrenciesToFetch = nativeCurrencies.reduce(
         (acc, nativeCurrency) => {
           acc[nativeCurrency] = testnetSymbols.includes(nativeCurrency)
             ? FALL_BACK_VS_CURRENCY
@@ -177,7 +177,7 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
 
       const fetchExchangeRateResponse = await this.fetchMultiExchangeRate(
         currentCurrency,
-        Object.values(nativeCurrenciesToFetch),
+        [...new Set(Object.values(nativeCurrenciesToFetch))],
         this.includeUsdRate,
       );
 

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -11,7 +11,7 @@ import type { NetworkControllerGetNetworkClientByIdAction } from '@metamask/netw
 import { StaticIntervalPollingController } from '@metamask/polling-controller';
 import { Mutex } from 'async-mutex';
 
-import { fetchExchangeRate as defaultFetchExchangeRate } from './crypto-compare-service';
+import { fetchMultiExchangeRate as defaultFetchMultiExchangeRate } from './crypto-compare-service';
 
 /**
  * @type CurrencyRateState
@@ -77,7 +77,7 @@ const defaultState = {
 
 /** The input to start polling for the {@link CurrencyRateController} */
 type CurrencyRatePollingInput = {
-  nativeCurrency: string;
+  nativeCurrencies: string[];
 };
 
 /**
@@ -91,7 +91,7 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
 > {
   private readonly mutex = new Mutex();
 
-  private readonly fetchExchangeRate;
+  private readonly fetchMultiExchangeRate;
 
   private readonly includeUsdRate;
 
@@ -103,20 +103,20 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
    * @param options.interval - The polling interval, in milliseconds.
    * @param options.messenger - A reference to the messaging system.
    * @param options.state - Initial state to set on this controller.
-   * @param options.fetchExchangeRate - Fetches the exchange rate from an external API. This option is primarily meant for use in unit tests.
+   * @param options.fetchMultiExchangeRate - Fetches the exchange rate from an external API. This option is primarily meant for use in unit tests.
    */
   constructor({
     includeUsdRate = false,
     interval = 180000,
     messenger,
     state,
-    fetchExchangeRate = defaultFetchExchangeRate,
+    fetchMultiExchangeRate = defaultFetchMultiExchangeRate,
   }: {
     includeUsdRate?: boolean;
     interval?: number;
     messenger: CurrencyRateMessenger;
     state?: Partial<CurrencyRateState>;
-    fetchExchangeRate?: typeof defaultFetchExchangeRate;
+    fetchMultiExchangeRate?: typeof defaultFetchMultiExchangeRate;
   }) {
     super({
       name,
@@ -126,7 +126,7 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
     });
     this.includeUsdRate = includeUsdRate;
     this.setIntervalLength(interval);
-    this.fetchExchangeRate = fetchExchangeRate;
+    this.fetchMultiExchangeRate = fetchMultiExchangeRate;
   }
 
   /**
@@ -148,81 +148,65 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
       releaseLock();
     }
     // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    nativeCurrencies.forEach(this.updateExchangeRate.bind(this));
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.updateExchangeRate(nativeCurrencies);
   }
 
   /**
-   * Updates the exchange rate for the current currency and native currency pair.
+   * Updates the exchange rate for the current currency and native currency pairs.
    *
-   * @param nativeCurrency - The ticker symbol for the chain.
+   * @param nativeCurrencies - The native currency symbols to fetch exchange rates for.
    */
-  async updateExchangeRate(nativeCurrency: string): Promise<void> {
+  async updateExchangeRate(nativeCurrencies: string[]): Promise<void> {
     const releaseLock = await this.mutex.acquire();
-    const { currentCurrency, currencyRates } = this.state;
-
-    let conversionDate: number | null = null;
-    let conversionRate: number | null = null;
-    let usdConversionRate: number | null = null;
-
-    // For preloaded testnets (Goerli, Sepolia) we want to fetch exchange rate for real ETH.
-    const nativeCurrencyForExchangeRate = Object.values(
-      TESTNET_TICKER_SYMBOLS,
-    ).includes(nativeCurrency)
-      ? FALL_BACK_VS_CURRENCY // ETH
-      : nativeCurrency;
-
-    let shouldUpdateState = true;
     try {
-      if (
-        currentCurrency &&
-        nativeCurrency &&
-        // if either currency is an empty string we can skip the comparison
-        // because it will result in an error from the api and ultimately
-        // a null conversionRate either way.
-        currentCurrency !== '' &&
-        nativeCurrency !== ''
-      ) {
-        const fetchExchangeRateResponse = await this.fetchExchangeRate(
-          currentCurrency,
-          nativeCurrencyForExchangeRate,
-          this.includeUsdRate,
-        );
-        conversionRate = fetchExchangeRateResponse.conversionRate;
-        usdConversionRate = fetchExchangeRateResponse.usdConversionRate;
-        conversionDate = Date.now() / 1000;
-      }
-    } catch (error) {
-      if (
-        !(
-          error instanceof Error &&
-          error.message.includes('market does not exist for this coin pair')
-        )
-      ) {
-        // Don't update state on transient / unexpected errors
-        shouldUpdateState = false;
-        throw error;
-      }
-    } finally {
-      try {
-        if (shouldUpdateState) {
-          this.update(() => {
-            return {
-              currencyRates: {
-                ...currencyRates,
-                [nativeCurrency]: {
-                  conversionDate,
-                  conversionRate,
-                  usdConversionRate,
-                },
-              },
-              currentCurrency,
+      const { currentCurrency } = this.state;
+
+      // For preloaded testnets (Goerli, Sepolia) we want to fetch exchange rate for real ETH.
+      // Map each native currency to the symbol we want to fetch for it.
+      const testnetSymbols = Object.values(TESTNET_TICKER_SYMBOLS);
+      const nativeCurrenciesToFetch = [...new Set(nativeCurrencies)].reduce(
+        (acc, nativeCurrency) => {
+          acc[nativeCurrency] = testnetSymbols.includes(nativeCurrency)
+            ? FALL_BACK_VS_CURRENCY
+            : nativeCurrency;
+          return acc;
+        },
+        {} as Record<string, string>,
+      );
+
+      const fetchExchangeRateResponse = await this.fetchMultiExchangeRate(
+        currentCurrency,
+        Object.values(nativeCurrenciesToFetch),
+        this.includeUsdRate,
+      );
+
+      const rates = Object.entries(nativeCurrenciesToFetch).reduce(
+        (acc, [nativeCurrency, fetchedCurrency]) => {
+          const rate = fetchExchangeRateResponse[fetchedCurrency.toLowerCase()];
+          if (rate) {
+            acc[nativeCurrency] = {
+              conversionDate: Date.now() / 1000,
+              conversionRate: rate[currentCurrency.toLowerCase()],
+              usdConversionRate: rate.usd,
             };
-          });
-        }
-      } finally {
-        releaseLock();
-      }
+          }
+          return acc;
+        },
+        {} as CurrencyRateState['currencyRates'],
+      );
+
+      this.update((state) => {
+        state.currencyRates = {
+          ...state.currencyRates,
+          ...rates,
+        };
+      });
+    } catch (error) {
+      console.error('Failed to fetch exchange rates.', error);
+      throw error;
+    } finally {
+      releaseLock();
     }
   }
 
@@ -240,12 +224,12 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
    * Updates exchange rate for the current currency.
    *
    * @param input - The input for the poll.
-   * @param input.nativeCurrency - The native currency symbol to poll prices for.
+   * @param input.nativeCurrencies - The native currency symbols to poll prices for.
    */
   async _executePoll({
-    nativeCurrency,
+    nativeCurrencies,
   }: CurrencyRatePollingInput): Promise<void> {
-    await this.updateExchangeRate(nativeCurrency);
+    await this.updateExchangeRate(nativeCurrencies);
   }
 }
 

--- a/packages/assets-controllers/src/RatesController/RatesController.test.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.test.ts
@@ -119,7 +119,7 @@ describe('RatesController', () => {
       const publishActionSpy = jest.spyOn(messenger, 'publish');
 
       jest.spyOn(global.Date, 'now').mockImplementation(() => getStubbedDate());
-      const mockRateValue = '57715.42';
+      const mockRateValue = 57715.42;
       const fetchExchangeRateStub = jest.fn(() => {
         return Promise.resolve({
           btc: {
@@ -142,7 +142,7 @@ describe('RatesController', () => {
       expect(ratesPreUpdate).toStrictEqual({
         btc: {
           conversionDate: 0,
-          conversionRate: '0',
+          conversionRate: 0,
         },
       });
 
@@ -177,12 +177,12 @@ describe('RatesController', () => {
 
     it('starts the polling process with custom values', async () => {
       jest.spyOn(global.Date, 'now').mockImplementation(() => getStubbedDate());
-      const mockBtcUsdRateValue = '62235.48';
-      const mockSolUsdRateValue = '148.41';
-      const mockStrkUsdRateValue = '1.248';
-      const mockBtcEurRateValue = '57715.42';
-      const mockSolEurRateValue = '137.68';
-      const mockStrkEurRateValue = '1.157';
+      const mockBtcUsdRateValue = 62235.48;
+      const mockSolUsdRateValue = 148.41;
+      const mockStrkUsdRateValue = 1.248;
+      const mockBtcEurRateValue = 57715.42;
+      const mockSolEurRateValue = 137.68;
+      const mockStrkEurRateValue = 1.157;
       const fetchExchangeRateStub = jest.fn(() => {
         return Promise.resolve({
           btc: {

--- a/packages/assets-controllers/src/RatesController/RatesController.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.ts
@@ -29,7 +29,7 @@ const defaultState = {
   rates: {
     [Cryptocurrency.Btc]: {
       conversionDate: 0,
-      conversionRate: '0',
+      conversionRate: 0,
     },
   },
   cryptocurrencies: [Cryptocurrency.Btc],
@@ -119,7 +119,7 @@ export class RatesController extends BaseController<
       const { fiatCurrency, cryptocurrencies } = this.state;
       const response: Record<
         Cryptocurrency,
-        Record<string, string>
+        Record<string, number>
       > = await this.#fetchMultiExchangeRate(
         fiatCurrency,
         cryptocurrencies,

--- a/packages/assets-controllers/src/RatesController/types.ts
+++ b/packages/assets-controllers/src/RatesController/types.ts
@@ -12,17 +12,16 @@ import type {
 
 /**
  * Represents the conversion rates from one currency to others, including the conversion date.
- * The `conversionRate` field is a string that maps a cryptocurrency code (e.g., "BTC") to its
- * conversion rate. For this field we use string as the data type to avoid potential rounding
- * errors and precision loss.
- * The `usdConversionRate` provides the conversion rate to USD as a string, or `null` if the
- * conversion rate to USD is not available. We also use string for the same reason as stated before.
+ * The `conversionRate` field is a number that maps a cryptocurrency code (e.g., "BTC") to its
+ * conversion rate.
+ * The `usdConversionRate` provides the conversion rate to USD as a number, or `null` if the
+ * conversion rate to USD is not available.
  * The `conversionDate` is a Unix timestamp (number) indicating when the conversion rate was last updated.
  */
 export type Rate = {
-  conversionRate: string;
+  conversionRate: number;
   conversionDate: number;
-  usdConversionRate?: string;
+  usdConversionRate?: number;
 };
 
 /**

--- a/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
+++ b/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
@@ -38,29 +38,30 @@ function getPricingURL(
 
 /**
  * Get the CryptoCompare API URL for getting the conversion rate from a given array of native currencies
- * to the given currency. Optionally, the conversion rate from the native currency to USD can also be
+ * to the given currencies. Optionally, the conversion rate from the native currency to USD can also be
  * included in the response.
  *
  * @param fsyms - The native currencies to get conversion rates for.
- * @param tsyms - The currency to convert to.
+ * @param tsyms - The currencies to convert to.
  * @param includeUSDRate - Whether or not the native currency to USD conversion rate should be included.
  * @returns The API URL for getting the conversion rates.
  */
 function getMultiPricingURL(
-  fsyms: string,
-  tsyms: string,
+  fsyms: string[],
+  tsyms: string[],
   includeUSDRate = false,
 ) {
   const updatedTsyms =
-    includeUSDRate && !tsyms.includes('USD') ? `${tsyms},USD` : tsyms;
+    includeUSDRate && !tsyms.some((t) => t.toUpperCase() === 'USD')
+      ? [...tsyms, 'USD']
+      : tsyms;
 
   const params = new URLSearchParams();
-  params.append('fsyms', fsyms);
-  params.append('tsyms', updatedTsyms);
+  params.append('fsyms', fsyms.join(','));
+  params.append('tsyms', updatedTsyms.join(','));
 
   const url = new URL(`${CRYPTO_COMPARE_DOMAIN}/data/pricemulti`);
   url.search = params.toString();
-
   return url.toString();
 }
 
@@ -139,19 +140,19 @@ export async function fetchMultiExchangeRate(
   fiatCurrency: string,
   cryptocurrencies: string[],
   includeUSDRate: boolean,
-): Promise<Record<string, Record<string, string>>> {
+): Promise<Record<string, Record<string, number>>> {
   const url = getMultiPricingURL(
-    Object.values(cryptocurrencies).join(','),
-    fiatCurrency,
+    cryptocurrencies,
+    [fiatCurrency],
     includeUSDRate,
   );
   const response = await handleFetch(url);
   handleErrorResponse(response);
 
-  const rates: Record<string, Record<string, string>> = {};
+  const rates: Record<string, Record<string, number>> = {};
   for (const [cryptocurrency, values] of Object.entries(response) as [
     string,
-    Record<string, string>,
+    Record<string, number>,
   ][]) {
     rates[cryptocurrency.toLowerCase()] = {
       [fiatCurrency.toLowerCase()]: values[fiatCurrency.toUpperCase()],


### PR DESCRIPTION
## Explanation

Updates the currency rate controller to use the `pricemulti` endpoint of crypto compare.  This allows us to fetch exchange rates for multiple native currencies in a single http request.

## References


## Changelog


### `@metamask/assets-controllers`

- **BREAKING**: `CurrencyRateController` now accepts an array of native currencies as its polling input.
- **BREAKING**: `RatesController` now types the `conversionRate` and `usdConversionRate` in its state as `number` instead of `string`, to match what it was actually storing.


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
