### PR TITLE
fix: issue where `QueuedRequestController.state.queuedRequestCount` is not updated after flushing requests for an origin

### DIFF
--- a/packages/queued-request-controller/src/QueuedRequestController.ts
+++ b/packages/queued-request-controller/src/QueuedRequestController.ts
@@ -268,6 +268,7 @@ export class QueuedRequestController extends BaseController<
     this.#requestQueue = this.#requestQueue.filter(
       ({ request }) => request.origin !== flushOrigin,
     );
+    this.#updateQueuedRequestCount();
   }
 
   /**


### PR DESCRIPTION
## Explanation

Fix issue where `QueuedRequestController.state.queuedRequestCount` is not updated after flushing requests for an origin

## References
- https://github.com/MetaMask/core/pull/4846
- https://github.com/MetaMask/metamask-extension/pull/28090

## Fixes
- Bug identified [in v12.7.0 RC Thread](https://consensys.slack.com/archives/C029JG63136/p1730918073046389?thread_ts=1729246801.516029&cid=C029JG63136)

## Before

https://drive.google.com/file/d/1ujdQgVLlT8KlwRwO-Cc3XvRHPrkpxIg_/view?usp=drive_link

## After

https://github.com/user-attachments/assets/e77928e5-165b-441a-b4da-0e10471c0529


## Changelog

### `@metamask/queued-request-controller`

- **FIX**: Ensure queuedRequestCount value is updated properly after flushing the queue for a given origin

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
