### PR TITLE
chore: bump `@metamask/{keyring-api,eth-snap-keyring}`

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -49,8 +49,8 @@
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",
     "@metamask/base-controller": "^7.0.2",
-    "@metamask/eth-snap-keyring": "^5.0.1",
-    "@metamask/keyring-api": "^10.1.0",
+    "@metamask/eth-snap-keyring": "^6.0.0",
+    "@metamask/keyring-api": "^11.1.0",
     "@metamask/snaps-sdk": "^6.7.0",
     "@metamask/snaps-utils": "^8.3.0",
     "@metamask/utils": "^10.0.0",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -79,7 +79,7 @@
     "@metamask/approval-controller": "^7.1.1",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/ethjs-provider-http": "^0.3.0",
-    "@metamask/keyring-api": "^10.1.0",
+    "@metamask/keyring-api": "^11.1.0",
     "@metamask/keyring-controller": "^19.0.1",
     "@metamask/network-controller": "^22.1.0",
     "@metamask/preferences-controller": "^15.0.1",

--- a/packages/chain-controller/package.json
+++ b/packages/chain-controller/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@metamask/base-controller": "^7.0.2",
     "@metamask/chain-api": "^0.1.0",
-    "@metamask/keyring-api": "^10.1.0",
+    "@metamask/keyring-api": "^11.1.0",
     "@metamask/snaps-controllers": "^9.10.0",
     "@metamask/snaps-sdk": "^6.7.0",
     "@metamask/snaps-utils": "^8.3.0",

--- a/packages/chain-controller/src/SnapHandlerClient.ts
+++ b/packages/chain-controller/src/SnapHandlerClient.ts
@@ -1,4 +1,4 @@
-import type { JsonRpcRequest } from '@metamask/keyring-api/dist/JsonRpcRequest';
+import type { JsonRpcRequest } from '@metamask/keyring-api';
 import type { SnapController } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
 import { HandlerType } from '@metamask/snaps-utils';

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -54,7 +54,7 @@
     "@metamask/eth-hd-keyring": "^7.0.4",
     "@metamask/eth-sig-util": "^8.0.0",
     "@metamask/eth-simple-keyring": "^6.0.5",
-    "@metamask/keyring-api": "^10.1.0",
+    "@metamask/keyring-api": "^11.1.0",
     "@metamask/message-manager": "^11.0.2",
     "@metamask/utils": "^10.0.0",
     "async-mutex": "^0.5.0",

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^7.0.2",
-    "@metamask/keyring-api": "^10.1.0",
+    "@metamask/keyring-api": "^11.1.0",
     "@metamask/keyring-controller": "^19.0.1",
     "@metamask/network-controller": "^22.1.0",
     "@metamask/snaps-sdk": "^6.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,8 +2041,8 @@ __metadata:
     "@ethereumjs/util": "npm:^8.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.2"
-    "@metamask/eth-snap-keyring": "npm:^5.0.1"
-    "@metamask/keyring-api": "npm:^10.1.0"
+    "@metamask/eth-snap-keyring": "npm:^6.0.0"
+    "@metamask/keyring-api": "npm:^11.1.0"
     "@metamask/keyring-controller": "npm:^19.0.1"
     "@metamask/providers": "npm:^18.1.1"
     "@metamask/snaps-controllers": "npm:^9.10.0"
@@ -2161,7 +2161,7 @@ __metadata:
     "@metamask/controller-utils": "npm:^11.4.4"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-provider-http": "npm:^0.3.0"
-    "@metamask/keyring-api": "npm:^10.1.0"
+    "@metamask/keyring-api": "npm:^11.1.0"
     "@metamask/keyring-controller": "npm:^19.0.1"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^22.1.0"
@@ -2298,7 +2298,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/chain-api": "npm:^0.1.0"
-    "@metamask/keyring-api": "npm:^10.1.0"
+    "@metamask/keyring-api": "npm:^11.1.0"
     "@metamask/providers": "npm:^18.1.1"
     "@metamask/snaps-controllers": "npm:^9.10.0"
     "@metamask/snaps-sdk": "npm:^6.7.0"
@@ -2671,9 +2671,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-snap-keyring@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@metamask/eth-snap-keyring@npm:5.0.1"
+"@metamask/eth-snap-keyring@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/eth-snap-keyring@npm:6.0.0"
   dependencies:
     "@ethereumjs/tx": "npm:^4.2.0"
     "@metamask/eth-sig-util": "npm:^8.0.0"
