### PR TITLE
Add label for use in github project auto add workflow

### DIFF
--- a/.github/workflows/create-update-issues.yaml
+++ b/.github/workflows/create-update-issues.yaml
@@ -36,8 +36,8 @@ jobs:
               if [[ $version == *.0.0 ]]; then
                 # Fetch responsible team from file
                 teams=$(jq -r --arg key "$package_name" '.[$key]' teams.json)
-                gh issue create --title "Update ${package_name} to version ${version}" --body "Please update ${package_name} to version ${version}" --repo "MetaMask/metamask-extension" --label "$teams"
-                gh issue create --title "Update ${package_name} to version ${version}" --body "Please update ${package_name} to version ${version}" --repo "MetaMask/metamask-mobile" --label "$teams"
+                gh issue create --title "Update ${package_name} to version ${version}" --body "Please update ${package_name} to version ${version}" --repo "MetaMask/metamask-extension" --label "$teams, client-controller-update"
+                gh issue create --title "Update ${package_name} to version ${version}" --body "Please update ${package_name} to version ${version}" --repo "MetaMask/metamask-mobile" --label "$teams, client-controller-update"
               fi
             fi
           done


### PR DESCRIPTION
## Explanation

We have a github project setup to track client controller upgrade issues that are created by this github action. Github projects workflow is not working for auto adding solely based on title match and the options for what to match on are very limited. Labels are one way we can do that.

This PR adds a label that we can trigger the auto add workflow on. 

## References


## Changelog

n/a

## Checklist
n/a
