### PR TITLE
feat: Update `PreferencesController` with `tokenNetworkFilter`

### DIFF
--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add tokenNetworkFilter to preferencesController state (default value: `{}`) ([#4875](https://github.com/MetaMask/core/pull/4875))
+- Add `tokenNetworkFilter` preference (default value: `{}`) ([#4875](https://github.com/MetaMask/core/pull/4875))
 - Add `useSafeChainsListValidation` preference ([#4860](https://github.com/MetaMask/core/pull/4860))
   - Add `useSafeChainsListValidation` property to the `PreferencesController` state (default: `true`)
   - Add `setUseSafeChainsListValidation` method to set this property

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add tokenNetworkFilter to preferencesController state TBD
+- Add tokenNetworkFilter to preferencesController state (default value: `{}`) ([#4875](https://github.com/MetaMask/core/pull/4875))
 
 ### Added
 

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add tokenNetworkFilter to preferencesController state TBD
+
 ### Added
 
 - Add `useSafeChainsListValidation` preference ([#4860](https://github.com/MetaMask/core/pull/4860))

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,10 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add tokenNetworkFilter to preferencesController state (default value: `{}`) ([#4875](https://github.com/MetaMask/core/pull/4875))
-
 ### Added
 
+- Add tokenNetworkFilter to preferencesController state (default value: `{}`) ([#4875](https://github.com/MetaMask/core/pull/4875))
 - Add `useSafeChainsListValidation` preference ([#4860](https://github.com/MetaMask/core/pull/4860))
   - Add `useSafeChainsListValidation` property to the `PreferencesController` state (default: `true`)
   - Add `setUseSafeChainsListValidation` method to set this property

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -129,6 +129,10 @@ export type PreferencesState = {
    */
   tokenSortConfig: TokenSortConfig;
   /**
+   * Controls which order tokens are sorted in
+   */
+  tokenNetworkFilter: Record<string, boolean>;
+  /**
    * Controls whether balance and assets are hidden or not
    */
   privacyMode: boolean;
@@ -153,6 +157,7 @@ const metadata = {
   useMultiRpcMigration: { persist: true, anonymous: true },
   useSafeChainsListValidation: { persist: true, anonymous: true },
   tokenSortConfig: { persist: true, anonymous: true },
+  tokenNetworkFilter: { persist: true, anonymous: true },
   privacyMode: { persist: true, anonymous: true },
 };
 
@@ -232,6 +237,7 @@ export function getDefaultPreferencesState(): PreferencesState {
       order: 'dsc',
       sortCallback: 'stringNumeric',
     },
+    tokenNetworkFilter: {},
     privacyMode: false,
   };
 }
@@ -561,6 +567,17 @@ export class PreferencesController extends BaseController<
   setTokenSortConfig(tokenSortConfig: TokenSortConfig) {
     this.update((state) => {
       state.tokenSortConfig = tokenSortConfig;
+    });
+  }
+
+  /**
+   * A setter to update the user's selected chains in the token network filter.
+   *
+   * @param tokenNetworkFilter - an representing which chains to include in the token network filter.
+   */
+  setTokenNetworkFilter(tokenNetworkFilter: Record<string, boolean>) {
+    this.update((state) => {
+      state.tokenNetworkFilter = tokenNetworkFilter;
     });
   }
 


### PR DESCRIPTION
## Explanation

Adds tokenNetworkFilter setting. Required for: https://github.com/MetaMask/metamask-mobile/pull/11808

## References

https://github.com/MetaMask/metamask-mobile/pull/11808

## Changelog

Adds `tokenNetworkFilter` with a default value of `{}` type `Record<string, boolean>`

### `@metamask/preferences-controller`

- **<PreferencesController>**: Updates controller with tokenNetworkFilter object, along with setters and types.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
