### PR TITLE
fixed: Avoid returning a new reference inside 'selectAvailableNetwork…

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -594,11 +594,10 @@ export function getDefaultNetworkControllerState(): NetworkState {
  * @param state - NetworkController state
  * @returns A list of all available network configurations
  */
-export function getNetworkConfigurations(
-  state: NetworkState,
-): NetworkConfiguration[] {
-  return Object.values(state.networkConfigurationsByChainId);
-}
+export const getNetworkConfigurations = createSelector(
+  (state: NetworkState): Record<Hex, NetworkConfiguration> => state.networkConfigurationsByChainId,
+  (networkConfigurationsByChainId): NetworkConfiguration[] => Object.values(networkConfigurationsByChainId),
+)
 
 /**
  * Get a list of all available client IDs from a list of


### PR DESCRIPTION
…ClientIds' selector

## Explanation

fixed warning that avoid returning a new reference as shown in the screenshot.

<img width="1266" alt="Screenshot 2025-01-15 at 16 53 04" src="https://github.com/user-attachments/assets/77dc62ef-7ce4-4d4a-ab74-1171d727fecb" />


## References

## Changelog

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes