### PR TITLE
fix: create-package script

### DIFF
--- a/scripts/create-package/utils.test.ts
+++ b/scripts/create-package/utils.test.ts
@@ -87,9 +87,10 @@ describe('create-package/utils', () => {
         nodeVersions: '>=18.0.0',
       };
 
-      (fs.promises.stat as jest.Mock).mockResolvedValueOnce({
-        isDirectory: () => false,
-      });
+      const mockError = new Error('Not found') as NodeJS.ErrnoException;
+      mockError.code = 'ENOENT';
+
+      jest.spyOn(fs.promises, 'stat').mockRejectedValue(mockError);
 
       (fsUtils.readAllFiles as jest.Mock).mockResolvedValueOnce({
         'src/index.ts': 'export default 42;',
@@ -170,9 +171,7 @@ describe('create-package/utils', () => {
         nodeVersions: '20.0.0',
       };
 
-      (fs.promises.stat as jest.Mock).mockResolvedValueOnce({
-        isDirectory: () => true,
-      });
+      (fs.promises.stat as jest.Mock).mockResolvedValue({});
 
       await expect(
         finalizeAndWriteData(packageData, monorepoFileData),
@@ -180,6 +179,35 @@ describe('create-package/utils', () => {
 
       expect(fs.promises.mkdir).not.toHaveBeenCalled();
       expect(fs.promises.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('throws if fs.stat fails with an error other than ENOENT', async () => {
+      const mockError = new Error('Permission denied') as NodeJS.ErrnoException;
+      mockError.code = 'EACCES';
+
+      jest.spyOn(fs.promises, 'stat').mockRejectedValue(mockError);
+
+      const packageData: PackageData = {
+        name: '@metamask/foo',
+        description: 'A foo package.',
+        directoryName: 'foo',
+        nodeVersions: '20.0.0',
+        currentYear: '2023',
+      };
+
+      const monorepoFileData = {
+        tsConfig: {
+          references: [{ path: './packages/bar' }],
+        },
+        tsConfigBuild: {
+          references: [{ path: './packages/bar' }],
+        },
+        nodeVersions: '20.0.0',
+      };
+
+      await expect(
+        finalizeAndWriteData(packageData, monorepoFileData),
+      ).rejects.toThrow('Permission denied');
     });
   });
 });

--- a/scripts/create-package/utils.ts
+++ b/scripts/create-package/utils.ts
@@ -94,8 +94,13 @@ export async function finalizeAndWriteData(
   monorepoFileData: MonorepoFileData,
 ) {
   const packagePath = path.join(PACKAGES_PATH, packageData.directoryName);
-  if ((await fs.stat(packagePath)).isDirectory()) {
+  try {
+    await fs.stat(packagePath);
     throw new Error(`The package directory already exists: ${packagePath}`);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
   }
 
   console.log('Writing package and monorepo files...');
@@ -136,7 +141,7 @@ async function writeJsonFile(
 ): Promise<void> {
   await fs.writeFile(
     filePath,
-    prettierFormat(fileContent, { ...prettierRc, parser: 'json' }),
+    await prettierFormat(fileContent, { ...prettierRc, parser: 'json' }),
   );
 }
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR addresses a bug in the yarn `create-package` script introduced in [this change](https://github.com/MetaMask/core/pull/3672/files#diff-3424bcceb4f9219f700e2bd2da507f2c742767c7a30f6be5512f62d3b44ffd7aR97), where `fstatSync` was replaced with `await fs.stat(packagePath)).isDirectory()`.

The issue arises because fs.stat now throws an `ENOENT` error if the packagePath is empty. To resolve this, the script has been updated to handle empty paths gracefully, ensuring the process works as expected when creating new packages.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
