### PR TITLE
fix: signature decoding api should be called for typed sign V3 also

### DIFF
--- a/packages/signature-controller/src/utils/decoding-api.test.ts
+++ b/packages/signature-controller/src/utils/decoding-api.test.ts
@@ -88,9 +88,26 @@ describe('Decoding api', () => {
     expect(result.error.type).toBe('DECODING_FAILED_WITH_ERROR');
   });
 
-  it('return undefined for request not of method eth_signTypedData_v4', async () => {
+  it('return data if method is method eth_signTypedData_v3', async () => {
+    fetchMock = jest.spyOn(global, 'fetch') as jest.MockedFunction<
+      typeof fetch
+    >;
+    mockFetchResponse(MOCK_RESULT);
     const result = await decodeSignature(
-      { method: 'eth_signTypedData_v3' } as OriginalRequest,
+      {
+        ...PERMIT_REQUEST_MOCK,
+        method: 'eth_signTypedData_v3',
+      } as OriginalRequest,
+      '0x1',
+      'https://testdecodingurl.com',
+    );
+
+    expect(result.stateChanges).toStrictEqual(MOCK_RESULT.stateChanges);
+  });
+
+  it('return undefined for request not of method eth_signTypedData_v1', async () => {
+    const result = await decodeSignature(
+      { method: 'eth_signTypedData_v1' } as OriginalRequest,
       '0x1',
       'https://testdecodingurl.com',
     );

--- a/packages/signature-controller/src/utils/decoding-api.ts
+++ b/packages/signature-controller/src/utils/decoding-api.ts
@@ -21,7 +21,10 @@ export async function decodeSignature(
 ) {
   try {
     const { method, origin, params } = request;
-    if (request.method === EthMethod.SignTypedDataV4) {
+    if (
+      request.method === EthMethod.SignTypedDataV3 ||
+      request.method === EthMethod.SignTypedDataV4
+    ) {
       const response = await fetch(
         `${decodingApiUrl}/signature?chainId=${chainId}`,
         {


### PR DESCRIPTION
## Explanation
Signature decoding api should be called for typed sign V3 also

## References
Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3756

## Changelog
### `@metamask/signature-controller`

- **change**: Fix signature decoding api should be called for typed sign V3 also.

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [X] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
