### PR TITLE
chore(permission): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/permission-controller/ARCHITECTURE.md
+++ b/packages/permission-controller/ARCHITECTURE.md
@@ -318,7 +318,7 @@ const permissionSpecifications = {
 
 const permissionController = new PermissionController({
   caveatSpecifications,
-  messenger: controllerMessenger, // assume this was given
+  messenger: permissionControllerMessenger, // assume this was given
   permissionSpecifications,
   unrestrictedMethods: ['wallet_unrestrictedMethod'],
 });

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -4,7 +4,7 @@ import type {
   HasApprovalRequest,
   RejectRequest as RejectApprovalRequest,
 } from '@metamask/approval-controller';
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { isPlainObject } from '@metamask/controller-utils';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import type { Json, JsonRpcRequest } from '@metamask/utils';
@@ -566,19 +566,19 @@ type AddPermissionRequestParams = {
 type AddPermissionRequestArgs = [string, AddPermissionRequestParams];
 
 /**
- * Gets a unrestricted controller messenger. Used for tests.
+ * Gets an unrestricted messenger. Used for tests.
  *
  * @returns The unrestricted messenger.
  */
 function getUnrestrictedMessenger() {
-  return new ControllerMessenger<
+  return new Messenger<
     PermissionControllerActions | AllowedActions,
     PermissionControllerEvents
   >();
 }
 
 /**
- * Gets a restricted controller messenger.
+ * Gets a restricted messenger.
  * Used as a default in {@link getPermissionControllerOptions}.
  *
  * @param messenger - Optional parameter to pass in a messenger

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -7,7 +7,7 @@ import type {
 } from '@metamask/approval-controller';
 import type {
   StateMetadata,
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   ActionConstraint,
   EventConstraint,
   ControllerGetStateAction,
@@ -356,7 +356,7 @@ export type GetEndowments = {
 };
 
 /**
- * The {@link ControllerMessenger} actions of the {@link PermissionController}.
+ * The {@link Messenger} actions of the {@link PermissionController}.
  */
 export type PermissionControllerActions =
   | ClearPermissions
@@ -384,7 +384,7 @@ export type PermissionControllerStateChange = ControllerStateChangeEvent<
 >;
 
 /**
- * The {@link ControllerMessenger} events of the {@link PermissionController}.
+ * The {@link Messenger} events of the {@link PermissionController}.
  *
  * The permission controller only emits its generic state change events.
  * Consumers should use selector subscriptions to subscribe to relevant
@@ -393,7 +393,7 @@ export type PermissionControllerStateChange = ControllerStateChangeEvent<
 export type PermissionControllerEvents = PermissionControllerStateChange;
 
 /**
- * The external {@link ControllerMessenger} actions available to the
+ * The external {@link Messenger} actions available to the
  * {@link PermissionController}.
  */
 type AllowedActions =
@@ -406,7 +406,7 @@ type AllowedActions =
 /**
  * The messenger of the {@link PermissionController}.
  */
-export type PermissionControllerMessenger = RestrictedControllerMessenger<
+export type PermissionControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   PermissionControllerActions | AllowedActions,
   PermissionControllerEvents,
@@ -417,7 +417,7 @@ export type PermissionControllerMessenger = RestrictedControllerMessenger<
 export type SideEffectMessenger<
   Actions extends ActionConstraint,
   Events extends EventConstraint,
-> = RestrictedControllerMessenger<
+> = RestrictedMessenger<
   typeof controllerName,
   Actions | AllowedActions,
   Events,
@@ -565,7 +565,7 @@ export type PermissionControllerOptions<
  * document for details.
  *
  * Assumes the existence of an {@link ApprovalController} reachable via the
- * {@link ControllerMessenger}.
+ * {@link Messenger}.
  *
  * @template ControllerPermissionSpecification - A union of the types of all
  * permission specifications available to the controller. Any referenced caveats
@@ -629,7 +629,7 @@ export class PermissionController<
    * {@link PermissionSpecificationMap} and the README for more details.
    * @param options.unrestrictedMethods - The callable names of all JSON-RPC
    * methods ignored by the new controller.
-   * @param options.messenger - The controller messenger. See
+   * @param options.messenger - The messenger. See
    * {@link BaseController} for more information.
    * @param options.state - Existing state to hydrate the controller with at
    * initialization.

--- a/packages/permission-controller/src/SubjectMetadataController.test.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import type { Json } from '@metamask/utils';
 
 import type { HasPermissions } from './PermissionController';
@@ -14,27 +14,24 @@ import {
 const controllerName = 'SubjectMetadataController';
 
 /**
- * Utility function for creating a controller messenger.
+ * Utility function for creating a messenger.
  *
  * @returns A tuple containing the messenger and a spy for the "hasPermission" action handler
  */
 function getSubjectMetadataControllerMessenger() {
-  const controllerMessenger = new ControllerMessenger<
+  const messenger = new Messenger<
     SubjectMetadataControllerActions | HasPermissions,
     SubjectMetadataControllerEvents
   >();
 
   const hasPermissionsSpy = jest.fn();
-  controllerMessenger.registerActionHandler(
+  messenger.registerActionHandler(
     'PermissionController:hasPermissions',
     hasPermissionsSpy,
   );
 
   return [
-    controllerMessenger.getRestricted<
-      typeof controllerName,
-      HasPermissions['type']
-    >({
+    messenger.getRestricted<typeof controllerName, HasPermissions['type']>({
       name: controllerName,
       allowedActions: ['PermissionController:hasPermissions'],
       allowedEvents: [],

--- a/packages/permission-controller/src/SubjectMetadataController.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.ts
@@ -1,7 +1,7 @@
 import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
 import type { Json } from '@metamask/utils';
@@ -84,7 +84,7 @@ export type SubjectMetadataControllerEvents = SubjectMetadataStateChange;
 
 type AllowedActions = HasPermissions;
 
-export type SubjectMetadataControllerMessenger = RestrictedControllerMessenger<
+export type SubjectMetadataControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   SubjectMetadataControllerActions | AllowedActions,
   SubjectMetadataControllerEvents,


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger` in the `@metamask/permission-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
