### PR TITLE
chore: add PRs to PR queue for WF team

### DIFF
--- a/.github/workflows/add-prs-to-project.yml
+++ b/.github/workflows/add-prs-to-project.yml
@@ -18,7 +18,9 @@ jobs:
     steps:
       - name: Add PR to project board
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
-	if: ${{ github.event.requested_team.name == env.TEAM_NAME}}
+        if: |
+          github.event.requested_team.name == env.TEAM_NAME || 
+          contains(github.event.pull_request.labels.*.name, env.TEAM_LABEL)
         with:
           project-url: https://github.com/orgs/MetaMask/projects/113
           github-token: ${{ secrets.CORE_ADD_PRS_TO_PROJECT }}

--- a/.github/workflows/add-prs-to-project.yml
+++ b/.github/workflows/add-prs-to-project.yml
@@ -9,12 +9,12 @@ jobs:
   add-to-project:
     name: Add PR to Project Board
     runs-on: ubuntu-latest
-    
+
     # Define reusable variables
     env:
       TEAM_NAME: 'wallet-framework-engineers'
       TEAM_LABEL: 'team-wallet-framework'
-    
+
     steps:
       - name: Add PR to project board
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
@@ -24,4 +24,3 @@ jobs:
         with:
           project-url: https://github.com/orgs/MetaMask/projects/113
           github-token: ${{ secrets.CORE_ADD_PRS_TO_PROJECT }}
-

--- a/.github/workflows/add-prs-to-project.yml
+++ b/.github/workflows/add-prs-to-project.yml
@@ -9,8 +9,6 @@ jobs:
   add-to-project:
     name: Add PR to Project Board
     runs-on: ubuntu-latest
-
-    # Define reusable variables
     env:
       TEAM_NAME: 'wallet-framework-engineers'
       TEAM_LABEL: 'team-wallet-framework'

--- a/.github/workflows/add-prs-to-project.yml
+++ b/.github/workflows/add-prs-to-project.yml
@@ -1,0 +1,25 @@
+name: 'Add PR to Project Board - Wallet Framework Team'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, labeled, review_requested]
+
+jobs:
+  add-to-project:
+    name: Add PR to Project Board
+    runs-on: ubuntu-latest
+    
+    # Define reusable variables
+    env:
+      TEAM_NAME: 'wallet-framework-engineers'
+      TEAM_LABEL: 'team-wallet-framework'
+    
+    steps:
+      - name: Add PR to project board
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
+	if: ${{ github.event.requested_team.name == env.TEAM_NAME}}
+        with:
+          project-url: https://github.com/orgs/MetaMask/projects/113
+          github-token: ${{ secrets.CORE_ADD_PRS_TO_PROJECT }}
+


### PR DESCRIPTION
## Explanation

This GitHub Action automatically adds pull requests to a project board for the Wallet Framework Team. It triggers on PR events like opening, labeling, or review requests. The action checks if the PR is relevant by matching the requested team or labels against the Wallet Frameworks team name and label. If matched, it adds the PR to our project board using a GitHub token for authentication. This will allow the team to more easily see PRs which need our attention

## References
n/a

## Changelog
n/a

## Testing
I did manual testing on a fork of the repo. It is not a one for one match because the access token setup is slightly different based on Organization -> projects vs Individual -> projects but the core of the workflow worked and is the same. 

## Checklist (none applicable) 

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
