### PR TITLE
chore(notification-services): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import * as ControllerUtils from '@metamask/controller-utils';
 import type {
   KeyringControllerGetAccountsAction,
@@ -946,10 +946,7 @@ const typedMockAction = <Action extends { handler: AnyFunc }>() =>
  * @returns mock notification messenger and other messenger mocks
  */
 function mockNotificationMessenger() {
-  const globalMessenger = new ControllerMessenger<
-    AllowedActions,
-    AllowedEvents
-  >();
+  const globalMessenger = new Messenger<AllowedActions, AllowedEvents>();
 
   const messenger = globalMessenger.getRestricted({
     name: 'NotificationServicesController',

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -1,5 +1,5 @@
 import type {
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   ControllerGetStateAction,
   ControllerStateChangeEvent,
   StateMetadata,
@@ -271,14 +271,13 @@ export type AllowedEvents =
   | NotificationServicesPushControllerOnNewNotification;
 
 // Type for the messenger of NotificationServicesController
-export type NotificationServicesControllerMessenger =
-  RestrictedControllerMessenger<
-    typeof controllerName,
-    Actions | AllowedActions,
-    Events | AllowedEvents,
-    AllowedActions['type'],
-    AllowedEvents['type']
-  >;
+export type NotificationServicesControllerMessenger = RestrictedMessenger<
+  typeof controllerName,
+  Actions | AllowedActions,
+  Events | AllowedEvents,
+  AllowedActions['type'],
+  AllowedEvents['type']
+>;
 
 type FeatureAnnouncementEnv = {
   spaceId: string;

--- a/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import type { AuthenticationController } from '@metamask/profile-sync-controller';
 import log from 'loglevel';
 
@@ -134,10 +134,7 @@ describe('NotificationServicesPushController', () => {
 
 // Test helper functions
 const buildPushPlatformNotificationsControllerMessenger = () => {
-  const globalMessenger = new ControllerMessenger<
-    AllowedActions,
-    AllowedEvents
-  >();
+  const globalMessenger = new Messenger<AllowedActions, AllowedEvents>();
 
   return globalMessenger.getRestricted<
     'NotificationServicesPushController',

--- a/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
@@ -1,5 +1,5 @@
 import type {
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   ControllerGetStateAction,
   ControllerStateChangeEvent,
   StateMetadata,
@@ -81,14 +81,13 @@ export type Events =
 
 export type AllowedEvents = never;
 
-export type NotificationServicesPushControllerMessenger =
-  RestrictedControllerMessenger<
-    typeof controllerName,
-    Actions | AllowedActions,
-    Events | AllowedEvents,
-    AllowedActions['type'],
-    AllowedEvents['type']
-  >;
+export type NotificationServicesPushControllerMessenger = RestrictedMessenger<
+  typeof controllerName,
+  Actions | AllowedActions,
+  Events | AllowedEvents,
+  AllowedActions['type'],
+  AllowedEvents['type']
+>;
 
 export const defaultState: NotificationServicesPushControllerState = {
   fcmToken: '',


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger` in the `@metamask/notification-services-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
