### PR TITLE
fix: improve token rate response aborting

### DIFF
--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -538,7 +538,10 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
 
     const tokenAddresses = this.#getTokenAddresses(chainId);
 
-    // Key also compromises token addresses, as we do want to re-fetch if there are new tokens discovered
+    // Key dependencies that will trigger a new request instead of aborting:
+    // - chainId - different chains require a new request
+    // - nativeCurrency - changing native currency requires fetching different rates
+    // - tokenAddress length - if we have detected any new tokens, we will need to make a new request for the rates
     const updateKey: `${Hex}:${string}` = `${chainId}:${nativeCurrency}:${tokenAddresses.length}`;
     if (updateKey in this.#inProcessExchangeRateUpdates) {
       // This prevents redundant updates

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -538,7 +538,8 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
 
     const tokenAddresses = this.#getTokenAddresses(chainId);
 
-    const updateKey: `${Hex}:${string}` = `${chainId}:${nativeCurrency}`;
+    // Key also compromises token addresses, as we do want to re-fetch if there are new tokens discovered
+    const updateKey: `${Hex}:${string}` = `${chainId}:${nativeCurrency}:${tokenAddresses.length}`;
     if (updateKey in this.#inProcessExchangeRateUpdates) {
       // This prevents redundant updates
       // This promise is resolved after the in-progress update has finished,


### PR DESCRIPTION


## Explanation

When onboarding, we make token rates requests with 0 tokens, and then follows up with >0 tokens (once detected).
However the old approach aborts the most recent request (that contains new tokens), which prevents the UI from updating with rates until the next polling cycle (or if we stop/start polling again).

My hypothesis is, since we've improved the front-end performance on Extension and Mobile to reduce re-renders, we have optimised our polling hooks to not be recalled (reducing the number of times we stop/start the polling services). And because of the reduced poll restarts, we've uncovered this bug.


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/assets-controllers`

- **FIXED**: updated token rate request key to handle when new tokens are detected inside the `TokenRatesController`


## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
