### PR TITLE
chore: Change ownership of SelectedNetworkController

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,6 +43,7 @@
 ## Wallet API Platform Team
 /packages/multichain                       @MetaMask/wallet-api-platform-engineers
 /packages/queued-request-controller        @MetaMask/wallet-api-platform-engineers
+/packages/selected-network-controller      @MetaMask/wallet-api-platform-engineers
 
 ## Wallet Framework Team
 /packages/base-controller              @MetaMask/wallet-framework-engineers
@@ -62,7 +63,6 @@
 /packages/network-controller           @MetaMask/wallet-framework-engineers @MetaMask/metamask-assets
 /packages/permission-controller        @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers @MetaMask/snaps-devs
 /packages/permission-log-controller    @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers
-/packages/selected-network-controller  @MetaMask/wallet-api-platform-engineers @MetaMask/wallet-framework-engineers @MetaMask/metamask-assets
 /packages/profile-sync-controller      @MetaMask/notifications @MetaMask/identity
 
 ## Package Release related


### PR DESCRIPTION
## Explanation

The package `@metamask/selected-network-controller` is now owned solely by the Wallet API Platform team, rather than being shared between multiple teams. This team has the most context for what this code does, and it will in the future be increasingly less relevant to the rest of the wallet apart from supporting the EIP-1193 provider.

## References

N/A

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
