### PR TITLE
fix: handle missing keyring in notification listener

### DIFF
--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -410,16 +410,18 @@ export default class NotificationServicesController extends BaseController<
     isNotificationAccountsSetup: false,
 
     getNotificationAccounts: async () => {
-      const mainHDWalletAccounts = (await this.messagingSystem.call(
-        'KeyringController:withKeyring',
-        {
-          type: KeyringTypes.hd,
-          index: 0,
-        },
-        async ({ keyring }): Promise<string[]> => {
-          return await keyring.getAccounts();
-        },
-      )) as string[];
+      const mainHDWalletAccounts = (await this.messagingSystem
+        .call(
+          'KeyringController:withKeyring',
+          {
+            type: KeyringTypes.hd,
+            index: 0,
+          },
+          async ({ keyring }): Promise<string[]> => {
+            return await keyring.getAccounts();
+          },
+        )
+        .catch(() => null)) as string[] | null;
 
       return mainHDWalletAccounts;
     },
@@ -433,6 +435,15 @@ export default class NotificationServicesController extends BaseController<
       // Get previous and current account sets
       const nonChecksumAccounts =
         await this.#accounts.getNotificationAccounts();
+
+      if (!nonChecksumAccounts) {
+        return {
+          accountsAdded: [],
+          accountsRemoved: [],
+          accounts: [],
+        };
+      }
+
       const accounts = nonChecksumAccounts
         .map((a) => toChecksumHexAddress(a))
         .filter((a) => isValidHexAddress(a));


### PR DESCRIPTION
## Explanation

Ensures that we handle the `keyring:withKeyring` action throwing an error (when there is a missing keyring)

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/notification-services-controller`

- **FIXED**: return null when `KeyringController:withKeyring` errors inside `NotificationServicesController` 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
