### PR TITLE
chore: Move BigNumber.js to dependencies

### DIFF
--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -53,6 +53,7 @@
     "@metamask/utils": "^10.0.0",
     "@spruceid/siwe-parser": "2.1.0",
     "@types/bn.js": "^5.1.5",
+    "bignumber.js": "^9.1.2",
     "bn.js": "^5.2.1",
     "eth-ens-namehash": "^2.0.8",
     "fast-deep-equal": "^3.1.3"
@@ -60,7 +61,6 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@types/jest": "^27.4.1",
-    "bignumber.js": "^9.1.2",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "nock": "^13.3.1",


### PR DESCRIPTION
## Explanation

Since `bignumber.js` is used for typing in `controller-utils`, it should likely be a dependency to prevent issues when building with TS downstream.

There is probably a larger conversation to have here about when to use types as devDeps and when to use them as deps, but in our architecture today we rely heavily on all types to be included as dependencies. This causes a lot of potentially avoidable dependency management.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/controller-utils`

- **Fixed**: Move `bignumber.js` to dependencies

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
