### PR TITLE
Fix invalid type import path in `@metamask/multichain`

### DIFF
--- a/packages/multichain/src/handlers/wallet-getSession.ts
+++ b/packages/multichain/src/handlers/wallet-getSession.ts
@@ -1,6 +1,5 @@
 import type { Caveat } from '@metamask/permission-controller';
 import type { JsonRpcRequest, JsonRpcSuccess } from '@metamask/utils';
-import type { NormalizedScopesObject } from '../scope/types';
 
 import { getSessionScopes } from '../adapters/caip-permission-adapter-session-scopes';
 import type { Caip25CaveatValue } from '../caip25Permission';
@@ -8,6 +7,7 @@ import {
   Caip25CaveatType,
   Caip25EndowmentPermissionName,
 } from '../caip25Permission';
+import type { NormalizedScopesObject } from '../scope/types';
 
 /**
  * Handler for the `wallet_getSession` RPC method as specified by [CAIP-312](https://chainagnostic.org/CAIPs/caip-312).

--- a/packages/multichain/src/handlers/wallet-getSession.ts
+++ b/packages/multichain/src/handlers/wallet-getSession.ts
@@ -1,6 +1,6 @@
 import type { Caveat } from '@metamask/permission-controller';
 import type { JsonRpcRequest, JsonRpcSuccess } from '@metamask/utils';
-import type { NormalizedScopesObject } from 'src/scope/types';
+import type { NormalizedScopesObject } from '../scope/types';
 
 import { getSessionScopes } from '../adapters/caip-permission-adapter-session-scopes';
 import type { Caip25CaveatValue } from '../caip25Permission';


### PR DESCRIPTION
## Explanation

`@metamask/multichain` was importing `src/scope/types`, which does not work when importing the library in other projects. I've changed it to `../scope/types` instead.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/multichain`

- **FIXED**: Fix invalid type import path

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
