### PR TITLE
Fix the package name in the changelog scripts defined in package.json

### DIFF
--- a/packages/remote-feature-flag-controller/package.json
+++ b/packages/remote-feature-flag-controller/package.json
@@ -37,8 +37,8 @@
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",
     "build:docs": "typedoc",
-    "changelog:update": "../../scripts/update-changelog.sh @metamask/remote-feature-flag-controllers",
-    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/remote-feature-flag-controllers",
+    "changelog:update": "../../scripts/update-changelog.sh @metamask/remote-feature-flag-controller",
+    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/remote-feature-flag-controller",
     "publish:preview": "yarn npm publish --tag preview",
     "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",


### PR DESCRIPTION
## Explanation

The package name in the changelog scripts had a typo. So to validate our changelogs correctly, this needs to be fixed to correctly match the package name.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

### `@metamask/remote-feature-flag-controller`

- **fix**: fix the name of the package in the changelog update and validate scripts in package.json

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
