### PR TITLE
fix: gas estimation for type 4 transactions

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix gas estimation for type 4 transactions ([#5519](https://github.com/MetaMask/core/pull/5519))
+
 ## [52.0.0]
 
 ### Changed

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1924,9 +1924,10 @@ describe('TransactionController', () => {
 
       expect(updateGasMock).toHaveBeenCalledTimes(1);
       expect(updateGasMock).toHaveBeenCalledWith({
-        ethQuery: expect.any(Object),
         chainId: CHAIN_ID_MOCK,
+        ethQuery: expect.any(Object),
         isCustomNetwork: false,
+        isSimulationEnabled: true,
         txMeta: expect.any(Object),
       });
     });

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1168,10 +1168,12 @@ describe('TransactionController', () => {
       );
 
       expect(estimateGasMock).toHaveBeenCalledTimes(1);
-      expect(estimateGasMock).toHaveBeenCalledWith(
-        transactionParamsMock,
-        expect.anything(),
-      );
+      expect(estimateGasMock).toHaveBeenCalledWith({
+        chainId: CHAIN_ID_MOCK,
+        ethQuery: expect.anything(),
+        isSimulationEnabled: true,
+        txParams: transactionParamsMock,
+      });
 
       expect(addGasBufferMock).toHaveBeenCalledTimes(1);
       expect(addGasBufferMock).toHaveBeenCalledWith(

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -3966,6 +3966,7 @@ export class TransactionController extends BaseController<
       chainId,
       ethQuery,
       isCustomNetwork,
+      isSimulationEnabled: this.#isSimulationEnabled(),
       txMeta: transactionMeta,
     });
   }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1485,10 +1485,12 @@ export class TransactionController extends BaseController<
       networkClientId,
     });
 
-    const { estimatedGas, simulationFails } = await estimateGas(
-      transaction,
+    const { estimatedGas, simulationFails } = await estimateGas({
+      chainId: this.#getChainId(networkClientId),
       ethQuery,
-    );
+      isSimulationEnabled: this.#isSimulationEnabled(),
+      txParams: transaction,
+    });
 
     return { gas: estimatedGas, simulationFails };
   }
@@ -1510,10 +1512,12 @@ export class TransactionController extends BaseController<
       networkClientId,
     });
 
-    const { blockGasLimit, estimatedGas, simulationFails } = await estimateGas(
-      transaction,
+    const { blockGasLimit, estimatedGas, simulationFails } = await estimateGas({
+      chainId: this.#getChainId(networkClientId),
       ethQuery,
-    );
+      isSimulationEnabled: this.#isSimulationEnabled(),
+      txParams: transaction,
+    });
 
     const gas = addGasBuffer(estimatedGas, blockGasLimit, multiplier);
 

--- a/packages/transaction-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.ts
@@ -4,8 +4,8 @@ import { isValidSignature } from './signature';
 import { projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
 
-export const FEATURE_FLAG_TRANSACTIONS = 'confirmations-transactions';
-export const FEATURE_FLAG_EIP_7702 = 'confirmations-eip-7702';
+export const FEATURE_FLAG_TRANSACTIONS = 'confirmations_transactions';
+export const FEATURE_FLAG_EIP_7702 = 'confirmations_eip_7702';
 
 const DEFAULT_BATCH_SIZE_LIMIT = 10;
 

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -57,6 +57,7 @@ const UPDATE_GAS_REQUEST_MOCK = {
   txMeta: TRANSACTION_META_MOCK,
   chainId: '0x0',
   isCustomNetwork: false,
+  isSimulationEnabled: false,
   ethQuery: ETH_QUERY_MOCK,
 } as UpdateGasRequest;
 

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -508,7 +508,42 @@ describe('gas', () => {
       ]);
     });
 
