### PR TITLE
[composable-controller] Enable handling of non-controller input

### DIFF
--- a/packages/base-controller/src/BaseControllerV1.test.ts
+++ b/packages/base-controller/src/BaseControllerV1.test.ts
@@ -51,7 +51,6 @@ describe('isBaseControllerV1', () => {
 
   it('should return false if passed a non-controller', () => {
     const notController = new JsonRpcEngine();
-    // @ts-expect-error Intentionally passing invalid input to test runtime behavior
     expect(isBaseControllerV1(notController)).toBe(false);
   });
 });

--- a/packages/base-controller/src/BaseControllerV1.ts
+++ b/packages/base-controller/src/BaseControllerV1.ts
@@ -1,6 +1,4 @@
-import type { PublicInterface } from '@metamask/utils';
-
-import type { ControllerInstance } from './BaseControllerV2';
+import { isNullOrUndefined, type PublicInterface } from '@metamask/utils';
 
 /**
  * Determines if the given controller is an instance of `BaseControllerV1`
@@ -9,9 +7,11 @@ import type { ControllerInstance } from './BaseControllerV2';
  * @returns True if the controller is an instance of `BaseControllerV1`
  */
 export function isBaseControllerV1(
-  controller: ControllerInstance,
+  controller: unknown,
 ): controller is BaseControllerV1Instance {
   return (
+    typeof controller === 'object' &&
+    !isNullOrUndefined(controller) &&
     'name' in controller &&
     typeof controller.name === 'string' &&
     'config' in controller &&

--- a/packages/base-controller/src/BaseControllerV2.test.ts
+++ b/packages/base-controller/src/BaseControllerV2.test.ts
@@ -203,7 +203,6 @@ describe('isBaseController', () => {
 
   it('should return false if passed a non-controller', () => {
     const notController = new JsonRpcEngine();
-    // @ts-expect-error Intentionally passing invalid input to test runtime behavior
     expect(isBaseController(notController)).toBe(false);
   });
 });

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -1,4 +1,8 @@
-import type { Json, PublicInterface } from '@metamask/utils';
+import {
+  isNullOrUndefined,
+  type Json,
+  type PublicInterface,
+} from '@metamask/utils';
 import { enablePatches, produceWithPatches, applyPatches, freeze } from 'immer';
 import type { Draft, Patch } from 'immer';
 
@@ -21,9 +25,11 @@ enablePatches();
  * @returns True if the controller is an instance of `BaseController`
  */
 export function isBaseController(
-  controller: ControllerInstance,
+  controller: unknown,
 ): controller is BaseControllerInstance {
   return (
+    typeof controller === 'object' &&
+    !isNullOrUndefined(controller) &&
     'name' in controller &&
     typeof controller.name === 'string' &&
     'state' in controller &&

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -136,7 +136,7 @@ export type StateMetadataConstraint = Record<
 >;
 
 /**
- * The widest subtype of all controller instances that inherit from `BaseController` (formerly `BaseControllerV2`).
+ * The narrowest supertype of all controller instances that inherit from `BaseController` (formerly `BaseControllerV2`).
  * Any `BaseController` subclass instance can be assigned to this type.
  */
 export type BaseControllerInstance = Omit<
@@ -153,7 +153,7 @@ export type BaseControllerInstance = Omit<
 };
 
 /**
- * A widest subtype of all controller instances that inherit from `BaseController` (formerly `BaseControllerV2`) or `BaseControllerV1`.
+ * A narrowest supertype of all controller instances that inherit from `BaseController` (formerly `BaseControllerV2`) or `BaseControllerV1`.
  * Any `BaseController` or `BaseControllerV1` subclass instance can be assigned to this type.
  */
 // TODO: Remove once BaseControllerV2 migrations are completed for all controllers.

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -15,10 +15,7 @@ import type {
   ChildControllerStateChangeEvents,
   ComposableControllerEvents,
 } from './ComposableController';
-import {
-  ComposableController,
-  INVALID_CONTROLLER_ERROR,
-} from './ComposableController';
+import { ComposableController } from './ComposableController';
 
 // Mock BaseController classes
 
@@ -531,7 +528,7 @@ describe('ComposableController', () => {
       ).toThrow('Messaging system is required');
     });
 
-    it('should throw if composing a controller that does not extend from BaseController', () => {
+    it('should not throw if composing a controller that does not extend from BaseController', () => {
       type ComposableControllerState = {
         // TODO: Either fix this lint violation or explain why it's necessary to ignore.
         // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -564,7 +561,7 @@ describe('ComposableController', () => {
             controllers: [notController, fooController],
             messenger: composableControllerMessenger,
           }),
-      ).toThrow(INVALID_CONTROLLER_ERROR);
+      ).not.toThrow();
     });
   });
 });

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -20,7 +20,7 @@ export const controllerName = 'ComposableController';
  * A universal supertype for modules with a 'string'-type `name` property.
  * This type is intended to encompass controller and non-controller input that can be passed into the {@link ComposableController} `controllers` constructor option.
  */
