### PR TITLE
chore: remove keyring-api dependency from transaction controller

### DIFF
--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -75,7 +75,6 @@
     "@metamask/eth-json-rpc-provider": "^4.1.6",
     "@metamask/ethjs-provider-http": "^0.3.0",
     "@metamask/gas-fee-controller": "^22.0.1",
-    "@metamask/keyring-api": "^10.1.0",
     "@metamask/network-controller": "^22.0.2",
     "@types/bn.js": "^5.1.5",
     "@types/jest": "^27.4.1",

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable jest/expect-expect */
 import type { TypedTransaction } from '@ethereumjs/tx';
 import { TransactionFactory } from '@ethereumjs/tx';
-import type { AccountsController } from '@metamask/accounts-controller';
 import type {
   AddApprovalRequest,
   AddResult,
@@ -70,6 +69,7 @@ import type {
   GasFeeFlow,
   GasFeeFlowResponse,
   SubmitHistoryEntry,
+  InternalAccount,
 } from './types';
 import {
   GasFeeEstimateType,
@@ -399,7 +399,7 @@ const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
 
 const ACCOUNT_MOCK = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
 
-const INTERNAL_ACCOUNT_MOCK = {
+const INTERNAL_ACCOUNT_MOCK: InternalAccount = {
   id: '58def058-d35f-49a1-a7ab-e2580565f6f5',
   address: ACCOUNT_MOCK,
   type: 'eip155:eoa',
@@ -411,7 +411,7 @@ const INTERNAL_ACCOUNT_MOCK = {
     importTime: 1631619180000,
     lastSelected: 1631619180000,
   },
-} as unknown as AccountsController['getSelectedAccount'];
+};
 
 const ACCOUNT_2_MOCK = '0x08f137f335ea1b8f193b8f6ea92561a60d23a211';
 const NONCE_MOCK = 12;
@@ -562,7 +562,7 @@ describe('TransactionController', () => {
         typeof mockAddTransactionApprovalRequest
       >[1];
     };
-    selectedAccount?: AccountsController['getSelectedAccount'];
+    selectedAccount?: InternalAccount;
     mockNetworkClientConfigurationsByNetworkClientId?: Record<
       NetworkClientId,
       NetworkClientConfiguration

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable jest/expect-expect */
 import type { TypedTransaction } from '@ethereumjs/tx';
 import { TransactionFactory } from '@ethereumjs/tx';
+import type { AccountsController } from '@metamask/accounts-controller';
 import type {
   AddApprovalRequest,
   AddResult,
@@ -17,8 +18,6 @@ import {
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import EthQuery from '@metamask/eth-query';
 import HttpProvider from '@metamask/ethjs-provider-http';
-import type { InternalAccount } from '@metamask/keyring-api';
-import { EthAccountType } from '@metamask/keyring-api';
 import type {
   BlockTracker,
   NetworkClientConfiguration,
@@ -399,10 +398,11 @@ const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
 };
 
 const ACCOUNT_MOCK = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+
 const INTERNAL_ACCOUNT_MOCK = {
   id: '58def058-d35f-49a1-a7ab-e2580565f6f5',
   address: ACCOUNT_MOCK,
-  type: EthAccountType.Eoa,
+  type: 'eip155:eoa',
   options: {},
   methods: [],
   metadata: {
@@ -411,7 +411,7 @@ const INTERNAL_ACCOUNT_MOCK = {
     importTime: 1631619180000,
     lastSelected: 1631619180000,
   },
-};
+} as unknown as AccountsController['getSelectedAccount'];
 
 const ACCOUNT_2_MOCK = '0x08f137f335ea1b8f193b8f6ea92561a60d23a211';
 const NONCE_MOCK = 12;
@@ -562,7 +562,7 @@ describe('TransactionController', () => {
         typeof mockAddTransactionApprovalRequest
       >[1];
     };
-    selectedAccount?: InternalAccount;
+    selectedAccount?: AccountsController['getSelectedAccount'];
     mockNetworkClientConfigurationsByNetworkClientId?: Record<
       NetworkClientId,
       NetworkClientConfiguration

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -13,8 +13,6 @@ import {
   InfuraNetworkType,
   NetworkType,
 } from '@metamask/controller-utils';
-import type { InternalAccount } from '@metamask/keyring-api';
-import { EthAccountType, EthMethod } from '@metamask/keyring-api';
 import {
   NetworkController,
   NetworkClientType,
@@ -61,7 +59,7 @@ import type {
   TransactionControllerOptions,
 } from './TransactionController';
 import { TransactionController } from './TransactionController';
-import type { TransactionMeta } from './types';
+import type { InternalAccount, TransactionMeta } from './types';
 import { TransactionStatus, TransactionType } from './types';
 import { getEtherscanApiHost } from './utils/etherscan';
 import * as etherscanUtils from './utils/etherscan';
@@ -104,22 +102,15 @@ const createMockInternalAccount = ({
     id,
     address,
     options: {},
-    methods: [
-      EthMethod.PersonalSign,
-      EthMethod.Sign,
-      EthMethod.SignTransaction,
-      EthMethod.SignTypedDataV1,
-      EthMethod.SignTypedDataV3,
-      EthMethod.SignTypedDataV4,
-    ],
-    type: EthAccountType.Eoa,
+    methods: [],
+    type: 'eip155:eoa',
     metadata: {
       name,
       keyring: { type: 'HD Key Tree' },
       importTime,
       lastSelected,
     },
-  } as InternalAccount;
+  };
 };
 
 const ACCOUNT_MOCK = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1,4 +1,5 @@
 import type { AccessList } from '@ethereumjs/tx';
+import type { AccountsController } from '@metamask/accounts-controller';
 import type EthQuery from '@metamask/eth-query';
 import type { GasFeeState } from '@metamask/gas-fee-controller';
 import type { NetworkClientId, Provider } from '@metamask/network-controller';
@@ -1344,3 +1345,7 @@ export type SubmitHistoryEntry = {
   /** The transaction parameters that were submitted. */
   transaction: TransactionParams;
 };
+
+export type InternalAccount = ReturnType<
+  AccountsController['getSelectedAccount']
+>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3684,7 +3684,6 @@ __metadata:
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-provider-http": "npm:^0.3.0"
     "@metamask/gas-fee-controller": "npm:^22.0.1"
-    "@metamask/keyring-api": "npm:^10.1.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^22.0.2"
     "@metamask/nonce-tracker": "npm:^6.0.0"


### PR DESCRIPTION
## Explanation

Remove dependency on `@metamask/keyring-api` from `@metamask/transaction-controller` as it was only used for types in unit tests.

## References

## Changelog

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
