### PR TITLE
chore(base): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/base-controller/src/BaseControllerV1.test.ts
+++ b/packages/base-controller/src/BaseControllerV1.test.ts
@@ -16,7 +16,7 @@ import {
   countControllerStateMetadata,
   getCountMessenger,
 } from './BaseControllerV2.test';
-import { ControllerMessenger } from './Messenger';
+import { Messenger } from './Messenger';
 
 const STATE = { name: 'foo' };
 const CONFIG = { disabled: true };
@@ -36,12 +36,12 @@ describe('isBaseControllerV1', () => {
   });
 
   it('should return false if passed a V2 controller', () => {
-    const controllerMessenger = new ControllerMessenger<
+    const messenger = new Messenger<
       CountControllerAction,
       CountControllerEvent
     >();
     const controller = new CountController({
-      messenger: getCountMessenger(controllerMessenger),
+      messenger: getCountMessenger(messenger),
       name: countControllerName,
       state: { count: 0 },
       metadata: countControllerStateMetadata,

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -8,8 +8,8 @@ import type {
 } from './BaseControllerV1';
 import type { ActionConstraint, EventConstraint } from './Messenger';
 import type {
-  RestrictedControllerMessenger,
-  RestrictedControllerMessengerConstraint,
+  RestrictedMessenger,
+  RestrictedMessengerConstraint,
 } from './RestrictedMessenger';
 
 enablePatches();
@@ -135,11 +135,7 @@ export type StateMetadataConstraint = Record<
  */
 export type BaseControllerInstance = Omit<
   PublicInterface<
-    BaseController<
-      string,
-      StateConstraint,
-      RestrictedControllerMessengerConstraint
-    >
+    BaseController<string, StateConstraint, RestrictedMessengerConstraint>
   >,
   'metadata'
 > & {
@@ -189,7 +185,7 @@ export class BaseController<
   ControllerState extends StateConstraint,
   // TODO: Either fix this lint violation or explain why it's necessary to ignore.
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  messenger extends RestrictedControllerMessenger<
+  messenger extends RestrictedMessenger<
     ControllerName,
     ActionConstraint | ControllerActions<ControllerName, ControllerState>,
     EventConstraint | ControllerEvents<ControllerName, ControllerState>,

--- a/packages/base-controller/src/Messenger.ts
+++ b/packages/base-controller/src/Messenger.ts
@@ -407,7 +407,7 @@ export class Messenger<
    * namespace. Ownership allows registering actions and publishing events, as well as
    * unregistering actions and clearing event subscriptions.
    *
-   * @param options - Controller messenger options.
+   * @param options - Messenger options.
    * @param options.name - The name of the thing this messenger will be handed to (e.g. the
    * controller name). This grants "ownership" of actions and events under this namespace to the
    * restricted messenger returned.

--- a/packages/base-controller/tests/helpers.ts
+++ b/packages/base-controller/tests/helpers.ts
@@ -1,15 +1,9 @@
-import type { RestrictedControllerMessenger } from '@metamask/base-controller';
+import type { RestrictedMessenger } from '@metamask/base-controller';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // We don't care about the types marked with `any` for this type.
 export type ExtractAvailableAction<Messenger> =
-  Messenger extends RestrictedControllerMessenger<
-    any,
-    infer Action,
-    any,
-    any,
-    any
-  >
+  Messenger extends RestrictedMessenger<any, infer Action, any, any, any>
     ? Action
     : never;
 /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -17,13 +11,7 @@ export type ExtractAvailableAction<Messenger> =
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // We don't care about the types marked with `any` for this type.
 export type ExtractAvailableEvent<Messenger> =
-  Messenger extends RestrictedControllerMessenger<
-    any,
-    any,
-    infer Event,
-    any,
-    any
-  >
+  Messenger extends RestrictedMessenger<any, any, infer Event, any, any>
     ? Event
     : never;
 /* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger` in the `@metamask/base-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
