### PR TITLE
chore: change bridge state structure to have all fields at root of state

### DIFF
--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -196,7 +196,6 @@ describe('BridgeController', function () {
       srcChainId: 1,
       slippage: 0.5,
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
-      walletAddress: undefined,
     });
 
     await bridgeController.updateBridgeQuoteRequestParams({ destChainId: 10 });
@@ -204,7 +203,6 @@ describe('BridgeController', function () {
       destChainId: 10,
       slippage: 0.5,
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
-      walletAddress: undefined,
     });
 
     await bridgeController.updateBridgeQuoteRequestParams({
@@ -214,7 +212,6 @@ describe('BridgeController', function () {
       destChainId: undefined,
       slippage: 0.5,
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
-      walletAddress: undefined,
     });
 
     await bridgeController.updateBridgeQuoteRequestParams({
@@ -223,7 +220,6 @@ describe('BridgeController', function () {
     expect(bridgeController.state.quoteRequest).toStrictEqual({
       slippage: 0.5,
       srcTokenAddress: undefined,
-      walletAddress: undefined,
     });
 
     await bridgeController.updateBridgeQuoteRequestParams({
@@ -231,14 +227,12 @@ describe('BridgeController', function () {
       destTokenAddress: '0x123',
       slippage: 0.5,
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
-      walletAddress: undefined,
     });
     expect(bridgeController.state.quoteRequest).toStrictEqual({
       srcTokenAmount: '100000',
       destTokenAddress: '0x123',
       slippage: 0.5,
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
-      walletAddress: undefined,
     });
 
     await bridgeController.updateBridgeQuoteRequestParams({
@@ -247,14 +241,12 @@ describe('BridgeController', function () {
     expect(bridgeController.state.quoteRequest).toStrictEqual({
       slippage: 0.5,
       srcTokenAddress: '0x2ABC',
-      walletAddress: undefined,
     });
 
     bridgeController.resetState();
     expect(bridgeController.state.quoteRequest).toStrictEqual({
       slippage: 0.5,
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
-      walletAddress: undefined,
     });
   });
 
@@ -724,7 +716,7 @@ describe('BridgeController', function () {
         BridgeClientId.EXTENSION,
         mockFetchFn,
       );
-      expect(bridgeController.state.quotesLastFetched).toBeUndefined();
+      expect(bridgeController.state.quotesLastFetched).toBeNull();
 
       expect(bridgeController.state).toStrictEqual(
         expect.objectContaining({
@@ -825,7 +817,7 @@ describe('BridgeController', function () {
     await flushPromises();
 
     // Verify state wasn't updated due to abort
-    expect(bridgeController.state.quoteFetchError).toBeUndefined();
+    expect(bridgeController.state.quoteFetchError).toBeNull();
     expect(bridgeController.state.quotesLoadingStatus).toBe(0);
     expect(bridgeController.state.quotes).toStrictEqual([]);
 
@@ -838,7 +830,7 @@ describe('BridgeController', function () {
     await flushPromises();
 
     // Verify state wasn't updated due to reset
-    expect(bridgeController.state.quoteFetchError).toBeUndefined();
+    expect(bridgeController.state.quoteFetchError).toBeNull();
     expect(bridgeController.state.quotesLoadingStatus).toBe(0);
     expect(bridgeController.state.quotes).toStrictEqual([]);
   });

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -339,7 +339,7 @@ describe('BridgeController', function () {
       BridgeClientId.EXTENSION,
       mockFetchFn,
     );
-    expect(bridgeController.state.quotesLastFetched).toBeUndefined();
+    expect(bridgeController.state.quotesLastFetched).toBeNull();
 
     expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
@@ -373,7 +373,7 @@ describe('BridgeController', function () {
           ...mockBridgeQuotesNativeErc20Eth,
         ],
         quotesLoadingStatus: 1,
-        quoteFetchError: undefined,
+        quoteFetchError: null,
         quotesRefreshCount: 2,
       }),
     );
@@ -470,7 +470,7 @@ describe('BridgeController', function () {
         quoteRequest: { ...quoteRequest, walletAddress: undefined },
         quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
         quotesLastFetched: DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLastFetched,
-        quotesInitialLoadTime: undefined,
+        quotesInitialLoadTime: null,
         quotesLoadingStatus:
           DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLoadingStatus,
       }),
@@ -489,7 +489,7 @@ describe('BridgeController', function () {
       BridgeClientId.EXTENSION,
       mockFetchFn,
     );
-    expect(bridgeController.state.quotesLastFetched).toBeUndefined();
+    expect(bridgeController.state.quotesLastFetched).toBeNull();
 
     expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -20,9 +20,7 @@ import mockBridgeQuotesErc20Native from '../tests/mock-quotes-erc20-native.json'
 import mockBridgeQuotesNativeErc20Eth from '../tests/mock-quotes-native-erc20-eth.json';
 import mockBridgeQuotesNativeErc20 from '../tests/mock-quotes-native-erc20.json';
 
-const EMPTY_INIT_STATE = {
-  bridgeState: DEFAULT_BRIDGE_CONTROLLER_STATE,
-};
+const EMPTY_INIT_STATE = DEFAULT_BRIDGE_CONTROLLER_STATE;
 
 const messengerMock = {
   call: jest.fn(),
@@ -174,14 +172,14 @@ describe('BridgeController', function () {
     );
 
     await bridgeController.setBridgeFeatureFlags();
-    expect(bridgeController.state.bridgeState.bridgeFeatureFlags).toStrictEqual(
+    expect(bridgeController.state.bridgeFeatureFlags).toStrictEqual(
       expectedFeatureFlagsResponse,
     );
     expect(setIntervalLengthSpy).toHaveBeenCalledTimes(1);
     expect(setIntervalLengthSpy).toHaveBeenCalledWith(3);
 
     bridgeController.resetState();
-    expect(bridgeController.state.bridgeState).toStrictEqual(
+    expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
         bridgeFeatureFlags: expectedFeatureFlagsResponse,
         quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
@@ -194,7 +192,7 @@ describe('BridgeController', function () {
 
   it('updateBridgeQuoteRequestParams should update the quoteRequest state', async function () {
     await bridgeController.updateBridgeQuoteRequestParams({ srcChainId: 1 });
-    expect(bridgeController.state.bridgeState.quoteRequest).toStrictEqual({
+    expect(bridgeController.state.quoteRequest).toStrictEqual({
       srcChainId: 1,
       slippage: 0.5,
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
@@ -202,7 +200,7 @@ describe('BridgeController', function () {
     });
 
     await bridgeController.updateBridgeQuoteRequestParams({ destChainId: 10 });
-    expect(bridgeController.state.bridgeState.quoteRequest).toStrictEqual({
+    expect(bridgeController.state.quoteRequest).toStrictEqual({
       destChainId: 10,
       slippage: 0.5,
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
@@ -212,7 +210,7 @@ describe('BridgeController', function () {
     await bridgeController.updateBridgeQuoteRequestParams({
       destChainId: undefined,
     });
-    expect(bridgeController.state.bridgeState.quoteRequest).toStrictEqual({
+    expect(bridgeController.state.quoteRequest).toStrictEqual({
       destChainId: undefined,
       slippage: 0.5,
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
@@ -222,7 +220,7 @@ describe('BridgeController', function () {
     await bridgeController.updateBridgeQuoteRequestParams({
       srcTokenAddress: undefined,
     });
-    expect(bridgeController.state.bridgeState.quoteRequest).toStrictEqual({
+    expect(bridgeController.state.quoteRequest).toStrictEqual({
       slippage: 0.5,
       srcTokenAddress: undefined,
       walletAddress: undefined,
@@ -235,7 +233,7 @@ describe('BridgeController', function () {
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
       walletAddress: undefined,
     });
-    expect(bridgeController.state.bridgeState.quoteRequest).toStrictEqual({
+    expect(bridgeController.state.quoteRequest).toStrictEqual({
       srcTokenAmount: '100000',
       destTokenAddress: '0x123',
       slippage: 0.5,
@@ -246,14 +244,14 @@ describe('BridgeController', function () {
     await bridgeController.updateBridgeQuoteRequestParams({
       srcTokenAddress: '0x2ABC',
     });
-    expect(bridgeController.state.bridgeState.quoteRequest).toStrictEqual({
+    expect(bridgeController.state.quoteRequest).toStrictEqual({
       slippage: 0.5,
       srcTokenAddress: '0x2ABC',
       walletAddress: undefined,
     });
 
     bridgeController.resetState();
-    expect(bridgeController.state.bridgeState.quoteRequest).toStrictEqual({
+    expect(bridgeController.state.quoteRequest).toStrictEqual({
       slippage: 0.5,
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
       walletAddress: undefined,
@@ -326,7 +324,7 @@ describe('BridgeController', function () {
       },
     });
 
-    expect(bridgeController.state.bridgeState).toStrictEqual(
+    expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
         quoteRequest: { ...quoteRequest, walletAddress: undefined },
         quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
@@ -349,11 +347,9 @@ describe('BridgeController', function () {
       BridgeClientId.EXTENSION,
       mockFetchFn,
     );
-    expect(
-      bridgeController.state.bridgeState.quotesLastFetched,
-    ).toBeUndefined();
+    expect(bridgeController.state.quotesLastFetched).toBeUndefined();
 
-    expect(bridgeController.state.bridgeState).toStrictEqual(
+    expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
         quoteRequest: { ...quoteRequest, insufficientBal: false },
         quotes: [],
@@ -364,20 +360,20 @@ describe('BridgeController', function () {
     // After first fetch
     jest.advanceTimersByTime(10000);
     await flushPromises();
-    expect(bridgeController.state.bridgeState).toStrictEqual(
+    expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
         quoteRequest: { ...quoteRequest, insufficientBal: false },
         quotes: mockBridgeQuotesNativeErc20Eth,
         quotesLoadingStatus: 1,
       }),
     );
-    const firstFetchTime = bridgeController.state.bridgeState.quotesLastFetched;
+    const firstFetchTime = bridgeController.state.quotesLastFetched;
     expect(firstFetchTime).toBeGreaterThan(0);
 
     // After 2nd fetch
     jest.advanceTimersByTime(50000);
     await flushPromises();
-    expect(bridgeController.state.bridgeState).toStrictEqual(
+    expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
         quoteRequest: { ...quoteRequest, insufficientBal: false },
         quotes: [
@@ -390,8 +386,7 @@ describe('BridgeController', function () {
       }),
     );
     expect(fetchBridgeQuotesSpy).toHaveBeenCalledTimes(2);
-    const secondFetchTime =
-      bridgeController.state.bridgeState.quotesLastFetched;
+    const secondFetchTime = bridgeController.state.quotesLastFetched;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(secondFetchTime).toBeGreaterThan(firstFetchTime!);
 
@@ -399,7 +394,7 @@ describe('BridgeController', function () {
     jest.advanceTimersByTime(50000);
     await flushPromises();
     expect(fetchBridgeQuotesSpy).toHaveBeenCalledTimes(3);
-    expect(bridgeController.state.bridgeState).toStrictEqual(
+    expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
         quoteRequest: { ...quoteRequest, insufficientBal: false },
         quotes: [
@@ -412,7 +407,7 @@ describe('BridgeController', function () {
       }),
     );
     expect(
-      bridgeController.state.bridgeState.quotesLastFetched,
+      bridgeController.state.quotesLastFetched,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     ).toBeGreaterThan(secondFetchTime!);
 
@@ -478,7 +473,7 @@ describe('BridgeController', function () {
       },
     });
 
-    expect(bridgeController.state.bridgeState).toStrictEqual(
+    expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
         quoteRequest: { ...quoteRequest, walletAddress: undefined },
         quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
@@ -502,11 +497,9 @@ describe('BridgeController', function () {
       BridgeClientId.EXTENSION,
       mockFetchFn,
     );
-    expect(
-      bridgeController.state.bridgeState.quotesLastFetched,
-    ).toBeUndefined();
+    expect(bridgeController.state.quotesLastFetched).toBeUndefined();
 
-    expect(bridgeController.state.bridgeState).toStrictEqual(
+    expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
         quoteRequest: { ...quoteRequest, insufficientBal: true },
         quotes: [],
@@ -517,7 +510,7 @@ describe('BridgeController', function () {
     // After first fetch
     jest.advanceTimersByTime(10000);
     await flushPromises();
-    expect(bridgeController.state.bridgeState).toStrictEqual(
+    expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
         quoteRequest: { ...quoteRequest, insufficientBal: true },
         quotes: mockBridgeQuotesNativeErc20Eth,
@@ -526,14 +519,14 @@ describe('BridgeController', function () {
         quotesInitialLoadTime: 11000,
       }),
     );
-    const firstFetchTime = bridgeController.state.bridgeState.quotesLastFetched;
+    const firstFetchTime = bridgeController.state.quotesLastFetched;
     expect(firstFetchTime).toBeGreaterThan(0);
 
     // After 2nd fetch
     jest.advanceTimersByTime(50000);
     await flushPromises();
     expect(fetchBridgeQuotesSpy).toHaveBeenCalledTimes(1);
-    expect(bridgeController.state.bridgeState).toStrictEqual(
+    expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
         quoteRequest: { ...quoteRequest, insufficientBal: true },
         quotes: mockBridgeQuotesNativeErc20Eth,
@@ -542,8 +535,7 @@ describe('BridgeController', function () {
         quotesInitialLoadTime: 11000,
       }),
     );
-    const secondFetchTime =
-      bridgeController.state.bridgeState.quotesLastFetched;
+    const secondFetchTime = bridgeController.state.quotesLastFetched;
     expect(secondFetchTime).toStrictEqual(firstFetchTime);
     expect(getLayer1GasFeeMock).not.toHaveBeenCalled();
   });
@@ -566,7 +558,7 @@ describe('BridgeController', function () {
     expect(stopAllPollingSpy).toHaveBeenCalledTimes(1);
     expect(startPollingSpy).not.toHaveBeenCalled();
 
-    expect(bridgeController.state.bridgeState).toStrictEqual(
+    expect(bridgeController.state).toStrictEqual(
       expect.objectContaining({
         quoteRequest: {
           srcChainId: 1,
@@ -709,7 +701,7 @@ describe('BridgeController', function () {
         },
       });
 
-      expect(bridgeController.state.bridgeState).toStrictEqual(
+      expect(bridgeController.state).toStrictEqual(
         expect.objectContaining({
           quoteRequest: { ...quoteRequest, walletAddress: undefined },
           quotes: DEFAULT_BRIDGE_CONTROLLER_STATE.quotes,
@@ -732,11 +724,9 @@ describe('BridgeController', function () {
         BridgeClientId.EXTENSION,
         mockFetchFn,
       );
-      expect(
-        bridgeController.state.bridgeState.quotesLastFetched,
-      ).toBeUndefined();
+      expect(bridgeController.state.quotesLastFetched).toBeUndefined();
 
-      expect(bridgeController.state.bridgeState).toStrictEqual(
+      expect(bridgeController.state).toStrictEqual(
         expect.objectContaining({
           quoteRequest: { ...quoteRequest, insufficientBal: true },
           quotes: [],
@@ -747,8 +737,8 @@ describe('BridgeController', function () {
       // After first fetch
       jest.advanceTimersByTime(1500);
       await flushPromises();
-      const { quotes } = bridgeController.state.bridgeState;
-      expect(bridgeController.state.bridgeState).toStrictEqual(
+      const { quotes } = bridgeController.state;
+      expect(bridgeController.state).toStrictEqual(
         expect.objectContaining({
           quoteRequest: { ...quoteRequest, insufficientBal: true },
           quotesLoadingStatus: 1,
@@ -761,8 +751,7 @@ describe('BridgeController', function () {
         expect(quote).toEqual(expectedQuote);
       });
 
-      const firstFetchTime =
-        bridgeController.state.bridgeState.quotesLastFetched;
+      const firstFetchTime = bridgeController.state.quotesLastFetched;
       expect(firstFetchTime).toBeGreaterThan(0);
 
       expect(getLayer1GasFeeMock).toHaveBeenCalledTimes(
@@ -799,7 +788,7 @@ describe('BridgeController', function () {
 
     expect(fetchBridgeQuotesSpy).not.toHaveBeenCalled();
     expect(hasSufficientBalanceSpy).toHaveBeenCalledTimes(1);
-    expect(bridgeController.state.bridgeState.quotesLoadingStatus).toBe(
+    expect(bridgeController.state.quotesLoadingStatus).toBe(
       DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLoadingStatus,
     );
   });
@@ -836,9 +825,9 @@ describe('BridgeController', function () {
     await flushPromises();
 
     // Verify state wasn't updated due to abort
-    expect(bridgeController.state.bridgeState.quoteFetchError).toBeUndefined();
-    expect(bridgeController.state.bridgeState.quotesLoadingStatus).toBe(0);
-    expect(bridgeController.state.bridgeState.quotes).toStrictEqual([]);
+    expect(bridgeController.state.quoteFetchError).toBeUndefined();
+    expect(bridgeController.state.quotesLoadingStatus).toBe(0);
+    expect(bridgeController.state.quotes).toStrictEqual([]);
 
     // Test reset abort
     fetchBridgeQuotesSpy.mockRejectedValueOnce('Reset controller state');
@@ -849,8 +838,8 @@ describe('BridgeController', function () {
     await flushPromises();
 
     // Verify state wasn't updated due to reset
-    expect(bridgeController.state.bridgeState.quoteFetchError).toBeUndefined();
-    expect(bridgeController.state.bridgeState.quotesLoadingStatus).toBe(0);
-    expect(bridgeController.state.bridgeState.quotes).toStrictEqual([]);
+    expect(bridgeController.state.quoteFetchError).toBeUndefined();
+    expect(bridgeController.state.quotesLoadingStatus).toBe(0);
+    expect(bridgeController.state.quotes).toStrictEqual([]);
   });
 });

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -9,11 +9,11 @@ import type { Hex } from '@metamask/utils';
 import { BrowserProvider, Contract } from 'ethers';
 
 import type { BridgeClientId } from './constants/bridge';
-import { REFRESH_INTERVAL_MS } from './constants/bridge';
 import {
   BRIDGE_CONTROLLER_NAME,
   DEFAULT_BRIDGE_CONTROLLER_STATE,
   METABRIDGE_CHAIN_TO_ADDRESS_MAP,
+  REFRESH_INTERVAL_MS,
 } from './constants/bridge';
 import { CHAIN_IDS } from './constants/chains';
 import {
@@ -22,10 +22,11 @@ import {
   type QuoteResponse,
   type TxData,
   type BridgeControllerState,
+  type BridgeControllerMessenger,
+  type FetchFunction,
   BridgeFeatureFlagsKey,
   RequestStatus,
 } from './types';
-import type { BridgeControllerMessenger, FetchFunction } from './types';
 import { hasSufficientBalance } from './utils/balance';
 import { getDefaultBridgeControllerState, sumHexes } from './utils/bridge';
 import { fetchBridgeFeatureFlags, fetchBridgeQuotes } from './utils/fetch';

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -31,8 +31,36 @@ import { getDefaultBridgeControllerState, sumHexes } from './utils/bridge';
 import { fetchBridgeFeatureFlags, fetchBridgeQuotes } from './utils/fetch';
 import { isValidQuoteRequest } from './utils/quote';
 
-const metadata: StateMetadata<{ bridgeState: BridgeControllerState }> = {
-  bridgeState: {
+const metadata: StateMetadata<BridgeControllerState> = {
+  bridgeFeatureFlags: {
+    persist: false,
+    anonymous: false,
+  },
+  quoteRequest: {
+    persist: false,
+    anonymous: false,
+  },
+  quotes: {
+    persist: false,
+    anonymous: false,
+  },
+  quotesInitialLoadTime: {
+    persist: false,
+    anonymous: false,
+  },
+  quotesLastFetched: {
+    persist: false,
+    anonymous: false,
+  },
+  quotesLoadingStatus: {
+    persist: false,
+    anonymous: false,
+  },
+  quoteFetchError: {
+    persist: false,
+    anonymous: false,
+  },
+  quotesRefreshCount: {
     persist: false,
     anonymous: false,
   },
@@ -48,7 +76,7 @@ type BridgePollingInput = {
 
 export class BridgeController extends StaticIntervalPollingController<BridgePollingInput>()<
   typeof BRIDGE_CONTROLLER_NAME,
-  { bridgeState: BridgeControllerState },
+  BridgeControllerState,
   BridgeControllerMessenger
 > {
   #abortController: AbortController | undefined;
@@ -85,10 +113,8 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
       metadata,
       messenger,
       state: {
-        bridgeState: {
-          ...getDefaultBridgeControllerState(),
-          ...state,
-        },
+        ...getDefaultBridgeControllerState(),
+        ...state,
       },
     });
 
@@ -134,17 +160,16 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     };
 
     this.update((state) => {
-      state.bridgeState.quoteRequest = updatedQuoteRequest;
-      state.bridgeState.quotes = DEFAULT_BRIDGE_CONTROLLER_STATE.quotes;
-      state.bridgeState.quotesLastFetched =
+      state.quoteRequest = updatedQuoteRequest;
+      state.quotes = DEFAULT_BRIDGE_CONTROLLER_STATE.quotes;
+      state.quotesLastFetched =
         DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLastFetched;
-      state.bridgeState.quotesLoadingStatus =
+      state.quotesLoadingStatus =
         DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLoadingStatus;
-      state.bridgeState.quoteFetchError =
-        DEFAULT_BRIDGE_CONTROLLER_STATE.quoteFetchError;
-      state.bridgeState.quotesRefreshCount =
+      state.quoteFetchError = DEFAULT_BRIDGE_CONTROLLER_STATE.quoteFetchError;
+      state.quotesRefreshCount =
         DEFAULT_BRIDGE_CONTROLLER_STATE.quotesRefreshCount;
-      state.bridgeState.quotesInitialLoadTime =
+      state.quotesInitialLoadTime =
         DEFAULT_BRIDGE_CONTROLLER_STATE.quotesInitialLoadTime;
     });
 
@@ -191,11 +216,22 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     this.#abortController?.abort(RESET_STATE_ABORT_MESSAGE);
 
     this.update((state) => {
-      state.bridgeState = {
-        ...DEFAULT_BRIDGE_CONTROLLER_STATE,
-        quotes: [],
-        bridgeFeatureFlags: state.bridgeState.bridgeFeatureFlags,
-      };
+      // Cannot do direct assignment to state, i.e. state = {... }, need to manually assign each field
+      state.quoteRequest = DEFAULT_BRIDGE_CONTROLLER_STATE.quoteRequest;
+      state.quotesInitialLoadTime =
+        DEFAULT_BRIDGE_CONTROLLER_STATE.quotesInitialLoadTime;
+      state.quotes = DEFAULT_BRIDGE_CONTROLLER_STATE.quotes;
+      state.quotesLastFetched =
+        DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLastFetched;
+      state.quotesLoadingStatus =
+        DEFAULT_BRIDGE_CONTROLLER_STATE.quotesLoadingStatus;
+      state.quoteFetchError = DEFAULT_BRIDGE_CONTROLLER_STATE.quoteFetchError;
+      state.quotesRefreshCount =
+        DEFAULT_BRIDGE_CONTROLLER_STATE.quotesRefreshCount;
+
+      // Keep feature flags
+      const originalFeatureFlags = state.bridgeFeatureFlags;
+      state.bridgeFeatureFlags = originalFeatureFlags;
     });
   };
 
@@ -205,7 +241,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
       this.#fetchFn,
     );
     this.update((state) => {
-      state.bridgeState.bridgeFeatureFlags = bridgeFeatureFlags;
+      state.bridgeFeatureFlags = bridgeFeatureFlags;
     });
     this.setIntervalLength(
       bridgeFeatureFlags[BridgeFeatureFlagsKey.EXTENSION_CONFIG].refreshRate,
@@ -216,17 +252,17 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     networkClientId: _networkClientId,
     updatedQuoteRequest,
   }: BridgePollingInput) => {
-    const { bridgeState } = this.state;
+    const { bridgeFeatureFlags, quotesInitialLoadTime, quotesRefreshCount } =
+      this.state;
     this.#abortController?.abort('New quote request');
     this.#abortController = new AbortController();
     if (updatedQuoteRequest.srcChainId === updatedQuoteRequest.destChainId) {
       return;
     }
     this.update((state) => {
-      state.bridgeState.quotesLoadingStatus = RequestStatus.LOADING;
-      state.bridgeState.quoteRequest = updatedQuoteRequest;
-      state.bridgeState.quoteFetchError =
-        DEFAULT_BRIDGE_CONTROLLER_STATE.quoteFetchError;
+      state.quotesLoadingStatus = RequestStatus.LOADING;
+      state.quoteRequest = updatedQuoteRequest;
+      state.quoteFetchError = DEFAULT_BRIDGE_CONTROLLER_STATE.quoteFetchError;
     });
 
     try {
@@ -244,8 +280,8 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
       const quotesWithL1GasFees = await this.#appendL1GasFees(quotes);
 
       this.update((state) => {
-        state.bridgeState.quotes = quotesWithL1GasFees;
-        state.bridgeState.quotesLoadingStatus = RequestStatus.FETCHED;
+        state.quotes = quotesWithL1GasFees;
+        state.quotesLoadingStatus = RequestStatus.FETCHED;
       });
     } catch (error) {
       const isAbortError = (error as Error).name === 'AbortError';
@@ -255,16 +291,16 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
       }
 
       this.update((state) => {
-        state.bridgeState.quoteFetchError =
+        state.quoteFetchError =
           error instanceof Error ? error.message : 'Unknown error';
-        state.bridgeState.quotesLoadingStatus = RequestStatus.ERROR;
+        state.quotesLoadingStatus = RequestStatus.ERROR;
       });
       console.log('Failed to fetch bridge quotes', error);
     } finally {
       const { maxRefreshCount } =
-        bridgeState.bridgeFeatureFlags[BridgeFeatureFlagsKey.EXTENSION_CONFIG];
+        bridgeFeatureFlags[BridgeFeatureFlagsKey.EXTENSION_CONFIG];
 
-      const updatedQuotesRefreshCount = bridgeState.quotesRefreshCount + 1;
+      const updatedQuotesRefreshCount = quotesRefreshCount + 1;
       // Stop polling if the maximum number of refreshes has been reached
       if (
         updatedQuoteRequest.insufficientBal ||
@@ -277,12 +313,12 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
       // Update quote fetching stats
       const quotesLastFetched = Date.now();
       this.update((state) => {
-        state.bridgeState.quotesInitialLoadTime =
+        state.quotesInitialLoadTime =
           updatedQuotesRefreshCount === 1 && this.#quotesFirstFetched
             ? quotesLastFetched - this.#quotesFirstFetched
-            : bridgeState.quotesInitialLoadTime;
-        state.bridgeState.quotesLastFetched = quotesLastFetched;
-        state.bridgeState.quotesRefreshCount = updatedQuotesRefreshCount;
+            : quotesInitialLoadTime;
+        state.quotesLastFetched = quotesLastFetched;
+        state.quotesRefreshCount = updatedQuotesRefreshCount;
       });
     }
   };

--- a/packages/bridge-controller/src/constants/bridge.ts
+++ b/packages/bridge-controller/src/constants/bridge.ts
@@ -55,15 +55,14 @@ export const DEFAULT_BRIDGE_CONTROLLER_STATE: BridgeControllerState = {
     [BridgeFeatureFlagsKey.MOBILE_CONFIG]: DEFAULT_FEATURE_FLAG_CONFIG,
   },
   quoteRequest: {
-    walletAddress: undefined,
     srcTokenAddress: ZeroAddress,
     slippage: BRIDGE_DEFAULT_SLIPPAGE,
   },
-  quotesInitialLoadTime: undefined,
+  quotesInitialLoadTime: null,
   quotes: [],
-  quotesLastFetched: undefined,
-  quotesLoadingStatus: undefined,
-  quoteFetchError: undefined,
+  quotesLastFetched: null,
+  quotesLoadingStatus: null,
+  quoteFetchError: null,
   quotesRefreshCount: 0,
 };
 

--- a/packages/bridge-controller/src/types.ts
+++ b/packages/bridge-controller/src/types.ts
@@ -243,10 +243,10 @@ export type BridgeControllerState = {
   bridgeFeatureFlags: BridgeFeatureFlags;
   quoteRequest: Partial<QuoteRequest>;
   quotes: (QuoteResponse & L1GasFees)[];
-  quotesInitialLoadTime?: number;
-  quotesLastFetched?: number;
-  quotesLoadingStatus?: RequestStatus;
-  quoteFetchError?: string;
+  quotesInitialLoadTime: number | null;
+  quotesLastFetched: number | null;
+  quotesLoadingStatus: RequestStatus | null;
+  quoteFetchError: string | null;
   quotesRefreshCount: number;
 };
 

--- a/packages/bridge-status-controller/src/bridge-status-controller.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.test.ts
@@ -5,20 +5,21 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import { numberToHex } from '@metamask/utils';
 
 import { BridgeStatusController } from './bridge-status-controller';
-import { DEFAULT_BRIDGE_STATUS_STATE } from './constants';
-import type { BridgeStatusControllerMessenger } from './types';
+import { DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE } from './constants';
 import type {
   BridgeId,
   StatusTypes,
   ActionTypes,
   StartPollingForBridgeTxStatusArgsSerialized,
   BridgeHistoryItem,
+  BridgeStatusControllerState,
+  BridgeStatusControllerMessenger,
 } from './types';
 import * as bridgeStatusUtils from './utils/bridge-status';
 import { flushPromises } from '../../../tests/helpers';
 
-const EMPTY_INIT_STATE = {
-  bridgeStatusState: { ...DEFAULT_BRIDGE_STATUS_STATE },
+const EMPTY_INIT_STATE: BridgeStatusControllerState = {
+  ...DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
 };
 
 const MockStatusResponse = {
@@ -453,9 +454,7 @@ describe('BridgeStatusController', () => {
         clientId: BridgeClientId.EXTENSION,
         fetchFn: jest.fn(),
         state: {
-          bridgeStatusState: {
-            txHistory: MockTxHistory.getPending(),
-          },
+          txHistory: MockTxHistory.getPending(),
         },
       });
 
@@ -465,9 +464,7 @@ describe('BridgeStatusController', () => {
       );
 
       // Assertion
-      expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
-      ).toMatchSnapshot();
+      expect(bridgeStatusController.state.txHistory).toMatchSnapshot();
     });
     it('restarts polling for history items that are not complete', async () => {
       // Setup
@@ -482,9 +479,7 @@ describe('BridgeStatusController', () => {
       const bridgeStatusController = new BridgeStatusController({
         messenger: getMessengerMock(),
         state: {
-          bridgeStatusState: {
-            txHistory: MockTxHistory.getPending(),
-          },
+          txHistory: MockTxHistory.getPending(),
         },
         clientId: BridgeClientId.EXTENSION,
         fetchFn: jest.fn(),
@@ -511,9 +506,7 @@ describe('BridgeStatusController', () => {
       );
 
       // Assertion
-      expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
-      ).toMatchSnapshot();
+      expect(bridgeStatusController.state.txHistory).toMatchSnapshot();
     });
     it('starts polling and updates the tx history when the status response is received', async () => {
       const {
@@ -525,9 +518,9 @@ describe('BridgeStatusController', () => {
       // Assertions
       expect(startPollingSpy).toHaveBeenCalledTimes(1);
       expect(fetchBridgeTxStatusSpy).toHaveBeenCalled();
-      expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
-      ).toStrictEqual(MockTxHistory.getPending());
+      expect(bridgeStatusController.state.txHistory).toStrictEqual(
+        MockTxHistory.getPending(),
+      );
     });
     it('stops polling when the status response is complete', async () => {
       // Setup
@@ -561,9 +554,9 @@ describe('BridgeStatusController', () => {
 
       // Assertions
       expect(stopPollingByNetworkClientIdSpy).toHaveBeenCalledTimes(1);
-      expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
-      ).toStrictEqual(MockTxHistory.getComplete());
+      expect(bridgeStatusController.state.txHistory).toStrictEqual(
+        MockTxHistory.getComplete(),
+      );
 
       // Cleanup
       jest.restoreAllMocks();
@@ -626,12 +619,12 @@ describe('BridgeStatusController', () => {
 
       // Assertions
       expect(fetchBridgeTxStatusSpy).not.toHaveBeenCalled();
+      expect(bridgeStatusController.state.txHistory).toHaveProperty(
+        'bridgeTxMetaId1',
+      );
       expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
-      ).toHaveProperty('bridgeTxMetaId1');
-      expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory.bridgeTxMetaId1
-          .status.srcChain.txHash,
+        bridgeStatusController.state.txHistory.bridgeTxMetaId1.status.srcChain
+          .txHash,
       ).toBeUndefined();
 
       // Cleanup
@@ -777,8 +770,8 @@ describe('BridgeStatusController', () => {
 
       // Verify initial state has no srcTxHash
       expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory.bridgeTxMetaId1
-          .status.srcChain.txHash,
+        bridgeStatusController.state.txHistory.bridgeTxMetaId1.status.srcChain
+          .txHash,
       ).toBeUndefined();
 
       // Advance timer to trigger polling with new hash
@@ -787,8 +780,8 @@ describe('BridgeStatusController', () => {
 
       // Verify the srcTxHash was updated
       expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory.bridgeTxMetaId1
-          .status.srcChain.txHash,
+        bridgeStatusController.state.txHistory.bridgeTxMetaId1.status.srcChain
+          .txHash,
       ).toBe('0xnewTxHash');
 
       // Cleanup
@@ -800,13 +793,13 @@ describe('BridgeStatusController', () => {
       const { bridgeStatusController } =
         await executePollingWithPendingStatus();
 
-      expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
-      ).toStrictEqual(MockTxHistory.getPending());
+      expect(bridgeStatusController.state.txHistory).toStrictEqual(
+        MockTxHistory.getPending(),
+      );
       bridgeStatusController.resetState();
-      expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
-      ).toStrictEqual(EMPTY_INIT_STATE.bridgeStatusState.txHistory);
+      expect(bridgeStatusController.state.txHistory).toStrictEqual(
+        EMPTY_INIT_STATE.txHistory,
+      );
     });
   });
   describe('wipeBridgeStatus', () => {
@@ -882,12 +875,12 @@ describe('BridgeStatusController', () => {
       expect(fetchBridgeTxStatusSpy).toHaveBeenCalledTimes(2);
 
       // Check that both accounts have a tx history entry
-      expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
-      ).toHaveProperty('bridgeTxMetaId1');
-      expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
-      ).toHaveProperty('bridgeTxMetaId2');
+      expect(bridgeStatusController.state.txHistory).toHaveProperty(
+        'bridgeTxMetaId1',
+      );
+      expect(bridgeStatusController.state.txHistory).toHaveProperty(
+        'bridgeTxMetaId2',
+      );
 
       // Wipe the status for 1 account only
       bridgeStatusController.wipeBridgeStatus({
@@ -897,7 +890,7 @@ describe('BridgeStatusController', () => {
 
       // Assertions
       const txHistoryItems = Object.values(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
+        bridgeStatusController.state.txHistory,
       );
       expect(txHistoryItems).toHaveLength(1);
       expect(txHistoryItems[0].account).toBe('0xaccount2');
@@ -972,21 +965,19 @@ describe('BridgeStatusController', () => {
 
       // Check we have a tx history entry for each chainId
       expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory.bridgeTxMetaId1
-          .quote.srcChainId,
+        bridgeStatusController.state.txHistory.bridgeTxMetaId1.quote.srcChainId,
       ).toBe(42161);
       expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory.bridgeTxMetaId1
-          .quote.destChainId,
+        bridgeStatusController.state.txHistory.bridgeTxMetaId1.quote
+          .destChainId,
       ).toBe(1);
 
       expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory.bridgeTxMetaId2
-          .quote.srcChainId,
+        bridgeStatusController.state.txHistory.bridgeTxMetaId2.quote.srcChainId,
       ).toBe(10);
       expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory.bridgeTxMetaId2
-          .quote.destChainId,
+        bridgeStatusController.state.txHistory.bridgeTxMetaId2.quote
+          .destChainId,
       ).toBe(123);
 
       bridgeStatusController.wipeBridgeStatus({
@@ -996,7 +987,7 @@ describe('BridgeStatusController', () => {
 
       // Assertions
       const txHistoryItems = Object.values(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
+        bridgeStatusController.state.txHistory,
       );
       expect(txHistoryItems).toHaveLength(0);
     });
@@ -1071,21 +1062,19 @@ describe('BridgeStatusController', () => {
 
       // Check we have a tx history entry for each chainId
       expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory.bridgeTxMetaId1
-          .quote.srcChainId,
+        bridgeStatusController.state.txHistory.bridgeTxMetaId1.quote.srcChainId,
       ).toBe(42161);
       expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory.bridgeTxMetaId1
-          .quote.destChainId,
+        bridgeStatusController.state.txHistory.bridgeTxMetaId1.quote
+          .destChainId,
       ).toBe(1);
 
       expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory.bridgeTxMetaId2
-          .quote.srcChainId,
+        bridgeStatusController.state.txHistory.bridgeTxMetaId2.quote.srcChainId,
       ).toBe(10);
       expect(
-        bridgeStatusController.state.bridgeStatusState.txHistory.bridgeTxMetaId2
-          .quote.destChainId,
+        bridgeStatusController.state.txHistory.bridgeTxMetaId2.quote
+          .destChainId,
       ).toBe(123);
 
       bridgeStatusController.wipeBridgeStatus({
@@ -1095,7 +1084,7 @@ describe('BridgeStatusController', () => {
 
       // Assertions
       const txHistoryItems = Object.values(
-        bridgeStatusController.state.bridgeStatusState.txHistory,
+        bridgeStatusController.state.txHistory,
       );
       expect(txHistoryItems).toHaveLength(1);
       expect(txHistoryItems[0].quote.srcChainId).toBe(10);

--- a/packages/bridge-status-controller/src/bridge-status-controller.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.ts
@@ -5,14 +5,13 @@ import { numberToHex, type Hex } from '@metamask/utils';
 
 import {
   BRIDGE_STATUS_CONTROLLER_NAME,
-  DEFAULT_BRIDGE_STATUS_STATE,
+  DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
   REFRESH_INTERVAL_MS,
 } from './constants';
 import { StatusTypes, type BridgeStatusControllerMessenger } from './types';
 import type {
   BridgeStatusControllerState,
   StartPollingForBridgeTxStatusArgsSerialized,
-  BridgeStatusState,
   FetchFunction,
 } from './types';
 import {
@@ -23,7 +22,7 @@ import {
 const metadata: StateMetadata<BridgeStatusControllerState> = {
   // We want to persist the bridge status state so that we can show the proper data for the Activity list
   // basically match the behavior of TransactionController
-  bridgeStatusState: {
+  txHistory: {
     persist: true,
     anonymous: false,
   },
@@ -54,7 +53,7 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
     fetchFn,
   }: {
     messenger: BridgeStatusControllerMessenger;
-    state?: { bridgeStatusState?: Partial<BridgeStatusState> };
+    state?: Partial<BridgeStatusControllerState>;
     clientId: BridgeClientId;
     fetchFn: FetchFunction;
   }) {
@@ -64,11 +63,8 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
       messenger,
       // Restore the persisted state
       state: {
+        ...DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
         ...state,
-        bridgeStatusState: {
-          ...DEFAULT_BRIDGE_STATUS_STATE,
-          ...state?.bridgeStatusState,
-        },
       },
     });
 
@@ -100,9 +96,7 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
 
   resetState = () => {
     this.update((state) => {
-      state.bridgeStatusState = {
-        ...DEFAULT_BRIDGE_STATUS_STATE,
-      };
+      state.txHistory = DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE.txHistory;
     });
   };
 
@@ -116,9 +110,7 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
     // Wipe all networks for this address
     if (ignoreNetwork) {
       this.update((state) => {
-        state.bridgeStatusState = {
-          ...DEFAULT_BRIDGE_STATUS_STATE,
-        };
+        state.txHistory = DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE.txHistory;
       });
     } else {
       const { selectedNetworkClientId } = this.messagingSystem.call(
@@ -136,8 +128,8 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
 
   readonly #restartPollingForIncompleteHistoryItems = () => {
     // Check for historyItems that do not have a status of complete and restart polling
-    const { bridgeStatusState } = this.state;
-    const historyItems = Object.values(bridgeStatusState.txHistory);
+    const { txHistory } = this.state;
+    const historyItems = Object.values(txHistory);
     const incompleteHistoryItems = historyItems
       .filter(
         (historyItem) =>
@@ -207,7 +199,7 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
     };
     this.update((state) => {
       // Use the txMeta.id as the key so we can reference the txMeta in TransactionController
-      state.bridgeStatusState.txHistory[bridgeTxMeta.id] = txHistoryItem;
+      state.txHistory[bridgeTxMeta.id] = txHistoryItem;
     });
 
     this.#pollingTokensByTxMetaId[bridgeTxMeta.id] = this.startPolling({
@@ -228,13 +220,13 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
   readonly #fetchBridgeTxStatus = async ({
     bridgeTxMetaId,
   }: FetchBridgeTxStatusArgs) => {
-    const { bridgeStatusState } = this.state;
+    const { txHistory } = this.state;
 
     try {
       // We try here because we receive 500 errors from Bridge API if we try to fetch immediately after submitting the source tx
       // Oddly mostly happens on Optimism, never on Arbitrum. By the 2nd fetch, the Bridge API responds properly.
       // Also srcTxHash may not be available immediately for STX, so we don't want to fetch in those cases
-      const historyItem = bridgeStatusState.txHistory[bridgeTxMetaId];
+      const historyItem = txHistory[bridgeTxMetaId];
       const srcTxHash = this.#getSrcTxHash(bridgeTxMetaId);
       if (!srcTxHash) {
         return;
@@ -266,8 +258,7 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
       // we need to keep track of the account that this is associated with as well so that we don't show it in Activity list for other accounts
       // First stab at this will not stop polling when you are on a different account
       this.update((state) => {
-        state.bridgeStatusState.txHistory[bridgeTxMetaId] =
-          newBridgeHistoryItem;
+        state.txHistory[bridgeTxMetaId] = newBridgeHistoryItem;
       });
 
       const pollingToken = this.#pollingTokensByTxMetaId[bridgeTxMetaId];
@@ -298,11 +289,10 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
   };
 
   readonly #getSrcTxHash = (bridgeTxMetaId: string): string | undefined => {
-    const { bridgeStatusState } = this.state;
+    const { txHistory } = this.state;
     // Prefer the srcTxHash from bridgeStatusState so we don't have to l ook up in TransactionController
     // But it is possible to have bridgeHistoryItem in state without the srcTxHash yet when it is an STX
-    const srcTxHash =
-      bridgeStatusState.txHistory[bridgeTxMetaId].status.srcChain.txHash;
+    const srcTxHash = txHistory[bridgeTxMetaId].status.srcChain.txHash;
 
     if (srcTxHash) {
       return srcTxHash;
@@ -319,14 +309,13 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
   };
 
   readonly #updateSrcTxHash = (bridgeTxMetaId: string, srcTxHash: string) => {
-    const { bridgeStatusState } = this.state;
-    if (bridgeStatusState.txHistory[bridgeTxMetaId].status.srcChain.txHash) {
+    const { txHistory } = this.state;
+    if (txHistory[bridgeTxMetaId].status.srcChain.txHash) {
       return;
     }
 
     this.update((state) => {
-      state.bridgeStatusState.txHistory[bridgeTxMetaId].status.srcChain.txHash =
-        srcTxHash;
+      state.txHistory[bridgeTxMetaId].status.srcChain.txHash = srcTxHash;
     });
   };
 
@@ -336,19 +325,20 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
     address: string,
     selectedChainId: Hex,
   ) => {
-    const sourceTxMetaIdsToDelete = Object.keys(
-      this.state.bridgeStatusState.txHistory,
-    ).filter((txMetaId) => {
-      const bridgeHistoryItem =
-        this.state.bridgeStatusState.txHistory[txMetaId];
+    const sourceTxMetaIdsToDelete = Object.keys(this.state.txHistory).filter(
+      (txMetaId) => {
+        const bridgeHistoryItem = this.state.txHistory[txMetaId];
 
-      const hexSourceChainId = numberToHex(bridgeHistoryItem.quote.srcChainId);
+        const hexSourceChainId = numberToHex(
+          bridgeHistoryItem.quote.srcChainId,
+        );
 
-      return (
-        bridgeHistoryItem.account === address &&
-        hexSourceChainId === selectedChainId
-      );
-    });
+        return (
+          bridgeHistoryItem.account === address &&
+          hexSourceChainId === selectedChainId
+        );
+      },
+    );
 
     sourceTxMetaIdsToDelete.forEach((sourceTxMetaId) => {
       const pollingToken = this.#pollingTokensByTxMetaId[sourceTxMetaId];
@@ -361,12 +351,12 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
     });
 
     this.update((state) => {
-      state.bridgeStatusState.txHistory = sourceTxMetaIdsToDelete.reduce(
+      state.txHistory = sourceTxMetaIdsToDelete.reduce(
         (acc, sourceTxMetaId) => {
           delete acc[sourceTxMetaId];
           return acc;
         },
-        state.bridgeStatusState.txHistory,
+        state.txHistory,
       );
     });
   };

--- a/packages/bridge-status-controller/src/constants.ts
+++ b/packages/bridge-status-controller/src/constants.ts
@@ -1,13 +1,10 @@
-import type { BridgeStatusState } from './types';
+import type { BridgeStatusControllerState } from './types';
 
 export const REFRESH_INTERVAL_MS = 10 * 1000;
 
 export const BRIDGE_STATUS_CONTROLLER_NAME = 'BridgeStatusController';
 
-export const DEFAULT_BRIDGE_STATUS_STATE: BridgeStatusState = {
-  txHistory: {},
-};
-
-export const DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE = {
-  bridgeStatusState: { ...DEFAULT_BRIDGE_STATUS_STATE },
-};
+export const DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE: BridgeStatusControllerState =
+  {
+    txHistory: {},
+  };

--- a/packages/bridge-status-controller/src/index.ts
+++ b/packages/bridge-status-controller/src/index.ts
@@ -1,7 +1,6 @@
 // Export constants
 export {
   REFRESH_INTERVAL_MS,
-  DEFAULT_BRIDGE_STATUS_STATE,
   DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
 } from './constants';
 
@@ -17,7 +16,6 @@ export type {
   RefuelStatusResponse,
   RefuelData,
   BridgeHistoryItem,
-  BridgeStatusState,
   BridgeStatusControllerState,
   BridgeStatusControllerMessenger,
   BridgeStatusControllerActions,

--- a/packages/bridge-status-controller/src/types.ts
+++ b/packages/bridge-status-controller/src/types.ts
@@ -15,8 +15,10 @@ import type {
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetStateAction,
 } from '@metamask/network-controller';
-import type { TransactionControllerGetStateAction } from '@metamask/transaction-controller';
-import type { TransactionMeta } from '@metamask/transaction-controller';
+import type {
+  TransactionControllerGetStateAction,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
 
 import type { BridgeStatusController } from './bridge-status-controller';
 import type { BRIDGE_STATUS_CONTROLLER_NAME } from './constants';
@@ -247,12 +249,8 @@ export type StartPollingForBridgeTxStatusArgsSerialized = Omit<
 
 export type SourceChainTxMetaId = string;
 
-export type BridgeStatusState = {
-  txHistory: Record<SourceChainTxMetaId, BridgeHistoryItem>;
-};
-
 export type BridgeStatusControllerState = {
-  bridgeStatusState: BridgeStatusState;
+  txHistory: Record<SourceChainTxMetaId, BridgeHistoryItem>;
 };
 
 // Actions


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR changes the state shape of `BridgeController` and `BridgeStatusController` to better match the standard shape with all the relevant fields at the root of `state` rather than behind a redundant field like `state.bridgeState` or `state.bridgeStatusState`.

It also changes the default values from `undefined` to `null` to better support Mobile efforts.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/bridge-controller`

- BREAKING: Data fields have been moved to the root of the `state` object, rather than behind a redundant field `state.bridgeState`
- BREAKING: Default values have been changed from `undefined` to `null`.

### `@metamask/bridge-status-controller`

- BREAKING: Data fields have been moved to the root of the `state` object, rather than behind a redundant field `state.bridgeStatusState`
- BREAKING: Redundant type `BridgeStatusState` removed from exports

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
