### PR TITLE
export `KnownSessionProperties` from chain-agnostic-permission package

### DIFF
--- a/packages/chain-agnostic-permission/src/index.test.ts
+++ b/packages/chain-agnostic-permission/src/index.test.ts
@@ -38,6 +38,7 @@ describe('@metamask/chain-agnostic-permission', () => {
         "caip25EndowmentBuilder",
         "Caip25CaveatMutators",
         "generateCaip25Caveat",
+        "KnownSessionProperties",
       ]
     `);
   });

--- a/packages/chain-agnostic-permission/src/index.ts
+++ b/packages/chain-agnostic-permission/src/index.ts
@@ -62,3 +62,4 @@ export {
   Caip25CaveatMutators,
   generateCaip25Caveat,
 } from './caip25Permission';
+export { KnownSessionProperties } from './scope/constants';


### PR DESCRIPTION
Tiny oversight. Need to export `KnownSessionProperties` from the package index file!