### PR TITLE
fix: Add MANTLE support for conversion rates

### DIFF
--- a/packages/assets-controllers/src/crypto-compare-service/crypto-compare.test.ts
+++ b/packages/assets-controllers/src/crypto-compare-service/crypto-compare.test.ts
@@ -150,6 +150,15 @@ describe('CryptoCompare', () => {
     expect(conversionRate).toBe(123);
   });
 
+  it('should override currency symbol when the CryptoCompare identifier is different', async () => {
+    nock(cryptoCompareHost)
+      .get('/data/price?fsym=USD&tsyms=MANTLE')
+      .reply(200, { MANTLE: 1234 });
+
+    const { conversionRate } = await fetchExchangeRate('MNT', 'USD');
+    expect(conversionRate).toBe(1234);
+  });
+
   describe('fetchMultiExchangeRate', () => {
     it('should return CAD and USD conversion rate for BTC, ETH, and SOL', async () => {
       nock(cryptoCompareHost)

--- a/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
+++ b/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
@@ -29,11 +29,9 @@ function getPricingURL(
   nativeCurrency: string,
   includeUSDRate?: boolean,
 ) {
-  nativeCurrency = nativeCurrency.toUpperCase();
-  const fsym = nativeSymbolOverrides.get(nativeCurrency) ?? nativeCurrency;
   return (
     `${CRYPTO_COMPARE_DOMAIN}/data/price?fsym=` +
-    `${fsym}&tsyms=${currentCurrency.toUpperCase()}` +
+    `${nativeCurrency}&tsyms=${currentCurrency}` +
     `${includeUSDRate && currentCurrency.toUpperCase() !== 'USD' ? ',USD' : ''}`
   );
 }
@@ -100,6 +98,11 @@ export async function fetchExchangeRate(
   conversionRate: number;
   usdConversionRate: number;
 }> {
+  currency = currency.toUpperCase();
+  nativeCurrency = nativeCurrency.toUpperCase();
+  currency = nativeSymbolOverrides.get(currency) ?? currency;
+  nativeCurrency = nativeSymbolOverrides.get(nativeCurrency) ?? nativeCurrency;
+
   const json = await handleFetch(
     getPricingURL(currency, nativeCurrency, includeUSDRate),
   );


### PR DESCRIPTION
## Explanation

Inspecting extension shows that we fetch the conversion rate using this URL:
https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=MNT

This is incorrect as it is not using the correct symbol override. The url should be:
https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=MANTLE

This gives a much better unsupported conversion number that what it currently is.

## References

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **FIXED**: update `crypto-compare-service` `fetchExchangeRate` to allow symbol overrides for mantle.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
