### PR TITLE
chore(docs): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/docs/writing-controllers.md
+++ b/docs/writing-controllers.md
@@ -48,7 +48,7 @@ class FooController extends BaseController</* ... */> {
     messenger,
     state = {},
   }: {
-    messenger: FooMessenger;
+    messenger: FooControllerMessenger;
     state?: Partial<FooControllerState>;
   }) {
     super({
@@ -86,7 +86,7 @@ class FooController extends BaseController</* ... */> {
     messenger,
     state = {},
   }: {
-    messenger: FooMessenger;
+    messenger: FooControllerMessenger;
     state?: Partial<FooControllerState>;
   }) {
     super({
@@ -157,7 +157,7 @@ class FooController extends BaseController</* ... */> {
       messenger,
       state = {},
     }: {
-      messenger: FooMessenger;
+      messenger: FooControllerMessenger;
       state?: Partial<FooControllerState>;
     },
     isEnabled: boolean,
@@ -176,7 +176,7 @@ class FooController extends BaseController</* ... */> {
     state = {},
     isEnabled,
   }: {
-    messenger: FooMessenger;
+    messenger: FooControllerMessenger;
     state?: Partial<FooControllerState>;
     isEnabled: boolean;
   }) {
@@ -223,7 +223,7 @@ If the recipient controller supports the messaging system, however, the callback
 
 const name = 'FooController';
 
-type FooMessenger = RestrictedMessenger<
+type FooControllerMessenger = RestrictedMessenger<
   typeof name,
   never,
   never,
@@ -234,9 +234,9 @@ type FooMessenger = RestrictedMessenger<
 class FooController extends BaseController<
   'FooController',
   // ...,
-  FooMessenger
+  FooControllerMessenger
 > {
-  constructor({ messenger /*, ... */ }, { messenger: FooMessenger }) {
+  constructor({ messenger /*, ... */ }, { messenger: FooControllerMessenger }) {
     super({ messenger /* ... */ });
 
     messenger.subscribe('BarController:stateChange', (state) => {
@@ -304,7 +304,7 @@ However, this pattern can be replaced with the use of the messenger:
 
 const name = 'FooController';
 
-type FooMessenger = RestrictedMessenger<
+type FooControllerMessenger = RestrictedMessenger<
   typeof name,
   never,
   never,
@@ -315,9 +315,9 @@ type FooMessenger = RestrictedMessenger<
 class FooController extends BaseController<
   'FooController',
   // ...,
-  FooMessenger
+  FooControllerMessenger
 > {
-  constructor({ messenger /*, ... */ }, { messenger: FooMessenger }) {
+  constructor({ messenger /*, ... */ }, { messenger: FooControllerMessenger }) {
     super({ messenger /*, ... */ });
   }
 
@@ -508,7 +508,7 @@ export type FooControllerActions =
   | FooControllerUpdateCurrencyAction
   | FooControllerUpdateRatesAction;
 
-export type FooMessenger = RestrictedMessenger<
+export type FooControllerMessenger = RestrictedMessenger<
   'FooController',
   FooControllerActions,
   never,
@@ -524,7 +524,7 @@ export type FooControllerActions =
   | FooControllerUpdateCurrencyAction
   | FooControllerUpdateRatesAction;
 
-export type FooMessenger = RestrictedMessenger<
+export type FooControllerMessenger = RestrictedMessenger<
   'FooController',
   FooControllerActions,
   never,
@@ -548,7 +548,7 @@ export type FooControllerEvents =
   | FooControllerMessageReceivedEvent
   | FooControllerNotificationAddedEvent;
 
-export type FooMessenger = RestrictedMessenger<
+export type FooControllerMessenger = RestrictedMessenger<
   'FooController',
   never,
   FooControllerEvents,
@@ -564,7 +564,7 @@ export type FooControllerEvents =
   | FooControllerMessageReceivedEvent
   | FooControllerNotificationAddedEvent;
 
-export type FooMessenger = RestrictedMessenger<
+export type FooControllerMessenger = RestrictedMessenger<
   'FooController',
   never,
   FooControllerEvents,
@@ -590,7 +590,7 @@ export type AllowedActions =
   | BarControllerDoSomethingAction
   | BarControllerDoSomethingElseAction;
 
-export type FooMessenger = RestrictedMessenger<
+export type FooControllerMessenger = RestrictedMessenger<
   'FooController',
   AllowedActions,
   never,
@@ -608,7 +608,7 @@ export type AllowedActions =
   | BarControllerDoSomethingAction
   | BarControllerDoSomethingElseAction;
 
-export type FooMessenger = RestrictedMessenger<
+export type FooControllerMessenger = RestrictedMessenger<
   'FooController',
   AllowedActions,
   never,
@@ -628,7 +628,7 @@ type AllowedActions =
   | BarControllerDoSomethingAction
   | BarControllerDoSomethingElseAction;
 
-export type FooMessenger = RestrictedMessenger<
+export type FooControllerMessenger = RestrictedMessenger<
   'FooController',
   AllowedActions,
   never,
@@ -643,7 +643,10 @@ If, in a test, you need to access all of the actions included in a controller's 
 // NOTE: You may need to adjust the path depending on where you are
 import { ExtractAvailableAction } from '../../base-controller/tests/helpers';
 
-const messenger = new Messenger<ExtractAvailableAction<FooMessenger>, never>();
+const messenger = new Messenger<
+  ExtractAvailableAction<FooControllerMessenger>,
+  never
+>();
 ```
 
 ## Define, but do not export, a type union for external event types
@@ -663,7 +666,7 @@ export type AllowedEvents =
   | BarControllerSomethingHappenedEvent
   | BarControllerSomethingElseHappenedEvent;
 
-export type FooMessenger = RestrictedMessenger<
+export type FooControllerMessenger = RestrictedMessenger<
   'FooController',
   never,
   AllowedEvents,
@@ -681,7 +684,7 @@ export type AllowedEvents =
   | BarControllerSomethingHappenedEvent
   | BarControllerSomethingElseHappenedEvent;
 
-export type FooMessenger = RestrictedMessenger<
+export type FooControllerMessenger = RestrictedMessenger<
   'FooController',
   never,
   AllowedEvents,
@@ -701,7 +704,7 @@ type AllowedEvents =
   | BarControllerSomethingHappenedEvent
   | BarControllerSomethingElseHappenedEvent;
 
-export type FooMessenger = RestrictedMessenger<
+export type FooControllerMessenger = RestrictedMessenger<
   'FooController',
   never,
   AllowedEvents,
@@ -716,7 +719,10 @@ If, in a test, you need to access all of the events included in a controller's m
 // NOTE: You may need to adjust the path depending on where you are
 import { ExtractAvailableEvent } from '../../base-controller/tests/helpers';
 
-const messenger = new Messenger<never, ExtractAvailableEvent<FooMessenger>>();
+const messenger = new Messenger<
+  never,
+  ExtractAvailableEvent<FooControllerMessenger>
+>();
 ```
 
 ## Define and export a type for the controller's messenger
@@ -849,7 +855,7 @@ export class FooController extends BaseController<
   //   Property 'bar' is incompatible with index signature.
   //     Type 'string | undefined' is not assignable to type 'Json'.
   FooControllerState,
-  FooMessenger
+  FooControllerMessenger
 > {
   // ...
 }
@@ -866,7 +872,7 @@ export class FooController extends BaseController<
   'FooController',
   // No error
   FooControllerState,
-  FooMessenger
+  FooControllerMessenger
 > {
   // ...
 }

--- a/docs/writing-controllers.md
+++ b/docs/writing-controllers.md
@@ -940,7 +940,7 @@ class TokensController extends BaseController</* ... */> {
     messenger,
   }: // ...
   {
-    messenger: TokensMessenger;
+    messenger: TokensControllerMessenger;
     // ...
   }) {
     // ...
@@ -1296,7 +1296,7 @@ type AllowedActions =
   | AccountsControllerGetActiveAccountsAction
   | AccountsControllerGetInactiveAccountsAction;
 
-export type TokensMessenger = RestrictedMessenger<
+export type TokensControllerMessenger = RestrictedMessenger<
   'TokensController',
   AllowedActions,
   never,
@@ -1309,7 +1309,7 @@ class TokensController extends BaseController</* ... */> {
     messenger,
   }: // ...
   {
-    messenger: TokensMessenger;
+    messenger: TokensControllerMessenger;
     // ...
   }) {
     // ...
@@ -1394,7 +1394,7 @@ import { accountsControllerSelectors } from '@metamask/accounts-controller';
 
 type AllowedActions = AccountsControllerGetStateAction;
 
-export type TokensMessenger = RestrictedMessenger<
+export type TokensControllerMessenger = RestrictedMessenger<
   'TokensController',
   AllowedActions,
   never,
@@ -1407,7 +1407,7 @@ class TokensController extends BaseController</* ... */> {
     messenger,
     // ...
   }: {
-    messenger: TokensMessenger,
+    messenger: TokensControllerMessenger,
     // ...
   }) {
     // ...

--- a/docs/writing-controllers.md
+++ b/docs/writing-controllers.md
@@ -248,17 +248,17 @@ class FooController extends BaseController<
 // === Client repo ===
 
 const rootMessenger = new Messenger<'BarController:stateChange', never>();
-const barMessenger = rootMessenger.getRestricted({
+const barControllerMessenger = rootMessenger.getRestricted({
   name: 'BarController',
 });
 const barController = new BarController({
-  messenger: barMessenger,
+  messenger: barControllerMessenger,
 });
-const fooMessenger = rootMessenger.getRestricted({
+const fooControllerMessenger = rootMessenger.getRestricted({
   name: 'FooController',
 });
 const fooController = new FooController({
-  messenger: fooMessenger,
+  messenger: fooControllerMessenger,
 });
 ```
 
@@ -329,11 +329,11 @@ class FooController extends BaseController<
 // === Client repo ===
 
 const rootMessenger = new Messenger<'FooController:someEvent', never>();
-const fooMessenger = rootMessenger.getRestricted({
+const fooControllerMessenger = rootMessenger.getRestricted({
   name: 'FooController',
 });
 const fooController = new FooController({
-  messenger: fooMessenger,
+  messenger: fooControllerMessenger,
 });
 rootMessenger.subscribe('FooController:someEvent', () => {
   // do something with the event
@@ -784,7 +784,7 @@ export type AllowedEvents =
   | ApprovalControllerApprovalRequestApprovedEvent
   | ApprovalControllerApprovalRequestRejectedEvent;
 
-export type SwapsMessenger = RestrictedMessenger<
+export type SwapsControllerMessenger = RestrictedMessenger<
   'SwapsController',
   SwapsControllerActions | AllowedActions,
   SwapsControllerEvents | AllowedEvents,
@@ -796,7 +796,7 @@ export type SwapsMessenger = RestrictedMessenger<
 A messenger that allows no actions or events (whether internal or external) looks like this:
 
 ```typescript
-export type SwapsMessenger = RestrictedMessenger<
+export type SwapsControllerMessenger = RestrictedMessenger<
   'SwapsController',
   never,
   never,
@@ -890,7 +890,7 @@ class GasFeeController extends BaseController</* ... */> {
     messenger,
   }: // ...
   {
-    messenger: GasFeeMessenger;
+    messenger: GasFeeControllerMessenger;
     // ...
   }) {
     // ...
@@ -915,7 +915,7 @@ class GasFeeController extends BaseController</* ... */> {
     messenger,
   }: // ...
   {
-    messenger: GasFeeMessenger;
+    messenger: GasFeeControllerMessenger;
     // ...
   }) {
     // ...
@@ -968,7 +968,7 @@ But this gets unwieldy if there are multiple properties to check:
 
 ```typescript
 class NftController extends BaseController/*<...>*/ {
-  constructor({ messenger }, { messenger: NftMessenger }) {
+  constructor({ messenger }, { messenger: NftControllerMessenger }) {
     // ...
 
     let preferencesControllerState = messenger.call(
@@ -1037,7 +1037,7 @@ const selectPreferencesControllerState = createSelector(
 );
 
 class NftController extends BaseController /*<...>*/ {
-  constructor({ messenger }, { messenger: NftMessenger }) {
+  constructor({ messenger }, { messenger: NftControllerMessenger }) {
     // ...
 
     messenger.subscribe(
@@ -1169,7 +1169,7 @@ import { AccountsControllerGetStateAction } from '@metamask/accounts-controller'
 
 type AllowedActions = AccountsControllerGetStateAction;
 
-type PreferencesMessenger = RestrictedMessenger<
+type PreferencesControllerMessenger = RestrictedMessenger<
   'PreferencesController',
   AllowedActions,
   never,
@@ -1180,13 +1180,13 @@ type PreferencesMessenger = RestrictedMessenger<
 class PreferencesController extends BaseController<
   'PreferencesController',
   // ...
-  PreferencesMessenger
+  PreferencesControllerMessenger
 > {
   constructor({
     messenger,
   }: // ...
   {
-    messenger: PreferencesMessenger;
+    messenger: PreferencesControllerMessenger;
     // ...
   }) {
     // ...
@@ -1267,7 +1267,7 @@ type AccountsControllerActions =
   | AccountsControllerGetActiveAccountAction
   | AccountsControllerGetInactiveAccountsAction;
 
-export type AccountsMessenger = RestrictedMessenger<
+export type AccountsControllerMessenger = RestrictedMessenger<
   'AccountsController',
   AccountsControllerActions,
   never,
@@ -1377,7 +1377,7 @@ export type AccountsControllerGetStateAction = ControllerGetStateAction<
 
 type AccountsControllerActions = AccountsControllerGetStateAccountAction;
 
-export type AccountsMessenger = RestrictedMessenger<
+export type AccountsControllerMessenger = RestrictedMessenger<
   'AccountsController',
   AccountsControllerActions,
   never,

--- a/docs/writing-controllers.md
+++ b/docs/writing-controllers.md
@@ -48,7 +48,7 @@ class FooController extends BaseController</* ... */> {
     messenger,
     state = {},
   }: {
-    messenger: FooControllerMessenger;
+    messenger: FooMessenger;
     state?: Partial<FooControllerState>;
   }) {
     super({
@@ -86,7 +86,7 @@ class FooController extends BaseController</* ... */> {
     messenger,
     state = {},
   }: {
-    messenger: FooControllerMessenger;
+    messenger: FooMessenger;
     state?: Partial<FooControllerState>;
   }) {
     super({
@@ -157,7 +157,7 @@ class FooController extends BaseController</* ... */> {
       messenger,
       state = {},
     }: {
-      messenger: FooControllerMessenger;
+      messenger: FooMessenger;
       state?: Partial<FooControllerState>;
     },
     isEnabled: boolean,
@@ -176,7 +176,7 @@ class FooController extends BaseController</* ... */> {
     state = {},
     isEnabled,
   }: {
-    messenger: FooControllerMessenger;
+    messenger: FooMessenger;
     state?: Partial<FooControllerState>;
     isEnabled: boolean;
   }) {
@@ -223,7 +223,7 @@ If the recipient controller supports the messaging system, however, the callback
 
 const name = 'FooController';
 
-type FooControllerMessenger = RestrictedControllerMessenger<
+type FooMessenger = RestrictedMessenger<
   typeof name,
   never,
   never,
@@ -234,9 +234,9 @@ type FooControllerMessenger = RestrictedControllerMessenger<
 class FooController extends BaseController<
   'FooController',
   // ...,
-  FooControllerMessenger
+  FooMessenger
 > {
-  constructor({ messenger /*, ... */ }, { messenger: FooControllerMessenger }) {
+  constructor({ messenger /*, ... */ }, { messenger: FooMessenger }) {
     super({ messenger /* ... */ });
 
     messenger.subscribe('BarController:stateChange', (state) => {
@@ -247,21 +247,18 @@ class FooController extends BaseController<
 
 // === Client repo ===
 
-const rootMessenger = new ControllerMessenger<
-  'BarController:stateChange',
-  never
->();
-const barControllerMessenger = rootMessenger.getRestricted({
+const rootMessenger = new Messenger<'BarController:stateChange', never>();
+const barMessenger = rootMessenger.getRestricted({
   name: 'BarController',
 });
 const barController = new BarController({
-  messenger: barControllerMessenger,
+  messenger: barMessenger,
 });
-const fooControllerMessenger = rootMessenger.getRestricted({
+const fooMessenger = rootMessenger.getRestricted({
   name: 'FooController',
 });
 const fooController = new FooController({
-  messenger: fooControllerMessenger,
+  messenger: fooMessenger,
 });
 ```
 
@@ -307,7 +304,7 @@ However, this pattern can be replaced with the use of the messenger:
 
 const name = 'FooController';
 
-type FooControllerMessenger = RestrictedControllerMessenger<
+type FooMessenger = RestrictedMessenger<
   typeof name,
   never,
   never,
@@ -318,9 +315,9 @@ type FooControllerMessenger = RestrictedControllerMessenger<
 class FooController extends BaseController<
   'FooController',
   // ...,
-  FooControllerMessenger
+  FooMessenger
 > {
-  constructor({ messenger /*, ... */ }, { messenger: FooControllerMessenger }) {
+  constructor({ messenger /*, ... */ }, { messenger: FooMessenger }) {
     super({ messenger /*, ... */ });
   }
 
@@ -331,15 +328,12 @@ class FooController extends BaseController<
 
 // === Client repo ===
 
-const rootMessenger = new ControllerMessenger<
-  'FooController:someEvent',
-  never
->();
-const fooControllerMessenger = rootMessenger.getRestricted({
+const rootMessenger = new Messenger<'FooController:someEvent', never>();
+const fooMessenger = rootMessenger.getRestricted({
   name: 'FooController',
 });
 const fooController = new FooController({
-  messenger: fooControllerMessenger,
+  messenger: fooMessenger,
 });
 rootMessenger.subscribe('FooController:someEvent', () => {
   // do something with the event
@@ -505,7 +499,7 @@ A controller should define and export a type union that holds all of its actions
 
 The name of this type should be `${ControllerName}Actions`.
 
-This type should be only passed to `RestrictedControllerMessenger` as the 2nd type parameter. It should _not_ be included in its 4th type parameter, as that is is used for external actions.
+This type should be only passed to `RestrictedMessenger` as the 2nd type parameter. It should _not_ be included in its 4th type parameter, as that is is used for external actions.
 
 🚫 **`FooController['type']` is passed as the 4th type parameter**
 
@@ -514,7 +508,7 @@ export type FooControllerActions =
   | FooControllerUpdateCurrencyAction
   | FooControllerUpdateRatesAction;
 
-export type FooControllerMessenger = RestrictedControllerMessenger<
+export type FooMessenger = RestrictedMessenger<
   'FooController',
   FooControllerActions,
   never,
@@ -530,7 +524,7 @@ export type FooControllerActions =
   | FooControllerUpdateCurrencyAction
   | FooControllerUpdateRatesAction;
 
-export type FooControllerMessenger = RestrictedControllerMessenger<
+export type FooMessenger = RestrictedMessenger<
   'FooController',
   FooControllerActions,
   never,
@@ -545,7 +539,7 @@ A controller should define and export a type union that holds all of its events.
 
 The name of this type should be `${ControllerName}Events`.
 
-This type should be only passed to `RestrictedControllerMessenger` as the 3rd type parameter. It should _not_ be included in its 5th type parameter, as that is is used for external events.
+This type should be only passed to `RestrictedMessenger` as the 3rd type parameter. It should _not_ be included in its 5th type parameter, as that is is used for external events.
 
 🚫 **`FooControllerEvents['type']` is passed as the 5th type parameter**
 
@@ -554,7 +548,7 @@ export type FooControllerEvents =
   | FooControllerMessageReceivedEvent
   | FooControllerNotificationAddedEvent;
 
-export type FooControllerMessenger = RestrictedControllerMessenger<
+export type FooMessenger = RestrictedMessenger<
   'FooController',
   never,
   FooControllerEvents,
@@ -570,7 +564,7 @@ export type FooControllerEvents =
   | FooControllerMessageReceivedEvent
   | FooControllerNotificationAddedEvent;
 
-export type FooControllerMessenger = RestrictedControllerMessenger<
+export type FooMessenger = RestrictedMessenger<
   'FooController',
   never,
   FooControllerEvents,
@@ -583,11 +577,11 @@ export type FooControllerMessenger = RestrictedControllerMessenger<
 
 A controller may wish to call actions defined by other controllers, and therefore will need to define them in the messenger's allowlist.
 
-In this case, the controller should group these types into a type union so that they can be easily passed to the `RestrictedControllerMessenger` type. However, it should not export this type, as it would then be re-exporting types that another package has already exported.
+In this case, the controller should group these types into a type union so that they can be easily passed to the `RestrictedMessenger` type. However, it should not export this type, as it would then be re-exporting types that another package has already exported.
 
 The name of this type should be `AllowedActions`.
 
-This type should not only be passed to `RestrictedControllerMessenger` as the 2nd type parameter, but should also be included in its 4th type parameter.
+This type should not only be passed to `RestrictedMessenger` as the 2nd type parameter, but should also be included in its 4th type parameter.
 
 🚫 **`never` is passed as the 4th type parameter**
 
@@ -596,7 +590,7 @@ export type AllowedActions =
   | BarControllerDoSomethingAction
   | BarControllerDoSomethingElseAction;
 
-export type FooControllerMessenger = RestrictedControllerMessenger<
+export type FooMessenger = RestrictedMessenger<
   'FooController',
   AllowedActions,
   never,
@@ -614,7 +608,7 @@ export type AllowedActions =
   | BarControllerDoSomethingAction
   | BarControllerDoSomethingElseAction;
 
-export type FooControllerMessenger = RestrictedControllerMessenger<
+export type FooMessenger = RestrictedMessenger<
   'FooController',
   AllowedActions,
   never,
@@ -634,7 +628,7 @@ type AllowedActions =
   | BarControllerDoSomethingAction
   | BarControllerDoSomethingElseAction;
 
-export type FooControllerMessenger = RestrictedControllerMessenger<
+export type FooMessenger = RestrictedMessenger<
   'FooController',
   AllowedActions,
   never,
@@ -649,21 +643,18 @@ If, in a test, you need to access all of the actions included in a controller's 
 // NOTE: You may need to adjust the path depending on where you are
 import { ExtractAvailableAction } from '../../base-controller/tests/helpers';
 
-const messenger = new ControllerMessenger<
-  ExtractAvailableAction<FooControllerMessenger>,
-  never
->();
+const messenger = new Messenger<ExtractAvailableAction<FooMessenger>, never>();
 ```
 
 ## Define, but do not export, a type union for external event types
 
 A controller may wish to subscribe to events defined by other controllers, and therefore will need to define them in the messenger's allowlist.
 
-In this case, the controller should group these types into a type union so that they can be easily passed to the `RestrictedControllerMessenger` type. However, it should not export this type, as it would then be re-exporting types that another package has already exported.
+In this case, the controller should group these types into a type union so that they can be easily passed to the `RestrictedMessenger` type. However, it should not export this type, as it would then be re-exporting types that another package has already exported.
 
 The name of this type should be `AllowedEvents`.
 
-This type should not only be passed to `RestrictedControllerMessenger` as the 3rd type parameter, but should also be included in its 5th type parameter.
+This type should not only be passed to `RestrictedMessenger` as the 3rd type parameter, but should also be included in its 5th type parameter.
 
 🚫 **`never` is passed as the 5th type parameter**
 
@@ -672,7 +663,7 @@ export type AllowedEvents =
   | BarControllerSomethingHappenedEvent
   | BarControllerSomethingElseHappenedEvent;
 
-export type FooControllerMessenger = RestrictedControllerMessenger<
+export type FooMessenger = RestrictedMessenger<
   'FooController',
   never,
   AllowedEvents,
@@ -690,7 +681,7 @@ export type AllowedEvents =
   | BarControllerSomethingHappenedEvent
   | BarControllerSomethingElseHappenedEvent;
 
-export type FooControllerMessenger = RestrictedControllerMessenger<
+export type FooMessenger = RestrictedMessenger<
   'FooController',
   never,
   AllowedEvents,
@@ -710,7 +701,7 @@ type AllowedEvents =
   | BarControllerSomethingHappenedEvent
   | BarControllerSomethingElseHappenedEvent;
 
-export type FooControllerMessenger = RestrictedControllerMessenger<
+export type FooMessenger = RestrictedMessenger<
   'FooController',
   never,
   AllowedEvents,
@@ -725,10 +716,7 @@ If, in a test, you need to access all of the events included in a controller's m
 // NOTE: You may need to adjust the path depending on where you are
 import { ExtractAvailableEvent } from '../../base-controller/tests/helpers';
 
-const messenger = new ControllerMessenger<
-  never,
-  ExtractAvailableEvent<FooControllerMessenger>
->();
+const messenger = new Messenger<never, ExtractAvailableEvent<FooMessenger>>();
 ```
 
 ## Define and export a type for the controller's messenger
@@ -790,7 +778,7 @@ export type AllowedEvents =
   | ApprovalControllerApprovalRequestApprovedEvent
   | ApprovalControllerApprovalRequestRejectedEvent;
 
-export type SwapsControllerMessenger = RestrictedControllerMessenger<
+export type SwapsMessenger = RestrictedMessenger<
   'SwapsController',
   SwapsControllerActions | AllowedActions,
   SwapsControllerEvents | AllowedEvents,
@@ -802,7 +790,7 @@ export type SwapsControllerMessenger = RestrictedControllerMessenger<
 A messenger that allows no actions or events (whether internal or external) looks like this:
 
 ```typescript
-export type SwapsControllerMessenger = RestrictedControllerMessenger<
+export type SwapsMessenger = RestrictedMessenger<
   'SwapsController',
   never,
   never,
@@ -861,7 +849,7 @@ export class FooController extends BaseController<
   //   Property 'bar' is incompatible with index signature.
   //     Type 'string | undefined' is not assignable to type 'Json'.
   FooControllerState,
-  FooControllerMessenger
+  FooMessenger
 > {
   // ...
 }
@@ -878,7 +866,7 @@ export class FooController extends BaseController<
   'FooController',
   // No error
   FooControllerState,
-  FooControllerMessenger
+  FooMessenger
 > {
   // ...
 }
@@ -896,7 +884,7 @@ class GasFeeController extends BaseController</* ... */> {
     messenger,
   }: // ...
   {
-    messenger: GasFeeControllerMessenger;
+    messenger: GasFeeMessenger;
     // ...
   }) {
     // ...
@@ -921,7 +909,7 @@ class GasFeeController extends BaseController</* ... */> {
     messenger,
   }: // ...
   {
-    messenger: GasFeeControllerMessenger;
+    messenger: GasFeeMessenger;
     // ...
   }) {
     // ...
@@ -946,7 +934,7 @@ class TokensController extends BaseController</* ... */> {
     messenger,
   }: // ...
   {
-    messenger: TokensControllerMessenger;
+    messenger: TokensMessenger;
     // ...
   }) {
     // ...
@@ -974,7 +962,7 @@ But this gets unwieldy if there are multiple properties to check:
 
 ```typescript
 class NftController extends BaseController/*<...>*/ {
-  constructor({ messenger }, { messenger: NftControllerMessenger }) {
+  constructor({ messenger }, { messenger: NftMessenger }) {
     // ...
 
     let preferencesControllerState = messenger.call(
@@ -1043,7 +1031,7 @@ const selectPreferencesControllerState = createSelector(
 );
 
 class NftController extends BaseController /*<...>*/ {
-  constructor({ messenger }, { messenger: NftControllerMessenger }) {
+  constructor({ messenger }, { messenger: NftMessenger }) {
     // ...
 
     messenger.subscribe(
@@ -1175,7 +1163,7 @@ import { AccountsControllerGetStateAction } from '@metamask/accounts-controller'
 
 type AllowedActions = AccountsControllerGetStateAction;
 
-type PreferencesControllerMessenger = RestrictedControllerMessenger<
+type PreferencesMessenger = RestrictedMessenger<
   'PreferencesController',
   AllowedActions,
   never,
@@ -1186,13 +1174,13 @@ type PreferencesControllerMessenger = RestrictedControllerMessenger<
 class PreferencesController extends BaseController<
   'PreferencesController',
   // ...
-  PreferencesControllerMessenger
+  PreferencesMessenger
 > {
   constructor({
     messenger,
   }: // ...
   {
-    messenger: PreferencesControllerMessenger;
+    messenger: PreferencesMessenger;
     // ...
   }) {
     // ...
@@ -1273,7 +1261,7 @@ type AccountsControllerActions =
   | AccountsControllerGetActiveAccountAction
   | AccountsControllerGetInactiveAccountsAction;
 
-export type AccountsControllerMessenger = RestrictedControllerMessenger<
+export type AccountsMessenger = RestrictedMessenger<
   'AccountsController',
   AccountsControllerActions,
   never,
@@ -1302,7 +1290,7 @@ type AllowedActions =
   | AccountsControllerGetActiveAccountsAction
   | AccountsControllerGetInactiveAccountsAction;
 
-export type TokensControllerMessenger = RestrictedControllerMessenger<
+export type TokensMessenger = RestrictedMessenger<
   'TokensController',
   AllowedActions,
   never,
@@ -1315,7 +1303,7 @@ class TokensController extends BaseController</* ... */> {
     messenger,
   }: // ...
   {
-    messenger: TokensControllerMessenger;
+    messenger: TokensMessenger;
     // ...
   }) {
     // ...
@@ -1383,7 +1371,7 @@ export type AccountsControllerGetStateAction = ControllerGetStateAction<
 
 type AccountsControllerActions = AccountsControllerGetStateAccountAction;
 
-export type AccountsControllerMessenger = RestrictedControllerMessenger<
+export type AccountsMessenger = RestrictedMessenger<
   'AccountsController',
   AccountsControllerActions,
   never,
@@ -1400,7 +1388,7 @@ import { accountsControllerSelectors } from '@metamask/accounts-controller';
 
 type AllowedActions = AccountsControllerGetStateAction;
 
-export type TokensControllerMessenger = RestrictedControllerMessenger<
+export type TokensMessenger = RestrictedMessenger<
   'TokensController',
   AllowedActions,
   never,
@@ -1413,7 +1401,7 @@ class TokensController extends BaseController</* ... */> {
     messenger,
     // ...
   }: {
-    messenger: TokensControllerMessenger,
+    messenger: TokensMessenger,
     // ...
   }) {
     // ...

--- a/examples/example-controllers/src/gas-prices-controller.test.ts
+++ b/examples/example-controllers/src/gas-prices-controller.test.ts
@@ -1,6 +1,6 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { GasPricesController } from '@metamask/example-controllers';
-import type { GasPricesControllerMessenger } from '@metamask/example-controllers';
+import type { GasPricesMessenger } from '@metamask/example-controllers';
 
 import type {
   ExtractAvailableAction,
@@ -27,7 +27,7 @@ describe('GasPricesController', () => {
         },
       };
       const controller = new GasPricesController({
-        messenger: getControllerMessenger(),
+        messenger: getMessenger(),
         state: givenState,
         gasPricesService,
       });
@@ -38,7 +38,7 @@ describe('GasPricesController', () => {
     it('fills in missing state properties with default values', () => {
       const gasPricesService = buildGasPricesService();
       const controller = new GasPricesController({
-        messenger: getControllerMessenger(),
+        messenger: getMessenger(),
         gasPricesService,
       });
 
@@ -66,14 +66,14 @@ describe('GasPricesController', () => {
         average: 10,
         high: 15,
       });
-      const rootMessenger = getRootControllerMessenger({
+      const rootMessenger = getRootMessenger({
         networkControllerGetStateActionHandler: () => ({
           ...getDefaultNetworkControllerState(),
           chainId: '0x42',
         }),
       });
       const controller = new GasPricesController({
-        messenger: getControllerMessenger(rootMessenger),
+        messenger: getMessenger(rootMessenger),
         gasPricesService,
       });
 
@@ -96,12 +96,12 @@ describe('GasPricesController', () => {
 /**
  * The union of actions that the root messenger allows.
  */
-type RootAction = ExtractAvailableAction<GasPricesControllerMessenger>;
+type RootAction = ExtractAvailableAction<GasPricesMessenger>;
 
 /**
  * The union of events that the root messenger allows.
  */
-type RootEvent = ExtractAvailableEvent<GasPricesControllerMessenger>;
+type RootEvent = ExtractAvailableEvent<GasPricesMessenger>;
 
 /**
  * Constructs the unrestricted messenger. This can be used to call actions and
@@ -112,7 +112,7 @@ type RootEvent = ExtractAvailableEvent<GasPricesControllerMessenger>;
  * `NetworkController:getState` action on the messenger.
  * @returns The unrestricted messenger suited for GasPricesController.
  */
-function getRootControllerMessenger({
+function getRootMessenger({
   networkControllerGetStateActionHandler = jest
     .fn<
       ReturnType<NetworkControllerGetStateAction['handler']>,
@@ -121,8 +121,8 @@ function getRootControllerMessenger({
     .mockReturnValue(getDefaultNetworkControllerState()),
 }: {
   networkControllerGetStateActionHandler?: NetworkControllerGetStateAction['handler'];
-} = {}): ControllerMessenger<RootAction, RootEvent> {
-  const rootMessenger = new ControllerMessenger<RootAction, RootEvent>();
+} = {}): Messenger<RootAction, RootEvent> {
+  const rootMessenger = new Messenger<RootAction, RootEvent>();
   rootMessenger.registerActionHandler(
     'NetworkController:getState',
     networkControllerGetStateActionHandler,
@@ -137,9 +137,7 @@ function getRootControllerMessenger({
  * @param rootMessenger - The root messenger to restrict.
  * @returns The restricted messenger.
  */
-function getControllerMessenger(
-  rootMessenger = getRootControllerMessenger(),
-): GasPricesControllerMessenger {
+function getMessenger(rootMessenger = getRootMessenger()): GasPricesMessenger {
   return rootMessenger.getRestricted({
     name: 'GasPricesController',
     allowedActions: ['NetworkController:getState'],

--- a/examples/example-controllers/src/gas-prices-controller.test.ts
+++ b/examples/example-controllers/src/gas-prices-controller.test.ts
@@ -1,6 +1,6 @@
 import { Messenger } from '@metamask/base-controller';
 import { GasPricesController } from '@metamask/example-controllers';
-import type { GasPricesMessenger } from '@metamask/example-controllers';
+import type { GasPricesControllerMessenger } from '@metamask/example-controllers';
 
 import type {
   ExtractAvailableAction,
@@ -96,12 +96,12 @@ describe('GasPricesController', () => {
 /**
  * The union of actions that the root messenger allows.
  */
-type RootAction = ExtractAvailableAction<GasPricesMessenger>;
+type RootAction = ExtractAvailableAction<GasPricesControllerMessenger>;
 
 /**
  * The union of events that the root messenger allows.
  */
-type RootEvent = ExtractAvailableEvent<GasPricesMessenger>;
+type RootEvent = ExtractAvailableEvent<GasPricesControllerMessenger>;
 
 /**
  * Constructs the unrestricted messenger. This can be used to call actions and
@@ -137,7 +137,9 @@ function getRootMessenger({
  * @param rootMessenger - The root messenger to restrict.
  * @returns The restricted messenger.
  */
-function getMessenger(rootMessenger = getRootMessenger()): GasPricesMessenger {
+function getMessenger(
+  rootMessenger = getRootMessenger(),
+): GasPricesControllerMessenger {
   return rootMessenger.getRestricted({
     name: 'GasPricesController',
     allowedActions: ['NetworkController:getState'],

--- a/examples/example-controllers/src/gas-prices-controller.ts
+++ b/examples/example-controllers/src/gas-prices-controller.ts
@@ -1,7 +1,7 @@
 import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   StateMetadata,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
@@ -121,7 +121,7 @@ type AllowedEvents = never;
  * The messenger which is restricted to actions and events accessed by
  * {@link GasPricesController}.
  */
-export type GasPricesControllerMessenger = RestrictedControllerMessenger<
+export type GasPricesMessenger = RestrictedMessenger<
   typeof controllerName,
   GasPricesControllerActions | AllowedActions,
   GasPricesControllerEvents | AllowedEvents,
@@ -151,7 +151,7 @@ export function getDefaultGasPricesControllerState(): GasPricesControllerState {
  * @example
  *
  * ``` ts
- * import { ControllerMessenger } from '@metamask/base-controller';
+ * import { Messenger } from '@metamask/base-controller';
  * import {
  *   GasPricesController,
  *   GasPricesService
@@ -164,7 +164,7 @@ export function getDefaultGasPricesControllerState(): GasPricesControllerState {
  *
  * // Assuming that you're using this in the browser
  * const gasPricesService = new GasPricesService({ fetch });
- * const rootMessenger = new ControllerMessenger<
+ * const rootMessenger = new Messenger<
  *  GasPricesControllerActions | NetworkControllerGetStateAction,
  *  GasPricesControllerEvents
  * >();
@@ -188,7 +188,7 @@ export function getDefaultGasPricesControllerState(): GasPricesControllerState {
 export class GasPricesController extends BaseController<
   typeof controllerName,
   GasPricesControllerState,
-  GasPricesControllerMessenger
+  GasPricesMessenger
 > {
   /**
    * The service object that is used to obtain gas prices.
@@ -210,7 +210,7 @@ export class GasPricesController extends BaseController<
     state,
     gasPricesService,
   }: {
-    messenger: GasPricesControllerMessenger;
+    messenger: GasPricesMessenger;
     state?: Partial<GasPricesControllerState>;
     gasPricesService: AbstractGasPricesService;
   }) {

--- a/examples/example-controllers/src/gas-prices-controller.ts
+++ b/examples/example-controllers/src/gas-prices-controller.ts
@@ -121,7 +121,7 @@ type AllowedEvents = never;
  * The messenger which is restricted to actions and events accessed by
  * {@link GasPricesController}.
  */
-export type GasPricesMessenger = RestrictedMessenger<
+export type GasPricesControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   GasPricesControllerActions | AllowedActions,
   GasPricesControllerEvents | AllowedEvents,
@@ -188,7 +188,7 @@ export function getDefaultGasPricesControllerState(): GasPricesControllerState {
 export class GasPricesController extends BaseController<
   typeof controllerName,
   GasPricesControllerState,
-  GasPricesMessenger
+  GasPricesControllerMessenger
 > {
   /**
    * The service object that is used to obtain gas prices.
@@ -210,7 +210,7 @@ export class GasPricesController extends BaseController<
     state,
     gasPricesService,
   }: {
-    messenger: GasPricesMessenger;
+    messenger: GasPricesControllerMessenger;
     state?: Partial<GasPricesControllerState>;
     gasPricesService: AbstractGasPricesService;
   }) {

--- a/examples/example-controllers/src/index.ts
+++ b/examples/example-controllers/src/index.ts
@@ -2,7 +2,7 @@ export type {
   GasPricesControllerActions,
   GasPricesControllerEvents,
   GasPricesControllerGetStateAction,
-  GasPricesMessenger,
+  GasPricesControllerMessenger,
   GasPricesControllerState,
   GasPricesControllerStateChangeEvent,
 } from './gas-prices-controller';
@@ -14,7 +14,7 @@ export type {
   PetNamesControllerActions,
   PetNamesControllerEvents,
   PetNamesControllerGetStateAction,
-  PetNamesMessenger,
+  PetNamesControllerMessenger,
   PetNamesControllerState,
   PetNamesControllerStateChangeEvent,
 } from './pet-names-controller';

--- a/examples/example-controllers/src/index.ts
+++ b/examples/example-controllers/src/index.ts
@@ -2,7 +2,7 @@ export type {
   GasPricesControllerActions,
   GasPricesControllerEvents,
   GasPricesControllerGetStateAction,
-  GasPricesControllerMessenger,
+  GasPricesMessenger,
   GasPricesControllerState,
   GasPricesControllerStateChangeEvent,
 } from './gas-prices-controller';
@@ -14,7 +14,7 @@ export type {
   PetNamesControllerActions,
   PetNamesControllerEvents,
   PetNamesControllerGetStateAction,
-  PetNamesControllerMessenger,
+  PetNamesMessenger,
   PetNamesControllerState,
   PetNamesControllerStateChangeEvent,
 } from './pet-names-controller';

--- a/examples/example-controllers/src/pet-names-controller.test.ts
+++ b/examples/example-controllers/src/pet-names-controller.test.ts
@@ -1,11 +1,11 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 
 import type {
   ExtractAvailableAction,
   ExtractAvailableEvent,
 } from '../../../packages/base-controller/tests/helpers';
 import { PROTOTYPE_POLLUTION_BLOCKLIST } from '../../../packages/controller-utils/src/util';
-import type { PetNamesControllerMessenger } from './pet-names-controller';
+import type { PetNamesMessenger } from './pet-names-controller';
 import { PetNamesController } from './pet-names-controller';
 
 describe('PetNamesController', () => {
@@ -20,7 +20,7 @@ describe('PetNamesController', () => {
         },
       };
       const controller = new PetNamesController({
-        messenger: getControllerMessenger(),
+        messenger: getMessenger(),
         state: givenState,
       });
 
@@ -29,7 +29,7 @@ describe('PetNamesController', () => {
 
     it('fills in missing state properties with default values', () => {
       const controller = new PetNamesController({
-        messenger: getControllerMessenger(),
+        messenger: getMessenger(),
       });
 
       expect(controller.state).toMatchInlineSnapshot(`
@@ -44,7 +44,7 @@ describe('PetNamesController', () => {
     for (const blockedKey of PROTOTYPE_POLLUTION_BLOCKLIST) {
       it(`throws if given a chainId of "${blockedKey}"`, () => {
         const controller = new PetNamesController({
-          messenger: getControllerMessenger(),
+          messenger: getMessenger(),
         });
 
         expect(() =>
@@ -56,7 +56,7 @@ describe('PetNamesController', () => {
 
     it('registers the given pet name in state with the given chain ID and address', () => {
       const controller = new PetNamesController({
-        messenger: getControllerMessenger(),
+        messenger: getMessenger(),
         state: {
           namesByChainIdAndAddress: {
             '0x1': {
@@ -80,7 +80,7 @@ describe('PetNamesController', () => {
 
     it("creates a new group for the chain if it doesn't already exist", () => {
       const controller = new PetNamesController({
-        messenger: getControllerMessenger(),
+        messenger: getMessenger(),
       });
 
       controller.assignPetName('0x1', '0xaaaaaa', 'My Account');
@@ -96,7 +96,7 @@ describe('PetNamesController', () => {
 
     it('overwrites any existing pet name for the address', () => {
       const controller = new PetNamesController({
-        messenger: getControllerMessenger(),
+        messenger: getMessenger(),
         state: {
           namesByChainIdAndAddress: {
             '0x1': {
@@ -119,7 +119,7 @@ describe('PetNamesController', () => {
 
     it('lowercases the given address before registering it to avoid duplicate entries', () => {
       const controller = new PetNamesController({
-        messenger: getControllerMessenger(),
+        messenger: getMessenger(),
         state: {
           namesByChainIdAndAddress: {
             '0x1': {
@@ -145,12 +145,12 @@ describe('PetNamesController', () => {
 /**
  * The union of actions that the root messenger allows.
  */
-type RootAction = ExtractAvailableAction<PetNamesControllerMessenger>;
+type RootAction = ExtractAvailableAction<PetNamesMessenger>;
 
 /**
  * The union of events that the root messenger allows.
  */
-type RootEvent = ExtractAvailableEvent<PetNamesControllerMessenger>;
+type RootEvent = ExtractAvailableEvent<PetNamesMessenger>;
 
 /**
  * Constructs the unrestricted messenger. This can be used to call actions and
@@ -158,11 +158,8 @@ type RootEvent = ExtractAvailableEvent<PetNamesControllerMessenger>;
  *
  * @returns The unrestricted messenger suited for PetNamesController.
  */
-function getRootControllerMessenger(): ControllerMessenger<
-  RootAction,
-  RootEvent
-> {
-  return new ControllerMessenger<RootAction, RootEvent>();
+function getRootMessenger(): Messenger<RootAction, RootEvent> {
+  return new Messenger<RootAction, RootEvent>();
 }
 
 /**
@@ -172,9 +169,7 @@ function getRootControllerMessenger(): ControllerMessenger<
  * @param rootMessenger - The root messenger to restrict.
  * @returns The restricted messenger.
  */
-function getControllerMessenger(
-  rootMessenger = getRootControllerMessenger(),
-): PetNamesControllerMessenger {
+function getMessenger(rootMessenger = getRootMessenger()): PetNamesMessenger {
   return rootMessenger.getRestricted({
     name: 'PetNamesController',
     allowedActions: [],

--- a/examples/example-controllers/src/pet-names-controller.test.ts
+++ b/examples/example-controllers/src/pet-names-controller.test.ts
@@ -5,7 +5,7 @@ import type {
   ExtractAvailableEvent,
 } from '../../../packages/base-controller/tests/helpers';
 import { PROTOTYPE_POLLUTION_BLOCKLIST } from '../../../packages/controller-utils/src/util';
-import type { PetNamesMessenger } from './pet-names-controller';
+import type { PetNamesControllerMessenger } from './pet-names-controller';
 import { PetNamesController } from './pet-names-controller';
 
 describe('PetNamesController', () => {
@@ -145,12 +145,12 @@ describe('PetNamesController', () => {
 /**
  * The union of actions that the root messenger allows.
  */
-type RootAction = ExtractAvailableAction<PetNamesMessenger>;
+type RootAction = ExtractAvailableAction<PetNamesControllerMessenger>;
 
 /**
  * The union of events that the root messenger allows.
  */
-type RootEvent = ExtractAvailableEvent<PetNamesMessenger>;
+type RootEvent = ExtractAvailableEvent<PetNamesControllerMessenger>;
 
 /**
  * Constructs the unrestricted messenger. This can be used to call actions and
@@ -169,7 +169,9 @@ function getRootMessenger(): Messenger<RootAction, RootEvent> {
  * @param rootMessenger - The root messenger to restrict.
  * @returns The restricted messenger.
  */
-function getMessenger(rootMessenger = getRootMessenger()): PetNamesMessenger {
+function getMessenger(
+  rootMessenger = getRootMessenger(),
+): PetNamesControllerMessenger {
   return rootMessenger.getRestricted({
     name: 'PetNamesController',
     allowedActions: [],

--- a/examples/example-controllers/src/pet-names-controller.ts
+++ b/examples/example-controllers/src/pet-names-controller.ts
@@ -89,7 +89,7 @@ type AllowedEvents = never;
  * The messenger which is restricted to actions and events accessed by
  * {@link PetNamesController}.
  */
-export type PetNamesMessenger = RestrictedMessenger<
+export type PetNamesControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   PetNamesControllerActions | AllowedActions,
   PetNamesControllerEvents | AllowedEvents,
@@ -151,7 +151,7 @@ export function getDefaultPetNamesControllerState(): PetNamesControllerState {
 export class PetNamesController extends BaseController<
   typeof controllerName,
   PetNamesControllerState,
-  PetNamesMessenger
+  PetNamesControllerMessenger
 > {
   /**
    * Constructs a new {@link PetNamesController}.
@@ -165,7 +165,7 @@ export class PetNamesController extends BaseController<
     messenger,
     state,
   }: {
-    messenger: PetNamesMessenger;
+    messenger: PetNamesControllerMessenger;
     state?: Partial<PetNamesControllerState>;
   }) {
     super({

--- a/examples/example-controllers/src/pet-names-controller.ts
+++ b/examples/example-controllers/src/pet-names-controller.ts
@@ -1,7 +1,7 @@
 import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   StateMetadata,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
@@ -89,7 +89,7 @@ type AllowedEvents = never;
  * The messenger which is restricted to actions and events accessed by
  * {@link PetNamesController}.
  */
-export type PetNamesControllerMessenger = RestrictedControllerMessenger<
+export type PetNamesMessenger = RestrictedMessenger<
   typeof controllerName,
   PetNamesControllerActions | AllowedActions,
   PetNamesControllerEvents | AllowedEvents,
@@ -120,13 +120,13 @@ export function getDefaultPetNamesControllerState(): PetNamesControllerState {
  * @example
  *
  * ``` ts
- * import { ControllerMessenger } from '@metamask/base-controller';
+ * import { Messenger } from '@metamask/base-controller';
  * import type {
  *   PetNamesControllerActions,
  *   PetNamesControllerEvents
  * } from '@metamask/example-controllers';
  *
- * const rootMessenger = new ControllerMessenger<
+ * const rootMessenger = new Messenger<
  *  PetNamesControllerActions,
  *  PetNamesControllerEvents
  * >();
@@ -151,7 +151,7 @@ export function getDefaultPetNamesControllerState(): PetNamesControllerState {
 export class PetNamesController extends BaseController<
   typeof controllerName,
   PetNamesControllerState,
-  PetNamesControllerMessenger
+  PetNamesMessenger
 > {
   /**
    * Constructs a new {@link PetNamesController}.
@@ -165,7 +165,7 @@ export class PetNamesController extends BaseController<
     messenger,
     state,
   }: {
-    messenger: PetNamesControllerMessenger;
+    messenger: PetNamesMessenger;
     state?: Partial<PetNamesControllerState>;
   }) {
     super({


### PR DESCRIPTION
## Explanation

Rename `ControllerMessenger` to `Messenger` in the controller docs and examples.

## References

Relates to #4538

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
