### PR TITLE
[composable-controller] perf: Optimize expensive reduce operations, fix metadata instantiation

### DIFF
--- a/packages/composable-controller/CHANGELOG.md
+++ b/packages/composable-controller/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** `ComposableController` constructor option `controllers` and generic type argument `ChildControllers` are re-defined from an array of controller instances to an object that maps controller names to controller instances.
-- **BREAKING:** `ComposableController` class field objects `state` and `metadata` exclude child controllers that do not extend from `BaseController` or `BaseControllerV1`. Any non-controller entries that are passed into the constructor will be removed automatically.
+- **BREAKING:** `ComposableController` constructor option `controllers` and generic type argument `ChildControllers` are re-defined from an array of controller instances to an object that maps controller names to controller instances ([#4968](https://github.com/MetaMask/core/pull/4968))
+- **BREAKING:** `ComposableController` class field objects `state` and `metadata` exclude child controllers that do not extend from `BaseController` or `BaseControllerV1`. Any non-controller entries that are passed into the constructor will be removed automatically ([#4968](https://github.com/MetaMask/core/pull/4968))
 
 ### Fixed
 
-- **BREAKING:** `ComposableController` class field object `metadata` now assigns the `StateMetadataProperty`-type object `{ persist: true, anonymous: true }` to each child controller name.
+- **BREAKING:** `ComposableController` class field object `metadata` now assigns the `StateMetadataProperty`-type object `{ persist: true, anonymous: true }` to each child controller name ([#4968](https://github.com/MetaMask/core/pull/4968))
   - Previously, V2 child controllers were erroneously assigned their own metadata object. This issue was introduced in `@metamask/base-controller@6.0.0`.
 
 ## [9.0.1]

--- a/packages/composable-controller/CHANGELOG.md
+++ b/packages/composable-controller/CHANGELOG.md
@@ -10,12 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** `ComposableController` constructor option `controllers` and generic type argument `ChildControllers` are re-defined from an array of controller instances to an object that maps controller names to controller instances.
-- **BREAKING:** `ComposableController` `state` field and `metadata` objects exclude child controllers that do not extend from `BaseController` or `BaseControllerV1`.
+- **BREAKING:** `ComposableController` class field objects `state` and `metadata` exclude child controllers that do not extend from `BaseController` or `BaseControllerV1`. Any non-controller entries that are passed into the constructor will be removed automatically.
 
 ## Fixed
 
-- **BREAKING:** `ComposableController` `metadata` field object now correctly populates `BaseControllerV1` controller properties with a metadata object that maps state property names to `StateMetadataProperty` type objects.
-  - Previously, during `metadata` object instantiation, `BaseControllerV1` controllers were assigned the object `{ persist: true, anonymous: true }`, and their state properties were overwritten.
+- **BREAKING:** `ComposableController` class field object `metadata` now assigns the `StateMetadataProperty`-type object `{ persist: true, anonymous: true }` to each child controller name.
+  - Previously, V2 child controllers were erroneously assigned their own metadata object. This issue was introduced in `@metamask/base-controller@6.0.0`.
 
 ## [9.0.1]
 

--- a/packages/composable-controller/CHANGELOG.md
+++ b/packages/composable-controller/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** `ComposableController` constructor option `controllers` and generic type argument `ChildControllers` are re-defined from an array of controller instances to an object that maps controller names to controller instances.
 - **BREAKING:** `ComposableController` class field objects `state` and `metadata` exclude child controllers that do not extend from `BaseController` or `BaseControllerV1`. Any non-controller entries that are passed into the constructor will be removed automatically.
 
-## Fixed
+### Fixed
 
 - **BREAKING:** `ComposableController` class field object `metadata` now assigns the `StateMetadataProperty`-type object `{ persist: true, anonymous: true }` to each child controller name.
   - Previously, V2 child controllers were erroneously assigned their own metadata object. This issue was introduced in `@metamask/base-controller@6.0.0`.

--- a/packages/composable-controller/CHANGELOG.md
+++ b/packages/composable-controller/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** `ComposableController` constructor option `controllers` and generic type argument `ChildControllers` are re-defined from an array of controller instances to an object that maps controller names to controller instances.
+- **BREAKING:** `ComposableController` `state` field and `metadata` objects exclude child controllers that do not extend from `BaseController` or `BaseControllerV1`.
+
+## Fixed
+
+- **BREAKING:** `ComposableController` `metadata` field object now correctly populates `BaseControllerV1` controller properties with a metadata object that maps state property names to `StateMetadataProperty` type objects.
+  - Previously, during `metadata` object instantiation, `BaseControllerV1` controllers were assigned the object `{ persist: true, anonymous: true }`, and their state properties were overwritten.
+
 ## [9.0.1]
 
 ### Fixed

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -1,3 +1,6 @@
+// `ComposableControllerState` type objects are keyed with controller names written in PascalCase.
+/* eslint-disable @typescript-eslint/naming-convention */
+
 import type {
   BaseState,
   RestrictedControllerMessenger,
@@ -166,17 +169,9 @@ class BazController extends BaseControllerV1<never, BazControllerState> {
 }
 
 type ControllersMap = {
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   FooController: FooController;
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   QuzController: QuzController;
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   BarController: BarController;
-  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   BazController: BazController;
 };
 
@@ -188,11 +183,7 @@ describe('ComposableController', () => {
   describe('BaseControllerV1', () => {
     it('should compose controller state', () => {
       type ComposableControllerState = {
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         BarController: BarControllerState;
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         BazController: BazControllerState;
       };
 
@@ -233,8 +224,6 @@ describe('ComposableController', () => {
 
     it('should notify listeners of nested state change', () => {
       type ComposableControllerState = {
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         BarController: BarControllerState;
       };
       const controllerMessenger = new ControllerMessenger<
@@ -274,11 +263,7 @@ describe('ComposableController', () => {
   describe('BaseControllerV2', () => {
     it('should compose controller state', () => {
       type ComposableControllerState = {
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         QuzController: QuzControllerState;
       };
       const controllerMessenger = new ControllerMessenger<
@@ -330,8 +315,6 @@ describe('ComposableController', () => {
 
     it('should notify listeners of nested state change', () => {
       type ComposableControllerState = {
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
       };
       const controllerMessenger = new ControllerMessenger<
@@ -379,11 +362,7 @@ describe('ComposableController', () => {
   describe('Mixed BaseControllerV1 and BaseControllerV2', () => {
     it('should compose controller state', () => {
       type ComposableControllerState = {
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         BarController: BarControllerState;
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
       };
       const barController = new BarController();
@@ -424,11 +403,7 @@ describe('ComposableController', () => {
 
     it('should notify listeners of BaseControllerV1 state change', () => {
       type ComposableControllerState = {
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         BarController: BarControllerState;
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
       };
       const barController = new BarController();
@@ -481,11 +456,7 @@ describe('ComposableController', () => {
 
     it('should notify listeners of BaseControllerV2 state change', () => {
       type ComposableControllerState = {
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         BarController: BarControllerState;
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
       };
       const barController = new BarController();
@@ -563,8 +534,6 @@ describe('ComposableController', () => {
 
     it('should throw if composing a controller that does not extend from BaseController', () => {
       type ComposableControllerState = {
-        // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         FooController: FooControllerState;
       };
       const notController = new JsonRpcEngine();

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -168,40 +168,40 @@ class BazController extends BaseControllerV1<never, BazControllerState> {
   }
 }
 
-type QuxControllerState = {
+type ControllerWithoutStateChangeEventState = {
   qux: string;
 };
 
-type QuxMessenger = RestrictedControllerMessenger<
-  'QuxController',
+type ControllerWithoutStateChangeEventMessenger = RestrictedControllerMessenger<
+  'ControllerWithoutStateChangeEvent',
   never,
-  never,
+  QuzControllerEvent,
   never,
   QuzControllerEvent['type']
 >;
 
-const quxControllerStateMetadata = {
+const controllerWithoutStateChangeEventStateMetadata = {
   qux: {
     persist: true,
     anonymous: true,
   },
 };
 
-class QuxController extends BaseController<
-  'QuxController',
-  QuxControllerState,
-  QuxMessenger
+class ControllerWithoutStateChangeEvent extends BaseController<
+  'ControllerWithoutStateChangeEvent',
+  ControllerWithoutStateChangeEventState,
+  ControllerWithoutStateChangeEventMessenger
 > {
-  constructor(messagingSystem: QuxMessenger) {
+  constructor(messagingSystem: ControllerWithoutStateChangeEventMessenger) {
     super({
       messenger: messagingSystem,
-      metadata: quxControllerStateMetadata,
-      name: 'QuxController',
+      metadata: controllerWithoutStateChangeEventStateMetadata,
+      name: 'ControllerWithoutStateChangeEvent',
       state: { qux: 'qux' },
     });
   }
 
-  updateQux(qux: string) {
+  updateState(qux: string) {
     super.update((state) => {
       state.qux = qux;
     });
@@ -213,7 +213,7 @@ type ControllersMap = {
   QuzController: QuzController;
   BarController: BarController;
   BazController: BazController;
-  QuxController: QuzController;
+  ControllerWithoutStateChangeEvent: ControllerWithoutStateChangeEvent;
 };
 
 describe('ComposableController', () => {
@@ -621,12 +621,16 @@ describe('ComposableController', () => {
       never,
       FooControllerEvent
     >();
-    const quxControllerMessenger = controllerMessenger.getRestricted({
-      name: 'QuxController',
-      allowedActions: [],
-      allowedEvents: [],
-    });
-    const quxController = new QuxController(quxControllerMessenger);
+    const controllerWithoutStateChangeEventMessenger =
+      controllerMessenger.getRestricted({
+        name: 'ControllerWithoutStateChangeEvent',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+    const controllerWithoutStateChangeEvent =
+      new ControllerWithoutStateChangeEvent(
+        controllerWithoutStateChangeEventMessenger,
+      );
     const fooControllerMessenger = controllerMessenger.getRestricted({
       name: 'FooController',
       allowedActions: [],
@@ -637,7 +641,8 @@ describe('ComposableController', () => {
       () =>
         new ComposableController({
           controllers: {
-            QuxController: quxController,
+            ControllerWithoutStateChangeEvent:
+              controllerWithoutStateChangeEvent,
             FooController: fooController,
           },
           messenger: controllerMessenger.getRestricted({

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -203,7 +203,10 @@ describe('ComposableController', () => {
       >().getRestricted({
         name: 'ComposableController',
         allowedActions: [],
-        allowedEvents: ['BazController:stateChange'],
+        allowedEvents: [
+          'BarController:stateChange',
+          'BazController:stateChange',
+        ],
       });
       const controller = new ComposableController<
         ComposableControllerState,
@@ -236,12 +239,13 @@ describe('ComposableController', () => {
       };
       const controllerMessenger = new ControllerMessenger<
         never,
-        ComposableControllerEvents<ComposableControllerState>
+        | ComposableControllerEvents<ComposableControllerState>
+        | ChildControllerStateChangeEvents<ComposableControllerState>
       >();
       const composableMessenger = controllerMessenger.getRestricted({
         name: 'ComposableController',
         allowedActions: [],
-        allowedEvents: [],
+        allowedEvents: ['BarController:stateChange'],
       });
       const barController = new BarController();
       new ComposableController<
@@ -386,7 +390,7 @@ describe('ComposableController', () => {
       const controllerMessenger = new ControllerMessenger<
         never,
         | ComposableControllerEvents<ComposableControllerState>
-        | FooControllerEvent
+        | ChildControllerStateChangeEvents<ComposableControllerState>
       >();
       const fooControllerMessenger = controllerMessenger.getRestricted({
         name: 'FooController',
@@ -397,7 +401,10 @@ describe('ComposableController', () => {
       const composableControllerMessenger = controllerMessenger.getRestricted({
         name: 'ComposableController',
         allowedActions: [],
-        allowedEvents: ['FooController:stateChange'],
+        allowedEvents: [
+          'BarController:stateChange',
+          'FooController:stateChange',
+        ],
       });
       const composableController = new ComposableController<
         ComposableControllerState,
@@ -428,7 +435,7 @@ describe('ComposableController', () => {
       const controllerMessenger = new ControllerMessenger<
         never,
         | ComposableControllerEvents<ComposableControllerState>
-        | FooControllerEvent
+        | ChildControllerStateChangeEvents<ComposableControllerState>
       >();
       const fooControllerMessenger = controllerMessenger.getRestricted({
         name: 'FooController',
@@ -439,7 +446,10 @@ describe('ComposableController', () => {
       const composableControllerMessenger = controllerMessenger.getRestricted({
         name: 'ComposableController',
         allowedActions: [],
-        allowedEvents: ['FooController:stateChange'],
+        allowedEvents: [
+          'BarController:stateChange',
+          'FooController:stateChange',
+        ],
       });
       new ComposableController<
         ComposableControllerState,
@@ -482,7 +492,7 @@ describe('ComposableController', () => {
       const controllerMessenger = new ControllerMessenger<
         never,
         | ComposableControllerEvents<ComposableControllerState>
-        | FooControllerEvent
+        | ChildControllerStateChangeEvents<ComposableControllerState>
       >();
       const fooControllerMessenger = controllerMessenger.getRestricted({
         name: 'FooController',
@@ -493,7 +503,10 @@ describe('ComposableController', () => {
       const composableControllerMessenger = controllerMessenger.getRestricted({
         name: 'ComposableController',
         allowedActions: [],
-        allowedEvents: ['FooController:stateChange'],
+        allowedEvents: [
+          'BarController:stateChange',
+          'FooController:stateChange',
+        ],
       });
       new ComposableController<
         ComposableControllerState,

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -207,18 +207,18 @@ describe('ComposableController', () => {
       });
       const controller = new ComposableController<
         ComposableControllerState,
-        ControllersMap[keyof ComposableControllerState]
+        Pick<ControllersMap, keyof ComposableControllerState>
       >({
-        controllers: [
-          new BarController(),
-          new BazController({
+        controllers: {
+          BarController: new BarController(),
+          BazController: new BazController({
             messenger: new ControllerMessenger<never, never>().getRestricted({
               name: 'BazController',
               allowedActions: [],
               allowedEvents: [],
             }),
           }),
-        ],
+        },
         messenger: composableMessenger,
       });
 
@@ -246,9 +246,9 @@ describe('ComposableController', () => {
       const barController = new BarController();
       new ComposableController<
         ComposableControllerState,
-        ControllersMap[keyof ComposableControllerState]
+        Pick<ControllersMap, keyof ComposableControllerState>
       >({
-        controllers: [barController],
+        controllers: { BarController: barController },
         messenger: composableMessenger,
       });
       const listener = sinon.stub();
@@ -310,9 +310,12 @@ describe('ComposableController', () => {
       });
       const composableController = new ComposableController<
         ComposableControllerState,
-        ControllersMap[keyof ComposableControllerState]
+        Pick<ControllersMap, keyof ComposableControllerState>
       >({
-        controllers: [fooController, quzController],
+        controllers: {
+          FooController: fooController,
+          QuzController: quzController,
+        },
         messenger: composableControllerMessenger,
       });
       expect(composableController.state).toStrictEqual({
@@ -345,9 +348,11 @@ describe('ComposableController', () => {
       });
       new ComposableController<
         ComposableControllerState,
-        ControllersMap[keyof ComposableControllerState]
+        Pick<ControllersMap, keyof ComposableControllerState>
       >({
-        controllers: [fooController],
+        controllers: {
+          FooController: fooController,
+        },
         messenger: composableControllerMessenger,
       });
 
@@ -396,9 +401,12 @@ describe('ComposableController', () => {
       });
       const composableController = new ComposableController<
         ComposableControllerState,
-        ControllersMap[keyof ComposableControllerState]
+        Pick<ControllersMap, keyof ComposableControllerState>
       >({
-        controllers: [barController, fooController],
+        controllers: {
+          BarController: barController,
+          FooController: fooController,
+        },
         messenger: composableControllerMessenger,
       });
       expect(composableController.state).toStrictEqual({
@@ -435,9 +443,12 @@ describe('ComposableController', () => {
       });
       new ComposableController<
         ComposableControllerState,
-        ControllersMap[keyof ComposableControllerState]
+        Pick<ControllersMap, keyof ComposableControllerState>
       >({
-        controllers: [barController, fooController],
+        controllers: {
+          BarController: barController,
+          FooController: fooController,
+        },
         messenger: composableControllerMessenger,
       });
       const listener = sinon.stub();
@@ -486,9 +497,12 @@ describe('ComposableController', () => {
       });
       new ComposableController<
         ComposableControllerState,
-        ControllersMap[keyof ComposableControllerState]
+        Pick<ControllersMap, keyof ComposableControllerState>
       >({
-        controllers: [barController, fooController],
+        controllers: {
+          BarController: barController,
+          FooController: fooController,
+        },
         messenger: composableControllerMessenger,
       });
 
@@ -526,7 +540,10 @@ describe('ComposableController', () => {
         () =>
           // @ts-expect-error - Suppressing type error to test for runtime error handling
           new ComposableController({
-            controllers: [barController, fooController],
+            controllers: {
+              BarController: barController,
+              FooController: fooController,
+            },
           }),
       ).toThrow('Messaging system is required');
     });
@@ -558,7 +575,7 @@ describe('ComposableController', () => {
         () =>
           new ComposableController<
             ComposableControllerState,
-            ControllersMap[keyof ComposableControllerState]
+            Pick<ControllersMap, keyof ComposableControllerState>
           >({
             // @ts-expect-error - Suppressing type error to test for runtime error handling
             controllers: [notController, fooController],

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -587,11 +587,19 @@ describe('ComposableController', () => {
       expect(
         () =>
           new ComposableController<
-            ComposableControllerState,
-            Pick<ControllersMap, keyof ComposableControllerState>
-          >({
+            ComposableControllerState & {
+              JsonRpcEngine: Record<string, unknown>;
+            },
             // @ts-expect-error - Suppressing type error to test for runtime error handling
-            controllers: [notController, fooController],
+            {
+              JsonRpcEngine: typeof notController;
+              FooController: FooController;
+            }
+          >({
+            controllers: {
+              JsonRpcEngine: notController,
+              FooController: fooController,
+            },
             messenger: composableControllerMessenger,
           }),
       ).toThrow(INVALID_CONTROLLER_ERROR);

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -193,12 +193,11 @@ export class ComposableController<
   #updateChildController(controller: ControllerInstance): void {
     const { name } = controller;
     if (!isBaseController(controller) && !isBaseControllerV1(controller)) {
-      if (name in this.metadata && this.metadata[name]) {
+      try {
         delete this.metadata[name];
-      }
-      if (name in this.state && this.state[name]) {
         delete this.state[name];
-      }
+        // eslint-disable-next-line no-empty
+      } catch (_) {}
       // False negative. `name` is a string type.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       throw new Error(`${name} - ${INVALID_CONTROLLER_ERROR}`);

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -3,7 +3,7 @@ import type {
   StateConstraint,
   StateConstraintV1,
   StateMetadata,
-  StateMetadataConstraint,
+  StatePropertyMetadataConstraint,
   ControllerStateChangeEvent,
   LegacyControllerStateConstraint,
   ControllerInstance,
@@ -157,26 +157,14 @@ export class ComposableController<
 
     super({
       name: controllerName,
-      metadata: Object.entries(controllers).reduce<
+      metadata: Object.keys(controllers).reduce<
         StateMetadata<ComposableControllerState>
-      >((metadata, [name, controller]) => {
-        if (isBaseController(controller)) {
-          // Type assertion is necessary to assign new properties to a generic type - ts(2862)
-          (metadata as unknown as Record<string, StateMetadataConstraint>)[
-            name
-          ] = controller.metadata;
-        } else if (isBaseControllerV1(controller)) {
-          // Type assertion is necessary to assign new properties to a generic type - ts(2862)
-          (metadata as unknown as Record<string, StateMetadataConstraint>)[
-            name
-          ] = Object.keys(controller.state).reduce<StateMetadataConstraint>(
-            (acc, curr) => {
-              acc[curr] = { persist: true, anonymous: true };
-              return acc;
-            },
-            {} as never,
-          );
-        }
+      >((metadata, name) => {
+        // Type assertion is necessary to assign new properties to a generic type - ts(2862)
+        (metadata as Record<string, StatePropertyMetadataConstraint>)[name] = {
+          persist: true,
+          anonymous: true,
+        };
         return metadata;
       }, {} as never),
       state: Object.entries(controllers).reduce<ComposableControllerState>(

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -194,8 +194,12 @@ export class ComposableController<
   #updateChildController(controller: ControllerInstance): void {
     const { name } = controller;
     if (!isBaseController(controller) && !isBaseControllerV1(controller)) {
-      delete this.metadata[name];
-      delete this.state[name];
+      if (name in this.metadata && this.metadata[name]) {
+        delete this.metadata[name];
+      }
+      if (name in this.state && this.state[name]) {
+        delete this.state[name];
+      }
       // False negative. `name` is a string type.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       throw new Error(`${name} - ${INVALID_CONTROLLER_ERROR}`);

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -158,17 +158,18 @@ export class ComposableController<
     super({
       name: controllerName,
       metadata: controllers.reduce<StateMetadata<ComposableControllerState>>(
-        (metadata, controller) => ({
-          ...metadata,
-          [controller.name]: isBaseController(controller)
+        (metadata, controller) => {
+          metadata[controller.name] = isBaseController(controller)
             ? controller.metadata
-            : { persist: true, anonymous: true },
-        }),
+            : { persist: true, anonymous: true };
+          return metadata;
+        },
         {} as never,
       ),
       state: controllers.reduce<ComposableControllerState>(
         (state, controller) => {
-          return { ...state, [controller.name]: controller.state };
+          state[controller.name] = controller.state;
+          return state;
         },
         {} as never,
       ),

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -160,7 +160,10 @@ export class ComposableController<
       name: controllerName,
       metadata: controllers.reduce<StateMetadata<ComposableControllerState>>(
         (metadata, controller) => {
-          metadata[controller.name] = isBaseController(controller)
+          // Type assertion is necessary for to assign new properties to a generic type - ts(2862)
+          (metadata as unknown as Record<string, StateMetadataConstraint>)[
+            controller.name
+          ] = isBaseController(controller)
             ? controller.metadata
             : Object.keys(controller.state).reduce<StateMetadataConstraint>(
                 (acc, curr) => {
@@ -175,7 +178,10 @@ export class ComposableController<
       ),
       state: controllers.reduce<ComposableControllerState>(
         (state, controller) => {
-          state[controller.name] = controller.state;
+          // Type assertion is necessary for to assign new properties to a generic type - ts(2862)
+          // TODO: Remove the 'object' member once `BaseControllerV2` migrations are completed for all controllers.
+          (state as Record<string, StateConstraint | object>)[controller.name] =
+            controller.state;
           return state;
         },
         {} as never,

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -184,7 +184,7 @@ export class ComposableController<
           if (isBaseController(controller) || isBaseControllerV1(controller)) {
             // Type assertion is necessary to assign new properties to a generic type - ts(2862)
             // TODO: Remove the 'object' member once `BaseControllerV2` migrations are completed for all controllers.
-            (state as Record<string, StateConstraint | object>)[name] =
+            (state as LegacyComposableControllerStateConstraint)[name] =
               controller.state;
           }
           return state;
@@ -218,7 +218,8 @@ export class ComposableController<
         `${name}:stateChange`,
         (childState: LegacyControllerStateConstraint) => {
           this.update((state) => {
-            Object.assign(state, { [name]: childState });
+            (state as LegacyComposableControllerStateConstraint)[name] =
+              childState;
           });
         },
       );
@@ -230,7 +231,7 @@ export class ComposableController<
     if (isBaseControllerV1(controller)) {
       controller.subscribe((childState: StateConstraintV1) => {
         this.update((state) => {
-          Object.assign(state, { [name]: childState });
+          (state as Record<string, StateConstraintV1>)[name] = childState;
         });
       });
     }

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -3,6 +3,7 @@ import type {
   StateConstraint,
   StateConstraintV1,
   StateMetadata,
+  StateMetadataConstraint,
   ControllerStateChangeEvent,
   LegacyControllerStateConstraint,
   ControllerInstance,
@@ -161,7 +162,13 @@ export class ComposableController<
         (metadata, controller) => {
           metadata[controller.name] = isBaseController(controller)
             ? controller.metadata
-            : { persist: true, anonymous: true };
+            : Object.keys(controller.state).reduce<StateMetadataConstraint>(
+                (acc, curr) => {
+                  acc[curr] = { persist: true, anonymous: true };
+                  return acc;
+                },
+                {} as never,
+              );
           return metadata;
         },
         {} as never,

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -127,7 +127,7 @@ export type ComposableControllerMessenger<
  * Controller that composes multiple child controllers and maintains up-to-date composed state.
  *
  * @template ComposableControllerState - A type object containing the names and state types of the child controllers.
- * @template ChildControllers - A union type of the child controllers being used to instantiate the {@link ComposableController}.
+ * @template ChildControllers - A type object containing child controllers that are being used to instantiate the {@link ComposableController}.
  */
 export class ComposableController<
   ComposableControllerState extends LegacyComposableControllerStateConstraint,
@@ -141,7 +141,7 @@ export class ComposableController<
    * Creates a ComposableController instance.
    *
    * @param options - Initial options used to configure this controller
-   * @param options.controllers - An object of child controller instances to compose that is keyed with the names of the controllers.
+   * @param options.controllers - An object that maps child controller names to corresponding controller instances.
    * @param options.messenger - A restricted controller messenger.
    */
   constructor({
@@ -161,12 +161,12 @@ export class ComposableController<
         StateMetadata<ComposableControllerState>
       >((metadata, [name, controller]) => {
         if (isBaseController(controller)) {
-          // Type assertion is necessary for to assign new properties to a generic type - ts(2862)
+          // Type assertion is necessary to assign new properties to a generic type - ts(2862)
           (metadata as unknown as Record<string, StateMetadataConstraint>)[
             name
           ] = controller.metadata;
         } else if (isBaseControllerV1(controller)) {
-          // Type assertion is necessary for to assign new properties to a generic type - ts(2862)
+          // Type assertion is necessary to assign new properties to a generic type - ts(2862)
           (metadata as unknown as Record<string, StateMetadataConstraint>)[
             name
           ] = Object.keys(controller.state).reduce<StateMetadataConstraint>(
@@ -182,7 +182,7 @@ export class ComposableController<
       state: Object.entries(controllers).reduce<ComposableControllerState>(
         (state, [name, controller]) => {
           if (isBaseController(controller) || isBaseControllerV1(controller)) {
-            // Type assertion is necessary for to assign new properties to a generic type - ts(2862)
+            // Type assertion is necessary to assign new properties to a generic type - ts(2862)
             // TODO: Remove the 'object' member once `BaseControllerV2` migrations are completed for all controllers.
             (state as Record<string, StateConstraint | object>)[name] =
               controller.state;

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -127,11 +127,11 @@ export type ComposableControllerMessenger<
  * Controller that composes multiple child controllers and maintains up-to-date composed state.
  *
  * @template ComposableControllerState - A type object containing the names and state types of the child controllers.
- * @template ChildControllers - A type object that specifies the child controllers which are used to instantiate the {@link ComposableController}.
+ * @template ChildControllersMap - A type object that specifies the child controllers which are used to instantiate the {@link ComposableController}.
  */
 export class ComposableController<
   ComposableControllerState extends LegacyComposableControllerStateConstraint,
-  ChildControllers extends Record<
+  ChildControllersMap extends Record<
     keyof ComposableControllerState,
     ControllerInstance
   >,
@@ -151,7 +151,7 @@ export class ComposableController<
     controllers,
     messenger,
   }: {
-    controllers: ChildControllers;
+    controllers: ChildControllersMap;
     messenger: ComposableControllerMessenger<ComposableControllerState>;
   }) {
     if (messenger === undefined) {

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -160,6 +160,7 @@ export class ComposableController<
 
     super({
       name: controllerName,
+      // This reduce operation intentionally reuses its output object. This provides a significant performance benefit over returning a new object on each iteration.
       metadata: Object.keys(controllers).reduce<
         StateMetadata<ComposableControllerState>
       >((metadata, name) => {
@@ -169,8 +170,10 @@ export class ComposableController<
         };
         return metadata;
       }, {} as never),
+      // This reduce operation intentionally reuses its output object. This provides a significant performance benefit over returning a new object on each iteration.
       state: Object.values(controllers).reduce<ComposableControllerState>(
         (state, controller) => {
+          // Type assertion is necessary for property assignment to a generic type. This does not pollute or widen the type of the asserted variable.
           (state as ComposableControllerStateConstraint)[controller.name] =
             controller.state;
           return state;
@@ -209,6 +212,7 @@ export class ComposableController<
         `${name}:stateChange`,
         (childState: LegacyControllerStateConstraint) => {
           this.update((state) => {
+            // Type assertion is necessary for property assignment to a generic type. This does not pollute or widen the type of the asserted variable.
             (state as ComposableControllerStateConstraint)[name] = childState;
           });
         },
@@ -221,6 +225,7 @@ export class ComposableController<
     if (isBaseControllerV1(controller)) {
       controller.subscribe((childState: StateConstraintV1) => {
         this.update((state) => {
+          // Type assertion is necessary for property assignment to a generic type. This does not pollute or widen the type of the asserted variable.
           (state as ComposableControllerStateConstraint)[name] = childState;
         });
       });

--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -127,7 +127,7 @@ export type ComposableControllerMessenger<
  * Controller that composes multiple child controllers and maintains up-to-date composed state.
  *
  * @template ComposableControllerState - A type object containing the names and state types of the child controllers.
- * @template ChildControllers - A type object containing child controllers that are being used to instantiate the {@link ComposableController}.
+ * @template ChildControllers - A type object that specifies the child controllers which are used to instantiate the {@link ComposableController}.
  */
 export class ComposableController<
   ComposableControllerState extends LegacyComposableControllerStateConstraint,
@@ -141,7 +141,7 @@ export class ComposableController<
    * Creates a ComposableController instance.
    *
    * @param options - Initial options used to configure this controller
-   * @param options.controllers - An object that maps child controller names to corresponding controller instances.
+   * @param options.controllers - An object that contains child controllers keyed by their names.
    * @param options.messenger - A restricted controller messenger.
    */
   constructor({


### PR DESCRIPTION
## Motivation

Expensive operations during `ComposableController` instantiation contribute to downstream performance issues in our client apps' initialization times. Optimizing these operations may be especially impactful since `ComposableController` takes large inputs consisting of all of the controllers used by a given client.

## Explanation 

- Remove wasteful `reduce` operations that create temporary objects on each iteration and replace with implementations that re-use their output objects.
- Refactor `ComposableController` to accept an object instead of an array. Now that the mobile Engine creates a controllers object, this saves us an extra operation for converting the object into an array.
  - For downstream application, see https://github.com/MetaMask/metamask-mobile/pull/10441/commits/5ceb81c587c7b5d038f53d678daba8c3ded352ca
  - An auxiliary benefit of this is slightly improved type safety. Since we were previously using a type array instead of a type tuple, we were vulnerable to duplicate entries in the `controllers` input. This is now resolved by using a type object.
- Fixes issues with 'state', 'metadata' field instantiation (see changelogs).

## References

- For more information on the optimizing reduce, see https://github.com/MetaMask/metamask-mobile/pull/12374
- Blocks https://github.com/MetaMask/metamask-mobile/pull/10441
  - E2E passing with preview build from this PR: https://github.com/MetaMask/metamask-mobile/pull/10441#issuecomment-2514006873
  - Blocks https://github.com/MetaMask/metamask-mobile/pull/12509

## Changelog

## `@metamask/composable-controller`

### Changed

- **BREAKING:** `ComposableController` constructor option `controllers` and generic type argument `ChildControllers` are re-defined from an array of controller instances to an object that maps controller names to controller instances.
- **BREAKING:** `ComposableController` class field objects `state` and `metadata` exclude child controllers that do not extend from `BaseController` or `BaseControllerV1`. Any non-controller entries that are passed into the constructor will be removed automatically.

### Fixed

- **BREAKING:** `ComposableController` class field object `metadata` now assigns the `StateMetadataProperty`-type object `{ persist: true, anonymous: true }` to each child controller name.
  - Previously, V2 child controllers were erroneously assigned their own metadata object. This issue was introduced in `@metamask/base-controller@6.0.0`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
