### PR TITLE
fix: disable notifications

### DIFF
--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
@@ -43,6 +43,7 @@ import { processSnapNotification } from './processors/process-snap-notifications
 import * as OnChainNotifications from './services/onchain-notifications';
 import type { UserStorage } from './types/user-storage/user-storage';
 import * as Utils from './utils/utils';
+import { INotification } from './types';
 
 // Mock type used for testing purposes
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -834,7 +835,13 @@ describe('metamask-notifications - disableMetamaskNotifications()', () => {
     const controller = new NotificationServicesController({
       messenger: mocks.messenger,
       env: { featureAnnouncements: featureAnnouncementsEnv },
-      state: { isNotificationServicesEnabled: true },
+      state: {
+        isNotificationServicesEnabled: true,
+        metamaskNotificationsList: [
+          createMockFeatureAnnouncementRaw() as INotification,
+          createMockSnapNotification() as INotification,
+        ],
+      },
     });
 
     const promise = controller.disableNotificationServices();
@@ -847,6 +854,9 @@ describe('metamask-notifications - disableMetamaskNotifications()', () => {
     // Act - final state
     expect(controller.state.isUpdatingMetamaskNotifications).toBe(false);
     expect(controller.state.isNotificationServicesEnabled).toBe(false);
+    expect(controller.state.metamaskNotificationsList).toStrictEqual([
+      createMockSnapNotification(),
+    ]);
 
     expect(mocks.mockDisablePushNotifications).toHaveBeenCalled();
 

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
@@ -41,9 +41,9 @@ import { processFeatureAnnouncement } from './processors';
 import { processNotification } from './processors/process-notifications';
 import { processSnapNotification } from './processors/process-snap-notifications';
 import * as OnChainNotifications from './services/onchain-notifications';
+import type { INotification } from './types';
 import type { UserStorage } from './types/user-storage/user-storage';
 import * as Utils from './utils/utils';
-import { INotification } from './types';
 
 // Mock type used for testing purposes
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -924,11 +924,17 @@ export default class NotificationServicesController extends BaseController<
       const UUIDs = Utils.getAllUUIDs(userStorage);
       await this.#pushNotifications.disablePushNotifications(UUIDs);
 
+      const snapNotifications = this.state.metamaskNotificationsList.filter(
+        (notification) => notification.type === TRIGGER_TYPES.SNAP,
+      );
+
       // Clear Notification States (toggles and list)
       this.update((state) => {
         state.isNotificationServicesEnabled = false;
         state.isFeatureAnnouncementsEnabled = false;
-        state.metamaskNotificationsList = [];
+        // reassigning the notifications list with just snaps
+        // since the disable shouldn't affect snaps notifications
+        state.metamaskNotificationsList = snapNotifications;
       });
     } catch (e) {
       log.error('Unable to disable notifications', e);


### PR DESCRIPTION
## Explanation

* What is the current state of things and why does it need to change? If notifications are disable while there is an unread notification, the notifications are wiped from state.
* What is the solution your changes offer and how does it work? In the disable function, we repopulate the list with the currently exist snap notifications.
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain? This was only uncovered in manual QA in my extension PR: https://github.com/MetaMask/metamask-extension/pull/27975

## Changelog

### `@metamask/notification-services-controller`

- **FIX**: Updated disable notifications function to repopulate state with existing snap notifications instead of emptying the list entirely.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
