### PR TITLE
feat: add batch delete endpoint support for UserStorageController & profile sync SDK

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -439,8 +439,8 @@ describe('user-storage/user-storage-controller - performBatchDeleteStorage() tes
     });
 
     await controller.performBatchDeleteStorage('notifications', [
-      'notifications.notification_settings',
-      'new data',
+      'notification_settings',
+      'notification_settings',
     ]);
     expect(mockAPI.isDone()).toBe(true);
   });
@@ -458,8 +458,8 @@ describe('user-storage/user-storage-controller - performBatchDeleteStorage() tes
 
     await expect(
       controller.performBatchDeleteStorage('notifications', [
-        'notifications.notification_settings',
-        'new data',
+        'notification_settings',
+        'notification_settings',
       ]),
     ).rejects.toThrow(expect.any(Error));
   });
@@ -496,8 +496,8 @@ describe('user-storage/user-storage-controller - performBatchDeleteStorage() tes
 
       await expect(
         controller.performBatchDeleteStorage('notifications', [
-          'notifications.notification_settings',
-          'new data',
+          'notification_settings',
+          'notification_settings',
         ]),
       ).rejects.toThrow(expect.any(Error));
     },
@@ -512,8 +512,8 @@ describe('user-storage/user-storage-controller - performBatchDeleteStorage() tes
 
     await expect(
       controller.performBatchDeleteStorage('notifications', [
-        'notifications.notification_settings',
-        'new data',
+        'notification_settings',
+        'notification_settings',
       ]),
     ).rejects.toThrow(expect.any(Error));
     mockAPI.done();

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -20,6 +20,7 @@ import {
   mockEndpointUpsertUserStorage,
   mockEndpointDeleteUserStorageAllFeatureEntries,
   mockEndpointDeleteUserStorage,
+  mockEndpointBatchDeleteUserStorage,
 } from './__fixtures__/mockServices';
 import {
   MOCK_STORAGE_DATA,
@@ -400,6 +401,106 @@ describe('user-storage/user-storage-controller - performBatchSetStorage() tests'
     await expect(
       controller.performBatchSetStorage('notifications', [
         ['notifications.notification_settings', 'new data'],
+      ]),
+    ).rejects.toThrow(expect.any(Error));
+    mockAPI.done();
+  });
+});
+
+describe('user-storage/user-storage-controller - performBatchDeleteStorage() tests', () => {
+  const arrangeMocks = (mockResponseStatus?: number) => {
+    return {
+      messengerMocks: mockUserStorageMessenger(),
+      mockAPI: mockEndpointBatchDeleteUserStorage(
+        'notifications',
+        mockResponseStatus ? { status: mockResponseStatus } : undefined,
+      ),
+    };
+  };
+
+  it('batch deletes entries in user storage', async () => {
+    const { messengerMocks, mockAPI } = arrangeMocks();
+    const controller = new UserStorageController({
+      messenger: messengerMocks.messenger,
+      getMetaMetricsState: () => true,
+    });
+
+    await controller.performBatchDeleteStorage('notifications', [
+      'notifications.notification_settings',
+      'new data',
+    ]);
+    expect(mockAPI.isDone()).toBe(true);
+  });
+
+  it('rejects if UserStorage is not enabled', async () => {
+    const { messengerMocks } = arrangeMocks();
+    const controller = new UserStorageController({
+      messenger: messengerMocks.messenger,
+      getMetaMetricsState: () => true,
+      state: {
+        isProfileSyncingEnabled: false,
+        isProfileSyncingUpdateLoading: false,
+      },
+    });
+
+    await expect(
+      controller.performBatchDeleteStorage('notifications', [
+        'notifications.notification_settings',
+        'new data',
+      ]),
+    ).rejects.toThrow(expect.any(Error));
+  });
+
+  it.each([
+    [
+      'fails when no bearer token is found (auth errors)',
+      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+        messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
+          new Error('MOCK FAILURE'),
+        ),
+    ],
+    [
+      'fails when no session identifier is found (auth errors)',
+      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+        messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
+          new Error('MOCK FAILURE'),
+        ),
+    ],
+  ])(
+    'rejects on auth failure - %s',
+    async (
+      _: string,
+      arrangeFailureCase: (
+        messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
+      ) => void,
+    ) => {
+      const { messengerMocks } = arrangeMocks();
+      arrangeFailureCase(messengerMocks);
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+        getMetaMetricsState: () => true,
+      });
+
+      await expect(
+        controller.performBatchDeleteStorage('notifications', [
+          'notifications.notification_settings',
+          'new data',
+        ]),
+      ).rejects.toThrow(expect.any(Error));
+    },
+  );
+
+  it('rejects if api call fails', async () => {
+    const { messengerMocks, mockAPI } = arrangeMocks(500);
+    const controller = new UserStorageController({
+      messenger: messengerMocks.messenger,
+      getMetaMetricsState: () => true,
+    });
+
+    await expect(
+      controller.performBatchDeleteStorage('notifications', [
+        'notifications.notification_settings',
+        'new data',
       ]),
     ).rejects.toThrow(expect.any(Error));
     mockAPI.done();

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -44,6 +44,7 @@ import {
 } from './accounts/user-storage';
 import { startNetworkSyncing } from './network-syncing/controller-integration';
 import {
+  batchDeleteUserStorage,
   batchUpsertUserStorage,
   deleteUserStorage,
   deleteUserStorageAllFeatureEntries,
@@ -728,6 +729,31 @@ export default class UserStorageController extends BaseController<
       path,
       bearerToken,
       storageKey,
+    });
+  }
+
+  /**
+   * Allows delete of multiple user data entries for one specific feature. Data deleted must be string formatted.
+   * Developers can extend the entry path through the `schema.ts` file.
+   *
+   * @param path - string in the form of `${feature}` that matches schema
+   * @param values - data to store, in the form of an array of entryKey[]
+   * @returns nothing. NOTE that an error is thrown if fails to store data.
+   */
+  public async performBatchDeleteStorage(
+    path: UserStoragePathWithFeatureOnly,
+    values: UserStoragePathWithKeyOnly[],
+  ): Promise<void> {
+    this.#assertProfileSyncingEnabled();
+
+    const { bearerToken, storageKey } =
+      await this.#getStorageKeyAndBearerToken();
+
+    await batchDeleteUserStorage(values, {
+      path,
+      bearerToken,
+      storageKey,
+      nativeScryptCrypto: this.#nativeScryptCrypto,
     });
   }
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -745,9 +745,11 @@ export default class UserStorageController extends BaseController<
    * @param values - data to store, in the form of an array of entryKey[]
    * @returns nothing. NOTE that an error is thrown if fails to store data.
    */
