### PR TITLE
fix(actions): Calling workflow must have the permissions set

### DIFF
--- a/.github/workflows/add-wallet-framework-team-prs-and-issues-to-project.yml
+++ b/.github/workflows/add-wallet-framework-team-prs-and-issues-to-project.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   call_shared_workflow:
     name: 'Call the Shared Workflow'
+    permissions:
+      issues: write
+      pull-requests: write
     uses: metamask/github-tools/.github/workflows/add-item-to-project.yml@bce51a03da4736bef72f67b71ca77714a38fc067
     with:
       project-url: 'https://github.com/orgs/MetaMask/projects/113'


### PR DESCRIPTION
## Explanation
The calling workflow needs to set the permissions



## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
