### PR TITLE
fix(scripts): fix create-package path check

### DIFF
--- a/scripts/create-package/utils.ts
+++ b/scripts/create-package/utils.ts
@@ -83,6 +83,24 @@ export async function readMonorepoFiles(): Promise<MonorepoFileData> {
 }
 
 /**
+ * Checks if a package path already exists.
+ *
+ * @param packagePath - The package path.
+ * @returns True if the path exists, false otherwise.
+ */
+async function packagePathExists(packagePath: string) {
+  try {
+    // We use `access`, cause no matter if `packagePath` is a directory or a file, we won't
+    // be able to write anything there if it already exists.
+    await fs.access(packagePath);
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Finalizes package and repo files, writes them to disk, and performs necessary
  * postprocessing (e.g. running `yarn install`).
  *
@@ -94,7 +112,7 @@ export async function finalizeAndWriteData(
   monorepoFileData: MonorepoFileData,
 ) {
   const packagePath = path.join(PACKAGES_PATH, packageData.directoryName);
-  if ((await fs.stat(packagePath)).isDirectory()) {
+  if (await packagePathExists(packagePath)) {
     throw new Error(`The package directory already exists: ${packagePath}`);
   }
 


### PR DESCRIPTION
## Explanation

It was not possible to use `yarn create-package` to create new package with the current implementation since `fs.stat` throws an error if the path does not exists.

Also, I replaced `stat` by `access`, cause if the path already exists (no matter if it's a dir or file), the script will fail since the path is not "available".

## References

N/A

## Changelog

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
