### PR TITLE
chore: Remove unused OpenSea key

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -526,6 +526,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `TokenBalancesController` was fixed to fetch erc20 token balances even if there's an invalid token in state whose address does not point to a smart contract.
 - Fix state changes for `ignoreTokens` for non-selected networks ([#5014](https://github.com/MetaMask/core/pull/5014))
 
+### Removed
+
+- **BREAKING:** Remove `NftController` property `openSeaApiKey` and method `setApiKey` ([#5088](https://github.com/MetaMask/core/pull/5088))
+  - This key was not actively used. No functional changes.
+
 ## [45.1.2]
 
 ### Changed

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-api` from `^19.0.0` to `^20.0.0` ([#6248](https://github.com/MetaMask/core/pull/6248))
 
+### Removed
+
+- **BREAKING:** Remove `NftController` property `openSeaApiKey` and method `setApiKey` ([#5088](https://github.com/MetaMask/core/pull/5088))
+  - This key was not actively used. No functional changes.
+
 ### Fixed
 
 - Correct the polling rate for the DeFiPositionsController from 1 minute to 10 minutes. ([#6242](https://github.com/MetaMask/core/pull/6242))
@@ -525,11 +530,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix multicall revert in `TokenBalancesController` ([#5083](https://github.com/MetaMask/core/pull/5083))
   - `TokenBalancesController` was fixed to fetch erc20 token balances even if there's an invalid token in state whose address does not point to a smart contract.
 - Fix state changes for `ignoreTokens` for non-selected networks ([#5014](https://github.com/MetaMask/core/pull/5014))
-
-### Removed
-
-- **BREAKING:** Remove `NftController` property `openSeaApiKey` and method `setApiKey` ([#5088](https://github.com/MetaMask/core/pull/5088))
-  - This key was not actively used. No functional changes.
 
 ## [45.1.2]
 

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -468,13 +468,6 @@ describe('NftController', () => {
     });
   });
 
-  it('should set api key', async () => {
-    const { nftController } = setupController();
-
-    nftController.setApiKey('testkey');
-    expect(nftController.openSeaApiKey).toBe('testkey');
-  });
-
   describe('watchNft', function () {
     const ERC721_NFT = {
       address: ERC721_NFT_ADDRESS,

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -290,11 +290,6 @@ export class NftController extends BaseController<
 > {
   readonly #mutex = new Mutex();
 
-  /**
-   * Optional API key to use with opensea
-   */
-  openSeaApiKey?: string;
-
   #selectedAccountId: string;
 
   #ipfsGateway: string;
@@ -1351,15 +1346,6 @@ export class NftController extends BaseController<
       userAddress,
       source: Source.Dapp,
     });
-  }
-
-  /**
-   * Sets an OpenSea API key to retrieve NFT information.
-   *
-   * @param openSeaApiKey - OpenSea API key.
-   */
-  setApiKey(openSeaApiKey: string) {
-    this.openSeaApiKey = openSeaApiKey;
   }
 
   /**


### PR DESCRIPTION
## Explanation

Remove unused OpenSea API key. This is a breaking change because of the API/type change, but it's not a functional change since it was already unused.

## References

N/A

## Changelog

See diff

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
  - I skipped this step in this case because the changes are trivial, despite being breaking.
