### PR TITLE
chore: align keyring controller sign authorization action

### DIFF
--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -26,6 +26,7 @@ import type {
   FetchGasFeeEstimateOptions,
   GasFeeState,
 } from '@metamask/gas-fee-controller';
+import type { KeyringControllerSignEip7702AuthorizationAction } from '@metamask/keyring-controller';
 import type {
   BlockTracker,
   NetworkClientId,
@@ -105,7 +106,6 @@ import {
   SimulationErrorCode,
 } from './types';
 import { addTransactionBatch, isAtomicBatchSupported } from './utils/batch';
-import type { KeyringControllerSignAuthorization } from './utils/eip7702';
 import { signAuthorizationList } from './utils/eip7702';
 import { validateConfirmedExternalTransaction } from './utils/external-transactions';
 import { addGasBuffer, estimateGas, updateGas } from './utils/gas';
@@ -379,7 +379,7 @@ export type AllowedActions =
   | AccountsControllerGetSelectedAccountAction
   | AccountsControllerGetStateAction
   | AddApprovalRequest
-  | KeyringControllerSignAuthorization
+  | KeyringControllerSignEip7702AuthorizationAction
   | NetworkControllerFindNetworkClientIdByChainIdAction
   | NetworkControllerGetNetworkClientByIdAction
   | RemoteFeatureFlagControllerGetStateAction;

--- a/packages/transaction-controller/src/utils/eip7702.test.ts
+++ b/packages/transaction-controller/src/utils/eip7702.test.ts
@@ -4,7 +4,6 @@ import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote
 import type { Hex } from '@metamask/utils';
 import { remove0x } from '@metamask/utils';
 
-import type { KeyringControllerSignAuthorization } from './eip7702';
 import {
   DELEGATION_PREFIX,
   doesChainSupportEIP7702,
@@ -17,6 +16,7 @@ import {
   getEIP7702SupportedChains,
 } from './feature-flags';
 import { Messenger } from '../../../base-controller/src';
+import type { KeyringControllerSignEip7702AuthorizationAction } from '../../../keyring-controller/src';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { AuthorizationList } from '../types';
 import { TransactionStatus, type TransactionMeta } from '../types';
@@ -72,7 +72,7 @@ const AUTHORIZATION_LIST_MOCK: AuthorizationList = [
 
 describe('EIP-7702 Utils', () => {
   let baseMessenger: Messenger<
-    | KeyringControllerSignAuthorization
+    | KeyringControllerSignEip7702AuthorizationAction
     | RemoteFeatureFlagControllerGetStateAction,
     never
   >;
@@ -87,7 +87,7 @@ describe('EIP-7702 Utils', () => {
   );
 
   let signAuthorizationMock: jest.MockedFn<
-    KeyringControllerSignAuthorization['handler']
+    KeyringControllerSignEip7702AuthorizationAction['handler']
   >;
 
   beforeEach(() => {
@@ -100,13 +100,13 @@ describe('EIP-7702 Utils', () => {
       .mockResolvedValue(AUTHORIZATION_SIGNATURE_MOCK);
 
     baseMessenger.registerActionHandler(
-      'KeyringController:signEip7702AuthorizationMessage',
+      'KeyringController:signEip7702Authorization',
       signAuthorizationMock,
     );
 
     controllerMessenger = baseMessenger.getRestricted({
       name: 'TransactionController',
-      allowedActions: ['KeyringController:signEip7702AuthorizationMessage'],
+      allowedActions: ['KeyringController:signEip7702Authorization'],
       allowedEvents: [],
     });
   });

--- a/packages/transaction-controller/src/utils/eip7702.ts
+++ b/packages/transaction-controller/src/utils/eip7702.ts
@@ -18,22 +18,6 @@ import type {
   TransactionMeta,
 } from '../types';
 
-export type KeyringControllerAuthorization = [
-  chainId: number,
-  contractAddress: string,
-  nonce: number,
-];
-
-export type KeyringControllerSignAuthorization = {
-  type: 'KeyringController:signEip7702AuthorizationMessage';
-  handler: (authorization: {
-    chainId: number;
-    contractAddress: string;
-    from: string;
-    nonce: number;
-  }) => Promise<string>;
-};
-
 export const DELEGATION_PREFIX = '0xef0100';
 export const BATCH_FUNCTION_NAME = 'execute';
 export const CALLS_SIGNATURE = '(address,uint256,bytes)[]';
@@ -208,7 +192,7 @@ async function signAuthorization(
   const nonceDecimal = parseInt(nonce, 16);
 
   const signature = await messenger.call(
-    'KeyringController:signEip7702AuthorizationMessage',
+    'KeyringController:signEip7702Authorization',
     {
       chainId: chainIdDecimal,
       contractAddress: address,


### PR DESCRIPTION
## Explanation

Update the `TransactionController` to use the sign authorization action type defined in the `KeyringController` rather than the internal one created for testing.

## References

## Changelog

### `@metamask/transaction-controller`

- **BREAKING**: Require messenger permissions for `KeyringController:signEip7702Authorization` action.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
