### PR TITLE
feat: support transaction batch metrics

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add additional metadata for batch metrics ([#5488](https://github.com/MetaMask/core/pull/5488))
+  - Add `delegationAddress` to `TransactionMetadata`.
+  - Add `NestedTransactionMetadata` type containing `BatchTransactionParams` and `type`.
+  - Add optional `type` to `TransactionBatchSingleRequest`.
+
 ### Changed
 
+- **BREAKING:** Add additional metadata for batch metrics ([#5488](https://github.com/MetaMask/core/pull/5488))
+  - Change `error` in `TransactionMetadata` to optional for all statuses.
+  - Change `nestedTransactions` in `TransactionMetadata` to array of `NestedTransactionMetadata`.
 - Throw if `addTransactionBatch` called with external origin and size limit exceeded ([#5489](https://github.com/MetaMask/core/pull/5489))
 
 ## [49.0.0]

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -76,7 +76,7 @@ import {
   WalletDevice,
 } from './types';
 import { addTransactionBatch } from './utils/batch';
-import { isAccountUpgradedToEIP7702 } from './utils/eip7702';
+import { getDelegationAddress } from './utils/eip7702';
 import { addGasBuffer, estimateGas, updateGas } from './utils/gas';
 import { updateGasFees } from './utils/gas-fees';
 import { getGasFeeFlow } from './utils/gas-flow';
@@ -131,7 +131,7 @@ jest.mock('./helpers/ResimulateHelper', () => ({
 
 jest.mock('./utils/eip7702', () => ({
   ...jest.requireActual('./utils/eip7702'),
-  isAccountUpgradedToEIP7702: jest.fn(),
+  getDelegationAddress: jest.fn(),
 }));
 
 // TODO: Replace `any` with type
@@ -503,9 +503,7 @@ describe('TransactionController', () => {
   );
   const addTransactionBatchMock = jest.mocked(addTransactionBatch);
   const methodDataHelperClassMock = jest.mocked(MethodDataHelper);
-  const isAccountUpgradedToEIP7702Mock = jest.mocked(
-    isAccountUpgradedToEIP7702,
-  );
+  const getDelegationAddressMock = jest.mocked(getDelegationAddress);
 
   let mockEthQuery: EthQuery;
   let getNonceLockSpy: jest.Mock;
@@ -698,10 +696,7 @@ describe('TransactionController', () => {
       {} as any,
     );
 
-    isAccountUpgradedToEIP7702Mock.mockResolvedValue({
-      delegationAddress: undefined,
-      isSupported: false,
-    });
+    getDelegationAddressMock.mockResolvedValue(undefined);
 
     remoteFeatureFlagControllerGetStateMock.mockReturnValue({
       remoteFeatureFlags: {},
@@ -1966,10 +1961,7 @@ describe('TransactionController', () => {
     it('adds delegration address to metadata', async () => {
       const { controller } = setupController();
 
-      isAccountUpgradedToEIP7702Mock.mockResolvedValueOnce({
-        delegationAddress: ACCOUNT_MOCK,
-        isSupported: true,
-      });
+      getDelegationAddressMock.mockResolvedValueOnce(ACCOUNT_MOCK);
 
       await controller.addTransaction(
         {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -35,7 +35,6 @@ import assert from 'assert';
 // eslint-disable-next-line import-x/namespace
 import * as uuidModule from 'uuid';
 
-import { determineTransactionType } from '.';
 import { getAccountAddressRelationship } from './api/accounts-api';
 import { CHAIN_IDS } from './constants';
 import { DefaultGasFeeFlow } from './gas-flows/DefaultGasFeeFlow';

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1156,6 +1156,7 @@ export class TransactionController extends BaseController<
       ({ delegationAddress } = await isAccountUpgradedToEIP7702(
         txParams.from as Hex,
         chainId,
+        this.#publicKeyEIP7702 as Hex,
         this.messagingSystem,
         ethQuery,
       ));

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -45,7 +45,7 @@ import type {
 import { NonceTracker } from '@metamask/nonce-tracker';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { errorCodes, rpcErrors, providerErrors } from '@metamask/rpc-errors';
-import type { Hex } from '@metamask/utils';
+import type { Hex, Json } from '@metamask/utils';
 import { add0x, hexToNumber } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 // This package purposefully relies on Node's EventEmitter module.
@@ -108,6 +108,7 @@ import {
 import { addTransactionBatch, isAtomicBatchSupported } from './utils/batch';
 import {
   generateEIP7702BatchTransaction,
+  isAccountUpgradedToEIP7702,
   signAuthorizationList,
 } from './utils/eip7702';
 import { validateConfirmedExternalTransaction } from './utils/external-transactions';
@@ -1149,10 +1150,17 @@ export class TransactionController extends BaseController<
     const transactionType =
       type ?? (await determineTransactionType(txParams, ethQuery)).type;
 
+    const { delegationAddress } = await isAccountUpgradedToEIP7702(
+      txParams.from as Hex,
+      chainId,
+      this.messagingSystem,
+      ethQuery,
+    );
+
     const existingTransactionMeta = this.getTransactionWithActionId(actionId);
 
     // If a request to add a transaction with the same actionId is submitted again, a new transaction will not be created for it.
-    let addedTransactionMeta = existingTransactionMeta
+    let addedTransactionMeta: TransactionMeta = existingTransactionMeta
       ? cloneDeep(existingTransactionMeta)
       : {
           // Add actionId to txMeta to check if same actionId is seen again
@@ -1160,6 +1168,7 @@ export class TransactionController extends BaseController<
           batchId,
           chainId,
           dappSuggestedGasFees,
+          delegationAddress,
           deviceConfirmedOn,
           id: random(),
           isFirstTimeInteraction: undefined,
@@ -1209,7 +1218,7 @@ export class TransactionController extends BaseController<
         swaps,
         {
           isSwapsDisabled: this.isSwapsDisabled,
-          cancelTransaction: this.cancelTransaction.bind(this),
+          cancelTransaction: this.#rejectTransaction.bind(this),
           messenger: this.messagingSystem,
         },
       );
@@ -1618,6 +1627,7 @@ export class TransactionController extends BaseController<
     );
 
     this.update((state) => {
+      // @ts-expect-error - Excessively deep and possibly infinite.
       state.transactions = this.trimTransactionsForState(newTransactions);
     });
   }
@@ -2614,20 +2624,15 @@ export class TransactionController extends BaseController<
             },
           );
         }
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
+      } catch (rawError: unknown) {
+        const error = rawError as Error & { code?: number; data?: Json };
+
         const { isCompleted: isTxCompleted } =
           this.isTransactionCompleted(transactionId);
-        if (!isTxCompleted) {
-          if (error?.code === errorCodes.provider.userRejectedRequest) {
-            this.cancelTransaction(transactionId, actionId);
 
-            throw providerErrors.userRejectedRequest({
-              message:
-                'MetaMask Tx Signature: User denied transaction signature.',
-              data: error?.data,
-            });
+        if (!isTxCompleted) {
+          if (this.#isRejectError(error)) {
+            this.#rejectTransactionAndThrow(transactionId, actionId, error);
           } else {
             this.failTransaction(meta, error, actionId);
           }
@@ -2639,8 +2644,9 @@ export class TransactionController extends BaseController<
 
     switch (finalMeta?.status) {
       case TransactionStatus.failed:
-        resultCallbacks?.error(finalMeta.error);
-        throw rpcErrors.internal(finalMeta.error.message);
+        const error = finalMeta.error as Error;
+        resultCallbacks?.error(error);
+        throw rpcErrors.internal(error.message);
 
       case TransactionStatus.submitted:
         resultCallbacks?.success();
@@ -2843,41 +2849,43 @@ export class TransactionController extends BaseController<
   }
 
   /**
-   * Cancels a transaction based on its ID by setting its status to "rejected"
+   * Rejects a transaction based on its ID by setting its status to "rejected"
    * and emitting a `<tx.id>:finished` hub event.
    *
    * @param transactionId - The ID of the transaction to cancel.
    * @param actionId - The actionId passed from UI
+   * @param error - The error that caused the rejection.
    */
-  private cancelTransaction(transactionId: string, actionId?: string) {
-    const transactionMeta = this.state.transactions.find(
-      ({ id }) => id === transactionId,
-    );
+  #rejectTransaction(transactionId: string, actionId?: string, error?: Error) {
+    const transactionMeta = this.getTransaction(transactionId);
+
     if (!transactionMeta) {
       return;
     }
-    this.update((state) => {
-      const transactions = state.transactions.filter(
-        ({ id }) => id !== transactionId,
-      );
-      state.transactions = this.trimTransactionsForState(transactions);
-    });
-    const updatedTransactionMeta = {
+
+    this.#deleteTransaction(transactionId);
+
+    const updatedTransactionMeta: TransactionMeta = {
       ...transactionMeta,
       status: TransactionStatus.rejected as const,
+      error: normalizeTxError(error ?? providerErrors.userRejectedRequest()),
     };
+
     this.messagingSystem.publish(
       `${controllerName}:transactionFinished`,
       updatedTransactionMeta,
     );
+
     this.#internalEvents.emit(
       `${transactionMeta.id}:finished`,
       updatedTransactionMeta,
     );
+
     this.messagingSystem.publish(`${controllerName}:transactionRejected`, {
       transactionMeta: updatedTransactionMeta,
       actionId,
     });
+
     this.onTransactionStatusChange(updatedTransactionMeta);
   }
 
@@ -3978,5 +3986,39 @@ export class TransactionController extends BaseController<
       isCustomNetwork,
       txMeta: transactionMeta,
     });
+  }
+
+  #deleteTransaction(transactionId: string) {
+    this.update((state) => {
+      const transactions = state.transactions.filter(
+        ({ id }) => id !== transactionId,
+      );
+
+      state.transactions = this.trimTransactionsForState(transactions);
+    });
+  }
+
+  #isRejectError(error: Error & { code?: number }) {
+    return [
+      errorCodes.provider.userRejectedRequest,
+      errorCodes.rpc.methodNotSupported,
+    ].includes(error.code as number);
+  }
+
+  #rejectTransactionAndThrow(
+    transactionId: string,
+    actionId: string | undefined,
+    error: Error & { code?: number; data?: Json },
+  ) {
+    this.#rejectTransaction(transactionId, actionId, error);
+
+    if (error.code === errorCodes.provider.userRejectedRequest) {
+      throw providerErrors.userRejectedRequest({
+        message: 'MetaMask Tx Signature: User denied transaction signature.',
+        data: error?.data,
+      });
+    }
+
+    throw error;
   }
 }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1150,7 +1150,7 @@ export class TransactionController extends BaseController<
     const transactionType =
       type ?? (await determineTransactionType(txParams, ethQuery)).type;
 
-    let delegationAddress = undefined;
+    let delegationAddress;
 
     try {
       ({ delegationAddress } = await isAccountUpgradedToEIP7702(

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1627,7 +1627,6 @@ export class TransactionController extends BaseController<
     );
 
     this.update((state) => {
-      // @ts-expect-error - Excessively deep and possibly infinite.
       state.transactions = this.trimTransactionsForState(newTransactions);
     });
   }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1150,12 +1150,18 @@ export class TransactionController extends BaseController<
     const transactionType =
       type ?? (await determineTransactionType(txParams, ethQuery)).type;
 
-    const { delegationAddress } = await isAccountUpgradedToEIP7702(
-      txParams.from as Hex,
-      chainId,
-      this.messagingSystem,
-      ethQuery,
-    );
+    let delegationAddress = undefined;
+
+    try {
+      ({ delegationAddress } = await isAccountUpgradedToEIP7702(
+        txParams.from as Hex,
+        chainId,
+        this.messagingSystem,
+        ethQuery,
+      ));
+    } catch (error) {
+      log('Error checking if account is upgraded to EIP-7702', error);
+    }
 
     const existingTransactionMeta = this.getTransactionWithActionId(actionId);
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -108,7 +108,7 @@ import {
 import { addTransactionBatch, isAtomicBatchSupported } from './utils/batch';
 import {
   generateEIP7702BatchTransaction,
-  isAccountUpgradedToEIP7702,
+  getDelegationAddress,
   signAuthorizationList,
 } from './utils/eip7702';
 import { validateConfirmedExternalTransaction } from './utils/external-transactions';
@@ -1153,13 +1153,10 @@ export class TransactionController extends BaseController<
     let delegationAddress;
 
     try {
-      ({ delegationAddress } = await isAccountUpgradedToEIP7702(
+      delegationAddress = await getDelegationAddress(
         txParams.from as Hex,
-        chainId,
-        this.#publicKeyEIP7702 as Hex,
-        this.messagingSystem,
         ethQuery,
-      ));
+      );
     } catch (error) {
       log('Error checking if account is upgraded to EIP-7702', error);
     }

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -43,6 +43,7 @@ import {
   buildCustomNetworkClientConfiguration,
   buildUpdateNetworkCustomRpcEndpointFields,
 } from '../../network-controller/tests/helpers';
+import type { RemoteFeatureFlagControllerGetStateAction } from '../../remote-feature-flag-controller/src';
 import {
   buildEthGasPriceRequestMock,
   buildEthBlockNumberRequestMock,
@@ -65,12 +66,13 @@ jest.mock('uuid', () => {
 });
 
 type UnrestrictedMessenger = Messenger<
-  | NetworkControllerActions
+  | AccountsControllerActions
   | ApprovalControllerActions
+  | NetworkControllerActions
   | TransactionControllerActions
-  | AccountsControllerActions,
-  | NetworkControllerEvents
+  | RemoteFeatureFlagControllerGetStateAction,
   | ApprovalControllerEvents
+  | NetworkControllerEvents
   | TransactionControllerEvents
 >;
 
@@ -186,11 +188,12 @@ const setupController = async (
   const messenger = unrestrictedMessenger.getRestricted({
     name: 'TransactionController',
     allowedActions: [
+      'AccountsController:getSelectedAccount',
+      'AccountsController:getState',
       'ApprovalController:addRequest',
       'NetworkController:getNetworkClientById',
       'NetworkController:findNetworkClientIdByChainId',
-      'AccountsController:getSelectedAccount',
-      'AccountsController:getState',
+      'RemoteFeatureFlagController:getState',
     ],
     allowedEvents: ['NetworkController:stateChange'],
   });
@@ -207,6 +210,11 @@ const setupController = async (
   unrestrictedMessenger.registerActionHandler(
     'AccountsController:getState',
     () => ({}) as never,
+  );
+
+  unrestrictedMessenger.registerActionHandler(
+    'RemoteFeatureFlagController:getState',
+    () => ({ cacheTimestamp: 0, remoteFeatureFlags: {} }),
   );
 
   const options: TransactionControllerOptions = {
@@ -399,6 +407,7 @@ describe('TransactionController Integration', () => {
           ),
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
+            buildEthGetCodeRequestMock(ACCOUNT_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
             buildEthGasPriceRequestMock(),
           ],
@@ -427,6 +436,7 @@ describe('TransactionController Integration', () => {
             buildEthBlockNumberRequestMock('0x1'),
             buildEthGetBlockByNumberRequestMock('0x1'),
             buildEthBlockNumberRequestMock('0x2'),
+            buildEthGetCodeRequestMock(ACCOUNT_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
             buildEthEstimateGasRequestMock(ACCOUNT_MOCK, ACCOUNT_2_MOCK),
             buildEthGasPriceRequestMock(),
@@ -468,6 +478,7 @@ describe('TransactionController Integration', () => {
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
             buildEthGetBlockByNumberRequestMock('0x1'),
+            buildEthGetCodeRequestMock(ACCOUNT_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
             buildEthEstimateGasRequestMock(ACCOUNT_MOCK, ACCOUNT_2_MOCK),
             buildEthGasPriceRequestMock(),
@@ -516,6 +527,7 @@ describe('TransactionController Integration', () => {
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
             buildEthGetBlockByNumberRequestMock('0x1'),
+            buildEthGetCodeRequestMock(ACCOUNT_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
             buildEthEstimateGasRequestMock(ACCOUNT_MOCK, ACCOUNT_2_MOCK),
             buildEthGasPriceRequestMock(),
@@ -536,6 +548,7 @@ describe('TransactionController Integration', () => {
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
             buildEthGetBlockByNumberRequestMock('0x1'),
+            buildEthGetCodeRequestMock(ACCOUNT_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
             buildEthEstimateGasRequestMock(ACCOUNT_MOCK, ACCOUNT_2_MOCK),
             buildEthGasPriceRequestMock(),
@@ -604,6 +617,7 @@ describe('TransactionController Integration', () => {
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
             buildEthGetBlockByNumberRequestMock('0x1'),
+            buildEthGetCodeRequestMock(ACCOUNT_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
             buildEthEstimateGasRequestMock(ACCOUNT_MOCK, ACCOUNT_2_MOCK),
             buildEthGasPriceRequestMock(),
@@ -656,6 +670,7 @@ describe('TransactionController Integration', () => {
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
             buildEthGetBlockByNumberRequestMock('0x1'),
+            buildEthGetCodeRequestMock(ACCOUNT_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
             buildEthEstimateGasRequestMock(ACCOUNT_MOCK, ACCOUNT_2_MOCK),
             buildEthGasPriceRequestMock(),
@@ -731,6 +746,7 @@ describe('TransactionController Integration', () => {
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
             buildEthGetBlockByNumberRequestMock('0x1'),
+            buildEthGetCodeRequestMock(ACCOUNT_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
             buildEthEstimateGasRequestMock(ACCOUNT_MOCK, ACCOUNT_2_MOCK),
             buildEthGasPriceRequestMock(),
@@ -817,6 +833,7 @@ describe('TransactionController Integration', () => {
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
             buildEthGetBlockByNumberRequestMock('0x1'),
+            buildEthGetCodeRequestMock(ACCOUNT_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
             buildEthEstimateGasRequestMock(ACCOUNT_MOCK, ACCOUNT_2_MOCK),
             buildEthGasPriceRequestMock(),
@@ -846,6 +863,7 @@ describe('TransactionController Integration', () => {
             buildEthBlockNumberRequestMock('0x1'),
             buildEthBlockNumberRequestMock('0x1'),
             buildEthGetBlockByNumberRequestMock('0x1'),
+            buildEthGetCodeRequestMock(ACCOUNT_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
             buildEthEstimateGasRequestMock(ACCOUNT_MOCK, ACCOUNT_2_MOCK),
             buildEthGasPriceRequestMock(),
@@ -938,6 +956,7 @@ describe('TransactionController Integration', () => {
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
             buildEthGetBlockByNumberRequestMock('0x1'),
+            buildEthGetCodeRequestMock(ACCOUNT_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
             buildEthGetCodeRequestMock(ACCOUNT_3_MOCK),
             buildEthEstimateGasRequestMock(ACCOUNT_MOCK, ACCOUNT_2_MOCK),
@@ -1016,6 +1035,7 @@ describe('TransactionController Integration', () => {
         buildEthBlockNumberRequestMock('0x1'),
         buildEthBlockNumberRequestMock('0x1'),
         buildEthGetBlockByNumberRequestMock('0x1'),
+        buildEthGetCodeRequestMock(ACCOUNT_MOCK),
         buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
         buildEthGasPriceRequestMock(),
       ],
@@ -1028,6 +1048,7 @@ describe('TransactionController Integration', () => {
         buildEthBlockNumberRequestMock('0x1'),
         buildEthBlockNumberRequestMock('0x1'),
         buildEthGetBlockByNumberRequestMock('0x1'),
+        buildEthGetCodeRequestMock(ACCOUNT_MOCK),
         buildEthGetCodeRequestMock(ACCOUNT_2_MOCK),
         buildEthGasPriceRequestMock(),
       ],

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -44,6 +44,7 @@ export type {
   InferTransactionTypeResult,
   LegacyGasFeeEstimates,
   Log,
+  NestedTransactionMetadata,
   SavedGasFees,
   SecurityAlertResponse,
   SecurityProviderRequest,

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1126,8 +1126,6 @@ export type TransactionError = {
   // <https://github.com/immerjs/immer/issues/839>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   rpc?: any;
-
-  data?: Json;
 };
 
 /**

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -24,23 +24,9 @@ type MakeJsonCompatible<T> = T extends Json
 type JsonCompatibleOperation = MakeJsonCompatible<Operation>;
 
 /**
- * Representation of transaction metadata.
- */
-export type TransactionMeta = TransactionMetaBase &
-  (
-    | {
-        status: Exclude<TransactionStatus, TransactionStatus.failed>;
-      }
-    | {
-        status: TransactionStatus.failed;
-        error: TransactionError;
-      }
-  );
-
-/**
  * Information about a single transaction such as status and block number.
  */
-type TransactionMetaBase = {
+export type TransactionMeta = {
   /**
    * ID of the transaction that approved the swap token transfer.
    */
@@ -120,6 +106,12 @@ type TransactionMetaBase = {
   defaultGasEstimates?: DefaultGasEstimates;
 
   /**
+   * Address of the sender's current contract code delegation.
+   * Introduced in EIP-7702.
+   */
+  delegationAddress?: Hex;
+
+  /**
    * String to indicate what device the transaction was confirmed on.
    */
   deviceConfirmedOn?: WalletDevice;
@@ -148,6 +140,11 @@ type TransactionMetaBase = {
    * The symbol of the token being received with swap.
    */
   destinationTokenSymbol?: string;
+
+  /**
+   * Error that occurred during the transaction processing.
+   */
+  error?: TransactionError;
 
   /**
    * The estimated base fee of the transaction.
@@ -228,10 +225,10 @@ type TransactionMetaBase = {
   layer1GasFee?: Hex;
 
   /**
-   * Parameters for any nested transactions encoded in the data.
+   * Data for any nested transactions.
    * For example, in an atomic batch transaction via EIP-7702.
    */
-  nestedTransactions?: BatchTransactionParams[];
+  nestedTransactions?: NestedTransactionMetadata[];
 
   /**
    * The ID of the network client used by the transaction.
@@ -361,6 +358,9 @@ type TransactionMetaBase = {
       blockGasLimit?: string;
     };
   };
+
+  /** Current status of the transaction. */
+  status: TransactionStatus;
 
   /**
    * The time the transaction was submitted to the network, in Unix epoch time (ms).
@@ -1126,6 +1126,8 @@ export type TransactionError = {
   // <https://github.com/immerjs/immer/issues/839>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   rpc?: any;
+
+  data?: Json;
 };
 
 /**
@@ -1438,12 +1440,21 @@ export type BatchTransactionParams = {
   value?: Hex;
 };
 
+/** Metadata for a nested transaction within a standard transaction. */
+export type NestedTransactionMetadata = BatchTransactionParams & {
+  /** Type of the neted transaction. */
+  type?: TransactionType;
+};
+
 /**
  * Specification for a single transaction within a batch request.
  */
 export type TransactionBatchSingleRequest = {
   /** Parameters of the single transaction. */
   params: BatchTransactionParams;
+
+  /** Type of the transaction. */
+  type?: TransactionType;
 };
 
 /**

--- a/packages/transaction-controller/src/utils/batch.test.ts
+++ b/packages/transaction-controller/src/utils/batch.test.ts
@@ -261,16 +261,16 @@ describe('Batch Utils', () => {
         expect.any(Object),
         expect.objectContaining({
           nestedTransactions: [
-            {
+            expect.objectContaining({
               to: TO_MOCK,
               data: DATA_MOCK,
               value: VALUE_MOCK,
-            },
-            {
+            }),
+            expect.objectContaining({
               to: TO_MOCK,
               data: DATA_MOCK,
               value: VALUE_MOCK,
-            },
+            }),
           ],
         }),
       );

--- a/packages/transaction-controller/src/utils/batch.test.ts
+++ b/packages/transaction-controller/src/utils/batch.test.ts
@@ -15,10 +15,13 @@ import {
   TransactionEnvelopeType,
   type TransactionControllerMessenger,
   type TransactionMeta,
+  determineTransactionType,
+  TransactionType,
 } from '..';
 
 jest.mock('./eip7702');
 jest.mock('./feature-flags');
+jest.mock('./transaction-type');
 
 jest.mock('./validation', () => ({
   ...jest.requireActual('./validation'),
@@ -47,6 +50,7 @@ describe('Batch Utils', () => {
   const doesChainSupportEIP7702Mock = jest.mocked(doesChainSupportEIP7702);
   const getEIP7702SupportedChainsMock = jest.mocked(getEIP7702SupportedChains);
   const validateBatchRequestMock = jest.mocked(validateBatchRequest);
+  const determineTransactionTypeMock = jest.mocked(determineTransactionType);
 
   const isAccountUpgradedToEIP7702Mock = jest.mocked(
     isAccountUpgradedToEIP7702,
@@ -75,6 +79,10 @@ describe('Batch Utils', () => {
       jest.resetAllMocks();
       addTransactionMock = jest.fn();
       getChainIdMock = jest.fn();
+
+      determineTransactionTypeMock.mockResolvedValue({
+        type: TransactionType.simpleSend,
+      });
 
       request = {
         addTransaction: addTransactionMock,
@@ -270,6 +278,51 @@ describe('Batch Utils', () => {
               to: TO_MOCK,
               data: DATA_MOCK,
               value: VALUE_MOCK,
+            }),
+          ],
+        }),
+      );
+    });
+
+    it('determines transaction type for nested transactions', async () => {
+      doesChainSupportEIP7702Mock.mockReturnValueOnce(true);
+
+      isAccountUpgradedToEIP7702Mock.mockResolvedValueOnce({
+        delegationAddress: undefined,
+        isSupported: true,
+      });
+
+      addTransactionMock.mockResolvedValueOnce({
+        transactionMeta: TRANSACTION_META_MOCK,
+        result: Promise.resolve(''),
+      });
+
+      generateEIP7702BatchTransactionMock.mockReturnValueOnce({
+        to: TO_MOCK,
+        data: DATA_MOCK,
+        value: VALUE_MOCK,
+      });
+
+      determineTransactionTypeMock
+        .mockResolvedValueOnce({
+          type: TransactionType.tokenMethodSafeTransferFrom,
+        })
+        .mockResolvedValueOnce({
+          type: TransactionType.simpleSend,
+        });
+
+      await addTransactionBatch(request);
+
+      expect(addTransactionMock).toHaveBeenCalledTimes(1);
+      expect(addTransactionMock).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          nestedTransactions: [
+            expect.objectContaining({
+              type: TransactionType.tokenMethodSafeTransferFrom,
+            }),
+            expect.objectContaining({
+              type: TransactionType.simpleSend,
             }),
           ],
         }),

--- a/packages/transaction-controller/src/utils/eip7702.test.ts
+++ b/packages/transaction-controller/src/utils/eip7702.test.ts
@@ -8,6 +8,7 @@ import {
   DELEGATION_PREFIX,
   doesChainSupportEIP7702,
   generateEIP7702BatchTransaction,
+  getDelegationAddress,
   isAccountUpgradedToEIP7702,
   signAuthorizationList,
 } from './eip7702';
@@ -423,6 +424,44 @@ describe('EIP-7702 Utils', () => {
         data: DATA_MISSING_PROPS_MOCK,
         to: ADDRESS_MOCK,
       });
+    });
+  });
+
+  describe('getDelegationAddress', () => {
+    it('returns the delegation address', async () => {
+      getCodeMock.mockResolvedValueOnce(
+        `${DELEGATION_PREFIX}${remove0x(ADDRESS_2_MOCK)}`,
+      );
+
+      expect(
+        await getDelegationAddress(ADDRESS_MOCK, ETH_QUERY_MOCK),
+      ).toStrictEqual(ADDRESS_2_MOCK);
+    });
+
+    it('returns undefined if no code', async () => {
+      getCodeMock.mockResolvedValueOnce(undefined);
+
+      expect(
+        await getDelegationAddress(ADDRESS_MOCK, ETH_QUERY_MOCK),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined if empty code', async () => {
+      getCodeMock.mockResolvedValueOnce('0x');
+
+      expect(
+        await getDelegationAddress(ADDRESS_MOCK, ETH_QUERY_MOCK),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined if not delegation code', async () => {
+      getCodeMock.mockResolvedValueOnce(
+        '0x1234567890123456789012345678901234567890123456789012345678901234567890',
+      );
+
+      expect(
+        await getDelegationAddress(ADDRESS_MOCK, ETH_QUERY_MOCK),
+      ).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Explanation

Add additional transaction metadata to support client metrics for transaction batch.

Specifically:

- Save `delegationAddress` for each transaction.
- Determine `transactionType` for each nested transaction.
- Add `error` to metadata in `transactionRejected` event.
- Simplify `TransactionMetadata` type.

## References

## Changelog

See `CHANGELOG.md`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
