### PR TITLE
fix(3741): refactor remote-feature-flag controller with generateDeterministicRandomNumber and getMetaMetricsId

### DIFF
--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
@@ -134,6 +134,23 @@ describe('ClientConfigApiService', () => {
     });
   });
 
+  describe('getClient', () => {
+    it('returns configured client type', () => {
+      const clientConfigApiService = new ClientConfigApiService({
+        fetch: createMockFetch({}),
+        config: {
+          client: ClientType.Extension,
+          distribution: DistributionType.Main,
+          environment: EnvironmentType.Production,
+        },
+      });
+
+      expect(clientConfigApiService.getClient()).toStrictEqual(
+        ClientType.Extension,
+      );
+    });
+  });
+
   describe('circuit breaker', () => {
     it('opens the circuit breaker after consecutive failures', async () => {
       const mockFetch = createMockFetch({ error: networkError });

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
@@ -149,6 +149,14 @@ export class ClientConfigApiService {
   }
 
   /**
+   * Gets the client type configured for this service.
+   * @returns The configured ClientType
+   */
+  public getClient(): ClientType {
+    return this.#client;
+  }
+
+  /**
    * Flattens an array of feature flag objects into a single feature flags object.
    * @param responseData - Array of objects containing feature flag key-value pairs
    * @returns A single object containing all feature flags merged together

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -59,7 +59,7 @@ function createController(
     state: Partial<RemoteFeatureFlagControllerState>;
     clientConfigApiService: AbstractClientConfigApiService;
     disabled: boolean;
-    getMetaMetricsId: () => Promise<string> | string;
+    getMetaMetricsId: () => string;
   }> = {},
 ) {
   return new RemoteFeatureFlagController({
@@ -68,8 +68,7 @@ function createController(
     clientConfigApiService:
       options.clientConfigApiService ?? buildClientConfigApiService(),
     disabled: options.disabled,
-    getMetaMetricsId:
-      options.getMetaMetricsId ?? (() => Promise.resolve(MOCK_METRICS_ID)),
+    getMetaMetricsId: options.getMetaMetricsId ?? (() => MOCK_METRICS_ID),
   });
 }
 
@@ -273,7 +272,7 @@ describe('RemoteFeatureFlagController', () => {
       });
       const controller = createController({
         clientConfigApiService,
-        getMetaMetricsId: () => Promise.resolve(MOCK_METRICS_ID),
+        getMetaMetricsId: () => MOCK_METRICS_ID,
       });
       await controller.updateRemoteFeatureFlags();
 
@@ -291,32 +290,13 @@ describe('RemoteFeatureFlagController', () => {
       });
       const controller = createController({
         clientConfigApiService,
-        getMetaMetricsId: () => Promise.resolve(MOCK_METRICS_ID),
+        getMetaMetricsId: () => MOCK_METRICS_ID,
       });
       await controller.updateRemoteFeatureFlags();
 
       const { testFlagForThreshold, ...nonThresholdFlags } =
         controller.state.remoteFeatureFlags;
       expect(nonThresholdFlags).toStrictEqual(MOCK_FLAGS);
-    });
-
-    it('handles synchronous metaMetricsId', async () => {
-      const clientConfigApiService = buildClientConfigApiService({
-        remoteFeatureFlags: MOCK_FLAGS_WITH_THRESHOLD,
-      });
-      const controller = createController({
-        clientConfigApiService,
-        getMetaMetricsId: () => MOCK_METRICS_ID,
-      });
-
-      await controller.updateRemoteFeatureFlags();
-
-      expect(
-        controller.state.remoteFeatureFlags.testFlagForThreshold,
-      ).toStrictEqual({
-        name: 'groupC',
-        value: 'valueC',
-      });
     });
   });
 

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -102,7 +102,7 @@ export class RemoteFeatureFlagController extends BaseController<
 
   #inProgressFlagUpdate?: Promise<ServiceResponse>;
 
-  #getMetaMetricsId: () => string | Promise<string>;
+  #getMetaMetricsId: () => string;
 
   /**
    * Constructs a new RemoteFeatureFlagController instance.
@@ -126,7 +126,7 @@ export class RemoteFeatureFlagController extends BaseController<
     messenger: RemoteFeatureFlagControllerMessenger;
     state?: Partial<RemoteFeatureFlagControllerState>;
     clientConfigApiService: AbstractClientConfigApiService;
-    getMetaMetricsId: () => string | Promise<string>;
+    getMetaMetricsId: () => string;
     fetchInterval?: number;
     disabled?: boolean;
   }) {
@@ -208,11 +208,7 @@ export class RemoteFeatureFlagController extends BaseController<
     remoteFeatureFlags: FeatureFlags,
   ): Promise<FeatureFlags> {
     const processedRemoteFeatureFlags: FeatureFlags = {};
-    const metaMetricsIdResult = this.#getMetaMetricsId();
-    const metaMetricsId =
-      metaMetricsIdResult instanceof Promise
-        ? await metaMetricsIdResult
-        : metaMetricsIdResult;
+    const metaMetricsId = this.#getMetaMetricsId();
 
     const clientType = this.#clientConfigApiService.getClient();
     const thresholdValue = generateDeterministicRandomNumber(

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
@@ -10,8 +10,8 @@ const MOCK_METRICS_IDS = {
   MOBILE_VALID: '123e4567-e89b-4456-a456-426614174000',
   EXTENSION_VALID:
     '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
-  MOBILE_MIN: '00000000-0000-0000-0000-000000000000',
-  MOBILE_MAX: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+  MOBILE_MIN: '00000000-4000-0000-0000-000000000000',
+  MOBILE_MAX: 'ffffffff-4fff-ffff-ffff-ffffffffffff',
   EXTENSION_MIN: `0x${'0'.repeat(64)}`,
   EXTENSION_MAX: `0x${'f'.repeat(64)}`,
 };

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
@@ -1,17 +1,20 @@
-import { validate as uuidValidate, version as uuidVersion } from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
+import { ClientType } from '../remote-feature-flag-controller-types';
 import {
   generateDeterministicRandomNumber,
   isFeatureFlagWithScopeValue,
-  generateFallbackMetaMetricsId,
 } from './user-segmentation-utils';
 
-const MOCK_METRICS_IDS = [
-  '123e4567-e89b-4456-a456-426614174000',
-  '987fcdeb-51a2-4c4b-9876-543210fedcba',
-  'a1b2c3d4-e5f6-4890-abcd-ef1234567890',
-  'f9e8d7c6-b5a4-4210-9876-543210fedcba',
-];
+const MOCK_METRICS_IDS = {
+  MOBILE_VALID: '123e4567-e89b-4456-a456-426614174000',
+  EXTENSION_VALID:
+    '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
+  MOBILE_MIN: '00000000-0000-0000-0000-000000000000',
+  MOBILE_MAX: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+  EXTENSION_MIN: `0x${'0'.repeat(64)}`,
+  EXTENSION_MAX: `0x${'f'.repeat(64)}`,
+};
 
 const MOCK_FEATURE_FLAGS = {
   VALID: {
@@ -31,26 +34,112 @@ const MOCK_FEATURE_FLAGS = {
 
 describe('user-segmentation-utils', () => {
   describe('generateDeterministicRandomNumber', () => {
-    it('generates consistent numbers for the same input', () => {
-      const result1 = generateDeterministicRandomNumber(MOCK_METRICS_IDS[0]);
-      const result2 = generateDeterministicRandomNumber(MOCK_METRICS_IDS[0]);
+    describe('Mobile client (uuidv4)', () => {
+      it('generates consistent results for same uuidv4', () => {
+        const result1 = generateDeterministicRandomNumber(
+          ClientType.Mobile,
+          MOCK_METRICS_IDS.MOBILE_VALID,
+        );
+        const result2 = generateDeterministicRandomNumber(
+          ClientType.Mobile,
+          MOCK_METRICS_IDS.MOBILE_VALID,
+        );
+        expect(result1).toBe(result2);
+      });
 
-      expect(result1).toBe(result2);
-    });
+      it('handles minimum uuidv4 value', () => {
+        const result = generateDeterministicRandomNumber(
+          ClientType.Mobile,
+          MOCK_METRICS_IDS.MOBILE_MIN,
+        );
+        expect(result).toBeGreaterThanOrEqual(0);
+        expect(result).toBeLessThanOrEqual(1);
+      });
 
-    it('generates numbers between 0 and 1', () => {
-      MOCK_METRICS_IDS.forEach((id) => {
-        const result = generateDeterministicRandomNumber(id);
+      it('handles maximum uuidv4 value', () => {
+        const result = generateDeterministicRandomNumber(
+          ClientType.Mobile,
+          MOCK_METRICS_IDS.MOBILE_MAX,
+        );
         expect(result).toBeGreaterThanOrEqual(0);
         expect(result).toBeLessThanOrEqual(1);
       });
     });
 
-    it('generates different numbers for different inputs', () => {
-      const result1 = generateDeterministicRandomNumber(MOCK_METRICS_IDS[0]);
-      const result2 = generateDeterministicRandomNumber(MOCK_METRICS_IDS[1]);
+    describe('Extension client (hex string)', () => {
+      it('generates consistent results for same hex', () => {
+        const result1 = generateDeterministicRandomNumber(
+          ClientType.Extension,
+          MOCK_METRICS_IDS.EXTENSION_VALID,
+        );
+        const result2 = generateDeterministicRandomNumber(
+          ClientType.Extension,
+          MOCK_METRICS_IDS.EXTENSION_VALID,
+        );
+        expect(result1).toBe(result2);
+      });
 
-      expect(result1).not.toBe(result2);
+      it('handles minimum hex value', () => {
+        const result = generateDeterministicRandomNumber(
+          ClientType.Extension,
+          MOCK_METRICS_IDS.EXTENSION_MIN,
+        );
+        expect(result).toBe(0);
+      });
+
+      it('handles maximum hex value', () => {
+        const result = generateDeterministicRandomNumber(
+          ClientType.Extension,
+          MOCK_METRICS_IDS.EXTENSION_MAX,
+        );
+        expect(result).toBe(1);
+      });
+    });
+
+    describe('Distribution validation', () => {
+      it('produces uniform distribution', () => {
+        const samples = 1000;
+        const buckets = 10;
+        const distribution = new Array(buckets).fill(0);
+
+        // Generate samples using valid UUIDs
+        Array.from({ length: samples }).forEach(() => {
+          const randomUUID = uuidv4();
+          const value = generateDeterministicRandomNumber(
+            ClientType.Mobile,
+            randomUUID,
+          );
+          const bucketIndex = Math.floor(value * buckets);
+          distribution[bucketIndex] += 1;
+        });
+
+        // Check distribution
+        const expectedPerBucket = samples / buckets;
+        const tolerance = expectedPerBucket * 0.3; // 30% tolerance
+
+        distribution.forEach((count) => {
+          expect(count).toBeGreaterThanOrEqual(expectedPerBucket - tolerance);
+          expect(count).toBeLessThanOrEqual(expectedPerBucket + tolerance);
+        });
+      });
+    });
+
+    describe('Client type handling', () => {
+      it('defaults to Extension handling for undefined client type', () => {
+        const undefinedClient = 'undefined' as unknown as ClientType;
+        const result = generateDeterministicRandomNumber(
+          undefinedClient,
+          MOCK_METRICS_IDS.EXTENSION_VALID,
+        );
+
+        // Should match Extension result
+        const extensionResult = generateDeterministicRandomNumber(
+          ClientType.Extension,
+          MOCK_METRICS_IDS.EXTENSION_VALID,
+        );
+
+        expect(result).toBe(extensionResult);
+      });
     });
   });
 
@@ -73,14 +162,6 @@ describe('user-segmentation-utils', () => {
       expect(
         isFeatureFlagWithScopeValue(MOCK_FEATURE_FLAGS.INVALID_NO_SCOPE),
       ).toBe(false);
-    });
-  });
-
-  describe('generateFallbackMetaMetricsId', () => {
-    it('returns a valid uuidv4', () => {
-      const result = generateFallbackMetaMetricsId();
-      expect(uuidValidate(result)).toBe(true);
-      expect(uuidVersion(result)).toBe(4);
     });
   });
 });


### PR DESCRIPTION
## Explanation
Changes introduced in this PR including:
- remove fallback of `metaMetricsId` and rely on client side always returning a value
- change logic of `generateDeterministicRandomNumber` to handle both mobile(uuidv4) and extension(hex) side
- refactor `getMetaMetricsId` to only handle synchronous (extension) function

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References
Address feedback about

- https://github.com/MetaMask/core/pull/5051#discussion_r1883046468
- https://github.com/MetaMask/core/pull/5051#discussion_r1883056128
<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/remote-feature-flag-controller`

- **ADDED**: Expand signature of `getMetaMetricsId` to handle both synchronous function
- **CHANGED**: Modify `generateDeterministicRandomNumber` to handle both mobile(uuidv4) and extension(hex) side
- **CHANGED**:  Remove fallback of `metaMetricsId`

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
