### PR TITLE
chore: Removing the too wide codeowners rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,6 @@
 # Note: Please keep this synchronized with the `teams.json` file in the repository root.
 # That file is used for some automated workflows, and maps controller to owning team(s).
 
-*                                    @MetaMask/engineering
 /.github/                            @MetaMask/wallet-framework-engineers
 
 ## Accounts Team


### PR DESCRIPTION
## Explanation

It has been discussed that having "Engineering" as codeowners on `core` repo is a bit too wide so we are removing that line. 

## References
n/a

## Changelog

n/a


## Checklist

N/A

