### PR TITLE
feat: add EIP-7702 signature validations

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -492,14 +492,8 @@
   "packages/selected-network-controller/tests/SelectedNetworkController.test.ts": {
     "jest/no-conditional-in-test": 1
   },
-  "packages/signature-controller/src/SignatureController.test.ts": {
-    "import-x/order": 1,
-    "jsdoc/tag-lines": 3
-  },
   "packages/signature-controller/src/SignatureController.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 4,
-    "@typescript-eslint/prefer-readonly": 3,
-    "jsdoc/tag-lines": 8
+    "@typescript-eslint/no-unsafe-enum-comparison": 4
   },
   "packages/signature-controller/src/utils/decoding-api.test.ts": {
     "import-x/order": 1,
@@ -515,13 +509,9 @@
     "@typescript-eslint/no-unused-vars": 1,
     "jsdoc/tag-lines": 2
   },
-  "packages/signature-controller/src/utils/validation.test.ts": {
-    "import-x/order": 1
-  },
   "packages/signature-controller/src/utils/validation.ts": {
     "@typescript-eslint/no-base-to-string": 1,
-    "@typescript-eslint/no-unused-vars": 2,
-    "jsdoc/tag-lines": 4
+    "@typescript-eslint/no-unused-vars": 2
   },
   "packages/user-operation-controller/src/UserOperationController.test.ts": {
     "jsdoc/tag-lines": 4

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -56,6 +56,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@metamask/accounts-controller": "^26.0.0",
     "@metamask/approval-controller": "^7.1.3",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-controller": "^21.0.0",
@@ -70,6 +71,7 @@
     "typescript": "~5.2.2"
   },
   "peerDependencies": {
+    "@metamask/accounts-controller": "^26.0.0",
     "@metamask/approval-controller": "^7.0.0",
     "@metamask/keyring-controller": "^21.0.0",
     "@metamask/logging-controller": "^6.0.0",

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -4,7 +4,6 @@ import { SignTypedDataVersion } from '@metamask/keyring-controller';
 import { LogType, SigningStage } from '@metamask/logging-controller';
 import { v1 } from 'uuid';
 
-import { flushPromises } from '../../../tests/helpers';
 import type {
   SignatureControllerMessenger,
   SignatureControllerOptions,
@@ -23,6 +22,7 @@ import {
   normalizePersonalMessageParams,
   normalizeTypedMessageParams,
 } from './utils/normalize';
+import { flushPromises } from '../../../tests/helpers';
 
 jest.mock('uuid');
 jest.mock('./utils/validation');
@@ -89,26 +89,30 @@ const PERMIT_REQUEST_MOCK = {
 
 /**
  * Create a mock messenger instance.
+ *
  * @returns The mock messenger instance plus individual mock functions for each action.
  */
 function createMessengerMock() {
-  const loggingControllerAddMock = jest.fn();
+  const accountsControllerGetStateMock = jest.fn();
   const approvalControllerAddRequestMock = jest.fn();
   const keyringControllerSignPersonalMessageMock = jest.fn();
   const keyringControllerSignTypedMessageMock = jest.fn();
+  const loggingControllerAddMock = jest.fn();
   const networkControllerGetNetworkClientByIdMock = jest.fn();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const callMock = (method: string, ...args: any[]) => {
     switch (method) {
-      case 'LoggingController:add':
-        return loggingControllerAddMock(...args);
+      case 'AccountsController:getState':
+        return accountsControllerGetStateMock(...args);
       case 'ApprovalController:addRequest':
         return approvalControllerAddRequestMock(...args);
       case 'KeyringController:signPersonalMessage':
         return keyringControllerSignPersonalMessageMock(...args);
       case 'KeyringController:signTypedMessage':
         return keyringControllerSignTypedMessageMock(...args);
+      case 'LoggingController:add':
+        return loggingControllerAddMock(...args);
       case 'NetworkController:getNetworkClientById':
         return networkControllerGetNetworkClientByIdMock(...args);
       default:
@@ -122,6 +126,12 @@ function createMessengerMock() {
     publish: jest.fn(),
     call: callMock,
   } as unknown as jest.Mocked<SignatureControllerMessenger>;
+
+  accountsControllerGetStateMock.mockReturnValue({
+    internalAccounts: {
+      accounts: [],
+    },
+  });
 
   approvalControllerAddRequestMock.mockResolvedValue({});
   loggingControllerAddMock.mockResolvedValue({});
@@ -143,6 +153,7 @@ function createMessengerMock() {
 
 /**
  * Create a new instance of the SignatureController.
+ *
  * @param options - Optional overrides for the default options.
  * @returns The controller instance plus individual mock functions for each action.
  */
@@ -159,6 +170,7 @@ function createController(options?: Partial<SignatureControllerOptions>) {
 
 /**
  * Create a mock error.
+ *
  * @returns The mock error instance.
  */
 function createErrorMock(): Error {

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -955,6 +955,7 @@ export class SignatureController extends BaseController<
   #getInternalAccounts(): Hex[] {
     const state = this.messagingSystem.call('AccountsController:getState');
 
+    /* istanbul ignore next */
     return Object.values(state.internalAccounts?.accounts ?? {})
       .filter((account) => account.type === 'eip155:eoa')
       .map((account) => account.address as Hex);

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -1,3 +1,4 @@
+import type { AccountsControllerGetStateAction } from '@metamask/accounts-controller';
 import type {
   AddApprovalRequest,
   AcceptResultCallbacks,
@@ -89,30 +90,35 @@ export type SignatureControllerState = {
 
   /**
    * Map of personal messages with the unapproved status, keyed by ID.
+   *
    * @deprecated - Use `signatureRequests` instead.
    */
   unapprovedPersonalMsgs: Record<string, LegacyStateMessage>;
 
   /**
    * Map of typed messages with the unapproved status, keyed by ID.
+   *
    * @deprecated - Use `signatureRequests` instead.
    */
   unapprovedTypedMessages: Record<string, LegacyStateMessage>;
 
   /**
    * Number of unapproved personal messages.
+   *
    * @deprecated - Use `signatureRequests` instead.
    */
   unapprovedPersonalMsgCount: number;
 
   /**
    * Number of unapproved typed messages.
+   *
    * @deprecated - Use `signatureRequests` instead.
    */
   unapprovedTypedMessagesCount: number;
 };
 
 type AllowedActions =
+  | AccountsControllerGetStateAction
   | AddApprovalRequest
   | KeyringControllerSignMessageAction
   | KeyringControllerSignPersonalMessageAction
@@ -189,11 +195,11 @@ export class SignatureController extends BaseController<
 > {
   hub: EventEmitter;
 
-  #decodingApiUrl?: string;
+  readonly #decodingApiUrl?: string;
 
-  #isDecodeSignatureRequestEnabled?: () => boolean;
+  readonly #isDecodeSignatureRequestEnabled?: () => boolean;
 
-  #trace: TraceCallback;
+  readonly #trace: TraceCallback;
 
   /**
    * Construct a Sign controller.
@@ -230,6 +236,7 @@ export class SignatureController extends BaseController<
 
   /**
    * A getter for the number of 'unapproved' PersonalMessages in this.messages.
+   *
    * @deprecated Use `signatureRequests` state instead.
    * @returns The number of 'unapproved' PersonalMessages in this.messages
    */
@@ -239,6 +246,7 @@ export class SignatureController extends BaseController<
 
   /**
    * A getter for the number of 'unapproved' TypedMessages in this.messages.
+   *
    * @deprecated Use `signatureRequests` state instead.
    * @returns The number of 'unapproved' TypedMessages in this.messages
    */
@@ -248,6 +256,7 @@ export class SignatureController extends BaseController<
 
   /**
    * A getter for returning all messages.
+   *
    * @deprecated Use `signatureRequests` state instead.
    * @returns The object containing all messages.
    */
@@ -346,12 +355,15 @@ export class SignatureController extends BaseController<
     options: { traceContext?: TraceContext } = {},
   ): Promise<string> {
     const chainId = this.#getChainId(request);
+    const internalAccounts = this.#getInternalAccounts();
 
-    validateTypedSignatureRequest(
-      messageParams,
-      version as SignTypedDataVersion,
-      chainId,
-    );
+    validateTypedSignatureRequest({
+      currentChainId: chainId,
+      internalAccounts,
+      messageData: messageParams,
+      request,
+      version: version as SignTypedDataVersion,
+    });
 
     const normalizedMessageParams = normalizeTypedMessageParams(
       messageParams,
@@ -386,6 +398,7 @@ export class SignatureController extends BaseController<
 
   /**
    * Set custom metadata on a signature request.
+   *
    * @param signatureRequestId - The ID of the signature request.
    * @param metadata - The custom metadata to set.
    */
@@ -937,5 +950,13 @@ export class SignatureController extends BaseController<
           draftMetadata.decodingLoading = false;
         }),
       );
+  }
+
+  #getInternalAccounts(): Hex[] {
+    const state = this.messagingSystem.call('AccountsController:getState');
+
+    return Object.values(state.internalAccounts?.accounts ?? {})
+      .filter((account) => account.type === 'eip155:eoa')
+      .map((account) => account.address as Hex);
   }
 }

--- a/packages/signature-controller/src/types.ts
+++ b/packages/signature-controller/src/types.ts
@@ -86,18 +86,18 @@ export type MessageParamsPersonal = MessageParams & {
   siwe?: StateSIWEMessage;
 };
 
+/** Typed data used in the signTypedData request. */
+export type MessageParamsTypedData = {
+  types: Record<string, Json>;
+  domain: Record<string, Json>;
+  primaryType: string;
+  message: Json;
+};
+
 /** Typed message parameters that were requested to be signed. */
 export type MessageParamsTyped = MessageParams & {
   /** Structured data to sign. */
-  data:
-    | Record<string, Json>[]
-    | string
-    | {
-        types: Record<string, Json>;
-        domain: Record<string, Json>;
-        primaryType: string;
-        message: Json;
-      };
+  data: Record<string, Json>[] | string | MessageParamsTypedData;
   /** Version of the signTypedData request. */
   version?: string;
 };

--- a/packages/signature-controller/src/utils/validation.test.ts
+++ b/packages/signature-controller/src/utils/validation.test.ts
@@ -1,8 +1,10 @@
 import { ORIGIN_METAMASK } from '@metamask/approval-controller';
 import { convertHexToDecimal, toHex } from '@metamask/controller-utils';
 import { SignTypedDataVersion } from '@metamask/keyring-controller';
+import type { Hex } from '@metamask/utils';
 
 import {
+  PRIMARY_TYPE_DELEGATION,
   validatePersonalSignatureRequest,
   validateTypedSignatureRequest,
 } from './validation';
@@ -12,7 +14,6 @@ import type {
   MessageParamsTyped,
   OriginalRequest,
 } from '../types';
-import { Hex } from '@metamask/utils';
 
 const CHAIN_ID_MOCK = '0x1';
 const ORIGIN_MOCK = 'test.com';
@@ -395,7 +396,7 @@ describe('Validation Utils', () => {
           it('throws if external origin in request and delegation from internal account', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
 
-            data.primaryType = 'Delegation';
+            data.primaryType = PRIMARY_TYPE_DELEGATION;
             data.types.Delegation = [{ name: 'delegator', type: 'address' }];
             data.message.delegator = INTERNAL_ACCOUNT_MOCK;
 
@@ -418,7 +419,7 @@ describe('Validation Utils', () => {
           it('throws if external origin in message params and delegation from internal account', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
 
-            data.primaryType = 'Delegation';
+            data.primaryType = PRIMARY_TYPE_DELEGATION;
             data.types.Delegation = [{ name: 'delegator', type: 'address' }];
             data.message.delegator = INTERNAL_ACCOUNT_MOCK;
 
@@ -442,7 +443,7 @@ describe('Validation Utils', () => {
           it('throws if external origin and delegation from internal account with different case', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
 
-            data.primaryType = 'Delegation';
+            data.primaryType = PRIMARY_TYPE_DELEGATION;
             data.types.Delegation = [{ name: 'delegator', type: 'address' }];
             data.message.delegator = INTERNAL_ACCOUNT_MOCK;
 
@@ -468,7 +469,7 @@ describe('Validation Utils', () => {
           it('does not throw if internal origin and delegation from internal account', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
 
-            data.primaryType = 'Delegation';
+            data.primaryType = PRIMARY_TYPE_DELEGATION;
             data.types.Delegation = [{ name: 'delegator', type: 'address' }];
             data.message.delegator = INTERNAL_ACCOUNT_MOCK;
 
@@ -489,7 +490,7 @@ describe('Validation Utils', () => {
           it('does not throw if no origin and delegation from internal account', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
 
-            data.primaryType = 'Delegation';
+            data.primaryType = PRIMARY_TYPE_DELEGATION;
             data.types.Delegation = [{ name: 'delegator', type: 'address' }];
             data.message.delegator = INTERNAL_ACCOUNT_MOCK;
 

--- a/packages/signature-controller/src/utils/validation.test.ts
+++ b/packages/signature-controller/src/utils/validation.test.ts
@@ -1,20 +1,23 @@
 import { convertHexToDecimal, toHex } from '@metamask/controller-utils';
 import { SignTypedDataVersion } from '@metamask/keyring-controller';
 
-import type {
-  MessageParams,
-  MessageParamsPersonal,
-  MessageParamsTyped,
-} from '../types';
 import {
   validatePersonalSignatureRequest,
   validateTypedSignatureRequest,
 } from './validation';
+import type {
+  MessageParams,
+  MessageParamsPersonal,
+  MessageParamsTyped,
+  OriginalRequest,
+} from '../types';
 
 const CHAIN_ID_MOCK = '0x1';
 
 const DATA_TYPED_MOCK =
   '{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Person":[{"name":"name","type":"string"},{"name":"wallet","type":"address"}],"Mail":[{"name":"from","type":"Person"},{"name":"to","type":"Person"},{"name":"contents","type":"string"}]},"primaryType":"Mail","domain":{"name":"Ether Mail","version":"1","chainId":1,"verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"},"message":{"from":{"name":"Cow","wallet":"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"},"to":{"name":"Bob","wallet":"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"},"contents":"Hello, Bob!"}}';
+
+const REQUEST_MOCK = {} as OriginalRequest;
 
 describe('Validation Utils', () => {
   describe.each([
@@ -26,11 +29,13 @@ describe('Validation Utils', () => {
     [
       'validateTypedSignatureRequest',
       (params: MessageParams) =>
-        validateTypedSignatureRequest(
-          params as MessageParamsTyped,
-          SignTypedDataVersion.V1,
-          CHAIN_ID_MOCK,
-        ),
+        validateTypedSignatureRequest({
+          currentChainId: CHAIN_ID_MOCK,
+          internalAccounts: [],
+          messageData: params as MessageParamsTyped,
+          request: REQUEST_MOCK,
+          version: SignTypedDataVersion.V1,
+        }),
     ],
   ] as const)('%s', (_title, fn) => {
     it('throws if no from address', () => {
@@ -83,39 +88,45 @@ describe('Validation Utils', () => {
     describe('V1', () => {
       it('throws if incorrect data', () => {
         expect(() =>
-          validateTypedSignatureRequest(
-            {
+          validateTypedSignatureRequest({
+            currentChainId: CHAIN_ID_MOCK,
+            internalAccounts: [],
+            messageData: {
               data: '0x879a05',
               from: '0x3244e191f1b4903970224322180f1fbbc415696b',
             },
-            SignTypedDataVersion.V1,
-            CHAIN_ID_MOCK,
-          ),
+            request: REQUEST_MOCK,
+            version: SignTypedDataVersion.V1,
+          }),
         ).toThrow('Invalid message "data":');
       });
 
       it('throws if no data', () => {
         expect(() =>
-          validateTypedSignatureRequest(
-            {
+          validateTypedSignatureRequest({
+            currentChainId: CHAIN_ID_MOCK,
+            internalAccounts: [],
+            messageData: {
               from: '0x3244e191f1b4903970224322180f1fbbc415696b',
             } as MessageParamsTyped,
-            SignTypedDataVersion.V1,
-            CHAIN_ID_MOCK,
-          ),
+            request: REQUEST_MOCK,
+            version: SignTypedDataVersion.V1,
+          }),
         ).toThrow('Invalid message "data":');
       });
 
       it('throws if invalid type data', () => {
         expect(() =>
-          validateTypedSignatureRequest(
-            {
+          validateTypedSignatureRequest({
+            currentChainId: CHAIN_ID_MOCK,
+            internalAccounts: [],
+            messageData: {
               data: [],
               from: '0x3244e191f1b4903970224322180f1fbbc415696b',
             } as MessageParamsTyped,
-            SignTypedDataVersion.V1,
-            CHAIN_ID_MOCK,
-          ),
+            request: REQUEST_MOCK,
+            version: SignTypedDataVersion.V1,
+          }),
         ).toThrow('Expected EIP712 typed data.');
       });
     });
@@ -125,52 +136,60 @@ describe('Validation Utils', () => {
       (version) => {
         it('throws if array data', () => {
           expect(() =>
-            validateTypedSignatureRequest(
-              {
+            validateTypedSignatureRequest({
+              currentChainId: CHAIN_ID_MOCK,
+              internalAccounts: [],
+              messageData: {
                 data: [],
                 from: '0x3244e191f1b4903970224322180f1fbbc415696b',
               },
+              request: REQUEST_MOCK,
               version,
-              CHAIN_ID_MOCK,
-            ),
+            }),
           ).toThrow('Invalid message "data":');
         });
 
         it('throws if no array data', () => {
           expect(() =>
-            validateTypedSignatureRequest(
-              {
+            validateTypedSignatureRequest({
+              currentChainId: CHAIN_ID_MOCK,
+              internalAccounts: [],
+              messageData: {
                 from: '0x3244e191f1b4903970224322180f1fbbc415696b',
               } as MessageParamsTyped,
+              request: REQUEST_MOCK,
               version,
-              CHAIN_ID_MOCK,
-            ),
+            }),
           ).toThrow('Invalid message "data":');
         });
 
         it('throws if no JSON valid data', () => {
           expect(() =>
-            validateTypedSignatureRequest(
-              {
+            validateTypedSignatureRequest({
+              currentChainId: CHAIN_ID_MOCK,
+              internalAccounts: [],
+              messageData: {
                 data: 'uh oh',
                 from: '0x3244e191f1b4903970224322180f1fbbc415696b',
               } as MessageParamsTyped,
+              request: REQUEST_MOCK,
               version,
-              CHAIN_ID_MOCK,
-            ),
+            }),
           ).toThrow('Data must be passed as a valid JSON string.');
         });
 
         it('throws if current chain ID is not present', () => {
           expect(() =>
-            validateTypedSignatureRequest(
-              {
+            validateTypedSignatureRequest({
+              currentChainId: undefined,
+              internalAccounts: [],
+              messageData: {
                 data: DATA_TYPED_MOCK,
                 from: '0x3244e191f1b4903970224322180f1fbbc415696b',
               },
+              request: REQUEST_MOCK,
               version,
-              undefined,
-            ),
+            }),
           ).toThrow('Current chainId cannot be null or undefined.');
         });
 
@@ -178,14 +197,16 @@ describe('Validation Utils', () => {
           const unexpectedChainId = 'unexpected chain id';
 
           expect(() =>
-            validateTypedSignatureRequest(
-              {
+            validateTypedSignatureRequest({
+              currentChainId: unexpectedChainId as never,
+              internalAccounts: [],
+              messageData: {
                 data: DATA_TYPED_MOCK.replace(`"chainId":1`, `"chainId":"0x1"`),
                 from: '0x3244e191f1b4903970224322180f1fbbc415696b',
               },
+              request: REQUEST_MOCK,
               version,
-              unexpectedChainId as never,
-            ),
+            }),
           ).toThrow(
             `Cannot sign messages for chainId "${String(
               convertHexToDecimal(CHAIN_ID_MOCK),
@@ -197,21 +218,22 @@ describe('Validation Utils', () => {
           const chainId = toHex(2);
 
           expect(() =>
-            validateTypedSignatureRequest(
-              {
+            validateTypedSignatureRequest({
+              currentChainId: chainId,
+              internalAccounts: [],
+              messageData: {
                 data: DATA_TYPED_MOCK,
                 from: '0x3244e191f1b4903970224322180f1fbbc415696b',
               },
+              request: REQUEST_MOCK,
               version,
-              chainId,
-            ),
+            }),
           ).toThrow(
             // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+
             `Provided chainId "${convertHexToDecimal(
               CHAIN_ID_MOCK,
               // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             )}" must match the active chainId "${convertHexToDecimal(
               chainId,
             )}"`,
@@ -220,40 +242,46 @@ describe('Validation Utils', () => {
 
         it('throws if data not in typed message schema', () => {
           expect(() =>
-            validateTypedSignatureRequest(
-              {
+            validateTypedSignatureRequest({
+              currentChainId: CHAIN_ID_MOCK,
+              internalAccounts: [],
+              messageData: {
                 data: '{"greetings":"I am Alice"}',
                 from: '0x3244e191f1b4903970224322180f1fbbc415696b',
               },
+              request: REQUEST_MOCK,
               version,
-              CHAIN_ID_MOCK,
-            ),
+            }),
           ).toThrow('Data must conform to EIP-712 schema.');
         });
 
         it('does not throw if data is correct', () => {
           expect(() =>
-            validateTypedSignatureRequest(
-              {
+            validateTypedSignatureRequest({
+              currentChainId: CHAIN_ID_MOCK,
+              internalAccounts: [],
+              messageData: {
                 data: DATA_TYPED_MOCK.replace(`"chainId":1`, `"chainId":"1"`),
                 from: '0x3244e191f1b4903970224322180f1fbbc415696b',
               },
+              request: REQUEST_MOCK,
               version,
-              CHAIN_ID_MOCK,
-            ),
+            }),
           ).not.toThrow();
         });
 
         it('does not throw if data is correct (object format)', () => {
           expect(() =>
-            validateTypedSignatureRequest(
-              {
+            validateTypedSignatureRequest({
+              currentChainId: CHAIN_ID_MOCK,
+              internalAccounts: [],
+              messageData: {
                 data: JSON.parse(DATA_TYPED_MOCK),
                 from: '0x3244e191f1b4903970224322180f1fbbc415696b',
               },
+              request: REQUEST_MOCK,
               version,
-              CHAIN_ID_MOCK,
-            ),
+            }),
           ).not.toThrow();
         });
       },

--- a/packages/signature-controller/src/utils/validation.ts
+++ b/packages/signature-controller/src/utils/validation.ts
@@ -16,6 +16,9 @@ import type {
   OriginalRequest,
 } from '../types';
 
+export const PRIMARY_TYPE_DELEGATION = 'Delegation';
+export const DELEGATOR_FIELD = 'delegator';
+
 /**
  * Validate a personal signature request.
  *
@@ -252,12 +255,14 @@ function validateDelegation({
 }) {
   const { primaryType } = data;
 
-  if (primaryType !== 'Delegation') {
+  if (primaryType !== PRIMARY_TYPE_DELEGATION) {
     return;
   }
 
   const isExternal = origin && origin !== ORIGIN_METAMASK;
-  const delegator = (data.message as Record<string, Json>)?.delegator as Hex;
+  const delegator = (data.message as Record<string, Json>)?.[
+    DELEGATOR_FIELD
+  ] as Hex;
 
   if (
     isExternal &&

--- a/packages/signature-controller/src/utils/validation.ts
+++ b/packages/signature-controller/src/utils/validation.ts
@@ -257,7 +257,7 @@ function validateDelegation({
   }
 
   const isExternal = origin && origin !== ORIGIN_METAMASK;
-  const delegator = (data.message as Record<string, Json>)?.delegate as Hex;
+  const delegator = (data.message as Record<string, Json>)?.delegator as Hex;
 
   if (
     isExternal &&

--- a/packages/signature-controller/src/utils/validation.ts
+++ b/packages/signature-controller/src/utils/validation.ts
@@ -1,16 +1,24 @@
+import { ORIGIN_METAMASK } from '@metamask/approval-controller';
 import { isValidHexAddress } from '@metamask/controller-utils';
 import {
   TYPED_MESSAGE_SCHEMA,
   typedSignatureHash,
 } from '@metamask/eth-sig-util';
 import { SignTypedDataVersion } from '@metamask/keyring-controller';
+import type { Json } from '@metamask/utils';
 import { type Hex } from '@metamask/utils';
 import { validate } from 'jsonschema';
 
-import type { MessageParamsPersonal, MessageParamsTyped } from '../types';
+import type {
+  MessageParamsPersonal,
+  MessageParamsTyped,
+  MessageParamsTypedData,
+  OriginalRequest,
+} from '../types';
 
 /**
  * Validate a personal signature request.
+ *
  * @param messageData - The message data to validate.
  */
 export function validatePersonalSignatureRequest(
@@ -27,26 +35,44 @@ export function validatePersonalSignatureRequest(
 
 /**
  * Validate a typed signature request.
- * @param messageData - The message data to validate.
- * @param version - The version of the typed signature request.
- * @param currentChainId - The current chain ID.
+ *
+ * @param options - Options bag.
+ * @param options.currentChainId - The current chain ID.
+ * @param options.internalAccounts - The addresses of all internal accounts.
+ * @param options.messageData - The message data to validate.
+ * @param options.request - The original request.
+ * @param options.version - The version of the typed signature request.
  */
-export function validateTypedSignatureRequest(
-  messageData: MessageParamsTyped,
-  version: SignTypedDataVersion,
-  currentChainId: Hex | undefined,
-) {
+export function validateTypedSignatureRequest({
+  currentChainId,
+  internalAccounts,
+  messageData,
+  request,
+  version,
+}: {
+  currentChainId: Hex | undefined;
+  internalAccounts: Hex[];
+  messageData: MessageParamsTyped;
+  request: OriginalRequest;
+  version: SignTypedDataVersion;
+}) {
   validateAddress(messageData.from, 'from');
 
   if (version === SignTypedDataVersion.V1) {
     validateTypedSignatureRequestV1(messageData);
   } else {
-    validateTypedSignatureRequestV3V4(messageData, currentChainId);
+    validateTypedSignatureRequestV3V4({
+      currentChainId,
+      internalAccounts,
+      messageData,
+      request,
+    });
   }
 }
 
 /**
  * Validate a V1 typed signature request.
+ *
  * @param messageData - The message data to validate.
  */
 function validateTypedSignatureRequestV1(messageData: MessageParamsTyped) {
@@ -71,13 +97,23 @@ function validateTypedSignatureRequestV1(messageData: MessageParamsTyped) {
 /**
  * Validate a V3 or V4 typed signature request.
  *
- * @param messageData - The message data to validate.
- * @param currentChainId - The current chain ID.
+ * @param options - Options bag.
+ * @param options.currentChainId - The current chain ID.
+ * @param options.internalAccounts - The addresses of all internal accounts.
+ * @param options.messageData - The message data to validate.
+ * @param options.request - The original request.
  */
-function validateTypedSignatureRequestV3V4(
-  messageData: MessageParamsTyped,
-  currentChainId: Hex | undefined,
-) {
+function validateTypedSignatureRequestV3V4({
+  currentChainId,
+  internalAccounts,
+  messageData,
+  request,
+}: {
+  currentChainId: Hex | undefined;
+  internalAccounts: Hex[];
+  messageData: MessageParamsTyped;
+  request: OriginalRequest;
+}) {
   if (
     !messageData.data ||
     Array.isArray(messageData.data) ||
@@ -134,10 +170,25 @@ function validateTypedSignatureRequestV3V4(
       );
     }
   }
+
+  const origin = request?.origin ?? messageData?.origin;
+
+  validateVerifyingContract({
+    data,
+    internalAccounts,
+    origin,
+  });
+
+  validateDelegation({
+    data,
+    internalAccounts,
+    origin,
+  });
 }
 
 /**
  * Validate an Ethereum address.
+ *
  * @param address - The address to validate.
  * @param propertyName - The name of the property source to use in the error message.
  */
@@ -145,6 +196,78 @@ function validateAddress(address: string, propertyName: string) {
   if (!address || typeof address !== 'string' || !isValidHexAddress(address)) {
     throw new Error(
       `Invalid "${propertyName}" address: ${address} must be a valid string.`,
+    );
+  }
+}
+
+/**
+ * Validate the verifying contract from a typed signature request.
+ *
+ * @param options - Options bag.
+ * @param options.data - The typed data to validate.
+ * @param options.internalAccounts - The internal accounts.
+ * @param options.origin - The origin of the request.
+ */
+function validateVerifyingContract({
+  data,
+  internalAccounts,
+  origin,
+}: {
+  data: MessageParamsTypedData;
+  internalAccounts: Hex[];
+  origin: string | undefined;
+}) {
+  const verifyingContract = data?.domain?.verifyingContract as Hex;
+  const isExternal = origin && origin !== ORIGIN_METAMASK;
+
+  if (
+    isExternal &&
+    internalAccounts.some(
+      (internalAccount) =>
+        internalAccount.toLowerCase() === verifyingContract.toLowerCase(),
+    )
+  ) {
+    throw new Error(
+      `External signature requests cannot use internal accounts as the verifying contract.`,
+    );
+  }
+}
+
+/**
+ * Validate a delegation signature request.
+ *
+ * @param options - Options bag.
+ * @param options.data - The typed data to validate.
+ * @param options.internalAccounts - The internal accounts.
+ * @param options.origin - The origin of the request.
+ */
+function validateDelegation({
+  data,
+  internalAccounts,
+  origin,
+}: {
+  data: MessageParamsTypedData;
+  internalAccounts: Hex[];
+  origin: string | undefined;
+}) {
+  const { primaryType } = data;
+
+  if (primaryType !== 'Delegation') {
+    return;
+  }
+
+  const isExternal = origin && origin !== ORIGIN_METAMASK;
+  const delegator = (data.message as Record<string, Json>)?.delegate as Hex;
+
+  if (
+    isExternal &&
+    internalAccounts.some(
+      (internalAccount) =>
+        internalAccount.toLowerCase() === delegator?.toLowerCase(),
+    )
+  ) {
+    throw new Error(
+      `External signature requests cannot sign delegations for internal accounts.`,
     );
   }
 }

--- a/packages/signature-controller/tsconfig.build.json
+++ b/packages/signature-controller/tsconfig.build.json
@@ -7,6 +7,9 @@
   },
   "references": [
     {
+      "path": "../accounts-controller/tsconfig.build.json"
+    },
+    {
       "path": "../approval-controller/tsconfig.build.json"
     },
     {

--- a/packages/signature-controller/tsconfig.json
+++ b/packages/signature-controller/tsconfig.json
@@ -5,6 +5,9 @@
   },
   "references": [
     {
+      "path": "../accounts-controller"
+    },
+    {
       "path": "../approval-controller"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4057,6 +4057,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/signature-controller@workspace:packages/signature-controller"
   dependencies:
+    "@metamask/accounts-controller": "npm:^26.0.0"
     "@metamask/approval-controller": "npm:^7.1.3"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^8.0.0"
@@ -4077,6 +4078,7 @@ __metadata:
     typescript: "npm:~5.2.2"
     uuid: "npm:^8.3.2"
   peerDependencies:
+    "@metamask/accounts-controller": ^26.0.0
     "@metamask/approval-controller": ^7.0.0
     "@metamask/keyring-controller": ^21.0.0
     "@metamask/logging-controller": ^6.0.0


### PR DESCRIPTION
## Explanation

Add additional validations to `signTypedData` requests to protect EOAs that have been upgraded to a smart contract account via EIP-7702.

Specifically:

- Throw if `verifyingContract` matches any internal EOA account.
- Throw if `primaryType` is `Delegation` and `delegator` matches any internal EOA account.
- Add dependency on `@metamask/accounts-controller`.

## References

## Changelog

See `CHANGELOG.md`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
