### PR TITLE
fix: prevent non-current network tokens from being hidden incorrectly

### DIFF
--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -576,10 +576,6 @@ export class TokensController extends BaseController<
     tokenAddressesToIgnore: string[],
     networkClientId?: NetworkClientId,
   ) {
-    const { ignoredTokens, detectedTokens, tokens } = this.state;
-    const ignoredTokensMap: { [key: string]: true } = {};
-    let newIgnoredTokens: string[] = [...ignoredTokens];
-
     let interactingChainId;
     if (networkClientId) {
       interactingChainId = this.messagingSystem.call(
@@ -587,6 +583,24 @@ export class TokensController extends BaseController<
         networkClientId,
       ).configuration.chainId;
     }
+
+    const { allTokens, allDetectedTokens, allIgnoredTokens } = this.state;
+    const ignoredTokensMap: { [key: string]: true } = {};
+    const ignoredTokens =
+      allIgnoredTokens[interactingChainId ?? this.#chainId]?.[
+        this.#getSelectedAddress()
+      ] || [];
+    let newIgnoredTokens: string[] = [...ignoredTokens];
+
+    const tokens =
+      allTokens[interactingChainId ?? this.#chainId]?.[
+        this.#getSelectedAddress()
+      ] || [];
+
+    const detectedTokens =
+      allDetectedTokens[interactingChainId ?? this.#chainId]?.[
+        this.#getSelectedAddress()
+      ] || [];
 
     const checksummedTokenAddresses = tokenAddressesToIgnore.map((address) => {
       const checksumAddress = toChecksumHexAddress(address);


### PR DESCRIPTION
## Explanation

### Current State
Currently, the `ignoreTokens` method in the `TokensController` is using a static set of tokens (`ignoredTokens`, `detectedTokens`, and `tokens`) without accounting for tokens scoped to specific networks. This causes issues when attempting to hide tokens that do not belong to the currently active network, potentially leading to incorrect behavior.

### Changes Introduced
- Updated the method to use `allTokens`, `allDetectedTokens`, and `allIgnoredTokens`, scoped by `interactingChainId` or the current network's `chainId` and selected address.
- Ensured the `ignoredTokens` array is derived dynamically based on the active network and address, preventing interference from tokens of other networks.

### How It Works
- The changes introduce a more granular approach by retrieving the correct token lists (`allTokens`, `allDetectedTokens`, and `allIgnoredTokens`) scoped to the relevant network and address.
- The method now dynamically calculates `ignoredTokens` for the active network, avoiding issues with overlapping or incorrect tokens.

These updates ensure that the `ignoreTokens` function operates correctly when handling network-specific tokens, reducing the risk of unintended behavior.

---

## References

- None.

---

## Changelog

### `@metamask/assets-controllers`
- **FIXED**: Resolved an issue where `ignoreTokens` could incorrectly hide tokens from networks other than the current one.
- **CHANGED**: Updated `ignoreTokens` logic to use network- and address-specific token lists (`allTokens`, `allDetectedTokens`, `allIgnoredTokens`).

---

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate.
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate.
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate.
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes.

--- 

This format is ready to be used in your PR description field on platforms like GitHub.