-  public async performBatchDeleteStorage(
-    path: UserStoragePathWithFeatureOnly,
-    values: UserStoragePathWithKeyOnly[],
+  public async performBatchDeleteStorage<
+    FeatureName extends UserStoragePathWithFeatureOnly,
+  >(
+    path: FeatureName,
+    values: UserStorageFeatureKeys<FeatureName>[],
   ): Promise<void> {
     this.#assertProfileSyncingEnabled();
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockResponses.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockResponses.ts
@@ -118,6 +118,16 @@ export const getMockUserStorageBatchPutResponse = (
   } satisfies MockResponse;
 };
 
+export const getMockUserStorageBatchDeleteResponse = (
+  path: UserStoragePathWithFeatureOnly = 'notifications',
+) => {
+  return {
+    url: getMockUserStorageEndpoint(path),
+    requestMethod: 'PUT',
+    response: null,
+  } satisfies MockResponse;
+};
+
 export const deleteMockUserStorageResponse = (
   path: UserStoragePathWithFeatureAndKey = 'notifications.notification_settings',
 ) => {

--- a/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockServices.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockServices.ts
@@ -9,6 +9,7 @@ import {
   getMockUserStoragePutResponse,
   getMockUserStorageAllFeatureEntriesResponse,
   getMockUserStorageBatchPutResponse,
+  getMockUserStorageBatchDeleteResponse,
   deleteMockUserStorageAllFeatureEntriesResponse,
   deleteMockUserStorageResponse,
 } from './mockResponses';
@@ -105,5 +106,19 @@ export const mockEndpointDeleteUserStorageAllFeatureEntries = (
 
   const mockEndpoint = nock(mockResponse.url).delete('').reply(reply.status);
 
+  return mockEndpoint;
+};
+
+export const mockEndpointBatchDeleteUserStorage = (
+  path: UserStoragePathWithFeatureOnly = 'notifications',
+  mockReply?: Pick<MockReply, 'status'>,
+  callback?: (uri: string, requestBody: nock.Body) => Promise<void>,
+) => {
+  const mockResponse = getMockUserStorageBatchDeleteResponse(path);
+  const mockEndpoint = nock(mockResponse.url)
+    .put('')
+    .reply(mockReply?.status ?? 204, async (uri, requestBody) => {
+      return await callback?.(uri, requestBody);
+    });
   return mockEndpoint;
 };

--- a/packages/profile-sync-controller/src/controllers/user-storage/services.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/services.test.ts
@@ -391,14 +391,14 @@ describe('user-storage/services.ts - batchDeleteUserStorage() tests', () => {
   const actCallBatchDeleteUserStorage = async () => {
     return await batchDeleteUserStorage(keysToDelete, {
       bearerToken: 'MOCK_BEARER_TOKEN',
-      path: 'accounts',
+      path: USER_STORAGE_FEATURE_NAMES.accounts,
       storageKey: MOCK_STORAGE_KEY,
     });
   };
 
   it('invokes upsert endpoint with no errors', async () => {
     const mockDeleteUserStorage = mockEndpointBatchDeleteUserStorage(
-      'accounts',
+      USER_STORAGE_FEATURE_NAMES.accounts,
       undefined,
       async (_uri, requestBody) => {
         if (typeof requestBody === 'string') {
@@ -420,7 +420,7 @@ describe('user-storage/services.ts - batchDeleteUserStorage() tests', () => {
 
   it('throws error if unable to upsert user storage', async () => {
     const mockDeleteUserStorage = mockEndpointBatchDeleteUserStorage(
-      'accounts',
+      USER_STORAGE_FEATURE_NAMES.accounts,
       {
         status: 500,
       },

--- a/packages/profile-sync-controller/src/controllers/user-storage/services.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/services.test.ts
@@ -384,7 +384,9 @@ describe('user-storage/services.ts - deleteUserStorageAllFeatureEntries() tests'
 });
 
 describe('user-storage/services.ts - batchDeleteUserStorage() tests', () => {
-  const keysToDelete: UserStoragePathWithKeyOnly[] = ['0x123', '0x456'];
+  const keysToDelete: UserStorageFeatureKeys<
+    typeof USER_STORAGE_FEATURE_NAMES.accounts
+  >[] = ['0x123', '0x456'];
 
   const actCallBatchDeleteUserStorage = async () => {
     return await batchDeleteUserStorage(keysToDelete, {

--- a/packages/profile-sync-controller/src/controllers/user-storage/services.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/services.ts
@@ -276,7 +276,7 @@ export async function deleteUserStorage(
  * @param opts - storage options
  */
 export async function batchDeleteUserStorage(
-  data: UserStoragePathWithKeyOnly[],
+  data: string[],
   opts: UserStorageBatchUpsertOptions,
 ): Promise<void> {
   if (!data.length) {

--- a/packages/profile-sync-controller/src/controllers/user-storage/services.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/services.ts
@@ -270,6 +270,49 @@ export async function deleteUserStorage(
 }
 
 /**
+ * User Storage Service - Delete multiple storage entries for one specific feature.
+ * You cannot use this method to delete multiple features at once.
+ *
+ * @param data - data to delete, in the form of an array entryKey[]
+ * @param opts - storage options
+ */
+export async function batchDeleteUserStorage(
+  data: UserStoragePathWithKeyOnly[],
+  opts: UserStorageBatchUpsertOptions,
+): Promise<void> {
+  if (!data.length) {
+    return;
+  }
+
+  const { bearerToken, path, storageKey } = opts;
+
+  const encryptedData: string[] = [];
+
+  for (const d of data) {
+    encryptedData.push(createSHA256Hash(d + storageKey));
+  }
+
+  const url = new URL(`${USER_STORAGE_ENDPOINT}/${path}`);
+
+  console.log('body', `batch_delete: ${JSON.stringify(encryptedData)}`);
+  console.log('url', url.toString());
+
+  const res = await fetch(url.toString(), {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${bearerToken}`,
+    },
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    body: JSON.stringify({ batch_delete: encryptedData }),
+  });
+
+  if (!res.ok) {
+    throw new Error('user-storage - unable to batch delete data');
+  }
+}
+
+/**
  * User Storage Service - Delete all storage entries for a specific feature.
  *
  * @param opts - User Storage Options

--- a/packages/profile-sync-controller/src/controllers/user-storage/services.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/services.ts
@@ -293,9 +293,6 @@ export async function batchDeleteUserStorage(
 
   const url = new URL(`${USER_STORAGE_ENDPOINT}/${path}`);
 
-  console.log('body', `batch_delete: ${JSON.stringify(encryptedData)}`);
-  console.log('url', url.toString());
-
   const res = await fetch(url.toString(), {
     method: 'PUT',
     headers: {

--- a/packages/profile-sync-controller/src/sdk/__fixtures__/mock-userstorage.ts
+++ b/packages/profile-sync-controller/src/sdk/__fixtures__/mock-userstorage.ts
@@ -77,6 +77,21 @@ export const handleMockUserStoragePut = (
   return mockEndpoint;
 };
 
+export const handleMockUserStorageBatchDelete = (
+  mockReply?: MockReply,
+  callback?: (uri: string, requestBody: nock.Body) => Promise<void>,
+) => {
+  const reply = mockReply ?? { status: 204 };
+  const mockEndpoint = nock(MOCK_STORAGE_URL)
+    .persist()
+    .put(/.*/u)
+    .reply(reply.status, async (uri, requestBody) => {
+      return await callback?.(uri, requestBody);
+    });
+
+  return mockEndpoint;
+};
+
 export const handleMockUserStorageDelete = async (mockReply?: MockReply) => {
   const reply = mockReply ?? { status: 204 };
   const mockEndpoint = nock(MOCK_STORAGE_URL)

--- a/packages/profile-sync-controller/src/sdk/user-storage.test.ts
+++ b/packages/profile-sync-controller/src/sdk/user-storage.test.ts
@@ -210,7 +210,9 @@ describe('User Storage', () => {
   });
 
   it('user storage: batch delete items', async () => {
-    const keysToDelete: UserStoragePathWithKeyOnly[] = ['0x123', '0x456'];
+    const keysToDelete: UserStorageFeatureKeys<
+      typeof USER_STORAGE_FEATURE_NAMES.accounts
+    >[] = ['0x123', '0x456'];
     const { auth } = arrangeAuth('SRP', MOCK_SRP);
     const { userStorage } = arrangeUserStorage(auth);
 
@@ -229,7 +231,7 @@ describe('User Storage', () => {
       },
     );
 
-    await userStorage.batchDeleteItems('accounts', keysToDelete);
+    await userStorage.batchDeleteItems('accounts_v2', keysToDelete);
     expect(mockPut.isDone()).toBe(true);
   });
 
@@ -286,7 +288,10 @@ describe('User Storage', () => {
     });
 
     await expect(
-      userStorage.batchDeleteItems('notifications', ['key', 'key2']),
+      userStorage.batchDeleteItems(USER_STORAGE_FEATURE_NAMES.accounts, [
+        'key',
+        'key2',
+      ]),
     ).rejects.toThrow(UserStorageError);
   });
 

--- a/packages/profile-sync-controller/src/sdk/user-storage.ts
+++ b/packages/profile-sync-controller/src/sdk/user-storage.ts
@@ -87,9 +87,9 @@ export class UserStorage {
     return this.#deleteUserStorageAllFeatureEntries(path);
   }
 
-  async batchDeleteItems(
+  async batchDeleteItems<FeatureName extends UserStorageFeatureNames>(
     path: UserStoragePathWithFeatureOnly,
-    values: UserStoragePathWithKeyOnly[],
+    values: UserStorageFeatureKeys<FeatureName>[],
   ) {
     return this.#batchDeleteUserStorage(path, values);
   }

--- a/packages/profile-sync-controller/src/sdk/user-storage.ts
+++ b/packages/profile-sync-controller/src/sdk/user-storage.ts
@@ -88,7 +88,7 @@ export class UserStorage {
   }
 
   async batchDeleteItems<FeatureName extends UserStorageFeatureNames>(
-    path: UserStoragePathWithFeatureOnly,
+    path: FeatureName,
     values: UserStorageFeatureKeys<FeatureName>[],
   ) {
     return this.#batchDeleteUserStorage(path, values);
@@ -393,9 +393,9 @@ export class UserStorage {
     }
   }
 
-  async #batchDeleteUserStorage(
-    path: UserStoragePathWithFeatureOnly,
-    data: UserStoragePathWithKeyOnly[],
+  async #batchDeleteUserStorage<FeatureName extends UserStorageFeatureNames>(
+    path: FeatureName,
+    data: UserStorageFeatureKeys<FeatureName>[],
   ): Promise<void> {
     try {
       if (!data.length) {


### PR DESCRIPTION
## Explanation

This PR adds support for the batch delete endpoint, for both `UserStorageController` and the SDK

## References

Fixes https://github.com/MetaMask/core/issues/4936

## Changelog

### `@metamask/profile-sync-controller`

- **ADDED**: support for the batch delete endpoint for both `UserStorageController` and profile-sync SDK

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
