### PR TITLE
feat: Show Staked ETH position in mobile homepage along with other tokens

### DIFF
--- a/packages/assets-controllers/src/AccountTrackerController.test.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.test.ts
@@ -248,6 +248,123 @@ describe('AccountTrackerController', () => {
           },
         );
       });
+
+      it('should update staked balance when includeStakedAssets is enabled', async () => {
+        mockedQuery
+          .mockReturnValueOnce(Promise.resolve('0x10'))
+          .mockReturnValueOnce(Promise.resolve('0x11'));
+
+        await withController(
+          {
+            options: {
+              includeStakedAssets: true,
+              getStakedBalanceForChain: jest.fn().mockResolvedValue('0x1'),
+            },
+            isMultiAccountBalancesEnabled: false,
+            selectedAccount: ACCOUNT_1,
+            listAccounts: [ACCOUNT_1, ACCOUNT_2],
+          },
+          async ({ controller }) => {
+            await controller.refresh();
+
+            expect(controller.state).toStrictEqual({
+              accounts: {
+                [CHECKSUM_ADDRESS_1]: { balance: '0x10', stakedBalance: '0x1' },
+                [CHECKSUM_ADDRESS_2]: { balance: '0x0' },
+              },
+              accountsByChainId: {
+                '0x1': {
+                  [CHECKSUM_ADDRESS_1]: {
+                    balance: '0x10',
+                    stakedBalance: '0x1',
+                  },
+                  [CHECKSUM_ADDRESS_2]: {
+                    balance: '0x0',
+                  },
+                },
+              },
+            });
+          },
+        );
+      });
+
+      it('should not update staked balance when includeStakedAssets is disabled', async () => {
+        mockedQuery
+          .mockReturnValueOnce(Promise.resolve('0x13'))
+          .mockReturnValueOnce(Promise.resolve('0x14'));
+
+        await withController(
+          {
+            options: {
+              includeStakedAssets: false,
+              getStakedBalanceForChain: jest.fn().mockResolvedValue('0x1'),
+            },
+            isMultiAccountBalancesEnabled: false,
+            selectedAccount: ACCOUNT_1,
+            listAccounts: [ACCOUNT_1, ACCOUNT_2],
+          },
+          async ({ controller }) => {
+            await controller.refresh();
+
+            expect(controller.state).toStrictEqual({
+              accounts: {
+                [CHECKSUM_ADDRESS_1]: { balance: '0x13' },
+                [CHECKSUM_ADDRESS_2]: { balance: '0x0' },
+              },
+              accountsByChainId: {
+                '0x1': {
+                  [CHECKSUM_ADDRESS_1]: {
+                    balance: '0x13',
+                  },
+                  [CHECKSUM_ADDRESS_2]: {
+                    balance: '0x0',
+                  },
+                },
+              },
+            });
+          },
+        );
+      });
+
+      it('should update staked balance when includeStakedAssets and multi-account is enabled', async () => {
+        mockedQuery
+          .mockReturnValueOnce(Promise.resolve('0x11'))
+          .mockReturnValueOnce(Promise.resolve('0x12'));
+
+        await withController(
+          {
+            options: {
+              includeStakedAssets: true,
+              getStakedBalanceForChain: jest.fn().mockResolvedValue('0x1'),
+            },
+            isMultiAccountBalancesEnabled: true,
+            selectedAccount: ACCOUNT_1,
+            listAccounts: [ACCOUNT_1, ACCOUNT_2],
+          },
+          async ({ controller }) => {
+            await controller.refresh();
+
+            expect(controller.state).toStrictEqual({
+              accounts: {
+                [CHECKSUM_ADDRESS_1]: { balance: '0x11', stakedBalance: '0x1' },
+                [CHECKSUM_ADDRESS_2]: { balance: '0x12', stakedBalance: '0x1' },
+              },
+              accountsByChainId: {
+                '0x1': {
+                  [CHECKSUM_ADDRESS_1]: {
+                    balance: '0x11',
+                    stakedBalance: '0x1',
+                  },
+                  [CHECKSUM_ADDRESS_2]: {
+                    balance: '0x12',
+                    stakedBalance: '0x1',
+                  },
+                },
+              },
+            });
+          },
+        );
+      });
     });
 
     describe('with networkClientId', () => {
@@ -438,6 +555,185 @@ describe('AccountTrackerController', () => {
           },
         );
       });
