### PR TITLE
fix: change maxNumberOfAccountsToAdd default value from 100 to Infinity

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/controller-integration.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/controller-integration.ts
@@ -123,7 +123,7 @@ export async function syncInternalAccountsWithUserStorage(
   }
 
   const {
-    maxNumberOfAccountsToAdd = 100,
+    maxNumberOfAccountsToAdd = Infinity,
     onAccountAdded,
     onAccountNameUpdated,
     onAccountSyncErroneousSituation,


### PR DESCRIPTION
## Explanation

This PR changes the default value for account syncing's `maxNumberOfAccountsToAdd` from `100` to `Infinity`.
It will become the client's responsibility to set this number to a specific value. If not specified, account sync will synchronize every account.

## References

Related to: https://consensyssoftware.atlassian.net/browse/IDENTITY-28

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/profile-sync-controller`

- **CHANGED**: change `maxNumberOfAccountsToAdd` default value from `100` to `Infinity`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
