### PR TITLE
fix: fix mantle price when calling fetchMultiExchangeRate

### DIFF
--- a/packages/assets-controllers/src/assetsUtil.test.ts
+++ b/packages/assets-controllers/src/assetsUtil.test.ts
@@ -743,6 +743,17 @@ describe('assetsUtil', () => {
       }
     });
   });
+
+  describe('getKeyByValue', () => {
+    it('should return correct key for a specific value', () => {
+      const testMap = new Map([
+        ['toto', 'koko'],
+        ['foo', 'bar'],
+      ]);
+      const result = assetsUtil.getKeyByValue(testMap, 'koko');
+      expect(result).toBe('toto');
+    });
+  });
 });
 
 /**

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -433,3 +433,18 @@ export async function fetchTokenContractExchangeRates({
     {},
   );
 }
+
+/**
+ * Function to search for a specific value in a given map and return the key
+ * @param map - map input to search value
+ * @param value - the value to search for
+ * @returns returns key that corresponds to the value
+ */
+export function getKeyByValue(map: Map<string, string>, value: string) {
+  for (const [key, val] of map.entries()) {
+    if (val === value) {
+      return key;
+    }
+  }
+  return null; // Return null if no match is found
+}

--- a/packages/assets-controllers/src/crypto-compare-service/crypto-compare.test.ts
+++ b/packages/assets-controllers/src/crypto-compare-service/crypto-compare.test.ts
@@ -195,5 +195,21 @@ describe('CryptoCompare', () => {
         sol: { eur: 3000 },
       });
     });
+
+    it('should override native symbol for mantle native token', async () => {
+      nock(cryptoCompareHost)
+        .get('/data/pricemulti?fsyms=MANTLE,ETH&tsyms=EUR')
+        .reply(200, {
+          MANTLE: { EUR: 1000 },
+          ETH: { EUR: 2000 },
+        });
+
+      // @ts-expect-error Testing the case where the USD rate is not included
+      const response = await fetchMultiExchangeRate('EUR', ['MNT', 'ETH']);
+      expect(response).toStrictEqual({
+        eth: { eur: 2000 },
+        mnt: { eur: 1000 },
+      });
+    });
   });
 });

--- a/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
+++ b/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
@@ -1,5 +1,7 @@
 import { handleFetch } from '@metamask/controller-utils';
 
+import { getKeyByValue } from '../assetsUtil';
+
 /**
  * A map from native currency symbol to CryptoCompare identifier.
  * This is only needed when the values don't match.
@@ -141,11 +143,11 @@ export async function fetchMultiExchangeRate(
   cryptocurrencies: string[],
   includeUSDRate: boolean,
 ): Promise<Record<string, Record<string, number>>> {
-  const url = getMultiPricingURL(
-    cryptocurrencies,
-    [fiatCurrency],
-    includeUSDRate,
+  const fsyms = cryptocurrencies.map(
+    (nativeCurrency) =>
+      nativeSymbolOverrides.get(nativeCurrency) ?? nativeCurrency,
   );
+  const url = getMultiPricingURL(fsyms, [fiatCurrency], includeUSDRate);
   const response = await handleFetch(url);
   handleErrorResponse(response);
 
@@ -154,7 +156,8 @@ export async function fetchMultiExchangeRate(
     string,
     Record<string, number>,
   ][]) {
-    rates[cryptocurrency.toLowerCase()] = {
+    const key = getKeyByValue(nativeSymbolOverrides, cryptocurrency);
+    rates[key?.toLowerCase() ?? cryptocurrency.toLowerCase()] = {
       [fiatCurrency.toLowerCase()]: values[fiatCurrency.toUpperCase()],
       ...(includeUSDRate && { usd: values.USD }),
     };

--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -130,6 +130,7 @@ export {
   formatIconUrlWithProxy,
   getFormattedIpfsUrl,
   fetchTokenContractExchangeRates,
+  getKeyByValue,
 } from './assetsUtil';
 export {
   CodefiTokenPricesServiceV2,


### PR DESCRIPTION
## Explanation

PR to fix the MANTLE price fetched for chainId: 5000.

Cryptocompare api provides prices for both MANTLE and MNT: https://min-api.cryptocompare.com/data/pricemulti?fsyms=ETH%2CMNT%2CMANTLE&tsyms=usd
And it is returning the the price for 'MNT' when the user in on MANTLE chain.


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **FIXED**: Added a check if any of the provided cyrptocurrencies to `fetchMultiExchangeRate` fct exists in `nativeSymbolOverrides` map
- **ADDED**: Added utility function `getKeyByValue` to assetsUtils


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
