### PR TITLE
update TokenRatesController to poll on chain id instead of network client id

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -25,6 +25,7 @@ import { createMockInternalAccount } from '../../accounts-controller/src/tests/m
 import {
   buildCustomNetworkClientConfiguration,
   buildMockGetNetworkClientById,
+  buildNetworkConfiguration,
 } from '../../network-controller/tests/helpers';
 import { TOKEN_PRICES_BATCH_SIZE } from './assetsUtil';
 import type {
@@ -1280,7 +1281,7 @@ describe('TokenRatesController', () => {
         },
         async ({ controller }) => {
           controller.startPolling({
-            networkClientId: 'mainnet',
+            chainId: ChainId.mainnet,
           });
 
           await advanceTime({ clock, duration: 0 });
@@ -1334,7 +1335,7 @@ describe('TokenRatesController', () => {
             },
             async ({ controller }) => {
               controller.startPolling({
-                networkClientId: 'mainnet',
+                chainId: ChainId.mainnet,
               });
               await advanceTime({ clock, duration: 0 });
 
@@ -1404,18 +1405,17 @@ describe('TokenRatesController', () => {
                 return currency !== 'LOL';
               },
             });
-            const selectedNetworkClientConfiguration =
-              buildCustomNetworkClientConfiguration({
-                chainId: ChainId.mainnet,
-                ticker: 'LOL',
-              });
             await withController(
               {
                 options: {
                   tokenPricesService,
                 },
-                mockNetworkClientConfigurationsByNetworkClientId: {
-                  mainnet: selectedNetworkClientConfiguration,
+                mockNetworkState: {
+                  networkConfigurationsByChainId: {
+                    [ChainId.mainnet]: buildNetworkConfiguration({
+                      nativeCurrency: 'LOL',
+                    }),
+                  },
                 },
                 mockTokensControllerState: {
                   allTokens: {
@@ -1440,7 +1440,7 @@ describe('TokenRatesController', () => {
               },
               async ({ controller }) => {
                 controller.startPolling({
-                  networkClientId: 'mainnet',
+                  chainId: ChainId.mainnet,
                 });
                 // flush promises and advance setTimeouts they enqueue 3 times
                 // needed because fetch() doesn't resolve immediately, so any
@@ -1542,7 +1542,7 @@ describe('TokenRatesController', () => {
               },
               async ({ controller }) => {
                 controller.startPolling({
-                  networkClientId: 'mainnet',
+                  chainId: ChainId.mainnet,
                 });
                 // flush promises and advance setTimeouts they enqueue 3 times
                 // needed because fetch() doesn't resolve immediately, so any
@@ -1585,7 +1585,7 @@ describe('TokenRatesController', () => {
           },
           async ({ controller }) => {
             const pollingToken = controller.startPolling({
-              networkClientId: 'mainnet',
+              chainId: ChainId.mainnet,
             });
             await advanceTime({ clock, duration: 0 });
             expect(tokenPricesService.fetchTokenPrices).toHaveBeenCalledTimes(


### PR DESCRIPTION
## Explanation

Updates the polling input for `TokenRatesController` to a chain id instead of a network client id.


## References

* Related to https://github.com/MetaMask/metamask-extension/pull/28158

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **BREAKING**: The `TokenRatesController` now accepts `{chainId: Hex}` as its polling input to `startPolling()` instead of `{networkClientId: NetworkClientId}`

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
