### PR TITLE
Release/295.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "294.0.0",
+  "version": "295.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: mark `@metamask/snaps-controllers` peer dependency bump as breaking in CHANGELOG ([#5267](https://github.com/MetaMask/core/pull/5267))
+- chore(accounts): fix AccountsController eslint warnings & errors ([#5266](https://github.com/MetaMask/core/pull/5266))
+- chore(accounts): Rename `ControllerMessenger` to `Messenger` ([#5090](https://github.com/MetaMask/core/pull/5090))
+- fix(accounts-controller): export `*` in index ([#5224](https://github.com/MetaMask/core/pull/5224))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- feat: bump snaps-sdk to v6.16.0 ([#5220](https://github.com/MetaMask/core/pull/5220))
+
 ### Changed
 
 - **BREAKING:** Bump `@metamask/snaps-controllers` peer dependency from `^9.7.0` to `^9.19.0` ([#5265](https://github.com/MetaMask/core/pull/5265))

--- a/packages/address-book-controller/CHANGELOG.md
+++ b/packages/address-book-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(address-book-controller): Rename `ControllerMessenger` to `Messenger` ([#5091](https://github.com/MetaMask/core/pull/5091))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+- Bump `@metamask/utils` to `^11.0.1` and `@metamask/rpc-errors` to `^7.0.2` ([#5080](https://github.com/MetaMask/core/pull/5080))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))

--- a/packages/announcement-controller/CHANGELOG.md
+++ b/packages/announcement-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore(accouncement): Rename `ControllerMessenger` to `Messenger` ([#5092](https://github.com/MetaMask/core/pull/5092))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore(approval): Rename `ControllerMessenger` to `Messenger` ([#5228](https://github.com/MetaMask/core/pull/5228))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+
 ## [7.1.2]
 
 ### Changed

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: update multichain controllers to listen for new update events ([#5221](https://github.com/MetaMask/core/pull/5221))
+- chore(multichain-assets): Rename `ControllerMessenger` to `Messenger` ([#5282](https://github.com/MetaMask/core/pull/5282))
+- chore(multichain-assets): Rename `RestrictedControllerMessenger` to `RestrictedMessenger` ([#5281](https://github.com/MetaMask/core/pull/5281))
+- feat: add multichain assets controller ([#5138](https://github.com/MetaMask/core/pull/5138))
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- fix: fix tokens state ([#5257](https://github.com/MetaMask/core/pull/5257))
+- chore(assets): Rename `ControllerMessenger` to `Messenger` ([#5229](https://github.com/MetaMask/core/pull/5229))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- feat: bump snaps-sdk to v6.16.0 ([#5220](https://github.com/MetaMask/core/pull/5220))
+
 ### Changed
 
 - Bump `@metamask/snaps-utils` from `^8.9.0` to `^8.10.0` ([#5265](https://github.com/MetaMask/core/pull/5265))

--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(base): Rename `ControllerMessenger` to `Messenger` ([#5246](https://github.com/MetaMask/core/pull/5246))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+
 ### Changed
 
 - **BREAKING:** Remove deprecated messenger-related exports and simplify `RestrictedMessenger` constructor ([#5260](https://github.com/MetaMask/core/pull/5260))

--- a/packages/build-utils/CHANGELOG.md
+++ b/packages/build-utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Bump `eslint` to `^9.11.1` and migrate to flat config ([#4727](https://github.com/MetaMask/core/pull/4727))
+- Bump `@metamask/utils` to `^11.0.1` and `@metamask/rpc-errors` to `^7.0.2` ([#5080](https://github.com/MetaMask/core/pull/5080))
+
 ## [3.0.2]
 
 ### Changed

--- a/packages/composable-controller/CHANGELOG.md
+++ b/packages/composable-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(composable): Rename `ControllerMessenger` to `Messenger` ([#5230](https://github.com/MetaMask/core/pull/5230))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+- Release 274.0.0 ([#5082](https://github.com/MetaMask/core/pull/5082))
+
 ### Changed
 
 - **BREAKING:** Re-define `ComposableControllerStateConstraint` type using `StateConstraint` instead of `LegacyControllerStateConstraint` ([#5018](https://github.com/MetaMask/core/pull/5018/))

--- a/packages/earn-controller/CHANGELOG.md
+++ b/packages/earn-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+
 ## [0.1.0]
 
 ### Added

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(ens): Rename `ControllerMessenger` to `Messenger` ([#5231](https://github.com/MetaMask/core/pull/5231))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+- Bump `@metamask/utils` to `^11.0.1` and `@metamask/rpc-errors` to `^7.0.2` ([#5080](https://github.com/MetaMask/core/pull/5080))
+- Release 266.0.0 ([#5038](https://github.com/MetaMask/core/pull/5038))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(gas-fee): Rename `ControllerMessenger` to `Messenger` ([#5232](https://github.com/MetaMask/core/pull/5232))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+- Bump `@metamask/utils` to `^11.0.1` and `@metamask/rpc-errors` to `^7.0.2` ([#5080](https://github.com/MetaMask/core/pull/5080))
+- Release 266.0.0 ([#5038](https://github.com/MetaMask/core/pull/5038))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))

--- a/packages/json-rpc-middleware-stream/CHANGELOG.md
+++ b/packages/json-rpc-middleware-stream/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Fix ESLint config ([#5132](https://github.com/MetaMask/core/pull/5132))
+
 ## [8.0.6]
 
 ### Changed
@@ -203,13 +209,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [7.0.0]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@6.0.2...@metamask/json-rpc-middleware-stream@7.0.0
 [6.0.2]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@6.0.1...@metamask/json-rpc-middleware-stream@6.0.2
 [6.0.1]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@6.0.0...@metamask/json-rpc-middleware-stream@6.0.1
-[6.0.0]: https://github.com/MetaMask/core/compare/json-rpc-middleware-stream@5.0.1...@metamask/json-rpc-middleware-stream@6.0.0
-[5.0.1]: https://github.com/MetaMask/core/compare/json-rpc-middleware-stream@5.0.0...json-rpc-middleware-stream@5.0.1
-[5.0.0]: https://github.com/MetaMask/core/compare/json-rpc-middleware-stream@4.2.3...json-rpc-middleware-stream@5.0.0
-[4.2.3]: https://github.com/MetaMask/core/compare/json-rpc-middleware-stream@4.2.2...json-rpc-middleware-stream@4.2.3
-[4.2.2]: https://github.com/MetaMask/core/compare/json-rpc-middleware-stream@4.2.1...json-rpc-middleware-stream@4.2.2
-[4.2.1]: https://github.com/MetaMask/core/compare/json-rpc-middleware-stream@4.2.0...json-rpc-middleware-stream@4.2.1
-[4.2.0]: https://github.com/MetaMask/core/compare/json-rpc-middleware-stream@4.1.0...json-rpc-middleware-stream@4.2.0
-[4.1.0]: https://github.com/MetaMask/core/compare/json-rpc-middleware-stream@4.0.0...json-rpc-middleware-stream@4.1.0
-[4.0.0]: https://github.com/MetaMask/core/compare/json-rpc-middleware-stream@3.0.0...json-rpc-middleware-stream@4.0.0
-[3.0.0]: https://github.com/MetaMask/core/releases/tag/json-rpc-middleware-stream@3.0.0
+[6.0.0]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@5.0.1...@metamask/json-rpc-middleware-stream@6.0.0
+[5.0.1]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@5.0.0...@metamask/json-rpc-middleware-stream@5.0.1
+[5.0.0]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@4.2.3...@metamask/json-rpc-middleware-stream@5.0.0
+[4.2.3]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@4.2.2...@metamask/json-rpc-middleware-stream@4.2.3
+[4.2.2]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@4.2.1...@metamask/json-rpc-middleware-stream@4.2.2
+[4.2.1]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@4.2.0...@metamask/json-rpc-middleware-stream@4.2.1
+[4.2.0]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@4.1.0...@metamask/json-rpc-middleware-stream@4.2.0
+[4.1.0]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@4.0.0...@metamask/json-rpc-middleware-stream@4.1.0
+[4.0.0]: https://github.com/MetaMask/core/compare/@metamask/json-rpc-middleware-stream@3.0.0...@metamask/json-rpc-middleware-stream@4.0.0
+[3.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/json-rpc-middleware-stream@3.0.0

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: fix lint warnings in `KeyringController` ([#5170](https://github.com/MetaMask/core/pull/5170))
+- chore(keyring): Rename `RestrictedControllerMessenger` to `RestrictedMessenger` ([#5239](https://github.com/MetaMask/core/pull/5239))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+
 ### Changed
 
 - Bump `@metamask/keyring-api"` from `^16.1.0` to `^17.0.0` ([#5280](https://github.com/MetaMask/core/pull/5280))

--- a/packages/logging-controller/CHANGELOG.md
+++ b/packages/logging-controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(logging): Rename `ControllerMessenger` to `Messenger` ([#5235](https://github.com/MetaMask/core/pull/5235))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(message-manager): Rename `ControllerMessenger` to `Messenger` ([#5233](https://github.com/MetaMask/core/pull/5233))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+
 ## [12.0.0]
 
 ### Changed

--- a/packages/multichain-transactions-controller/CHANGELOG.md
+++ b/packages/multichain-transactions-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: update multichain controllers to listen for new update events ([#5221](https://github.com/MetaMask/core/pull/5221))
+- chore: mark `@metamask/snaps-controllers` peer dependency bump as breaking in CHANGELOG ([#5267](https://github.com/MetaMask/core/pull/5267))
+- chore(multichain-transactions): Rename `RestrictedControllerMessenger` to `RestrictedMessenger` ([#5240](https://github.com/MetaMask/core/pull/5240))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- feat: bump snaps-sdk to v6.16.0 ([#5220](https://github.com/MetaMask/core/pull/5220))
+
 ### Changed
 
 - **BREAKING:** Bump `@metamask/snaps-controllers` peer dependency from `^9.10.0` to `^9.19.0` ([#5265](https://github.com/MetaMask/core/pull/5265))

--- a/packages/multichain/CHANGELOG.md
+++ b/packages/multichain/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+
 ## [2.1.0]
 
 ### Added

--- a/packages/name-controller/CHANGELOG.md
+++ b/packages/name-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(name): Rename `RestrictedControllerMessenger` to `RestrictedMessenger` ([#5236](https://github.com/MetaMask/core/pull/5236))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+- Bump `@metamask/utils` to `^11.0.1` and `@metamask/rpc-errors` to `^7.0.2` ([#5080](https://github.com/MetaMask/core/pull/5080))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(permission): Rename `ControllerMessenger` to `Messenger` ([#5245](https://github.com/MetaMask/core/pull/5245))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Fix ESLint config ([#5132](https://github.com/MetaMask/core/pull/5132))
+
 ## [11.0.5]
 
 ### Changed

--- a/packages/permission-log-controller/CHANGELOG.md
+++ b/packages/permission-log-controller/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(permission-log): Rename `ControllerMessenger` to `Messenger` ([#5247](https://github.com/MetaMask/core/pull/5247))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+- Release 274.0.0 ([#5082](https://github.com/MetaMask/core/pull/5082))
+- Bump `@metamask/utils` to `^11.0.1` and `@metamask/rpc-errors` to `^7.0.2` ([#5080](https://github.com/MetaMask/core/pull/5080))
+- chore: bump nanoid dependency ([#5073](https://github.com/MetaMask/core/pull/5073))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))

--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(phishing): Rename `ControllerMessenger` to `Messenger` ([#5248](https://github.com/MetaMask/core/pull/5248))
+- Fix ESLint config ([#5132](https://github.com/MetaMask/core/pull/5132))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))

--- a/packages/polling-controller/CHANGELOG.md
+++ b/packages/polling-controller/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(polling): Rename `ControllerMessenger` to `Messenger` ([#5249](https://github.com/MetaMask/core/pull/5249))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Fix ESLint config ([#5132](https://github.com/MetaMask/core/pull/5132))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+- Bump `@metamask/utils` to `^11.0.1` and `@metamask/rpc-errors` to `^7.0.2` ([#5080](https://github.com/MetaMask/core/pull/5080))
+- Release 266.0.0 ([#5038](https://github.com/MetaMask/core/pull/5038))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(preferences): Rename `ControllerMessenger` to `Messenger` ([#5251](https://github.com/MetaMask/core/pull/5251))
+- Release 290.0.0 ([#5218](https://github.com/MetaMask/core/pull/5218))
+- Release 287.0.0 ([#5182](https://github.com/MetaMask/core/pull/5182))
+- Release 281.0.0 ([#5140](https://github.com/MetaMask/core/pull/5140))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+- Release 270.0.0 ([#5058](https://github.com/MetaMask/core/pull/5058))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))

--- a/packages/queued-request-controller/CHANGELOG.md
+++ b/packages/queued-request-controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(queued-request): Rename `ControllerMessenger` to `Messenger` ([#5254](https://github.com/MetaMask/core/pull/5254))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+
 ## [9.0.0]
 
 ### Added

--- a/packages/rate-limit-controller/CHANGELOG.md
+++ b/packages/rate-limit-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore(rate-limit): Rename `ControllerMessenger` to `Messenger` ([#5255](https://github.com/MetaMask/core/pull/5255))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+- Bump `@metamask/utils` to `^11.0.1` and `@metamask/rpc-errors` to `^7.0.2` ([#5080](https://github.com/MetaMask/core/pull/5080))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^7.0.0` to `^7.1.0` ([#5079](https://github.com/MetaMask/core/pull/5079))

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(remote-feature-flag): Rename `ControllerMessenger` to `Messenger` ([#5253](https://github.com/MetaMask/core/pull/5253))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+
 ### Added
 
 - Add `onBreak` and `onDegraded` methods to `ClientConfigApiService` ([#5109](https://github.com/MetaMask/core/pull/5109))

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(selected-network): Rename `ControllerMessenger` to `Messenger` ([#5256](https://github.com/MetaMask/core/pull/5256))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+
 ## [21.0.0]
 
 ### Added

--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- chore(signature): Rename `RestrictedControllerMessenger` to `RestrictedMessenger` ([#5237](https://github.com/MetaMask/core/pull/5237))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Release 290.0.0 ([#5218](https://github.com/MetaMask/core/pull/5218))
+- Release 287.0.0 ([#5182](https://github.com/MetaMask/core/pull/5182))
+- Fix ESLint config ([#5132](https://github.com/MetaMask/core/pull/5132))
+- Release 281.0.0 ([#5140](https://github.com/MetaMask/core/pull/5140))
+- Release 280.0.0 ([#5135](https://github.com/MetaMask/core/pull/5135))
+
 ## [23.2.0]
 
 ### Changed

--- a/packages/token-search-discovery-controller/CHANGELOG.md
+++ b/packages/token-search-discovery-controller/CHANGELOG.md
@@ -7,18 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- feat: MMPD-1522 add fetch trending token data ([#5214](https://github.com/MetaMask/core/pull/5214))
-- chore(token-search-discovery): Rename `ControllerMessenger` to `Messenger` ([#5243](https://github.com/MetaMask/core/pull/5243))
-- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
-- feat: add logo url to token search api service and update searchTokens path ([#5195](https://github.com/MetaMask/core/pull/5195))
+## [1.1.0]
 
 ### Added
 
-- Introduce the `logoUrl` property to the `TokenSearchApiService` response
+- Rename `ControllerMessenger` to `Messenger` ([#5243](https://github.com/MetaMask/core/pull/5243))
+- Bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- Introduce the `logoUrl` property to the `TokenSearchApiService` response ([#5195](https://github.com/MetaMask/core/pull/5195))
   - Specifically in the `TokenSearchResponseItem` type
-- Introduce `TokenDiscoveryApiService` to keep discovery and search responsibilities separate
+- Introduce `TokenDiscoveryApiService` to keep discovery and search responsibilities separate ([#5214](https://github.com/MetaMask/core/pull/5214))
   - This service is responsible for fetching discover related data
   - Add `getTrendingTokens` method to fetch trending tokens by chain
   - Add `TokenTrendingResponseItem` type for trending token responses
@@ -26,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update the TokenSearchApiService to use the updated URL for `searchTokens`
+- Update the TokenSearchApiService to use the updated URL for `searchTokens` ([#5195](https://github.com/MetaMask/core/pull/5195))
   - The URL is now `/tokens-search` instead of `/tokens-search/name`
 - Changed the "name" parameter to "query" in the `searchTokens` method
 - These updates align with the Portfolio API's `/tokens-search` endpoint
@@ -41,5 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This service is responsible for making search related requests to the Portfolio API
   - Specifically, it handles the `tokens-search` endpoint which returns a list of tokens based on the provided query parameters
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/token-search-discovery-controller@1.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/token-search-discovery-controller@1.1.0...HEAD
+[1.1.0]: https://github.com/MetaMask/core/compare/@metamask/token-search-discovery-controller@1.0.0...@metamask/token-search-discovery-controller@1.1.0
 [1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/token-search-discovery-controller@1.0.0

--- a/packages/token-search-discovery-controller/CHANGELOG.md
+++ b/packages/token-search-discovery-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat: MMPD-1522 add fetch trending token data ([#5214](https://github.com/MetaMask/core/pull/5214))
+- chore(token-search-discovery): Rename `ControllerMessenger` to `Messenger` ([#5243](https://github.com/MetaMask/core/pull/5243))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+- feat: add logo url to token search api service and update searchTokens path ([#5195](https://github.com/MetaMask/core/pull/5195))
+
 ### Added
 
 - Introduce the `logoUrl` property to the `TokenSearchApiService` response

--- a/packages/token-search-discovery-controller/package.json
+++ b/packages/token-search-discovery-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/token-search-discovery-controller",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Manages token search and discovery through the Portfolio API",
   "keywords": [
     "MetaMask",

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+
 ## [44.1.0]
 
 ### Changed

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Release 293.0.0 ([#5272](https://github.com/MetaMask/core/pull/5272))
+- Release 291.0.0 ([#5264](https://github.com/MetaMask/core/pull/5264))
+- chore(user-operation): Rename `RestrictedControllerMessenger` to `RestrictedMessenger` ([#5238](https://github.com/MetaMask/core/pull/5238))
+- feat: bump @metamask/utils to v11.1.0 ([#5223](https://github.com/MetaMask/core/pull/5223))
+
 ## [23.0.0]
 
 ### Changed


### PR DESCRIPTION
Explanation
This is a RC for v295.0.0.

@metamask/token-search-discovery-controller@1.1.0

## Highlights:
## Added
- Introduce the `logoUrl`
- Introduce `TokenDiscoveryApiService`
    - Add `getTrendingTokens` method
- Export types from pakage index for easier access to consumers

## Changed
- TokenSearchApiService uses the updated URL for `searchTokens`
  - "name" parameter is now "query"

Changelog has complete details.

Checklist
- [x]  I've updated the test suite for new or updated code as appropriate
- [x]  I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x]  I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x]  I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes