### PR TITLE
perf: Don't emit `:stateChange` from `BaseController` unnecessarily

### DIFF
--- a/packages/base-controller/src/BaseControllerV2.test.ts
+++ b/packages/base-controller/src/BaseControllerV2.test.ts
@@ -331,6 +331,25 @@ describe('BaseController', () => {
     expect(controller.state).toStrictEqual({ count: 1 });
   });
 
+  it('should not call publish if the state has not been modified', () => {
+    const messenger = getCountMessenger();
+    const publishSpy = jest.spyOn(messenger, 'publish');
+
+    const controller = new CountController({
+      messenger,
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    controller.update((_draft) => {
+      // no-op
+    });
+
+    expect(controller.state).toStrictEqual({ count: 0 });
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+
   it('should return next state, patches and inverse patches after an update', () => {
     const controller = new CountController({
       messenger: getCountMessenger(),

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -271,12 +271,15 @@ export class BaseController<
       ) => [ControllerState, Patch[], Patch[]]
     )(this.#internalState, callback);
 
-    this.#internalState = nextState;
-    this.messagingSystem.publish(
-      `${this.name}:stateChange`,
-      nextState,
-      patches,
-    );
+    // Protect against unnecessary state updates when there is no state diff.
+    if (patches.length > 0) {
+      this.#internalState = nextState;
+      this.messagingSystem.publish(
+        `${this.name}:stateChange`,
+        nextState,
+        patches,
+      );
+    }
 
     return { nextState, patches, inversePatches };
   }


### PR DESCRIPTION
## Explanation

Some controllers may use conditionals inside `this.update()` and potentially end up not modifying the `draftState` at all. In this case, we would currently still emit `:stateChange` and listening controllers would treat this as a state update if they don't inspect the `patches`. This PR adjusts this logic slightly, letting us only emit events when the state has actually changed. This reduces unnecessary events being emitted and consumed by listening controllers.

Feedback appreciated!

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/base-controller`

- **Changed**: Don't emit `:stateChange` from `BaseController` unnecessarily

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
