### PR TITLE
feat: add accounts in bulk and only care about primary SRP hd keyring for account syncing

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -15,7 +15,7 @@ import {
   type KeyringControllerGetStateAction,
   type KeyringControllerLockEvent,
   type KeyringControllerUnlockEvent,
-  type KeyringControllerAddNewAccountAction,
+  type KeyringControllerWithKeyringAction,
 } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type {
@@ -244,7 +244,7 @@ export type AllowedActions =
   // Account Syncing
   | AccountsControllerListAccountsAction
   | AccountsControllerUpdateAccountMetadataAction
-  | KeyringControllerAddNewAccountAction
+  | KeyringControllerWithKeyringAction
   // Network Syncing
   | NetworkControllerGetStateAction
   | NetworkControllerAddNetworkAction

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/__fixtures__/test-utils.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/__fixtures__/test-utils.ts
@@ -1,3 +1,4 @@
+import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
 import { MOCK_INTERNAL_ACCOUNTS } from './mockAccounts';
@@ -20,12 +21,20 @@ export function mockUserStorageMessengerForAccountSyncing(options?: {
 }) {
   const messengerMocks = mockUserStorageMessenger();
 
-  messengerMocks.mockKeyringAddNewAccount.mockImplementation(async () => {
+  messengerMocks.mockKeyringAddAccounts.mockImplementation(async () => {
     messengerMocks.baseMessenger.publish(
       'AccountsController:accountAdded',
       MOCK_INTERNAL_ACCOUNTS.ONE[0] as InternalAccount,
     );
-    return MOCK_INTERNAL_ACCOUNTS.ONE[0].address;
+  });
+
+  messengerMocks.mockKeyringGetAccounts.mockImplementation(async () => {
+    return (
+      options?.accounts?.accountsList
+        ?.filter((a) => a.metadata.keyring.type === KeyringTypes.hd)
+        .map((a) => a.address) ??
+      MOCK_INTERNAL_ACCOUNTS.ALL.map((a) => a.address)
+    );
   });
 
   messengerMocks.mockAccountsListAccounts.mockReturnValue(

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/controller-integration.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/controller-integration.test.ts
@@ -286,11 +286,13 @@ describe('user-storage/account-syncing/controller-integration - syncInternalAcco
 
     expect(mockAPI.mockEndpointGetUserStorage.isDone()).toBe(true);
 
-    expect(messengerMocks.mockKeyringAddNewAccount).toHaveBeenCalledTimes(
+    const numberOfAddedAccounts =
       MOCK_USER_STORAGE_ACCOUNTS.SAME_AS_INTERNAL_ALL.length -
-        MOCK_INTERNAL_ACCOUNTS.ONE.length,
-    );
+      MOCK_INTERNAL_ACCOUNTS.ONE.length;
 
+    expect(messengerMocks.mockKeyringAddAccounts).toHaveBeenCalledWith(
+      numberOfAddedAccounts,
+    );
     expect(mockAPI.mockEndpointBatchDeleteUserStorage.isDone()).toBe(true);
 
     expect(controller.state.hasAccountSyncingSyncedAtLeastOnce).toBe(true);
@@ -555,7 +557,7 @@ describe('user-storage/account-syncing/controller-integration - syncInternalAcco
     expect(mockAPI.mockEndpointGetUserStorage.isDone()).toBe(true);
     expect(mockAPI.mockEndpointBatchUpsertUserStorage.isDone()).toBe(true);
 
-    expect(messengerMocks.mockKeyringAddNewAccount).not.toHaveBeenCalled();
+    expect(messengerMocks.mockKeyringAddAccounts).not.toHaveBeenCalled();
   });
 
   describe('User storage name is a default name', () => {

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/controller-integration.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/controller-integration.ts
@@ -1,4 +1,5 @@
 import { isEvmAccountType } from '@metamask/keyring-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
 import {
@@ -8,7 +9,7 @@ import {
 } from './sync-utils';
 import type { AccountSyncingConfig, AccountSyncingOptions } from './types';
 import {
-  doesInternalAccountHaveCorrectKeyringType,
+  isInternalAccountFromPrimarySRPHdKeyring,
   isNameDefaultAccountName,
   mapInternalAccountToUserStorageAccount,
 } from './utils';
@@ -33,7 +34,7 @@ export async function saveInternalAccountToUserStorage(
     !isAccountSyncingEnabled ||
     !canPerformAccountSyncing(config, options) ||
     !isEvmAccountType(internalAccount.type) ||
-    !doesInternalAccountHaveCorrectKeyringType(internalAccount)
+    !(await isInternalAccountFromPrimarySRPHdKeyring(internalAccount, options))
   ) {
     return;
   }
@@ -173,8 +174,21 @@ export async function syncInternalAccountsWithUserStorage(
         internalAccountsList.length;
 
       // Create new accounts to match the user storage accounts list
+      // NOTE: we only support the primary SRP HD keyring for now
+      // This is why we are hardcoding the index to 0
+      await getMessenger().call(
+        'KeyringController:withKeyring',
+        {
+          type: KeyringTypes.hd,
+          index: 0,
+        },
+        async (keyring) => {
+          keyring.addAccounts(numberOfAccountsToAdd);
+        },
+      );
+
+      // TODO: below code is kept for analytics but should probably be re-thought
       for (let i = 0; i < numberOfAccountsToAdd; i++) {
-        await getMessenger().call('KeyringController:addNewAccount');
         onAccountAdded?.();
       }
     }

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/sync-utils.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/sync-utils.ts
@@ -5,7 +5,7 @@ import type {
   AccountSyncingOptions,
   UserStorageAccount,
 } from './types';
-import { doesInternalAccountHaveCorrectKeyringType } from './utils';
+import { mapInternalAccountsListToPrimarySRPHdKeyringInternalAccountsList } from './utils';
 import { USER_STORAGE_FEATURE_NAMES } from '../../../shared/storage-schema';
 
 /**
@@ -42,6 +42,8 @@ export function canPerformAccountSyncing(
 
 /**
  * Get the list of internal accounts
+ * This function returns only the internal accounts that are from the primary SRP
+ * and are from the HD keyring
  *
  * @param options - parameters used for getting the list of internal accounts
  * @returns the list of internal accounts
@@ -55,8 +57,9 @@ export async function getInternalAccountsList(
     'AccountsController:listAccounts',
   );
 
-  return internalAccountsList?.filter(
-    doesInternalAccountHaveCorrectKeyringType,
+  return await mapInternalAccountsListToPrimarySRPHdKeyringInternalAccountsList(
+    internalAccountsList,
+    options,
   );
 }
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/utils.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/utils.test.ts
@@ -4,9 +4,10 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { getMockRandomDefaultAccountName } from './__fixtures__/mockAccounts';
 import { USER_STORAGE_VERSION, USER_STORAGE_VERSION_KEY } from './constants';
 import {
-  doesInternalAccountHaveCorrectKeyringType,
   isNameDefaultAccountName,
   mapInternalAccountToUserStorageAccount,
+  isInternalAccountFromPrimarySRPHdKeyring,
+  mapInternalAccountsListToPrimarySRPHdKeyringInternalAccountsList,
 } from './utils';
 
 describe('user-storage/account-syncing/utils', () => {
@@ -28,6 +29,7 @@ describe('user-storage/account-syncing/utils', () => {
       expect(isNameDefaultAccountName('Mon compte 34')).toBe(false);
     });
   });
+
   describe('mapInternalAccountToUserStorageAccount', () => {
     const internalAccount = {
       address: '0x123',
@@ -76,33 +78,106 @@ describe('user-storage/account-syncing/utils', () => {
     });
   });
 
-  describe('doesInternalAccountHaveCorrectKeyringType', () => {
-    it('should return true if the internal account has the correct keyring type', () => {
-      const internalAccount = {
+  describe('isInternalAccountFromPrimarySRPHdKeyring', () => {
+    const internalAccount = {
+      address: '0x123',
+      id: '1',
+      metadata: {
+        name: `${getMockRandomDefaultAccountName()} 1`,
+        nameLastUpdatedAt: 1620000000000,
+        keyring: {
+          type: KeyringTypes.hd,
+        },
+      },
+    } as InternalAccount;
+
+    const getMessenger = jest.fn();
+    const getUserStorageControllerInstance = jest.fn();
+
+    it('should return true if the internal account is from the primary SRP and is from the HD keyring', async () => {
+      getMessenger.mockReturnValue({
+        call: jest.fn().mockResolvedValue(['0x123']),
+      });
+
+      const result = await isInternalAccountFromPrimarySRPHdKeyring(
+        internalAccount,
+        { getMessenger, getUserStorageControllerInstance },
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the internal account is not from the primary SRP', async () => {
+      getMessenger.mockReturnValue({
+        call: jest.fn().mockResolvedValue(['0x456']),
+      });
+
+      const result = await isInternalAccountFromPrimarySRPHdKeyring(
+        internalAccount,
+        { getMessenger, getUserStorageControllerInstance },
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the internal account is not from the HD keyring', async () => {
+      getMessenger.mockReturnValue({
+        call: jest.fn().mockResolvedValue(['0x123']),
+      });
+
+      const result = await isInternalAccountFromPrimarySRPHdKeyring(
+        {
+          ...internalAccount,
+          metadata: { keyring: { type: KeyringTypes.simple } },
+        } as InternalAccount,
+        { getMessenger, getUserStorageControllerInstance },
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('mapInternalAccountsListToPrimarySRPHdKeyringInternalAccountsList', () => {
+    const internalAccountsList = [
+      {
+        address: '0x123',
+        id: '1',
         metadata: {
+          name: `${getMockRandomDefaultAccountName()} 1`,
+          nameLastUpdatedAt: 1620000000000,
           keyring: {
             type: KeyringTypes.hd,
           },
         },
-      } as InternalAccount;
-
-      expect(doesInternalAccountHaveCorrectKeyringType(internalAccount)).toBe(
-        true,
-      );
-    });
-
-    it('should return false if the internal account does not have the correct keyring type', () => {
-      const internalAccount = {
+      } as InternalAccount,
+      {
+        address: '0x456',
+        id: '2',
         metadata: {
+          name: `${getMockRandomDefaultAccountName()} 2`,
+          nameLastUpdatedAt: 1620000000000,
           keyring: {
-            type: KeyringTypes.snap,
+            type: KeyringTypes.simple,
           },
         },
-      } as InternalAccount;
+      } as InternalAccount,
+    ];
 
-      expect(doesInternalAccountHaveCorrectKeyringType(internalAccount)).toBe(
-        false,
-      );
+    const getMessenger = jest.fn();
+    const getUserStorageControllerInstance = jest.fn();
+
+    it('should return a list of internal accounts that are from the primary SRP and are from the HD keyring', async () => {
+      getMessenger.mockReturnValue({
+        call: jest.fn().mockResolvedValue(['0x123']),
+      });
+
+      const result =
+        await mapInternalAccountsListToPrimarySRPHdKeyringInternalAccountsList(
+          internalAccountsList,
+          { getMessenger, getUserStorageControllerInstance },
+        );
+
+      expect(result).toStrictEqual([internalAccountsList[0]]);
     });
   });
 });


### PR DESCRIPTION
## Explanation

This PR does two things related to account syncing:

- use `KeyringController:withKeyring` to add accounts in bulk instead of 1 by 1
- use `KeyringController:withKeyring` to filter and care only about the primary SRP's HD Keyring accounts

## References

Fixes: https://consensyssoftware.atlassian.net/browse/IDENTITY-6
Related to: https://consensyssoftware.atlassian.net/browse/IDENTITY-28

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/profile-sync-controller`

- **CHANGED**: Account syncing - add accounts in bulk instead of 1 by 1
- **CHANGED**: Account syncing - filter and care only about the primary SRP's HD Keyring accounts

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