+
+      it('should update staked balance when includeStakedAssets is enabled', async () => {
+        const networkClientId = 'holesky';
+        mockedQuery
+          .mockReturnValueOnce(Promise.resolve('0x10'))
+          .mockReturnValueOnce(Promise.resolve('0x11'));
+
+        await withController(
+          {
+            options: {
+              includeStakedAssets: true,
+              getStakedBalanceForChain: jest.fn().mockResolvedValue('0x1'),
+            },
+            isMultiAccountBalancesEnabled: false,
+            selectedAccount: ACCOUNT_1,
+            listAccounts: [ACCOUNT_1, ACCOUNT_2],
+            networkClientById: {
+              [networkClientId]: buildCustomNetworkClientConfiguration({
+                chainId: '0x4268',
+              }),
+            },
+          },
+          async ({ controller }) => {
+            await controller.refresh();
+
+            expect(controller.state).toStrictEqual({
+              accounts: {
+                [CHECKSUM_ADDRESS_1]: { balance: '0x10', stakedBalance: '0x1' },
+                [CHECKSUM_ADDRESS_2]: { balance: '0x0' },
+              },
+              accountsByChainId: {
+                '0x1': {
+                  [CHECKSUM_ADDRESS_1]: {
+                    balance: '0x10',
+                    stakedBalance: '0x1',
+                  },
+                  [CHECKSUM_ADDRESS_2]: {
+                    balance: '0x0',
+                  },
+                },
+              },
+            });
+          },
+        );
+      });
+
+      it('should not update staked balance when includeStakedAssets is disabled', async () => {
+        const networkClientId = 'holesky';
+        mockedQuery
+          .mockReturnValueOnce(Promise.resolve('0x13'))
+          .mockReturnValueOnce(Promise.resolve('0x14'));
+
+        await withController(
+          {
+            options: {
+              includeStakedAssets: false,
+              getStakedBalanceForChain: jest.fn().mockResolvedValue('0x1'),
+            },
+            isMultiAccountBalancesEnabled: false,
+            selectedAccount: ACCOUNT_1,
+            listAccounts: [ACCOUNT_1, ACCOUNT_2],
+            networkClientById: {
+              [networkClientId]: buildCustomNetworkClientConfiguration({
+                chainId: '0x4268',
+              }),
+            },
+          },
+          async ({ controller }) => {
+            await controller.refresh();
+
+            expect(controller.state).toStrictEqual({
+              accounts: {
+                [CHECKSUM_ADDRESS_1]: { balance: '0x13' },
+                [CHECKSUM_ADDRESS_2]: { balance: '0x0' },
+              },
+              accountsByChainId: {
+                '0x1': {
+                  [CHECKSUM_ADDRESS_1]: {
+                    balance: '0x13',
+                  },
+                  [CHECKSUM_ADDRESS_2]: {
+                    balance: '0x0',
+                  },
+                },
+              },
+            });
+          },
+        );
+      });
+
+      it('should update staked balance when includeStakedAssets and multi-account is enabled', async () => {
+        const networkClientId = 'holesky';
+        mockedQuery
+          .mockReturnValueOnce(Promise.resolve('0x11'))
+          .mockReturnValueOnce(Promise.resolve('0x12'));
+
+        await withController(
+          {
+            options: {
+              includeStakedAssets: true,
+              getStakedBalanceForChain: jest.fn().mockResolvedValue('0x1'),
+            },
+            isMultiAccountBalancesEnabled: true,
+            selectedAccount: ACCOUNT_1,
+            listAccounts: [ACCOUNT_1, ACCOUNT_2],
+            networkClientById: {
+              [networkClientId]: buildCustomNetworkClientConfiguration({
+                chainId: '0x4268',
+              }),
+            },
+          },
+          async ({ controller }) => {
+            await controller.refresh();
+
+            expect(controller.state).toStrictEqual({
+              accounts: {
+                [CHECKSUM_ADDRESS_1]: { balance: '0x11', stakedBalance: '0x1' },
+                [CHECKSUM_ADDRESS_2]: { balance: '0x12', stakedBalance: '0x1' },
+              },
+              accountsByChainId: {
+                '0x1': {
+                  [CHECKSUM_ADDRESS_1]: {
+                    balance: '0x11',
+                    stakedBalance: '0x1',
+                  },
+                  [CHECKSUM_ADDRESS_2]: {
+                    balance: '0x12',
+                    stakedBalance: '0x1',
+                  },
+                },
+              },
+            });
+          },
+        );
+      });
+
+      it('should not update staked balance when includeStakedAssets and multi-account is enabled if network unsupported', async () => {
+        const networkClientId = 'polygon';
+        mockedQuery
+          .mockReturnValueOnce(Promise.resolve('0x11'))
+          .mockReturnValueOnce(Promise.resolve('0x12'));
+
+        await withController(
+          {
+            options: {
+              includeStakedAssets: true,
+              getStakedBalanceForChain: jest.fn().mockResolvedValue(undefined),
+            },
+            isMultiAccountBalancesEnabled: true,
+            selectedAccount: ACCOUNT_1,
+            listAccounts: [ACCOUNT_1, ACCOUNT_2],
+            networkClientById: {
+              [networkClientId]: buildCustomNetworkClientConfiguration({
+                chainId: '0x89',
+              }),
+            },
+          },
+          async ({ controller }) => {
+            await controller.refresh();
+
+            expect(controller.state).toStrictEqual({
+              accounts: {
+                [CHECKSUM_ADDRESS_1]: { balance: '0x11' },
+                [CHECKSUM_ADDRESS_2]: { balance: '0x12' },
+              },
+              accountsByChainId: {
+                '0x1': {
+                  [CHECKSUM_ADDRESS_1]: {
+                    balance: '0x11',
+                  },
+                  [CHECKSUM_ADDRESS_2]: {
+                    balance: '0x12',
+                  },
+                },
+              },
+            });
+          },
+        );
+      });
     });
   });
 
