### PR TITLE
Jl/caip multichain api/drop unsupported methods notifications

### DIFF
--- a/packages/multichain/src/index.test.ts
+++ b/packages/multichain/src/index.test.ts
@@ -25,6 +25,7 @@ describe('@metamask/multichain', () => {
         "KnownWalletNamespaceRpcMethods",
         "KnownNotifications",
         "KnownWalletScopeString",
+        "filterScopeObjectsSupported",
         "parseScopeString",
         "normalizeScope",
         "mergeScopeObject",

--- a/packages/multichain/src/index.ts
+++ b/packages/multichain/src/index.ts
@@ -33,9 +33,7 @@ export {
   KnownNotifications,
   KnownWalletScopeString,
 } from './scope/constants';
-export {
-  filterScopeObjectsSupported
-} from './scope/filter';
+export { filterScopeObjectsSupported } from './scope/filter';
 export type {
   ExternalScopeString,
   ExternalScopeObject,

--- a/packages/multichain/src/index.ts
+++ b/packages/multichain/src/index.ts
@@ -33,6 +33,9 @@ export {
   KnownNotifications,
   KnownWalletScopeString,
 } from './scope/constants';
+export {
+  filterScopeObjectsSupported
+} from './scope/filter';
 export type {
   ExternalScopeString,
   ExternalScopeObject,

--- a/packages/multichain/src/scope/filter.test.ts
+++ b/packages/multichain/src/scope/filter.test.ts
@@ -1,10 +1,23 @@
 import * as Assert from './assert';
-import { filterScopesSupported, bucketScopesBySupport } from './filter';
+import {
+  filterScopesSupported,
+  bucketScopesBySupport,
+  filterScopeObjectsSupported,
+} from './filter';
+import * as Supported from './supported';
 
 jest.mock('./assert', () => ({
+  ...jest.requireActual('./assert'),
   assertScopeSupported: jest.fn(),
 }));
 const MockAssert = jest.mocked(Assert);
+
+jest.mock('./supported', () => ({
+  ...jest.requireActual('./supported'),
+  isSupportedMethod: jest.fn(),
+  isSupportedNotification: jest.fn(),
+}));
+const MockSupported = jest.mocked(Supported);
 
 describe('filter', () => {
   afterEach(() => {
@@ -161,6 +174,182 @@ describe('filter', () => {
             notifications: [],
             accounts: [],
           },
+        },
+      });
+    });
+  });
+
+  describe('filterScopeObjectsSupported', () => {
+    it('checks if each scopeObject method is supported', () => {
+      filterScopeObjectsSupported({
+        'eip155:1': {
+          methods: ['method1', 'method2'],
+          notifications: [],
+          accounts: [],
+        },
+        'eip155:5': {
+          methods: ['methodA', 'methodB'],
+          notifications: [],
+          accounts: [],
+        },
+      });
+
+      expect(MockSupported.isSupportedMethod).toHaveBeenCalledTimes(4);
+      expect(MockSupported.isSupportedMethod).toHaveBeenCalledWith(
+        'eip155:1',
+        'method1',
+      );
+      expect(MockSupported.isSupportedMethod).toHaveBeenCalledWith(
+        'eip155:1',
+        'method2',
+      );
+      expect(MockSupported.isSupportedMethod).toHaveBeenCalledWith(
+        'eip155:5',
+        'methodA',
+      );
+      expect(MockSupported.isSupportedMethod).toHaveBeenCalledWith(
+        'eip155:5',
+        'methodB',
+      );
+    });
+
+    it('returns only supported methods', () => {
+      MockSupported.isSupportedMethod.mockImplementation(
+        (scopeString, method) => {
+          if (scopeString === 'eip155:1' && method === 'method1') {
+            return false;
+          }
+          if (scopeString === 'eip155:5' && method === 'methodB') {
+            return false;
+          }
+          return true;
+        },
+      );
+
+      const result = filterScopeObjectsSupported({
+        'eip155:1': {
+          methods: ['method1', 'method2'],
+          notifications: [],
+          accounts: [],
+        },
+        'eip155:5': {
+          methods: ['methodA', 'methodB'],
+          notifications: [],
+          accounts: [],
+        },
+      });
+
+      expect(result).toStrictEqual({
+        'eip155:1': {
+          methods: ['method2'],
+          notifications: [],
+          accounts: [],
+        },
+        'eip155:5': {
+          methods: ['methodA'],
+          notifications: [],
+          accounts: [],
+        },
+      });
+    });
+
+    it('checks if each scopeObject notification is supported', () => {
+      filterScopeObjectsSupported({
+        'eip155:1': {
+          methods: [],
+          notifications: ['notification1', 'notification2'],
+          accounts: [],
+        },
+        'eip155:5': {
+          methods: [],
+          notifications: ['notificationA', 'notificationB'],
+          accounts: [],
+        },
+      });
+
+      expect(MockSupported.isSupportedNotification).toHaveBeenCalledTimes(4);
+      expect(MockSupported.isSupportedNotification).toHaveBeenCalledWith(
+        'eip155:1',
+        'notification1',
+      );
+      expect(MockSupported.isSupportedNotification).toHaveBeenCalledWith(
+        'eip155:1',
+        'notification2',
+      );
+      expect(MockSupported.isSupportedNotification).toHaveBeenCalledWith(
+        'eip155:5',
+        'notificationA',
+      );
+      expect(MockSupported.isSupportedNotification).toHaveBeenCalledWith(
+        'eip155:5',
+        'notificationB',
+      );
+    });
+
+    it('returns only supported notifications', () => {
+      MockSupported.isSupportedNotification.mockImplementation(
+        (scopeString, notification) => {
+          if (scopeString === 'eip155:1' && notification === 'notification1') {
+            return false;
+          }
+          if (scopeString === 'eip155:5' && notification === 'notificationB') {
+            return false;
+          }
+          return true;
+        },
+      );
+
+      const result = filterScopeObjectsSupported({
+        'eip155:1': {
+          methods: [],
+          notifications: ['notification1', 'notification2'],
+          accounts: [],
+        },
+        'eip155:5': {
+          methods: [],
+          notifications: ['notificationA', 'notificationB'],
+          accounts: [],
+        },
+      });
+
+      expect(result).toStrictEqual({
+        'eip155:1': {
+          methods: [],
+          notifications: ['notification2'],
+          accounts: [],
+        },
+        'eip155:5': {
+          methods: [],
+          notifications: ['notificationA'],
+          accounts: [],
+        },
+      });
+    });
+
+    it('does not modify accounts', () => {
+      const result = filterScopeObjectsSupported({
+        'eip155:1': {
+          methods: [],
+          notifications: [],
+          accounts: ['eip155:1:0xdeadbeef'],
+        },
+        'eip155:5': {
+          methods: [],
+          notifications: [],
+          accounts: ['eip155:5:0xdeadbeef'],
+        },
+      });
+
+      expect(result).toStrictEqual({
+        'eip155:1': {
+          methods: [],
+          notifications: [],
+          accounts: ['eip155:1:0xdeadbeef'],
+        },
+        'eip155:5': {
+          methods: [],
+          notifications: [],
+          accounts: ['eip155:5:0xdeadbeef'],
         },
       });
     });


### PR DESCRIPTION
## Explanation

Adds and exports `filterScopeObjectsSupported` which filters out unsupported methods and notifications from each ScopeObject in a ScopesObject

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

Extension: https://github.com/MetaMask/metamask-extension/pull/29001

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/package-a`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

### `@metamask/package-b`

- **<CATEGORY>**: Your change here
- **<CATEGORY>**: Your change here

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
