### PR TITLE
feat: bump snaps-sdk to v6.16.0

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -52,7 +52,7 @@
     "@metamask/eth-snap-keyring": "^9.1.1",
     "@metamask/keyring-api": "^16.1.0",
     "@metamask/keyring-internal-api": "^4.0.1",
-    "@metamask/snaps-sdk": "^6.7.0",
+    "@metamask/snaps-sdk": "^6.16.0",
     "@metamask/snaps-utils": "^8.9.0",
     "@metamask/utils": "^11.0.1",
     "deepmerge": "^4.2.2",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -88,7 +88,7 @@
     "@metamask/preferences-controller": "^15.0.1",
     "@metamask/providers": "^18.1.1",
     "@metamask/snaps-controllers": "^9.10.0",
-    "@metamask/snaps-sdk": "^6.7.0",
+    "@metamask/snaps-sdk": "^6.16.0",
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.191",
     "@types/node": "^16.18.54",

--- a/packages/multichain-transactions-controller/package.json
+++ b/packages/multichain-transactions-controller/package.json
@@ -53,7 +53,7 @@
     "@metamask/keyring-snap-client": "^3.0.3",
     "@metamask/polling-controller": "^12.0.2",
     "@metamask/snaps-controllers": "^9.10.0",
-    "@metamask/snaps-sdk": "^6.7.0",
+    "@metamask/snaps-sdk": "^6.16.0",
     "@metamask/snaps-utils": "^8.9.0",
     "@metamask/utils": "^11.0.1",
     "@types/uuid": "^8.3.0",

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -104,7 +104,7 @@
     "@metamask/keyring-api": "^16.1.0",
     "@metamask/keyring-controller": "^19.0.5",
     "@metamask/network-controller": "^22.1.1",
-    "@metamask/snaps-sdk": "^6.7.0",
+    "@metamask/snaps-sdk": "^6.16.0",
     "@metamask/snaps-utils": "^8.9.0",
     "@noble/ciphers": "^0.5.2",
     "@noble/hashes": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2313,7 +2313,7 @@ __metadata:
     "@metamask/keyring-internal-api": "npm:^4.0.1"
     "@metamask/providers": "npm:^18.1.1"
     "@metamask/snaps-controllers": "npm:^9.10.0"
-    "@metamask/snaps-sdk": "npm:^6.7.0"
+    "@metamask/snaps-sdk": "npm:^6.16.0"
     "@metamask/snaps-utils": "npm:^8.9.0"
     "@metamask/utils": "npm:^11.0.1"
     "@types/jest": "npm:^27.4.1"
@@ -2439,7 +2439,7 @@ __metadata:
     "@metamask/providers": "npm:^18.1.1"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/snaps-controllers": "npm:^9.10.0"
-    "@metamask/snaps-sdk": "npm:^6.7.0"
+    "@metamask/snaps-sdk": "npm:^6.16.0"
     "@metamask/snaps-utils": "npm:^8.9.0"
     "@metamask/utils": "npm:^11.0.1"
     "@types/bn.js": "npm:^5.1.5"
@@ -3370,7 +3370,7 @@ __metadata:
     "@metamask/keyring-snap-client": "npm:^3.0.3"
     "@metamask/polling-controller": "npm:^12.0.2"
     "@metamask/snaps-controllers": "npm:^9.10.0"
-    "@metamask/snaps-sdk": "npm:^6.7.0"
+    "@metamask/snaps-sdk": "npm:^6.16.0"
     "@metamask/snaps-utils": "npm:^8.9.0"
     "@metamask/utils": "npm:^11.0.1"
     "@types/jest": "npm:^27.4.1"
@@ -3698,7 +3698,7 @@ __metadata:
     "@metamask/network-controller": "npm:^22.1.1"
     "@metamask/providers": "npm:^18.1.1"
     "@metamask/snaps-controllers": "npm:^9.10.0"
-    "@metamask/snaps-sdk": "npm:^6.7.0"
+    "@metamask/snaps-sdk": "npm:^6.16.0"
     "@metamask/snaps-utils": "npm:^8.9.0"
     "@noble/ciphers": "npm:^0.5.2"
     "@noble/hashes": "npm:^1.4.0"
@@ -3975,7 +3975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^6.10.0, @metamask/snaps-sdk@npm:^6.11.0, @metamask/snaps-sdk@npm:^6.16.0, @metamask/snaps-sdk@npm:^6.7.0":
+"@metamask/snaps-sdk@npm:^6.10.0, @metamask/snaps-sdk@npm:^6.11.0, @metamask/snaps-sdk@npm:^6.16.0":
   version: 6.16.0
   resolution: "@metamask/snaps-sdk@npm:6.16.0"
   dependencies:


### PR DESCRIPTION
## Explanation

This PR bumps `@metamask/snaps-sdk `to v6.16.0

## References

N/A
## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/accounts-controller`

- **CHANGED**: Bump `@metamask/snaps-sdk` to `v6.16.0`

### `@metamask/assets-controllers`

- **CHANGED**: Bump `@metamask/snaps-sdk` to `v6.16.0`

### `@metamask/multichain-transactions-controller`

- **CHANGED**: Bump `@metamask/snaps-sdk` to `v6.16.0`

### `@metamask/profile-sync-controller`

- **CHANGED**: Bump `@metamask/snaps-sdk` to `v6.16.0`

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
