### PR TITLE
chore(selected-network): Rename `ControllerMessenger` to `Messenger`

### DIFF
--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -1,4 +1,4 @@
-import type { RestrictedControllerMessenger } from '@metamask/base-controller';
+import type { RestrictedMessenger } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
 import type {
   BlockTrackerProxy,
@@ -91,7 +91,7 @@ export type AllowedEvents =
   | NetworkControllerStateChangeEvent
   | PermissionControllerStateChange;
 
-export type SelectedNetworkControllerMessenger = RestrictedControllerMessenger<
+export type SelectedNetworkControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   SelectedNetworkControllerActions | AllowedActions,
   SelectedNetworkControllerEvents | AllowedEvents,
@@ -130,7 +130,7 @@ export class SelectedNetworkController extends BaseController<
    * Construct a SelectedNetworkController controller.
    *
    * @param options - The controller options.
-   * @param options.messenger - The restricted controller messenger for the EncryptionPublicKey controller.
+   * @param options.messenger - The restricted messenger for the EncryptionPublicKey controller.
    * @param options.state - The controllers initial state.
    * @param options.useRequestQueuePreference - A boolean indicating whether to use the request queue preference.
    * @param options.onPreferencesStateChange - A callback that is called when the preference state changes.

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import {
   type ProviderProxy,
   type BlockTrackerProxy,
@@ -25,33 +25,33 @@ import {
 } from '../src/SelectedNetworkController';
 
 /**
- * Builds a new instance of the ControllerMessenger class for the SelectedNetworkController.
+ * Builds a new instance of the Messenger class for the SelectedNetworkController.
  *
- * @returns A new instance of the ControllerMessenger class for the SelectedNetworkController.
+ * @returns A new instance of the Messenger class for the SelectedNetworkController.
  */
 function buildMessenger() {
-  return new ControllerMessenger<
+  return new Messenger<
     SelectedNetworkControllerActions | AllowedActions,
     SelectedNetworkControllerEvents | AllowedEvents
   >();
 }
 
 /**
- * Build a restricted controller messenger for the selected network controller.
+ * Build a restricted messenger for the selected network controller.
  *
  * @param options - The options bag.
- * @param options.messenger - A controller messenger.
+ * @param options.messenger - A messenger.
  * @param options.getSubjectNames - Permissions controller list of domains with permissions
  * @returns The network controller restricted messenger.
  */
 function buildSelectedNetworkControllerMessenger({
-  messenger = new ControllerMessenger<
+  messenger = new Messenger<
     SelectedNetworkControllerActions | AllowedActions,
     SelectedNetworkControllerEvents | AllowedEvents
   >(),
   getSubjectNames,
 }: {
-  messenger?: ControllerMessenger<
+  messenger?: Messenger<
     SelectedNetworkControllerActions | AllowedActions,
     SelectedNetworkControllerEvents | AllowedEvents
   >;

--- a/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkMiddleware.test.ts
@@ -1,4 +1,4 @@
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import type { JsonRpcResponse } from '@metamask/utils';
 
@@ -13,7 +13,7 @@ import type { SelectedNetworkMiddlewareJsonRpcRequest } from '../src/SelectedNet
 import { createSelectedNetworkMiddleware } from '../src/SelectedNetworkMiddleware';
 
 const buildMessenger = () => {
-  return new ControllerMessenger<
+  return new Messenger<
     SelectedNetworkControllerActions | AllowedActions,
     SelectedNetworkControllerEvents | AllowedEvents
   >();


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger` in the `@metamask/selected-network-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