-    describe('with type 4 transaction', () => {
+    it('normalizes authorization list in estimate request', async () => {
+      mockQuery({
+        getBlockByNumberResponse: { gasLimit: toHex(BLOCK_GAS_LIMIT_MOCK) },
+        estimateGasResponse: toHex(GAS_MOCK),
+      });
+
+      await estimateGas({
+        chainId: CHAIN_ID_MOCK,
+        ethQuery: ETH_QUERY_MOCK,
+        isSimulationEnabled: false,
+        txParams: {
+          ...TRANSACTION_META_MOCK.txParams,
+          authorizationList: AUTHORIZATION_LIST_MOCK,
+          value: undefined,
+        },
+      });
+
+      expect(queryMock).toHaveBeenCalledWith(ETH_QUERY_MOCK, 'estimateGas', [
+        {
+          ...TRANSACTION_META_MOCK.txParams,
+          authorizationList: [
+            {
+              ...AUTHORIZATION_LIST_MOCK[0],
+              chainId: CHAIN_ID_MOCK,
+              nonce: '0x1',
+              r: DUMMY_AUTHORIZATION_SIGNATURE,
+              s: DUMMY_AUTHORIZATION_SIGNATURE,
+              yParity: '0x1',
+            },
+          ],
+          value: '0x0',
+        },
+      ]);
+    });
+
+    describe('with type 4 transaction and data to self', () => {
       it('returns combination of provider estimate and simulation', async () => {
         mockQuery({
           getBlockByNumberResponse: { gasLimit: toHex(BLOCK_GAS_LIMIT_MOCK) },
@@ -530,6 +565,7 @@ describe('gas', () => {
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
             authorizationList: AUTHORIZATION_LIST_MOCK,
+            to: TRANSACTION_META_MOCK.txParams.from,
             type: TransactionEnvelopeType.setCode,
           },
         });
@@ -561,7 +597,17 @@ describe('gas', () => {
           isSimulationEnabled: true,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
-            authorizationList: AUTHORIZATION_LIST_MOCK,
+            authorizationList: [
+              {
+                ...AUTHORIZATION_LIST_MOCK[0],
+                chainId: CHAIN_ID_MOCK,
+                nonce: '0x1',
+                r: DUMMY_AUTHORIZATION_SIGNATURE,
+                s: DUMMY_AUTHORIZATION_SIGNATURE,
+                yParity: '0x1',
+              },
+            ],
+            to: TRANSACTION_META_MOCK.txParams.from,
             type: TransactionEnvelopeType.setCode,
           },
         });
@@ -580,6 +626,7 @@ describe('gas', () => {
               },
             ],
             data: '0x',
+            to: TRANSACTION_META_MOCK.txParams.from,
             type: TransactionEnvelopeType.setCode,
           },
         ]);
@@ -606,12 +653,18 @@ describe('gas', () => {
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
             authorizationList: AUTHORIZATION_LIST_MOCK,
+            to: TRANSACTION_META_MOCK.txParams.from,
             type: TransactionEnvelopeType.setCode,
           },
         });
 
         expect(simulateTransactionsMock).toHaveBeenCalledWith(CHAIN_ID_MOCK, {
-          transactions: [TRANSACTION_META_MOCK.txParams],
+          transactions: [
+            {
+              ...TRANSACTION_META_MOCK.txParams,
+              to: TRANSACTION_META_MOCK.txParams.from,
+            },
+          ],
           overrides: {
             [TRANSACTION_META_MOCK.txParams.from]: {
               code:
@@ -635,6 +688,7 @@ describe('gas', () => {
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
             authorizationList: AUTHORIZATION_LIST_MOCK,
+            to: TRANSACTION_META_MOCK.txParams.from,
             type: TransactionEnvelopeType.setCode,
           },
         });
@@ -667,6 +721,7 @@ describe('gas', () => {
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
             authorizationList: AUTHORIZATION_LIST_MOCK,
+            to: TRANSACTION_META_MOCK.txParams.from,
             type: TransactionEnvelopeType.setCode,
           },
         });

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -19,9 +19,10 @@ import {
 } from '../types';
 
 export type UpdateGasRequest = {
+  chainId: Hex;
   ethQuery: EthQuery;
   isCustomNetwork: boolean;
-  chainId: Hex;
+  isSimulationEnabled: boolean;
   txMeta: TransactionMeta;
 };
 
@@ -199,7 +200,7 @@ export function addGasBuffer(
 async function getGas(
   request: UpdateGasRequest,
 ): Promise<[string, TransactionMeta['simulationFails']?, string?]> {
-  const { isCustomNetwork, chainId, txMeta } = request;
+  const { chainId, isCustomNetwork, isSimulationEnabled, txMeta } = request;
 
   if (txMeta.txParams.gas) {
     log('Using value from request', txMeta.txParams.gas);
@@ -214,7 +215,7 @@ async function getGas(
   const { blockGasLimit, estimatedGas, simulationFails } = await estimateGas({
     chainId: request.chainId,
     ethQuery: request.ethQuery,
-    isSimulationEnabled: false,
+    isSimulationEnabled,
     txParams: txMeta.txParams,
   });
 

--- a/packages/transaction-controller/src/utils/simulation-api.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.ts
@@ -47,12 +47,15 @@ export type SimulationRequest = {
   };
 
   /**
-   * Overrides to the state of the blockchain, keyed by smart contract address.
+   * Overrides to the state of the blockchain, keyed by address.
    */
   overrides?: {
     [address: Hex]: {
-      /** Overrides to the storage slots for a smart contract account. */
-      stateDiff: {
+      /** Override the code for an address. */
+      code?: Hex;
+
+      /** Overrides to the storage slots for an address. */
+      stateDiff?: {
         [slot: Hex]: Hex;
       };
     };
@@ -113,14 +116,17 @@ export type SimulationResponseStateDiff = {
 
 /** Response from the simulation API for a single transaction. */
 export type SimulationResponseTransaction = {
+  /** Hierarchy of call data including nested calls and logs. */
+  callTrace?: SimulationResponseCallTrace;
+
   /** An error message indicating the transaction could not be simulated. */
   error?: string;
 
+  /** The total gas used by the transaction. */
+  gasUsed?: Hex;
+
   /** Return value of the transaction, such as the balance if calling balanceOf. */
   return: Hex;
-
-  /** Hierarchy of call data including nested calls and logs. */
-  callTrace?: SimulationResponseCallTrace;
 
   /** Changes to the blockchain state. */
   stateDiff?: {


### PR DESCRIPTION
## Explanation

The gas for type 4 transactions that include `data` to the upgraded account can only be estimated using `eth_estimateGas` if the real signature properties are included, otherwise the upgraded address cannot be known since it is derived from the signature itself.

As we don't want to sign an authorisation until the user approves the transaction, we will instead:

1. Estimate only the upgrade, with no data and a dummy signature, using `eth_estimateGas`.
2. Estimate the data only on the resulting upgraded EOA using the simulation API to override the account code.
3. Add the two values together, and subtract the intrinsic gas cost (`21000`).

## References

Fixes [#31140](https://github.com/MetaMask/metamask-extension/issues/31140)

## Changelog

See `CHANGELOG.md`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