@@ -2685,8 +2685,8 @@ __metadata:
     "@types/uuid": "npm:^9.0.8"
     uuid: "npm:^9.0.1"
   peerDependencies:
-    "@metamask/keyring-api": ^10.1.0
-  checksum: 10/4d9d700b7c2ecc1b17e92f716f7aeb04bbd03836601b5d37f639bed7fba4d5f00bafadf5359d2416c319cdf18eb2f9417c7353654737af87a6e8579d5e5bab79
+    "@metamask/keyring-api": ^11.0.0
+  checksum: 10/cc9cc1f9baedbc8f9879a0107eead5198d1c31214d13ff26cb7b974af89eb0db46c4bf205a38dc66ce5049153573af98c970c6687c6769d5878fcbfaa2c2117e
   languageName: node
   linkType: hard
 
@@ -2954,20 +2954,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "@metamask/keyring-api@npm:10.1.0"
+"@metamask/keyring-api@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "@metamask/keyring-api@npm:11.1.0"
   dependencies:
     "@metamask/snaps-sdk": "npm:^6.7.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^9.2.1"
+    "@metamask/utils": "npm:^9.3.0"
     "@types/uuid": "npm:^9.0.8"
     bech32: "npm:^2.0.0"
     uuid: "npm:^9.0.1"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/providers": ^18.1.0
-  checksum: 10/de22b9f5f3aecc290210fa78161e157aa8358f8dad421a093c9f6dbe35c4755067472a732f10d1ddbfba789e871c64edd8ea1c4c7316a392b214a187efd46ebe
+  checksum: 10/29a2cf68a9b38a427ab89bf8880864c06aae0b3587c53a55ff6bb2eaf9d27ec703bf2143916914844dd9497d221d092d12cb32cf101b41535d6859aa4aaa6bcb
   languageName: node
   linkType: hard
 
@@ -2988,7 +2988,7 @@ __metadata:
     "@metamask/eth-hd-keyring": "npm:^7.0.4"
     "@metamask/eth-sig-util": "npm:^8.0.0"
     "@metamask/eth-simple-keyring": "npm:^6.0.5"
-    "@metamask/keyring-api": "npm:^10.1.0"
+    "@metamask/keyring-api": "npm:^11.1.0"
     "@metamask/message-manager": "npm:^11.0.2"
     "@metamask/providers": "npm:^18.1.1"
     "@metamask/scure-bip39": "npm:^2.1.1"
@@ -3358,7 +3358,7 @@ __metadata:
     "@metamask/accounts-controller": "npm:^20.0.1"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^7.0.2"
-    "@metamask/keyring-api": "npm:^10.1.0"
+    "@metamask/keyring-api": "npm:^11.1.0"
     "@metamask/keyring-controller": "npm:^19.0.1"
     "@metamask/network-controller": "npm:^22.1.0"
     "@metamask/providers": "npm:^18.1.1"
@@ -3835,7 +3835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^9.0.0, @metamask/utils@npm:^9.1.0, @metamask/utils@npm:^9.2.1":
+"@metamask/utils@npm:^9.0.0, @metamask/utils@npm:^9.1.0, @metamask/utils@npm:^9.2.1, @metamask/utils@npm:^9.3.0":
   version: 9.3.0
   resolution: "@metamask/utils@npm:9.3.0"
   dependencies:


### PR DESCRIPTION
## Explanation

Bumping to the new major `keyring-api` and `eth-snap-keyring` that uses `ts-bridge` as their main building tool.

The new `keyring-api` also includes the new `listAccountTransactions` keyring method, which is not yet used anywhere.

## References

Test PR:
- https://github.com/MetaMask/metamask-extension/pull/28991

## Changelog

### `@metamask/accounts-controller`

- **CHANGED**: Bump `keyring-api` to `^11.1.0`
- **CHANGED**: Bump `eth-snap-keyring` to `^6.0.0`

### `@metamask/assets-controllers`

- **CHANGED**: Bump `keyring-api` to `^11.1.0`

### `@metamask/chain-controller`

- **CHANGED**: Bump `keyring-api` to `^11.1.0`

### `@metamask/keyring-controller`

- **CHANGED**: Bump `keyring-api` to `^11.1.0`

### `@metamask/profile-sync-controller`

- **CHANGED**: Bump `keyring-api` to `^11.1.0`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
