### PR TITLE
feat: remove metametrics dependencies in UserStorageController

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -600,13 +600,6 @@ describe('user-storage/user-storage-controller - getStorageKey() tests', () => {
     const { messengerMocks } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      state: {
-        isProfileSyncingEnabled: false,
-        isProfileSyncingUpdateLoading: false,
-        hasAccountSyncingSyncedAtLeastOnce: false,
-        isAccountSyncingReadyToBeDispatched: false,
-        isAccountSyncingInProgress: false,
-      },
     });
 
     messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -34,7 +34,6 @@ describe('user-storage/user-storage-controller - constructor() tests', () => {
     const { messengerMocks } = arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     expect(controller.state.isProfileSyncingEnabled).toBe(true);
@@ -60,7 +59,6 @@ describe('user-storage/user-storage-controller - constructor() tests', () => {
     const { messengerMocks } = arrangeMocks();
     new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
       env: {
         isNetworkSyncingEnabled: true,
       },
@@ -88,7 +86,6 @@ describe('user-storage/user-storage-controller - performGetStorage() tests', () 
     const { messengerMocks, mockAPI } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     const result = await controller.performGetStorage(
@@ -102,7 +99,6 @@ describe('user-storage/user-storage-controller - performGetStorage() tests', () 
     const { messengerMocks } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
@@ -146,7 +142,6 @@ describe('user-storage/user-storage-controller - performGetStorage() tests', () 
       arrangeFailureCase(messengerMocks);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
-        getMetaMetricsState: () => true,
       });
 
       await expect(
@@ -170,7 +165,6 @@ describe('user-storage/user-storage-controller - performGetStorageAllFeatureEntr
     const { messengerMocks, mockAPI } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     const result =
@@ -183,7 +177,6 @@ describe('user-storage/user-storage-controller - performGetStorageAllFeatureEntr
     const { messengerMocks } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
@@ -227,7 +220,6 @@ describe('user-storage/user-storage-controller - performGetStorageAllFeatureEntr
       arrangeFailureCase(messengerMocks);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
-        getMetaMetricsState: () => true,
       });
 
       await expect(
@@ -251,7 +243,6 @@ describe('user-storage/user-storage-controller - performSetStorage() tests', () 
     const { messengerMocks, mockAPI } = arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     await controller.performSetStorage(
@@ -265,7 +256,6 @@ describe('user-storage/user-storage-controller - performSetStorage() tests', () 
     const { messengerMocks } = arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
@@ -310,7 +300,6 @@ describe('user-storage/user-storage-controller - performSetStorage() tests', () 
       arrangeFailureCase(messengerMocks);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
-        getMetaMetricsState: () => true,
       });
 
       await expect(
@@ -331,7 +320,6 @@ describe('user-storage/user-storage-controller - performSetStorage() tests', () 
     });
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
     await expect(
       controller.performSetStorage(
@@ -357,7 +345,6 @@ describe('user-storage/user-storage-controller - performBatchSetStorage() tests'
     const { messengerMocks, mockAPI } = arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     await controller.performBatchSetStorage(
@@ -371,7 +358,6 @@ describe('user-storage/user-storage-controller - performBatchSetStorage() tests'
     const { messengerMocks } = arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
@@ -416,7 +402,6 @@ describe('user-storage/user-storage-controller - performBatchSetStorage() tests'
       arrangeFailureCase(messengerMocks);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
-        getMetaMetricsState: () => true,
       });
 
       await expect(
@@ -432,7 +417,6 @@ describe('user-storage/user-storage-controller - performBatchSetStorage() tests'
     const { messengerMocks, mockAPI } = arrangeMocks(500);
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     await expect(
@@ -460,7 +444,6 @@ describe('user-storage/user-storage-controller - performBatchDeleteStorage() tes
     const { messengerMocks, mockAPI } = arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     await controller.performBatchDeleteStorage('notifications', [
@@ -474,7 +457,6 @@ describe('user-storage/user-storage-controller - performBatchDeleteStorage() tes
     const { messengerMocks } = arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
@@ -519,7 +501,6 @@ describe('user-storage/user-storage-controller - performBatchDeleteStorage() tes
       arrangeFailureCase(messengerMocks);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
-        getMetaMetricsState: () => true,
       });
 
       await expect(
@@ -535,7 +516,6 @@ describe('user-storage/user-storage-controller - performBatchDeleteStorage() tes
     const { messengerMocks, mockAPI } = arrangeMocks(500);
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     await expect(
@@ -563,7 +543,6 @@ describe('user-storage/user-storage-controller - performDeleteStorage() tests', 
     const { messengerMocks, mockAPI } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     await controller.performDeleteStorage(
@@ -578,7 +557,6 @@ describe('user-storage/user-storage-controller - performDeleteStorage() tests', 
     const { messengerMocks } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
@@ -622,7 +600,6 @@ describe('user-storage/user-storage-controller - performDeleteStorage() tests', 
       arrangeFailureCase(messengerMocks);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
-        getMetaMetricsState: () => true,
       });
 
       await expect(
@@ -637,7 +614,6 @@ describe('user-storage/user-storage-controller - performDeleteStorage() tests', 
     const { messengerMocks, mockAPI } = await arrangeMocks(500);
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     await expect(
@@ -664,7 +640,6 @@ describe('user-storage/user-storage-controller - performDeleteStorageAllFeatureE
     const { messengerMocks, mockAPI } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     await controller.performDeleteStorageAllFeatureEntries(
@@ -679,7 +654,6 @@ describe('user-storage/user-storage-controller - performDeleteStorageAllFeatureE
     const { messengerMocks } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
@@ -723,7 +697,6 @@ describe('user-storage/user-storage-controller - performDeleteStorageAllFeatureE
       arrangeFailureCase(messengerMocks);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
-        getMetaMetricsState: () => true,
       });
 
       await expect(
@@ -738,7 +711,6 @@ describe('user-storage/user-storage-controller - performDeleteStorageAllFeatureE
     const { messengerMocks, mockAPI } = await arrangeMocks(500);
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     await expect(
@@ -761,7 +733,6 @@ describe('user-storage/user-storage-controller - getStorageKey() tests', () => {
     const { messengerMocks } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     const result = await controller.getStorageKey();
@@ -772,7 +743,6 @@ describe('user-storage/user-storage-controller - getStorageKey() tests', () => {
     const { messengerMocks } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
@@ -797,7 +767,6 @@ describe('user-storage/user-storage-controller - disableProfileSyncing() tests',
     const { messengerMocks } = await arrangeMocks();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
     });
 
     expect(controller.state.isProfileSyncingEnabled).toBe(true);
@@ -819,7 +788,6 @@ describe('user-storage/user-storage-controller - enableProfileSyncing() tests', 
 
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      getMetaMetricsState: () => true,
       state: {
         isProfileSyncingEnabled: false,
         isProfileSyncingUpdateLoading: false,
@@ -862,7 +830,6 @@ describe('user-storage/user-storage-controller - syncInternalAccountsWithUserSto
       arrangeMocks();
     const controller = new UserStorageController({
       messenger,
-      getMetaMetricsState: () => true,
       env: {
         // We're only verifying that calling this controller method will call the integration module
         // The actual implementation is tested in the integration tests
@@ -924,7 +891,6 @@ describe('user-storage/user-storage-controller - saveInternalAccountToUserStorag
     const { messenger, mockSaveInternalAccountToUserStorage } = arrangeMocks();
     const controller = new UserStorageController({
       messenger,
-      getMetaMetricsState: () => true,
       env: {
         // We're only verifying that calling this controller method will call the integration module
         // The actual implementation is tested in the integration tests
@@ -970,15 +936,10 @@ describe('user-storage/user-storage-controller - syncNetworks() tests', () => {
     };
   };
 
-  const nonImportantControllerProps = () => ({
-    getMetaMetricsState: () => true,
-  });
-
   it('should not be invoked if the feature is not enabled', async () => {
     const { messenger, mockGetSessionProfile, mockPerformMainNetworkSync } =
       arrangeMocks();
     const controller = new UserStorageController({
-      ...nonImportantControllerProps(),
       messenger,
       env: {
         isNetworkSyncingEnabled: false,
@@ -997,7 +958,6 @@ describe('user-storage/user-storage-controller - syncNetworks() tests', () => {
     const { messenger, mockGetSessionProfile, mockPerformMainNetworkSync } =
       arrangeMocks();
     const controller = new UserStorageController({
-      ...nonImportantControllerProps(),
       messenger,
       env: {
         isNetworkSyncingEnabled: true,

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -380,14 +380,11 @@ export default class UserStorageController extends BaseController<
 
   readonly #nativeScryptCrypto: NativeScrypt | undefined = undefined;
 
-  getMetaMetricsState: () => boolean;
-
   constructor({
     messenger,
     state,
     env,
     config,
-    getMetaMetricsState,
     nativeScryptCrypto,
   }: {
     messenger: UserStorageControllerMessenger;
@@ -397,7 +394,6 @@ export default class UserStorageController extends BaseController<
       isAccountSyncingEnabled?: boolean;
       isNetworkSyncingEnabled?: boolean;
     };
-    getMetaMetricsState: () => boolean;
     nativeScryptCrypto?: NativeScrypt;
   }) {
     super({
@@ -411,7 +407,6 @@ export default class UserStorageController extends BaseController<
     this.#env.isNetworkSyncingEnabled = Boolean(env?.isNetworkSyncingEnabled);
     this.#config = config;
 
-    this.getMetaMetricsState = getMetaMetricsState;
     this.#keyringController.setupLockedStateSubscriptions();
     this.#registerMessageHandlers();
     this.#nativeScryptCrypto = nativeScryptCrypto;
@@ -543,12 +538,6 @@ export default class UserStorageController extends BaseController<
 
       if (isNotificationServicesEnabled) {
         await this.#notificationServices.disableNotificationServices();
-      }
-
-      const isMetaMetricsParticipation = this.getMetaMetricsState();
-
-      if (!isMetaMetricsParticipation) {
-        await this.#auth.signOut();
       }
 
       this.#setIsProfileSyncingUpdateLoading(false);

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/controller-integration.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/controller-integration.test.ts
@@ -48,7 +48,6 @@ const arrangeMocks = async ({
     env: {
       isAccountSyncingEnabled,
     },
-    getMetaMetricsState: () => true,
     state: {
       ...baseState,
       ...stateOverrides,


### PR DESCRIPTION
## Explanation

This PR removes MetaMetrics dependencies in `UserStorageController` as those are needed only for `AuthenticationController`. 

## References

Fixes: https://consensyssoftware.atlassian.net/browse/IDENTITY-15

## Changelog

### `@metamask/profile-sync-controller`

- **BREAKING**: Remove MetaMetrics dependencies from `UserStorageController`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
