### PR TITLE
perf: Simplify account iteration logic

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1676,7 +1676,14 @@ describe('AccountsController', () => {
 
       const messenger = buildMessenger();
 
-      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.hd, accounts: [mockAddress1, mockAddress2] }] }));
+      messenger.registerActionHandler(
+        'KeyringController:getState',
+        mockGetState.mockReturnValue({
+          keyrings: [
+            { type: KeyringTypes.hd, accounts: [mockAddress1, mockAddress2] },
+          ],
+        }),
+      );
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -1722,7 +1729,17 @@ describe('AccountsController', () => {
 
     it('update accounts with Snap accounts when snap keyring is defined and has accounts', async () => {
       const messenger = buildMessenger();
-      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.snap, accounts: [mockSnapAccount, mockSnapAccount2] }] }));
+      messenger.registerActionHandler(
+        'KeyringController:getState',
+        mockGetState.mockReturnValue({
+          keyrings: [
+            {
+              type: KeyringTypes.snap,
+              accounts: [mockSnapAccount, mockSnapAccount2],
+            },
+          ],
+        }),
+      );
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -1775,7 +1792,10 @@ describe('AccountsController', () => {
 
     it('return an empty array if the Snap keyring is not defined', async () => {
       const messenger = buildMessenger();
-      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [] }));
+      messenger.registerActionHandler(
+        'KeyringController:getState',
+        mockGetState.mockReturnValue({ keyrings: [] }),
+      );
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -1805,7 +1825,14 @@ describe('AccountsController', () => {
       mockUUIDWithNormalAccounts([mockAccount]);
 
       const messenger = buildMessenger();
-      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.hd, accounts: [mockAddress1, mockAddress2] }] }));
+      messenger.registerActionHandler(
+        'KeyringController:getState',
+        mockGetState.mockReturnValue({
+          keyrings: [
+            { type: KeyringTypes.hd, accounts: [mockAddress1, mockAddress2] },
+          ],
+        }),
+      );
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -1861,7 +1888,15 @@ describe('AccountsController', () => {
       );
 
       // first account will be normal, second will be a snap account
-      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.hd, accounts: [mockAddress1] }, { type: KeyringTypes.snap, accounts: ['0x1234'] }] }));
+      messenger.registerActionHandler(
+        'KeyringController:getState',
+        mockGetState.mockReturnValue({
+          keyrings: [
+            { type: KeyringTypes.hd, accounts: [mockAddress1] },
+            { type: KeyringTypes.snap, accounts: ['0x1234'] },
+          ],
+        }),
+      );
 
       const { accountsController } = setupAccountsController({
         initialState: {
@@ -1910,7 +1945,15 @@ describe('AccountsController', () => {
       );
 
       // first account will be normal, second will be a snap account
-      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.snap, accounts: ['0x1234'] }, { type: KeyringTypes.hd, accounts: [mockAddress1] }] }));
+      messenger.registerActionHandler(
+        'KeyringController:getState',
+        mockGetState.mockReturnValue({
+          keyrings: [
+            { type: KeyringTypes.snap, accounts: ['0x1234'] },
+            { type: KeyringTypes.hd, accounts: [mockAddress1] },
+          ],
+        }),
+      );
 
       const { accountsController } = setupAccountsController({
         initialState: {
@@ -1958,7 +2001,12 @@ describe('AccountsController', () => {
 
       const messenger = buildMessenger();
 
-      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: keyringType, accounts: [mockAddress1] }] }));
+      messenger.registerActionHandler(
+        'KeyringController:getState',
+        mockGetState.mockReturnValue({
+          keyrings: [{ type: keyringType, accounts: [mockAddress1] }],
+        }),
+      );
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -2000,7 +2048,12 @@ describe('AccountsController', () => {
       mockUUIDWithNormalAccounts([mockAccount]);
 
       const messenger = buildMessenger();
-      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: 'unknown', accounts: [mockAddress1] }] }));
+      messenger.registerActionHandler(
+        'KeyringController:getState',
+        mockGetState.mockReturnValue({
+          keyrings: [{ type: 'unknown', accounts: [mockAddress1] }],
+        }),
+      );
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -2084,8 +2137,16 @@ describe('AccountsController', () => {
         );
 
         // first account will be normal, second will be a snap account
-        messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.snap, accounts: ['0x1234'] }, { type: KeyringTypes.hd, accounts: [mockAddress1]}] }));
-        
+        messenger.registerActionHandler(
+          'KeyringController:getState',
+          mockGetState.mockReturnValue({
+            keyrings: [
+              { type: KeyringTypes.snap, accounts: ['0x1234'] },
+              { type: KeyringTypes.hd, accounts: [mockAddress1] },
+            ],
+          }),
+        );
+
         const { accountsController } = setupAccountsController({
           initialState: {
             internalAccounts: {
@@ -3017,7 +3078,10 @@ describe('AccountsController', () => {
     describe('updateAccounts', () => {
       it('update accounts', async () => {
         const messenger = buildMessenger();
-        messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [] }));
+        messenger.registerActionHandler(
+          'KeyringController:getState',
+          mockGetState.mockReturnValue({ keyrings: [] }),
+        );
         messenger.registerActionHandler(
           'KeyringController:getKeyringsByType',
           mockGetKeyringByType.mockReturnValueOnce([]),

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -52,6 +52,7 @@ const defaultState: AccountsControllerState = {
 const mockGetKeyringForAccount = jest.fn();
 const mockGetKeyringByType = jest.fn();
 const mockGetAccounts = jest.fn();
+const mockGetState = jest.fn();
 
 const mockAccount: InternalAccount = {
   id: 'mock-id',
@@ -210,8 +211,7 @@ function buildAccountsControllerMessenger(messenger = buildMessenger()) {
       'MultichainNetworkController:networkDidChange',
     ],
     allowedActions: [
-      'KeyringController:getAccounts',
-      'KeyringController:getKeyringForAccount',
+      'KeyringController:getState',
       'KeyringController:getKeyringsByType',
     ],
   });
@@ -1675,15 +1675,8 @@ describe('AccountsController', () => {
       mockUUIDWithNormalAccounts([mockAccount, mockAccount2]);
 
       const messenger = buildMessenger();
-      messenger.registerActionHandler(
-        'KeyringController:getAccounts',
-        mockGetAccounts.mockResolvedValueOnce([mockAddress1, mockAddress2]),
-      );
 
-      messenger.registerActionHandler(
-        'KeyringController:getKeyringForAccount',
-        mockGetKeyringForAccount.mockResolvedValue({ type: KeyringTypes.hd }),
-      );
+      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.hd, accounts: [mockAddress1, mockAddress2] }] }));
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -1729,10 +1722,7 @@ describe('AccountsController', () => {
 
     it('update accounts with Snap accounts when snap keyring is defined and has accounts', async () => {
       const messenger = buildMessenger();
-      messenger.registerActionHandler(
-        'KeyringController:getAccounts',
-        mockGetAccounts.mockResolvedValueOnce([]),
-      );
+      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.snap, accounts: [mockSnapAccount, mockSnapAccount2] }] }));
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -1785,10 +1775,7 @@ describe('AccountsController', () => {
 
     it('return an empty array if the Snap keyring is not defined', async () => {
       const messenger = buildMessenger();
-      messenger.registerActionHandler(
-        'KeyringController:getAccounts',
-        mockGetAccounts.mockResolvedValueOnce([]),
-      );
+      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [] }));
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -1818,15 +1805,7 @@ describe('AccountsController', () => {
       mockUUIDWithNormalAccounts([mockAccount]);
 
       const messenger = buildMessenger();
-      messenger.registerActionHandler(
-        'KeyringController:getAccounts',
-        mockGetAccounts.mockResolvedValueOnce([mockAddress1, mockAddress2]),
-      );
-
-      messenger.registerActionHandler(
-        'KeyringController:getKeyringForAccount',
-        mockGetKeyringForAccount.mockResolvedValue({ type: KeyringTypes.hd }),
-      );
+      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.hd, accounts: [mockAddress1, mockAddress2] }] }));
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -1882,16 +1861,7 @@ describe('AccountsController', () => {
       );
 
       // first account will be normal, second will be a snap account
-      messenger.registerActionHandler(
-        'KeyringController:getAccounts',
-        mockGetAccounts.mockResolvedValue([mockAddress1, '0x1234']),
-      );
-      messenger.registerActionHandler(
-        'KeyringController:getKeyringForAccount',
-        mockGetKeyringForAccount
-          .mockResolvedValueOnce({ type: KeyringTypes.hd })
-          .mockResolvedValueOnce({ type: KeyringTypes.snap }),
-      );
+      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.hd, accounts: [mockAddress1] }, { type: KeyringTypes.snap, accounts: ['0x1234'] }] }));
 
       const { accountsController } = setupAccountsController({
         initialState: {
@@ -1940,16 +1910,7 @@ describe('AccountsController', () => {
       );
 
       // first account will be normal, second will be a snap account
-      messenger.registerActionHandler(
-        'KeyringController:getAccounts',
-        mockGetAccounts.mockResolvedValue(['0x1234', mockAddress1]),
-      );
-      messenger.registerActionHandler(
-        'KeyringController:getKeyringForAccount',
-        mockGetKeyringForAccount
-          .mockResolvedValueOnce({ type: KeyringTypes.snap })
-          .mockResolvedValueOnce({ type: KeyringTypes.hd }),
-      );
+      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.snap, accounts: ['0x1234'] }, { type: KeyringTypes.hd, accounts: [mockAddress1] }] }));
 
       const { accountsController } = setupAccountsController({
         initialState: {
@@ -1996,14 +1957,8 @@ describe('AccountsController', () => {
       mockUUIDWithNormalAccounts([mockAccount]);
 
       const messenger = buildMessenger();
-      messenger.registerActionHandler(
-        'KeyringController:getAccounts',
-        mockGetAccounts.mockResolvedValue([mockAddress1]),
-      );
-      messenger.registerActionHandler(
-        'KeyringController:getKeyringForAccount',
-        mockGetKeyringForAccount.mockResolvedValue({ type: keyringType }),
-      );
+
+      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: keyringType, accounts: [mockAddress1] }] }));
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -2045,14 +2000,7 @@ describe('AccountsController', () => {
       mockUUIDWithNormalAccounts([mockAccount]);
 
       const messenger = buildMessenger();
-      messenger.registerActionHandler(
-        'KeyringController:getAccounts',
-        mockGetAccounts.mockResolvedValue([mockAddress1]),
-      );
-      messenger.registerActionHandler(
-        'KeyringController:getKeyringForAccount',
-        mockGetKeyringForAccount.mockResolvedValue({ type: 'unknown' }),
-      );
+      messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: 'unknown', accounts: [mockAddress1] }] }));
 
       messenger.registerActionHandler(
         'KeyringController:getKeyringsByType',
@@ -2136,17 +2084,8 @@ describe('AccountsController', () => {
         );
 
         // first account will be normal, second will be a snap account
-        messenger.registerActionHandler(
-          'KeyringController:getAccounts',
-          mockGetAccounts.mockResolvedValue(['0x1234', mockAddress1]),
-        );
-        messenger.registerActionHandler(
-          'KeyringController:getKeyringForAccount',
-          mockGetKeyringForAccount
-            .mockResolvedValueOnce({ type: KeyringTypes.snap })
-            .mockResolvedValueOnce({ type: KeyringTypes.hd }),
-        );
-
+        messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [{ type: KeyringTypes.snap, accounts: ['0x1234'] }, { type: KeyringTypes.hd, accounts: [mockAddress1]}] }));
+        
         const { accountsController } = setupAccountsController({
           initialState: {
             internalAccounts: {
@@ -3078,17 +3017,10 @@ describe('AccountsController', () => {
     describe('updateAccounts', () => {
       it('update accounts', async () => {
         const messenger = buildMessenger();
-        messenger.registerActionHandler(
-          'KeyringController:getAccounts',
-          mockGetAccounts.mockResolvedValueOnce([]),
-        );
+        messenger.registerActionHandler('KeyringController:getState', mockGetState.mockReturnValue({ keyrings: [] }));
         messenger.registerActionHandler(
           'KeyringController:getKeyringsByType',
           mockGetKeyringByType.mockReturnValueOnce([]),
-        );
-        messenger.registerActionHandler(
-          'KeyringController:getKeyringForAccount',
-          mockGetKeyringForAccount.mockResolvedValueOnce([]),
         );
 
         const { accountsController } = setupAccountsController({

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -49,9 +49,7 @@ const defaultState: AccountsControllerState = {
   },
 };
 
-const mockGetKeyringForAccount = jest.fn();
 const mockGetKeyringByType = jest.fn();
-const mockGetAccounts = jest.fn();
 const mockGetState = jest.fn();
 
 const mockAccount: InternalAccount = {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -33,12 +33,7 @@ import type {
 } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
 import type { Snap } from '@metamask/snaps-utils';
-import {
-  type Keyring,
-  type Json,
-  type CaipChainId,
-  isCaipChainId,
-} from '@metamask/utils';
+import { type CaipChainId, isCaipChainId } from '@metamask/utils';
 
 import type { MultichainNetworkControllerNetworkDidChangeEvent } from './types';
 import {


### PR DESCRIPTION
## Explanation

Speed up account iteration logic in `updateAccounts` by using `KeyringController:getState` instead of getting all of the addresses upfront and matching them to the keyring afterwards. The current implementation is fast on extension, but really slows down on mobile once you have a couple of accounts added. This simplified implementation has better performance characteristics and as such performs better on mobile.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/accounts-controller`

- **Changed**: Speed up `updateAccounts` logic when iterating over multiple accounts
  - This requires allowlisting `KeyringController:getState` as an allowed action for the AccountsController

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
