### PR TITLE
chore: Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `ControllerMessenger` to `Messenger` ([#5050](https://github.com/MetaMask/core/pull/5050))
+  - `ControllerMessenger` has been renamed to `Messenger`
+  - `RestrictedControllerMessengerConstraint` has been renamed to `RestrictedMessengerConstraint`
+  - `RestrictedControllerMessenger` has been renamed to `RestrictedMessenger`
+  - The `RestrictedMessenger` constructor parameter `controllerMessenger` has been renamed to `messenger`, though the old name is still accepted
+  - The old names remain exported as deprecated aliases of the new names, so this is not a breaking change.
+
 ## [7.0.2]
 
 ### Changed

--- a/packages/base-controller/src/BaseControllerV1.test.ts
+++ b/packages/base-controller/src/BaseControllerV1.test.ts
@@ -16,7 +16,7 @@ import {
   countControllerStateMetadata,
   getCountMessenger,
 } from './BaseControllerV2.test';
-import { ControllerMessenger } from './ControllerMessenger';
+import { ControllerMessenger } from './Messenger';
 
 const STATE = { name: 'foo' };
 const CONFIG = { disabled: true };

--- a/packages/base-controller/src/BaseControllerV2.test.ts
+++ b/packages/base-controller/src/BaseControllerV2.test.ts
@@ -14,8 +14,8 @@ import {
   getPersistentState,
   isBaseController,
 } from './BaseControllerV2';
-import { ControllerMessenger } from './ControllerMessenger';
-import type { RestrictedControllerMessenger } from './RestrictedControllerMessenger';
+import { ControllerMessenger } from './Messenger';
+import type { RestrictedControllerMessenger } from './RestrictedMessenger';
 
 export const countControllerName = 'CountController';
 

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -6,11 +6,11 @@ import type {
   BaseControllerV1Instance,
   StateConstraint as StateConstraintV1,
 } from './BaseControllerV1';
-import type { ActionConstraint, EventConstraint } from './ControllerMessenger';
+import type { ActionConstraint, EventConstraint } from './Messenger';
 import type {
   RestrictedControllerMessenger,
   RestrictedControllerMessengerConstraint,
-} from './RestrictedControllerMessenger';
+} from './RestrictedMessenger';
 
 enablePatches();
 

--- a/packages/base-controller/src/Messenger.test.ts
+++ b/packages/base-controller/src/Messenger.test.ts
@@ -1,30 +1,29 @@
 import type { Patch } from 'immer';
 import * as sinon from 'sinon';
 
-import { ControllerMessenger } from './ControllerMessenger';
+import { Messenger } from './Messenger';
 
-describe('ControllerMessenger', () => {
+describe('Messenger', () => {
   afterEach(() => {
     sinon.restore();
   });
 
   it('should allow registering and calling an action handler', () => {
     type CountAction = { type: 'count'; handler: (increment: number) => void };
-    const controllerMessenger = new ControllerMessenger<CountAction, never>();
+    const messenger = new Messenger<CountAction, never>();
 
     let count = 0;
-    controllerMessenger.registerActionHandler('count', (increment: number) => {
+    messenger.registerActionHandler('count', (increment: number) => {
       count += increment;
     });
-    controllerMessenger.call('count', 1);
+    messenger.call('count', 1);
 
     expect(count).toBe(1);
   });
 
   it('should allow registering and calling multiple different action handlers', () => {
-    // These 'Other' types are included to demonstrate that controller messenger
-    // generics can indeed be unions of actions and events from different
-    // controllers.
+    // These 'Other' types are included to demonstrate that messenger generics can indeed be unions
+    // of actions and events from different modules.
     type GetOtherState = {
       type: `OtherController:getState`;
       handler: () => { stuff: string };
@@ -38,41 +37,35 @@ describe('ControllerMessenger', () => {
     type MessageAction =
       | { type: 'concat'; handler: (message: string) => void }
       | { type: 'reset'; handler: (initialMessage: string) => void };
-    const controllerMessenger = new ControllerMessenger<
+    const messenger = new Messenger<
       MessageAction | GetOtherState,
       OtherStateChange
     >();
 
     let message = '';
-    controllerMessenger.registerActionHandler(
-      'reset',
-      (initialMessage: string) => {
-        message = initialMessage;
-      },
-    );
+    messenger.registerActionHandler('reset', (initialMessage: string) => {
+      message = initialMessage;
+    });
 
-    controllerMessenger.registerActionHandler('concat', (s: string) => {
+    messenger.registerActionHandler('concat', (s: string) => {
       message += s;
     });
 
-    controllerMessenger.call('reset', 'hello');
-    controllerMessenger.call('concat', ', world');
+    messenger.call('reset', 'hello');
+    messenger.call('concat', ', world');
 
     expect(message).toBe('hello, world');
   });
 
   it('should allow registering and calling an action handler with no parameters', () => {
     type IncrementAction = { type: 'increment'; handler: () => void };
-    const controllerMessenger = new ControllerMessenger<
-      IncrementAction,
-      never
-    >();
+    const messenger = new Messenger<IncrementAction, never>();
 
     let count = 0;
-    controllerMessenger.registerActionHandler('increment', () => {
+    messenger.registerActionHandler('increment', () => {
       count += 1;
     });
-    controllerMessenger.call('increment');
+    messenger.call('increment');
 
     expect(count).toBe(1);
   });
@@ -82,98 +75,98 @@ describe('ControllerMessenger', () => {
       type: 'message';
       handler: (to: string, message: string) => void;
     };
-    const controllerMessenger = new ControllerMessenger<MessageAction, never>();
+    const messenger = new Messenger<MessageAction, never>();
 
     const messages: Record<string, string> = {};
-    controllerMessenger.registerActionHandler('message', (to, message) => {
+    messenger.registerActionHandler('message', (to, message) => {
       messages[to] = message;
     });
-    controllerMessenger.call('message', '0x123', 'hello');
+    messenger.call('message', '0x123', 'hello');
 
     expect(messages['0x123']).toBe('hello');
   });
 
   it('should allow registering and calling an action handler with a return value', () => {
     type AddAction = { type: 'add'; handler: (a: number, b: number) => number };
-    const controllerMessenger = new ControllerMessenger<AddAction, never>();
+    const messenger = new Messenger<AddAction, never>();
 
-    controllerMessenger.registerActionHandler('add', (a, b) => {
+    messenger.registerActionHandler('add', (a, b) => {
       return a + b;
     });
-    const result = controllerMessenger.call('add', 5, 10);
+    const result = messenger.call('add', 5, 10);
 
     expect(result).toBe(15);
   });
 
   it('should not allow registering multiple action handlers under the same name', () => {
     type PingAction = { type: 'ping'; handler: () => void };
-    const controllerMessenger = new ControllerMessenger<PingAction, never>();
+    const messenger = new Messenger<PingAction, never>();
 
-    controllerMessenger.registerActionHandler('ping', () => undefined);
+    messenger.registerActionHandler('ping', () => undefined);
 
     expect(() => {
-      controllerMessenger.registerActionHandler('ping', () => undefined);
+      messenger.registerActionHandler('ping', () => undefined);
     }).toThrow('A handler for ping has already been registered');
   });
 
   it('should throw when calling unregistered action', () => {
     type PingAction = { type: 'ping'; handler: () => void };
-    const controllerMessenger = new ControllerMessenger<PingAction, never>();
+    const messenger = new Messenger<PingAction, never>();
 
     expect(() => {
-      controllerMessenger.call('ping');
+      messenger.call('ping');
     }).toThrow('A handler for ping has not been registered');
   });
 
   it('should throw when calling an action that has been unregistered', () => {
     type PingAction = { type: 'ping'; handler: () => void };
-    const controllerMessenger = new ControllerMessenger<PingAction, never>();
+    const messenger = new Messenger<PingAction, never>();
 
     expect(() => {
-      controllerMessenger.call('ping');
+      messenger.call('ping');
     }).toThrow('A handler for ping has not been registered');
 
     let pingCount = 0;
-    controllerMessenger.registerActionHandler('ping', () => {
+    messenger.registerActionHandler('ping', () => {
       pingCount += 1;
     });
 
-    controllerMessenger.unregisterActionHandler('ping');
+    messenger.unregisterActionHandler('ping');
 
     expect(() => {
-      controllerMessenger.call('ping');
+      messenger.call('ping');
     }).toThrow('A handler for ping has not been registered');
     expect(pingCount).toBe(0);
   });
 
   it('should throw when calling an action after actions have been reset', () => {
     type PingAction = { type: 'ping'; handler: () => void };
-    const controllerMessenger = new ControllerMessenger<PingAction, never>();
+    const messenger = new Messenger<PingAction, never>();
 
     expect(() => {
-      controllerMessenger.call('ping');
+      messenger.call('ping');
     }).toThrow('A handler for ping has not been registered');
 
     let pingCount = 0;
-    controllerMessenger.registerActionHandler('ping', () => {
+    messenger.registerActionHandler('ping', () => {
       pingCount += 1;
     });
 
-    controllerMessenger.clearActions();
+    messenger.clearActions();
 
     expect(() => {
-      controllerMessenger.call('ping');
+      messenger.call('ping');
     }).toThrow('A handler for ping has not been registered');
     expect(pingCount).toBe(0);
   });
 
   it('should publish event to subscriber', () => {
     type MessageEvent = { type: 'message'; payload: [string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler = sinon.stub();
-    controllerMessenger.subscribe('message', handler);
-    controllerMessenger.publish('message', 'hello');
+    messenger.subscribe('message', handler);
+    messenger.publish('message', 'hello');
 
     expect(handler.calledWithExactly('hello')).toBe(true);
     expect(handler.callCount).toBe(1);
@@ -183,15 +176,15 @@ describe('ControllerMessenger', () => {
     type MessageEvent =
       | { type: 'message'; payload: [string] }
       | { type: 'ping'; payload: [] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const messageHandler = sinon.stub();
     const pingHandler = sinon.stub();
-    controllerMessenger.subscribe('message', messageHandler);
-    controllerMessenger.subscribe('ping', pingHandler);
+    messenger.subscribe('message', messageHandler);
+    messenger.subscribe('ping', pingHandler);
 
-    controllerMessenger.publish('message', 'hello');
-    controllerMessenger.publish('ping');
+    messenger.publish('message', 'hello');
+    messenger.publish('ping');
 
     expect(messageHandler.calledWithExactly('hello')).toBe(true);
     expect(messageHandler.callCount).toBe(1);
@@ -201,11 +194,11 @@ describe('ControllerMessenger', () => {
 
   it('should publish event with no payload to subscriber', () => {
     type PingEvent = { type: 'ping'; payload: [] };
-    const controllerMessenger = new ControllerMessenger<never, PingEvent>();
+    const messenger = new Messenger<never, PingEvent>();
 
     const handler = sinon.stub();
-    controllerMessenger.subscribe('ping', handler);
-    controllerMessenger.publish('ping');
+    messenger.subscribe('ping', handler);
+    messenger.publish('ping');
 
     expect(handler.calledWithExactly()).toBe(true);
     expect(handler.callCount).toBe(1);
@@ -213,11 +206,11 @@ describe('ControllerMessenger', () => {
 
   it('should publish event with multiple payload parameters to subscriber', () => {
     type MessageEvent = { type: 'message'; payload: [string, string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler = sinon.stub();
-    controllerMessenger.subscribe('message', handler);
-    controllerMessenger.publish('message', 'hello', 'there');
+    messenger.subscribe('message', handler);
+    messenger.publish('message', 'hello', 'there');
 
     expect(handler.calledWithExactly('hello', 'there')).toBe(true);
     expect(handler.callCount).toBe(1);
@@ -225,12 +218,12 @@ describe('ControllerMessenger', () => {
 
   it('should publish event once to subscriber even if subscribed multiple times', () => {
     type MessageEvent = { type: 'message'; payload: [string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler = sinon.stub();
-    controllerMessenger.subscribe('message', handler);
-    controllerMessenger.subscribe('message', handler);
-    controllerMessenger.publish('message', 'hello');
+    messenger.subscribe('message', handler);
+    messenger.subscribe('message', handler);
+    messenger.publish('message', 'hello');
 
     expect(handler.calledWithExactly('hello')).toBe(true);
     expect(handler.callCount).toBe(1);
@@ -238,13 +231,13 @@ describe('ControllerMessenger', () => {
 
   it('should publish event to many subscribers', () => {
     type MessageEvent = { type: 'message'; payload: [string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler1 = sinon.stub();
     const handler2 = sinon.stub();
-    controllerMessenger.subscribe('message', handler1);
-    controllerMessenger.subscribe('message', handler2);
-    controllerMessenger.publish('message', 'hello');
+    messenger.subscribe('message', handler1);
+    messenger.subscribe('message', handler2);
+    messenger.publish('message', 'hello');
 
     expect(handler1.calledWithExactly('hello')).toBe(true);
     expect(handler1.callCount).toBe(1);
@@ -262,23 +255,16 @@ describe('ControllerMessenger', () => {
         type: 'complexMessage';
         payload: [typeof state];
       };
-      const controllerMessenger = new ControllerMessenger<
-        never,
-        MessageEvent
-      >();
-      controllerMessenger.registerInitialEventPayload({
+      const messenger = new Messenger<never, MessageEvent>();
+      messenger.registerInitialEventPayload({
         eventType: 'complexMessage',
         getPayload: () => [state],
       });
       const handler = sinon.stub();
-      controllerMessenger.subscribe(
-        'complexMessage',
-        handler,
-        (obj) => obj.propA,
-      );
+      messenger.subscribe('complexMessage', handler, (obj) => obj.propA);
 
       state.propA += 1;
-      controllerMessenger.publish('complexMessage', state);
+      messenger.publish('complexMessage', state);
 
       expect(handler.getCall(0)?.args).toStrictEqual([2, 1]);
       expect(handler.callCount).toBe(1);
@@ -293,22 +279,15 @@ describe('ControllerMessenger', () => {
         type: 'complexMessage';
         payload: [typeof state];
       };
-      const controllerMessenger = new ControllerMessenger<
-        never,
-        MessageEvent
-      >();
-      controllerMessenger.registerInitialEventPayload({
+      const messenger = new Messenger<never, MessageEvent>();
+      messenger.registerInitialEventPayload({
         eventType: 'complexMessage',
         getPayload: () => [state],
       });
       const handler = sinon.stub();
-      controllerMessenger.subscribe(
-        'complexMessage',
-        handler,
-        (obj) => obj.propA,
-      );
+      messenger.subscribe('complexMessage', handler, (obj) => obj.propA);
 
-      controllerMessenger.publish('complexMessage', state);
+      messenger.publish('complexMessage', state);
 
       expect(handler.callCount).toBe(0);
     });
@@ -324,19 +303,12 @@ describe('ControllerMessenger', () => {
         type: 'complexMessage';
         payload: [typeof state];
       };
-      const controllerMessenger = new ControllerMessenger<
-        never,
-        MessageEvent
-      >();
+      const messenger = new Messenger<never, MessageEvent>();
       const handler = sinon.stub();
-      controllerMessenger.subscribe(
-        'complexMessage',
-        handler,
-        (obj) => obj.propA,
-      );
+      messenger.subscribe('complexMessage', handler, (obj) => obj.propA);
 
       state.propA += 1;
-      controllerMessenger.publish('complexMessage', state);
+      messenger.publish('complexMessage', state);
 
       expect(handler.getCall(0)?.args).toStrictEqual([2, undefined]);
       expect(handler.callCount).toBe(1);
@@ -351,18 +323,11 @@ describe('ControllerMessenger', () => {
         type: 'complexMessage';
         payload: [typeof state];
       };
-      const controllerMessenger = new ControllerMessenger<
-        never,
-        MessageEvent
-      >();
+      const messenger = new Messenger<never, MessageEvent>();
       const handler = sinon.stub();
-      controllerMessenger.subscribe(
-        'complexMessage',
-        handler,
-        (obj) => obj.propA,
-      );
+      messenger.subscribe('complexMessage', handler, (obj) => obj.propA);
 
-      controllerMessenger.publish('complexMessage', state);
+      messenger.publish('complexMessage', state);
 
       expect(handler.getCall(0)?.args).toStrictEqual([1, undefined]);
       expect(handler.callCount).toBe(1);
@@ -377,18 +342,11 @@ describe('ControllerMessenger', () => {
         type: 'complexMessage';
         payload: [typeof state];
       };
-      const controllerMessenger = new ControllerMessenger<
-        never,
-        MessageEvent
-      >();
+      const messenger = new Messenger<never, MessageEvent>();
       const handler = sinon.stub();
-      controllerMessenger.subscribe(
-        'complexMessage',
-        handler,
-        (obj) => obj.propA,
-      );
+      messenger.subscribe('complexMessage', handler, (obj) => obj.propA);
 
-      controllerMessenger.publish('complexMessage', state);
+      messenger.publish('complexMessage', state);
 
       expect(handler.callCount).toBe(0);
     });
@@ -400,19 +358,12 @@ describe('ControllerMessenger', () => {
         type: 'complexMessage';
         payload: [Record<string, unknown>];
       };
-      const controllerMessenger = new ControllerMessenger<
-        never,
-        MessageEvent
-      >();
+      const messenger = new Messenger<never, MessageEvent>();
 
       const handler = sinon.stub();
-      controllerMessenger.subscribe(
-        'complexMessage',
-        handler,
-        (obj) => obj.prop1,
-      );
-      controllerMessenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
-      controllerMessenger.publish('complexMessage', { prop1: 'z', prop2: 'b' });
+      messenger.subscribe('complexMessage', handler, (obj) => obj.prop1);
+      messenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
+      messenger.publish('complexMessage', { prop1: 'z', prop2: 'b' });
 
       expect(handler.getCall(0).calledWithExactly('a', undefined)).toBe(true);
       expect(handler.getCall(1).calledWithExactly('z', 'a')).toBe(true);
@@ -424,18 +375,11 @@ describe('ControllerMessenger', () => {
         type: 'complexMessage';
         payload: [Record<string, unknown>];
       };
-      const controllerMessenger = new ControllerMessenger<
-        never,
-        MessageEvent
-      >();
+      const messenger = new Messenger<never, MessageEvent>();
 
       const handler = sinon.stub();
-      controllerMessenger.subscribe(
-        'complexMessage',
-        handler,
-        (obj) => obj.prop1,
-      );
-      controllerMessenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
+      messenger.subscribe('complexMessage', handler, (obj) => obj.prop1);
+      messenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
 
       expect(handler.calledWithExactly('a', undefined)).toBe(true);
       expect(handler.callCount).toBe(1);
@@ -446,19 +390,12 @@ describe('ControllerMessenger', () => {
         type: 'complexMessage';
         payload: [Record<string, unknown>];
       };
-      const controllerMessenger = new ControllerMessenger<
-        never,
-        MessageEvent
-      >();
+      const messenger = new Messenger<never, MessageEvent>();
 
       const handler = sinon.stub();
-      controllerMessenger.subscribe(
-        'complexMessage',
-        handler,
-        (obj) => obj.prop1,
-      );
-      controllerMessenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
-      controllerMessenger.publish('complexMessage', { prop1: 'a', prop3: 'c' });
+      messenger.subscribe('complexMessage', handler, (obj) => obj.prop1);
+      messenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
+      messenger.publish('complexMessage', { prop1: 'a', prop3: 'c' });
 
       expect(handler.calledWithExactly('a', undefined)).toBe(true);
       expect(handler.callCount).toBe(1);
@@ -470,15 +407,15 @@ describe('ControllerMessenger', () => {
       type: 'complexMessage';
       payload: [Record<string, unknown>];
     };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler1 = sinon.stub();
     const handler2 = sinon.stub();
     const selector = sinon.fake((obj: Record<string, unknown>) => obj.prop1);
-    controllerMessenger.subscribe('complexMessage', handler1, selector);
-    controllerMessenger.subscribe('complexMessage', handler2, selector);
-    controllerMessenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
-    controllerMessenger.publish('complexMessage', { prop1: 'a', prop3: 'c' });
+    messenger.subscribe('complexMessage', handler1, selector);
+    messenger.subscribe('complexMessage', handler2, selector);
+    messenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
+    messenger.publish('complexMessage', { prop1: 'a', prop3: 'c' });
 
     expect(handler1.calledWithExactly('a', undefined)).toBe(true);
     expect(handler1.callCount).toBe(1);
@@ -505,12 +442,12 @@ describe('ControllerMessenger', () => {
   it('should throw subscriber errors in a timeout', () => {
     const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
     type MessageEvent = { type: 'message'; payload: [string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler = sinon.stub().throws(() => new Error('Example error'));
-    controllerMessenger.subscribe('message', handler);
+    messenger.subscribe('message', handler);
 
-    expect(() => controllerMessenger.publish('message', 'hello')).not.toThrow();
+    expect(() => messenger.publish('message', 'hello')).not.toThrow();
     expect(setTimeoutStub.callCount).toBe(1);
     const onTimeout = setTimeoutStub.firstCall.args[0];
     expect(() => onTimeout()).toThrow('Example error');
@@ -519,14 +456,14 @@ describe('ControllerMessenger', () => {
   it('should continue calling subscribers when one throws', () => {
     const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
     type MessageEvent = { type: 'message'; payload: [string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler1 = sinon.stub().throws(() => new Error('Example error'));
     const handler2 = sinon.stub();
-    controllerMessenger.subscribe('message', handler1);
-    controllerMessenger.subscribe('message', handler2);
+    messenger.subscribe('message', handler1);
+    messenger.subscribe('message', handler2);
 
-    expect(() => controllerMessenger.publish('message', 'hello')).not.toThrow();
+    expect(() => messenger.publish('message', 'hello')).not.toThrow();
 
     expect(handler1.calledWithExactly('hello')).toBe(true);
     expect(handler1.callCount).toBe(1);
@@ -539,12 +476,12 @@ describe('ControllerMessenger', () => {
 
   it('should not call subscriber after unsubscribing', () => {
     type MessageEvent = { type: 'message'; payload: [string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler = sinon.stub();
-    controllerMessenger.subscribe('message', handler);
-    controllerMessenger.unsubscribe('message', handler);
-    controllerMessenger.publish('message', 'hello');
+    messenger.subscribe('message', handler);
+    messenger.unsubscribe('message', handler);
+    messenger.publish('message', 'hello');
 
     expect(handler.callCount).toBe(0);
   });
@@ -554,13 +491,13 @@ describe('ControllerMessenger', () => {
       type: 'complexMessage';
       payload: [Record<string, unknown>];
     };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler = sinon.stub();
     const selector = sinon.fake((obj: Record<string, unknown>) => obj.prop1);
-    controllerMessenger.subscribe('complexMessage', handler, selector);
-    controllerMessenger.unsubscribe('complexMessage', handler);
-    controllerMessenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
+    messenger.subscribe('complexMessage', handler, selector);
+    messenger.unsubscribe('complexMessage', handler);
+    messenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
 
     expect(handler.callCount).toBe(0);
     expect(selector.callCount).toBe(0);
@@ -568,56 +505,54 @@ describe('ControllerMessenger', () => {
 
   it('should throw when unsubscribing when there are no subscriptions', () => {
     type MessageEvent = { type: 'message'; payload: [string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler = sinon.stub();
-    expect(() => controllerMessenger.unsubscribe('message', handler)).toThrow(
+    expect(() => messenger.unsubscribe('message', handler)).toThrow(
       'Subscription not found for event: message',
     );
   });
 
   it('should throw when unsubscribing a handler that is not subscribed', () => {
     type MessageEvent = { type: 'message'; payload: [string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler1 = sinon.stub();
     const handler2 = sinon.stub();
-    controllerMessenger.subscribe('message', handler1);
+    messenger.subscribe('message', handler1);
 
-    expect(() => controllerMessenger.unsubscribe('message', handler2)).toThrow(
+    expect(() => messenger.unsubscribe('message', handler2)).toThrow(
       'Subscription not found for event: message',
     );
   });
 
   it('should not call subscriber after clearing event subscriptions', () => {
     type MessageEvent = { type: 'message'; payload: [string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler = sinon.stub();
-    controllerMessenger.subscribe('message', handler);
-    controllerMessenger.clearEventSubscriptions('message');
-    controllerMessenger.publish('message', 'hello');
+    messenger.subscribe('message', handler);
+    messenger.clearEventSubscriptions('message');
+    messenger.publish('message', 'hello');
 
     expect(handler.callCount).toBe(0);
   });
 
   it('should not throw when clearing event that has no subscriptions', () => {
     type MessageEvent = { type: 'message'; payload: [string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
-    expect(() =>
-      controllerMessenger.clearEventSubscriptions('message'),
-    ).not.toThrow();
+    expect(() => messenger.clearEventSubscriptions('message')).not.toThrow();
   });
 
   it('should not call subscriber after resetting subscriptions', () => {
     type MessageEvent = { type: 'message'; payload: [string] };
-    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const messenger = new Messenger<never, MessageEvent>();
 
     const handler = sinon.stub();
-    controllerMessenger.subscribe('message', handler);
-    controllerMessenger.clearSubscriptions();
-    controllerMessenger.publish('message', 'hello');
+    messenger.subscribe('message', handler);
+    messenger.clearSubscriptions();
+    messenger.publish('message', 'hello');
 
     expect(handler.callCount).toBe(0);
   });

--- a/packages/base-controller/src/Messenger.ts
+++ b/packages/base-controller/src/Messenger.ts
@@ -1,4 +1,4 @@
-import { RestrictedControllerMessenger } from './RestrictedControllerMessenger';
+import { RestrictedMessenger } from './RestrictedMessenger';
 
 export type ActionHandler<
   Action extends ActionConstraint,
@@ -114,16 +114,16 @@ type NarrowToAllowed<Name, Allowed extends string> = Name extends {
   : never;
 
 /**
- * A messaging system for controllers.
+ * A message broker for "actions" and "events".
  *
- * The controller messenger allows registering functions as 'actions' that can be called elsewhere,
+ * The messenger allows registering functions as 'actions' that can be called elsewhere,
  * and it allows publishing and subscribing to events. Both actions and events are identified by
  * unique strings.
  *
  * @template Action - A type union of all Action types.
  * @template Event - A type union of all Event types.
  */
-export class ControllerMessenger<
+export class Messenger<
   Action extends ActionConstraint,
   Event extends EventConstraint,
 > {
@@ -399,30 +399,30 @@ export class ControllerMessenger<
   }
 
   /**
-   * Get a restricted controller messenger
+   * Get a restricted messenger
    *
-   * Returns a wrapper around the controller messenger instance that restricts access to actions
-   * and events. The provided allowlists grant the ability to call the listed actions and subscribe
-   * to the listed events. The "name" provided grants ownership of any actions and events under
-   * that namespace. Ownership allows registering actions and publishing events, as well as
+   * Returns a wrapper around the messenger instance that restricts access to actions and events.
+   * The provided allowlists grant the ability to call the listed actions and subscribe to the
+   * listed events. The "name" provided grants ownership of any actions and events under that
+   * namespace. Ownership allows registering actions and publishing events, as well as
    * unregistering actions and clearing event subscriptions.
    *
    * @param options - Controller messenger options.
    * @param options.name - The name of the thing this messenger will be handed to (e.g. the
    * controller name). This grants "ownership" of actions and events under this namespace to the
-   * restricted controller messenger returned.
-   * @param options.allowedActions - The list of actions that this restricted controller messenger
-   * should be alowed to call.
-   * @param options.allowedEvents - The list of events that this restricted controller messenger
-   * should be allowed to subscribe to.
-   * @template Namespace - The namespace for this messenger. Typically this is the name of the controller or
+   * restricted messenger returned.
+   * @param options.allowedActions - The list of actions that this restricted messenger should be
+   * allowed to call.
+   * @param options.allowedEvents - The list of events that this restricted messenger should be
+   * allowed to subscribe to.
+   * @template Namespace - The namespace for this messenger. Typically this is the name of the
    * module that this messenger has been created for. The authority to publish events and register
    * actions under this namespace is granted to this restricted messenger instance.
    * @template AllowedAction - A type union of the 'type' string for any allowed actions.
    * This must not include internal actions that are in the messenger's namespace.
    * @template AllowedEvent - A type union of the 'type' string for any allowed events.
    * This must not include internal events that are in the messenger's namespace.
-   * @returns The restricted controller messenger.
+   * @returns The restricted messenger.
    */
   getRestricted<
     Namespace extends string,
@@ -442,7 +442,7 @@ export class ControllerMessenger<
       Namespace,
       Extract<Event['type'], AllowedEvent>
     >[];
-  }): RestrictedControllerMessenger<
+  }): RestrictedMessenger<
     Namespace,
     | NarrowToNamespace<Action, Namespace>
     | NarrowToAllowed<Action, AllowedAction>,
@@ -450,11 +450,28 @@ export class ControllerMessenger<
     AllowedAction,
     AllowedEvent
   > {
-    return new RestrictedControllerMessenger({
-      controllerMessenger: this,
+    return new RestrictedMessenger({
+      messenger: this,
       name,
       allowedActions,
       allowedEvents,
     });
   }
 }
+
+/**
+ * A message broker for "actions" and "events".
+ *
+ * The messenger allows registering functions as 'actions' that can be called elsewhere,
+ * and it allows publishing and subscribing to events. Both actions and events are identified by
+ * unique strings.
+ *
+ * @template Action - A type union of all Action types.
+ * @template Event - A type union of all Event types.
+ * @deprecated This has been renamed to `Messenger`.
+ */
+export const ControllerMessenger = Messenger;
+export type ControllerMessenger<
+  Action extends ActionConstraint,
+  Event extends EventConstraint,
+> = Messenger<Action, Event>;

--- a/packages/base-controller/src/Messenger.ts
+++ b/packages/base-controller/src/Messenger.ts
@@ -459,19 +459,4 @@ export class Messenger<
   }
 }
 
-/**
- * A message broker for "actions" and "events".
- *
- * The messenger allows registering functions as 'actions' that can be called elsewhere,
- * and it allows publishing and subscribing to events. Both actions and events are identified by
- * unique strings.
- *
- * @template Action - A type union of all Action types.
- * @template Event - A type union of all Event types.
- * @deprecated This has been renamed to `Messenger`.
- */
-export const ControllerMessenger = Messenger;
-export type ControllerMessenger<
-  Action extends ActionConstraint,
-  Event extends EventConstraint,
-> = Messenger<Action, Event>;
+export { Messenger as ControllerMessenger };

--- a/packages/base-controller/src/RestrictedMessenger.ts
+++ b/packages/base-controller/src/RestrictedMessenger.ts
@@ -1,7 +1,7 @@
 import type {
   ActionConstraint,
   ActionHandler,
-  ControllerMessenger,
+  Messenger,
   EventConstraint,
   ExtractActionParameters,
   ExtractActionResponse,
@@ -11,29 +11,40 @@ import type {
   NotNamespacedBy,
   SelectorEventHandler,
   SelectorFunction,
-} from './ControllerMessenger';
+} from './Messenger';
 
 /**
- * A universal supertype of all `RestrictedControllerMessenger` instances.
- * This type can be assigned to any `RestrictedControllerMessenger` type.
+ * A universal supertype of all `RestrictedMessenger` instances. This type can be assigned to any
+ * `RestrictedMessenger` type.
  *
- * @template ControllerName - Name of the controller. Optionally can be used to
- * narrow this type to a constraint for the messenger of a specific controller.
+ * @template Namespace - Name of the module this messenger is for. Optionally can be used to
+ * narrow this type to a constraint for the messenger of a specific module.
+ */
+export type RestrictedMessengerConstraint<Namespace extends string = string> =
+  RestrictedMessenger<
+    Namespace,
+    ActionConstraint,
+    EventConstraint,
+    string,
+    string
+  >;
+
+/**
+ * A universal supertype of all `RestrictedMessenger` instances. This type can be assigned to any
+ * `RestrictedMessenger` type.
+ *
+ * @template Namespace - Name of the module this messenger is for. Optionally can be used to
+ * narrow this type to a constraint for the messenger of a specific module.
+ * @deprecated This has been renamed to `RestrictedMessengerConstraint`.
  */
 export type RestrictedControllerMessengerConstraint<
-  ControllerName extends string = string,
-> = RestrictedControllerMessenger<
-  ControllerName,
-  ActionConstraint,
-  EventConstraint,
-  string,
-  string
->;
+  Namespace extends string = string,
+> = RestrictedMessengerConstraint<Namespace>;
 
 /**
- * A restricted controller messenger.
+ * A restricted messenger.
  *
- * This acts as a wrapper around the controller messenger instance that restricts access to actions
+ * This acts as a wrapper around the messenger instance that restricts access to actions
  * and events.
  *
  * @template Namespace - The namespace for this messenger. Typically this is the name of the controller or
@@ -46,55 +57,64 @@ export type RestrictedControllerMessengerConstraint<
  * @template AllowedEvent - A type union of the 'type' string for any allowed events.
  * This must not include internal events that are in the messenger's namespace.
  */
-export class RestrictedControllerMessenger<
+export class RestrictedMessenger<
   Namespace extends string,
   Action extends ActionConstraint,
   Event extends EventConstraint,
   AllowedAction extends string,
   AllowedEvent extends string,
 > {
-  readonly #controllerMessenger: ControllerMessenger<
-    ActionConstraint,
-    EventConstraint
-  >;
+  readonly #messenger: Messenger<ActionConstraint, EventConstraint>;
 
-  readonly #controllerName: Namespace;
+  readonly #namespace: Namespace;
 
   readonly #allowedActions: NotNamespacedBy<Namespace, AllowedAction>[];
 
   readonly #allowedEvents: NotNamespacedBy<Namespace, AllowedEvent>[];
 
   /**
-   * Constructs a restricted controller messenger
+   * Constructs a restricted messenger
    *
    * The provided allowlists grant the ability to call the listed actions and subscribe to the
    * listed events. The "name" provided grants ownership of any actions and events under that
    * namespace. Ownership allows registering actions and publishing events, as well as
    * unregistering actions and clearing event subscriptions.
    *
-   * @param options - The controller options.
-   * @param options.controllerMessenger - The controller messenger instance that is being wrapped.
+   * @param options - Options.
+   * @param options.controllerMessenger - The messenger instance that is being wrapped. (deprecated)
+   * @param options.messenger - The messenger instance that is being wrapped.
    * @param options.name - The name of the thing this messenger will be handed to (e.g. the
    * controller name). This grants "ownership" of actions and events under this namespace to the
-   * restricted controller messenger returned.
-   * @param options.allowedActions - The list of actions that this restricted controller messenger
-   * should be alowed to call.
-   * @param options.allowedEvents - The list of events that this restricted controller messenger
-   * should be allowed to subscribe to.
+   * restricted messenger returned.
+   * @param options.allowedActions - The list of actions that this restricted messenger should be
+   * allowed to call.
+   * @param options.allowedEvents - The list of events that this restricted messenger should be
+   * allowed to subscribe to.
    */
   constructor({
     controllerMessenger,
+    messenger,
     name,
     allowedActions,
     allowedEvents,
   }: {
-    controllerMessenger: ControllerMessenger<ActionConstraint, EventConstraint>;
+    controllerMessenger?: Messenger<ActionConstraint, EventConstraint>;
+    messenger?: Messenger<ActionConstraint, EventConstraint>;
     name: Namespace;
     allowedActions: NotNamespacedBy<Namespace, AllowedAction>[];
     allowedEvents: NotNamespacedBy<Namespace, AllowedEvent>[];
   }) {
-    this.#controllerMessenger = controllerMessenger;
-    this.#controllerName = name;
+    if (messenger && controllerMessenger) {
+      throw new Error(
+        `Both messenger properties provided. Provide message using only 'messenger' option, 'controllerMessenger' is deprecated`,
+      );
+    } else if (!messenger && !controllerMessenger) {
+      throw new Error('Messenger not provided');
+    }
+    // The above condition guarantees that one of these options is defined.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.#messenger = (messenger ?? controllerMessenger)!;
+    this.#namespace = name;
     this.#allowedActions = allowedActions;
     this.#allowedEvents = allowedEvents;
   }
@@ -119,11 +139,11 @@ export class RestrictedControllerMessenger<
     if (!this.#isInCurrentNamespace(action)) {
       throw new Error(
         `Only allowed registering action handlers prefixed by '${
-          this.#controllerName
+          this.#namespace
         }:'`,
       );
     }
-    this.#controllerMessenger.registerActionHandler(action, handler);
+    this.#messenger.registerActionHandler(action, handler);
   }
 
   /**
@@ -144,11 +164,11 @@ export class RestrictedControllerMessenger<
     if (!this.#isInCurrentNamespace(action)) {
       throw new Error(
         `Only allowed unregistering action handlers prefixed by '${
-          this.#controllerName
+          this.#namespace
         }:'`,
       );
     }
-    this.#controllerMessenger.unregisterActionHandler(action);
+    this.#messenger.unregisterActionHandler(action);
   }
 
   /**
@@ -177,10 +197,7 @@ export class RestrictedControllerMessenger<
     if (!this.#isAllowedAction(actionType)) {
       throw new Error(`Action missing from allow list: ${actionType}`);
     }
-    const response = this.#controllerMessenger.call<ActionType>(
-      actionType,
-      ...params,
-    );
+    const response = this.#messenger.call<ActionType>(actionType, ...params);
 
     return response;
   }
@@ -210,10 +227,10 @@ export class RestrictedControllerMessenger<
     /* istanbul ignore if */ // Branch unreachable with valid types
     if (!this.#isInCurrentNamespace(eventType)) {
       throw new Error(
-        `Only allowed publishing events prefixed by '${this.#controllerName}:'`,
+        `Only allowed publishing events prefixed by '${this.#namespace}:'`,
       );
     }
-    this.#controllerMessenger.registerInitialEventPayload({
+    this.#messenger.registerInitialEventPayload({
       eventType,
       getPayload,
     });
@@ -239,10 +256,10 @@ export class RestrictedControllerMessenger<
     /* istanbul ignore if */ // Branch unreachable with valid types
     if (!this.#isInCurrentNamespace(event)) {
       throw new Error(
-        `Only allowed publishing events prefixed by '${this.#controllerName}:'`,
+        `Only allowed publishing events prefixed by '${this.#namespace}:'`,
       );
     }
-    this.#controllerMessenger.publish(event, ...payload);
+    this.#messenger.publish(event, ...payload);
   }
 
   /**
@@ -255,7 +272,7 @@ export class RestrictedControllerMessenger<
    * @param eventType - The event type. This is a unique identifier for this event.
    * @param handler - The event handler. The type of the parameters for this event handler must
    * match the type of the payload for this event type.
-   * @throws Will throw if the given event is not an allowed event for this controller messenger.
+   * @throws Will throw if the given event is not an allowed event for this messenger.
    * @template EventType - A type union of Event type strings.
    */
   subscribe<
@@ -280,7 +297,7 @@ export class RestrictedControllerMessenger<
    * @param selector - The selector function used to select relevant data from
    * the event payload. The type of the parameters for this selector must match
    * the type of the payload for this event type.
-   * @throws Will throw if the given event is not an allowed event for this controller messenger.
+   * @throws Will throw if the given event is not an allowed event for this messenger.
    * @template EventType - A type union of Event type strings.
    * @template SelectorReturnValue - The selector return value.
    */
@@ -310,9 +327,9 @@ export class RestrictedControllerMessenger<
     }
 
     if (selector) {
-      return this.#controllerMessenger.subscribe(event, handler, selector);
+      return this.#messenger.subscribe(event, handler, selector);
     }
-    return this.#controllerMessenger.subscribe(event, handler);
+    return this.#messenger.subscribe(event, handler);
   }
 
   /**
@@ -324,7 +341,7 @@ export class RestrictedControllerMessenger<
    *
    * @param event - The event type. This is a unique identifier for this event.
    * @param handler - The event handler to unregister.
-   * @throws Will throw if the given event is not an allowed event for this controller messenger.
+   * @throws Will throw if the given event is not an allowed event for this messenger.
    * @template EventType - A type union of allowed Event type strings.
    */
   unsubscribe<
@@ -335,7 +352,7 @@ export class RestrictedControllerMessenger<
     if (!this.#isAllowedEvent(event)) {
       throw new Error(`Event missing from allow list: ${event}`);
     }
-    this.#controllerMessenger.unsubscribe(event, handler);
+    this.#messenger.unsubscribe(event, handler);
   }
 
   /**
@@ -354,10 +371,10 @@ export class RestrictedControllerMessenger<
   >(event: EventType) {
     if (!this.#isInCurrentNamespace(event)) {
       throw new Error(
-        `Only allowed clearing events prefixed by '${this.#controllerName}:'`,
+        `Only allowed clearing events prefixed by '${this.#namespace}:'`,
       );
     }
-    this.#controllerMessenger.clearEventSubscriptions(event);
+    this.#messenger.clearEventSubscriptions(event);
   }
 
   /**
@@ -409,6 +426,35 @@ export class RestrictedControllerMessenger<
    * @returns Whether the name is within the current namespace
    */
   #isInCurrentNamespace(name: string): name is NamespacedName<Namespace> {
-    return name.startsWith(`${this.#controllerName}:`);
+    return name.startsWith(`${this.#namespace}:`);
   }
 }
+
+/**
+ * Constructs a restricted messenger
+ *
+ * The provided allowlists grant the ability to call the listed actions and subscribe to the
+ * listed events. The "name" provided grants ownership of any actions and events under that
+ * namespace. Ownership allows registering actions and publishing events, as well as
+ * unregistering actions and clearing event subscriptions.
+ *
+ * @param options - Options.
+ * @param options.controllerMessenger - The messenger instance that is being wrapped. (deprecated)
+ * @param options.messenger - The messenger instance that is being wrapped.
+ * @param options.name - The name of the thing this messenger will be handed to (e.g. the
+ * controller name). This grants "ownership" of actions and events under this namespace to the
+ * restricted messenger returned.
+ * @param options.allowedActions - The list of actions that this restricted messenger should be
+ * allowed to call.
+ * @param options.allowedEvents - The list of events that this restricted messenger should be
+ * allowed to subscribe to.
+ * @deprecated This has been renamed to `RestrictedMessenger`.
+ */
+export const RestrictedControllerMessenger = RestrictedMessenger;
+export type RestrictedControllerMessenger<
+  Namespace extends string,
+  Action extends ActionConstraint,
+  Event extends EventConstraint,
+  AllowedAction extends string,
+  AllowedEvent extends string,
+> = RestrictedMessenger<Namespace, Action, Event, AllowedAction, AllowedEvent>;

--- a/packages/base-controller/src/RestrictedMessenger.ts
+++ b/packages/base-controller/src/RestrictedMessenger.ts
@@ -430,31 +430,4 @@ export class RestrictedMessenger<
   }
 }
 
-/**
- * Constructs a restricted messenger
- *
- * The provided allowlists grant the ability to call the listed actions and subscribe to the
- * listed events. The "name" provided grants ownership of any actions and events under that
- * namespace. Ownership allows registering actions and publishing events, as well as
- * unregistering actions and clearing event subscriptions.
- *
- * @param options - Options.
- * @param options.controllerMessenger - The messenger instance that is being wrapped. (deprecated)
- * @param options.messenger - The messenger instance that is being wrapped.
- * @param options.name - The name of the thing this messenger will be handed to (e.g. the
- * controller name). This grants "ownership" of actions and events under this namespace to the
- * restricted messenger returned.
- * @param options.allowedActions - The list of actions that this restricted messenger should be
- * allowed to call.
- * @param options.allowedEvents - The list of events that this restricted messenger should be
- * allowed to subscribe to.
- * @deprecated This has been renamed to `RestrictedMessenger`.
- */
-export const RestrictedControllerMessenger = RestrictedMessenger;
-export type RestrictedControllerMessenger<
-  Namespace extends string,
-  Action extends ActionConstraint,
-  Event extends EventConstraint,
-  AllowedAction extends string,
-  AllowedEvent extends string,
-> = RestrictedMessenger<Namespace, Action, Event, AllowedAction, AllowedEvent>;
+export { RestrictedMessenger as RestrictedControllerMessenger };

--- a/packages/base-controller/src/index.ts
+++ b/packages/base-controller/src/index.ts
@@ -41,7 +41,13 @@ export type {
   NamespacedBy,
   NotNamespacedBy,
   NamespacedName,
-} from './ControllerMessenger';
-export { ControllerMessenger } from './ControllerMessenger';
-export type { RestrictedControllerMessengerConstraint } from './RestrictedControllerMessenger';
-export { RestrictedControllerMessenger } from './RestrictedControllerMessenger';
+} from './Messenger';
+export { ControllerMessenger, Messenger } from './Messenger';
+export type {
+  RestrictedControllerMessengerConstraint,
+  RestrictedMessengerConstraint,
+} from './RestrictedMessenger';
+export {
+  RestrictedControllerMessenger,
+  RestrictedMessenger,
+} from './RestrictedMessenger';


### PR DESCRIPTION
## Explanation

Rename the `ControllerMessenger` to `Messenger` so that it is clear it can be used for more than just controllers.

This was decided by this ADR: https://github.com/MetaMask/decisions/blob/main/decisions/core/0001-messaging-non-controllers.md

Previous names have been preserved as aliases to avoid making this a breaking change.

## References

Relates to #4538

## Changelog

See diff

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
