### PR TITLE
feat: add account sync analytics & add state helpers

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -92,6 +92,8 @@ describe('user-storage/user-storage-controller - performGetStorage() tests', () 
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
+        hasAccountSyncingSyncedAtLeastOnce: false,
+        isAccountSyncingReadyToBeDispatched: false,
       },
     });
 
@@ -171,6 +173,8 @@ describe('user-storage/user-storage-controller - performGetStorageAllFeatureEntr
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
+        hasAccountSyncingSyncedAtLeastOnce: false,
+        isAccountSyncingReadyToBeDispatched: false,
       },
     });
 
@@ -250,6 +254,8 @@ describe('user-storage/user-storage-controller - performSetStorage() tests', () 
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
+        hasAccountSyncingSyncedAtLeastOnce: false,
+        isAccountSyncingReadyToBeDispatched: false,
       },
     });
 
@@ -353,6 +359,8 @@ describe('user-storage/user-storage-controller - performBatchSetStorage() tests'
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
+        hasAccountSyncingSyncedAtLeastOnce: false,
+        isAccountSyncingReadyToBeDispatched: false,
       },
     });
 
@@ -453,6 +461,8 @@ describe('user-storage/user-storage-controller - performBatchDeleteStorage() tes
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
+        hasAccountSyncingSyncedAtLeastOnce: false,
+        isAccountSyncingReadyToBeDispatched: false,
       },
     });
 
@@ -554,6 +564,8 @@ describe('user-storage/user-storage-controller - performDeleteStorage() tests', 
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
+        hasAccountSyncingSyncedAtLeastOnce: false,
+        isAccountSyncingReadyToBeDispatched: false,
       },
     });
 
@@ -652,6 +664,8 @@ describe('user-storage/user-storage-controller - performDeleteStorageAllFeatureE
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
+        hasAccountSyncingSyncedAtLeastOnce: false,
+        isAccountSyncingReadyToBeDispatched: false,
       },
     });
 
@@ -742,6 +756,8 @@ describe('user-storage/user-storage-controller - getStorageKey() tests', () => {
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
+        hasAccountSyncingSyncedAtLeastOnce: false,
+        isAccountSyncingReadyToBeDispatched: false,
       },
     });
 
@@ -786,6 +802,8 @@ describe('user-storage/user-storage-controller - enableProfileSyncing() tests', 
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
+        hasAccountSyncingSyncedAtLeastOnce: false,
+        isAccountSyncingReadyToBeDispatched: false,
       },
     });
 
@@ -816,6 +834,8 @@ describe('user-storage/user-storage-controller - syncInternalAccountsWithUserSto
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
+        hasAccountSyncingSyncedAtLeastOnce: false,
+        isAccountSyncingReadyToBeDispatched: false,
       },
     });
 
@@ -956,7 +976,7 @@ describe('user-storage/user-storage-controller - syncInternalAccountsWithUserSto
     expect(mockAPI.mockEndpointBatchUpsertUserStorage.isDone()).toBe(true);
   });
 
