### PR TITLE
chore(approval): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/approval-controller/src/ApprovalController.test.ts
+++ b/packages/approval-controller/src/ApprovalController.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jest/expect-expect */
 
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { errorCodes, JsonRpcError } from '@metamask/rpc-errors';
 import { nanoid } from 'nanoid';
 
@@ -223,21 +223,20 @@ function getError(message: string, code?: number) {
 }
 
 /**
- * Constructs a restricted controller messenger.
+ * Constructs a restricted messenger.
  *
- * @returns A restricted controller messenger.
+ * @returns A restricted messenger.
  */
 function getRestrictedMessenger() {
-  const controllerMessenger = new ControllerMessenger<
+  const messenger = new Messenger<
     ApprovalControllerActions,
     ApprovalControllerEvents
   >();
-  const messenger = controllerMessenger.getRestricted({
+  return messenger.getRestricted({
     name: 'ApprovalController',
     allowedActions: [],
     allowedEvents: [],
   });
-  return messenger;
 }
 
 describe('approval controller', () => {
@@ -1270,7 +1269,7 @@ describe('approval controller', () => {
 
   describe('actions', () => {
     it('addApprovalRequest: shouldShowRequest = true', async () => {
-      const messenger = new ControllerMessenger<
+      const messenger = new Messenger<
         ApprovalControllerActions,
         ApprovalControllerEvents
       >();
@@ -1296,7 +1295,7 @@ describe('approval controller', () => {
     });
 
     it('addApprovalRequest: shouldShowRequest = false', async () => {
-      const messenger = new ControllerMessenger<
+      const messenger = new Messenger<
         ApprovalControllerActions,
         ApprovalControllerEvents
       >();
@@ -1322,7 +1321,7 @@ describe('approval controller', () => {
     });
 
     it('updateRequestState', () => {
-      const messenger = new ControllerMessenger<
+      const messenger = new Messenger<
         ApprovalControllerActions,
         ApprovalControllerEvents
       >();

--- a/packages/approval-controller/src/ApprovalController.ts
+++ b/packages/approval-controller/src/ApprovalController.ts
@@ -2,7 +2,7 @@ import type { ControllerGetStateAction } from '@metamask/base-controller';
 import {
   BaseController,
   type ControllerStateChangeEvent,
-  type RestrictedControllerMessenger,
+  type RestrictedMessenger,
 } from '@metamask/base-controller';
 import type { JsonRpcError, DataWithOptionalCause } from '@metamask/rpc-errors';
 import { rpcErrors } from '@metamask/rpc-errors';
@@ -119,7 +119,7 @@ export type ApprovalControllerState = {
   approvalFlows: ApprovalFlowState[];
 };
 
-export type ApprovalControllerMessenger = RestrictedControllerMessenger<
+export type ApprovalControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   ApprovalControllerActions,
   ApprovalControllerEvents,
@@ -367,7 +367,7 @@ export class ApprovalController extends BaseController<
    * @param options - The controller options.
    * @param options.showApprovalRequest - Function for opening the UI such that
    * the request can be displayed to the user.
-   * @param options.messenger - The restricted controller messenger for the Approval controller.
+   * @param options.messenger - The restricted messenger for the Approval controller.
    * @param options.state - The initial controller state.
    * @param options.typesExcludedFromRateLimiting - Array of approval types which allow multiple pending approval requests from the same origin.
    */


### PR DESCRIPTION
## Explanation

Rename `ControllerMessenger` to `Messenger` in the `@metamask/approval-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
