### PR TITLE
Release 286.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "285.0.0",
+  "version": "286.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -7,9 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0]
+
+### Added
+
+- **BREAKING:** `createQueuedRequestMiddleware` now expects a `useRequestQueue` option ([#5065](https://github.com/MetaMask/core/pull/5065))
+  - This was previously removed in 20.0.0, but has been re-added for compatibility with Mobile.
+
 ### Changed
 
-- Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))
+- **BREAKING:** Bump peer dependency `@metamask/selected-network-controller` from `^20.0.2` to `^21.0.0` ([#5178](https://github.com/MetaMask/core/pull/5178))
+- Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.1` ([#5079](https://github.com/MetaMask/core/pull/5079)), [#5135](https://github.com/MetaMask/core/pull/5135))
+- Bump `@metamask/controller-utils` from `^11.4.4` to `^11.4.5` ([#5135](https://github.com/MetaMask/core/pull/5135))
+- Bump `@metamask/json-rpc-engine` from `^10.0.1` to `^10.0.2` ([#5082](https://github.com/MetaMask/core/pull/5082))
+- Bump `@metamask/rpc-errors` from `^7.0.1` to `^7.0.2` ([#5080](https://github.com/MetaMask/core/pull/5080))
+- Bump `@metamask/utils` from `^10.0.0` to `^11.0.1` ([#5080](https://github.com/MetaMask/core/pull/5080))
+  - This upgrade is not a breaking change because this package does not use `generateRandomMnemonic`.
 
 ## [8.0.2]
 
@@ -324,7 +337,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@8.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@9.0.0...HEAD
+[9.0.0]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@8.0.2...@metamask/queued-request-controller@9.0.0
 [8.0.2]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@8.0.1...@metamask/queued-request-controller@8.0.2
 [8.0.1]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@8.0.0...@metamask/queued-request-controller@8.0.1
 [8.0.0]: https://github.com/MetaMask/core/compare/@metamask/queued-request-controller@7.0.1...@metamask/queued-request-controller@8.0.0

--- a/packages/queued-request-controller/package.json
+++ b/packages/queued-request-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/queued-request-controller",
-  "version": "8.0.2",
+  "version": "9.0.0",
   "description": "Includes a controller and middleware that implements a request queue",
   "keywords": [
     "MetaMask",
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/network-controller": "^22.1.1",
-    "@metamask/selected-network-controller": "^20.0.2",
+    "@metamask/selected-network-controller": "^21.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "@metamask/network-controller": "^22.0.0",
-    "@metamask/selected-network-controller": "^20.0.0"
+    "@metamask/selected-network-controller": "^21.0.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [21.0.0]
+
+### Added
+
+- **BREAKING:** The `SelectedNetworkController` constructor now expects both `useRequestQueuePreference` and `onPreferencesStateChange` options ([#5065](https://github.com/MetaMask/core/pull/5065))
+  - These were previously removed in 20.0.0, but have been re-added for compatibility with Mobile.
+
 ### Changed
 
-- Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))
+- Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.1` ([#5079](https://github.com/MetaMask/core/pull/5079)), [#5135](https://github.com/MetaMask/core/pull/5135))
+- Bump `@metamask/json-rpc-engine` from `^10.0.1` to `^10.0.2` ([#5082](https://github.com/MetaMask/core/pull/5082))
+- Bump `@metamask/utils` from `^10.0.0` to `^11.0.1` ([#5080](https://github.com/MetaMask/core/pull/5080))
+  - This upgrade is not a breaking change because this package does not use `generateRandomMnemonic`.
 
 ## [20.0.2]
 
@@ -327,7 +337,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Release ([#1643](https://github.com/MetaMask/core/pull/1643))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@20.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@21.0.0...HEAD
+[21.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@20.0.2...@metamask/selected-network-controller@21.0.0
 [20.0.2]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@20.0.1...@metamask/selected-network-controller@20.0.2
 [20.0.1]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@20.0.0...@metamask/selected-network-controller@20.0.1
 [20.0.0]: https://github.com/MetaMask/core/compare/@metamask/selected-network-controller@19.0.0...@metamask/selected-network-controller@20.0.0

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/selected-network-controller",
-  "version": "20.0.2",
+  "version": "21.0.0",
   "description": "Provides an interface to the currently selected networkClientId for a given domain",
   "keywords": [
     "MetaMask",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3672,7 +3672,7 @@ __metadata:
     "@metamask/json-rpc-engine": "npm:^10.0.2"
     "@metamask/network-controller": "npm:^22.1.1"
     "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/selected-network-controller": "npm:^20.0.2"
+    "@metamask/selected-network-controller": "npm:^21.0.0"
     "@metamask/swappable-obj-proxy": "npm:^2.3.0"
     "@metamask/utils": "npm:^11.0.1"
     "@types/jest": "npm:^27.4.1"
@@ -3688,7 +3688,7 @@ __metadata:
     typescript: "npm:~5.2.2"
   peerDependencies:
     "@metamask/network-controller": ^22.0.0
-    "@metamask/selected-network-controller": ^20.0.0
+    "@metamask/selected-network-controller": ^21.0.0
   languageName: unknown
   linkType: soft
 
@@ -3759,7 +3759,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/selected-network-controller@npm:^20.0.2, @metamask/selected-network-controller@workspace:packages/selected-network-controller":
+"@metamask/selected-network-controller@npm:^21.0.0, @metamask/selected-network-controller@workspace:packages/selected-network-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/selected-network-controller@workspace:packages/selected-network-controller"
   dependencies:


### PR DESCRIPTION
This release centers around reverting changes to the following packages so that a per-dapp selected network is not the default, but rather opt-in. This is required in order to be able to keep Mobile on the latest versions of these packages as it has not yet been updated to support the Per-Dapp Selected Network feature.

- `@metamask/queued-request-controller` (8.0.2 -> 9.0.0)
- `@metamask/selected-network-controller` (20.0.2 -> 21.0.0)