### PR TITLE
fix: should update cache if the cached tokens is {}

### DIFF
--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -303,7 +303,7 @@ export class TokenListController extends StaticIntervalPollingController<TokenLi
       const cachedTokens = await safelyExecute(() =>
         this.#fetchFromCache(chainId),
       );
-      if (cachedTokens) {
+      if (cachedTokens && Object.keys(cachedTokens).length > 0) {
         // Use non-expired cached tokens
         tokenList = { ...cachedTokens };
       } else {


### PR DESCRIPTION
## Explanation

should update cache if the cached tokens is `{}`

## References

## Changelog

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

