### PR TITLE
chore: Bump `@metamask/create-release-branch` from v3.0 to v3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@lavamoat/allow-scripts": "^3.0.4",
-    "@metamask/create-release-branch": "^3.0.0",
+    "@metamask/create-release-branch": "^3.1.0",
     "@metamask/eslint-config": "^12.2.0",
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,7 +2361,7 @@ __metadata:
     "@babel/plugin-transform-modules-commonjs": "npm:^7.23.3"
     "@babel/preset-typescript": "npm:^7.23.3"
     "@lavamoat/allow-scripts": "npm:^3.0.4"
-    "@metamask/create-release-branch": "npm:^3.0.0"
+    "@metamask/create-release-branch": "npm:^3.1.0"
     "@metamask/eslint-config": "npm:^12.2.0"
     "@metamask/eslint-config-jest": "npm:^12.1.0"
     "@metamask/eslint-config-nodejs": "npm:^12.1.0"
@@ -2407,9 +2407,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/create-release-branch@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "@metamask/create-release-branch@npm:3.0.1"
+"@metamask/create-release-branch@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/create-release-branch@npm:3.1.0"
   dependencies:
     "@metamask/action-utils": "npm:^1.0.0"
     "@metamask/auto-changelog": "npm:~3.3.0"
@@ -2418,6 +2418,7 @@ __metadata:
     execa: "npm:^8.0.1"
     pony-cause: "npm:^2.1.9"
     semver: "npm:^7.5.4"
+    validate-npm-package-name: "npm:^5.0.0"
     which: "npm:^3.0.0"
     yaml: "npm:^2.2.2"
     yargs: "npm:^17.7.1"
@@ -2425,7 +2426,7 @@ __metadata:
     prettier: ^2
   bin:
     create-release-branch: bin/create-release-branch.js
-  checksum: 10/7a0b0044d64d9446bfb5de17311d06f6f52544c79367d4bb3963c060b43e9d6dde5215ef555d590a37175e1a6aa9313d2042eb06faed4c8eb73c4d17593ab47e
+  checksum: 10/a922c04e16ad4d2e5472a783d1a2e3e45724708bca2288f6257552669da305b3b25e492475692084f4ad19ac87a51921ebfa01e9f2c43b22e953ed88db48511d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

The `@metamask/create-release-branch` package has been updated one minor version. This was done to get support for `npm:` aliases, which is needed to re-introduce #4844 (which was reverted).

## References

Unblocks the re-application of #4844

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
