### PR TITLE
chore: downgrade `snaps-controllers` peer dependency from `^9.10.0` to `^9.7.0`

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^18.0.0",
-    "@metamask/snaps-controllers": "^9.10.0"
+    "@metamask/snaps-controllers": "^9.7.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2054,7 +2054,7 @@ __metadata:
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@metamask/keyring-controller": ^18.0.0
-    "@metamask/snaps-controllers": ^9.10.0
+    "@metamask/snaps-controllers": ^9.7.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Explanation

This change was not required, and bumping peer dependency does require the "consumer" of that packages to potentially update his packages too, which would result in a breaking change for the `accounts-controller` here.

## References

- https://github.com/MetaMask/core/pull/4956#discussion_r1852398241

## Changelog

N/A (since we would revert to the state of the last release of the `accounts-controller` for that specific line).

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
