### PR TITLE
fix(actions): Update to work for classic projects

### DIFF
--- a/.github/workflows/add-wallet-framework-team-prs-and-issues-to-project.yml
+++ b/.github/workflows/add-wallet-framework-team-prs-and-issues-to-project.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
-      projects: write
+      repository-projects: write
     uses: metamask/github-tools/.github/workflows/add-item-to-project.yml@bce51a03da4736bef72f67b71ca77714a38fc067
     with:
       project-url: 'https://github.com/orgs/MetaMask/projects/113'

--- a/.github/workflows/add-wallet-framework-team-prs-and-issues-to-project.yml
+++ b/.github/workflows/add-wallet-framework-team-prs-and-issues-to-project.yml
@@ -13,6 +13,7 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
+      projects: write
     uses: metamask/github-tools/.github/workflows/add-item-to-project.yml@bce51a03da4736bef72f67b71ca77714a38fc067
     with:
       project-url: 'https://github.com/orgs/MetaMask/projects/113'


### PR DESCRIPTION
## Explanation
We are using classic projects so need to add additional permissions of `projects: write`

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
