### PR TITLE
Disable type-specific checks for jsdoc/check-tag-names

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -16,9 +16,6 @@
   "packages/accounts-controller/src/AccountsController.test.ts": {
     "import-x/namespace": 1
   },
-  "packages/address-book-controller/src/AddressBookController.ts": {
-    "jsdoc/check-tag-names": 13
-  },
   "packages/approval-controller/src/ApprovalController.test.ts": {
     "import-x/order": 1,
     "jest/no-conditional-in-test": 16
@@ -35,22 +32,17 @@
     "import-x/namespace": 2
   },
   "packages/assets-controllers/src/AccountTrackerController.ts": {
-    "jsdoc/check-tag-names": 5,
     "jsdoc/tag-lines": 1
   },
   "packages/assets-controllers/src/AssetsContractController.test.ts": {
     "import-x/order": 3
   },
   "packages/assets-controllers/src/AssetsContractController.ts": {
-    "jsdoc/check-tag-names": 2,
     "jsdoc/tag-lines": 1
   },
   "packages/assets-controllers/src/CurrencyRateController.test.ts": {
     "import-x/order": 1,
     "jest/no-conditional-in-test": 1
-  },
-  "packages/assets-controllers/src/CurrencyRateController.ts": {
-    "jsdoc/check-tag-names": 6
   },
   "packages/assets-controllers/src/NftController.test.ts": {
     "import-x/namespace": 9,
@@ -59,7 +51,6 @@
   },
   "packages/assets-controllers/src/NftController.ts": {
     "@typescript-eslint/prefer-readonly": 1,
-    "jsdoc/check-tag-names": 46,
     "jsdoc/tag-lines": 4
   },
   "packages/assets-controllers/src/NftDetectionController.test.ts": {
@@ -67,7 +58,6 @@
     "import-x/order": 4
   },
   "packages/assets-controllers/src/NftDetectionController.ts": {
-    "jsdoc/check-tag-names": 34,
     "jsdoc/tag-lines": 1
   },
   "packages/assets-controllers/src/RatesController/RatesController.test.ts": {
@@ -93,7 +83,6 @@
   },
   "packages/assets-controllers/src/TokenBalancesController.ts": {
     "@typescript-eslint/prefer-readonly": 4,
-    "jsdoc/check-tag-names": 4,
     "jsdoc/tag-lines": 11
   },
   "packages/assets-controllers/src/TokenDetectionController.test.ts": {
@@ -103,7 +92,6 @@
   },
   "packages/assets-controllers/src/TokenDetectionController.ts": {
     "@typescript-eslint/prefer-readonly": 3,
-    "jsdoc/check-tag-names": 8,
     "jsdoc/tag-lines": 6,
     "no-unused-private-class-members": 2
   },
