### PR TITLE
refactor(permission-controller): Rationalize permission and caveat validation

### DIFF
--- a/packages/permission-controller/src/Caveat.ts
+++ b/packages/permission-controller/src/Caveat.ts
@@ -137,14 +137,15 @@ export type CaveatSpecificationBase = {
 
   /**
    * The validator function used to validate caveats of the associated type
-   * whenever they are instantiated. Caveat are instantiated whenever they are
-   * created or mutated.
+   * whenever they are constructed or mutated.
    *
    * The validator should throw an appropriate JSON-RPC error if validation fails.
    *
    * If no validator is specified, no validation of caveat values will be
-   * performed. Although caveats can also be validated by permission validators,
-   * validating caveat values separately is strongly recommended.
+   * performed. In instances where caveats are mutated but a permission's caveat
+   * array has not changed, any corresponding permission validator will not be
+   * called. For this reason, permission validators **must not** be relied upon
+   * to validate caveats.
    */
   // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -405,8 +405,12 @@ type PermissionSpecificationBase<Type extends PermissionType> = {
 
   /**
    * The validator function used to validate permissions of the associated type
-   * whenever they are mutated. The only way a permission can be legally mutated
-   * is when its caveats are modified by the permission controller.
+   * whenever they are granted or their caveat arrays are mutated.
+   *
+   * Permission validators are **not** invoked when a caveat is mutated, provided
+   * the caveat array has not changed. For this reason, permission validators
+   * **must not** be used to validate caveats. To validate caveats, use the
+   * corresponding caveat specification property.
    *
    * The validator should throw an appropriate JSON-RPC error if validation fails.
    */


### PR DESCRIPTION
## Explanation

Via discussion during https://github.com/MetaMask/metamask-extension/pull/27847, it became apparent that there was confusion re: the purpose of permission vs. caveat validators and when to use one vs. the other. This has now been properly documented in multiple places in the permission controller package.

In addition, the permission controller implementation contained some irregularities regarding its own permission validation logic. This surfaced in the form of redundant permission and caveat validator calls, both of which have now been removed. (In addition, one overly complicated "optimization" to avoid redundant caveat validator calls has been removed.)

Reviewers: although I doubt it's a problem, we should take care to ensure that we weren't relying on the old behavior in any of our existing caveat or permission specifications.

## References

- https://github.com/MetaMask/metamask-extension/pull/27847#discussion_r1879060900

## Changelog

### `@metamask/permission-controller`

- **CHANGED**: Remove redundant caveat validator calls
  - In some cases, caveats were being validated multiple times or without the possibility of having changed.
  - The intended purpose of permission and caveat validators has also been documented. See `ARCHITECTURE.md`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
