### PR TITLE
createServicePolicy: Convert callbacks to methods

### DIFF
--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `createServicePolicy` function to assist with reducing boilerplate for service classes ([#5154](https://github.com/MetaMask/core/pull/5154), [#5143](https://github.com/MetaMask/core/pull/5143), [#5149](https://github.com/MetaMask/core/pull/5149))
-  - Also add `DEFAULT_CIRCUIT_BREAK_DURATION`, `DEFAULT_DEGRADED_THRESHOLD`, `DEFAULT_MAX_CONSECUTIVE_FAILURES`, and `DEFAULT_MAX_RETRIES` constants and `IServicePolicy` type
+- Add utility function for reducing boilerplate for service classes ([#5154](https://github.com/MetaMask/core/pull/5154), [#5143](https://github.com/MetaMask/core/pull/5143), [#5149](https://github.com/MetaMask/core/pull/5149), [#5188](https://github.com/MetaMask/core/pull/5188))
+  - Add function `createServicePolicy`
+  - Add constants `DEFAULT_CIRCUIT_BREAK_DURATION`, `DEFAULT_DEGRADED_THRESHOLD`, `DEFAULT_MAX_CONSECUTIVE_FAILURES`, and `DEFAULT_MAX_RETRIES`
+  - Add types `ServicePolicy` and `CreateServicePolicyOptions`
 
 ## [11.4.5]
 

--- a/packages/controller-utils/src/create-service-policy.ts
+++ b/packages/controller-utils/src/create-service-policy.ts
@@ -7,9 +7,70 @@ import {
   wrap,
   CircuitState,
 } from 'cockatiel';
-import type { IPolicy, Policy } from 'cockatiel';
+import type {
+  CircuitBreakerPolicy,
+  IPolicy,
+  Policy,
+  RetryPolicy,
+} from 'cockatiel';
 
-export type { IPolicy as IServicePolicy };
+/**
+ * The options for `createServicePolicy`.
+ */
+export type CreateServicePolicyOptions = {
+  /**
+   * The length of time (in milliseconds) to pause retries of the action after
+   * the number of failures reaches `maxConsecutiveFailures`.
+   */
+  circuitBreakDuration?: number;
+  /**
+   * The length of time (in milliseconds) that governs when the service is
+   * regarded as degraded (affecting when `onDegraded` is called).
+   */
+  degradedThreshold?: number;
+  /**
+   * The maximum number of times that the service is allowed to fail before
+   * pausing further retries.
+   */
+  maxConsecutiveFailures?: number;
+  /**
+   * The maximum number of times that a failing service should be re-invoked
+   * before giving up.
+   */
+  maxRetries?: number;
+  /**
+   * The policy used to control when the service should be retried based on
+   * either the result of the service or an error that it throws. For instance,
+   * you could use this to retry only certain errors. See `handleWhen` and
+   * friends from Cockatiel for more.
+   */
+  retryFilterPolicy?: Policy;
+};
+
+/**
+ * The service policy object.
+ */
+export type ServicePolicy = IPolicy & {
+  /**
+   * A function which is called when the number of times that the service fails
+   * in a row meets the set maximum number of consecutive failures.
+   */
+  onBreak: CircuitBreakerPolicy['onBreak'];
+  /**
+   * A function which is called in two circumstances: 1) when the service
+   * succeeds before the maximum number of consecutive failures is reached, but
+   * takes more time than the `degradedThreshold` to run, or 2) if the service
+   * never succeeds before the retry policy gives up and before the maximum
+   * number of consecutive failures has been reached.
+   */
+  onDegraded: (fn: () => void) => void;
+  /**
+   * A function which will be called by the retry policy each time the service
+   * fails and the policy kicks off a timer to re-run the service. This is
+   * primarily useful in tests where we are mocking timers.
+   */
+  onRetry: RetryPolicy['onRetry'];
+};
 
 /**
  * The maximum number of times that a failing service should be re-run before
@@ -19,7 +80,9 @@ export const DEFAULT_MAX_RETRIES = 3;
 
 /**
  * The maximum number of times that the service is allowed to fail before
- * pausing further retries.
+ * pausing further retries. This is set to a value such that if given a
+ * service that continually fails, the policy needs to be executed 3 times
+ * before further retries are paused.
  */
 export const DEFAULT_MAX_CONSECUTIVE_FAILURES = (1 + DEFAULT_MAX_RETRIES) * 3;
 
@@ -65,14 +128,6 @@ export const DEFAULT_DEGRADED_THRESHOLD = 5_000;
  * @param options.degradedThreshold - The length of time (in milliseconds) that
  * governs when the service is regarded as degraded (affecting when `onDegraded`
  * is called). Defaults to 5 seconds.
- * @param options.onBreak - A function which is called when the service fails
- * too many times in a row (specifically, more than `maxConsecutiveFailures`).
- * @param options.onDegraded - A function which is called when the service
- * succeeds before `maxConsecutiveFailures` is reached, but takes more time than
- * the `degradedThreshold` to run.
- * @param options.onRetry - A function which will be called the moment the
- * policy kicks off a timer to re-run the function passed to the policy. This is
- * primarily useful in tests where we are mocking timers.
  * @returns The service policy.
  * @example
  * This function is designed to be used in the context of a service class like
@@ -112,25 +167,7 @@ export function createServicePolicy({
   maxConsecutiveFailures = DEFAULT_MAX_CONSECUTIVE_FAILURES,
   circuitBreakDuration = DEFAULT_CIRCUIT_BREAK_DURATION,
   degradedThreshold = DEFAULT_DEGRADED_THRESHOLD,
-  onBreak = () => {
-    // do nothing
-  },
-  onDegraded = () => {
-    // do nothing
-  },
-  onRetry = () => {
-    // do nothing
-  },
-}: {
-  maxRetries?: number;
-  retryFilterPolicy?: Policy;
-  maxConsecutiveFailures?: number;
-  circuitBreakDuration?: number;
-  degradedThreshold?: number;
-  onBreak?: () => void;
-  onDegraded?: () => void;
-  onRetry?: () => void;
-} = {}): IPolicy {
+}: CreateServicePolicyOptions = {}): ServicePolicy {
   const retryPolicy = retry(retryFilterPolicy, {
     // Note that although the option here is called "max attempts", it's really
     // maximum number of *retries* (attempts past the initial attempt).
@@ -139,6 +176,7 @@ export function createServicePolicy({
     // determined by a backoff formula.
     backoff: new ExponentialBackoff(),
   });
+  const onRetry = retryPolicy.onRetry.bind(retryPolicy);
 
   const circuitBreakerPolicy = circuitBreaker(handleAll, {
     // While the circuit is open, any additional invocations of the service
@@ -150,27 +188,14 @@ export function createServicePolicy({
     halfOpenAfter: circuitBreakDuration,
     breaker: new ConsecutiveBreaker(maxConsecutiveFailures),
   });
+  const onBreak = circuitBreakerPolicy.onBreak.bind(circuitBreakerPolicy);
 
-  // The `onBreak` callback will be called if the service consistently throws
-  // for as many times as exceeds the maximum consecutive number of failures.
-  // Combined with the retry policy, this can happen if:
-  // - `maxConsecutiveFailures` < the default max retries (3) and the policy is
-  // executed once
-  // - `maxConsecutiveFailures` >= the default max retries (3) but the policy is
-  //   executed multiple times, enough for the total number of retries to exceed
-  //   `maxConsecutiveFailures`
-  circuitBreakerPolicy.onBreak(onBreak);
-
-  // The `onRetryPolicy` callback will be called each time the service is
-  // invoked (including retries).
-  retryPolicy.onRetry(onRetry);
-
+  const onDegradedListeners: (() => void)[] = [];
   retryPolicy.onGiveUp(() => {
     if (circuitBreakerPolicy.state === CircuitState.Closed) {
-      // The `onDegraded` callback will be called if the number of retries is
-      // exceeded and the maximum number of consecutive failures has not been
-      // reached yet (whether the policy is called once or multiple times).
-      onDegraded();
+      for (const listener of onDegradedListeners) {
+        listener();
+      }
     }
   });
   retryPolicy.onSuccess(({ duration }) => {
@@ -178,14 +203,23 @@ export function createServicePolicy({
       circuitBreakerPolicy.state === CircuitState.Closed &&
       duration > degradedThreshold
     ) {
-      // The `onDegraded` callback will also be called if the service does not
-      // throw, but the time it takes for the service to run exceeds the
-      // `degradedThreshold`.
-      onDegraded();
+      for (const listener of onDegradedListeners) {
+        listener();
+      }
     }
   });
+  const onDegraded = (listener: () => void) => {
+    onDegradedListeners.push(listener);
+  };
 
-  // The retry policy really retries the circuit breaker policy, which invokes
-  // the service.
-  return wrap(retryPolicy, circuitBreakerPolicy);
+  // Every time the retry policy makes an attempt, it executes the circuit
+  // breaker policy, which executes the service.
+  const policy = wrap(retryPolicy, circuitBreakerPolicy);
+
+  return {
+    ...policy,
+    onBreak,
+    onDegraded,
+    onRetry,
+  };
 }

--- a/packages/controller-utils/src/index.ts
+++ b/packages/controller-utils/src/index.ts
@@ -5,7 +5,10 @@ export {
   DEFAULT_MAX_RETRIES,
   createServicePolicy,
 } from './create-service-policy';
-export type { IServicePolicy } from './create-service-policy';
+export type {
+  CreateServicePolicyOptions,
+  ServicePolicy,
+} from './create-service-policy';
 export * from './constants';
 export type { NonEmptyArray } from './util';
 export {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Both RetryPolicy and CircuitBreakerPolicy from the Cockatiel library allow for listening for events using `on*` methods. For instance, if you have a retry policy, you can listen for when the function is retried like so:

``` typescript
retryPolicy.onRetry(() => {
  // ...
})
```

Our "service policy" allows for listening to some of the same events as well as the "degraded" event. Instead of exposing `on*` methods, however, `createServicePolicy` takes callbacks in an options bag:

``` typescript
createServicePolicy({
  // ...
  onRetry: () => {
    // ...
  }
)
```

For parity with Cockatiel — and for easier use in general — this commit changes the API so that the object that `createServicePolicy` returns now includes similar `on*` methods. This way you can say:

``` typescript
const policy = createServicePolicy({ ... });
policy.onRetry(() => {
  // ...
});
``` 

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Progresses https://github.com/MetaMask/core/issues/4994.
Pre-requisite to https://github.com/MetaMask/core/issues/4990.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

(Updated in PR.)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
