### PR TITLE
feat: Allow capturing feature flags in debug snapshots

### DIFF
--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Update metadata to declare feature flags as anonymous ([#5004](https://github.com/MetaMask/core/pull/5004))
+  - This lets us capture these in debug state snapshots to help diagnose errors
+
 ## [1.0.0]
 
 ### Added

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -24,7 +24,7 @@ export type RemoteFeatureFlagControllerState = {
 };
 
 const remoteFeatureFlagControllerMetadata = {
-  remoteFeatureFlags: { persist: true, anonymous: false },
+  remoteFeatureFlags: { persist: true, anonymous: true },
   cacheTimestamp: { persist: true, anonymous: true },
 };
 


### PR DESCRIPTION
## Explanation

The controller metadata for the `RemoteFeatureFlagController` has been updated to declare the feature flag state as anonymous. These values are set by us and do not contain any PII. This allows us to capture this state in Sentry debug snapshots, which could be very useful for debugging.

## References

N/A

## Changelog

See changelog diff

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
