### PR TITLE
fix: fix peer deps for `@metamask/{accounts,multichain-network}-controller`

### DIFF
--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -49,10 +49,10 @@
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",
     "@metamask/base-controller": "^8.0.0",
-    "@metamask/network-controller": "^22.2.1",
     "@metamask/eth-snap-keyring": "^10.0.0",
     "@metamask/keyring-api": "^17.0.0",
     "@metamask/keyring-internal-api": "^4.0.1",
+    "@metamask/network-controller": "^22.2.1",
     "@metamask/snaps-sdk": "^6.17.1",
     "@metamask/snaps-utils": "^8.10.0",
     "@metamask/utils": "^11.1.0",

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",
     "@metamask/base-controller": "^8.0.0",
+    "@metamask/network-controller": "^22.2.1",
     "@metamask/eth-snap-keyring": "^10.0.0",
     "@metamask/keyring-api": "^17.0.0",
     "@metamask/keyring-internal-api": "^4.0.1",
@@ -63,7 +64,6 @@
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-controller": "^19.1.0",
-    "@metamask/network-controller": "^22.2.1",
     "@metamask/providers": "^18.1.1",
     "@metamask/snaps-controllers": "^9.19.0",
     "@types/jest": "^27.4.1",
@@ -77,6 +77,7 @@
   },
   "peerDependencies": {
     "@metamask/keyring-controller": "^19.0.0",
+    "@metamask/network-controller": "^22.0.0",
     "@metamask/providers": "^18.1.0",
     "@metamask/snaps-controllers": "^9.19.0",
     "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -76,8 +76,7 @@
     "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
-    "@metamask/keyring-controller": "^19.1.0",
-    "@metamask/network-controller": "^22.2.1",
+    "@metamask/keyring-controller": "^19.0.0",
     "@metamask/providers": "^18.1.0",
     "@metamask/snaps-controllers": "^9.19.0",
     "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"

--- a/packages/multichain-network-controller/package.json
+++ b/packages/multichain-network-controller/package.json
@@ -68,7 +68,8 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
-    "@metamask/network-controller": "^22.2.1"
+    "@metamask/accounts-controller": "^23.0.0",
+    "@metamask/network-controller": "^22.0.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2370,8 +2370,7 @@ __metadata:
     uuid: "npm:^8.3.2"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/keyring-controller": ^19.1.0
-    "@metamask/network-controller": ^22.2.1
+    "@metamask/keyring-controller": ^19.0.0
     "@metamask/providers": ^18.1.0
     "@metamask/snaps-controllers": ^9.19.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
@@ -3475,7 +3474,8 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/network-controller": ^22.2.1
+    "@metamask/accounts-controller": ^24.0.0
+    "@metamask/network-controller": ^22.0.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,6 +2371,7 @@ __metadata:
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/keyring-controller": ^19.0.0
+    "@metamask/network-controller": ^22.0.0
     "@metamask/providers": ^18.1.0
     "@metamask/snaps-controllers": ^9.19.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
@@ -3474,7 +3475,7 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.2.2"
   peerDependencies:
-    "@metamask/accounts-controller": ^24.0.0
+    "@metamask/accounts-controller": ^23.0.0
     "@metamask/network-controller": ^22.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Explanation

The 2 controllers depend on each other, however we cannot really express this with peer deps.

So for now, we only declare this "relation" on the new controller `mutltichain-network-controller`.

Also downgrading some peer dep to use the major version.

## References

N/A

## Changelog

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
