### PR TITLE
chore(polling): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/polling-controller/src/BlockTrackerPollingController.test.ts
+++ b/packages/polling-controller/src/BlockTrackerPollingController.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import type { NetworkClient } from '@metamask/network-controller';
 import EventEmitter from 'events';
 import { useFakeTimers } from 'sinon';
@@ -53,7 +53,7 @@ describe('BlockTrackerPollingController', () => {
   beforeEach(() => {
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockMessenger = new ControllerMessenger<any, any>();
+    mockMessenger = new Messenger<any, any>();
     controller = new ChildBlockTrackerPollingController({
       messenger: mockMessenger,
       metadata: {},

--- a/packages/polling-controller/src/StaticIntervalPollingController.test.ts
+++ b/packages/polling-controller/src/StaticIntervalPollingController.test.ts
@@ -1,9 +1,9 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { createDeferredPromise } from '@metamask/utils';
 import { useFakeTimers } from 'sinon';
 
-import { advanceTime } from '../../../tests/helpers';
 import { StaticIntervalPollingController } from './StaticIntervalPollingController';
+import { advanceTime } from '../../../tests/helpers';
 
 const TICK_TIME = 5;
 
@@ -46,7 +46,7 @@ describe('StaticIntervalPollingController', () => {
   beforeEach(() => {
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockMessenger = new ControllerMessenger<any, any>();
+    mockMessenger = new Messenger<any, any>();
     controller = new ChildBlockTrackerPollingController({
       messenger: mockMessenger,
       metadata: {},


### PR DESCRIPTION
## Explanation

Rename `ControllerMessenger` to `Messenger` in the `@metamask/polling-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
