### PR TITLE
chore(earn): Rename ControllerMessenger to Messenger

### DIFF
--- a/packages/earn-controller/src/EarnController.test.ts
+++ b/packages/earn-controller/src/EarnController.test.ts
@@ -1,5 +1,5 @@
 import type { AccountsController } from '@metamask/accounts-controller';
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { getDefaultNetworkControllerState } from '@metamask/network-controller';
 import { StakeSdk, StakingApiService } from '@metamask/stake-sdk';
 
@@ -30,12 +30,12 @@ jest.mock('@metamask/stake-sdk', () => ({
 }));
 
 /**
- * Builds a new instance of the ControllerMessenger class for the AccountsController.
+ * Builds a new instance of the Messenger class for the AccountsController.
  *
- * @returns A new instance of the ControllerMessenger class for the AccountsController.
+ * @returns A new instance of the Messenger class for the AccountsController.
  */
 function buildMessenger() {
-  return new ControllerMessenger<
+  return new Messenger<
     EarnControllerActions | AllowedActions,
     EarnControllerEvents | AllowedEvents
   >();

--- a/packages/earn-controller/src/EarnController.ts
+++ b/packages/earn-controller/src/EarnController.ts
@@ -6,7 +6,7 @@ import type {
 import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
-  RestrictedControllerMessenger,
+  RestrictedMessenger,
   StateMetadata,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
@@ -163,7 +163,7 @@ export type AllowedEvents =
  * The messenger which is restricted to actions and events accessed by
  * EarnController.
  */
-export type EarnControllerMessenger = RestrictedControllerMessenger<
+export type EarnControllerMessenger = RestrictedMessenger<
   typeof controllerName,
   EarnControllerActions | AllowedActions,
   EarnControllerEvents | AllowedEvents,


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger` in the `@metamask/earn-controller` package.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
