### PR TITLE
feat: Improve CAIP-25 builder error handling

### DIFF
--- a/packages/multichain/src/caip25Permission.ts
+++ b/packages/multichain/src/caip25Permission.ts
@@ -1,4 +1,7 @@
-import type { NetworkClientId } from '@metamask/network-controller';
+import {
+  NetworkControllerError,
+  type NetworkClientId,
+} from '@metamask/network-controller';
 import type {
   PermissionSpecificationBuilder,
   EndowmentGetterParams,
@@ -18,6 +21,7 @@ import {
   parseCaipAccountId,
   type Hex,
   type NonEmptyArray,
+  isObject,
 } from '@metamask/utils';
 import { cloneDeep, isEqual } from 'lodash';
 
@@ -156,8 +160,15 @@ export const caip25CaveatBuilder = ({
         try {
           findNetworkClientIdByChainId(chainId);
           return true;
-        } catch (err) {
-          return false;
+        } catch (error) {
+          if (
+            isObject(error) &&
+            hasProperty(error, 'message') &&
+            error.message === NetworkControllerError.ChainIdNotFound
+          ) {
+            return false;
+          }
+          throw error;
         }
       };
 

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -28,7 +28,11 @@ import { createSelector } from 'reselect';
 import * as URI from 'uri-js';
 import { v4 as uuidV4 } from 'uuid';
 
-import { INFURA_BLOCKED_KEY, NetworkStatus } from './constants';
+import {
+  INFURA_BLOCKED_KEY,
+  NetworkStatus,
+  NetworkControllerError,
+} from './constants';
 import type {
   AutoManagedNetworkClient,
   ProxyWithAccessibleTarget,
@@ -2119,7 +2123,7 @@ export class NetworkController extends BaseController<
       ([_, networkClient]) => networkClient.configuration.chainId === chainId,
     );
     if (networkClientEntry === undefined) {
-      throw new Error("Couldn't find networkClientId for chainId");
+      throw new Error(NetworkControllerError.ChainIdNotFound);
     }
     return networkClientEntry[0];
   }

--- a/packages/network-controller/src/constants.ts
+++ b/packages/network-controller/src/constants.ts
@@ -26,3 +26,7 @@ export enum NetworkStatus {
 }
 
 export const INFURA_BLOCKED_KEY = 'countryBlocked';
+
+export const NetworkControllerError = {
+  ChainIdNotFound: "Couldn't find networkClientId for chainId",
+};


### PR DESCRIPTION
## Explanation

The CAIP-25 builder will now re-throw unexpected errors when validating whether a given chain ID is supported. Previously when validating a chain ID, it would suppress the error without checking what it was, under the assumption that the chain ID was not found in state. This could be hiding a different error.

The expected error has been moved to a constant that is exported from the `@metamask/network-controller` package.

## References

I discovered this sub-optimal error handling while investigating https://github.com/MetaMask/metamask-extension/issues/30438

## Changelog

See diff

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