@@ -459,6 +755,33 @@ describe('AccountTrackerController', () => {
           ]);
           expect(result[ADDRESS_1].balance).toBe('0x10');
           expect(result[ADDRESS_2].balance).toBe('0x20');
+        },
+      );
+    });
+
+    it('should sync staked balance with addresses', async () => {
+      await withController(
+        {
+          options: {
+            includeStakedAssets: true,
+            getStakedBalanceForChain: jest.fn().mockResolvedValue('0x1'),
+          },
+          isMultiAccountBalancesEnabled: true,
+          selectedAccount: ACCOUNT_1,
+          listAccounts: [],
+        },
+        async ({ controller }) => {
+          mockedQuery
+            .mockReturnValueOnce(Promise.resolve('0x10'))
+            .mockReturnValueOnce(Promise.resolve('0x20'));
+          const result = await controller.syncBalanceWithAddresses([
+            ADDRESS_1,
+            ADDRESS_2,
+          ]);
+          expect(result[ADDRESS_1].balance).toBe('0x10');
+          expect(result[ADDRESS_2].balance).toBe('0x20');
+          expect(result[ADDRESS_1].stakedBalance).toBe('0x1');
+          expect(result[ADDRESS_2].stakedBalance).toBe('0x1');
         },
       );
     });
