### PR TITLE
chore: fix typo in CODEOWNERS (assets-controller -> assets-controllers)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,8 +68,8 @@
 /packages/announcement-controller/CHANGELOG.md    @MetaMask/wallet-ux @MetaMask/wallet-framework-engineers
 /packages/approval-controller/package.json        @MetaMask/confirmations @MetaMask/wallet-framework-engineers
 /packages/approval-controller/CHANGELOG.md        @MetaMask/confirmations @MetaMask/wallet-framework-engineers
-/packages/assets-controller/package.json          @MetaMask/metamask-assets @MetaMask/wallet-framework-engineers
-/packages/assets-controller/CHANGELOG.md          @MetaMask/metamask-assets @MetaMask/wallet-framework-engineers
+/packages/assets-controllers/package.json         @MetaMask/metamask-assets @MetaMask/wallet-framework-engineers
+/packages/assets-controllers/CHANGELOG.md         @MetaMask/metamask-assets @MetaMask/wallet-framework-engineers
 /packages/chain-controller/package.json           @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
 /packages/chain-controller/CHANGELOG.md           @MetaMask/accounts-engineers @MetaMask/wallet-framework-engineers
 /packages/ens-controller/package.json             @MetaMask/confirmations @MetaMask/wallet-framework-engineers


### PR DESCRIPTION
## Explanation

Found the same typo than last time, but on another section of the CODEOWNERS.

Spotted while doing this release:
- https://github.com/MetaMask/core/pull/5058

## References

Similar to:
- https://github.com/MetaMask/core/pull/5029

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
