### PR TITLE
Autofix: ci: "create-update-issues" workflow skips pre-1.0 breaking changes

### DIFF
--- a/.github/workflows/create-update-issues.yaml
+++ b/.github/workflows/create-update-issues.yaml
@@ -32,12 +32,16 @@ jobs:
               # Extract version number
               version="${tag##*@}"
 
-              # Check if version number ends with .0.0
-              if [[ $version == *.0.0 ]]; then
-                # Fetch responsible team from file
+
+               # Check if it's a breaking change (x.0.0 for >=1.0.0 or 0.x.0 for <1.0.0)
+               if [[ $version =~ ^[1-9][0-9]*\.0\.0$ || ($version =~ ^0\.[0-9]+\.0$ && $version != "0.0.0") ]]; then
+                 # Fetch responsible team from file
+                 teams=$(jq -r --arg key "$package_name" '.[$key]' teams.json)
                 teams=$(jq -r --arg key "$package_name" '.[$key]' teams.json)
-                gh issue create --title "Update ${package_name} to version ${version}" --body "Please update ${package_name} to version ${version}" --repo "MetaMask/metamask-extension" --label "$teams"
-                gh issue create --title "Update ${package_name} to version ${version}" --body "Please update ${package_name} to version ${version}" --repo "MetaMask/metamask-mobile" --label "$teams"
+
+                 gh issue create --title "Update ${package_name} to version ${version} (Breaking Change)" --body "Please update ${package_name} to version ${version}. This is a breaking change." --repo "MetaMask/metamask-extension" --label "$teams"
+                 gh issue create --title "Update ${package_name} to version ${version} (Breaking Change)" --body "Please update ${package_name} to version ${version}. This is a breaking change." --repo "MetaMask/metamask-mobile" --label "$teams"
+               fi
               fi
             fi
           done


### PR DESCRIPTION
Modified the create-update-issues workflow to create issues for breaking changes in pre-1.0 controllers. Now, it considers minor version bumps as breaking changes when the major version is zero. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    