### PR TITLE
add CaipReferenceRegexes and use in isSupportedScopeString

### DIFF
--- a/packages/multichain/src/scope/constants.ts
+++ b/packages/multichain/src/scope/constants.ts
@@ -10,6 +10,15 @@ export enum KnownWalletScopeString {
 }
 
 /**
+ * Regexes defining how references must be formed for non-wallet known CAIP namespaces
+ */
+export const CaipReferenceRegexes: Record<NonWalletKnownCaipNamespace, RegExp> =
+  {
+    eip155: /^(0|[1-9][0-9]*)$/u,
+    bip122: /.*/u,
+  };
+
+/**
  * Methods that do not belong exclusively to any CAIP namespace.
  */
 export const KnownWalletRpcMethods: string[] = [

--- a/packages/multichain/src/scope/supported.test.ts
+++ b/packages/multichain/src/scope/supported.test.ts
@@ -106,6 +106,16 @@ describe('Scope Support', () => {
         false,
       );
     });
+
+    it('returns false for the ethereum namespace when the reference is malformed', () => {
+      const isChainIdSupportedMock = jest.fn().mockReturnValue(true);
+      expect(isSupportedScopeString('eip155:01', isChainIdSupportedMock)).toBe(
+        false,
+      );
+      expect(isSupportedScopeString('eip155:1e1', isChainIdSupportedMock)).toBe(
+        false,
+      );
+    });
   });
 
   describe('isSupportedAccount', () => {

--- a/packages/multichain/src/scope/supported.ts
+++ b/packages/multichain/src/scope/supported.ts
@@ -3,6 +3,7 @@ import type { CaipAccountId, Hex } from '@metamask/utils';
 import { KnownCaipNamespace, parseCaipAccountId } from '@metamask/utils';
 
 import {
+  CaipReferenceRegexes,
   KnownNotifications,
   KnownRpcMethods,
   KnownWalletNamespaceRpcMethods,
@@ -27,7 +28,11 @@ export const isSupportedScopeString = (
     case KnownCaipNamespace.Wallet:
       return !reference || reference === KnownCaipNamespace.Eip155;
     case KnownCaipNamespace.Eip155:
-      return !reference || isChainIdSupported(toHex(reference));
+      return (
+        !reference ||
+        (CaipReferenceRegexes.eip155.test(reference) &&
+          isChainIdSupported(toHex(reference)))
+      );
     default:
       return false;
   }


### PR DESCRIPTION
## Explanation

Fixes bug where `0` prefixed and `e` exponent suffixed eip155 references were allowed. This PR adds eip155 reference validation against regex.

I'm unsure if this belongs in validation checks, or the supported checks. Validation checks currently do not check for ecosystem specific constraints

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
