### PR TITLE
refactor: migrate wallet handlers (and unit tests)

### DIFF
--- a/packages/multichain/src/constants/permissions.ts
+++ b/packages/multichain/src/constants/permissions.ts
@@ -1,0 +1,12 @@
+export const CaveatTypes = Object.freeze({
+  restrictReturnedAccounts: 'restrictReturnedAccounts' as const,
+  restrictNetworkSwitching: 'restrictNetworkSwitching' as const,
+});
+
+export const EndowmentTypes = Object.freeze({
+  permittedChains: 'endowment:permitted-chains',
+});
+
+export const RestrictedMethods = Object.freeze({
+  eth_accounts: 'eth_accounts',
+});

--- a/packages/multichain/src/handlers/wallet-getPermissions.test.ts
+++ b/packages/multichain/src/handlers/wallet-getPermissions.test.ts
@@ -1,0 +1,362 @@
+import {
+  Caip25CaveatType,
+  Caip25EndowmentPermissionName,
+} from '@metamask/multichain';
+import * as Multichain from '@metamask/multichain';
+import type {
+  Json,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+
+import { getPermissionsHandler } from './wallet-getPermissions';
+import {
+  CaveatTypes,
+  EndowmentTypes,
+  RestrictedMethods,
+} from '../constants/permissions';
+
+jest.mock('@metamask/multichain', () => ({
+  ...jest.requireActual('@metamask/multichain'),
+  getPermittedEthChainIds: jest.fn(),
+}));
+const MockMultichain = jest.mocked(Multichain);
+
+const baseRequest = {
+  jsonrpc: '2.0' as const,
+  id: 0,
+  method: 'wallet_getPermissions',
+};
+
+const createMockedHandler = () => {
+  const next = jest.fn();
+  const end = jest.fn();
+  const getPermissionsForOrigin = jest.fn().mockReturnValue(
+    Object.freeze({
+      [Caip25EndowmentPermissionName]: {
+        id: '1',
+        parentCapability: Caip25EndowmentPermissionName,
+        caveats: [
+          {
+            type: Caip25CaveatType,
+            value: {
+              requiredScopes: {
+                'eip155:1': {
+                  accounts: ['eip155:1:0x1', 'eip155:1:0x2'],
+                },
+                'eip155:5': {
+                  accounts: ['eip155:5:0x1', 'eip155:5:0x3'],
+                },
+              },
+              optionalScopes: {
+                'eip155:1': {
+                  accounts: ['eip155:1:0xdeadbeef'],
+                },
+              },
+            },
+          },
+        ],
+      },
+      otherPermission: {
+        id: '2',
+        parentCapability: 'otherPermission',
+        caveats: [
+          {
+            value: {
+              foo: 'bar',
+            },
+          },
+        ],
+      },
+    }),
+  );
+  const getAccounts = jest.fn().mockReturnValue([]);
+  const response: PendingJsonRpcResponse<Json> = {
+    jsonrpc: '2.0' as const,
+    id: 0,
+  };
+  const handler = (request: JsonRpcRequest<Json[]>) =>
+    getPermissionsHandler.implementation(request, response, next, end, {
+      getPermissionsForOrigin,
+      getAccounts,
+    });
+
+  return {
+    response,
+    next,
+    end,
+    getPermissionsForOrigin,
+    getAccounts,
+    handler,
+  };
+};
+
+describe('getPermissionsHandler', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  beforeEach(() => {
+    MockMultichain.getPermittedEthChainIds.mockReturnValue([]);
+  });
+
+  it('gets the permissions for the origin', async () => {
+    const { handler, getPermissionsForOrigin } = createMockedHandler();
+
+    await handler(baseRequest);
+    expect(getPermissionsForOrigin).toHaveBeenCalled();
+  });
+
+  it('returns permissions unmodified if no CAIP-25 endowment permission has been granted', async () => {
+    const { handler, getPermissionsForOrigin, response } =
+      createMockedHandler();
+
+    getPermissionsForOrigin.mockReturnValue(
+      Object.freeze({
+        otherPermission: {
+          id: '1',
+          parentCapability: 'otherPermission',
+          caveats: [
+            {
+              value: {
+                foo: 'bar',
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    await handler(baseRequest);
+    expect(response.result).toStrictEqual([
+      {
+        id: '1',
+        parentCapability: 'otherPermission',
+        caveats: [
+          {
+            value: {
+              foo: 'bar',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  describe('CAIP-25 endowment permissions has been granted', () => {
+    it('returns the permissions with the CAIP-25 permission removed', async () => {
+      const { handler, getAccounts, getPermissionsForOrigin, response } =
+        createMockedHandler();
+      getPermissionsForOrigin.mockReturnValue(
+        Object.freeze({
+          [Caip25EndowmentPermissionName]: {
+            id: '1',
+            parentCapability: Caip25EndowmentPermissionName,
+            caveats: [
+              {
+                type: Caip25CaveatType,
+                value: {
+                  requiredScopes: {},
+                  optionalScopes: {},
+                },
+              },
+            ],
+          },
+          otherPermission: {
+            id: '2',
+            parentCapability: 'otherPermission',
+            caveats: [
+              {
+                value: {
+                  foo: 'bar',
+                },
+              },
+            ],
+          },
+        }),
+      );
+      getAccounts.mockReturnValue([]);
+      MockMultichain.getPermittedEthChainIds.mockReturnValue([]);
+      await handler(baseRequest);
+      expect(response.result).toStrictEqual([
+        {
+          id: '2',
+          parentCapability: 'otherPermission',
+          caveats: [
+            {
+              value: {
+                foo: 'bar',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('gets the lastSelected sorted permissioned eth accounts for the origin', async () => {
+      const { handler, getAccounts } = createMockedHandler();
+      await handler(baseRequest);
+      expect(getAccounts).toHaveBeenCalledWith({ ignoreLock: true });
+    });
+
+    it('returns the permissions with an eth_accounts permission if some eth accounts are permissioned', async () => {
+      const { handler, getAccounts, response } = createMockedHandler();
+      getAccounts.mockReturnValue(['0x1', '0x2', '0x3', '0xdeadbeef']);
+
+      await handler(baseRequest);
+      expect(response.result).toStrictEqual([
+        {
+          id: '2',
+          parentCapability: 'otherPermission',
+          caveats: [
+            {
+              value: {
+                foo: 'bar',
+              },
+            },
+          ],
+        },
+        {
+          id: '1',
+          parentCapability: RestrictedMethods.eth_accounts,
+          caveats: [
+            {
+              type: CaveatTypes.restrictReturnedAccounts,
+              value: ['0x1', '0x2', '0x3', '0xdeadbeef'],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('gets the permitted eip155 chainIds from the CAIP-25 caveat value', async () => {
+      const { handler, getPermissionsForOrigin } = createMockedHandler();
+      getPermissionsForOrigin.mockReturnValue(
+        Object.freeze({
+          [Caip25EndowmentPermissionName]: {
+            id: '1',
+            parentCapability: Caip25EndowmentPermissionName,
+            caveats: [
+              {
+                type: Caip25CaveatType,
+                value: {
+                  requiredScopes: {
+                    'eip155:1': {
+                      accounts: [],
+                    },
+                    'eip155:5': {
+                      accounts: [],
+                    },
+                  },
+                  optionalScopes: {
+                    'eip155:1': {
+                      accounts: [],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          otherPermission: {
+            id: '2',
+            parentCapability: 'otherPermission',
+            caveats: [
+              {
+                value: {
+                  foo: 'bar',
+                },
+              },
+            ],
+          },
+        }),
+      );
+      await handler(baseRequest);
+      expect(MockMultichain.getPermittedEthChainIds).toHaveBeenCalledWith({
+        requiredScopes: {
+          'eip155:1': {
+            accounts: [],
+          },
+          'eip155:5': {
+            accounts: [],
+          },
+        },
+        optionalScopes: {
+          'eip155:1': {
+            accounts: [],
+          },
+        },
+      });
+    });
+
+    it('returns the permissions with a permittedChains permission if some eip155 chainIds are permissioned', async () => {
+      const { handler, response } = createMockedHandler();
+      MockMultichain.getPermittedEthChainIds.mockReturnValue(['0x1', '0x64']);
+
+      await handler(baseRequest);
+      expect(response.result).toStrictEqual([
+        {
+          id: '2',
+          parentCapability: 'otherPermission',
+          caveats: [
+            {
+              value: {
+                foo: 'bar',
+              },
+            },
+          ],
+        },
+        {
+          id: '1',
+          parentCapability: EndowmentTypes.permittedChains,
+          caveats: [
+            {
+              type: CaveatTypes.restrictNetworkSwitching,
+              value: ['0x1', '0x64'],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('returns the permissions with a eth_accounts and permittedChains permission if some eip155 accounts and chainIds are permissioned', async () => {
+      const { handler, getAccounts, response } = createMockedHandler();
+      getAccounts.mockReturnValue(['0x1', '0x2', '0xdeadbeef']);
+      MockMultichain.getPermittedEthChainIds.mockReturnValue(['0x1', '0x64']);
+
+      await handler(baseRequest);
+      expect(response.result).toStrictEqual([
+        {
+          id: '2',
+          parentCapability: 'otherPermission',
+          caveats: [
+            {
+              value: {
+                foo: 'bar',
+              },
+            },
+          ],
+        },
+        {
+          id: '1',
+          parentCapability: RestrictedMethods.eth_accounts,
+          caveats: [
+            {
+              type: CaveatTypes.restrictReturnedAccounts,
+              value: ['0x1', '0x2', '0xdeadbeef'],
+            },
+          ],
+        },
+        {
+          id: '1',
+          parentCapability: EndowmentTypes.permittedChains,
+          caveats: [
+            {
+              type: CaveatTypes.restrictNetworkSwitching,
+              value: ['0x1', '0x64'],
+            },
+          ],
+        },
+      ]);
+    });
+  });
+});

--- a/packages/multichain/src/handlers/wallet-getPermissions.ts
+++ b/packages/multichain/src/handlers/wallet-getPermissions.ts
@@ -1,0 +1,111 @@
+import type {
+  AsyncJsonRpcEngineNextCallback,
+  JsonRpcEngineEndCallback,
+} from '@metamask/json-rpc-engine';
+import {
+  Caip25CaveatType,
+  type Caip25CaveatValue,
+  Caip25EndowmentPermissionName,
+  getPermittedEthChainIds,
+} from '@metamask/multichain';
+import {
+  type CaveatSpecificationConstraint,
+  MethodNames,
+  type PermissionController,
+  type PermissionSpecificationConstraint,
+} from '@metamask/permission-controller';
+import type {
+  Json,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+
+import {
+  EndowmentTypes,
+  RestrictedMethods,
+  CaveatTypes,
+} from '../constants/permissions';
+
+export const getPermissionsHandler = {
+  methodNames: [MethodNames.GetPermissions],
+  implementation: getPermissionsImplementation,
+  hookNames: {
+    getPermissionsForOrigin: true,
+    getAccounts: true,
+  },
+};
+
+/**
+ * Get Permissions implementation to be used in JsonRpcEngine middleware.
+ *
+ * @param _req - The JsonRpcEngine request - unused
+ * @param res - The JsonRpcEngine result object
+ * @param _next - JsonRpcEngine next() callback - unused
+ * @param end - JsonRpcEngine end() callback
+ * @param options - Method hooks passed to the method implementation
+ * @param options.getPermissionsForOrigin - The specific method hook needed for this method implementation
+ * @param options.getAccounts - A hook that returns the permitted eth accounts for the origin sorted by lastSelected.
+ * @returns A promise that resolves to nothing
+ */
+async function getPermissionsImplementation(
+  _req: JsonRpcRequest<Json[]>,
+  res: PendingJsonRpcResponse<Json>,
+  _next: AsyncJsonRpcEngineNextCallback,
+  end: JsonRpcEngineEndCallback,
+  {
+    getPermissionsForOrigin,
+    getAccounts,
+  }: {
+    getPermissionsForOrigin: () => ReturnType<
+      PermissionController<
+        PermissionSpecificationConstraint,
+        CaveatSpecificationConstraint
+      >['getPermissions']
+    >;
+    getAccounts: (options?: { ignoreLock?: boolean }) => string[];
+  },
+) {
+  const permissions = { ...getPermissionsForOrigin() };
+  const caip25Endowment = permissions[Caip25EndowmentPermissionName];
+  const caip25CaveatValue = caip25Endowment?.caveats?.find(
+    ({ type }) => type === Caip25CaveatType,
+  )?.value as Caip25CaveatValue | undefined;
+  delete permissions[Caip25EndowmentPermissionName];
+
+  if (caip25CaveatValue) {
+    // We cannot derive ethAccounts directly from the CAIP-25 permission
+    // because the accounts will not be in order of lastSelected
+    const ethAccounts = getAccounts({ ignoreLock: true });
+
+    if (ethAccounts.length > 0) {
+      permissions[RestrictedMethods.eth_accounts] = {
+        ...caip25Endowment,
+        parentCapability: RestrictedMethods.eth_accounts,
+        caveats: [
+          {
+            type: CaveatTypes.restrictReturnedAccounts,
+            value: ethAccounts,
+          },
+        ],
+      };
+    }
+
+    const ethChainIds = getPermittedEthChainIds(caip25CaveatValue);
+
+    if (ethChainIds.length > 0) {
+      permissions[EndowmentTypes.permittedChains] = {
+        ...caip25Endowment,
+        parentCapability: EndowmentTypes.permittedChains,
+        caveats: [
+          {
+            type: CaveatTypes.restrictNetworkSwitching,
+            value: ethChainIds,
+          },
+        ],
+      };
+    }
+  }
+
+  res.result = Object.values(permissions);
+  return end();
+}

--- a/packages/multichain/src/handlers/wallet-requestPermissions.test.ts
+++ b/packages/multichain/src/handlers/wallet-requestPermissions.test.ts
@@ -1,0 +1,560 @@
+import {
+  Caip25CaveatType,
+  Caip25EndowmentPermissionName,
+} from '@metamask/multichain';
+import {
+  invalidParams,
+  type RequestedPermissions,
+} from '@metamask/permission-controller';
+import type {
+  Json,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+
+import { requestPermissionsHandler } from './wallet-requestPermissions';
+import {
+  CaveatTypes,
+  EndowmentTypes,
+  RestrictedMethods,
+} from '../constants/permissions';
+
+const getBaseRequest = (overrides = {}) => ({
+  jsonrpc: '2.0' as const,
+  id: 0,
+  method: 'wallet_requestPermissions',
+  networkClientId: 'mainnet',
+  origin: 'http://test.com',
+  params: [
+    {
+      eth_accounts: {},
+    },
+  ],
+  ...overrides,
+});
+
+const createMockedHandler = () => {
+  const next = jest.fn();
+  const end = jest.fn();
+  const requestPermissionsForOrigin = jest
+    .fn()
+    .mockResolvedValue([{ [Caip25EndowmentPermissionName]: {} }]);
+  const getAccounts = jest.fn().mockReturnValue([]);
+  const getCaip25PermissionFromLegacyPermissionsForOrigin = jest
+    .fn()
+    .mockReturnValue({});
+
+  const response: PendingJsonRpcResponse<Json> = {
+    jsonrpc: '2.0' as const,
+    id: 0,
+  };
+  const handler = (request: unknown) =>
+    requestPermissionsHandler.implementation(
+      request as JsonRpcRequest<[RequestedPermissions]> & { origin: string },
+      response,
+      next,
+      end,
+      {
+        getAccounts,
+        requestPermissionsForOrigin,
+        getCaip25PermissionFromLegacyPermissionsForOrigin,
+      },
+    );
+
+  return {
+    response,
+    next,
+    end,
+    getAccounts,
+    requestPermissionsForOrigin,
+    getCaip25PermissionFromLegacyPermissionsForOrigin,
+    handler,
+  };
+};
+
+describe('requestPermissionsHandler', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns an error if params is malformed', async () => {
+    const { handler, end } = createMockedHandler();
+
+    const malformedRequest = getBaseRequest({ params: [] });
+    await handler(malformedRequest);
+    expect(end).toHaveBeenCalledWith(
+      invalidParams({ data: { request: malformedRequest } }),
+    );
+  });
+
+  describe('only other permissions (non CAIP-25 equivalent) requested', () => {
+    it('requests the permission for the other permissions', async () => {
+      const { handler, requestPermissionsForOrigin } = createMockedHandler();
+
+      await handler(
+        getBaseRequest({
+          params: [
+            {
+              otherPermissionA: {},
+              otherPermissionB: {},
+            },
+          ],
+        }),
+      );
+
+      expect(requestPermissionsForOrigin).toHaveBeenCalledWith({
+        otherPermissionA: {},
+        otherPermissionB: {},
+      });
+    });
+
+    it('returns the other permissions that are granted', async () => {
+      const { handler, requestPermissionsForOrigin, response } =
+        createMockedHandler();
+
+      requestPermissionsForOrigin.mockResolvedValue([
+        {
+          otherPermissionA: { foo: 'bar' },
+          otherPermissionB: { hello: true },
+        },
+      ]);
+
+      await handler(
+        getBaseRequest({
+          params: [
+            {
+              otherPermissionA: {},
+              otherPermissionB: {},
+            },
+          ],
+        }),
+      );
+
+      expect(response.result).toStrictEqual([{ foo: 'bar' }, { hello: true }]);
+    });
+  });
+
+  describe('only CAIP-25 "endowment:caip25" permissions requested', () => {
+    it('should call "requestPermissionsForOrigin" hook with empty object', async () => {
+      const { handler, requestPermissionsForOrigin } = createMockedHandler();
+
+      await handler(
+        getBaseRequest({
+          params: [
+            {
+              [Caip25EndowmentPermissionName]: {
+                caveats: [
+                  {
+                    type: Caip25CaveatType,
+                    value: {
+                      requiredScopes: {},
+                      optionalScopes: {
+                        'eip155:5': { accounts: ['eip155:5:0xdead'] },
+                      },
+                      isMultichainOrigin: false,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      );
+
+      expect(requestPermissionsForOrigin).toHaveBeenCalledWith({});
+    });
+  });
+
+  describe('only CAIP-25 equivalent permissions ("eth_accounts" and/or "endowment:permittedChains") requested', () => {
+    it('requests the CAIP-25 permission using eth_accounts when only eth_accounts is specified in params', async () => {
+      const mockedRequestedPermissions = {
+        [Caip25EndowmentPermissionName]: {
+          caveats: [
+            {
+              type: Caip25CaveatType,
+              value: {
+                requiredScopes: {},
+                optionalScopes: {
+                  'wallet:eip155': { accounts: ['wallet:eip155:foo'] },
+                },
+                isMultichainOrigin: false,
+              },
+            },
+          ],
+        },
+      };
+
+      const {
+        handler,
+        getCaip25PermissionFromLegacyPermissionsForOrigin,
+        requestPermissionsForOrigin,
+        getAccounts,
+      } = createMockedHandler();
+      getCaip25PermissionFromLegacyPermissionsForOrigin.mockReturnValue(
+        mockedRequestedPermissions,
+      );
+      requestPermissionsForOrigin.mockResolvedValue([
+        mockedRequestedPermissions,
+      ]);
+      getAccounts.mockReturnValue(['foo']);
+
+      await handler(
+        getBaseRequest({
+          params: [
+            {
+              [RestrictedMethods.eth_accounts]: {
+                foo: 'bar',
+              },
+            },
+          ],
+        }),
+      );
+
+      expect(
+        getCaip25PermissionFromLegacyPermissionsForOrigin,
+      ).toHaveBeenCalledWith({
+        [RestrictedMethods.eth_accounts]: {
+          foo: 'bar',
+        },
+      });
+    });
+
+    it('requests the CAIP-25 permission for permittedChains when only permittedChains is specified in params', async () => {
+      const mockedRequestedPermissions = {
+        [Caip25EndowmentPermissionName]: {
+          caveats: [
+            {
+              type: Caip25CaveatType,
+              value: {
+                requiredScopes: {},
+                optionalScopes: {
+                  'eip155:100': { accounts: [] },
+                },
+                isMultichainOrigin: false,
+              },
+            },
+          ],
+        },
+      };
+
+      const {
+        handler,
+        requestPermissionsForOrigin,
+        getCaip25PermissionFromLegacyPermissionsForOrigin,
+      } = createMockedHandler();
+
+      getCaip25PermissionFromLegacyPermissionsForOrigin.mockReturnValue(
+        mockedRequestedPermissions,
+      );
+      requestPermissionsForOrigin.mockResolvedValue([
+        mockedRequestedPermissions,
+      ]);
+
+      await handler(
+        getBaseRequest({
+          params: [
+            {
+              [EndowmentTypes.permittedChains]: {
+                caveats: [
+                  {
+                    type: CaveatTypes.restrictNetworkSwitching,
+                    value: ['0x64'],
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      );
+
+      expect(
+        getCaip25PermissionFromLegacyPermissionsForOrigin,
+      ).toHaveBeenCalledWith({
+        [EndowmentTypes.permittedChains]: {
+          caveats: [
+            {
+              type: CaveatTypes.restrictNetworkSwitching,
+              value: ['0x64'],
+            },
+          ],
+        },
+      });
+    });
+
+    it('requests the CAIP-25 permission for eth_accounts and permittedChains when both are specified in params', async () => {
+      const mockedRequestedPermissions = {
+        [Caip25EndowmentPermissionName]: {
+          caveats: [
+            {
+              type: Caip25CaveatType,
+              value: {
+                requiredScopes: {},
+                optionalScopes: {
+                  'eip155:100': { accounts: ['bar'] },
+                },
+                isMultichainOrigin: false,
+              },
+            },
+          ],
+        },
+      };
+
+      const {
+        handler,
+        requestPermissionsForOrigin,
+        getAccounts,
+        getCaip25PermissionFromLegacyPermissionsForOrigin,
+      } = createMockedHandler();
+
+      requestPermissionsForOrigin.mockResolvedValue([
+        mockedRequestedPermissions,
+      ]);
+      getAccounts.mockReturnValue(['bar']);
+      getCaip25PermissionFromLegacyPermissionsForOrigin.mockReturnValue(
+        mockedRequestedPermissions,
+      );
+
+      await handler(
+        getBaseRequest({
+          params: [
+            {
+              [RestrictedMethods.eth_accounts]: {
+                foo: 'bar',
+              },
+              [EndowmentTypes.permittedChains]: {
+                caveats: [
+                  {
+                    type: CaveatTypes.restrictNetworkSwitching,
+                    value: ['0x64'],
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      );
+
+      expect(
+        getCaip25PermissionFromLegacyPermissionsForOrigin,
+      ).toHaveBeenCalledWith({
+        [RestrictedMethods.eth_accounts]: {
+          foo: 'bar',
+        },
+        [EndowmentTypes.permittedChains]: {
+          caveats: [
+            {
+              type: CaveatTypes.restrictNetworkSwitching,
+              value: ['0x64'],
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  describe('CAIP-25 equivalent permissions ("eth_accounts" and/or "endowment:permittedChains") alongside "endowment:caip25" requested', () => {
+    it('requests the CAIP-25 permission only for eth_accounts and permittedChains when both are specified in params (ignores "endowment:caip25")', async () => {
+      const mockedRequestedPermissions = {
+        [Caip25EndowmentPermissionName]: {
+          caveats: [
+            {
+              type: Caip25CaveatType,
+              value: {
+                requiredScopes: {},
+                optionalScopes: {
+                  'eip155:100': { accounts: ['bar'] },
+                },
+                isMultichainOrigin: false,
+              },
+            },
+          ],
+        },
+      };
+
+      const {
+        handler,
+        requestPermissionsForOrigin,
+        getAccounts,
+        getCaip25PermissionFromLegacyPermissionsForOrigin,
+      } = createMockedHandler();
+
+      requestPermissionsForOrigin.mockResolvedValue([
+        mockedRequestedPermissions,
+      ]);
+      getAccounts.mockReturnValue(['bar']);
+      getCaip25PermissionFromLegacyPermissionsForOrigin.mockReturnValue(
+        mockedRequestedPermissions,
+      );
+
+      await handler(
+        getBaseRequest({
+          params: [
+            {
+              [Caip25EndowmentPermissionName]: {
+                caveats: [
+                  {
+                    type: Caip25CaveatType,
+                    value: {
+                      requiredScopes: {},
+                      optionalScopes: {
+                        'eip155:5': { accounts: ['eip155:5:0xdead'] },
+                      },
+                      isMultichainOrigin: false,
+                    },
+                  },
+                ],
+              },
+              [RestrictedMethods.eth_accounts]: {
+                foo: 'bar',
+              },
+              [EndowmentTypes.permittedChains]: {
+                caveats: [
+                  {
+                    type: CaveatTypes.restrictNetworkSwitching,
+                    value: ['0x64'],
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      );
+
+      expect(
+        getCaip25PermissionFromLegacyPermissionsForOrigin,
+      ).toHaveBeenCalledWith({
+        [RestrictedMethods.eth_accounts]: {
+          foo: 'bar',
+        },
+        [EndowmentTypes.permittedChains]: {
+          caveats: [
+            {
+              type: CaveatTypes.restrictNetworkSwitching,
+              value: ['0x64'],
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  describe('both CAIP-25 equivalent and other permissions requested', () => {
+    describe('both CAIP-25 equivalent permissions and other permissions are approved', () => {
+      it('returns eth_accounts, permittedChains, and other permissions that were granted', async () => {
+        const mockedRequestedPermissions = {
+          otherPermissionA: { foo: 'bar' },
+          otherPermissionB: { hello: true },
+          [Caip25EndowmentPermissionName]: {
+            caveats: [
+              {
+                type: Caip25CaveatType,
+                value: {
+                  requiredScopes: {},
+                  optionalScopes: {
+                    'eip155:1': { accounts: ['eip155:1:0xdeadbeef'] },
+                    'eip155:5': { accounts: ['eip155:5:0xdeadbeef'] },
+                  },
+                  isMultichainOrigin: false,
+                },
+              },
+            ],
+          },
+        };
+
+        const {
+          handler,
+          requestPermissionsForOrigin,
+          getAccounts,
+          getCaip25PermissionFromLegacyPermissionsForOrigin,
+          response,
+        } = createMockedHandler();
+
+        requestPermissionsForOrigin.mockResolvedValue([
+          mockedRequestedPermissions,
+        ]);
+
+        getAccounts.mockReturnValue(['0xdeadbeef']);
+
+        getCaip25PermissionFromLegacyPermissionsForOrigin.mockReturnValue(
+          mockedRequestedPermissions,
+        );
+
+        await handler(
+          getBaseRequest({
+            params: [
+              {
+                eth_accounts: {},
+                'endowment:permitted-chains': {},
+                otherPermissionA: {},
+                otherPermissionB: {},
+              },
+            ],
+          }),
+        );
+        expect(response.result).toStrictEqual([
+          { foo: 'bar' },
+          { hello: true },
+          {
+            caveats: [
+              {
+                type: CaveatTypes.restrictReturnedAccounts,
+                value: ['0xdeadbeef'],
+              },
+            ],
+            parentCapability: RestrictedMethods.eth_accounts,
+          },
+          {
+            caveats: [
+              {
+                type: CaveatTypes.restrictNetworkSwitching,
+                value: ['0x1', '0x5'],
+              },
+            ],
+            parentCapability: EndowmentTypes.permittedChains,
+          },
+        ]);
+      });
+    });
+
+    describe('CAIP-25 equivalent permissions are approved, but other permissions are not approved', () => {
+      it('returns an error that the other permissions were not approved', async () => {
+        const { handler, requestPermissionsForOrigin } = createMockedHandler();
+        requestPermissionsForOrigin.mockRejectedValue(
+          new Error('other permissions rejected'),
+        );
+
+        await expect(
+          handler(
+            getBaseRequest({
+              params: [
+                {
+                  eth_accounts: {},
+                  'endowment:permitted-chains': {},
+                  otherPermissionA: {},
+                  otherPermissionB: {},
+                },
+              ],
+            }),
+          ),
+        ).rejects.toThrow('other permissions rejected');
+      });
+    });
+  });
+
+  describe('no permissions requested', () => {
+    it('returns an error by requesting empty permissions in params from the PermissionController if no permissions specified', async () => {
+      const { handler, requestPermissionsForOrigin } = createMockedHandler();
+      requestPermissionsForOrigin.mockRejectedValue(
+        new Error('failed to request unexpected permission'),
+      );
+
+      await expect(
+        handler(
+          getBaseRequest({
+            params: [{}],
+          }),
+        ),
+      ).rejects.toThrow('failed to request unexpected permission');
+    });
+  });
+});

--- a/packages/multichain/src/handlers/wallet-requestPermissions.ts
+++ b/packages/multichain/src/handlers/wallet-requestPermissions.ts
@@ -1,0 +1,178 @@
+import { isPlainObject } from '@metamask/controller-utils';
+import type {
+  AsyncJsonRpcEngineNextCallback,
+  JsonRpcEngineEndCallback,
+} from '@metamask/json-rpc-engine';
+import {
+  Caip25CaveatType,
+  type Caip25CaveatValue,
+  Caip25EndowmentPermissionName,
+  getPermittedEthChainIds,
+} from '@metamask/multichain';
+import {
+  type Caveat,
+  type CaveatSpecificationConstraint,
+  invalidParams,
+  MethodNames,
+  type PermissionController,
+  type PermissionSpecificationConstraint,
+  type RequestedPermissions,
+  type ValidPermission,
+} from '@metamask/permission-controller';
+import type {
+  Json,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+import { pick } from 'lodash';
+
+import {
+  CaveatTypes,
+  EndowmentTypes,
+  RestrictedMethods,
+} from '../constants/permissions';
+
+export const requestPermissionsHandler = {
+  methodNames: [MethodNames.RequestPermissions],
+  implementation: requestPermissionsImplementation,
+  hookNames: {
+    getAccounts: true,
+    requestPermissionsForOrigin: true,
+    getCaip25PermissionFromLegacyPermissionsForOrigin: true,
+  },
+};
+
+type AbstractPermissionController = PermissionController<
+  PermissionSpecificationConstraint,
+  CaveatSpecificationConstraint
+>;
+
+type GrantedPermissions = Awaited<
+  ReturnType<AbstractPermissionController['requestPermissions']>
+>[0];
+
+/**
+ * Request Permissions implementation to be used in JsonRpcEngine middleware.
+ *
+ * @param req - The JsonRpcEngine request
+ * @param res - The JsonRpcEngine result object
+ * @param _next - JsonRpcEngine next() callback - unused
+ * @param end - JsonRpcEngine end() callback
+ * @param options - Method hooks passed to the method implementation
+ * @param options.getAccounts - A hook that returns the permitted eth accounts for the origin sorted by lastSelected.
+ * @param options.getCaip25PermissionFromLegacyPermissionsForOrigin - A hook that returns a CAIP-25 permission from a legacy `eth_accounts` and `endowment:permitted-chains` permission.
+ * @param options.requestPermissionsForOrigin - A hook that requests CAIP-25 permissions for the origin.
+ * @returns A promise that resolves to nothing
+ */
+async function requestPermissionsImplementation(
+  req: JsonRpcRequest<[RequestedPermissions]> & { origin: string },
+  res: PendingJsonRpcResponse<Json>,
+  _next: AsyncJsonRpcEngineNextCallback,
+  end: JsonRpcEngineEndCallback,
+  {
+    getAccounts,
+    requestPermissionsForOrigin,
+    getCaip25PermissionFromLegacyPermissionsForOrigin,
+  }: {
+    getAccounts: () => string[];
+    requestPermissionsForOrigin: (
+      requestedPermissions: RequestedPermissions,
+    ) => Promise<[GrantedPermissions]>;
+    getCaip25PermissionFromLegacyPermissionsForOrigin: (
+      requestedPermissions?: RequestedPermissions,
+    ) => RequestedPermissions;
+  },
+) {
+  const { params } = req;
+
+  if (!Array.isArray(params) || !isPlainObject(params[0])) {
+    return end(invalidParams({ data: { request: req } }));
+  }
+
+  let [requestedPermissions] = params;
+  delete requestedPermissions[Caip25EndowmentPermissionName];
+
+  const caip25EquivalentPermissions: Partial<
+    Pick<RequestedPermissions, 'eth_accounts' | 'endowment:permitted-chains'>
+  > = pick(requestedPermissions, [
+    RestrictedMethods.eth_accounts,
+    EndowmentTypes.permittedChains,
+  ]);
+  delete requestedPermissions[RestrictedMethods.eth_accounts];
+  delete requestedPermissions[EndowmentTypes.permittedChains];
+
+  const hasCaip25EquivalentPermissions =
+    Object.keys(caip25EquivalentPermissions).length > 0;
+
+  if (hasCaip25EquivalentPermissions) {
+    const caip25Permission = getCaip25PermissionFromLegacyPermissionsForOrigin(
+      caip25EquivalentPermissions,
+    );
+    requestedPermissions = { ...requestedPermissions, ...caip25Permission };
+  }
+
+  let grantedPermissions: GrantedPermissions = {};
+
+  const [frozenGrantedPermissions] =
+    await requestPermissionsForOrigin(requestedPermissions);
+
+  grantedPermissions = { ...frozenGrantedPermissions };
+
+  if (hasCaip25EquivalentPermissions) {
+    const caip25Endowment = grantedPermissions[Caip25EndowmentPermissionName];
+
+    if (!caip25Endowment) {
+      throw new Error(
+        `could not find ${Caip25EndowmentPermissionName} permission.`,
+      );
+    }
+
+    const caip25CaveatValue = caip25Endowment.caveats?.find(
+      ({ type }) => type === Caip25CaveatType,
+    )?.value as Caip25CaveatValue | undefined;
+    if (!caip25CaveatValue) {
+      throw new Error(
+        `could not find ${Caip25CaveatType} in granted ${Caip25EndowmentPermissionName} permission.`,
+      );
+    }
+
+    delete grantedPermissions[Caip25EndowmentPermissionName];
+    // We cannot derive correct eth_accounts value directly from the CAIP-25 permission
+    // because the accounts will not be in order of lastSelected
+    const ethAccounts = getAccounts();
+
+    grantedPermissions[RestrictedMethods.eth_accounts] = {
+      ...caip25Endowment,
+      parentCapability: RestrictedMethods.eth_accounts,
+      caveats: [
+        {
+          type: CaveatTypes.restrictReturnedAccounts,
+          value: ethAccounts,
+        },
+      ],
+    };
+
+    const ethChainIds = getPermittedEthChainIds(caip25CaveatValue);
+
+    if (ethChainIds.length > 0) {
+      grantedPermissions[EndowmentTypes.permittedChains] = {
+        ...caip25Endowment,
+        parentCapability: EndowmentTypes.permittedChains,
+        caveats: [
+          {
+            type: CaveatTypes.restrictNetworkSwitching,
+            value: ethChainIds,
+          },
+        ],
+      };
+    }
+  }
+
+  res.result = Object.values(grantedPermissions).filter(
+    (
+      permission: ValidPermission<string, Caveat<string, Json>> | undefined,
+    ): permission is ValidPermission<string, Caveat<string, Json>> =>
+      permission !== undefined,
+  );
+  return end();
+}

--- a/packages/multichain/src/handlers/wallet-revokePermissions.test.ts
+++ b/packages/multichain/src/handlers/wallet-revokePermissions.test.ts
@@ -1,0 +1,153 @@
+import { Caip25EndowmentPermissionName } from '@metamask/multichain';
+import { invalidParams } from '@metamask/permission-controller';
+import type {
+  Json,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
+
+import { revokePermissionsHandler } from './wallet-revokePermissions';
+import { EndowmentTypes, RestrictedMethods } from '../constants/permissions';
+
+const baseRequest = {
+  jsonrpc: '2.0' as const,
+  id: 0,
+  method: 'wallet_revokePermissions',
+  params: [
+    {
+      [Caip25EndowmentPermissionName]: {},
+      otherPermission: {},
+    },
+  ],
+};
+
+const createMockedHandler = () => {
+  const next = jest.fn();
+  const end = jest.fn();
+  const revokePermissionsForOrigin = jest.fn();
+
+  const response: PendingJsonRpcResponse<Json> = {
+    jsonrpc: '2.0' as const,
+    id: 0,
+  };
+  const handler = (request: JsonRpcRequest<Json[]>) =>
+    revokePermissionsHandler.implementation(request, response, next, end, {
+      revokePermissionsForOrigin,
+    });
+
+  return {
+    response,
+    next,
+    end,
+    revokePermissionsForOrigin,
+    handler,
+  };
+};
+
+describe('revokePermissionsHandler', () => {
+  it('returns an error if params is malformed', () => {
+    const { handler, end } = createMockedHandler();
+
+    const malformedRequest = {
+      ...baseRequest,
+      params: [],
+    };
+    handler(malformedRequest);
+    expect(end).toHaveBeenCalledWith(
+      invalidParams({ data: { request: malformedRequest } }),
+    );
+  });
+
+  it('returns an error if params are empty', () => {
+    const { handler, end } = createMockedHandler();
+
+    const emptyRequest = {
+      ...baseRequest,
+      params: [{}],
+    };
+    handler(emptyRequest);
+    expect(end).toHaveBeenCalledWith(
+      invalidParams({ data: { request: emptyRequest } }),
+    );
+  });
+
+  it('returns an error if params only contains the CAIP-25 permission', () => {
+    const { handler, end } = createMockedHandler();
+
+    const emptyRequest = {
+      ...baseRequest,
+      params: [
+        {
+          [Caip25EndowmentPermissionName]: {},
+        },
+      ],
+    };
+    handler(emptyRequest);
+    expect(end).toHaveBeenCalledWith(
+      invalidParams({ data: { request: emptyRequest } }),
+    );
+  });
+
+  describe.each([
+    [RestrictedMethods.eth_accounts],
+    [EndowmentTypes.permittedChains],
+  ])('%s permission is specified', (permission: string) => {
+    it('revokes the CAIP-25 endowment permission', () => {
+      const { handler, revokePermissionsForOrigin } = createMockedHandler();
+
+      handler({
+        ...baseRequest,
+        params: [
+          {
+            [permission]: {},
+          },
+        ],
+      });
+      expect(revokePermissionsForOrigin).toHaveBeenCalledWith([
+        Caip25EndowmentPermissionName,
+      ]);
+    });
+
+    it('revokes other permissions specified', () => {
+      const { handler, revokePermissionsForOrigin } = createMockedHandler();
+
+      handler({
+        ...baseRequest,
+        params: [
+          {
+            [permission]: {},
+            otherPermission: {},
+          },
+        ],
+      });
+      expect(revokePermissionsForOrigin).toHaveBeenCalledWith([
+        'otherPermission',
+        Caip25EndowmentPermissionName,
+      ]);
+    });
+  });
+
+  it('revokes permissions other than eth_accounts, permittedChains, CAIP-25 if specified', () => {
+    const { handler, revokePermissionsForOrigin } = createMockedHandler();
+
+    handler({
+      ...baseRequest,
+      params: [
+        {
+          [Caip25EndowmentPermissionName]: {},
+          otherPermission: {},
+        },
+      ],
+    });
+    expect(revokePermissionsForOrigin).toHaveBeenCalledWith([
+      'otherPermission',
+    ]);
+  });
+
+  it('returns null', () => {
+    const { handler, response } = createMockedHandler();
+
+    handler(baseRequest);
+    expect(response.result).toBeNull();
+  });
+});

--- a/packages/multichain/src/handlers/wallet-revokePermissions.ts
+++ b/packages/multichain/src/handlers/wallet-revokePermissions.ts
@@ -1,0 +1,85 @@
+import type {
+  AsyncJsonRpcEngineNextCallback,
+  JsonRpcEngineEndCallback,
+} from '@metamask/json-rpc-engine';
+import { Caip25EndowmentPermissionName } from '@metamask/multichain';
+import { invalidParams, MethodNames } from '@metamask/permission-controller';
+import {
+  isNonEmptyArray,
+  type Json,
+  type JsonRpcRequest,
+  type PendingJsonRpcResponse,
+} from '@metamask/utils';
+
+import { EndowmentTypes, RestrictedMethods } from '../constants/permissions';
+
+export const revokePermissionsHandler = {
+  methodNames: [MethodNames.RevokePermissions],
+  implementation: revokePermissionsImplementation,
+  hookNames: {
+    revokePermissionsForOrigin: true,
+    updateCaveat: true,
+  },
+};
+
+/**
+ * Revoke Permissions implementation to be used in JsonRpcEngine middleware.
+ *
+ * @param req - The JsonRpcEngine request
+ * @param res - The JsonRpcEngine result object
+ * @param _next - JsonRpcEngine next() callback - unused
+ * @param end - JsonRpcEngine end() callback
+ * @param options - Method hooks passed to the method implementation
+ * @param options.revokePermissionsForOrigin - A hook that revokes given permission keys for an origin
+ * @returns A promise that resolves to nothing
+ */
+function revokePermissionsImplementation(
+  req: JsonRpcRequest<Json[]>,
+  res: PendingJsonRpcResponse<Json>,
+  _next: AsyncJsonRpcEngineNextCallback,
+  end: JsonRpcEngineEndCallback,
+  {
+    revokePermissionsForOrigin,
+  }: {
+    revokePermissionsForOrigin: (permissionKeys: string[]) => void;
+  },
+) {
+  const { params } = req;
+
+  const param = params?.[0];
+
+  if (!param) {
+    return end(invalidParams({ data: { request: req } }));
+  }
+
+  // For now, this API revokes the entire permission key
+  // even if caveats are specified.
+  const permissionKeys = Object.keys(param).filter(
+    (name) => name !== Caip25EndowmentPermissionName,
+  );
+
+  if (!isNonEmptyArray(permissionKeys)) {
+    return end(invalidParams({ data: { request: req } }));
+  }
+
+  const caip25EquivalentPermissions: string[] = [
+    RestrictedMethods.eth_accounts,
+    EndowmentTypes.permittedChains,
+  ];
+  const relevantPermissionKeys = permissionKeys.filter(
+    (name: string) => !caip25EquivalentPermissions.includes(name),
+  );
+
+  const shouldRevokeLegacyPermission =
+    relevantPermissionKeys.length !== permissionKeys.length;
+
+  if (shouldRevokeLegacyPermission) {
+    relevantPermissionKeys.push(Caip25EndowmentPermissionName);
+  }
+
+  revokePermissionsForOrigin(relevantPermissionKeys);
+
+  res.result = null;
+
+  return end();
+}

--- a/packages/multichain/src/index.ts
+++ b/packages/multichain/src/index.ts
@@ -12,6 +12,10 @@ export {
   getSessionScopes,
 } from './adapters/caip-permission-adapter-session-scopes';
 
+export { getPermissionsHandler } from './handlers/wallet-getPermissions';
+export { requestPermissionsHandler } from './handlers/wallet-requestPermissions';
+export { revokePermissionsHandler } from './handlers/wallet-revokePermissions';
+
 export { walletGetSession } from './handlers/wallet-getSession';
 export { walletInvokeMethod } from './handlers/wallet-invokeMethod';
 export { walletRevokeSession } from './handlers/wallet-revokeSession';


### PR DESCRIPTION
## Explanation

[Original ticket](https://github.com/MetaMask/MetaMask-planning/issues/4335)

Part of the scope of https://github.com/MetaMask/MetaMask-planning/issues/4129 is having the currently existing handlers for:

`wallet_getPermissions`
`wallet_revokePermissions`
`wallet_requestPermissions`

Available in the mobile codebase.

This raises an issue, where if future changes are required in any of these handlers, those would need to be done on both extension and mobile codebases, instead of having one single source of truth. Therefore, as part of this https://github.com/MetaMask/MetaMask-planning/issues/4129, we could extract the existing handlers on extension repo over to core and create a release for that so they can be imported in whichever code base needs them.

As part of this work, create another refactor ticket for these to later be imported on extension repo and removed from that codebase altogether (not urgent at the moment).

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

Original files from `extension` repo:

[wallet_requestPermissions](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/lib/rpc-method-middleware/handlers/wallet-requestPermissions.ts)

[wallet_requestPermissions test file](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/lib/rpc-method-middleware/handlers/wallet-requestPermissions.test.ts)

[wallet_revokePermissions](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.ts)

[wallet_revokePermissions test file](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/lib/rpc-method-middleware/handlers/wallet-revokePermissions.test.ts)

[wallet_getPermissions](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/lib/rpc-method-middleware/handlers/wallet-getPermissions.ts)

[wallet_getPermissions test file](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/lib/rpc-method-middleware/handlers/wallet-getPermissions.test.ts)

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

@metamask/multichain-api
ADDED: Added `wallet_getPermissions` handler (originally migrated from `extension` repo)
ADDED: Added `wallet_requestPermissions` handler (originally migrated from `extension` repo)
ADDED: Added `wallet_revokePermissions` handler (originally migrated from `extension` repo)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
