### PR TITLE
Update `createServicePolicy` to expose sub-policies; add re-exports from `cockatiel`

### DIFF
--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add utility function for reducing boilerplate for service classes ([#5154](https://github.com/MetaMask/core/pull/5154), [#5143](https://github.com/MetaMask/core/pull/5143), [#5149](https://github.com/MetaMask/core/pull/5149), [#5188](https://github.com/MetaMask/core/pull/5188))
+- Add utility function for reducing boilerplate for service classes ([#5154](https://github.com/MetaMask/core/pull/5154), [#5143](https://github.com/MetaMask/core/pull/5143), [#5149](https://github.com/MetaMask/core/pull/5149), [#5188](https://github.com/MetaMask/core/pull/5188), [#5192](https://github.com/MetaMask/core/pull/5192))
   - Add function `createServicePolicy`
   - Add constants `DEFAULT_CIRCUIT_BREAK_DURATION`, `DEFAULT_DEGRADED_THRESHOLD`, `DEFAULT_MAX_CONSECUTIVE_FAILURES`, and `DEFAULT_MAX_RETRIES`
   - Add types `ServicePolicy` and `CreateServicePolicyOptions`
+  - Re-export `BrokenCircuitError`, `CircuitState`, `handleAll`, and `handleWhen` from `cockatiel`
 
 ## [11.4.5]
 

--- a/packages/controller-utils/jest.config.js
+++ b/packages/controller-utils/jest.config.js
@@ -18,7 +18,7 @@ module.exports = merge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 78.12,
-      functions: 84.61,
+      functions: 80.7,
       lines: 87.3,
       statements: 86.5,
     },

--- a/packages/controller-utils/src/create-service-policy.ts
+++ b/packages/controller-utils/src/create-service-policy.ts
@@ -1,11 +1,13 @@
 import {
-  circuitBreaker,
+  BrokenCircuitError,
+  CircuitState,
   ConsecutiveBreaker,
   ExponentialBackoff,
+  circuitBreaker,
   handleAll,
+  handleWhen,
   retry,
   wrap,
-  CircuitState,
 } from 'cockatiel';
 import type {
   CircuitBreakerPolicy,
@@ -13,6 +15,8 @@ import type {
   Policy,
   RetryPolicy,
 } from 'cockatiel';
+
+export { CircuitState, BrokenCircuitError, handleAll, handleWhen };
 
 /**
  * The options for `createServicePolicy`.
@@ -51,6 +55,15 @@ export type CreateServicePolicyOptions = {
  * The service policy object.
  */
 export type ServicePolicy = IPolicy & {
+  /**
+   * The Cockatiel circuit breaker policy that the service policy uses
+   * internally.
+   */
+  circuitBreakerPolicy: CircuitBreakerPolicy;
+  /**
+   * The Cockatiel retry policy that the service policy uses internally.
+   */
+  retryPolicy: RetryPolicy;
   /**
    * A function which is called when the number of times that the service fails
    * in a row meets the set maximum number of consecutive failures.
@@ -218,6 +231,8 @@ export function createServicePolicy({
 
   return {
     ...policy,
+    circuitBreakerPolicy,
+    retryPolicy,
     onBreak,
     onDegraded,
     onRetry,

--- a/packages/controller-utils/src/index.test.ts
+++ b/packages/controller-utils/src/index.test.ts
@@ -4,11 +4,15 @@ describe('@metamask/controller-utils', () => {
   it('has expected JavaScript exports', () => {
     expect(Object.keys(allExports)).toMatchInlineSnapshot(`
       Array [
+        "BrokenCircuitError",
+        "CircuitState",
         "DEFAULT_CIRCUIT_BREAK_DURATION",
         "DEFAULT_DEGRADED_THRESHOLD",
         "DEFAULT_MAX_CONSECUTIVE_FAILURES",
         "DEFAULT_MAX_RETRIES",
         "createServicePolicy",
+        "handleAll",
+        "handleWhen",
         "BNToHex",
         "convertHexToDecimal",
         "fetchWithErrorHandling",

--- a/packages/controller-utils/src/index.ts
+++ b/packages/controller-utils/src/index.ts
@@ -1,9 +1,13 @@
 export {
+  BrokenCircuitError,
+  CircuitState,
   DEFAULT_CIRCUIT_BREAK_DURATION,
   DEFAULT_DEGRADED_THRESHOLD,
   DEFAULT_MAX_CONSECUTIVE_FAILURES,
   DEFAULT_MAX_RETRIES,
   createServicePolicy,
+  handleAll,
+  handleWhen,
 } from './create-service-policy';
 export type {
   CreateServicePolicyOptions,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Expose these exports from `cockatiel` so consumers can use them without needing to depend on the library directly:

- `BrokenCircuitError`
- `CircuitState`
- `handleAll`
- `handleWhen`

Also, update `createServicePolicy` to expose the retry and circuit breaker policies so that we can access their state in other modules that use this utility function.

This is needed to be able to create an RPC service.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Progresses https://github.com/MetaMask/core/issues/4994.
Pre-requisite to https://github.com/MetaMask/core/issues/4990.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

(Updated in changelog.)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
