### PR TITLE
chore(gas-fee): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -1,7 +1,7 @@
 import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
 } from '@metamask/base-controller';
 import {
   convertHexToDecimal,
@@ -240,7 +240,7 @@ type AllowedActions =
   | NetworkControllerGetNetworkClientByIdAction
   | NetworkControllerGetEIP1559CompatibilityAction;
 
-type GasFeeMessenger = RestrictedControllerMessenger<
+type GasFeeMessenger = RestrictedMessenger<
   typeof name,
   GasFeeControllerActions | AllowedActions,
   GasFeeControllerEvents | NetworkControllerNetworkDidChangeEvent,


### PR DESCRIPTION
## Explanation

Rename `ControllerMessenger` to `Messenger` in the `@metamask/gas-fee-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
