### PR TITLE
Add `getAssetMetadata` action to `MultichainAssetsController`

### DIFF
--- a/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.test.ts
+++ b/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.test.ts
@@ -773,4 +773,49 @@ describe('MultichainAssetsController', () => {
       });
     });
   });
+
+  describe('getAssetMetadata', () => {
+    it('returns the metadata for a given asset', async () => {
+      const { messenger } = setupController({
+        state: {
+          accountsAssets: {
+            [mockSolanaAccount.id]: mockHandleRequestOnAssetsLookupReturnValue,
+          },
+          assetsMetadata: mockGetMetadataReturnValue.assets,
+        } as MultichainAssetsControllerState,
+      });
+
+      const assetId = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1/slip44:501';
+
+      const metadata = messenger.call(
+        'MultichainAssetsController:getAssetMetadata',
+        assetId,
+      );
+
+      expect(metadata).toStrictEqual(
+        mockGetMetadataReturnValue.assets[assetId],
+      );
+    });
+
+    it('returns undefined if the asset metadata is not found', async () => {
+      const { messenger } = setupController({
+        state: {
+          accountsAssets: {
+            [mockSolanaAccount.id]: mockHandleRequestOnAssetsLookupReturnValue,
+          },
+          assetsMetadata: mockGetMetadataReturnValue.assets,
+        } as MultichainAssetsControllerState,
+      });
+
+      const assetId =
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+      const metadata = messenger.call(
+        'MultichainAssetsController:getAssetMetadata',
+        assetId,
+      );
+
+      expect(metadata).toBeUndefined();
+    });
+  });
 });

--- a/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.ts
+++ b/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.ts
@@ -69,6 +69,11 @@ export function getDefaultMultichainAssetsControllerState(): MultichainAssetsCon
   return { accountsAssets: {}, assetsMetadata: {} };
 }
 
+export type MultichainAssetsControllerGetAssetMetadataAction = {
+  type: 'MultichainAssetsController:getAssetMetadata';
+  handler: MultichainAssetsController['getAssetMetadata'];
+};
+
 /**
  * Returns the state of the {@link MultichainAssetsController}.
  */
@@ -90,7 +95,8 @@ export type MultichainAssetsControllerStateChangeEvent =
  * Actions exposed by the {@link MultichainAssetsController}.
  */
 export type MultichainAssetsControllerActions =
-  MultichainAssetsControllerGetStateAction;
+  | MultichainAssetsControllerGetStateAction
+  | MultichainAssetsControllerGetAssetMetadataAction;
 
 /**
  * Events emitted by {@link MultichainAssetsController}.
@@ -199,6 +205,8 @@ export class MultichainAssetsController extends BaseController<
       'AccountsController:accountAssetListUpdated',
       async (event) => await this.#handleAccountAssetListUpdatedEvent(event),
     );
+
+    this.#registerMessageHandlers();
   }
 
   async #handleAccountAssetListUpdatedEvent(
@@ -213,6 +221,27 @@ export class MultichainAssetsController extends BaseController<
     return this.#withControllerLock(async () =>
       this.#handleOnAccountAdded(account),
     );
+  }
+
+  /**
+   * Constructor helper for registering the controller's messaging system
+   * actions.
+   */
+  #registerMessageHandlers() {
+    this.messagingSystem.registerActionHandler(
+      'MultichainAssetsController:getAssetMetadata',
+      this.getAssetMetadata.bind(this),
+    );
+  }
+
+  /**
+   * Returns the metadata for the given asset
+   *
+   * @param asset - The asset to get metadata for
+   * @returns The metadata for the asset or undefined if not found.
+   */
+  getAssetMetadata(asset: CaipAssetType): FungibleAssetMetadata | undefined {
+    return this.state.assetsMetadata[asset];
   }
 
   /**


### PR DESCRIPTION
## Explanation

This adds an action to the `MultichainAssetsController` called `getAssetMetada` which allows to get a specific asset Metadata.

This allows us to get a specific metadata without having to pull the entire controller state.

## References

* Related to https://github.com/MetaMask/snaps/pull/3166

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controller`

- **ADDED**: Add `getAssetMetadata` action to `MultichainAssetsController`.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
