### PR TITLE
chore: fix typo in CODEOWNERS (assets-controller -> assets-controllers)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 /packages/chain-controller           @MetaMask/accounts-engineers
 
 ## Assets Team
-/packages/assets-controller          @MetaMask/metamask-assets
+/packages/assets-controllers         @MetaMask/metamask-assets
 
 ## Confirmations Team
 /packages/address-book-controller           @MetaMask/confirmations


### PR DESCRIPTION
## Explanation

Just spotted this small typo while reviewing some PRs.

## References

N/A

## Changelog

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
