### PR TITLE
fix: match signature request and message params ID

### DIFF
--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -185,7 +185,7 @@ describe('SignatureController', () => {
 
     normalizePersonalMessageParamsMock.mockImplementation((params) => params);
     normalizeTypedMessageParamsMock.mockImplementation((params) => params);
-    uuidV1Mock.mockReturnValue(ID_MOCK);
+    uuidV1Mock.mockReturnValueOnce(ID_MOCK);
   });
 
   describe('unapprovedPersonalMessagesCount', () => {

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -580,7 +580,7 @@ export class SignatureController extends BaseController<
 
     const metadata = {
       chainId,
-      id: random(),
+      id,
       messageParams: finalMessageParams,
       networkClientId,
       securityAlertResponse,


### PR DESCRIPTION
## Explanation

Ensure the signature request `id` and message params `metamaskId` use the same value so that legacy code using only the message params can locate the associated signature request.

## References

## Changelog

### `@metamask/signature-controller`

- **FIXED**: Use same value for signature request `id` and message params `metamaskId`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
