### PR TITLE
fix(3742): change getMetaMetricsId to only sync func type

### DIFF
--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -14,7 +14,6 @@ import type {
 import {
   generateDeterministicRandomNumber,
   isFeatureFlagWithScopeValue,
-  generateFallbackMetaMetricsId,
 } from './utils/user-segmentation-utils';
 
 // === GENERAL ===
@@ -103,7 +102,7 @@ export class RemoteFeatureFlagController extends BaseController<
 
   #inProgressFlagUpdate?: Promise<ServiceResponse>;
 
-  #getMetaMetricsId?: Promise<string | undefined>;
+  #getMetaMetricsId: () => string;
 
   /**
    * Constructs a new RemoteFeatureFlagController instance.
@@ -114,7 +113,7 @@ export class RemoteFeatureFlagController extends BaseController<
    * @param options.clientConfigApiService - The service instance to fetch remote feature flags.
    * @param options.fetchInterval - The interval in milliseconds before cached flags expire. Defaults to 1 day.
    * @param options.disabled - Determines if the controller should be disabled initially. Defaults to false.
-   * @param options.getMetaMetricsId - Promise that resolves to a metaMetricsId.
+   * @param options.getMetaMetricsId - Returns metaMetricsId.
    */
   constructor({
     messenger,
@@ -127,7 +126,7 @@ export class RemoteFeatureFlagController extends BaseController<
     messenger: RemoteFeatureFlagControllerMessenger;
     state?: Partial<RemoteFeatureFlagControllerState>;
     clientConfigApiService: AbstractClientConfigApiService;
-    getMetaMetricsId?: Promise<string | undefined>;
+    getMetaMetricsId: () => string;
     fetchInterval?: number;
     disabled?: boolean;
   }) {
@@ -209,8 +208,7 @@ export class RemoteFeatureFlagController extends BaseController<
     remoteFeatureFlags: FeatureFlags,
   ): Promise<FeatureFlags> {
     const processedRemoteFeatureFlags: FeatureFlags = {};
-    const metaMetricsId =
-      (await this.#getMetaMetricsId) || generateFallbackMetaMetricsId();
+    const metaMetricsId = this.#getMetaMetricsId();
     const thresholdValue = generateDeterministicRandomNumber(metaMetricsId);
 
     for (const [

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
@@ -1,9 +1,6 @@
-import { validate as uuidValidate, version as uuidVersion } from 'uuid';
-
 import {
   generateDeterministicRandomNumber,
   isFeatureFlagWithScopeValue,
-  generateFallbackMetaMetricsId,
 } from './user-segmentation-utils';
 
 const MOCK_METRICS_IDS = [
@@ -73,14 +70,6 @@ describe('user-segmentation-utils', () => {
       expect(
         isFeatureFlagWithScopeValue(MOCK_FEATURE_FLAGS.INVALID_NO_SCOPE),
       ).toBe(false);
-    });
-  });
-
-  describe('generateFallbackMetaMetricsId', () => {
-    it('returns a valid uuidv4', () => {
-      const result = generateFallbackMetaMetricsId();
-      expect(uuidValidate(result)).toBe(true);
-      expect(uuidVersion(result)).toBe(4);
     });
   });
 });

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts
@@ -1,5 +1,4 @@
 import type { Json } from '@metamask/utils';
-import { v4 as uuidV4 } from 'uuid';
 
 import type { FeatureFlagScopeValue } from '../remote-feature-flag-controller-types';
 
@@ -39,11 +38,3 @@ export const isFeatureFlagWithScopeValue = (
     'scope' in featureFlag
   );
 };
-
-/**
- * Generates UUIDv4 as a fallback metaMetricsId
- * @returns A UUIDv4 string
- */
-export function generateFallbackMetaMetricsId(): string {
-  return uuidV4();
-}


### PR DESCRIPTION
## Explanation
Changes introduced in this PR including:

- remove fallback of metaMetricsId and rely on client side always returning a value
- refactor getMetaMetricsId to only handle synchronous (extension) function

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References
Addressed feedback https://github.com/MetaMask/core/pull/5051#discussion_r1883046468
<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/remote-feature-flag-controller`

- **CHANGED**: Modify signature of `getMetaMetricsId` to handle only synchronous function
- **CHANGED**:  Remove fallback of `metaMetricsId`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
