### PR TITLE
ci: Add CODEOWNER constraints

### DIFF
--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -247,6 +247,8 @@ module.exports = defineConfig({
       if (isChildWorkspace) {
         // All non-root packages must have a valid README.md file.
         await expectReadme(workspace, workspaceBasename);
+
+        await expectCodeowner(workspace, workspaceBasename);
       }
     }
 
@@ -833,5 +835,62 @@ async function expectReadme(workspace, workspaceBasename) {
     workspace.error(
       `The README.md does not contain an example of how to install the package using npm (\`npm install @metamask/${workspaceBasename}\`). Please add an example.`,
     );
+  }
+}
+
+// A promise resolving to the codeowners file contents
+let cachedCodeownersFile;
+
+/**
+ * Expect that the workspace has a codeowner set, and that the CHANGELOG.md and
+ * package.json files are co-owned with the wallet framework team.
+ *
+ * @param {Workspace} workspace - The workspace to check.
+ * @param {string} workspaceBasename - The name of the workspace.
+ * @returns {Promise<void>}
+ */
+async function expectCodeowner(workspace, workspaceBasename) {
+  if (!cachedCodeownersFile) {
+    cachedCodeownersFile = readFile(
+      resolve(__dirname, '.github', 'CODEOWNERS'),
+      'utf8',
+    );
+  }
+  const codeownersFile = await cachedCodeownersFile;
+  const codeownerRules = codeownersFile.split('\n');
+
+  const packageCodeownerRule = codeownerRules.find((rule) =>
+    rule.startsWith(`/packages/${workspaceBasename}`),
+  );
+
+  if (!packageCodeownerRule) {
+    workspace.error('Missing CODEOWNER rule for package');
+    return;
+  }
+
+  if (!packageCodeownerRule.includes('@MetaMask/wallet-framework-engineers')) {
+    if (
+      !codeownerRules.some(
+        (rule) =>
+          rule.startsWith(`/packages/${workspaceBasename}/CHANGELOG.md`) &&
+          rule.includes('@MetaMask/wallet-framework-engineers'),
+      )
+    ) {
+      workspace.error(
+        'Missing CODEOWNER rule for CHANGELOG.md co-ownership with wallet framework team',
+      );
+    }
+
+    if (
+      !codeownerRules.some(
+        (rule) =>
+          rule.startsWith(`/packages/${workspaceBasename}/package.json`) &&
+          rule.includes('@MetaMask/wallet-framework-engineers'),
+      )
+    ) {
+      workspace.error(
+        'Missing CODEOWNER rule for package.json co-ownership with wallet framework team',
+      );
+    }
   }
 }

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -860,7 +860,9 @@ async function expectCodeowner(workspace, workspaceBasename) {
   const codeownerRules = codeownersFile.split('\n');
 
   const packageCodeownerRule = codeownerRules.find((rule) =>
-    rule.startsWith(`/packages/${workspaceBasename}`),
+    // Matcher includes intentional trailing space to ensure there is a package-wide rule, not
+    // just a rule for specific files/directories in the package.
+    rule.startsWith(`/packages/${workspaceBasename} `),
   );
 
   if (!packageCodeownerRule) {


### PR DESCRIPTION
## Explanation

Add Yarn constraints to ensure each package has a designated owner, and that any non-wallet-frameowrk packages have the wallet framework team set as co-owners of release related files.

## References

N/A

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
