### PR TITLE
chore(codeowners): Add Wallet API team as CODEOWNERS for multichain package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,6 +36,7 @@
 /packages/rate-limit-controller            @MetaMask/snaps-devs
 
 ## Wallet API Platform Team
+/packages/multichain                       @MetaMask/wallet-api-platform-engineers
 /packages/queued-request-controller        @MetaMask/wallet-api-platform-engineers
 
 ## Wallet Framework Team
@@ -90,6 +91,8 @@
 /packages/phishing-controller/CHANGELOG.md    @MetaMask/product-safety @MetaMask/wallet-framework-engineers
 /packages/profile-sync-controller/package.json    @MetaMask/notifications @MetaMask/identity @MetaMask/wallet-framework-engineers
 /packages/profile-sync-controller/CHANGELOG.md    @MetaMask/notifications @MetaMask/identity @MetaMask/wallet-framework-engineers
+/packages/multichain/package.json                 @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
+/packages/multichain/CHANGELOG.md                 @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
 /packages/queued-request-controller/package.json  @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
 /packages/queued-request-controller/CHANGELOG.md  @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
 /packages/signature-controller/package.json       @MetaMask/confirmations @MetaMask/wallet-framework-engineers


### PR DESCRIPTION
## Explanation
There was a new package added the `core` repo for `@metamask/multichain`. We want to make sure the proper team is set as CODEOWNERS

