### PR TITLE
chore(profile-sync): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 
 import {
   MOCK_ACCESS_TOKEN,
@@ -339,10 +339,7 @@ describe('authentication/authentication-controller - getSessionProfile() tests',
  * @returns Auth Messenger
  */
 function createAuthenticationMessenger() {
-  const messenger = new ControllerMessenger<
-    Actions | AllowedActions,
-    AllowedEvents
-  >();
+  const messenger = new Messenger<Actions | AllowedActions, AllowedEvents>();
   return messenger.getRestricted({
     name: 'AuthenticationController',
     allowedActions: [

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -1,7 +1,7 @@
 import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   StateMetadata,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
@@ -117,7 +117,7 @@ export type AllowedEvents =
   | KeyringControllerUnlockEvent;
 
 // Messenger
-export type AuthenticationControllerMessenger = RestrictedControllerMessenger<
+export type AuthenticationControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   Actions | AllowedActions,
   Events | AllowedEvents,

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -7,7 +7,7 @@ import type {
 import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   StateMetadata,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
@@ -286,7 +286,7 @@ export type AllowedEvents =
   | NetworkControllerNetworkRemovedEvent;
 
 // Messenger
-export type UserStorageControllerMessenger = RestrictedControllerMessenger<
+export type UserStorageControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   Actions | AllowedActions,
   Events | AllowedEvents,

--- a/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockMessenger.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/__fixtures__/mockMessenger.ts
@@ -1,5 +1,5 @@
 import type { NotNamespacedBy } from '@metamask/base-controller';
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 
 import { MOCK_STORAGE_KEY_SIGNATURE } from '.';
 import type {
@@ -45,10 +45,7 @@ type ExternalEvents = NotNamespacedBy<
 export function createCustomUserStorageMessenger(props?: {
   overrideEvents?: ExternalEvents[];
 }) {
-  const baseMessenger = new ControllerMessenger<
-    AllowedActions,
-    AllowedEvents
-  >();
+  const baseMessenger = new Messenger<AllowedActions, AllowedEvents>();
   const messenger = baseMessenger.getRestricted({
     name: 'UserStorageController',
     allowedActions: [
@@ -85,7 +82,7 @@ export function createCustomUserStorageMessenger(props?: {
 }
 
 type OverrideMessengers = {
-  baseMessenger: ControllerMessenger<AllowedActions, AllowedEvents>;
+  baseMessenger: Messenger<AllowedActions, AllowedEvents>;
   messenger: UserStorageControllerMessenger;
 };
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/network-syncing/controller-integration.update-network.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/network-syncing/controller-integration.update-network.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import type {
   NetworkState,
   NetworkControllerActions,
@@ -85,10 +85,7 @@ describe('network-syncing/controller-integration - dispatchUpdateNetwork()', () 
   };
 
   const arrangeNetworkController = (networkState: NetworkState) => {
-    const baseMessenger = new ControllerMessenger<
-      NetworkControllerActions,
-      never
-    >();
+    const baseMessenger = new Messenger<NetworkControllerActions, never>();
     const networkControllerMessenger = baseMessenger.getRestricted({
       name: 'NetworkController',
       allowedActions: [],


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger` in the `@metamask/profile-sunc-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
