### PR TITLE
feat: add gas fee tokens to transaction metadata

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `gasFeeTokens` to `TransactionMeta` ([#5524](https://github.com/MetaMask/core/pull/5524))
+  - Add `GasFeeToken` type.
+  - Add `selectedGasFeeToken` to `TransactionMeta`.
+  - Add `updateSelectedGasFeeToken` method.
 - Support security validation of transaction batches ([#5526](https://github.com/MetaMask/core/pull/5526))
   - Add `ValidateSecurityRequest` type.
   - Add optional `securityAlertId` to `SecurityAlertResponse`.
@@ -69,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add additional metadata for batch metrics ([#5488](https://github.com/MetaMask/core/pull/5488))
-  - Add `delegationAddress` to `TransactionMetadata`.
+  - Add `delegationAddress` to `TransactionMeta`.
   - Add `NestedTransactionMetadata` type containing `BatchTransactionParams` and `type`.
   - Add optional `type` to `TransactionBatchSingleRequest`.
 - Verify EIP-7702 contract address using signatures ([#5472](https://github.com/MetaMask/core/pull/5472))
@@ -80,8 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Bump `@metamask/accounts-controller` peer dependency to `^26.1.0` ([#5481](https://github.com/MetaMask/core/pull/5481))
 - **BREAKING:** Add additional metadata for batch metrics ([#5488](https://github.com/MetaMask/core/pull/5488))
-  - Change `error` in `TransactionMetadata` to optional for all statuses.
-  - Change `nestedTransactions` in `TransactionMetadata` to array of `NestedTransactionMetadata`.
+  - Change `error` in `TransactionMeta` to optional for all statuses.
+  - Change `nestedTransactions` in `TransactionMeta` to array of `NestedTransactionMetadata`.
 - Throw if `addTransactionBatch` called with external origin and size limit exceeded ([#5489](https://github.com/MetaMask/core/pull/5489))
 - Verify EIP-7702 contract address using signatures ([#5472](https://github.com/MetaMask/core/pull/5472))
   - Use new `contracts` property from feature flags instead of `contractAddresses`.

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -85,6 +85,7 @@ import {
   getTransactionLayer1GasFee,
   updateTransactionLayer1GasFee,
 } from './utils/layer1-gas-fee-flow';
+import type { GetSimulationDataResult } from './utils/simulation';
 import { getSimulationData } from './utils/simulation';
 import {
   updatePostTransactionBalance,
@@ -447,7 +448,7 @@ const TRANSACTION_META_2_MOCK = {
   },
 } as TransactionMeta;
 
-const SIMULATION_DATA_MOCK: Awaited<ReturnType<typeof getSimulationData>> = {
+const SIMULATION_DATA_RESULT_MOCK: GetSimulationDataResult = {
   gasFeeTokens: [],
   simulationData: {
     nativeBalanceChange: {
@@ -1992,7 +1993,7 @@ describe('TransactionController', () => {
 
     describe('updates simulation data', () => {
       it('by default', async () => {
-        getSimulationDataMock.mockResolvedValueOnce(SIMULATION_DATA_MOCK);
+        getSimulationDataMock.mockResolvedValueOnce(SIMULATION_DATA_RESULT_MOCK);
 
         const { controller } = setupController();
 
@@ -2023,12 +2024,12 @@ describe('TransactionController', () => {
         );
 
         expect(controller.state.transactions[0].simulationData).toStrictEqual(
-          SIMULATION_DATA_MOCK.simulationData,
+          SIMULATION_DATA_RESULT_MOCK.simulationData,
         );
       });
 
       it('with error if simulation disabled', async () => {
-        getSimulationDataMock.mockResolvedValueOnce(SIMULATION_DATA_MOCK);
+        getSimulationDataMock.mockResolvedValueOnce(SIMULATION_DATA_RESULT_MOCK);
 
         const { controller } = setupController({
           options: { isSimulationEnabled: () => false },
@@ -2055,7 +2056,7 @@ describe('TransactionController', () => {
       });
 
       it('unless approval not required', async () => {
-        getSimulationDataMock.mockResolvedValueOnce(SIMULATION_DATA_MOCK);
+        getSimulationDataMock.mockResolvedValueOnce(SIMULATION_DATA_RESULT_MOCK);
 
         const { controller } = setupController();
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1993,7 +1993,9 @@ describe('TransactionController', () => {
 
     describe('updates simulation data', () => {
       it('by default', async () => {
-        getSimulationDataMock.mockResolvedValueOnce(SIMULATION_DATA_RESULT_MOCK);
+        getSimulationDataMock.mockResolvedValueOnce(
+          SIMULATION_DATA_RESULT_MOCK,
+        );
 
         const { controller } = setupController();
 
@@ -2029,7 +2031,9 @@ describe('TransactionController', () => {
       });
 
       it('with error if simulation disabled', async () => {
-        getSimulationDataMock.mockResolvedValueOnce(SIMULATION_DATA_RESULT_MOCK);
+        getSimulationDataMock.mockResolvedValueOnce(
+          SIMULATION_DATA_RESULT_MOCK,
+        );
 
         const { controller } = setupController({
           options: { isSimulationEnabled: () => false },
@@ -2056,7 +2060,9 @@ describe('TransactionController', () => {
       });
 
       it('unless approval not required', async () => {
-        getSimulationDataMock.mockResolvedValueOnce(SIMULATION_DATA_RESULT_MOCK);
+        getSimulationDataMock.mockResolvedValueOnce(
+          SIMULATION_DATA_RESULT_MOCK,
+        );
 
         const { controller } = setupController();
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -62,7 +62,6 @@ import type {
   TransactionParams,
   TransactionHistoryEntry,
   TransactionError,
-  SimulationData,
   GasFeeFlow,
   GasFeeFlowResponse,
   SubmitHistoryEntry,
@@ -448,24 +447,27 @@ const TRANSACTION_META_2_MOCK = {
   },
 } as TransactionMeta;
 
-const SIMULATION_DATA_MOCK: SimulationData = {
-  nativeBalanceChange: {
-    previousBalance: '0x0',
-    newBalance: '0x1',
-    difference: '0x1',
-    isDecrease: false,
-  },
-  tokenBalanceChanges: [
-    {
-      address: '0x123',
-      standard: SimulationTokenStandard.erc721,
-      id: '0x456',
-      previousBalance: '0x1',
-      newBalance: '0x3',
-      difference: '0x2',
+const SIMULATION_DATA_MOCK: Awaited<ReturnType<typeof getSimulationData>> = {
+  gasFeeTokens: [],
+  simulationData: {
+    nativeBalanceChange: {
+      previousBalance: '0x0',
+      newBalance: '0x1',
+      difference: '0x1',
       isDecrease: false,
     },
-  ],
+    tokenBalanceChanges: [
+      {
+        address: '0x123',
+        standard: SimulationTokenStandard.erc721,
+        id: '0x456',
+        previousBalance: '0x1',
+        newBalance: '0x3',
+        difference: '0x2',
+        isDecrease: false,
+      },
+    ],
+  },
 };
 
 const GAS_FEE_ESTIMATES_MOCK: GasFeeFlowResponse = {
@@ -2021,7 +2023,7 @@ describe('TransactionController', () => {
         );
 
         expect(controller.state.transactions[0].simulationData).toStrictEqual(
-          SIMULATION_DATA_MOCK,
+          SIMULATION_DATA_MOCK.simulationData,
         );
       });
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -6649,4 +6649,59 @@ describe('TransactionController', () => {
       );
     });
   });
+
+  describe('updateSelectedGasFeeToken', () => {
+    it('updates selected gas fee token in state', () => {
+      const { controller } = setupController({
+        options: {
+          state: {
+            transactions: [
+              {
+                ...TRANSACTION_META_MOCK,
+                gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+              },
+            ],
+          },
+        },
+      });
+
+      controller.updateSelectedGasFeeToken(
+        TRANSACTION_META_MOCK.id,
+        GAS_FEE_TOKEN_MOCK.tokenAddress,
+      );
+
+      expect(controller.state.transactions[0].selectedGasFeeToken).toBe(
+        GAS_FEE_TOKEN_MOCK.tokenAddress,
+      );
+    });
+
+    it('throws if transaction does not exist', () => {
+      const { controller } = setupController();
+
+      expect(() =>
+        controller.updateSelectedGasFeeToken(
+          TRANSACTION_META_MOCK.id,
+          GAS_FEE_TOKEN_MOCK.tokenAddress,
+        ),
+      ).toThrow(
+        `Cannot update transaction as ID not found - ${TRANSACTION_META_MOCK.id}`,
+      );
+    });
+
+    it('throws if no matching gas fee token', () => {
+      const { controller } = setupController({
+        options: {
+          state: {
+            transactions: [
+              { ...TRANSACTION_META_MOCK, gasFeeTokens: [GAS_FEE_TOKEN_MOCK] },
+            ],
+          },
+        },
+      });
+
+      expect(() =>
+        controller.updateSelectedGasFeeToken(TRANSACTION_META_MOCK.id, '0x123'),
+      ).toThrow('No matching gas fee token found');
+    });
+  });
 });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -2510,8 +2510,25 @@ export class TransactionController extends BaseController<
     );
   }
 
-  updateGasFeeToken(transactionId: string, contractAddress: Hex) {
+  /**
+   * Update the selected gas fee token for a transaction.
+   *
+   * @param transactionId - The ID of the transaction to update.
+   * @param contractAddress - The contract address of the selected gas fee token.
+   */
+  updateSelectedGasFeeToken(transactionId: string, contractAddress: Hex) {
     this.#updateTransactionInternal({ transactionId }, (transactionMeta) => {
+      const hasMatchingGasFeeToken = transactionMeta.gasFeeTokens?.some(
+        (token) =>
+          token.tokenAddress.toLowerCase() === contractAddress.toLowerCase(),
+      );
+
+      if (!hasMatchingGasFeeToken) {
+        throw new Error(
+          `No matching gas fee token found with address - ${contractAddress}`,
+        );
+      }
+
       transactionMeta.selectedGasFeeToken = contractAddress;
     });
   }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -2516,14 +2516,17 @@ export class TransactionController extends BaseController<
    * @param transactionId - The ID of the transaction to update.
    * @param contractAddress - The contract address of the selected gas fee token.
    */
-  updateSelectedGasFeeToken(transactionId: string, contractAddress: Hex) {
+  updateSelectedGasFeeToken(
+    transactionId: string,
+    contractAddress: Hex | undefined,
+  ) {
     this.#updateTransactionInternal({ transactionId }, (transactionMeta) => {
       const hasMatchingGasFeeToken = transactionMeta.gasFeeTokens?.some(
         (token) =>
-          token.tokenAddress.toLowerCase() === contractAddress.toLowerCase(),
+          token.tokenAddress.toLowerCase() === contractAddress?.toLowerCase(),
       );
 
-      if (!hasMatchingGasFeeToken) {
+      if (contractAddress && !hasMatchingGasFeeToken) {
         throw new Error(
           `No matching gas fee token found with address - ${contractAddress}`,
         );

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -39,6 +39,7 @@ export type {
   FeeMarketGasFeeEstimateForLevel,
   FeeMarketGasFeeEstimates,
   GasFeeEstimates,
+  GasFeeToken,
   GasPriceGasFeeEstimates,
   GasPriceValue,
   InferTransactionTypeResult,

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -23,6 +23,16 @@ type MakeJsonCompatible<T> = T extends Json
  */
 type JsonCompatibleOperation = MakeJsonCompatible<Operation>;
 
+export type GasFeeToken = {
+  amount: Hex;
+  balance: Hex;
+  decimals: number;
+  rateWei: Hex;
+  recipient: Hex;
+  symbol: string;
+  tokenAddress: Hex;
+};
+
 /**
  * Information about a single transaction such as status and block number.
  */
@@ -183,6 +193,8 @@ export type TransactionMeta = {
    * The number of the latest block when the transaction submit was first retried.
    */
   firstRetryBlockNumber?: string;
+
+  gasFeeTokens?: GasFeeToken[];
 
   /**
    * Whether the transaction is active.
@@ -346,6 +358,8 @@ export type TransactionMeta = {
   // TODO: Replace `any` with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   securityProviderResponse?: Record<string, any>;
+
+  selectedGasFeeToken?: Hex;
 
   /**
    * An array of entries that describe the user's journey through the send flow.

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -23,16 +23,6 @@ type MakeJsonCompatible<T> = T extends Json
  */
 type JsonCompatibleOperation = MakeJsonCompatible<Operation>;
 
-export type GasFeeToken = {
-  amount: Hex;
-  balance: Hex;
-  decimals: number;
-  rateWei: Hex;
-  recipient: Hex;
-  symbol: string;
-  tokenAddress: Hex;
-};
-
 /**
  * Information about a single transaction such as status and block number.
  */
@@ -194,6 +184,7 @@ export type TransactionMeta = {
    */
   firstRetryBlockNumber?: string;
 
+  /** Available tokens that can be used to pay for gas. */
   gasFeeTokens?: GasFeeToken[];
 
   /**
@@ -359,6 +350,10 @@ export type TransactionMeta = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   securityProviderResponse?: Record<string, any>;
 
+  /**
+   * The token address of the selected gas fee token.
+   * Corresponds to the `gasFeeTokens` property.
+   */
   selectedGasFeeToken?: Hex;
 
   /**
@@ -1637,4 +1632,34 @@ export type ValidateSecurityRequest = {
 
   /** Optional EIP-7702 delegation to mock for the transaction sender. */
   delegationMock?: Hex;
+};
+
+/** Data required to pay for transaction gas using an ERC-20 token. */
+export type GasFeeToken = {
+  /** Amount needed for the gas fee. */
+  amount: Hex;
+
+  /** Current token balance of the sender. */
+  balance: Hex;
+
+  /** Decimals of the token. */
+  decimals: number;
+
+  /** The corresponding gas limit this token fee would equal. */
+  gas: Hex;
+
+  /** The corresponding maxFeePerGas this token fee would equal. */
+  maxFeePerGas: Hex;
+
+  /** Conversion rate of 1 token to native WEI. */
+  rateWei: Hex;
+
+  /** Account address to send the token to. */
+  recipient: Hex;
+
+  /** Symbol of the token. */
+  symbol: string;
+
+  /** Address of the token contract. */
+  tokenAddress: Hex;
 };

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1651,6 +1651,9 @@ export type GasFeeToken = {
   /** The corresponding maxFeePerGas this token fee would equal. */
   maxFeePerGas: Hex;
 
+  /** The corresponding maxPriorityFeePerGas this token fee would equal. */
+  maxPriorityFeePerGas: Hex;
+
   /** Conversion rate of 1 token to native WEI. */
   rateWei: Hex;
 

--- a/packages/transaction-controller/src/utils/simulation-api.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.ts
@@ -62,6 +62,11 @@ export type SimulationRequest = {
   };
 
   /**
+   * Whether to include available token fees.
+   */
+  suggestFees?: object;
+
+  /**
    * Whether to include call traces in the response.
    * Defaults to false.
    */
@@ -114,6 +119,24 @@ export type SimulationResponseStateDiff = {
   };
 };
 
+export type SmulationResponseTokenFee = {
+  token: {
+    address: Hex;
+
+    decimals: number;
+
+    symbol: string;
+  };
+
+  balanceNeededToken: Hex;
+
+  currentBalanceToken: Hex;
+
+  feeRecipient: Hex;
+
+  rateWei: Hex;
+};
+
 /** Response from the simulation API for a single transaction. */
 export type SimulationResponseTransaction = {
   /** Hierarchy of call data including nested calls and logs. */
@@ -121,6 +144,12 @@ export type SimulationResponseTransaction = {
 
   /** An error message indicating the transaction could not be simulated. */
   error?: string;
+
+  fees?: [
+    {
+      tokenFees: SmulationResponseTokenFee[];
+    },
+  ];
 
   /** The total gas used by the transaction. */
   gasUsed?: Hex;

--- a/packages/transaction-controller/src/utils/simulation-api.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.ts
@@ -153,21 +153,20 @@ export type SimulationResponseTransaction = {
   /** An error message indicating the transaction could not be simulated. */
   error?: string;
 
-  fees?: [
-    {
-      /** Gas limit for the fee level. */
-      gas: Hex;
+  /** Recommended gas fees for the transaction. */
+  fees?: {
+    /** Gas limit for the fee level. */
+    gas: Hex;
 
-      /** Maximum fee per gas for the fee level. */
-      maxFeePerGas: Hex;
+    /** Maximum fee per gas for the fee level. */
+    maxFeePerGas: Hex;
 
-      /** Maximum priority fee per gas for the fee level. */
-      maxPriorityFeePerGas: Hex;
+    /** Maximum priority fee per gas for the fee level. */
+    maxPriorityFeePerGas: Hex;
 
-      /** Token fee data for the fee level. */
-      tokenFees: SmulationResponseTokenFee[];
-    },
-  ];
+    /** Token fee data for the fee level. */
+    tokenFees: SmulationResponseTokenFee[];
+  }[];
 
   /** The total gas used by the transaction. */
   gasUsed?: Hex;

--- a/packages/transaction-controller/src/utils/simulation-api.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.ts
@@ -120,20 +120,28 @@ export type SimulationResponseStateDiff = {
 };
 
 export type SmulationResponseTokenFee = {
+  /** Token data independent of current transaction. */
   token: {
+    /** Address of the token contract. */
     address: Hex;
 
+    /** Decimals of the token. */
     decimals: number;
 
+    /** Symbol of the token. */
     symbol: string;
   };
 
+  /** Amount of tokens needed to pay for gas. */
   balanceNeededToken: Hex;
 
+  /** Current token balance of sender. */
   currentBalanceToken: Hex;
 
+  /** Account address that token should be transferred to. */
   feeRecipient: Hex;
 
+  /** Conversation rate of 1 token to native WEI. */
   rateWei: Hex;
 };
 
@@ -147,6 +155,16 @@ export type SimulationResponseTransaction = {
 
   fees?: [
     {
+      /** Gas limit for the fee level. */
+      gas: Hex;
+
+      /** Maximum fee per gas for the fee level. */
+      maxFeePerGas: Hex;
+
+      /** Maximum priority fee per gas for the fee level. */
+      maxPriorityFeePerGas: Hex;
+
+      /** Token fee data for the fee level. */
       tokenFees: SmulationResponseTokenFee[];
     },
   ];

--- a/packages/transaction-controller/src/utils/simulation-api.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.ts
@@ -64,7 +64,13 @@ export type SimulationRequest = {
   /**
    * Whether to include available token fees.
    */
-  suggestFees?: object;
+  suggestFees?: {
+    /* Whether to include the native transfer if available. */
+    withTransfer?: boolean;
+
+    /* Whether to include the gas fee of the token transfer. */
+    withFeeTransfer?: boolean;
+  };
 
   /**
    * Whether to include call traces in the response.

--- a/packages/transaction-controller/src/utils/simulation-api.ts
+++ b/packages/transaction-controller/src/utils/simulation-api.ts
@@ -125,7 +125,7 @@ export type SimulationResponseStateDiff = {
   };
 };
 
-export type SmulationResponseTokenFee = {
+export type SimulationResponseTokenFee = {
   /** Token data independent of current transaction. */
   token: {
     /** Address of the token contract. */
@@ -171,7 +171,7 @@ export type SimulationResponseTransaction = {
     maxPriorityFeePerGas: Hex;
 
     /** Token fee data for the fee level. */
-    tokenFees: SmulationResponseTokenFee[];
+    tokenFees: SimulationResponseTokenFee[];
   }[];
 
   /** The total gas used by the transaction. */

--- a/packages/transaction-controller/src/utils/simulation.test.ts
+++ b/packages/transaction-controller/src/utils/simulation.test.ts
@@ -274,9 +274,9 @@ describe('Simulation Utils', () => {
             createNativeBalanceResponse(previousBalance, newBalance),
           );
 
-          const simulationData = await getSimulationData(REQUEST_MOCK);
+          const result = await getSimulationData(REQUEST_MOCK);
 
-          expect(simulationData).toStrictEqual({
+          expect(result.simulationData).toStrictEqual({
             nativeBalanceChange: {
               difference: DIFFERENCE_MOCK,
               isDecrease,
@@ -293,9 +293,9 @@ describe('Simulation Utils', () => {
           createNativeBalanceResponse(BALANCE_1_MOCK, BALANCE_1_MOCK),
         );
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           nativeBalanceChange: undefined,
           tokenBalanceChanges: [],
         });
@@ -403,12 +403,12 @@ describe('Simulation Utils', () => {
               createBalanceOfResponse(previousBalances, newBalances),
             );
 
-          const simulationData = await getSimulationData({
+          const result = await getSimulationData({
             chainId: '0x1',
             from,
           });
 
-          expect(simulationData).toStrictEqual({
+          expect(result.simulationData).toStrictEqual({
             nativeBalanceChange: undefined,
             tokenBalanceChanges: [
               {
@@ -453,9 +453,9 @@ describe('Simulation Utils', () => {
             ),
           );
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           nativeBalanceChange: undefined,
           tokenBalanceChanges: [
             {
@@ -509,9 +509,9 @@ describe('Simulation Utils', () => {
             createBalanceOfResponse([BALANCE_2_MOCK], [BALANCE_1_MOCK]),
           );
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           nativeBalanceChange: undefined,
           tokenBalanceChanges: [
             {
@@ -553,9 +553,9 @@ describe('Simulation Utils', () => {
             ),
           );
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           nativeBalanceChange: undefined,
           tokenBalanceChanges: [
             {
@@ -614,7 +614,7 @@ describe('Simulation Utils', () => {
             ),
           );
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
         expect(simulateTransactionsMock).toHaveBeenCalledTimes(2);
 
@@ -648,7 +648,7 @@ describe('Simulation Utils', () => {
             ],
           },
         );
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           nativeBalanceChange: undefined,
           tokenBalanceChanges: [
             {
@@ -684,9 +684,9 @@ describe('Simulation Utils', () => {
             createBalanceOfResponse([BALANCE_1_MOCK], [BALANCE_2_MOCK]),
           );
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           nativeBalanceChange: undefined,
           tokenBalanceChanges: [],
         });
@@ -708,9 +708,9 @@ describe('Simulation Utils', () => {
           createEventResponseMock([createLogMock(CONTRACT_ADDRESS_1_MOCK)]),
         );
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           nativeBalanceChange: undefined,
           tokenBalanceChanges: [],
         });
@@ -729,9 +729,9 @@ describe('Simulation Utils', () => {
             createBalanceOfResponse([BALANCE_1_MOCK], [BALANCE_1_MOCK]),
           );
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           nativeBalanceChange: undefined,
           tokenBalanceChanges: [],
         });
@@ -746,9 +746,9 @@ describe('Simulation Utils', () => {
             createBalanceOfResponse([BALANCE_1_MOCK], [BALANCE_2_MOCK]),
           );
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           nativeBalanceChange: undefined,
           tokenBalanceChanges: [
             {
@@ -797,9 +797,9 @@ describe('Simulation Utils', () => {
             ],
           });
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           nativeBalanceChange: undefined,
           tokenBalanceChanges: [
             {
@@ -823,7 +823,9 @@ describe('Simulation Utils', () => {
           message: ERROR_MESSAGE_MOCK,
         });
 
-        expect(await getSimulationData(REQUEST_MOCK)).toStrictEqual({
+        const result = await getSimulationData(REQUEST_MOCK);
+
+        expect(result.simulationData).toStrictEqual({
           error: {
             code: ERROR_CODE_MOCK,
             message: ERROR_MESSAGE_MOCK,
@@ -837,7 +839,9 @@ describe('Simulation Utils', () => {
           code: ERROR_CODE_MOCK,
         });
 
-        expect(await getSimulationData(REQUEST_MOCK)).toStrictEqual({
+        const result = await getSimulationData(REQUEST_MOCK);
+
+        expect(result.simulationData).toStrictEqual({
           error: {
             code: ERROR_CODE_MOCK,
             message: undefined,
@@ -855,9 +859,9 @@ describe('Simulation Utils', () => {
           )
           .mockResolvedValueOnce(createBalanceOfResponse([], []));
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           error: {
             code: SimulationErrorCode.InvalidResponse,
             message: new SimulationInvalidResponseError().message,
@@ -876,9 +880,9 @@ describe('Simulation Utils', () => {
           ],
         });
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           error: {
             code: SimulationErrorCode.Reverted,
             message: new SimulationRevertedError().message,
@@ -897,9 +901,9 @@ describe('Simulation Utils', () => {
           ],
         });
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           error: {
             code: undefined,
             message: 'test 1 2 3',
@@ -914,9 +918,9 @@ describe('Simulation Utils', () => {
           message: 'test insufficient funds for gas test',
         });
 
-        const simulationData = await getSimulationData(REQUEST_MOCK);
+        const result = await getSimulationData(REQUEST_MOCK);
 
-        expect(simulationData).toStrictEqual({
+        expect(result.simulationData).toStrictEqual({
           error: {
             code: SimulationErrorCode.Reverted,
             message: new SimulationRevertedError().message,

--- a/packages/transaction-controller/src/utils/simulation.test.ts
+++ b/packages/transaction-controller/src/utils/simulation.test.ts
@@ -929,5 +929,157 @@ describe('Simulation Utils', () => {
         });
       });
     });
+
+    describe('returns gas fee tokens', () => {
+      it('using token fee data', async () => {
+        simulateTransactionsMock.mockResolvedValueOnce({
+          transactions: [
+            {
+              fees: [
+                {
+                  gas: '0x1',
+                  maxFeePerGas: '0x2',
+                  maxPriorityFeePerGas: '0x3',
+                  tokenFees: [
+                    {
+                      token: {
+                        address: CONTRACT_ADDRESS_1_MOCK,
+                        decimals: 3,
+                        symbol: 'TEST1',
+                      },
+                      balanceNeededToken: '0x4',
+                      currentBalanceToken: '0x5',
+                      feeRecipient: '0x6',
+                      rateWei: '0x7',
+                    },
+                    {
+                      token: {
+                        address: CONTRACT_ADDRESS_2_MOCK,
+                        decimals: 4,
+                        symbol: 'TEST2',
+                      },
+                      balanceNeededToken: '0x8',
+                      currentBalanceToken: '0x9',
+                      feeRecipient: '0xa',
+                      rateWei: '0xb',
+                    },
+                  ],
+                },
+              ],
+              return: '0x',
+            },
+          ],
+        });
+
+        const result = await getSimulationData(REQUEST_MOCK);
+
+        expect(result.gasFeeTokens).toStrictEqual([
+          {
+            amount: '0x4',
+            balance: '0x5',
+            decimals: 3,
+            gas: '0x1',
+            maxFeePerGas: '0x2',
+            maxPriorityFeePerGas: '0x3',
+            rateWei: '0x7',
+            recipient: '0x6',
+            symbol: 'TEST1',
+            tokenAddress: CONTRACT_ADDRESS_1_MOCK,
+          },
+          {
+            amount: '0x8',
+            balance: '0x9',
+            decimals: 4,
+            gas: '0x1',
+            maxFeePerGas: '0x2',
+            maxPriorityFeePerGas: '0x3',
+            rateWei: '0xb',
+            recipient: '0xa',
+            symbol: 'TEST2',
+            tokenAddress: CONTRACT_ADDRESS_2_MOCK,
+          },
+        ]);
+      });
+
+      it('using first fee level', async () => {
+        simulateTransactionsMock.mockResolvedValueOnce({
+          transactions: [
+            {
+              fees: [
+                {
+                  gas: '0x1',
+                  maxFeePerGas: '0x2',
+                  maxPriorityFeePerGas: '0x3',
+                  tokenFees: [
+                    {
+                      token: {
+                        address: CONTRACT_ADDRESS_1_MOCK,
+                        decimals: 3,
+                        symbol: 'TEST1',
+                      },
+                      balanceNeededToken: '0x4',
+                      currentBalanceToken: '0x5',
+                      feeRecipient: '0x6',
+                      rateWei: '0x7',
+                    },
+                  ],
+                },
+                {
+                  gas: '0x8',
+                  maxFeePerGas: '0x9',
+                  maxPriorityFeePerGas: '0xa',
+                  tokenFees: [
+                    {
+                      token: {
+                        address: CONTRACT_ADDRESS_2_MOCK,
+                        decimals: 4,
+                        symbol: 'TEST2',
+                      },
+                      balanceNeededToken: '0xb',
+                      currentBalanceToken: '0xc',
+                      feeRecipient: '0xd',
+                      rateWei: '0xe',
+                    },
+                  ],
+                },
+              ],
+              return: '0x',
+            },
+          ],
+        });
+
+        const result = await getSimulationData(REQUEST_MOCK);
+
+        expect(result.gasFeeTokens).toStrictEqual([
+          {
+            amount: '0x4',
+            balance: '0x5',
+            decimals: 3,
+            gas: '0x1',
+            maxFeePerGas: '0x2',
+            maxPriorityFeePerGas: '0x3',
+            rateWei: '0x7',
+            recipient: '0x6',
+            symbol: 'TEST1',
+            tokenAddress: CONTRACT_ADDRESS_1_MOCK,
+          },
+        ]);
+      });
+
+      it('as empty if missing data', async () => {
+        simulateTransactionsMock.mockResolvedValueOnce({
+          transactions: [
+            {
+              fees: [],
+              return: '0x',
+            },
+          ],
+        });
+
+        const result = await getSimulationData(REQUEST_MOCK);
+
+        expect(result.gasFeeTokens).toStrictEqual([]);
+      });
+    });
   });
 });

--- a/packages/transaction-controller/src/utils/simulation.ts
+++ b/packages/transaction-controller/src/utils/simulation.ts
@@ -131,13 +131,14 @@ export async function getSimulationData(
         {
           data,
           from,
-          maxFeePerGas: '0x0',
-          maxPriorityFeePerGas: '0x0',
           to,
           value,
         },
       ],
-      suggestFees: {},
+      suggestFees: {
+        withTransfer: true,
+        withFeeTransfer: true,
+      },
       withCallTrace: true,
       withLogs: true,
       ...(blockTime && {

--- a/packages/transaction-controller/src/utils/simulation.ts
+++ b/packages/transaction-controller/src/utils/simulation.ts
@@ -49,6 +49,11 @@ export type GetSimulationDataRequest = {
   value?: Hex;
 };
 
+export type GetSimulationDataResult = {
+  gasFeeTokens: GasFeeToken[];
+  simulationData: SimulationData;
+};
+
 type ParsedEvent = {
   contractAddress: Hex;
   tokenStandard: SimulationTokenStandard;
@@ -114,10 +119,7 @@ type BalanceTransactionMap = Map<SimulationToken, SimulationRequestTransaction>;
 export async function getSimulationData(
   request: GetSimulationDataRequest,
   options: GetSimulationDataOptions = {},
-): Promise<{
-  gasFeeTokens: GasFeeToken[];
-  simulationData: SimulationData;
-}> {
+): Promise<GetSimulationDataResult> {
   const { chainId, from, to, value, data } = request;
   const { blockTime } = options;
 

--- a/packages/transaction-controller/src/utils/simulation.ts
+++ b/packages/transaction-controller/src/utils/simulation.ts
@@ -169,7 +169,13 @@ export async function getSimulationData(
       tokenBalanceChanges,
     };
 
-    const gasFeeTokens = getGasFeeTokens(response);
+    let gasFeeTokens: GasFeeToken[] = [];
+
+    try {
+      gasFeeTokens = getGasFeeTokens(response);
+    } catch (error) {
+      log('Failed to parse gas fee tokens', error, response);
+    }
 
     return {
       gasFeeTokens,
@@ -711,8 +717,8 @@ function getContractInterfaces(): Map<SupportedToken, Interface> {
  * @returns An array of gas fee tokens.
  */
 function getGasFeeTokens(response: SimulationResponse): GasFeeToken[] {
-  const feeLevel = response.transactions[0]
-    .fees?.[0] as Required<SimulationResponseTransaction>['fees'][0];
+  const feeLevel = response.transactions?.[0]
+    ?.fees?.[0] as Required<SimulationResponseTransaction>['fees'][0];
 
   const tokenFees = feeLevel?.tokenFees ?? [];
 

--- a/packages/transaction-controller/src/utils/simulation.ts
+++ b/packages/transaction-controller/src/utils/simulation.ts
@@ -711,15 +711,21 @@ function getContractInterfaces(): Map<SupportedToken, Interface> {
  * @returns An array of gas fee tokens.
  */
 function getGasFeeTokens(response: SimulationResponse): GasFeeToken[] {
-  const tokenFees = response.transactions?.[0]?.fees?.[0]?.tokenFees ?? [];
+  const feeLevel = response.transactions[0]
+    .fees?.[0] as Required<SimulationResponseTransaction>['fees'][0];
 
-  return tokenFees.map((fee) => ({
-    amount: fee.balanceNeededToken,
-    balance: fee.currentBalanceToken,
-    decimals: fee.token.decimals,
-    rateWei: fee.rateWei,
-    recipient: fee.feeRecipient,
-    symbol: fee.token.symbol,
-    tokenAddress: fee.token.address,
+  const tokenFees = feeLevel?.tokenFees ?? [];
+
+  return tokenFees.map((tokenFee) => ({
+    amount: tokenFee.balanceNeededToken,
+    balance: tokenFee.currentBalanceToken,
+    decimals: tokenFee.token.decimals,
+    gas: feeLevel.gas,
+    maxFeePerGas: feeLevel.maxFeePerGas,
+    maxPriorityFeePerGas: feeLevel.maxPriorityFeePerGas,
+    rateWei: tokenFee.rateWei,
+    recipient: tokenFee.feeRecipient,
+    symbol: tokenFee.token.symbol,
+    tokenAddress: tokenFee.token.address,
   }));
 }


### PR DESCRIPTION
## Explanation

Retrieve the available gas fee tokens from the simulation API when adding a transaction, and save them in the transaction metadata.

Specifically:

- Add `gasFeeTokens` to `TransactionMetadata`.
- Add `selectedGasFeeToken` to `TransactionMetadata`.
- Add additional request and response properties to types in `utils/simulation-api.ts`.
- Update `utils/simulation.ts` to parse the gas fee tokens from the response. 

## References

Fixes [#4458](https://github.com/MetaMask/MetaMask-planning/issues/4458)

## Changelog

See `CHANGELOG.md`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
