### PR TITLE
ci: Fix `create-update-issues` workflow secret access

### DIFF
--- a/.github/workflows/create-update-issues.yaml
+++ b/.github/workflows/create-update-issues.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   create-update-issues:
+    environment: default-branch
     runs-on: ubuntu-latest
     steps:
       - name: Checkout head


### PR DESCRIPTION
## Explanation

The `create-update-issues` workflow was failing because it didn't have access to the secrets it needed. The `CORE_CREATE_UPDATE_ISSUES_TOKEN` secret is only available on hte `default-branch` environment.

The workflow has been updated to use that environment so that it may access the secret.

Example failure: https://github.com/MetaMask/core/actions/runs/11633589453/job/32399521142

## References

Fixes bug introduced in https://github.com/MetaMask/core/pull/4763

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