-  it('creates internal accounts if user storage has more accounts', async () => {
+  it('creates internal accounts if user storage has more accounts. it also updates hasAccountSyncingSyncedAtLeastOnce accordingly', async () => {
     const mockUserStorageAccountsResponse = async () => {
       return {
         status: 200,
@@ -1027,6 +1047,8 @@ describe('user-storage/user-storage-controller - syncInternalAccountsWithUserSto
     );
 
     expect(mockAPI.mockEndpointBatchDeleteUserStorage.isDone()).toBe(true);
+
+    expect(controller.state.hasAccountSyncingSyncedAtLeastOnce).toBe(true);
   });
 
   describe('handles corrupted user storage gracefully', () => {
@@ -1096,6 +1118,28 @@ describe('user-storage/user-storage-controller - syncInternalAccountsWithUserSto
       expect(mockAPI.mockEndpointGetUserStorage.isDone()).toBe(true);
       expect(mockAPI.mockEndpointBatchUpsertUserStorage.isDone()).toBe(false);
       expect(mockAPI.mockEndpointBatchDeleteUserStorage.isDone()).toBe(true);
+    });
+
+    it('fires the onAccountSyncErroneousSituation callback in erroneous situations', async () => {
+      const onAccountSyncErroneousSituation = jest.fn();
+
+      const { messengerMocks } = await arrangeMocksForBogusAccounts();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+        config: {
+          accountSyncing: {
+            onAccountSyncErroneousSituation,
+          },
+        },
+        env: {
+          isAccountSyncingEnabled: true,
+        },
+        getMetaMetricsState: () => true,
+      });
+
+      await controller.syncInternalAccountsWithUserStorage();
+
+      expect(onAccountSyncErroneousSituation).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1749,6 +1793,8 @@ describe('user-storage/user-storage-controller - saveInternalAccountToUserStorag
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
+        hasAccountSyncingSyncedAtLeastOnce: false,
+        isAccountSyncingReadyToBeDispatched: false,
       },
     });
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -100,11 +100,21 @@ export type UserStorageControllerState = {
    * Loading state for the profile syncing update
    */
   isProfileSyncingUpdateLoading: boolean;
+  /**
+   * Condition used by E2E tests to determine if account syncing has been dispatched at least once.
+   */
+  hasAccountSyncingSyncedAtLeastOnce: boolean;
+  /**
+   * Condition used by UI to determine if account syncing is ready to be dispatched.
+   */
+  isAccountSyncingReadyToBeDispatched: boolean;
 };
 
 export const defaultState: UserStorageControllerState = {
   isProfileSyncingEnabled: true,
   isProfileSyncingUpdateLoading: false,
+  hasAccountSyncingSyncedAtLeastOnce: false,
+  isAccountSyncingReadyToBeDispatched: false,
 };
 
 const metadata: StateMetadata<UserStorageControllerState> = {
@@ -113,6 +123,14 @@ const metadata: StateMetadata<UserStorageControllerState> = {
     anonymous: true,
   },
   isProfileSyncingUpdateLoading: {
+    persist: false,
+    anonymous: false,
+  },
+  hasAccountSyncingSyncedAtLeastOnce: {
+    persist: true,
+    anonymous: true,
+  },
+  isAccountSyncingReadyToBeDispatched: {
     persist: false,
     anonymous: false,
   },
@@ -132,6 +150,15 @@ type ControllerConfig = {
      * This is used for analytics.
      */
     onAccountNameUpdated?: (profileId: string) => void;
+
+    /**
+     * Callback that fires when an erroneous situation happens during account sync.
+     * This is used for analytics.
+     */
+    onAccountSyncErroneousSituation?: (
+      profileId: string,
+      situationMessage: string,
+    ) => void;
   };
 };
 
@@ -280,7 +307,6 @@ export default class UserStorageController extends BaseController<
     isAccountSyncingEnabled: false,
     isAccountSyncingInProgress: false,
     maxNumberOfAccountsToAdd: 0,
-    hasSyncedAtLeastOnce: false,
     canSync: () => {
       try {
         this.#assertProfileSyncingEnabled();
@@ -309,7 +335,7 @@ export default class UserStorageController extends BaseController<
         async (account) => {
           if (
             !this.#accounts.canSync() ||
-            !this.#accounts.hasSyncedAtLeastOnce
+            !this.state.hasAccountSyncingSyncedAtLeastOnce
           ) {
             return;
           }
@@ -324,7 +350,7 @@ export default class UserStorageController extends BaseController<
         async (account) => {
           if (
             !this.#accounts.canSync() ||
-            !this.#accounts.hasSyncedAtLeastOnce
+            !this.state.hasAccountSyncingSyncedAtLeastOnce
           ) {
             return;
           }
@@ -859,6 +885,24 @@ export default class UserStorageController extends BaseController<
     });
   }
 
+  private async setHasAccountSyncingSyncedAtLeastOnce(
+    hasAccountSyncingSyncedAtLeastOnce: boolean,
+  ): Promise<void> {
+    this.update((state) => {
+      state.hasAccountSyncingSyncedAtLeastOnce =
+        hasAccountSyncingSyncedAtLeastOnce;
+    });
+  }
+
+  public async setIsAccountSyncingReadyToBeDispatched(
+    isAccountSyncingReadyToBeDispatched: boolean,
+  ): Promise<void> {
+    this.update((state) => {
+      state.isAccountSyncingReadyToBeDispatched =
+        isAccountSyncingReadyToBeDispatched;
+    });
+  }
+
   /**
    * Syncs the internal accounts list with the user storage accounts list.
    * This method is used to make sure that the internal accounts list is up-to-date with the user storage accounts list and vice-versa.
@@ -879,6 +923,7 @@ export default class UserStorageController extends BaseController<
 
       if (!userStorageAccountsList || !userStorageAccountsList.length) {
         await this.#accounts.saveInternalAccountsListToUserStorage();
+        await this.setHasAccountSyncingSyncedAtLeastOnce(true);
         return;
       }
 
@@ -932,6 +977,10 @@ export default class UserStorageController extends BaseController<
         if (!userStorageAccount) {
           // If the account was just added in the previous step, skip saving it, it's likely to be a bogus account
           if (newlyAddedAccounts.includes(internalAccount)) {
+            this.#config?.accountSyncing?.onAccountSyncErroneousSituation?.(
+              profileId,
+              'An account was added to the internal accounts list but was not present in the user storage accounts list',
+            );
             continue;
           }
           // Otherwise, it means that this internal account was present before the sync, and needs to be saved to the user storage
@@ -1034,10 +1083,15 @@ export default class UserStorageController extends BaseController<
           USER_STORAGE_FEATURE_NAMES.accounts,
           userStorageAccountsToBeDeleted.map((account) => account.a),
         );
+        this.#config?.accountSyncing?.onAccountSyncErroneousSituation?.(
+          profileId,
+          'An account was present in the user storage accounts list but was not found in the internal accounts list after the sync',
+        );
       }
 
-      // We add this here and not in the finally statement because we want to make sure that the accounts are saved before we set this flag
-      this.#accounts.hasSyncedAtLeastOnce = true;
+      // We do this here and not in the finally statement because we want to make sure that
+      // the accounts are saved / updated / deleted at least once before we set this flag
+      await this.setHasAccountSyncingSyncedAtLeastOnce(true);
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : JSON.stringify(e);
       throw new Error(


### PR DESCRIPTION
## Explanation

This PR adds various account syncing improvements. 

- New `UserStorageController` state keys `hasAccountSyncingSyncedAtLeastOnce` and `isAccountSyncingReadyToBeDispatched`
- `onAccountSyncErroneousSituation` analytics callback to track how often erroneous situations happen during account syncing
- Set `hasAccountSyncingSyncedAtLeastOnce` also for a profile id first sync ever in `UserStorageController`

## References

## Changelog

### `@metamask/profile-sync-controller`

- **ADDED**: new `UserStorageController` state keys `hasAccountSyncingSyncedAtLeastOnce` and `isAccountSyncingReadyToBeDispatched`
- **ADDED**: `onAccountSyncErroneousSituation` analytics callback to track how often erroneous situations happen during account syncing
- **FIXED**: set `hasAccountSyncingSyncedAtLeastOnce` also for a profile id first sync ever in `UserStorageController`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