-export type NamedModule = { name: string } & Record<string, unknown>;
+export type NamedModule = { name: string };
 
 /**
  * A universal supertype for the composable controller state object.
@@ -129,11 +129,11 @@ export type ComposableControllerMessenger<
  * Controller that composes multiple child controllers and maintains up-to-date composed state.
  *
  * @template ComposableControllerState - A type object containing the names and state types of the child controllers. Any non-controllers with empty state should be omitted from this type argument.
- * @template ChildControllers - A union type of the child controllers being used to instantiate the {@link ComposableController}. Any non-controllers with empty state should be excluded from this type argument.
+ * @template ChildControllers - A union type of the child controllers being used to instantiate the {@link ComposableController}. Non-controllers that are passed into the `controllers` constructor option at runtime should be included in this type argument.
  */
 export class ComposableController<
   ComposableControllerState extends LegacyComposableControllerStateConstraint,
-  ChildControllers extends ControllerInstance,
+  ChildControllers extends NamedModule,
 > extends BaseController<
   typeof controllerName,
   ComposableControllerState,
@@ -143,7 +143,7 @@ export class ComposableController<
    * Creates a ComposableController instance.
    *
    * @param options - Initial options used to configure this controller
-   * @param options.controllers - List of child controller instances to compose. Any non-controllers that are included here will be excluded from the composed state object.
+   * @param options.controllers - List of child controller instances to compose. Any non-controllers that are included here will be excluded from the composed state object and from `stateChange` event subscription.
    * @param options.messenger - A restricted controller messenger.
    */
 
@@ -151,7 +151,7 @@ export class ComposableController<
     controllers,
     messenger,
   }: {
-    controllers: (ChildControllers | NamedModule)[];
+    controllers: ChildControllers[];
     messenger: ComposableControllerMessenger<ComposableControllerState>;
   }) {
     if (messenger === undefined) {
@@ -197,7 +197,7 @@ export class ComposableController<
    *
    * @param controller - Controller instance to update
    */
-  #updateChildController(controller: ChildControllers | NamedModule): void {
+  #updateChildController(controller: ChildControllers): void {
     if (!isBaseController(controller) && !isBaseControllerV1(controller)) {
       return;
     }

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -5,7 +5,6 @@ import type {
   StateMetadata,
   ControllerStateChangeEvent,
   LegacyControllerStateConstraint,
-  ControllerInstance,
 } from '@metamask/base-controller';
 import {
   BaseController,

--- a/packages/composable-controller/src/index.ts
+++ b/packages/composable-controller/src/index.ts
@@ -6,6 +6,5 @@ export type {
 } from './ComposableController';
 export {
   ComposableController,
-  isController,
   STATELESS_NONCONTROLLER_NAMES,
 } from './ComposableController';

--- a/packages/composable-controller/src/index.ts
+++ b/packages/composable-controller/src/index.ts
@@ -6,5 +6,6 @@ export type {
 } from './ComposableController';
 export {
   ComposableController,
+  isController,
   STATELESS_NONCONTROLLER_NAMES,
 } from './ComposableController';

--- a/packages/composable-controller/src/index.ts
+++ b/packages/composable-controller/src/index.ts
@@ -4,4 +4,7 @@ export type {
   ComposableControllerEvents,
   ComposableControllerMessenger,
 } from './ComposableController';
-export { ComposableController } from './ComposableController';
+export {
+  ComposableController,
+  STATELESS_NONCONTROLLER_NAMES,
+} from './ComposableController';


### PR DESCRIPTION
## References

- Closes https://github.com/MetaMask/core/issues/4444
- Blocking https://github.com/MetaMask/metamask-mobile/pull/10441

## Changelog

## `@metamask/composable-controller`

### Changed

- Widen `ComposableController` controller option `controllers` and generic type parameter `ChildControllers` to accept all objects with a 'name' property. Passing in non-controller input no longer produces a runtime error.
  - Note that the composed state output and `stateChange` event subscription operation will exclude non-controller input.
  - Generic type parameter `ComposableControllerState` only accepts controllers with a 'state' property.
- Widen input type for type guards `isBaseController`, `isBaseControllerV1` from `ControllerInstance` to `unknown`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
