### PR TITLE
Use Prettier 2 for Jest

### DIFF
--- a/jest.config.packages.js
+++ b/jest.config.packages.js
@@ -100,6 +100,10 @@ module.exports = {
   // A preset that is used as a base for Jest's configuration
   preset: 'ts-jest',
 
+  // The path to the Prettier executable used to format snapshots
+  // Jest doesn't support Prettier 3 yet, so we use Prettier 2
+  prettierPath: require.resolve('prettier-2'),
+
   // Run tests from one or more projects
   // projects: undefined
 

--- a/jest.config.scripts.js
+++ b/jest.config.scripts.js
@@ -50,6 +50,10 @@ module.exports = {
   // // A preset that is used as a base for Jest's configuration
   // preset: 'ts-jest',
 
+  // The path to the Prettier executable used to format snapshots
+  // Jest doesn't support Prettier 3 yet, so we use Prettier 2
+  prettierPath: require.resolve('prettier-2'),
+
   // "resetMocks" resets all mocks, including mocked modules, to jest.fn(),
   // between each test case.
   resetMocks: true,

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "lodash": "^4.17.21",
     "nock": "^13.3.1",
     "prettier": "^3.3.3",
+    "prettier-2": "npm:prettier@^2.8.8",
     "prettier-plugin-packagejson": "^2.4.5",
     "rimraf": "^5.0.5",
     "semver": "^7.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2747,6 +2747,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     nock: "npm:^13.3.1"
     prettier: "npm:^3.3.3"
+    prettier-2: "npm:prettier@^2.8.8"
     prettier-plugin-packagejson: "npm:^2.4.5"
     rimraf: "npm:^5.0.5"
     semver: "npm:^7.6.3"
@@ -11738,6 +11739,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-2@npm:prettier@^2.8.8, prettier@npm:^2.8.8":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8"
+  bin:
+    prettier: bin-prettier.js
+  checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
+  languageName: node
+  linkType: hard
+
 "prettier-linter-helpers@npm:^1.0.0":
   version: 1.0.0
   resolution: "prettier-linter-helpers@npm:1.0.0"
@@ -11759,15 +11769,6 @@ __metadata:
     prettier:
       optional: true
   checksum: 10/f280d69327a468cd104c72a81134258d3573e56d697a88a5c4498c8d02cecda9a27d9eb3f1d29cc726491782eb3f279c9d41ecf8364a197e20b239c5ccfd0269
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^2.8.8":
-  version: 2.8.8
-  resolution: "prettier@npm:2.8.8"
-  bin:
-    prettier: bin-prettier.js
-  checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

Jest doesn't support Prettier 3, so after the migration to ESLint 9 (requiring Prettier 3), Jest snapshots could no longer be created or updated. The recommended solution by Jest is to add `prettier-2` as separate dependency and referencing that in the config.