### PR TITLE
chore(network): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1,7 +1,7 @@
 import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
 import type { Partialize } from '@metamask/controller-utils';
@@ -518,7 +518,7 @@ export type NetworkControllerActions =
   | NetworkControllerRemoveNetworkAction
   | NetworkControllerUpdateNetworkAction;
 
-export type NetworkControllerMessenger = RestrictedControllerMessenger<
+export type NetworkControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   NetworkControllerActions,
   NetworkControllerEvents,

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import {
   BUILT_IN_NETWORKS,
   ChainId,
@@ -2923,10 +2923,7 @@ describe('NetworkController', () => {
         messenger,
         chainId,
       }: {
-        messenger: ControllerMessenger<
-          NetworkControllerActions,
-          NetworkControllerEvents
-        >;
+        messenger: Messenger<NetworkControllerActions, NetworkControllerEvents>;
         chainId: Hex;
       }) =>
         messenger.call(
@@ -3041,10 +3038,7 @@ describe('NetworkController', () => {
         messenger,
         networkClientId,
       }: {
-        messenger: ControllerMessenger<
-          NetworkControllerActions,
-          NetworkControllerEvents
-        >;
+        messenger: Messenger<NetworkControllerActions, NetworkControllerEvents>;
         networkClientId: NetworkClientId;
       }) =>
         messenger.call(
@@ -14384,22 +14378,19 @@ function lookupNetworkTests({
 }
 
 /**
- * Build a controller messenger that includes all events used by the network
+ * Build a messenger that includes all events used by the network
  * controller.
  *
- * @returns The controller messenger.
+ * @returns The messenger.
  */
 function buildMessenger() {
-  return new ControllerMessenger<
-    NetworkControllerActions,
-    NetworkControllerEvents
-  >();
+  return new Messenger<NetworkControllerActions, NetworkControllerEvents>();
 }
 
 /**
- * Build a restricted controller messenger for the network controller.
+ * Build a restricted messenger for the network controller.
  *
- * @param messenger - A controller messenger.
+ * @param messenger - A messenger.
  * @returns The network controller restricted messenger.
  */
 function buildNetworkControllerMessenger(messenger = buildMessenger()) {
@@ -14414,10 +14405,7 @@ type WithControllerCallback<ReturnValue> = ({
   controller,
 }: {
   controller: NetworkController;
-  messenger: ControllerMessenger<
-    NetworkControllerActions,
-    NetworkControllerEvents
-  >;
+  messenger: Messenger<NetworkControllerActions, NetworkControllerEvents>;
 }) => Promise<ReturnValue> | ReturnValue;
 
 type WithControllerOptions = Partial<NetworkControllerOptions>;
@@ -14589,10 +14577,7 @@ async function waitForPublishedEvents<E extends NetworkControllerEvents>({
     // do nothing
   },
 }: {
-  messenger: ControllerMessenger<
-    NetworkControllerActions,
-    NetworkControllerEvents
-  >;
+  messenger: Messenger<NetworkControllerActions, NetworkControllerEvents>;
   eventType: E['type'];
   count?: number;
   filter?: (payload: E['payload']) => boolean;
@@ -14723,10 +14708,7 @@ async function waitForStateChanges({
   operation,
   beforeResolving,
 }: {
-  messenger: ControllerMessenger<
-    NetworkControllerActions,
-    NetworkControllerEvents
-  >;
+  messenger: Messenger<NetworkControllerActions, NetworkControllerEvents>;
   propertyPath?: string[];
   count?: number;
   wait?: number;


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger` in the `@metamask/network-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
