### PR TITLE
feat: enable smart transactions by default for new users

### DIFF
--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -35,7 +35,7 @@ describe('PreferencesController', () => {
         acc[curr] = true;
         return acc;
       }, {} as { [chainId in EtherscanSupportedHexChainId]: boolean }),
-      smartTransactionsOptInStatus: false,
+      smartTransactionsOptInStatus: true,
       useSafeChainsListValidation: true,
       tokenSortConfig: {
         key: 'tokenFiatAmount',
@@ -423,10 +423,10 @@ describe('PreferencesController', () => {
     expect(controller.state.showIncomingTransactions['0x1']).toBe(false);
   });
 
-  it('should set smartTransactionsOptInStatus', () => {
+  it('should set smartTransactionsOptInStatus to false', () => {
     const controller = setupPreferencesController();
-    controller.setSmartTransactionsOptInStatus(true);
-    expect(controller.state.smartTransactionsOptInStatus).toBe(true);
+    controller.setSmartTransactionsOptInStatus(false);
+    expect(controller.state.smartTransactionsOptInStatus).toBe(false);
   });
 
   it('should set useTransactionSimulations', () => {

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -423,10 +423,12 @@ describe('PreferencesController', () => {
     expect(controller.state.showIncomingTransactions['0x1']).toBe(false);
   });
 
-  it('should set smartTransactionsOptInStatus to false', () => {
+  it('should set smartTransactionsOptInStatus', () => {
     const controller = setupPreferencesController();
     controller.setSmartTransactionsOptInStatus(false);
     expect(controller.state.smartTransactionsOptInStatus).toBe(false);
+    controller.setSmartTransactionsOptInStatus(true);
+    expect(controller.state.smartTransactionsOptInStatus).toBe(true);
   });
 
   it('should set useTransactionSimulations', () => {

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -224,7 +224,7 @@ export function getDefaultPreferencesState(): PreferencesState {
     useNftDetection: false,
     useTokenDetection: true,
     useMultiRpcMigration: true,
-    smartTransactionsOptInStatus: false,
+    smartTransactionsOptInStatus: true,
     useTransactionSimulations: true,
     useSafeChainsListValidation: true,
     tokenSortConfig: {


### PR DESCRIPTION
## Explanation
We want to enable smart transactions by default for new users.

## References


## Changelog

## `@metamask/preferences-controller`

```md
### Changed

- Enable smart transactions by default for new users by setting the initial value of the `smartTransactionsOptInStatus` state property to 'true' ([#4885](https://github.com/MetaMask/core/pull/4885))
```

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
