### PR TITLE
chore(ens): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/ens-controller/src/EnsController.test.ts
+++ b/packages/ens-controller/src/EnsController.test.ts
@@ -1,5 +1,5 @@
 import * as providersModule from '@ethersproject/providers';
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import {
   toChecksumHexAddress,
   toHex,
@@ -54,7 +54,7 @@ jest.mock('@ethersproject/providers', () => {
   };
 });
 
-type RootMessenger = ControllerMessenger<
+type RootMessenger = Messenger<
   ExtractAvailableAction<EnsControllerMessenger>,
   ExtractAvailableEvent<EnsControllerMessenger>
 >;
@@ -76,10 +76,10 @@ const name = 'EnsController';
 /**
  * Constructs the root messenger.
  *
- * @returns A restricted controller messenger.
+ * @returns A restricted messenger.
  */
 function getRootMessenger(): RootMessenger {
-  return new ControllerMessenger<
+  return new Messenger<
     ExtractAvailableAction<EnsControllerMessenger> | AllowedActions,
     ExtractAvailableEvent<EnsControllerMessenger> | never
   >();
@@ -91,7 +91,7 @@ function getRootMessenger(): RootMessenger {
  * @param rootMessenger - The root messenger to base the restricted messenger
  * off of.
  * @param getNetworkClientByIdMock - Optional mock version of `getNetworkClientById`.
- * @returns A restricted controller messenger.
+ * @returns A restricted messenger.
  */
 function getRestrictedMessenger(
   rootMessenger: RootMessenger,

--- a/packages/ens-controller/src/EnsController.ts
+++ b/packages/ens-controller/src/EnsController.ts
@@ -1,5 +1,5 @@
 import { Web3Provider } from '@ethersproject/providers';
-import type { RestrictedControllerMessenger } from '@metamask/base-controller';
+import type { RestrictedMessenger } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
 import type { ChainId } from '@metamask/controller-utils';
 import {
@@ -73,7 +73,7 @@ export type AllowedActions =
   | NetworkControllerGetNetworkClientByIdAction
   | NetworkControllerGetStateAction;
 
-export type EnsControllerMessenger = RestrictedControllerMessenger<
+export type EnsControllerMessenger = RestrictedMessenger<
   typeof name,
   AllowedActions,
   never,


### PR DESCRIPTION
## Explanation

Rename `ControllerMessenger` to `Messenger` in the `@metamask/ens-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
