### PR TITLE
chore(permission-log): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/permission-log-controller/src/PermissionLogController.ts
+++ b/packages/permission-log-controller/src/PermissionLogController.ts
@@ -1,6 +1,6 @@
 import {
   BaseController,
-  type RestrictedControllerMessenger,
+  type RestrictedMessenger,
 } from '@metamask/base-controller';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import {
@@ -70,7 +70,7 @@ export type PermissionLogControllerOptions = {
   messenger: PermissionLogControllerMessenger;
 };
 
-export type PermissionLogControllerMessenger = RestrictedControllerMessenger<
+export type PermissionLogControllerMessenger = RestrictedMessenger<
   typeof name,
   never,
   never,

--- a/packages/permission-log-controller/tests/PermissionLogController.test.ts
+++ b/packages/permission-log-controller/tests/PermissionLogController.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import type {
   JsonRpcEngineReturnHandler,
   JsonRpcEngineNextCallback,
@@ -41,7 +41,7 @@ const initController = ({
   restrictedMethods: Set<string>;
   state?: Partial<PermissionLogControllerState>;
 }): PermissionLogController => {
-  const messenger = new ControllerMessenger().getRestricted({
+  const messenger = new Messenger().getRestricted({
     name,
     allowedActions: [],
     allowedEvents: [],


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger` in the `@metamask/permission-log-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