@@ -113,7 +101,6 @@
     "jest/no-conditional-in-test": 2
   },
   "packages/assets-controllers/src/TokenListController.ts": {
-    "jsdoc/check-tag-names": 1,
     "jsdoc/tag-lines": 7
   },
   "packages/assets-controllers/src/TokenRatesController.test.ts": {
@@ -121,7 +108,6 @@
   },
   "packages/assets-controllers/src/TokenRatesController.ts": {
     "@typescript-eslint/prefer-readonly": 2,
-    "jsdoc/check-tag-names": 11,
     "no-unused-private-class-members": 1
   },
   "packages/assets-controllers/src/TokensController.test.ts": {
@@ -132,7 +118,6 @@
   "packages/assets-controllers/src/TokensController.ts": {
     "@typescript-eslint/no-unused-vars": 1,
     "@typescript-eslint/prefer-readonly": 1,
-    "jsdoc/check-tag-names": 13,
     "jsdoc/tag-lines": 3
   },
   "packages/assets-controllers/src/assetsUtil.test.ts": {
@@ -159,9 +144,6 @@
   "packages/base-controller/src/BaseControllerV2.test.ts": {
     "import-x/namespace": 16
   },
-  "packages/base-controller/src/BaseControllerV2.ts": {
-    "jsdoc/check-tag-names": 2
-  },
   "packages/base-controller/src/Messenger.test.ts": {
     "import-x/namespace": 33
   },
@@ -186,8 +168,7 @@
     "no-shadow": 2
   },
   "packages/controller-utils/src/siwe.ts": {
-    "@typescript-eslint/no-unused-vars": 1,
-    "jsdoc/check-tag-names": 5
+    "@typescript-eslint/no-unused-vars": 1
   },
   "packages/controller-utils/src/types.ts": {
     "@typescript-eslint/no-duplicate-enum-values": 2,
@@ -208,9 +189,6 @@
   "packages/ens-controller/src/EnsController.test.ts": {
     "import-x/order": 2
   },
-  "packages/ens-controller/src/EnsController.ts": {
-    "jsdoc/check-tag-names": 6
-  },
   "packages/eth-json-rpc-provider/src/safe-event-emitter-provider.test.ts": {
     "import-x/namespace": 1
   },
@@ -222,8 +200,7 @@
     "import-x/order": 1
   },
   "packages/gas-fee-controller/src/GasFeeController.ts": {
-    "@typescript-eslint/prefer-readonly": 1,
-    "jsdoc/check-tag-names": 21
+    "@typescript-eslint/prefer-readonly": 1
   },
   "packages/gas-fee-controller/src/determineGasFeeCalculations.ts": {
     "jsdoc/tag-lines": 4
@@ -255,9 +232,6 @@
   "packages/logging-controller/src/LoggingController.test.ts": {
     "import-x/namespace": 1
   },
-  "packages/logging-controller/src/LoggingController.ts": {
-    "jsdoc/check-tag-names": 1
-  },
   "packages/logging-controller/src/logTypes/index.ts": {
     "@typescript-eslint/consistent-type-exports": 1
   },
@@ -265,20 +239,13 @@
     "jest/no-conditional-in-test": 7
   },
   "packages/message-manager/src/AbstractMessageManager.ts": {
-    "jsdoc/check-tag-names": 25,
     "jsdoc/tag-lines": 2
   },
   "packages/message-manager/src/DecryptMessageManager.test.ts": {
     "jest/no-conditional-in-test": 3
   },
-  "packages/message-manager/src/DecryptMessageManager.ts": {
-    "jsdoc/check-tag-names": 11
-  },
   "packages/message-manager/src/EncryptionPublicKeyManager.test.ts": {
     "jest/no-conditional-in-test": 5
-  },
-  "packages/message-manager/src/EncryptionPublicKeyManager.ts": {
-    "jsdoc/check-tag-names": 13
   },
   "packages/message-manager/src/index.ts": {
     "@typescript-eslint/consistent-type-exports": 1
@@ -426,7 +393,6 @@
   },
   "packages/permission-log-controller/src/PermissionLogController.ts": {
     "@typescript-eslint/prefer-readonly": 1,
-    "jsdoc/check-tag-names": 2,
     "jsdoc/tag-lines": 1
   },
   "packages/permission-log-controller/tests/PermissionLogController.test.ts": {
@@ -436,7 +402,6 @@
     "import-x/no-named-as-default-member": 1
   },
   "packages/phishing-controller/src/PhishingController.ts": {
-    "jsdoc/check-tag-names": 42,
     "jsdoc/tag-lines": 1
   },
   "packages/phishing-controller/src/PhishingDetector.ts": {
@@ -464,7 +429,6 @@
     "@typescript-eslint/prefer-readonly": 2
   },
   "packages/rate-limit-controller/src/RateLimitController.ts": {
-    "jsdoc/check-tag-names": 4,
     "jsdoc/require-returns": 1,
     "jsdoc/tag-lines": 3
   },
@@ -479,7 +443,6 @@
   },
   "packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts": {
     "@typescript-eslint/prefer-readonly": 1,
-    "jsdoc/check-tag-names": 2,
     "prettier/prettier": 1
   },
   "packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts": {
@@ -596,13 +559,11 @@
   },
   "tests/fake-provider.ts": {
     "@typescript-eslint/prefer-promise-reject-errors": 1,
-    "@typescript-eslint/prefer-readonly": 2,
-    "jsdoc/check-tag-names": 12
+    "@typescript-eslint/prefer-readonly": 2
   },
   "tests/mock-network.ts": {
     "@typescript-eslint/no-unsafe-enum-comparison": 1,
-    "@typescript-eslint/prefer-readonly": 3,
-    "jsdoc/check-tag-names": 10
+    "@typescript-eslint/prefer-readonly": 3
   },
   "tests/setupAfterEnv/nock.ts": {
     "import-x/no-named-as-default-member": 3

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,6 +137,17 @@ const config = createConfig([
       // another
       'import-x/no-duplicates': 'off',
 
+      // This rule does not allow use of the `@property` tag, which is useful
+      // when documenting types that are intersections of other types.
+      // Unfortunately there's not a way to prevent the rule from checking just
+      // this property, so we have to disable all of the type-specific rules.
+      'jsdoc/check-tag-names': [
+        'warn',
+        {
+          typed: false,
+        },
+      ],
+
       // Enable rules that are disabled in `@metamask/eslint-config-typescript`
       '@typescript-eslint/no-explicit-any': 'error',
 
@@ -169,7 +180,6 @@ const config = createConfig([
       'import-x/namespace': 'warn',
       'import-x/no-named-as-default': 'warn',
       'import-x/order': 'warn',
-      'jsdoc/check-tag-names': 'warn',
       'jsdoc/require-returns': 'warn',
       'jsdoc/tag-lines': 'warn',
       'no-unused-private-class-members': 'warn',


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

The `jsdoc/check-tag-names` ESLint rule [disallows the use of the `@property` JSDoc tag in TypeScript projects](https://github.com/gajus/eslint-plugin-jsdoc/blob/9c69a9f2232f71369625068ad58e575dd9647072/src/rules/checkTagNames.js#L19), indicating that it is redundant. I don't think this is quite right: although we usually document properties in object types directly, the `@property` tag is useful to document properties that arrive via intersections of other types.

For instance, the following code:

``` typescript
/**
 * A set of gas price estimates for networks and accounts that don't support EIP-1559
 * These estimates include low, medium and high all as strings representing gwei in
 * decimal format.
 * @property high - gasPrice, in decimal gwei string format, suggested for fast inclusion
 * @property medium - gasPrice, in decimal gwei string format, suggested for avg inclusion
 * @property low - gasPrice, in decimal gwei string format, suggested for slow inclusion
 */
export type LegacyGasPriceEstimate = {
  high: string;
  medium: string;
  low: string;
};
```

should probably be converted to this:

``` typescript
/**
 * A set of gas price estimates for networks and accounts that don't support EIP-1559
 * These estimates include low, medium and high all as strings representing gwei in
 * decimal format.
 */
export type LegacyGasPriceEstimate = {
  /**
   * Gas price, in decimal gwei string format, suggested for "fast" inclusion.
   */
  high: string;
  /** 
   * Gas price, in decimal gwei string format, suggested for "avg" inclusion.
   */
  medium: string;
  /**
   * Gas price, in decimal gwei string format, suggested for "slow" inclusion.
   */
  low: string;
};
```

However, the following code should be allowed, because VSCode's Intellisense (and also TypeDoc) does not automatically bring over the JSDoc for `AbstractMessage`, so we have to copy over the docs for those properties:

``` typescript
/**
 * Represents and contains data about an `eth_decrypt` type signature request.
 * These are created when a signature for an `eth_decrypt` call is requested.
 * 
 * @property id - An ID to track and identify the message object.
 * @property messageParams - The parameters to pass to the `eth_decrypt` method once the request is approved.
 * @property type - The JSON-RPC signing method for which a signature request has been made.
 * A 'DecryptMessage' which always has a 'eth_decrypt' type.
 */
export type DecryptMessage = AbstractMessage & {
  messageParams: DecryptMessageParams;
};
```

Ideally we should update `eslint-plugin-jsdoc` to allow `@property` to be used somehow, but in the meantime we have to disable all of the type-specific checks within `jsdoc/check-tag-names` so we can avoid a lint error/warning.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

This lint warning was encountered while I was working on another PR.

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

N/A; developer-only change.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
