### PR TITLE
Fix peer dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@lavamoat/allow-scripts": "^3.0.4",
+    "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/create-release-branch": "^3.1.0",
     "@metamask/eslint-config": "^12.2.0",
     "@metamask/eslint-config-jest": "^12.1.0",

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add peer dependency `@metamask/providers@^18.1.1` ([#4974](https://github.com/MetaMask/core/pull/4974))
+  - This is a peer dependency of `@metamask/keyring-api`. Consumers may already need to add it as a dependency to create a working build; this change is therefore more of a formality.
+- Add peer dependency `webextension-polyfill@^0.12.0` ([#4974](https://github.com/MetaMask/core/pull/4974))
+  - This is a peer dependency of `@metamask/providers`. Consumers may already need to add it as a dependency to create a working build; this change is therefore more of a formality.
+
 ## [20.0.0]
 
 ### Changed

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Add peer dependency `@metamask/providers@^18.1.1` ([#4974](https://github.com/MetaMask/core/pull/4974))
-  - This is a peer dependency of `@metamask/keyring-api`. Consumers may already need to add it as a dependency to create a working build; this change is therefore more of a formality.
-- Add peer dependency `webextension-polyfill@^0.12.0` ([#4974](https://github.com/MetaMask/core/pull/4974))
-  - This is a peer dependency of `@metamask/providers`. Consumers may already need to add it as a dependency to create a working build; this change is therefore more of a formality.
+- Make implicit peer dependencies explicit ([#4974](https://github.com/MetaMask/core/pull/4974))
+  - Add the following packages as peer dependencies of this package to satisfy peer dependency requirements from other dependencies:
+    - `@metamask/providers` `^18.1.0` (required by `@metamask/keyring-api`)
+    - `webextension-polyfill` `^0.10.0 || ^0.11.0 || ^0.12.0` (required by `@metamask/providers`)
+  - These dependencies really should be present in projects that consume this package (e.g. MetaMask clients), and this change ensures that they now are.
+  - Furthermore, we are assuming that clients already use these dependencies, since otherwise it would be impossible to consume this package in its entirety or even create a working build. Hence, the addition of these peer dependencies is really a formality and should not be breaking.
 
 ## [20.0.0]
 

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -75,9 +75,9 @@
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^19.0.0",
-    "@metamask/providers": "^18.1.1",
+    "@metamask/providers": "^18.1.0",
     "@metamask/snaps-controllers": "^9.7.0",
-    "webextension-polyfill": "^0.12.0"
+    "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -75,7 +75,9 @@
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^19.0.0",
-    "@metamask/snaps-controllers": "^9.7.0"
+    "@metamask/providers": "^18.1.1",
+    "@metamask/snaps-controllers": "^9.7.0",
+    "webextension-polyfill": "^0.12.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-controller": "^19.0.0",
+    "@metamask/providers": "^18.1.1",
     "@metamask/snaps-controllers": "^9.10.0",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",
@@ -69,7 +70,8 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.2.2"
+    "typescript": "~5.2.2",
+    "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^19.0.0",

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make implicit peer dependencies explicit ([#4974](https://github.com/MetaMask/core/pull/4974))
+  - Add the following packages as peer dependencies of this package to satisfy peer dependency requirements from other dependencies:
+    - `@metamask/providers` `^18.1.0` (required by `@metamask/keyring-api`)
+    - `webextension-polyfill` `^0.10.0 || ^0.11.0 || ^0.12.0` (required by `@metamask/providers`)
+  - These dependencies really should be present in projects that consume this package (e.g. MetaMask clients), and this change ensures that they now are.
+  - Furthermore, we are assuming that clients already use these dependencies, since otherwise it would be impossible to consume this package in its entirety or even create a working build. Hence, the addition of these peer dependencies is really a formality and should not be breaking.
+
 ## [45.1.0]
 
 ### Added

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -103,7 +103,9 @@
     "@metamask/approval-controller": "^7.0.0",
     "@metamask/keyring-controller": "^19.0.0",
     "@metamask/network-controller": "^22.0.0",
-    "@metamask/preferences-controller": "^15.0.0"
+    "@metamask/preferences-controller": "^15.0.0",
+    "@metamask/providers": "^18.1.0",
+    "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -74,6 +74,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.23.9",
     "@metamask/accounts-controller": "^20.0.0",
     "@metamask/approval-controller": "^7.1.1",
     "@metamask/auto-changelog": "^3.4.4",
@@ -82,6 +83,7 @@
     "@metamask/keyring-controller": "^19.0.0",
     "@metamask/network-controller": "^22.0.2",
     "@metamask/preferences-controller": "^15.0.0",
+    "@metamask/providers": "^18.1.1",
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.191",
     "@types/node": "^16.18.54",
@@ -93,7 +95,8 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.2.2"
+    "typescript": "~5.2.2",
+    "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
     "@metamask/accounts-controller": "^20.0.0",

--- a/packages/chain-controller/CHANGELOG.md
+++ b/packages/chain-controller/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make implicit peer dependencies explicit ([#4974](https://github.com/MetaMask/core/pull/4974))
+  - Add the following packages as peer dependencies of this package to satisfy peer dependency requirements from other dependencies:
+    - `@metamask/providers` `^18.1.0` (required by `@metamask/keyring-api`)
+    - `webextension-polyfill` `^0.10.0 || ^0.11.0 || ^0.12.0` (required by `@metamask/providers`)
+  - These dependencies really should be present in projects that consume this package (e.g. MetaMask clients), and this change ensures that they now are.
+  - Furthermore, we are assuming that clients already use these dependencies, since otherwise it would be impossible to consume this package in its entirety or even create a working build. Hence, the addition of these peer dependencies is really a formality and should not be breaking.
+
 ## [0.2.0]
 
 ### Changed

--- a/packages/chain-controller/package.json
+++ b/packages/chain-controller/package.json
@@ -69,6 +69,10 @@
     "typescript": "~5.2.2",
     "webextension-polyfill": "^0.12.0"
   },
+  "peerDependencies": {
+    "@metamask/providers": "^18.1.0",
+    "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
+  },
   "engines": {
     "node": "^18.18 || >=20"
   },

--- a/packages/chain-controller/package.json
+++ b/packages/chain-controller/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/providers": "^18.1.1",
     "@types/jest": "^27.4.1",
     "@types/readable-stream": "^2.3.0",
     "deepmerge": "^4.2.2",
@@ -65,7 +66,8 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.2.2"
+    "typescript": "~5.2.2",
+    "webextension-polyfill": "^0.12.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make implicit peer dependencies explicit ([#4974](https://github.com/MetaMask/core/pull/4974))
+  - Add the following packages as peer dependencies of this package to satisfy peer dependency requirements from other dependencies:
+    - `@babel/runtime@^7.0.0` (required by `@metamask/ethjs-unit`)
+  - These dependencies really should be present in projects that consume this package (e.g. MetaMask clients), and this change ensures that they now are.
+  - Furthermore, we are assuming that clients already use these dependencies, since otherwise it would be impossible to consume this package in its entirety or even create a working build. Hence, the addition of these peer dependencies is really a formality and should not be breaking.
+
 ## [11.4.3]
 
 ### Changed

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -70,6 +70,9 @@
     "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "~5.2.2"
   },
+  "peerDependencies": {
+    "@babel/runtime": "^7.0.0"
+  },
   "engines": {
     "node": "^18.18 || >=20"
   },

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -59,6 +59,7 @@
     "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.23.9",
     "@metamask/auto-changelog": "^3.4.4",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make implicit peer dependencies explicit ([#4974](https://github.com/MetaMask/core/pull/4974))
+  - Add the following packages as peer dependencies of this package to satisfy peer dependency requirements from other dependencies:
+    - `@babel/runtime@^7.0.0` (required by `@metamask/ethjs-unit`)
+  - These dependencies really should be present in projects that consume this package (e.g. MetaMask clients), and this change ensures that they now are.
+  - Furthermore, we are assuming that clients already use these dependencies, since otherwise it would be impossible to consume this package in its entirety or even create a working build. Hence, the addition of these peer dependencies is really a formality and should not be breaking.
+
 ## [22.0.1]
 
 ### Changed

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -75,6 +75,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
+    "@babel/runtime": "^7.0.0",
     "@metamask/network-controller": "^22.0.0"
   },
   "engines": {

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -59,6 +59,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.23.9",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/network-controller": "^22.0.2",
     "@types/jest": "^27.4.1",

--- a/packages/json-rpc-engine/package.json
+++ b/packages/json-rpc-engine/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",
+    "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make implicit peer dependencies explicit ([#4974](https://github.com/MetaMask/core/pull/4974))
+  - Add the following packages as peer dependencies of this package to satisfy peer dependency requirements from other dependencies:
+    - `@metamask/providers` `^18.1.0` (required by `@metamask/keyring-api`)
+    - `webextension-polyfill` `^0.10.0 || ^0.11.0 || ^0.12.0` (required by `@metamask/providers`)
+  - These dependencies really should be present in projects that consume this package (e.g. MetaMask clients), and this change ensures that they now are.
+  - Furthermore, we are assuming that clients already use these dependencies, since otherwise it would be impossible to consume this package in its entirety or even create a working build. Hence, the addition of these peer dependencies is really a formality and should not be breaking.
+
 ## [19.0.0]
 
 ### Changed

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -66,7 +66,9 @@
     "@ethereumjs/tx": "^4.2.0",
     "@keystonehq/bc-ur-registry-eth": "^0.19.0",
     "@lavamoat/allow-scripts": "^3.0.4",
+    "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/providers": "^18.1.1",
     "@metamask/scure-bip39": "^2.1.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
@@ -77,7 +79,8 @@
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "~5.2.2",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "webextension-polyfill": "^0.12.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -82,6 +82,10 @@
     "uuid": "^8.3.2",
     "webextension-polyfill": "^0.12.0"
   },
+  "peerDependencies": {
+    "@metamask/providers": "^18.1.0",
+    "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
+  },
   "engines": {
     "node": "^18.18 || >=20"
   },

--- a/packages/notification-services-controller/package.json
+++ b/packages/notification-services-controller/package.json
@@ -110,6 +110,7 @@
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",
+    "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-controller": "^19.0.0",
     "@metamask/profile-sync-controller": "^2.0.0",

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make implicit peer dependencies explicit ([#4974](https://github.com/MetaMask/core/pull/4974))
+  - Add the following packages as peer dependencies of this package to satisfy peer dependency requirements from other dependencies:
+    - `@metamask/providers` `^18.1.0` (required by `@metamask/keyring-api`)
+    - `webextension-polyfill` `^0.10.0 || ^0.11.0 || ^0.12.0` (required by `@metamask/providers`)
+  - These dependencies really should be present in projects that consume this package (e.g. MetaMask clients), and this change ensures that they now are.
+  - Furthermore, we are assuming that clients already use these dependencies, since otherwise it would be impossible to consume this package in its entirety or even create a working build. Hence, the addition of these peer dependencies is really a formality and should not be breaking.
+
 ## [2.0.0]
 
 ### Changed

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -135,7 +135,9 @@
     "@metamask/accounts-controller": "^20.0.0",
     "@metamask/keyring-controller": "^19.0.0",
     "@metamask/network-controller": "^22.0.0",
-    "@metamask/snaps-controllers": "^9.10.0"
+    "@metamask/providers": "^18.1.0",
+    "@metamask/snaps-controllers": "^9.10.0",
+    "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -114,8 +114,10 @@
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",
+    "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/accounts-controller": "^20.0.0",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/providers": "^18.1.1",
     "@metamask/snaps-controllers": "^9.10.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
@@ -126,7 +128,8 @@
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^2.0.0",
-    "typescript": "~5.2.2"
+    "typescript": "~5.2.2",
+    "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
     "@metamask/accounts-controller": "^20.0.0",

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
-- Remove peer dependency `@babel/runtime@^7.23.9`
-  - This was presumably added because it is a peer dependency of `eth-method-registry`, but it only needs to be added as a dev dependency.
+- Make implicit peer dependencies explicit ([#4974](https://github.com/MetaMask/core/pull/4974))
+  - Add the following packages as peer dependencies of this package to satisfy peer dependency requirements from other dependencies:
+    - `@babel/runtime` `^7.0.0` (required by `@metamask/ethjs-provider-http`)
+    - `@metamask/eth-block-tracker` `>=9` (required by `@metamask/nonce-tracker`)
+  - These dependencies really should be present in projects that consume this package (e.g. MetaMask clients), and this change ensures that they now are.
+  - Furthermore, we are assuming that clients already use these dependencies, since otherwise it would be impossible to consume this package in its entirety or even create a working build. Hence, the addition of these peer dependencies is really a formality and should not be breaking.
 
 ## [40.1.0]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove peer dependency `@babel/runtime@^7.23.9`
+  - This was presumably added because it is a peer dependency of `eth-method-registry`, but it only needs to be added as a dev dependency.
+
 ## [40.1.0]
 
 ### Added

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -68,9 +68,11 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.23.9",
     "@metamask/accounts-controller": "^20.0.0",
     "@metamask/approval-controller": "^7.1.1",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/eth-block-tracker": "^11.0.2",
     "@metamask/eth-json-rpc-provider": "^4.1.6",
     "@metamask/ethjs-provider-http": "^0.3.0",
     "@metamask/gas-fee-controller": "^22.0.1",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -68,10 +68,10 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@babel/runtime": "^7.23.9",
     "@metamask/accounts-controller": "^20.0.0",
     "@metamask/approval-controller": "^7.1.1",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/eth-block-tracker": "^11.0.2",
     "@metamask/eth-json-rpc-provider": "^4.1.6",
     "@metamask/ethjs-provider-http": "^0.3.0",
     "@metamask/gas-fee-controller": "^22.0.1",
@@ -90,7 +90,6 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@babel/runtime": "^7.23.9",
     "@metamask/accounts-controller": "^20.0.0",
     "@metamask/approval-controller": "^7.0.0",
     "@metamask/gas-fee-controller": "^22.0.0",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -71,7 +71,6 @@
     "@metamask/accounts-controller": "^20.0.0",
     "@metamask/approval-controller": "^7.1.1",
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/eth-block-tracker": "^11.0.2",
     "@metamask/eth-json-rpc-provider": "^4.1.6",
     "@metamask/ethjs-provider-http": "^0.3.0",
     "@metamask/gas-fee-controller": "^22.0.1",
@@ -90,8 +89,10 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
+    "@babel/runtime": "^7.0.0",
     "@metamask/accounts-controller": "^20.0.0",
     "@metamask/approval-controller": "^7.0.0",
+    "@metamask/eth-block-tracker": ">=9",
     "@metamask/gas-fee-controller": "^22.0.0",
     "@metamask/network-controller": "^22.0.0"
   },

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
 - Make implicit peer dependencies explicit ([#4974](https://github.com/MetaMask/core/pull/4974))
   - Add the following packages as peer dependencies of this package to satisfy peer dependency requirements from other dependencies:
     - `@metamask/eth-block-tracker` `>=9` (required by `@metamask/transaction-controller`)

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Make implicit peer dependencies explicit ([#4974](https://github.com/MetaMask/core/pull/4974))
+  - Add the following packages as peer dependencies of this package to satisfy peer dependency requirements from other dependencies:
+    - `@metamask/eth-block-tracker` `>=9` (required by `@metamask/transaction-controller`)
+  - These dependencies really should be present in projects that consume this package (e.g. MetaMask clients), and this change ensures that they now are.
+  - Furthermore, we are assuming that clients already use these dependencies, since otherwise it would be impossible to consume this package in its entirety or even create a working build. Hence, the addition of these peer dependencies is really a formality and should not be breaking.
+
 ## [20.0.0]
 
 ### Changed

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@metamask/approval-controller": "^7.1.1",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/eth-block-tracker": "^11.0.2",
     "@metamask/gas-fee-controller": "^22.0.1",
     "@metamask/keyring-controller": "^19.0.0",
     "@metamask/network-controller": "^22.0.2",
@@ -77,6 +78,7 @@
   },
   "peerDependencies": {
     "@metamask/approval-controller": "^7.0.0",
+    "@metamask/eth-block-tracker": ">=9",
     "@metamask/gas-fee-controller": "^22.0.0",
     "@metamask/keyring-controller": "^19.0.0",
     "@metamask/network-controller": "^22.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2199,6 +2199,8 @@ __metadata:
     "@metamask/keyring-controller": ^19.0.0
     "@metamask/network-controller": ^22.0.0
     "@metamask/preferences-controller": ^15.0.0
+    "@metamask/providers": ^18.1.1
+    webextension-polyfill: ^0.12.0
   languageName: unknown
   linkType: soft
 
@@ -2312,6 +2314,9 @@ __metadata:
     typescript: "npm:~5.2.2"
     uuid: "npm:^8.3.2"
     webextension-polyfill: "npm:^0.12.0"
+  peerDependencies:
+    "@metamask/providers": ^18.1.1
+    webextension-polyfill: ^0.12.0
   languageName: unknown
   linkType: soft
 
@@ -2365,6 +2370,8 @@ __metadata:
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
+  peerDependencies:
+    "@babel/runtime": ^7.23.9
   languageName: unknown
   linkType: soft
 
@@ -2875,6 +2882,7 @@ __metadata:
     typescript: "npm:~5.2.2"
     uuid: "npm:^8.3.2"
   peerDependencies:
+    "@babel/runtime": ^7.23.9
     "@metamask/network-controller": ^22.0.0
   languageName: unknown
   linkType: soft
@@ -2999,6 +3007,9 @@ __metadata:
     typescript: "npm:~5.2.2"
     uuid: "npm:^8.3.2"
     webextension-polyfill: "npm:^0.12.0"
+  peerDependencies:
+    "@metamask/providers": ^18.1.1
+    webextension-polyfill: ^0.12.0
   languageName: unknown
   linkType: soft
 
@@ -3391,7 +3402,9 @@ __metadata:
     "@metamask/accounts-controller": ^20.0.0
     "@metamask/keyring-controller": ^19.0.0
     "@metamask/network-controller": ^22.0.0
+    "@metamask/providers": ^18.1.1
     "@metamask/snaps-controllers": ^9.10.0
+    webextension-polyfill: ^0.12.0
   languageName: unknown
   linkType: soft
 
@@ -3706,7 +3719,6 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/controller-utils": "npm:^11.4.3"
-    "@metamask/eth-block-tracker": "npm:^11.0.2"
     "@metamask/eth-json-rpc-provider": "npm:^4.1.6"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-provider-http": "npm:^0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2063,9 +2063,9 @@ __metadata:
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/keyring-controller": ^19.0.0
-    "@metamask/providers": ^18.1.1
+    "@metamask/providers": ^18.1.0
     "@metamask/snaps-controllers": ^9.7.0
-    webextension-polyfill: ^0.12.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   languageName: unknown
   linkType: soft
 
@@ -2199,8 +2199,8 @@ __metadata:
     "@metamask/keyring-controller": ^19.0.0
     "@metamask/network-controller": ^22.0.0
     "@metamask/preferences-controller": ^15.0.0
-    "@metamask/providers": ^18.1.1
-    webextension-polyfill: ^0.12.0
+    "@metamask/providers": ^18.1.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   languageName: unknown
   linkType: soft
 
@@ -2315,8 +2315,8 @@ __metadata:
     uuid: "npm:^8.3.2"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/providers": ^18.1.1
-    webextension-polyfill: ^0.12.0
+    "@metamask/providers": ^18.1.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   languageName: unknown
   linkType: soft
 
@@ -2371,7 +2371,7 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@babel/runtime": ^7.23.9
+    "@babel/runtime": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -2882,7 +2882,7 @@ __metadata:
     typescript: "npm:~5.2.2"
     uuid: "npm:^8.3.2"
   peerDependencies:
-    "@babel/runtime": ^7.23.9
+    "@babel/runtime": ^7.0.0
     "@metamask/network-controller": ^22.0.0
   languageName: unknown
   linkType: soft
@@ -3008,8 +3008,8 @@ __metadata:
     uuid: "npm:^8.3.2"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/providers": ^18.1.1
-    webextension-polyfill: ^0.12.0
+    "@metamask/providers": ^18.1.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   languageName: unknown
   linkType: soft
 
@@ -3402,9 +3402,9 @@ __metadata:
     "@metamask/accounts-controller": ^20.0.0
     "@metamask/keyring-controller": ^19.0.0
     "@metamask/network-controller": ^22.0.0
-    "@metamask/providers": ^18.1.1
+    "@metamask/providers": ^18.1.0
     "@metamask/snaps-controllers": ^9.10.0
-    webextension-polyfill: ^0.12.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   languageName: unknown
   linkType: soft
 
@@ -3708,6 +3708,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/transaction-controller@workspace:packages/transaction-controller"
   dependencies:
+    "@babel/runtime": "npm:^7.23.9"
     "@ethereumjs/common": "npm:^3.2.0"
     "@ethereumjs/tx": "npm:^4.2.0"
     "@ethereumjs/util": "npm:^8.1.0"
@@ -3719,6 +3720,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/controller-utils": "npm:^11.4.3"
+    "@metamask/eth-block-tracker": "npm:^11.0.2"
     "@metamask/eth-json-rpc-provider": "npm:^4.1.6"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-provider-http": "npm:^0.3.0"
@@ -3747,8 +3749,10 @@ __metadata:
     typescript: "npm:~5.2.2"
     uuid: "npm:^8.3.2"
   peerDependencies:
+    "@babel/runtime": ^7.0.0
     "@metamask/accounts-controller": ^20.0.0
     "@metamask/approval-controller": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
     "@metamask/gas-fee-controller": ^22.0.0
     "@metamask/network-controller": ^22.0.0
   languageName: unknown
@@ -3762,6 +3766,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/controller-utils": "npm:^11.4.3"
+    "@metamask/eth-block-tracker": "npm:^11.0.2"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/gas-fee-controller": "npm:^22.0.1"
     "@metamask/keyring-controller": "npm:^19.0.0"
@@ -3784,6 +3789,7 @@ __metadata:
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@metamask/approval-controller": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
     "@metamask/gas-fee-controller": ^22.0.0
     "@metamask/keyring-controller": ^19.0.0
     "@metamask/network-controller": ^22.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,6 +2017,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lavamoat/preinstall-always-fail@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@lavamoat/preinstall-always-fail@npm:2.1.0"
+  checksum: 10/385c3fac828b9edff2d8b5825bd29ea475206046984cdb3217518ad655f145ff37046414041534960d92cbe0759f0dc675f7c7dcf39a95003ae715a834fbd750
+  languageName: node
+  linkType: hard
+
 "@metamask/abi-utils@npm:^2.0.3, @metamask/abi-utils@npm:^2.0.4":
   version: 2.0.4
   resolution: "@metamask/abi-utils@npm:2.0.4"
@@ -2037,6 +2044,7 @@ __metadata:
     "@metamask/eth-snap-keyring": "npm:^5.0.1"
     "@metamask/keyring-api": "npm:^10.1.0"
     "@metamask/keyring-controller": "npm:^19.0.0"
+    "@metamask/providers": "npm:^18.1.1"
     "@metamask/snaps-controllers": "npm:^9.10.0"
     "@metamask/snaps-sdk": "npm:^6.7.0"
     "@metamask/snaps-utils": "npm:^8.3.0"
@@ -2052,6 +2060,7 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
     uuid: "npm:^8.3.2"
+    webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/keyring-controller": ^19.0.0
     "@metamask/snaps-controllers": ^9.7.0
@@ -2134,6 +2143,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/assets-controllers@workspace:packages/assets-controllers"
   dependencies:
+    "@babel/runtime": "npm:^7.23.9"
     "@ethereumjs/util": "npm:^8.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/address": "npm:^5.7.0"
@@ -2155,6 +2165,7 @@ __metadata:
     "@metamask/network-controller": "npm:^22.0.2"
     "@metamask/polling-controller": "npm:^12.0.1"
     "@metamask/preferences-controller": "npm:^15.0.0"
+    "@metamask/providers": "npm:^18.1.1"
     "@metamask/rpc-errors": "npm:^7.0.1"
     "@metamask/utils": "npm:^10.0.0"
     "@types/bn.js": "npm:^5.1.5"
@@ -2179,6 +2190,7 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
     uuid: "npm:^8.3.2"
+    webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/accounts-controller": ^20.0.0
     "@metamask/approval-controller": ^7.0.0
@@ -2283,6 +2295,7 @@ __metadata:
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/chain-api": "npm:^0.1.0"
     "@metamask/keyring-api": "npm:^10.1.0"
+    "@metamask/providers": "npm:^18.1.1"
     "@metamask/snaps-controllers": "npm:^9.10.0"
     "@metamask/snaps-sdk": "npm:^6.7.0"
     "@metamask/snaps-utils": "npm:^8.3.0"
@@ -2296,6 +2309,7 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
     uuid: "npm:^8.3.2"
+    webextension-polyfill: "npm:^0.12.0"
   languageName: unknown
   linkType: soft
 
@@ -2329,6 +2343,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/controller-utils@workspace:packages/controller-utils"
   dependencies:
+    "@babel/runtime": "npm:^7.23.9"
     "@ethereumjs/util": "npm:^8.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-query": "npm:^4.0.0"
@@ -2359,6 +2374,7 @@ __metadata:
     "@babel/plugin-transform-modules-commonjs": "npm:^7.23.3"
     "@babel/preset-typescript": "npm:^7.23.3"
     "@lavamoat/allow-scripts": "npm:^3.0.4"
+    "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/create-release-branch": "npm:^3.1.0"
     "@metamask/eslint-config": "npm:^12.2.0"
     "@metamask/eslint-config-jest": "npm:^12.1.0"
@@ -2832,6 +2848,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/gas-fee-controller@workspace:packages/gas-fee-controller"
   dependencies:
+    "@babel/runtime": "npm:^7.23.9"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/controller-utils": "npm:^11.4.3"
@@ -2865,6 +2882,7 @@ __metadata:
   resolution: "@metamask/json-rpc-engine@workspace:packages/json-rpc-engine"
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
+    "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/rpc-errors": "npm:^7.0.1"
     "@metamask/safe-event-emitter": "npm:^3.0.0"
@@ -2953,6 +2971,7 @@ __metadata:
     "@keystonehq/bc-ur-registry-eth": "npm:^0.19.0"
     "@keystonehq/metamask-airgapped-keyring": "npm:^0.14.1"
     "@lavamoat/allow-scripts": "npm:^3.0.4"
+    "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/browser-passworder": "npm:^4.3.0"
@@ -2961,6 +2980,7 @@ __metadata:
     "@metamask/eth-simple-keyring": "npm:^6.0.5"
     "@metamask/keyring-api": "npm:^10.1.0"
     "@metamask/message-manager": "npm:^11.0.1"
+    "@metamask/providers": "npm:^18.1.1"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/utils": "npm:^10.0.0"
     "@types/jest": "npm:^27.4.1"
@@ -2976,6 +2996,7 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
     uuid: "npm:^8.3.2"
+    webextension-polyfill: "npm:^0.12.0"
   languageName: unknown
   linkType: soft
 
@@ -3146,6 +3167,7 @@ __metadata:
   dependencies:
     "@contentful/rich-text-html-renderer": "npm:^16.5.2"
     "@lavamoat/allow-scripts": "npm:^3.0.4"
+    "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/controller-utils": "npm:^11.4.3"
@@ -3336,12 +3358,14 @@ __metadata:
   resolution: "@metamask/profile-sync-controller@workspace:packages/profile-sync-controller"
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
+    "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/accounts-controller": "npm:^20.0.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/keyring-api": "npm:^10.1.0"
     "@metamask/keyring-controller": "npm:^19.0.0"
     "@metamask/network-controller": "npm:^22.0.2"
+    "@metamask/providers": "npm:^18.1.1"
     "@metamask/snaps-controllers": "npm:^9.10.0"
     "@metamask/snaps-sdk": "npm:^6.7.0"
     "@metamask/snaps-utils": "npm:^8.3.0"
@@ -3360,6 +3384,7 @@ __metadata:
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
+    webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/accounts-controller": ^20.0.0
     "@metamask/keyring-controller": ^19.0.0
@@ -3668,7 +3693,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/transaction-controller@workspace:packages/transaction-controller"
   dependencies:
-    "@babel/runtime": "npm:^7.23.9"
     "@ethereumjs/common": "npm:^3.2.0"
     "@ethereumjs/tx": "npm:^4.2.0"
     "@ethereumjs/util": "npm:^8.1.0"
@@ -3680,6 +3704,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/controller-utils": "npm:^11.4.3"
+    "@metamask/eth-block-tracker": "npm:^11.0.2"
     "@metamask/eth-json-rpc-provider": "npm:^4.1.6"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-provider-http": "npm:^0.3.0"
@@ -3708,7 +3733,6 @@ __metadata:
     typescript: "npm:~5.2.2"
     uuid: "npm:^8.3.2"
   peerDependencies:
-    "@babel/runtime": ^7.23.9
     "@metamask/accounts-controller": ^20.0.0
     "@metamask/approval-controller": ^7.0.0
     "@metamask/gas-fee-controller": ^22.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2063,7 +2063,9 @@ __metadata:
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/keyring-controller": ^19.0.0
+    "@metamask/providers": ^18.1.1
     "@metamask/snaps-controllers": ^9.7.0
+    webextension-polyfill: ^0.12.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Explanation

When running `yarn install`, several packages generate peer dependency warnings. 

- `@lavamoat/preinstall-always-fail` is now a peer dependency of `@lavamoat/allow-scripts`, so we need to add it as a new dev dependency.
- For the other packages — `@babel/runtime`, `@metamask/providers`, `webextension-polyfill` — we really expect the _client_ to have these dependencies, so we also add them as dev and peer dependencies instead of dependencies. We have to do this because they will not get forwarded along.

## References

Fixes #4906.

## Changelog

Changes are documented in changelogs.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
