### PR TITLE
Revert "chore: Remove `useRequestQueue` toggle to turn on/off Per Dapp Selected Network Feature (#4941)"

### DIFF
--- a/packages/queued-request-controller/src/QueuedRequestMiddleware.test.ts
+++ b/packages/queued-request-controller/src/QueuedRequestMiddleware.test.ts
@@ -86,6 +86,7 @@ describe('createQueuedRequestMiddleware', () => {
     const mockEnqueueRequest = getMockEnqueueRequest();
     const middleware = buildQueuedRequestMiddleware({
       enqueueRequest: mockEnqueueRequest,
+      useRequestQueue: () => true,
     });
 
     const request = {
@@ -104,7 +105,7 @@ describe('createQueuedRequestMiddleware', () => {
     const mockEnqueueRequest = getMockEnqueueRequest();
     const middleware = buildQueuedRequestMiddleware({
       enqueueRequest: mockEnqueueRequest,
-
+      useRequestQueue: () => true,
       shouldEnqueueRequest: ({ method }) =>
         method === 'method_with_confirmation',
     });
@@ -144,6 +145,7 @@ describe('createQueuedRequestMiddleware', () => {
   it('calls next after a request is queued and processed', async () => {
     const middleware = buildQueuedRequestMiddleware({
       enqueueRequest: getMockEnqueueRequest(),
+      useRequestQueue: () => true,
     });
     const request = {
       ...getRequestDefaults(),
@@ -165,7 +167,7 @@ describe('createQueuedRequestMiddleware', () => {
         enqueueRequest: jest
           .fn()
           .mockRejectedValue(new Error('enqueuing error')),
-
+        useRequestQueue: () => true,
         shouldEnqueueRequest: () => true,
       });
       const request = {
@@ -189,7 +191,7 @@ describe('createQueuedRequestMiddleware', () => {
         enqueueRequest: jest
           .fn()
           .mockRejectedValue(new Error('enqueuing error')),
-
+        useRequestQueue: () => true,
         shouldEnqueueRequest: () => true,
       });
       const request = {
@@ -269,6 +271,7 @@ function buildQueuedRequestMiddleware(
 ) {
   const options = {
     enqueueRequest: getMockEnqueueRequest(),
+    useRequestQueue: () => false,
     shouldEnqueueRequest: () => false,
     ...overrideOptions,
   };

--- a/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
+++ b/packages/queued-request-controller/src/QueuedRequestMiddleware.ts
@@ -38,14 +38,17 @@ function hasRequiredMetadata(
  *
  * @param options - Configuration options.
  * @param options.enqueueRequest - A method for enqueueing a request.
+ * @param options.useRequestQueue - A function that determines if the request queue feature is enabled.
  * @param options.shouldEnqueueRequest - A function that returns if a request should be handled by the QueuedRequestController.
  * @returns The JSON-RPC middleware that manages queued requests.
  */
 export const createQueuedRequestMiddleware = ({
   enqueueRequest,
+  useRequestQueue,
   shouldEnqueueRequest,
 }: {
   enqueueRequest: QueuedRequestController['enqueueRequest'];
+  useRequestQueue: () => boolean;
   shouldEnqueueRequest: (
     request: QueuedRequestMiddlewareJsonRpcRequest,
   ) => boolean;
@@ -53,8 +56,9 @@ export const createQueuedRequestMiddleware = ({
   return createAsyncMiddleware(async (req: JsonRpcRequest, res, next) => {
     hasRequiredMetadata(req);
 
-    // if this method is not a confirmation method bypass the queue completely
-    if (!shouldEnqueueRequest(req)) {
+    // if the request queue feature is turned off, or this method is not a confirmation method
+    // bypass the queue completely
+    if (!useRequestQueue() || !shouldEnqueueRequest(req)) {
       return await next();
     }
 

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -102,6 +102,10 @@ export type SelectedNetworkControllerMessenger = RestrictedControllerMessenger<
 export type SelectedNetworkControllerOptions = {
   state?: SelectedNetworkControllerState;
   messenger: SelectedNetworkControllerMessenger;
+  useRequestQueuePreference: boolean;
+  onPreferencesStateChange: (
+    listener: (preferencesState: { useRequestQueue: boolean }) => void,
+  ) => void;
   domainProxyMap: Map<Domain, NetworkProxy>;
 };
 
@@ -120,17 +124,23 @@ export class SelectedNetworkController extends BaseController<
 > {
   #domainProxyMap: Map<Domain, NetworkProxy>;
 
+  #useRequestQueuePreference: boolean;
+
   /**
    * Construct a SelectedNetworkController controller.
    *
    * @param options - The controller options.
    * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
    * @param options.state - The controllers initial state.
+   * @param options.useRequestQueuePreference - A boolean indicating whether to use the request queue preference.
+   * @param options.onPreferencesStateChange - A callback that is called when the preference state changes.
    * @param options.domainProxyMap - A map for storing domain-specific proxies that are held in memory only during use.
    */
   constructor({
     messenger,
     state = getDefaultState(),
+    useRequestQueuePreference,
+    onPreferencesStateChange,
     domainProxyMap,
   }: SelectedNetworkControllerOptions) {
     super({
@@ -139,6 +149,7 @@ export class SelectedNetworkController extends BaseController<
       messenger,
       state,
     });
+    this.#useRequestQueuePreference = useRequestQueuePreference;
     this.#domainProxyMap = domainProxyMap;
     this.#registerMessageHandlers();
 
@@ -236,6 +247,21 @@ export class SelectedNetworkController extends BaseController<
         }
       },
     );
+
+    onPreferencesStateChange(({ useRequestQueue }) => {
+      if (this.#useRequestQueuePreference !== useRequestQueue) {
+        if (!useRequestQueue) {
+          // Loop through all domains and points each domain's proxy
+          // to the NetworkController's own proxy of the globally selected networkClient
+          Object.keys(this.state.domains).forEach((domain) => {
+            this.#unsetNetworkClientIdForDomain(domain);
+          });
+        } else {
+          this.#resetAllPermissionedDomains();
+        }
+        this.#useRequestQueuePreference = useRequestQueue;
+      }
+    });
   }
 
   #registerMessageHandlers(): void {
@@ -300,10 +326,31 @@ export class SelectedNetworkController extends BaseController<
     );
   }
 
+  // Loop through all domains and for those with permissions it points that domain's proxy
+  // to an unproxied instance of the globally selected network client.
+  // NOT the NetworkController's proxy of the globally selected networkClient
+  #resetAllPermissionedDomains() {
+    this.#domainProxyMap.forEach((_: NetworkProxy, domain: string) => {
+      const { selectedNetworkClientId } = this.messagingSystem.call(
+        'NetworkController:getState',
+      );
+      // can't use public setNetworkClientIdForDomain because it will throw an error
+      // rather than simply skip if the domain doesn't have permissions which can happen
+      // in this case since proxies are added for each site the user visits
+      if (this.#domainHasPermissions(domain)) {
+        this.#setNetworkClientIdForDomain(domain, selectedNetworkClientId);
+      }
+    });
+  }
+
   setNetworkClientIdForDomain(
     domain: Domain,
     networkClientId: NetworkClientId,
   ) {
+    if (!this.#useRequestQueuePreference) {
+      return;
+    }
+
     if (domain === METAMASK_DOMAIN) {
       throw new Error(
         `NetworkClientId for domain "${METAMASK_DOMAIN}" cannot be set on the SelectedNetworkController`,
@@ -326,6 +373,9 @@ export class SelectedNetworkController extends BaseController<
   getNetworkClientIdForDomain(domain: Domain): NetworkClientId {
     const { selectedNetworkClientId: metamaskSelectedNetworkClientId } =
       this.messagingSystem.call('NetworkController:getState');
+    if (!this.#useRequestQueuePreference) {
+      return metamaskSelectedNetworkClientId;
+    }
     return this.state.domains[domain] ?? metamaskSelectedNetworkClientId;
   }
 
@@ -353,7 +403,10 @@ export class SelectedNetworkController extends BaseController<
     let networkProxy = this.#domainProxyMap.get(domain);
     if (networkProxy === undefined) {
       let networkClient;
-      if (this.#domainHasPermissions(domain)) {
+      if (
+        this.#useRequestQueuePreference &&
+        this.#domainHasPermissions(domain)
+      ) {
         const networkClientId = this.getNetworkClientIdForDomain(domain);
         networkClient = this.messagingSystem.call(
           'NetworkController:getNetworkClientById',
@@ -363,11 +416,10 @@ export class SelectedNetworkController extends BaseController<
         networkClient = this.messagingSystem.call(
           'NetworkController:getSelectedNetworkClient',
         );
+        if (networkClient === undefined) {
+          throw new Error('Selected network not initialized');
+        }
       }
-      if (networkClient === undefined) {
-        throw new Error('Selected network not initialized');
-      }
-
       networkProxy = {
         provider: createEventEmitterProxy(networkClient.provider),
         blockTracker: createEventEmitterProxy(networkClient.blockTracker, {

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -121,10 +121,15 @@ jest.mock('@metamask/swappable-obj-proxy');
 const setup = ({
   getSubjectNames = [],
   state,
+  useRequestQueuePreference = false,
   domainProxyMap = new Map<Domain, NetworkProxy>(),
 }: {
   state?: SelectedNetworkControllerState;
   getSubjectNames?: string[];
+  useRequestQueuePreference?: boolean;
+  onPreferencesStateChange?: (
+    listener: (preferencesState: { useRequestQueue: boolean }) => void,
+  ) => void;
   domainProxyMap?: Map<Domain, NetworkProxy>;
 } = {}) => {
   const mockProviderProxy = {
@@ -168,11 +173,26 @@ const setup = ({
       getSubjectNames,
     });
 
+  const preferencesStateChangeListeners: ((state: {
+    useRequestQueue: boolean;
+  }) => void)[] = [];
   const controller = new SelectedNetworkController({
     messenger: restrictedMessenger,
     state,
+    useRequestQueuePreference,
+    onPreferencesStateChange: (listener) => {
+      preferencesStateChangeListeners.push(listener);
+    },
     domainProxyMap,
   });
+
+  const triggerPreferencesStateChange = (preferencesState: {
+    useRequestQueue: boolean;
+  }) => {
+    for (const listener of preferencesStateChangeListeners) {
+      listener(preferencesState);
+    }
+  };
 
   return {
     controller,
@@ -180,6 +200,7 @@ const setup = ({
     mockProviderProxy,
     mockBlockTrackerProxy,
     domainProxyMap,
+    triggerPreferencesStateChange,
     createEventEmitterProxyMock,
     ...mockMessengerActions,
   };
@@ -205,232 +226,296 @@ describe('SelectedNetworkController', () => {
       });
     });
 
-    it('should set networkClientId for domains not already in state', async () => {
-      const { controller } = setup({
-        state: {
-          domains: {
-            'existingdomain.com': 'initialNetworkId',
-          },
-        },
-        getSubjectNames: ['newdomain.com'],
-      });
-
-      expect(controller.state.domains).toStrictEqual({
-        'newdomain.com': 'mainnet',
-        'existingdomain.com': 'initialNetworkId',
-      });
-    });
-
-    it('should not modify domains already in state', async () => {
-      const { controller } = setup({
-        state: {
-          domains: {
-            'existingdomain.com': 'initialNetworkId',
-          },
-        },
-        getSubjectNames: ['existingdomain.com'],
-      });
-
-      expect(controller.state.domains).toStrictEqual({
-        'existingdomain.com': 'initialNetworkId',
-      });
-    });
-
-    describe('NetworkController:stateChange', () => {
-      describe('when a network is deleted from the network controller', () => {
-        const initialDomains = {
-          'not-deleted-network.com': 'linea-mainnet',
-          'deleted-network.com': 'goerli',
-        };
-
-        const deleteNetwork = (
-          chainId: Hex,
-          networkControllerState: NetworkState,
-          messenger: ReturnType<typeof buildMessenger>,
-          mockNetworkControllerGetState: jest.Mock,
-        ) => {
-          delete networkControllerState.networkConfigurationsByChainId[chainId];
-          mockNetworkControllerGetState.mockReturnValueOnce(
-            networkControllerState,
-          );
-          messenger.publish(
-            'NetworkController:stateChange',
-            networkControllerState,
-            [
-              {
-                op: 'remove',
-                path: ['networkConfigurationsByChainId', chainId],
-              },
-            ],
-          );
-        };
-
-        it('redirects domains to the globally selected network', () => {
-          const { controller, messenger, mockNetworkControllerGetState } =
-            setup({
-              state: { domains: initialDomains },
-            });
-
-          const networkControllerState = {
-            ...getDefaultNetworkControllerState(),
-            selectedNetworkClientId: 'mainnet',
-          };
-
-          deleteNetwork(
-            '0x5',
-            networkControllerState,
-            messenger,
-            mockNetworkControllerGetState,
-          );
-
-          expect(controller.state.domains).toStrictEqual({
-            ...initialDomains,
-            'deleted-network.com':
-              networkControllerState.selectedNetworkClientId,
-          });
-        });
-
-        it('redirects domains to the globally selected network and handles garbage collected proxies', () => {
-          const domainProxyMap = new Map();
-          const {
-            controller,
-            messenger,
-            mockNetworkControllerGetState,
-            mockGetNetworkClientById,
-          } = setup({
-            state: { domains: initialDomains },
-
-            domainProxyMap,
-          });
-
-          // Simulate proxies being garbage collected
-          domainProxyMap.clear();
-
-          const networkControllerState = {
-            ...getDefaultNetworkControllerState(),
-            selectedNetworkClientId: 'mainnet',
-          };
-
-          mockGetNetworkClientById.mockImplementation((id) => {
-            // Simulate the previous domain being deleted in NetworkController
-            if (id !== 'mainnet') {
-              throw new Error('Network client does not exist');
-            }
-
-            return {
-              provider: { request: jest.fn() },
-              blockTracker: { getLatestBlock: jest.fn() },
-            };
-          });
-
-          deleteNetwork(
-            '0x5',
-            networkControllerState,
-            messenger,
-            mockNetworkControllerGetState,
-          );
-
-          expect(controller.state.domains).toStrictEqual({
-            ...initialDomains,
-            'deleted-network.com':
-              networkControllerState.selectedNetworkClientId,
-          });
-        });
-      });
-
-      describe('when a network is updated', () => {
-        it('redirects domains when the default rpc endpoint is switched', () => {
-          const initialDomains = {
-            'different-chain.com': 'mainnet',
-            'chain-with-new-default.com': 'goerli',
-          };
-
-          const { controller, messenger, mockNetworkControllerGetState } =
-            setup({
-              state: { domains: initialDomains },
-            });
-
-          const networkControllerState = getDefaultNetworkControllerState();
-          const goerliNetwork =
-            networkControllerState.networkConfigurationsByChainId['0x5'];
-
-          goerliNetwork.defaultRpcEndpointIndex =
-            goerliNetwork.rpcEndpoints.push({
-              type: RpcEndpointType.Custom,
-              url: 'https://new-default.com',
-              networkClientId: 'new-default-network-client-id',
-            }) - 1;
-
-          mockNetworkControllerGetState.mockReturnValueOnce(
-            networkControllerState,
-          );
-
-          messenger.publish(
-            'NetworkController:stateChange',
-            networkControllerState,
-            [
-              {
-                op: 'replace',
-                path: ['networkConfigurationsByChainId', '0x5'],
-              },
-            ],
-          );
-
-          expect(controller.state.domains).toStrictEqual({
-            ...initialDomains,
-            'chain-with-new-default.com': 'new-default-network-client-id',
-          });
-        });
-
-        it('redirects domains when the default rpc endpoint is deleted and replaced', () => {
-          const initialDomains = {
-            'different-chain.com': 'mainnet',
-            'chain-with-new-default.com': 'goerli',
-          };
-
-          const { controller, messenger, mockNetworkControllerGetState } =
-            setup({
-              state: { domains: initialDomains },
-            });
-
-          const networkControllerState = getDefaultNetworkControllerState();
-          const goerliNetwork =
-            networkControllerState.networkConfigurationsByChainId['0x5'];
-
-          goerliNetwork.rpcEndpoints = [
-            {
-              type: RpcEndpointType.Custom,
-              url: 'https://new-default.com',
-              networkClientId: 'new-default-network-client-id',
+    describe('when useRequestQueuePreference is true', () => {
+      it('should set networkClientId for domains not already in state', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
             },
-          ];
+          },
+          getSubjectNames: ['newdomain.com'],
+          useRequestQueuePreference: true,
+        });
 
-          mockNetworkControllerGetState.mockReturnValueOnce(
-            networkControllerState,
-          );
+        expect(controller.state.domains).toStrictEqual({
+          'newdomain.com': 'mainnet',
+          'existingdomain.com': 'initialNetworkId',
+        });
+      });
 
-          messenger.publish(
-            'NetworkController:stateChange',
-            networkControllerState,
-            [
-              {
-                op: 'replace',
-                path: ['networkConfigurationsByChainId', '0x5'],
-              },
-            ],
-          );
+      it('should not modify domains already in state', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
+            },
+          },
+          getSubjectNames: ['existingdomain.com'],
+          useRequestQueuePreference: true,
+        });
 
-          expect(controller.state.domains).toStrictEqual({
-            ...initialDomains,
-            'chain-with-new-default.com': 'new-default-network-client-id',
-          });
+        expect(controller.state.domains).toStrictEqual({
+          'existingdomain.com': 'initialNetworkId',
         });
       });
     });
 
-    describe('setNetworkClientIdForDomain', () => {
+    describe('when useRequestQueuePreference is false', () => {
+      it('should not set networkClientId for new domains', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
+            },
+          },
+          getSubjectNames: ['newdomain.com'],
+        });
+
+        expect(controller.state.domains).toStrictEqual({
+          'existingdomain.com': 'initialNetworkId',
+        });
+      });
+
+      it('should not modify domains already in state', async () => {
+        const { controller } = setup({
+          state: {
+            domains: {
+              'existingdomain.com': 'initialNetworkId',
+            },
+          },
+          getSubjectNames: ['existingdomain.com'],
+        });
+
+        expect(controller.state.domains).toStrictEqual({
+          'existingdomain.com': 'initialNetworkId',
+        });
+      });
+    });
+  });
+
+  describe('NetworkController:stateChange', () => {
+    describe('when a network is deleted from the network controller', () => {
+      const initialDomains = {
+        'not-deleted-network.com': 'linea-mainnet',
+        'deleted-network.com': 'goerli',
+      };
+
+      const deleteNetwork = (
+        chainId: Hex,
+        networkControllerState: NetworkState,
+        messenger: ReturnType<typeof buildMessenger>,
+        mockNetworkControllerGetState: jest.Mock,
+      ) => {
+        delete networkControllerState.networkConfigurationsByChainId[chainId];
+        mockNetworkControllerGetState.mockReturnValueOnce(
+          networkControllerState,
+        );
+        messenger.publish(
+          'NetworkController:stateChange',
+          networkControllerState,
+          [
+            {
+              op: 'remove',
+              path: ['networkConfigurationsByChainId', chainId],
+            },
+          ],
+        );
+      };
+
+      it('does not update state when useRequestQueuePreference is false', () => {
+        const { controller, messenger, mockNetworkControllerGetState } = setup({
+          state: { domains: initialDomains },
+          useRequestQueuePreference: false,
+        });
+
+        const networkControllerState = getDefaultNetworkControllerState();
+        deleteNetwork(
+          '0x5',
+          networkControllerState,
+          messenger,
+          mockNetworkControllerGetState,
+        );
+
+        expect(controller.state.domains).toStrictEqual(initialDomains);
+      });
+
+      it('redirects domains to the globally selected network when useRequestQueuePreference is true', () => {
+        const { controller, messenger, mockNetworkControllerGetState } = setup({
+          state: { domains: initialDomains },
+          useRequestQueuePreference: true,
+        });
+
+        const networkControllerState = {
+          ...getDefaultNetworkControllerState(),
+          selectedNetworkClientId: 'mainnet',
+        };
+
+        deleteNetwork(
+          '0x5',
+          networkControllerState,
+          messenger,
+          mockNetworkControllerGetState,
+        );
+
+        expect(controller.state.domains).toStrictEqual({
+          ...initialDomains,
+          'deleted-network.com': networkControllerState.selectedNetworkClientId,
+        });
+      });
+
+      it('redirects domains to the globally selected network when useRequestQueuePreference is true and handles garbage collected proxies', () => {
+        const domainProxyMap = new Map();
+        const {
+          controller,
+          messenger,
+          mockNetworkControllerGetState,
+          mockGetNetworkClientById,
+        } = setup({
+          state: { domains: initialDomains },
+          useRequestQueuePreference: true,
+          domainProxyMap,
+        });
+
+        // Simulate proxies being garbage collected
+        domainProxyMap.clear();
+
+        const networkControllerState = {
+          ...getDefaultNetworkControllerState(),
+          selectedNetworkClientId: 'mainnet',
+        };
+
+        mockGetNetworkClientById.mockImplementation((id) => {
+          // Simulate the previous domain being deleted in NetworkController
+          if (id !== 'mainnet') {
+            throw new Error('Network client does not exist');
+          }
+
+          return {
+            provider: { request: jest.fn() },
+            blockTracker: { getLatestBlock: jest.fn() },
+          };
+        });
+
+        deleteNetwork(
+          '0x5',
+          networkControllerState,
+          messenger,
+          mockNetworkControllerGetState,
+        );
+
+        expect(controller.state.domains).toStrictEqual({
+          ...initialDomains,
+          'deleted-network.com': networkControllerState.selectedNetworkClientId,
+        });
+      });
+    });
+
+    describe('when a network is updated', () => {
+      it('redirects domains when the default rpc endpoint is switched', () => {
+        const initialDomains = {
+          'different-chain.com': 'mainnet',
+          'chain-with-new-default.com': 'goerli',
+        };
+
+        const { controller, messenger, mockNetworkControllerGetState } = setup({
+          state: { domains: initialDomains },
+          useRequestQueuePreference: true,
+        });
+
+        const networkControllerState = getDefaultNetworkControllerState();
+        const goerliNetwork =
+          networkControllerState.networkConfigurationsByChainId['0x5'];
+
+        goerliNetwork.defaultRpcEndpointIndex =
+          goerliNetwork.rpcEndpoints.push({
+            type: RpcEndpointType.Custom,
+            url: 'https://new-default.com',
+            networkClientId: 'new-default-network-client-id',
+          }) - 1;
+
+        mockNetworkControllerGetState.mockReturnValueOnce(
+          networkControllerState,
+        );
+
+        messenger.publish(
+          'NetworkController:stateChange',
+          networkControllerState,
+          [
+            {
+              op: 'replace',
+              path: ['networkConfigurationsByChainId', '0x5'],
+            },
+          ],
+        );
+
+        expect(controller.state.domains).toStrictEqual({
+          ...initialDomains,
+          'chain-with-new-default.com': 'new-default-network-client-id',
+        });
+      });
+
+      it('redirects domains when the default rpc endpoint is deleted and replaced', () => {
+        const initialDomains = {
+          'different-chain.com': 'mainnet',
+          'chain-with-new-default.com': 'goerli',
+        };
+
+        const { controller, messenger, mockNetworkControllerGetState } = setup({
+          state: { domains: initialDomains },
+          useRequestQueuePreference: true,
+        });
+
+        const networkControllerState = getDefaultNetworkControllerState();
+        const goerliNetwork =
+          networkControllerState.networkConfigurationsByChainId['0x5'];
+
+        goerliNetwork.rpcEndpoints = [
+          {
+            type: RpcEndpointType.Custom,
+            url: 'https://new-default.com',
+            networkClientId: 'new-default-network-client-id',
+          },
+        ];
+
+        mockNetworkControllerGetState.mockReturnValueOnce(
+          networkControllerState,
+        );
+
+        messenger.publish(
+          'NetworkController:stateChange',
+          networkControllerState,
+          [
+            {
+              op: 'replace',
+              path: ['networkConfigurationsByChainId', '0x5'],
+            },
+          ],
+        );
+
+        expect(controller.state.domains).toStrictEqual({
+          ...initialDomains,
+          'chain-with-new-default.com': 'new-default-network-client-id',
+        });
+      });
+    });
+  });
+
+  describe('setNetworkClientIdForDomain', () => {
+    it('does not update state when the useRequestQueuePreference is false', () => {
+      const { controller } = setup({
+        state: {
+          domains: {},
+        },
+      });
+
+      controller.setNetworkClientIdForDomain('1.com', '1');
+      expect(controller.state.domains).toStrictEqual({});
+    });
+
+    describe('when useRequestQueuePreference is true', () => {
       it('should throw an error when passed "metamask" as domain arg', () => {
-        const { controller } = setup();
+        const { controller } = setup({ useRequestQueuePreference: true });
         expect(() => {
           controller.setNetworkClientIdForDomain('metamask', 'mainnet');
         }).toThrow(
@@ -443,6 +528,7 @@ describe('SelectedNetworkController', () => {
         it('skips setting the networkClientId for the passed in domain', () => {
           const { controller, mockHasPermissions } = setup({
             state: { domains: {} },
+            useRequestQueuePreference: true,
           });
           mockHasPermissions.mockReturnValue(true);
           const snapDomainOne = 'npm:@metamask/bip32-example-snap';
@@ -473,6 +559,7 @@ describe('SelectedNetworkController', () => {
         it('sets the networkClientId for the passed in domain', () => {
           const { controller, mockHasPermissions } = setup({
             state: { domains: {} },
+            useRequestQueuePreference: true,
           });
           mockHasPermissions.mockReturnValue(true);
           const domain = 'example.com';
@@ -484,6 +571,7 @@ describe('SelectedNetworkController', () => {
         it('updates the provider and block tracker proxy when they already exist for the domain', () => {
           const { controller, mockProviderProxy, mockHasPermissions } = setup({
             state: { domains: {} },
+            useRequestQueuePreference: true,
           });
           mockHasPermissions.mockReturnValue(true);
           const initialNetworkClientId = '123';
@@ -515,6 +603,7 @@ describe('SelectedNetworkController', () => {
         it('throws an error and does not set the networkClientId for the passed in domain', () => {
           const { controller, mockHasPermissions } = setup({
             state: { domains: {} },
+            useRequestQueuePreference: true,
           });
           mockHasPermissions.mockReturnValue(false);
 
@@ -529,8 +618,17 @@ describe('SelectedNetworkController', () => {
         });
       });
     });
+  });
 
-    describe('getNetworkClientIdForDomain', () => {
+  describe('getNetworkClientIdForDomain', () => {
+    it('returns the selectedNetworkClientId from the NetworkController when useRequestQueuePreference is false', () => {
+      const { controller } = setup();
+      expect(controller.getNetworkClientIdForDomain('example.com')).toBe(
+        'mainnet',
+      );
+    });
+
+    describe('when useRequestQueuePreference is true', () => {
       it('returns the networkClientId from state when a networkClientId has been set for the requested domain', () => {
         const { controller } = setup({
           state: {
@@ -538,6 +636,7 @@ describe('SelectedNetworkController', () => {
               'example.com': '1',
             },
           },
+          useRequestQueuePreference: true,
         });
 
         const result = controller.getNetworkClientIdForDomain('example.com');
@@ -547,22 +646,438 @@ describe('SelectedNetworkController', () => {
       it('returns the selectedNetworkClientId from the NetworkController when no networkClientId has been set for the requested domain', () => {
         const { controller } = setup({
           state: { domains: {} },
+          useRequestQueuePreference: true,
         });
         expect(controller.getNetworkClientIdForDomain('example.com')).toBe(
           'mainnet',
         );
       });
     });
+  });
 
-    describe('getProviderAndBlockTracker', () => {
-      it('returns the cached proxy provider and block tracker when the domain already has a cached networkProxy in the domainProxyMap', () => {
-        const mockProxyProvider = {
-          setTarget: jest.fn(),
-        } as unknown as ProviderProxy;
-        const mockProxyBlockTracker = {
-          setTarget: jest.fn(),
-        } as unknown as BlockTrackerProxy;
+  describe('getProviderAndBlockTracker', () => {
+    it('returns the cached proxy provider and block tracker when the domain already has a cached networkProxy in the domainProxyMap', () => {
+      const mockProxyProvider = {
+        setTarget: jest.fn(),
+      } as unknown as ProviderProxy;
+      const mockProxyBlockTracker = {
+        setTarget: jest.fn(),
+      } as unknown as BlockTrackerProxy;
 
+      const domainProxyMap = new Map<Domain, NetworkProxy>([
+        [
+          'example.com',
+          {
+            provider: mockProxyProvider,
+            blockTracker: mockProxyBlockTracker,
+          },
+        ],
+        [
+          'test.com',
+          {
+            provider: mockProxyProvider,
+            blockTracker: mockProxyBlockTracker,
+          },
+        ],
+      ]);
+      const { controller } = setup({
+        state: {
+          domains: {},
+        },
+        useRequestQueuePreference: true,
+        domainProxyMap,
+      });
+
+      const result = controller.getProviderAndBlockTracker('example.com');
+      expect(result).toStrictEqual({
+        provider: mockProxyProvider,
+        blockTracker: mockProxyBlockTracker,
+      });
+    });
+
+    describe('when the domain does not have a cached networkProxy in the domainProxyMap and useRequestQueuePreference is true', () => {
+      describe('when the domain has permissions', () => {
+        it('calls to NetworkController:getNetworkClientById and creates a new proxy provider and block tracker with the non-proxied globally selected network client', () => {
+          const { controller, messenger, mockHasPermissions } = setup({
+            state: {
+              domains: {},
+            },
+            useRequestQueuePreference: true,
+          });
+          jest.spyOn(messenger, 'call');
+          mockHasPermissions.mockReturnValue(true);
+
+          const result = controller.getProviderAndBlockTracker('example.com');
+          expect(result).toBeDefined();
+          // unfortunately checking which networkController method is called is the best
+          // proxy (no pun intended) for checking that the correct instance of the networkClient is used
+          expect(messenger.call).toHaveBeenCalledWith(
+            'NetworkController:getNetworkClientById',
+            'mainnet',
+          );
+        });
+      });
+
+      describe('when the domain does not have permissions', () => {
+        it('calls to NetworkController:getSelectedNetworkClient and creates a new proxy provider and block tracker with the proxied globally selected network client', () => {
+          const { controller, messenger, mockHasPermissions } = setup({
+            state: {
+              domains: {},
+            },
+            useRequestQueuePreference: true,
+          });
+          jest.spyOn(messenger, 'call');
+          mockHasPermissions.mockReturnValue(false);
+          const result = controller.getProviderAndBlockTracker('example.com');
+          expect(result).toBeDefined();
+          // unfortunately checking which networkController method is called is the best
+          // proxy (no pun intended) for checking that the correct instance of the networkClient is used
+          expect(messenger.call).toHaveBeenCalledWith(
+            'NetworkController:getSelectedNetworkClient',
+          );
+        });
+
+        it('throws an error if the globally selected network client is not initialized', () => {
+          const { controller, mockGetSelectedNetworkClient } = setup({
+            state: {
+              domains: {},
+            },
+            useRequestQueuePreference: false,
+          });
+          mockGetSelectedNetworkClient.mockReturnValue(undefined);
+          expect(() =>
+            controller.getProviderAndBlockTracker('example.com'),
+          ).toThrow('Selected network not initialized');
+        });
+      });
+    });
+
+    describe('when the domain does not have a cached networkProxy in the domainProxyMap and useRequestQueuePreference is false', () => {
+      it('calls to NetworkController:getSelectedNetworkClient and creates a new proxy provider and block tracker with the proxied globally selected network client', () => {
+        const { controller, messenger } = setup({
+          state: {
+            domains: {},
+          },
+          useRequestQueuePreference: false,
+        });
+        jest.spyOn(messenger, 'call');
+
+        const result = controller.getProviderAndBlockTracker('example.com');
+        expect(result).toBeDefined();
+        // unfortunately checking which networkController method is called is the best
+        // proxy (no pun intended) for checking that the correct instance of the networkClient is used
+        expect(messenger.call).toHaveBeenCalledWith(
+          'NetworkController:getSelectedNetworkClient',
+        );
+      });
+    });
+
+    // TODO - improve these tests by using a full NetworkController and doing more robust behavioral testing
+    describe('when the domain is a snap (starts with "npm:" or "local:")', () => {
+      it('returns a proxied globally selected networkClient and does not create a new proxy in the domainProxyMap', () => {
+        const { controller, domainProxyMap, messenger } = setup({
+          state: {
+            domains: {},
+          },
+          useRequestQueuePreference: true,
+        });
+        jest.spyOn(messenger, 'call');
+        const snapDomain = 'npm:@metamask/bip32-example-snap';
+
+        const result = controller.getProviderAndBlockTracker(snapDomain);
+
+        expect(domainProxyMap.get(snapDomain)).toBeUndefined();
+        expect(messenger.call).toHaveBeenCalledWith(
+          'NetworkController:getSelectedNetworkClient',
+        );
+        expect(result).toBeDefined();
+      });
+
+      it('throws an error if the globally selected network client is not initialized', () => {
+        const { controller, mockGetSelectedNetworkClient } = setup({
+          state: {
+            domains: {},
+          },
+          useRequestQueuePreference: false,
+        });
+        const snapDomain = 'npm:@metamask/bip32-example-snap';
+        mockGetSelectedNetworkClient.mockReturnValue(undefined);
+
+        expect(() => controller.getProviderAndBlockTracker(snapDomain)).toThrow(
+          'Selected network not initialized',
+        );
+      });
+    });
+
+    describe('when the domain is a "metamask"', () => {
+      it('returns a proxied globally selected networkClient and does not create a new proxy in the domainProxyMap', () => {
+        const { controller, domainProxyMap, messenger } = setup({
+          state: {
+            domains: {},
+          },
+          useRequestQueuePreference: true,
+        });
+        jest.spyOn(messenger, 'call');
+
+        const result = controller.getProviderAndBlockTracker(METAMASK_DOMAIN);
+
+        expect(result).toBeDefined();
+        expect(domainProxyMap.get(METAMASK_DOMAIN)).toBeUndefined();
+        expect(messenger.call).toHaveBeenCalledWith(
+          'NetworkController:getSelectedNetworkClient',
+        );
+      });
+
+      it('throws an error if the globally selected network client is not initialized', () => {
+        const { controller, mockGetSelectedNetworkClient } = setup({
+          state: {
+            domains: {},
+          },
+          useRequestQueuePreference: false,
+        });
+        mockGetSelectedNetworkClient.mockReturnValue(undefined);
+
+        expect(() =>
+          controller.getProviderAndBlockTracker(METAMASK_DOMAIN),
+        ).toThrow('Selected network not initialized');
+      });
+    });
+  });
+
+  describe('PermissionController:stateChange', () => {
+    describe('on permission add', () => {
+      it('should add new domain to domains list when useRequestQueuePreference is true', async () => {
+        const { controller, messenger } = setup({
+          useRequestQueuePreference: true,
+        });
+        const mockPermission = {
+          parentCapability: 'eth_accounts',
+          id: 'example.com',
+          date: Date.now(),
+          caveats: [{ type: 'restrictToAccounts', value: ['0x...'] }],
+        };
+
+        messenger.publish(
+          'PermissionController:stateChange',
+          { subjects: {} },
+          [
+            {
+              op: 'add',
+              path: ['subjects', 'example.com', 'permissions'],
+              value: mockPermission,
+            },
+          ],
+        );
+
+        const { domains } = controller.state;
+        expect(domains['example.com']).toBeDefined();
+      });
+
+      it('should not add new domain to domains list when useRequestQueuePreference is false', async () => {
+        const { controller, messenger } = setup({});
+        const mockPermission = {
+          parentCapability: 'eth_accounts',
+          id: 'example.com',
+          date: Date.now(),
+          caveats: [{ type: 'restrictToAccounts', value: ['0x...'] }],
+        };
+
+        messenger.publish(
+          'PermissionController:stateChange',
+          { subjects: {} },
+          [
+            {
+              op: 'add',
+              path: ['subjects', 'example.com', 'permissions'],
+              value: mockPermission,
+            },
+          ],
+        );
+
+        const { domains } = controller.state;
+        expect(domains['example.com']).toBeUndefined();
+      });
+    });
+
+    describe('on permission removal', () => {
+      it('should remove domain from domains list', async () => {
+        const { controller, messenger } = setup({
+          state: { domains: { 'example.com': 'foo' } },
+        });
+
+        messenger.publish(
+          'PermissionController:stateChange',
+          { subjects: {} },
+          [
+            {
+              op: 'remove',
+              path: ['subjects', 'example.com', 'permissions'],
+            },
+          ],
+        );
+
+        const { domains } = controller.state;
+        expect(domains['example.com']).toBeUndefined();
+      });
+
+      it('should set the proxy to the globally selected network if the globally selected network client is initialized and a proxy exists for the domain', async () => {
+        const { controller, messenger, mockProviderProxy } = setup({
+          state: { domains: { 'example.com': 'foo' } },
+        });
+        controller.getProviderAndBlockTracker('example.com');
+
+        messenger.publish(
+          'PermissionController:stateChange',
+          { subjects: {} },
+          [
+            {
+              op: 'remove',
+              path: ['subjects', 'example.com', 'permissions'],
+            },
+          ],
+        );
+
+        expect(mockProviderProxy.setTarget).toHaveBeenCalledWith(
+          expect.objectContaining({ request: expect.any(Function) }),
+        );
+        expect(mockProviderProxy.setTarget).toHaveBeenCalledTimes(1);
+
+        const { domains } = controller.state;
+        expect(domains['example.com']).toBeUndefined();
+      });
+
+      it('should delete the proxy if the globally selected network client is not initialized but a proxy exists for the domain', async () => {
+        const {
+          controller,
+          messenger,
+          domainProxyMap,
+          mockProviderProxy,
+          mockGetSelectedNetworkClient,
+        } = setup({
+          state: { domains: { 'example.com': 'foo' } },
+        });
+        controller.getProviderAndBlockTracker('example.com');
+
+        mockGetSelectedNetworkClient.mockReturnValue(undefined);
+        expect(domainProxyMap.get('example.com')).toBeDefined();
+        messenger.publish(
+          'PermissionController:stateChange',
+          { subjects: {} },
+          [
+            {
+              op: 'remove',
+              path: ['subjects', 'example.com', 'permissions'],
+            },
+          ],
+        );
+
+        expect(mockProviderProxy.setTarget).toHaveBeenCalledTimes(0);
+        expect(domainProxyMap.get('example.com')).toBeUndefined();
+      });
+    });
+  });
+
+  // because of the opacity of the networkClient and proxy implementations,
+  // its impossible to make valuable assertions around which networkClient proxies
+  // should be targeted when the useRequestQueuePreference state is toggled on and off:
+  // When toggled on, the networkClient for the globally selected networkClientId should be used - **not** the NetworkController's proxy of this networkClient.
+  // When toggled off, the NetworkControllers proxy of the globally selected networkClient should be used
+  // TODO - improve these tests by using a full NetworkController and doing more robust behavioral testing
+  describe('onPreferencesStateChange', () => {
+    const mockProxyProvider = {
+      setTarget: jest.fn(),
+    } as unknown as ProviderProxy;
+    const mockProxyBlockTracker = {
+      setTarget: jest.fn(),
+    } as unknown as BlockTrackerProxy;
+
+    describe('when toggled from off to on', () => {
+      describe('when domains have permissions', () => {
+        it('sets the target of the existing proxies to the non-proxied networkClient for the globally selected networkClientId', () => {
+          const domainProxyMap = new Map<Domain, NetworkProxy>([
+            [
+              'example.com',
+              {
+                provider: mockProxyProvider,
+                blockTracker: mockProxyBlockTracker,
+              },
+            ],
+            [
+              'test.com',
+              {
+                provider: mockProxyProvider,
+                blockTracker: mockProxyBlockTracker,
+              },
+            ],
+          ]);
+
+          const {
+            mockHasPermissions,
+            triggerPreferencesStateChange,
+            messenger,
+          } = setup({
+            state: {
+              domains: {},
+            },
+            useRequestQueuePreference: false,
+            domainProxyMap,
+          });
+          jest.spyOn(messenger, 'call');
+
+          mockHasPermissions.mockReturnValue(true);
+
+          triggerPreferencesStateChange({ useRequestQueue: true });
+
+          // this is a very imperfect way to test this, but networkClients and proxies are opaque
+          // when the proxy is set with the networkClient fetched via NetworkController:getNetworkClientById
+          // it **is not** tied to the NetworkController's own proxy of the networkClient
+          expect(messenger.call).toHaveBeenCalledWith(
+            'NetworkController:getNetworkClientById',
+            'mainnet',
+          );
+          expect(mockProxyProvider.setTarget).toHaveBeenCalledTimes(2);
+          expect(mockProxyBlockTracker.setTarget).toHaveBeenCalledTimes(2);
+        });
+      });
+
+      describe('when domains do not have permissions', () => {
+        it('does not change the target of the existing proxy', () => {
+          const domainProxyMap = new Map<Domain, NetworkProxy>([
+            [
+              'example.com',
+              {
+                provider: mockProxyProvider,
+                blockTracker: mockProxyBlockTracker,
+              },
+            ],
+            [
+              'test.com',
+              {
+                provider: mockProxyProvider,
+                blockTracker: mockProxyBlockTracker,
+              },
+            ],
+          ]);
+          const { mockHasPermissions, triggerPreferencesStateChange } = setup({
+            state: {
+              domains: {},
+            },
+            useRequestQueuePreference: false,
+            domainProxyMap,
+          });
+
+          mockHasPermissions.mockReturnValue(false);
+
+          triggerPreferencesStateChange({ useRequestQueue: true });
+
+          expect(mockProxyProvider.setTarget).toHaveBeenCalledTimes(0);
+          expect(mockProxyBlockTracker.setTarget).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
+
+    describe('when toggled from on to off', () => {
+      it('sets the target of the existing proxies to the proxied globally selected networkClient', () => {
         const domainProxyMap = new Map<Domain, NetworkProxy>([
           [
             'example.com',
@@ -579,254 +1094,32 @@ describe('SelectedNetworkController', () => {
             },
           ],
         ]);
-        const { controller } = setup({
-          state: {
-            domains: {},
-          },
 
-          domainProxyMap,
-        });
-
-        const result = controller.getProviderAndBlockTracker('example.com');
-        expect(result).toStrictEqual({
-          provider: mockProxyProvider,
-          blockTracker: mockProxyBlockTracker,
-        });
-      });
-
-      it('throws an error if passed a domain that does not have permissions and the globally selected network client is not initialized', () => {
-        const { controller, mockGetSelectedNetworkClient, mockHasPermissions } =
-          setup();
-        mockGetSelectedNetworkClient.mockReturnValue(undefined);
-        mockHasPermissions.mockReturnValue(false);
-        expect(() => controller.getProviderAndBlockTracker('test.com')).toThrow(
-          'Selected network not initialized',
-        );
-      });
-
-      it('throws and error if passed a domain that has permissions and the globally selected network client is not initialized', () => {
-        const { controller, mockGetNetworkClientById, mockHasPermissions } =
-          setup();
-        mockGetNetworkClientById.mockReturnValue(undefined);
-        mockHasPermissions.mockReturnValue(true);
-        expect(() => controller.getProviderAndBlockTracker('test.com')).toThrow(
-          'Selected network not initialized',
-        );
-      });
-
-      describe('when the domain does not have a cached networkProxy in the domainProxyMap', () => {
-        describe('when the domain has permissions', () => {
-          it('calls to NetworkController:getNetworkClientById and creates a new proxy provider and block tracker with the non-proxied globally selected network client', () => {
-            const { controller, messenger, mockHasPermissions } = setup({
-              state: {
-                domains: {},
-              },
-            });
-            jest.spyOn(messenger, 'call');
-            mockHasPermissions.mockReturnValue(true);
-
-            const result = controller.getProviderAndBlockTracker('example.com');
-            expect(result).toBeDefined();
-            // unfortunately checking which networkController method is called is the best
-            // proxy (no pun intended) for checking that the correct instance of the networkClient is used
-            expect(messenger.call).toHaveBeenCalledWith(
-              'NetworkController:getNetworkClientById',
-              'mainnet',
-            );
-          });
-        });
-
-        describe('when the domain does not have permissions', () => {
-          it('calls to NetworkController:getSelectedNetworkClient and creates a new proxy provider and block tracker with the proxied globally selected network client', () => {
-            const { controller, messenger, mockHasPermissions } = setup({
-              state: {
-                domains: {},
-              },
-            });
-            jest.spyOn(messenger, 'call');
-            mockHasPermissions.mockReturnValue(false);
-            const result = controller.getProviderAndBlockTracker('example.com');
-            expect(result).toBeDefined();
-            // unfortunately checking which networkController method is called is the best
-            // proxy (no pun intended) for checking that the correct instance of the networkClient is used
-            expect(messenger.call).toHaveBeenCalledWith(
-              'NetworkController:getSelectedNetworkClient',
-            );
-          });
-        });
-      });
-
-      // TODO - improve these tests by using a full NetworkController and doing more robust behavioral testing
-      describe('when the domain is a snap (starts with "npm:" or "local:")', () => {
-        it('returns a proxied globally selected networkClient and does not create a new proxy in the domainProxyMap', () => {
-          const { controller, domainProxyMap, messenger } = setup({
+        const { mockHasPermissions, triggerPreferencesStateChange, messenger } =
+          setup({
             state: {
-              domains: {},
-            },
-          });
-          jest.spyOn(messenger, 'call');
-          const snapDomain = 'npm:@metamask/bip32-example-snap';
-
-          const result = controller.getProviderAndBlockTracker(snapDomain);
-
-          expect(domainProxyMap.get(snapDomain)).toBeUndefined();
-          expect(messenger.call).toHaveBeenCalledWith(
-            'NetworkController:getSelectedNetworkClient',
-          );
-          expect(result).toBeDefined();
-        });
-
-        it('throws an error if the globally selected network client is not initialized', () => {
-          const { controller, mockGetSelectedNetworkClient } = setup({
-            state: {
-              domains: {},
-            },
-          });
-          const snapDomain = 'npm:@metamask/bip32-example-snap';
-          mockGetSelectedNetworkClient.mockReturnValue(undefined);
-
-          expect(() =>
-            controller.getProviderAndBlockTracker(snapDomain),
-          ).toThrow('Selected network not initialized');
-        });
-      });
-
-      describe('when the domain is a "metamask"', () => {
-        it('returns a proxied globally selected networkClient and does not create a new proxy in the domainProxyMap', () => {
-          const { controller, domainProxyMap, messenger } = setup({
-            state: {
-              domains: {},
-            },
-          });
-          jest.spyOn(messenger, 'call');
-
-          const result = controller.getProviderAndBlockTracker(METAMASK_DOMAIN);
-
-          expect(result).toBeDefined();
-          expect(domainProxyMap.get(METAMASK_DOMAIN)).toBeUndefined();
-          expect(messenger.call).toHaveBeenCalledWith(
-            'NetworkController:getSelectedNetworkClient',
-          );
-        });
-
-        it('throws an error if the globally selected network client is not initialized', () => {
-          const { controller, mockGetSelectedNetworkClient } = setup({
-            state: {
-              domains: {},
-            },
-          });
-          mockGetSelectedNetworkClient.mockReturnValue(undefined);
-
-          expect(() =>
-            controller.getProviderAndBlockTracker(METAMASK_DOMAIN),
-          ).toThrow('Selected network not initialized');
-        });
-      });
-    });
-
-    describe('PermissionController:stateChange', () => {
-      describe('on permission add', () => {
-        it('should add new domain to domains list', async () => {
-          const { controller, messenger } = setup({});
-          const mockPermission = {
-            parentCapability: 'eth_accounts',
-            id: 'example.com',
-            date: Date.now(),
-            caveats: [{ type: 'restrictToAccounts', value: ['0x...'] }],
-          };
-
-          messenger.publish(
-            'PermissionController:stateChange',
-            { subjects: {} },
-            [
-              {
-                op: 'add',
-                path: ['subjects', 'example.com', 'permissions'],
-                value: mockPermission,
+              domains: {
+                'example.com': 'foo',
+                'test.com': 'bar',
               },
-            ],
-          );
-
-          const { domains } = controller.state;
-          expect(domains['example.com']).toBeDefined();
-        });
-      });
-
-      describe('on permission removal', () => {
-        it('should remove domain from domains list', async () => {
-          const { controller, messenger } = setup({
-            state: { domains: { 'example.com': 'foo' } },
-          });
-
-          messenger.publish(
-            'PermissionController:stateChange',
-            { subjects: {} },
-            [
-              {
-                op: 'remove',
-                path: ['subjects', 'example.com', 'permissions'],
-              },
-            ],
-          );
-
-          const { domains } = controller.state;
-          expect(domains['example.com']).toBeUndefined();
-        });
-
-        it('should set the proxy to the globally selected network if the globally selected network client is initialized and a proxy exists for the domain', async () => {
-          const { controller, messenger, mockProviderProxy } = setup({
-            state: { domains: { 'example.com': 'foo' } },
-          });
-          controller.getProviderAndBlockTracker('example.com');
-
-          messenger.publish(
-            'PermissionController:stateChange',
-            { subjects: {} },
-            [
-              {
-                op: 'remove',
-                path: ['subjects', 'example.com', 'permissions'],
-              },
-            ],
-          );
-
-          expect(mockProviderProxy.setTarget).toHaveBeenCalledWith(
-            expect.objectContaining({ request: expect.any(Function) }),
-          );
-          expect(mockProviderProxy.setTarget).toHaveBeenCalledTimes(1);
-
-          const { domains } = controller.state;
-          expect(domains['example.com']).toBeUndefined();
-        });
-
-        it('should delete the proxy if the globally selected network client is not initialized but a proxy exists for the domain', async () => {
-          const {
-            controller,
-            messenger,
+            },
+            useRequestQueuePreference: true,
             domainProxyMap,
-            mockProviderProxy,
-            mockGetSelectedNetworkClient,
-          } = setup({
-            state: { domains: { 'example.com': 'foo' } },
           });
-          controller.getProviderAndBlockTracker('example.com');
+        jest.spyOn(messenger, 'call');
 
-          mockGetSelectedNetworkClient.mockReturnValue(undefined);
-          expect(domainProxyMap.get('example.com')).toBeDefined();
-          messenger.publish(
-            'PermissionController:stateChange',
-            { subjects: {} },
-            [
-              {
-                op: 'remove',
-                path: ['subjects', 'example.com', 'permissions'],
-              },
-            ],
-          );
+        mockHasPermissions.mockReturnValue(true);
 
-          expect(mockProviderProxy.setTarget).toHaveBeenCalledTimes(0);
-          expect(domainProxyMap.get('example.com')).toBeUndefined();
-        });
+        triggerPreferencesStateChange({ useRequestQueue: false });
+
+        // this is a very imperfect way to test this, but networkClients and proxies are opaque
+        // when the proxy is set with the networkClient fetched via NetworkController:getSelectedNetworkClient
+        // it **is** tied to the NetworkController's own proxy of the networkClient
+        expect(messenger.call).toHaveBeenCalledWith(
+          'NetworkController:getSelectedNetworkClient',
+        );
+        expect(mockProxyProvider.setTarget).toHaveBeenCalledTimes(2);
+        expect(mockProxyBlockTracker.setTarget).toHaveBeenCalledTimes(2);
       });
     });
   });


### PR DESCRIPTION
This reverts commit 4814cf11670c76f7d3015206dbe3c78b383ddc3a.

## Explanation

We are not yet ready to release per-dapp selected network functionality on the mobile client and with this change there is no clean way to [update the version of SelectedNetworkController](https://github.com/MetaMask/metamask-mobile/issues/12434#issuecomment-2537358920) in the mobile client without having the Domains state starting to populate and possibly become corrupt since its not being consumed by/updated by the frontend in the expected way and may need to be migrated away when its time to actually start using the controller. 

Without this revert the @MetaMask/wallet-framework team is blocked from completing their goal to get both clients up to the latest versions of all controllers.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/queued-request-controller`

- **ADDED**: **BREAKING:** `createQueuedRequestMiddleware` now expects a
`useRequestQueue` property in its param options


### `@metamask/selected-network-controller`

- **ADDED**: **BREAKING:**  `SelectedNetworkController` constructor now expects
both a `useRequestQueuePreference` and a `onPreferencesStateChange` param

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
