### PR TITLE
feat: transaction batch security validation

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support security validation of transaction batches ([#5526](https://github.com/MetaMask/core/pull/5526))
+  - Add `ValidateSecurityRequest` type.
+  - Add optional `securityAlertId` to `SecurityAlertResponse`.
+  - Add optional `securityAlertId` to `TransactionBatchRequest`.
+  - Add optional `validateSecurity` callback to `TransactionBatchRequest`.
 - Support publish batch hook ([#5401](https://github.com/MetaMask/core/pull/5401))
   - Add `hooks.publishBatch` option to constructor.
   - Add `updateBatchTransactions` method.

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -68,6 +68,7 @@ export type {
   TransactionMeta,
   TransactionParams,
   TransactionReceipt,
+  ValidateSecurityRequest,
 } from './types';
 export {
   GasFeeEstimateLevel,

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1140,8 +1140,8 @@ export type TransactionError = {
 export type SecurityAlertResponse = {
   features?: string[];
   providerRequestsCount?: Record<string, number>;
-  reason?: string;
-  result_type?: string;
+  reason: string;
+  result_type: string;
   securityAlertId?: string;
 };
 

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1138,10 +1138,11 @@ export type TransactionError = {
  * Type for security alert response from transaction validator.
  */
 export type SecurityAlertResponse = {
-  reason: string;
   features?: string[];
-  result_type: string;
   providerRequestsCount?: Record<string, number>;
+  reason?: string;
+  result_type?: string;
+  securityAlertId?: string;
 };
 
 /** Alternate priority levels for which values are provided in gas fee estimates. */
@@ -1513,6 +1514,9 @@ export type TransactionBatchRequest = {
   /** Whether an approval request should be created to require confirmation from the user. */
   requireApproval?: boolean;
 
+  /** Security alert ID to persist on the transaction. */
+  securityAlertId?: string;
+
   /** Transactions to be submitted as part of the batch. */
   transactions: TransactionBatchSingleRequest[];
 
@@ -1521,6 +1525,17 @@ export type TransactionBatchRequest = {
    * Defaults to false.
    */
   useHook?: boolean;
+
+  /**
+   * Callback to trigger security validation in the client.
+   *
+   * @param request - The JSON-RPC request to validate.
+   * @param chainId - The chain ID of the transaction batch.
+   */
+  validateSecurity?: (
+    request: ValidateSecurityRequest,
+    chainId: Hex,
+  ) => Promise<void>;
 };
 
 /**
@@ -1595,3 +1610,17 @@ export type PublishBatchHook = (
   /** Data required to call the hook. */
   request: PublishBatchHookRequest,
 ) => Promise<PublishBatchHookResult>;
+
+/**
+ * Request to validate security of a transaction in the client.
+ */
+export type ValidateSecurityRequest = {
+  /** JSON-RPC method to validate. */
+  method: string;
+
+  /** Parameters of the JSON-RPC method to validate. */
+  params: unknown[];
+
+  /** Optional EIP-7702 delegation to mock for the transaction sender. */
+  delegationMock?: Hex;
+};

--- a/packages/transaction-controller/src/utils/batch.test.ts
+++ b/packages/transaction-controller/src/utils/batch.test.ts
@@ -52,6 +52,7 @@ const TRANSACTION_HASH_2_MOCK = '0x456';
 const TRANSACTION_SIGNATURE_MOCK = '0xabc';
 const TRANSACTION_SIGNATURE_2_MOCK = '0xdef';
 const ERROR_MESSAGE_MOCK = 'Test error';
+const SECURITY_ALERT_ID_MOCK = '123-456';
 
 const TRANSACTION_META_MOCK = {
   id: BATCH_ID_CUSTOM_MOCK,
@@ -61,7 +62,7 @@ const TRANSACTION_META_MOCK = {
     data: DATA_MOCK,
     value: VALUE_MOCK,
   },
-} as TransactionMeta;
+} as unknown as TransactionMeta;
 
 describe('Batch Utils', () => {
   const doesChainSupportEIP7702Mock = jest.mocked(doesChainSupportEIP7702);
@@ -100,11 +101,13 @@ describe('Batch Utils', () => {
       jest.resetAllMocks();
       addTransactionMock = jest.fn();
       getChainIdMock = jest.fn();
+      updateTransactionMock = jest.fn();
 
       determineTransactionTypeMock.mockResolvedValue({
         type: TransactionType.simpleSend,
       });
-      updateTransactionMock = jest.fn();
+
+      getChainIdMock.mockReturnValue(CHAIN_ID_MOCK);
 
       request = {
         addTransaction: addTransactionMock,
@@ -406,6 +409,138 @@ describe('Batch Utils', () => {
       await expect(addTransactionBatch(request)).rejects.toThrow(
         'Validation Error',
       );
+    });
+
+    it('adds security alert ID to transaction', async () => {
+      doesChainSupportEIP7702Mock.mockReturnValueOnce(true);
+
+      isAccountUpgradedToEIP7702Mock.mockResolvedValueOnce({
+        delegationAddress: undefined,
+        isSupported: true,
+      });
+
+      addTransactionMock.mockResolvedValueOnce({
+        transactionMeta: TRANSACTION_META_MOCK,
+        result: Promise.resolve(''),
+      });
+
+      generateEIP7702BatchTransactionMock.mockReturnValueOnce({
+        to: TO_MOCK,
+        data: DATA_MOCK,
+        value: VALUE_MOCK,
+      });
+
+      request.request.securityAlertId = SECURITY_ALERT_ID_MOCK;
+
+      await addTransactionBatch(request);
+
+      expect(addTransactionMock).toHaveBeenCalledTimes(1);
+      expect(addTransactionMock).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          securityAlertResponse: {
+            securityAlertId: SECURITY_ALERT_ID_MOCK,
+          },
+        }),
+      );
+    });
+
+    describe('validates security', () => {
+      it('using transaction params', async () => {
+        doesChainSupportEIP7702Mock.mockReturnValueOnce(true);
+
+        isAccountUpgradedToEIP7702Mock.mockResolvedValueOnce({
+          delegationAddress: undefined,
+          isSupported: true,
+        });
+
+        addTransactionMock.mockResolvedValueOnce({
+          transactionMeta: TRANSACTION_META_MOCK,
+          result: Promise.resolve(''),
+        });
+
+        generateEIP7702BatchTransactionMock.mockReturnValueOnce({
+          to: TO_MOCK,
+          data: DATA_MOCK,
+          value: VALUE_MOCK,
+        });
+
+        const validateSecurityMock = jest.fn();
+        validateSecurityMock.mockResolvedValueOnce({});
+
+        request.request.validateSecurity = validateSecurityMock;
+
+        await addTransactionBatch(request);
+
+        expect(validateSecurityMock).toHaveBeenCalledTimes(1);
+        expect(validateSecurityMock).toHaveBeenCalledWith(
+          {
+            delegationMock: undefined,
+            method: 'eth_sendTransaction',
+            params: [
+              {
+                authorizationList: undefined,
+                data: DATA_MOCK,
+                from: FROM_MOCK,
+                to: TO_MOCK,
+                type: TransactionEnvelopeType.feeMarket,
+                value: VALUE_MOCK,
+              },
+            ],
+          },
+          CHAIN_ID_MOCK,
+        );
+      });
+
+      it('using delegation mock if not upgraded', async () => {
+        doesChainSupportEIP7702Mock.mockReturnValueOnce(true);
+
+        isAccountUpgradedToEIP7702Mock.mockResolvedValueOnce({
+          delegationAddress: undefined,
+          isSupported: false,
+        });
+
+        addTransactionMock.mockResolvedValueOnce({
+          transactionMeta: TRANSACTION_META_MOCK,
+          result: Promise.resolve(''),
+        });
+
+        generateEIP7702BatchTransactionMock.mockReturnValueOnce({
+          to: TO_MOCK,
+          data: DATA_MOCK,
+          value: VALUE_MOCK,
+        });
+
+        getEIP7702UpgradeContractAddressMock.mockReturnValue(
+          CONTRACT_ADDRESS_MOCK,
+        );
+
+        const validateSecurityMock = jest.fn();
+        validateSecurityMock.mockResolvedValueOnce({});
+
+        request.request.validateSecurity = validateSecurityMock;
+
+        await addTransactionBatch(request);
+
+        expect(validateSecurityMock).toHaveBeenCalledTimes(1);
+        expect(validateSecurityMock).toHaveBeenCalledWith(
+          {
+            delegationMock: CONTRACT_ADDRESS_MOCK,
+            method: 'eth_sendTransaction',
+            params: [
+              {
+                authorizationList: undefined,
+                data: DATA_MOCK,
+                from: FROM_MOCK,
+                to: TO_MOCK,
+                type: TransactionEnvelopeType.feeMarket,
+                value: VALUE_MOCK,
+              },
+            ],
+          },
+          CHAIN_ID_MOCK,
+        );
+      });
     });
 
     describe('with publish batch hook', () => {

--- a/packages/transaction-controller/src/utils/batch.ts
+++ b/packages/transaction-controller/src/utils/batch.ts
@@ -26,6 +26,7 @@ import { CollectPublishHook } from '../hooks/CollectPublishHook';
 import { projectLogger } from '../logger';
 import type {
   NestedTransactionMetadata,
+  SecurityAlertResponse,
   TransactionBatchSingleRequest,
   PublishBatchHook,
   PublishBatchHookTransaction,
@@ -189,7 +190,7 @@ export async function addTransactionBatch(
   const batchId = batchIdOverride ?? generateBatchId();
 
   const securityAlertResponse = securityAlertId
-    ? { securityAlertId }
+    ? ({ securityAlertId } as SecurityAlertResponse)
     : undefined;
 
   const { result } = await addTransaction(txParams, {


### PR DESCRIPTION
## Explanation

Support triggering security validation in the client while processing transaction batches.

Specifically:

- Add `ValidateSecurityRequest` type.
- Add optional `validateSecurity` callback to `TransactionBatchRequest` type.
- Add optional `securityAlertId` to `AddTransactionBatchRequest` type.
- Add optional `securityAlertId` to `SecurityAlertResponse` type.
- Call `validateSecurity` callback after generating EIP-7702 transaction.
- Include `delegationMock` if an EIP-7702 type 4 transaction.

## References

Relates to [ #31263](https://github.com/MetaMask/metamask-extension/issues/31263)

## Changelog

See `CHANGELOG.md`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
