### PR TITLE
feat: expose all user storage methods through messenger actions

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -192,6 +192,9 @@ type ActionsObj = CreateActionsObj<
   | 'performGetStorage'
   | 'performGetStorageAllFeatureEntries'
   | 'performSetStorage'
+  | 'performBatchSetStorage'
+  | 'performDeleteStorage'
+  | 'performBatchDeleteStorage'
   | 'getStorageKey'
   | 'enableProfileSyncing'
   | 'disableProfileSyncing'
@@ -211,6 +214,12 @@ export type UserStorageControllerPerformGetStorageAllFeatureEntries =
   ActionsObj['performGetStorageAllFeatureEntries'];
 export type UserStorageControllerPerformSetStorage =
   ActionsObj['performSetStorage'];
+export type UserStorageControllerPerformBatchSetStorage =
+  ActionsObj['performBatchSetStorage'];
+export type UserStorageControllerPerformDeleteStorage =
+  ActionsObj['performDeleteStorage'];
+export type UserStorageControllerPerformBatchDeleteStorage =
+  ActionsObj['performBatchDeleteStorage'];
 export type UserStorageControllerGetStorageKey = ActionsObj['getStorageKey'];
 export type UserStorageControllerEnableProfileSyncing =
   ActionsObj['enableProfileSyncing'];
@@ -422,6 +431,21 @@ export default class UserStorageController extends BaseController<
     this.messagingSystem.registerActionHandler(
       'UserStorageController:performSetStorage',
       this.performSetStorage.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      'UserStorageController:performBatchSetStorage',
+      this.performBatchSetStorage.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      'UserStorageController:performDeleteStorage',
+      this.performDeleteStorage.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      'UserStorageController:performBatchDeleteStorage',
+      this.performBatchDeleteStorage.bind(this),
     );
 
     this.messagingSystem.registerActionHandler(


### PR DESCRIPTION
## Explanation

This PR exposes all (but the dangerous `deleteAllFeatureEntries`) user storage methods

## References

Fixes: 
- https://github.com/MetaMask/core/issues/4937
- https://consensyssoftware.atlassian.net/browse/IDENTITY-29

## Changelog

### `@metamask/profile-sync-controller`

- **ADDED**: Added `performBatchSetStorage`, `performDeleteStorage` and `performBatchDeleteStorage` to the exposed messenger actions

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
