### PR TITLE
chore(multichain-transactions):  Rename `RestrictedControllerMessenger` to `RestrictedMessenger`

### DIFF
--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import type { CaipAssetType, Transaction } from '@metamask/keyring-api';
 import {
   BtcAccountType,
@@ -97,13 +97,10 @@ const setupController = ({
     handleRequestReturnValue?: Record<CaipAssetType, Transaction>;
   };
 } = {}) => {
-  const controllerMessenger = new ControllerMessenger<
-    AllowedActions,
-    AllowedEvents
-  >();
+  const messenger = new Messenger<AllowedActions, AllowedEvents>();
 
   const multichainTransactionsControllerMessenger: MultichainTransactionsControllerMessenger =
-    controllerMessenger.getRestricted({
+    messenger.getRestricted({
       name: 'MultichainTransactionsController',
       allowedActions: [
         'SnapController:handleRequest',
@@ -116,7 +113,7 @@ const setupController = ({
     });
 
   const mockSnapHandleRequest = jest.fn();
-  controllerMessenger.registerActionHandler(
+  messenger.registerActionHandler(
     'SnapController:handleRequest',
     mockSnapHandleRequest.mockReturnValue(
       mocks?.handleRequestReturnValue ?? mockTransactionResult,
@@ -124,7 +121,7 @@ const setupController = ({
   );
 
   const mockListMultichainAccounts = jest.fn();
-  controllerMessenger.registerActionHandler(
+  messenger.registerActionHandler(
     'AccountsController:listMultichainAccounts',
     mockListMultichainAccounts.mockReturnValue(
       mocks?.listMultichainAccounts ?? [mockBtcAccount, mockEthAccount],
@@ -138,7 +135,7 @@ const setupController = ({
 
   return {
     controller,
-    messenger: controllerMessenger,
+    messenger,
     mockSnapHandleRequest,
     mockListMultichainAccounts,
   };

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
@@ -7,7 +7,7 @@ import {
   BaseController,
   type ControllerGetStateAction,
   type ControllerStateChangeEvent,
-  type RestrictedControllerMessenger,
+  type RestrictedMessenger,
 } from '@metamask/base-controller';
 import { isEvmAccountType, type Transaction } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
@@ -97,14 +97,13 @@ export type MultichainTransactionsControllerEvents =
 /**
  * Messenger type for the MultichainTransactionsController.
  */
-export type MultichainTransactionsControllerMessenger =
-  RestrictedControllerMessenger<
-    typeof controllerName,
-    MultichainTransactionsControllerActions | AllowedActions,
-    MultichainTransactionsControllerEvents | AllowedEvents,
-    AllowedActions['type'],
-    AllowedEvents['type']
-  >;
+export type MultichainTransactionsControllerMessenger = RestrictedMessenger<
+  typeof controllerName,
+  MultichainTransactionsControllerActions | AllowedActions,
+  MultichainTransactionsControllerEvents | AllowedEvents,
+  AllowedActions['type'],
+  AllowedEvents['type']
+>;
 
 /**
  * Actions that this controller is allowed to call.


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger` in the `@metamask/multichain-transactions` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
