### PR TITLE
feat(3742): Feature Flag Values with Scope Based on threshold

### DIFF
--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0]
+
+### Added
+
+- Added support for threshold-based feature flag scoping ([#5051](https://github.com/MetaMask/core/pull/5051))
+  - Enables percentage-based feature flag distribution across user base
+  - Uses deterministic random group assignment based on metaMetricsId
+
 ## [1.1.0]
 
 ### Added
@@ -26,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release of the RemoteFeatureFlagController. ([#4931](https://github.com/MetaMask/core/pull/4931))
   - This controller manages the retrieval and caching of remote feature flags. It fetches feature flags from a remote API, caches them, and provides methods to access and manage these flags. The controller ensures that feature flags are refreshed based on a specified interval and handles cases where the controller is disabled or the network is unavailable.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.2.0...HEAD
+[1.2.0]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.1.0...@metamask/remote-feature-flag-controller@1.2.0
 [1.1.0]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.0.0...@metamask/remote-feature-flag-controller@1.1.0
 [1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/remote-feature-flag-controller@1.0.0

--- a/packages/remote-feature-flag-controller/package.json
+++ b/packages/remote-feature-flag-controller/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@metamask/base-controller": "^7.0.2",
     "@metamask/utils": "^10.0.0",
+    "@noble/hashes": "^1.4.0",
     "cockatiel": "^3.1.2"
   },
   "devDependencies": {

--- a/packages/remote-feature-flag-controller/package.json
+++ b/packages/remote-feature-flag-controller/package.json
@@ -49,8 +49,8 @@
   "dependencies": {
     "@metamask/base-controller": "^7.0.2",
     "@metamask/utils": "^10.0.0",
-    "@noble/hashes": "^1.4.0",
-    "cockatiel": "^3.1.2"
+    "cockatiel": "^3.1.2",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-types.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-types.ts
@@ -23,6 +23,17 @@ export type FeatureFlags = {
   [key: string]: Json;
 };
 
+export type FeatureFlagScope = {
+  type: string;
+  value: number;
+};
+
+export type FeatureFlagScopeValue = {
+  name: string;
+  scope: FeatureFlagScope;
+  value: Json;
+};
+
 export type ApiDataResponse = FeatureFlags[];
 
 export type ServiceResponse = {

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -41,7 +41,8 @@ const MOCK_FLAGS_WITH_THRESHOLD = {
   ],
 };
 
-const MOCK_METRICS_ID = 'f9e8d7c6-b5a4-3210-9876-543210fedcba';
+const MOCK_METRICS_ID = 'f9e8d7c6-b5a4-4210-9876-543210fedcba';
+const MOCK_METRICS_ID_2 = '987fcdeb-51a2-4c4b-9876-543210fedcba';
 
 /**
  * Creates a controller instance with default parameters for testing
@@ -277,8 +278,8 @@ describe('RemoteFeatureFlagController', () => {
       expect(
         controller.state.remoteFeatureFlags.testFlagForThreshold,
       ).toStrictEqual({
-        name: 'groupB',
-        value: 'valueB',
+        name: 'groupC',
+        value: 'valueC',
       });
     });
 
@@ -300,7 +301,7 @@ describe('RemoteFeatureFlagController', () => {
     it('uses a fallback metaMetricsId if none is provided', async () => {
       jest
         .spyOn(userSegmentationUtils, 'generateFallbackMetaMetricsId')
-        .mockReturnValue(MOCK_METRICS_ID);
+        .mockReturnValue(MOCK_METRICS_ID_2);
       const clientConfigApiService = buildClientConfigApiService({
         remoteFeatureFlags: MOCK_FLAGS_WITH_THRESHOLD,
       });
@@ -312,8 +313,8 @@ describe('RemoteFeatureFlagController', () => {
       expect(
         controller.state.remoteFeatureFlags.testFlagForThreshold,
       ).toStrictEqual({
-        name: 'groupB',
-        value: 'valueB',
+        name: 'groupA',
+        value: 'valueA',
       });
     });
   });

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -59,7 +59,7 @@ function createController(
     state: Partial<RemoteFeatureFlagControllerState>;
     clientConfigApiService: AbstractClientConfigApiService;
     disabled: boolean;
-    metaMetricsId: string;
+    getMetaMetricsId: Promise<string | undefined>;
   }> = {},
 ) {
   return new RemoteFeatureFlagController({
@@ -68,7 +68,7 @@ function createController(
     clientConfigApiService:
       options.clientConfigApiService ?? buildClientConfigApiService(),
     disabled: options.disabled,
-    metaMetricsId: options.metaMetricsId,
+    getMetaMetricsId: options.getMetaMetricsId,
   });
 }
 
@@ -271,7 +271,7 @@ describe('RemoteFeatureFlagController', () => {
       });
       const controller = createController({
         clientConfigApiService,
-        metaMetricsId: MOCK_METRICS_ID,
+        getMetaMetricsId: Promise.resolve(MOCK_METRICS_ID),
       });
       await controller.updateRemoteFeatureFlags();
 
@@ -289,7 +289,7 @@ describe('RemoteFeatureFlagController', () => {
       });
       const controller = createController({
         clientConfigApiService,
-        metaMetricsId: MOCK_METRICS_ID,
+        getMetaMetricsId: Promise.resolve(MOCK_METRICS_ID),
       });
       await controller.updateRemoteFeatureFlags();
 

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -41,7 +41,7 @@ const MOCK_FLAGS_WITH_THRESHOLD = {
   ],
 };
 
-const MOCK_METRICS_ID = '0x1234567890abcdef';
+const MOCK_METRICS_ID = 'f9e8d7c6-b5a4-3210-9876-543210fedcba';
 
 /**
  * Creates a controller instance with default parameters for testing
@@ -72,12 +72,6 @@ function createController(
 }
 
 describe('RemoteFeatureFlagController', () => {
-  beforeEach(() => {
-    jest
-      .spyOn(userSegmentationUtils, 'generateFallbackMetaMetricsId')
-      .mockReturnValue(MOCK_METRICS_ID);
-  });
-
   describe('constructor', () => {
     it('initializes with default state', () => {
       const controller = createController();
@@ -304,6 +298,9 @@ describe('RemoteFeatureFlagController', () => {
     });
 
     it('uses a fallback metaMetricsId if none is provided', async () => {
+      jest
+        .spyOn(userSegmentationUtils, 'generateFallbackMetaMetricsId')
+        .mockReturnValue(MOCK_METRICS_ID);
       const clientConfigApiService = buildClientConfigApiService({
         remoteFeatureFlags: MOCK_FLAGS_WITH_THRESHOLD,
       });

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -5,6 +5,7 @@ import {
   RemoteFeatureFlagController,
   controllerName,
   DEFAULT_CACHE_DURATION,
+  getDefaultRemoteFeatureFlagControllerState,
 } from './remote-feature-flag-controller';
 import type {
   RemoteFeatureFlagControllerActions,
@@ -13,13 +14,34 @@ import type {
   RemoteFeatureFlagControllerStateChangeEvent,
 } from './remote-feature-flag-controller';
 import type { FeatureFlags } from './remote-feature-flag-controller-types';
+import * as userSegmentationUtils from './utils/user-segmentation-utils';
 
 const MOCK_FLAGS: FeatureFlags = {
   feature1: true,
   feature2: { chrome: '<109' },
+  feature3: [1, 2, 3],
 };
 
 const MOCK_FLAGS_TWO = { different: true };
+
+const MOCK_FLAGS_WITH_THRESHOLD = {
+  ...MOCK_FLAGS,
+  testFlagForThreshold: [
+    {
+      name: 'groupA',
+      scope: { type: 'threshold', value: 0.3 },
+      value: 'valueA',
+    },
+    {
+      name: 'groupB',
+      scope: { type: 'threshold', value: 0.5 },
+      value: 'valueB',
+    },
+    { name: 'groupC', scope: { type: 'threshold', value: 1 }, value: 'valueC' },
+  ],
+};
+
+const MOCK_METRICS_ID = '0x1234567890abcdef';
 
 /**
  * Creates a controller instance with default parameters for testing
@@ -36,6 +58,7 @@ function createController(
     state: Partial<RemoteFeatureFlagControllerState>;
     clientConfigApiService: AbstractClientConfigApiService;
     disabled: boolean;
+    metaMetricsId: string;
   }> = {},
 ) {
   return new RemoteFeatureFlagController({
@@ -44,10 +67,17 @@ function createController(
     clientConfigApiService:
       options.clientConfigApiService ?? buildClientConfigApiService(),
     disabled: options.disabled,
+    metaMetricsId: options.metaMetricsId,
   });
 }
 
 describe('RemoteFeatureFlagController', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(userSegmentationUtils, 'generateFallbackMetaMetricsId')
+      .mockReturnValue(MOCK_METRICS_ID);
+  });
+
   describe('constructor', () => {
     it('initializes with default state', () => {
       const controller = createController();
@@ -239,6 +269,58 @@ describe('RemoteFeatureFlagController', () => {
     });
   });
 
+  describe('threshold feature flags', () => {
+    it('processes threshold feature flags based on provided metaMetricsId', async () => {
+      const clientConfigApiService = buildClientConfigApiService({
+        remoteFeatureFlags: MOCK_FLAGS_WITH_THRESHOLD,
+      });
+      const controller = createController({
+        clientConfigApiService,
+        metaMetricsId: MOCK_METRICS_ID,
+      });
+      await controller.updateRemoteFeatureFlags();
+
+      expect(
+        controller.state.remoteFeatureFlags.testFlagForThreshold,
+      ).toStrictEqual({
+        name: 'groupB',
+        value: 'valueB',
+      });
+    });
+
+    it('preserves non-threshold feature flags unchanged', async () => {
+      const clientConfigApiService = buildClientConfigApiService({
+        remoteFeatureFlags: MOCK_FLAGS_WITH_THRESHOLD,
+      });
+      const controller = createController({
+        clientConfigApiService,
+        metaMetricsId: MOCK_METRICS_ID,
+      });
+      await controller.updateRemoteFeatureFlags();
+
+      const { testFlagForThreshold, ...nonThresholdFlags } =
+        controller.state.remoteFeatureFlags;
+      expect(nonThresholdFlags).toStrictEqual(MOCK_FLAGS);
+    });
+
+    it('uses a fallback metaMetricsId if none is provided', async () => {
+      const clientConfigApiService = buildClientConfigApiService({
+        remoteFeatureFlags: MOCK_FLAGS_WITH_THRESHOLD,
+      });
+      const controller = createController({
+        clientConfigApiService,
+      });
+      await controller.updateRemoteFeatureFlags();
+
+      expect(
+        controller.state.remoteFeatureFlags.testFlagForThreshold,
+      ).toStrictEqual({
+        name: 'groupB',
+        value: 'valueB',
+      });
+    });
+  });
+
   describe('enable and disable', () => {
     it('enables the controller and makes a network request to fetch', async () => {
       const clientConfigApiService = buildClientConfigApiService();
@@ -271,6 +353,15 @@ describe('RemoteFeatureFlagController', () => {
       await controller.updateRemoteFeatureFlags();
       expect(controller.state.remoteFeatureFlags).toStrictEqual(MOCK_FLAGS);
       expect(controller.state.remoteFeatureFlags).toStrictEqual(MOCK_FLAGS);
+    });
+  });
+
+  describe('getDefaultRemoteFeatureFlagControllerState', () => {
+    it('should return default state', () => {
+      expect(getDefaultRemoteFeatureFlagControllerState()).toStrictEqual({
+        remoteFeatureFlags: {},
+        cacheTimestamp: 0,
+      });
     });
   });
 });

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
@@ -7,10 +7,10 @@ import {
 } from './user-segmentation-utils';
 
 const MOCK_METRICS_IDS = [
-  '123e4567-e89b-12d3-a456-426614174000',
-  '987fcdeb-51a2-3c4b-9876-543210fedcba',
-  'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-  'f9e8d7c6-b5a4-3210-9876-543210fedcba',
+  '123e4567-e89b-4456-a456-426614174000',
+  '987fcdeb-51a2-4c4b-9876-543210fedcba',
+  'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
+  'f9e8d7c6-b5a4-4210-9876-543210fedcba',
 ];
 
 const MOCK_FEATURE_FLAGS = {

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
@@ -1,0 +1,103 @@
+import { webcrypto } from 'crypto';
+
+import {
+  generateDeterministicRandomNumber,
+  isFeatureFlagWithScopeValue,
+  generateFallbackMetaMetricsId,
+} from './user-segmentation-utils';
+
+const MOCK_METRICS_IDS = [
+  '0x1234567890abcdef',
+  '0xdeadbeefdeadbeef',
+  '0xabcdef0123456789',
+  '0xfedcba9876543210',
+];
+
+const MOCK_FEATURE_FLAGS = {
+  VALID: {
+    name: 'test-flag',
+    value: true,
+    scope: {
+      type: 'threshold',
+      value: 0.5,
+    },
+  },
+  INVALID_NO_SCOPE: {
+    name: 'test-flag',
+    value: true,
+  },
+  INVALID_VALUES: ['string', 123, true, null, []],
+};
+
+describe('user-segmentation-utils', () => {
+  describe('generateDeterministicRandomNumber', () => {
+    it('generates consistent numbers for the same input', () => {
+      const result1 = generateDeterministicRandomNumber(MOCK_METRICS_IDS[0]);
+      const result2 = generateDeterministicRandomNumber(MOCK_METRICS_IDS[0]);
+
+      expect(result1).toBe(result2);
+    });
+
+    it('generates numbers between 0 and 1', () => {
+      MOCK_METRICS_IDS.forEach((id) => {
+        const result = generateDeterministicRandomNumber(id);
+        expect(result).toBeGreaterThanOrEqual(0);
+        expect(result).toBeLessThanOrEqual(1);
+      });
+    });
+
+    it('generates different numbers for different inputs', () => {
+      const result1 = generateDeterministicRandomNumber(MOCK_METRICS_IDS[0]);
+      const result2 = generateDeterministicRandomNumber(MOCK_METRICS_IDS[1]);
+
+      expect(result1).not.toBe(result2);
+    });
+  });
+
+  describe('isFeatureFlagWithScopeValue', () => {
+    it('returns true for valid feature flag with scope', () => {
+      expect(isFeatureFlagWithScopeValue(MOCK_FEATURE_FLAGS.VALID)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isFeatureFlagWithScopeValue(null)).toBe(false);
+    });
+
+    it('returns false for non-objects', () => {
+      MOCK_FEATURE_FLAGS.INVALID_VALUES.forEach((value) => {
+        expect(isFeatureFlagWithScopeValue(value)).toBe(false);
+      });
+    });
+
+    it('returns false for objects without scope', () => {
+      expect(
+        isFeatureFlagWithScopeValue(MOCK_FEATURE_FLAGS.INVALID_NO_SCOPE),
+      ).toBe(false);
+    });
+  });
+
+  describe('generateFallbackMetaMetricsId', () => {
+    beforeAll(() => {
+      // Set up crypto for tests
+      Object.defineProperty(global, 'crypto', {
+        value: webcrypto,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('returns a properly formatted hex string', () => {
+      const result = generateFallbackMetaMetricsId();
+      expect(result.startsWith('0x')).toBe(true);
+      expect(result).toHaveLength(66);
+      expect(result.slice(2)).toMatch(/^[0-9a-f]+$/u);
+    });
+
+    it('generates unique values for each revoke', () => {
+      const result1 = generateFallbackMetaMetricsId();
+      const result2 = generateFallbackMetaMetricsId();
+
+      expect(result1).not.toBe(result2);
+    });
+  });
+});

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
@@ -1,4 +1,4 @@
-import { webcrypto } from 'crypto';
+import { validate as uuidValidate, version as uuidVersion } from 'uuid';
 
 import {
   generateDeterministicRandomNumber,
@@ -7,10 +7,10 @@ import {
 } from './user-segmentation-utils';
 
 const MOCK_METRICS_IDS = [
-  '0x1234567890abcdef',
-  '0xdeadbeefdeadbeef',
-  '0xabcdef0123456789',
-  '0xfedcba9876543210',
+  '123e4567-e89b-12d3-a456-426614174000',
+  '987fcdeb-51a2-3c4b-9876-543210fedcba',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  'f9e8d7c6-b5a4-3210-9876-543210fedcba',
 ];
 
 const MOCK_FEATURE_FLAGS = {
@@ -77,27 +77,10 @@ describe('user-segmentation-utils', () => {
   });
 
   describe('generateFallbackMetaMetricsId', () => {
-    beforeAll(() => {
-      // Set up crypto for tests
-      Object.defineProperty(global, 'crypto', {
-        value: webcrypto,
-        writable: true,
-        configurable: true,
-      });
-    });
-
-    it('returns a properly formatted hex string', () => {
+    it('returns a valid uuidv4', () => {
       const result = generateFallbackMetaMetricsId();
-      expect(result.startsWith('0x')).toBe(true);
-      expect(result).toHaveLength(66);
-      expect(result.slice(2)).toMatch(/^[0-9a-f]+$/u);
-    });
-
-    it('generates unique values for each revoke', () => {
-      const result1 = generateFallbackMetaMetricsId();
-      const result2 = generateFallbackMetaMetricsId();
-
-      expect(result1).not.toBe(result2);
+      expect(uuidValidate(result)).toBe(true);
+      expect(uuidVersion(result)).toBe(4);
     });
   });
 });

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts
@@ -1,0 +1,53 @@
+import type { Json } from '@metamask/utils';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+
+import type { FeatureFlagScopeValue } from '../remote-feature-flag-controller-types';
+
+/* eslint-disable no-bitwise */
+/**
+ * Generates a deterministic random number between 0 and 1 based on a profile ID.
+ * This is useful for A/B testing and feature flag rollouts where we want
+ * consistent group assignment for the same user.
+ *
+ * @param metaMetricsId - The unique identifier used to generate the deterministic random number
+ * @returns A number between 0 and 1 that is deterministic for the given metaMetricsId
+ */
+export function generateDeterministicRandomNumber(
+  metaMetricsId: string,
+): number {
+  const hash = [...metaMetricsId].reduce((acc, char) => {
+    const chr = char.charCodeAt(0);
+    return ((acc << 5) - acc + chr) | 0;
+  }, 0);
+
+  return (hash >>> 0) / 0xffffffff;
+}
+
+/**
+ * Type guard to check if a value is a feature flag with scope.
+ * Used to validate feature flag objects that contain scope-based configurations.
+ *
+ * @param featureFlag - The value to check if it's a feature flag with scope
+ * @returns True if the value is a feature flag with scope, false otherwise
+ */
+export const isFeatureFlagWithScopeValue = (
+  featureFlag: Json,
+): featureFlag is FeatureFlagScopeValue => {
+  return (
+    typeof featureFlag === 'object' &&
+    featureFlag !== null &&
+    'scope' in featureFlag
+  );
+};
+
+/**
+ * Generates a SHA-256 hash to use as a fallback metaMetricsId
+ * @returns A 32-byte hex string prefixed with '0x'
+ */
+export function generateFallbackMetaMetricsId(): string {
+  const random = new Uint8Array(32);
+  crypto.getRandomValues(random);
+  const hash = sha256(random);
+  return `0x${bytesToHex(hash)}`;
+}

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts
@@ -1,6 +1,5 @@
 import type { Json } from '@metamask/utils';
-import { sha256 } from '@noble/hashes/sha256';
-import { bytesToHex } from '@noble/hashes/utils';
+import { v4 as uuidV4 } from 'uuid';
 
 import type { FeatureFlagScopeValue } from '../remote-feature-flag-controller-types';
 
@@ -42,12 +41,9 @@ export const isFeatureFlagWithScopeValue = (
 };
 
 /**
- * Generates a SHA-256 hash to use as a fallback metaMetricsId
- * @returns A 32-byte hex string prefixed with '0x'
+ * Generates UUIDv4 as a fallback metaMetricsId
+ * @returns A UUIDv4 string
  */
 export function generateFallbackMetaMetricsId(): string {
-  const random = new Uint8Array(32);
-  crypto.getRandomValues(random);
-  const hash = sha256(random);
-  return `0x${bytesToHex(hash)}`;
+  return uuidV4();
 }

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts
@@ -5,7 +5,7 @@ import type { FeatureFlagScopeValue } from '../remote-feature-flag-controller-ty
 
 /* eslint-disable no-bitwise */
 /**
- * Generates a deterministic random number between 0 and 1 based on a profile ID.
+ * Generates a deterministic random number between 0 and 1 based on a metaMetricsId.
  * This is useful for A/B testing and feature flag rollouts where we want
  * consistent group assignment for the same user.
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -3512,6 +3512,7 @@ __metadata:
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/controller-utils": "npm:^11.4.4"
     "@metamask/utils": "npm:^10.0.0"
+    "@noble/hashes": "npm:^1.4.0"
     "@types/jest": "npm:^27.4.1"
     cockatiel: "npm:^3.1.2"
     deepmerge: "npm:^4.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3512,7 +3512,6 @@ __metadata:
     "@metamask/base-controller": "npm:^7.0.2"
     "@metamask/controller-utils": "npm:^11.4.4"
     "@metamask/utils": "npm:^10.0.0"
-    "@noble/hashes": "npm:^1.4.0"
     "@types/jest": "npm:^27.4.1"
     cockatiel: "npm:^3.1.2"
     deepmerge: "npm:^4.2.2"
@@ -3522,6 +3521,7 @@ __metadata:
     typedoc: "npm:^0.24.8"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
+    uuid: "npm:^8.3.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Explanation
This PR added ability for @metamask/remote-feature-flag-controller to take in a new param `metametricsId` and applied to the featureFlag processing. Furthermore, a threshold will be generated using a simple function, which generates a deterministic random group number between 0 and 1 from `metametricsId`. If encounters a flag from api with scope as `type: "threshold"`, controller will drill down to return the value that's matching the threshold generated based on `metametricsId`. 
Note: `metametricsId` will always be provided from client, a random SHA-256 hash will be used as fallback

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References
Fixes https://github.com/MetaMask/MetaMask-planning/issues/3742
<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/remote-feature-flag-controller`

- **ADDED**: Added support for threshold-based feature flag scoping


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
