### PR TITLE
feat: add new `addNewAccounts` method to `KeyringController`

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -247,8 +247,7 @@
   },
   "packages/keyring-controller/src/KeyringController.ts": {
     "@typescript-eslint/no-unsafe-enum-comparison": 5,
-    "@typescript-eslint/no-unused-vars": 2,
-    "jsdoc/tag-lines": 1
+    "@typescript-eslint/no-unused-vars": 2
   },
   "packages/keyring-controller/tests/mocks/mockKeyring.ts": {
     "@typescript-eslint/prefer-readonly": 1

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -177,6 +177,11 @@ export type KeyringControllerAddNewAccountAction = {
   handler: KeyringController['addNewAccount'];
 };
 
+export type KeyringControllerAddNewAccountsAction = {
+  type: `${typeof name}:addNewAccounts`;
+  handler: KeyringController['addNewAccounts'];
+};
+
 export type KeyringControllerStateChangeEvent = {
   type: `${typeof name}:stateChange`;
   payload: [KeyringControllerState, Patch[]];
@@ -216,7 +221,8 @@ export type KeyringControllerActions =
   | KeyringControllerPrepareUserOperationAction
   | KeyringControllerPatchUserOperationAction
   | KeyringControllerSignUserOperationAction
-  | KeyringControllerAddNewAccountAction;
+  | KeyringControllerAddNewAccountAction
+  | KeyringControllerAddNewAccountsAction;
 
 export type KeyringControllerEvents =
   | KeyringControllerStateChangeEvent
@@ -1834,6 +1840,11 @@ export class KeyringController extends BaseController<
     this.messagingSystem.registerActionHandler(
       `${name}:addNewAccount`,
       this.addNewAccount.bind(this),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${name}:addNewAccounts`,
+      this.addNewAccounts.bind(this),
     );
   }
 


### PR DESCRIPTION
## Explanation

This PR adds a new `addNewAccounts` method to the `KeyringController`.
This is needed so that the Account syncing feature can add accounts in bulk instead of in a 1-by-1 manner.

By doing that, we will stop calling `eth_getBalance` for each newly added account by account syncing, and instead rely on a stream of `eth_call`s, greatly improving our clients' performance.

## References

Related to: https://consensyssoftware.atlassian.net/browse/IDENTITY-32

## Changelog

### `@metamask/keyring-controller`

- **ADDED**: new `addNewAccounts` method that adds accounts in bulk

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