@@ -647,8 +970,8 @@ async function withController<ReturnValue>(
 
   const controller = new AccountTrackerController({
     messenger: accountTrackerMessenger,
-    ...options,
     getStakedBalanceForChain: jest.fn(),
+    ...options,
   });
 
   return await testFunction({

--- a/packages/assets-controllers/src/AccountTrackerController.test.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.test.ts
@@ -648,6 +648,7 @@ async function withController<ReturnValue>(
   const controller = new AccountTrackerController({
     messenger: accountTrackerMessenger,
     ...options,
+    getStakedBalanceForChain: jest.fn(),
   });
 
   return await testFunction({

--- a/packages/assets-controllers/src/AccountTrackerController.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.ts
@@ -26,6 +26,8 @@ import { type Hex, assert } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 import { cloneDeep } from 'lodash';
 
+import type { AssetsContractController } from './AssetsContractController';
+
 /**
  * The name of the {@link AccountTrackerController}.
  */
@@ -35,10 +37,12 @@ const controllerName = 'AccountTrackerController';
  * @type AccountInformation
  *
  * Account information object
- * @property balance - Hex string of an account balancec in wei
+ * @property balance - Hex string of an account balance in wei
+ * @property stakedBalance - Hex string of an account staked balance in wei
  */
 export type AccountInformation = {
   balance: string;
+  stakedBalance?: string;
 };
 
 /**
@@ -135,6 +139,10 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
 > {
   readonly #refreshMutex = new Mutex();
 
+  readonly #includeStakedAssets: boolean;
+
+  readonly #getStakedBalanceForChain: AssetsContractController['getStakedBalanceForChain'];
+
   #handle?: ReturnType<typeof setTimeout>;
 
   /**
@@ -144,15 +152,21 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
    * @param options.interval - Polling interval used to fetch new account balances.
    * @param options.state - Initial state to set on this controller.
    * @param options.messenger - The controller messaging system.
+   * @param options.getStakedBalanceForChain - The function to get the staked native asset balance for a chain.
+   * @param options.includeStakedAssets - Whether to include staked assets in the account balances.
    */
   constructor({
     interval = 10000,
     state,
     messenger,
+    getStakedBalanceForChain,
+    includeStakedAssets = false,
   }: {
     interval?: number;
     state?: Partial<AccountTrackerControllerState>;
     messenger: AccountTrackerControllerMessenger;
+    getStakedBalanceForChain: AssetsContractController['getStakedBalanceForChain'];
+    includeStakedAssets?: boolean;
   }) {
     const { selectedNetworkClientId } = messenger.call(
       'NetworkController:getState',
@@ -175,6 +189,10 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
       },
       metadata: accountTrackerMetadata,
     });
+    this.#getStakedBalanceForChain = getStakedBalanceForChain;
+
+    this.#includeStakedAssets = includeStakedAssets;
+
     this.setIntervalLength(interval);
 
     // TODO: Either fix this lint violation or explain why it's necessary to ignore.
@@ -358,6 +376,18 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
             balance,
           };
         }
+        if (this.#includeStakedAssets) {
+          const stakedBalance = await this.#getStakedBalanceForChain(
+            address,
+            networkClientId,
+          );
+          if (stakedBalance) {
+            accountsForChain[address] = {
+              ...accountsForChain[address],
+              stakedBalance,
+            };
+          }
+        }
       }
 
       this.update((state) => {
@@ -402,24 +432,37 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
     const { ethQuery } = this.#getCorrectNetworkClient(networkClientId);
 
     return await Promise.all(
-      addresses.map((address): Promise<[string, string] | undefined> => {
-        return safelyExecuteWithTimeout(async () => {
-          assert(ethQuery, 'Provider not set.');
-          const balance = await query(ethQuery, 'getBalance', [address]);
-          return [address, balance];
-        });
-      }),
+      addresses.map(
+        (
+          address,
+        ): Promise<[string, string, string | undefined] | undefined> => {
+          return safelyExecuteWithTimeout(async () => {
+            assert(ethQuery, 'Provider not set.');
+            const balance = await query(ethQuery, 'getBalance', [address]);
+
+            let stakedBalance: string | undefined;
+            if (this.#includeStakedAssets) {
+              stakedBalance = await this.#getStakedBalanceForChain(
+                address,
+                networkClientId,
+              );
+            }
+            return [address, balance, stakedBalance];
+          });
+        },
+      ),
     ).then((value) => {
       return value.reduce((obj, item) => {
         if (!item) {
           return obj;
         }
 
-        const [address, balance] = item;
+        const [address, balance, stakedBalance] = item;
         return {
           ...obj,
           [address]: {
             balance,
+            stakedBalance,
           },
         };
       }, {});

--- a/packages/assets-controllers/src/AccountTrackerController.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.ts
@@ -26,7 +26,10 @@ import { type Hex, assert } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 import { cloneDeep } from 'lodash';
 
-import type { AssetsContractController } from './AssetsContractController';
+import type {
+  AssetsContractController,
+  StakedBalance,
+} from './AssetsContractController';
 
 /**
  * The name of the {@link AccountTrackerController}.
@@ -428,19 +431,19 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
   async syncBalanceWithAddresses(
     addresses: string[],
     networkClientId?: NetworkClientId,
-  ): Promise<Record<string, { balance: string }>> {
+  ): Promise<
+    Record<string, { balance: string; stakedBalance?: StakedBalance }>
+  > {
     const { ethQuery } = this.#getCorrectNetworkClient(networkClientId);
 
     return await Promise.all(
       addresses.map(
-        (
-          address,
-        ): Promise<[string, string, string | undefined] | undefined> => {
+        (address): Promise<[string, string, StakedBalance] | undefined> => {
           return safelyExecuteWithTimeout(async () => {
             assert(ethQuery, 'Provider not set.');
             const balance = await query(ethQuery, 'getBalance', [address]);
 
-            let stakedBalance: string | undefined;
+            let stakedBalance: StakedBalance;
             if (this.#includeStakedAssets) {
               stakedBalance = await this.#getStakedBalanceForChain(
                 address,

--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -1274,4 +1274,140 @@ describe('AssetsContractController', () => {
     expect(uri.toLowerCase()).toStrictEqual(expectedUri);
     messenger.clearEventSubscriptions('NetworkController:networkDidChange');
   });
+
+  it('should get the staked ethereum balance for an address', async () => {
+    const { assetsContract, messenger, provider, networkClientConfiguration } =
+      await setupAssetContractControllers();
+    assetsContract.configure({ provider });
+
+    mockNetworkWithDefaultChainId({
+      networkClientConfiguration,
+      mocks: [
+        // getShares
+        {
+          request: {
+            method: 'eth_call',
+            params: [
+              {
+                to: '0x4fef9d741011476750a243ac70b9789a63dd47df',
+                data: '0xf04da65b0000000000000000000000005a3ca5cd63807ce5e4d7841ab32ce6b6d9bbba2d',
+              },
+              'latest',
+            ],
+          },
+          response: {
+            result:
+              '0x0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+          },
+        },
+        // convertToAssets
+        {
+          request: {
+            method: 'eth_call',
+            params: [
+              {
+                to: '0x4fef9d741011476750a243ac70b9789a63dd47df',
+                data: '0x07a2d13a0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+              },
+              'latest',
+            ],
+          },
+          response: {
+            result:
+              '0x0000000000000000000000000000000000000000000000001bc16d674ec80000',
+          },
+        },
+      ],
+    });
+
+    const balance = await assetsContract.getStakedBalanceForChain(
+      TEST_ACCOUNT_PUBLIC_ADDRESS,
+    );
+
+    // exchange rate shares = 1e18
+    // exchange rate share to assets = 2e18
+    // user shares = 1e18
+    // user assets = 2e18
+
+    expect(balance).toBeDefined();
+    expect(balance).toBe('0x1bc16d674ec80000');
+    expect(BigNumber.from(balance).toString()).toBe((2e18).toString());
+
+    messenger.clearEventSubscriptions('NetworkController:networkDidChange');
+  });
+
+  it('should return default of zero hex as staked ethereum balance if user has no shares', async () => {
+    const errorSpy = jest.spyOn(console, 'error');
+    const { assetsContract, messenger, provider, networkClientConfiguration } =
+      await setupAssetContractControllers();
+    assetsContract.configure({ provider });
+
+    mockNetworkWithDefaultChainId({
+      networkClientConfiguration,
+      mocks: [
+        // getShares
+        {
+          request: {
+            method: 'eth_call',
+            params: [
+              {
+                to: '0x4fef9d741011476750a243ac70b9789a63dd47df',
+                data: '0xf04da65b0000000000000000000000005a3ca5cd63807ce5e4d7841ab32ce6b6d9bbba2d',
+              },
+              'latest',
+            ],
+          },
+          response: {
+            result:
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+          },
+        },
+      ],
+    });
+
+    const balance = await assetsContract.getStakedBalanceForChain(
+      TEST_ACCOUNT_PUBLIC_ADDRESS,
+    );
+
+    expect(balance).toBeDefined();
+    expect(balance).toBe('0x00');
+    expect(BigNumber.from(balance).toString()).toBe('0');
+    expect(errorSpy).toHaveBeenCalledTimes(0);
+
+    errorSpy.mockRestore();
+    messenger.clearEventSubscriptions('NetworkController:networkDidChange');
+  });
+
+  it('should return default of zero hex as staked ethereum balance if there is any error thrown', async () => {
+    let error;
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementationOnce((e) => {
+        error = e;
+      });
+    const { assetsContract, messenger, provider } =
+      await setupAssetContractControllers();
+    assetsContract.configure({ provider });
+
+    const balance = await assetsContract.getStakedBalanceForChain(
+      TEST_ACCOUNT_PUBLIC_ADDRESS,
+    );
+
+    expect(balance).toBeDefined();
+    expect(balance).toBe('0x00');
+    expect(BigNumber.from(balance).toString()).toBe('0');
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(error);
+
+    errorSpy.mockRestore();
+    messenger.clearEventSubscriptions('NetworkController:networkDidChange');
+  });
+
+  it('should throw missing provider error when getting staked ethereum balance and missing provider', async () => {
+    const { assetsContract, messenger } = await setupAssetContractControllers();
+    await expect(
+      assetsContract.getStakedBalanceForChain(TEST_ACCOUNT_PUBLIC_ADDRESS),
+    ).rejects.toThrow(MISSING_PROVIDER_ERROR);
+    messenger.clearEventSubscriptions('NetworkController:networkDidChange');
+  });
 });

--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -1278,7 +1278,7 @@ describe('AssetsContractController', () => {
   it('should get the staked ethereum balance for an address', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
       await setupAssetContractControllers();
-    assetsContract.configure({ provider });
+    assetsContract.setProvider(provider);
 
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -1340,7 +1340,7 @@ describe('AssetsContractController', () => {
     const errorSpy = jest.spyOn(console, 'error');
     const { assetsContract, messenger, provider, networkClientConfiguration } =
       await setupAssetContractControllers();
-    assetsContract.configure({ provider });
+    assetsContract.setProvider(provider);
 
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -1387,7 +1387,7 @@ describe('AssetsContractController', () => {
       });
     const { assetsContract, messenger, provider } =
       await setupAssetContractControllers();
-    assetsContract.configure({ provider });
+    assetsContract.setProvider(provider);
 
     const balance = await assetsContract.getStakedBalanceForChain(
       TEST_ACCOUNT_PUBLIC_ADDRESS,

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -703,6 +703,13 @@ export class AssetsContractController {
     return nonZeroBalances;
   }
 
+  /**
+   * Get the staked ethereum balance for an address in a single call.
+   *
+   * @param address - The address to check staked ethereum balance for.
+   * @param networkClientId - Network Client ID to fetch the provider with.
+   * @returns The hex staked ethereum balance for address.
+   */
   async getStakedBalanceForChain(
     address: string,
     networkClientId?: NetworkClientId,

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -1,3 +1,5 @@
+// import { BigNumber } from '@ethersproject/bignumber';
+import { BigNumber } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
 import type {
@@ -19,7 +21,10 @@ import { getKnownPropertyNames, type Hex } from '@metamask/utils';
 import type BN from 'bn.js';
 import abiSingleCallBalancesContract from 'single-call-balance-checker-abi';
 
-import { SupportedTokenDetectionNetworks } from './assetsUtil';
+import {
+  SupportedStakedBalanceNetworks,
+  SupportedTokenDetectionNetworks,
+} from './assetsUtil';
 import { ERC20Standard } from './Standards/ERC20Standard';
 import { ERC1155Standard } from './Standards/NftStandards/ERC1155/ERC1155Standard';
 import { ERC721Standard } from './Standards/NftStandards/ERC721/ERC721Standard';
@@ -67,6 +72,13 @@ export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID = {
     '0x6aa75276052d96696134252587894ef5ffa520af',
   [SupportedTokenDetectionNetworks.moonriver]:
     '0x6aa75276052d96696134252587894ef5ffa520af',
+} as const satisfies Record<Hex, string>;
+
+export const STAKING_CONTRACT_ADDRESS_BY_CHAINID = {
+  [SupportedStakedBalanceNetworks.mainnet]:
+    '0x4fef9d741011476750a243ac70b9789a63dd47df',
+  [SupportedStakedBalanceNetworks.holesky]:
+    '0x37bf0883c27365cffcd0c4202918df930989891f',
 } as const satisfies Record<Hex, string>;
 
 export const MISSING_PROVIDER_ERROR =
@@ -196,6 +208,8 @@ export type AssetsContractControllerMessenger = RestrictedControllerMessenger<
   AllowedActions['type'],
   AllowedEvents['type']
 >;
+
+export type StakedBalance = string | undefined;
 
 /**
  * Controller that interacts with contracts on mainnet through web3
@@ -687,6 +701,78 @@ export class AssetsContractController {
       });
     }
     return nonZeroBalances;
+  }
+
+  async getStakedBalanceForChain(
+    address: string,
+    networkClientId?: NetworkClientId,
+  ): Promise<StakedBalance> {
+    const chainId = this.getChainId(networkClientId);
+    const provider = this.getProvider(networkClientId);
+
+    // balance defaults to zero
+    let balance: BigNumber = BigNumber.from(0);
+
+    // Only fetch staked balance on supported networks
+    if (
+      ![
+        SupportedStakedBalanceNetworks.mainnet,
+        SupportedStakedBalanceNetworks.holesky,
+      ].includes(chainId as SupportedStakedBalanceNetworks)
+    ) {
+      return undefined as StakedBalance;
+    }
+    // Only fetch staked balance if contract address exists
+    if (
+      !((id): id is keyof typeof STAKING_CONTRACT_ADDRESS_BY_CHAINID =>
+        id in STAKING_CONTRACT_ADDRESS_BY_CHAINID)(chainId)
+    ) {
+      return undefined as StakedBalance;
+    }
+
+    const contractAddress = STAKING_CONTRACT_ADDRESS_BY_CHAINID[chainId];
+    const abi = [
+      {
+        inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+        name: 'getShares',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
+        name: 'convertToAssets',
+        outputs: [{ internalType: 'uint256', name: 'assets', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ];
+
+    try {
+      const contract = new Contract(contractAddress, abi, provider);
+      const exchangeRateDenominator = BigNumber.from((1e18).toString());
+      const multiplier = exchangeRateDenominator;
+      const userShares = await contract.getShares(address);
+
+      // convert shares to assets only if address shares > 0 else return default balance
+      if (!userShares.lte(0)) {
+        const exchangeRateNumerator = await contract.convertToAssets(
+          exchangeRateDenominator,
+        );
+        const exchangeRate = exchangeRateNumerator
+          .mul(multiplier)
+          .div(exchangeRateDenominator);
+
+        const userAssets = userShares.mul(exchangeRate).div(multiplier);
+
+        balance = userAssets;
+      }
+    } catch (error) {
+      // if we get an error, log and return the default value
+      console.error(error);
+    }
+
+    return balance.toHexString();
   }
 }
 

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -750,22 +750,11 @@ export class AssetsContractController {
 
     try {
       const contract = new Contract(contractAddress, abi, provider);
-      const exchangeRateDenominator = BigNumber.from((1e18).toString());
-      const multiplier = exchangeRateDenominator;
       const userShares = await contract.getShares(address);
 
       // convert shares to assets only if address shares > 0 else return default balance
       if (!userShares.lte(0)) {
-        const exchangeRateNumerator = await contract.convertToAssets(
-          exchangeRateDenominator,
-        );
-        const exchangeRate = exchangeRateNumerator
-          .mul(multiplier)
-          .div(exchangeRateDenominator);
-
-        const userAssets = userShares.mul(exchangeRate).div(multiplier);
-
-        balance = userAssets;
+        balance = await contract.convertToAssets(userShares.toString());
       }
     } catch (error) {
       // if we get an error, log and return the default value

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -707,8 +707,8 @@ export class AssetsContractController {
     address: string,
     networkClientId?: NetworkClientId,
   ): Promise<StakedBalance> {
-    const chainId = this.getChainId(networkClientId);
-    const provider = this.getProvider(networkClientId);
+    const chainId = this.#getCorrectChainId(networkClientId);
+    const provider = this.#getCorrectProvider(networkClientId);
 
     // balance defaults to zero
     let balance: BigNumber = BigNumber.from(0);

--- a/packages/assets-controllers/src/AssetsContractControllerWithNetworkClientId.test.ts
+++ b/packages/assets-controllers/src/AssetsContractControllerWithNetworkClientId.test.ts
@@ -905,7 +905,7 @@ describe('AssetsContractController with NetworkClientId', () => {
   it('should get the staked ethereum balance for an address', async () => {
     const { assetsContract, messenger, provider, networkClientConfiguration } =
       await setupAssetContractControllers();
-    assetsContract.configure({ provider });
+    assetsContract.setProvider(provider);
 
     mockNetworkWithDefaultChainId({
       networkClientConfiguration,
@@ -966,7 +966,7 @@ describe('AssetsContractController with NetworkClientId', () => {
 
   it('should default staked ethereum balance to undefined if network is not supported', async () => {
     const { assetsContract, provider } = await setupAssetContractControllers();
-    assetsContract.configure({ provider });
+    assetsContract.setProvider(provider);
 
     const balance = await assetsContract.getStakedBalanceForChain(
       TEST_ACCOUNT_PUBLIC_ADDRESS,

--- a/packages/assets-controllers/src/AssetsContractControllerWithNetworkClientId.test.ts
+++ b/packages/assets-controllers/src/AssetsContractControllerWithNetworkClientId.test.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from '@ethersproject/bignumber';
 import { BUILT_IN_NETWORKS } from '@metamask/controller-utils';
 import { NetworkClientType } from '@metamask/network-controller';
 
@@ -899,5 +900,79 @@ describe('AssetsContractController with NetworkClientId', () => {
     );
     expect(uri.toLowerCase()).toStrictEqual(expectedUri);
     messenger.clearEventSubscriptions('NetworkController:networkDidChange');
+  });
+
+  it('should get the staked ethereum balance for an address', async () => {
+    const { assetsContract, messenger, provider, networkClientConfiguration } =
+      await setupAssetContractControllers();
+    assetsContract.configure({ provider });
+
+    mockNetworkWithDefaultChainId({
+      networkClientConfiguration,
+      mocks: [
+        // getShares
+        {
+          request: {
+            method: 'eth_call',
+            params: [
+              {
+                to: '0x4fef9d741011476750a243ac70b9789a63dd47df',
+                data: '0xf04da65b0000000000000000000000005a3ca5cd63807ce5e4d7841ab32ce6b6d9bbba2d',
+              },
+              'latest',
+            ],
+          },
+          response: {
+            result:
+              '0x0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+          },
+        },
+        // convertToAssets
+        {
+          request: {
+            method: 'eth_call',
+            params: [
+              {
+                to: '0x4fef9d741011476750a243ac70b9789a63dd47df',
+                data: '0x07a2d13a0000000000000000000000000000000000000000000000000de0b6b3a7640000',
+              },
+              'latest',
+            ],
+          },
+          response: {
+            result:
+              '0x0000000000000000000000000000000000000000000000001bc16d674ec80000',
+          },
+        },
+      ],
+    });
+
+    const balance = await assetsContract.getStakedBalanceForChain(
+      TEST_ACCOUNT_PUBLIC_ADDRESS,
+      'mainnet',
+    );
+
+    // exchange rate shares = 1e18
+    // exchange rate share to assets = 2e18
+    // user shares = 1e18
+    // user assets = 2e18
+
+    expect(balance).toBeDefined();
+    expect(balance).toBe('0x1bc16d674ec80000');
+    expect(BigNumber.from(balance).toString()).toBe((2e18).toString());
+
+    messenger.clearEventSubscriptions('NetworkController:networkDidChange');
+  });
+
+  it('should default staked ethereum balance to undefined if network is not supported', async () => {
+    const { assetsContract, provider } = await setupAssetContractControllers();
+    assetsContract.configure({ provider });
+
+    const balance = await assetsContract.getStakedBalanceForChain(
+      TEST_ACCOUNT_PUBLIC_ADDRESS,
+      'sepolia',
+    );
+
+    expect(balance).toBeUndefined();
   });
 });

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -188,6 +188,18 @@ export enum SupportedTokenDetectionNetworks {
 }
 
 /**
+ * Networks where staked balance is supported - Values are in hex format
+ */
+export enum SupportedStakedBalanceNetworks {
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  mainnet = '0x1', // decimal: 1
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  holesky = '0x4268', // decimal: 17000
+}
+
+/**
  * Check if token detection is enabled for certain networks.
  *
  * @param chainId - ChainID of network


### PR DESCRIPTION
## Explanation

**What is the current state of things and why does it need to change?**
- Currently the `metamask-mobile` app using the `assets-controllers` to get information about account token balances. We need to be able to support getting a new type of asset on mainnet and holesky chains, _Staked Ethereum_, which is not a token but represents the amount of ETH staked using our products.

**What is the solution your changes offer and how does it work?**
- We update the `AssetContractController` with a new method, `getStakedBalanceForChain`, which gets staked ethereum balances per account from the Stakewise vault contract. We update the AccountTrackerController with options to `includeStakedAssets` and to add a `getStakedBalanceForChain` method. 
- We bind `AssetContractController.getStakedBalanceForChain` to `getStakedBalanceForChain` option property in `metamask-mobile` code and then set `includeStakingAssets` option to the boolean feature flag for ETH Staking on Mobile. 
- We use the AccountTrackerController state in mobile to update the account `balance` and now, if enabled the `stakedBalance` as well.

**Are there any changes whose purpose might not obvious to those unfamiliar with the domain?**
- We don't want to show `stakedBalance` if not on a supported network, and so return undefined vs defaulting to zero hex. If there is an error and we are on a supported network, we want to default to zero hex.

**If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?**
- There is 1 package affected

**If you had to upgrade a dependency, why did you do so?**
- No need to update dependency

## References

**Are there any issues that this pull request is tied to?**
- Relates to https://consensyssoftware.atlassian.net/browse/STAKE-817

**Are there other links that reviewers should consult to understand these changes better?**
- https://github.com/MetaMask/metamask-mobile/pull/12146 PR to MM mobile with patched `assets-controllers@38.3.0`

**Are there client or consumer pull requests to adopt any breaking changes?**
- No

## Changelog

### `@metamask/assets-controllers`

**ADDED**: AssetsContractController.getStakedBalanceForChain method to get staked ethereum balance for an address
**ADDED**: AccountTrackerController options `includeStakedEthereum` and `getStakedBalanceForChain` for turning on staked balance functionality and providing a method to do so

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
