### PR TITLE
feat: earn controller convert method args to options bags

### DIFF
--- a/packages/earn-controller/src/EarnController.test.ts
+++ b/packages/earn-controller/src/EarnController.test.ts
@@ -98,8 +98,10 @@ const createMockInternalAccount = ({
   };
 };
 
+const mockAddress = '0x1234';
+
 const mockPooledStakes = {
-  account: '0x1234',
+  account: mockAddress,
   lifetimeRewards: '100',
   assets: '1000',
   exitRequests: [],
@@ -208,7 +210,7 @@ const setupController = ({
   })),
 
   mockGetSelectedAccount = jest.fn(() => ({
-    address: '0x1234',
+    address: mockAddress,
   })),
 }: {
   options?: Partial<ConstructorParameters<typeof EarnController>[0]>;
@@ -389,7 +391,7 @@ describe('EarnController', () => {
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         // First call occurs during setupController()
         2,
-        ['0x1234'],
+        [mockAddress],
         1,
         false,
       );
@@ -402,7 +404,7 @@ describe('EarnController', () => {
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         // First call occurs during setupController()
         2,
-        ['0x1234'],
+        [mockAddress],
         1,
         true,
       );
@@ -464,12 +466,12 @@ describe('EarnController', () => {
   describe('refreshPooledStakes', () => {
     it('fetches without resetting cache when resetCache is false', async () => {
       const { controller } = setupController();
-      await controller.refreshPooledStakes(false);
+      await controller.refreshPooledStakes({ resetCache: false });
 
       // Assertion on second call since the first is part of controller setup.
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         2,
-        ['0x1234'],
+        [mockAddress],
         1,
         false,
       );
@@ -482,7 +484,7 @@ describe('EarnController', () => {
       // Assertion on second call since the first is part of controller setup.
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         2,
-        ['0x1234'],
+        [mockAddress],
         1,
         false,
       );
@@ -490,14 +492,40 @@ describe('EarnController', () => {
 
     it('fetches while resetting cache', async () => {
       const { controller } = setupController();
-      await controller.refreshPooledStakes(true);
+      await controller.refreshPooledStakes({ resetCache: true });
 
       // Assertion on second call since the first is part of controller setup.
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         2,
-        ['0x1234'],
+        [mockAddress],
         1,
         true,
+      );
+    });
+
+    it('fetches using active account (default)', async () => {
+      const { controller } = setupController();
+      await controller.refreshPooledStakes();
+
+      // Assertion on second call since the first is part of controller setup.
+      expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
+        2,
+        [mockAddress],
+        1,
+        false,
+      );
+    });
+
+    it('fetches using options.address override', async () => {
+      const { controller } = setupController();
+      await controller.refreshPooledStakes({ address: mockAddress });
+
+      // Assertion on second call since the first is part of controller setup.
+      expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
+        2,
+        [mockAddress],
+        1,
+        false,
       );
     });
   });
@@ -511,14 +539,11 @@ describe('EarnController', () => {
       // Assertion on second call since the first is part of controller setup.
       expect(
         mockedStakingApiService.getPooledStakingEligibility,
-      ).toHaveBeenNthCalledWith(2, ['0x1234']);
+      ).toHaveBeenNthCalledWith(2, [mockAddress]);
     });
 
     it('fetches staking eligibility using options.address', async () => {
       const { controller } = setupController();
-
-      const mockAddress = '0xabc';
-
       await controller.refreshStakingEligibility({ address: mockAddress });
 
       // Assertion on second call since the first is part of controller setup.
@@ -530,7 +555,7 @@ describe('EarnController', () => {
 
   describe('subscription handlers', () => {
     const firstAccount = createMockInternalAccount({
-      address: '0x1234',
+      address: mockAddress,
     });
 
     it('updates vault data when network changes', () => {

--- a/packages/earn-controller/src/EarnController.test.ts
+++ b/packages/earn-controller/src/EarnController.test.ts
@@ -502,6 +502,32 @@ describe('EarnController', () => {
     });
   });
 
+  describe('refreshStakingEligibility', () => {
+    it('fetches staking eligibility using active account (default)', async () => {
+      const { controller } = setupController();
+
+      await controller.refreshStakingEligibility();
+
+      // Assertion on second call since the first is part of controller setup.
+      expect(
+        mockedStakingApiService.getPooledStakingEligibility,
+      ).toHaveBeenNthCalledWith(2, ['0x1234']);
+    });
+
+    it('fetches staking eligibility using options.address', async () => {
+      const { controller } = setupController();
+
+      const mockAddress = '0xabc';
+
+      await controller.refreshStakingEligibility({ address: mockAddress });
+
+      // Assertion on second call since the first is part of controller setup.
+      expect(
+        mockedStakingApiService.getPooledStakingEligibility,
+      ).toHaveBeenNthCalledWith(2, [mockAddress]);
+    });
+  });
+
   describe('subscription handlers', () => {
     const firstAccount = createMockInternalAccount({
       address: '0x1234',

--- a/packages/earn-controller/src/EarnController.test.ts
+++ b/packages/earn-controller/src/EarnController.test.ts
@@ -573,59 +573,66 @@ describe('EarnController', () => {
   });
 
   describe('subscription handlers', () => {
-    const firstAccount = createMockInternalAccount({
-      address: mockAccount1Address,
+    const account = createMockInternalAccount({
+      address: mockAccount2Address,
     });
 
-    it('updates vault data when network changes', () => {
-      const { controller, messenger } = setupController();
+    describe('On network change', () => {
+      it('updates vault data when network changes', () => {
+        const { controller, messenger } = setupController();
 
-      jest
-        .spyOn(controller, 'refreshPooledStakingVaultMetadata')
-        .mockResolvedValue();
-      jest
-        .spyOn(controller, 'refreshPooledStakingVaultDailyApys')
-        .mockResolvedValue();
-      jest
-        .spyOn(controller, 'refreshPooledStakingVaultApyAverages')
-        .mockResolvedValue();
+        jest
+          .spyOn(controller, 'refreshPooledStakingVaultMetadata')
+          .mockResolvedValue();
+        jest
+          .spyOn(controller, 'refreshPooledStakingVaultDailyApys')
+          .mockResolvedValue();
+        jest
+          .spyOn(controller, 'refreshPooledStakingVaultApyAverages')
+          .mockResolvedValue();
 
-      jest.spyOn(controller, 'refreshPooledStakes').mockResolvedValue();
+        jest.spyOn(controller, 'refreshPooledStakes').mockResolvedValue();
 
-      messenger.publish(
-        'NetworkController:stateChange',
-        {
-          ...getDefaultNetworkControllerState(),
-          selectedNetworkClientId: '2',
-        },
-        [],
-      );
+        messenger.publish(
+          'NetworkController:stateChange',
+          {
+            ...getDefaultNetworkControllerState(),
+            selectedNetworkClientId: '2',
+          },
+          [],
+        );
 
-      expect(
-        controller.refreshPooledStakingVaultMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        controller.refreshPooledStakingVaultDailyApys,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        controller.refreshPooledStakingVaultApyAverages,
-      ).toHaveBeenCalledTimes(1);
-      expect(controller.refreshPooledStakes).toHaveBeenCalledTimes(1);
+        expect(
+          controller.refreshPooledStakingVaultMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          controller.refreshPooledStakingVaultDailyApys,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          controller.refreshPooledStakingVaultApyAverages,
+        ).toHaveBeenCalledTimes(1);
+        expect(controller.refreshPooledStakes).toHaveBeenCalledTimes(1);
+      });
     });
 
-    it('updates staking eligibility when selected account changes', () => {
-      const { controller, messenger } = setupController();
+    describe('On selected account change', () => {
+      // TEMP: Workaround for issue: https://github.com/MetaMask/accounts-planning/issues/887
+      it('uses event payload account address to update staking eligibility', () => {
+        const { controller, messenger } = setupController();
 
-      jest.spyOn(controller, 'refreshStakingEligibility').mockResolvedValue();
-      jest.spyOn(controller, 'refreshPooledStakes').mockResolvedValue();
+        jest.spyOn(controller, 'refreshStakingEligibility').mockResolvedValue();
+        jest.spyOn(controller, 'refreshPooledStakes').mockResolvedValue();
 
-      messenger.publish(
-        'AccountsController:selectedAccountChange',
-        firstAccount,
-      );
+        messenger.publish('AccountsController:selectedAccountChange', account);
 
-      expect(controller.refreshStakingEligibility).toHaveBeenCalledTimes(1);
-      expect(controller.refreshPooledStakes).toHaveBeenCalledTimes(1);
+        expect(controller.refreshStakingEligibility).toHaveBeenNthCalledWith(
+          1,
+          { address: account.address },
+        );
+        expect(controller.refreshPooledStakes).toHaveBeenNthCalledWith(1, {
+          address: account.address,
+        });
+      });
     });
   });
 });

--- a/packages/earn-controller/src/EarnController.test.ts
+++ b/packages/earn-controller/src/EarnController.test.ts
@@ -98,10 +98,12 @@ const createMockInternalAccount = ({
   };
 };
 
-const mockAddress = '0x1234';
+const mockAccount1Address = '0x1234';
+
+const mockAccount2Address = '0xabc';
 
 const mockPooledStakes = {
-  account: mockAddress,
+  account: mockAccount1Address,
   lifetimeRewards: '100',
   assets: '1000',
   exitRequests: [],
@@ -210,7 +212,7 @@ const setupController = ({
   })),
 
   mockGetSelectedAccount = jest.fn(() => ({
-    address: mockAddress,
+    address: mockAccount1Address,
   })),
 }: {
   options?: Partial<ConstructorParameters<typeof EarnController>[0]>;
@@ -391,7 +393,7 @@ describe('EarnController', () => {
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         // First call occurs during setupController()
         2,
-        [mockAddress],
+        [mockAccount1Address],
         1,
         false,
       );
@@ -399,14 +401,29 @@ describe('EarnController', () => {
 
     it('invalidates cache when refreshing state', async () => {
       const { controller } = setupController();
-      await controller.refreshPooledStakingData(true);
+      await controller.refreshPooledStakingData({ resetCache: true });
 
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         // First call occurs during setupController()
         2,
-        [mockAddress],
+        [mockAccount1Address],
         1,
         true,
+      );
+    });
+
+    it('refreshes state using options.address', async () => {
+      const { controller } = setupController();
+      await controller.refreshPooledStakingData({
+        address: mockAccount2Address,
+      });
+
+      expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
+        // First call occurs during setupController()
+        2,
+        [mockAccount2Address],
+        1,
+        false,
       );
     });
 
@@ -471,7 +488,7 @@ describe('EarnController', () => {
       // Assertion on second call since the first is part of controller setup.
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         2,
-        [mockAddress],
+        [mockAccount1Address],
         1,
         false,
       );
@@ -484,7 +501,7 @@ describe('EarnController', () => {
       // Assertion on second call since the first is part of controller setup.
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         2,
-        [mockAddress],
+        [mockAccount1Address],
         1,
         false,
       );
@@ -497,7 +514,7 @@ describe('EarnController', () => {
       // Assertion on second call since the first is part of controller setup.
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         2,
-        [mockAddress],
+        [mockAccount1Address],
         1,
         true,
       );
@@ -510,7 +527,7 @@ describe('EarnController', () => {
       // Assertion on second call since the first is part of controller setup.
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         2,
-        [mockAddress],
+        [mockAccount1Address],
         1,
         false,
       );
@@ -518,12 +535,12 @@ describe('EarnController', () => {
 
     it('fetches using options.address override', async () => {
       const { controller } = setupController();
-      await controller.refreshPooledStakes({ address: mockAddress });
+      await controller.refreshPooledStakes({ address: mockAccount2Address });
 
       // Assertion on second call since the first is part of controller setup.
       expect(mockedStakingApiService.getPooledStakes).toHaveBeenNthCalledWith(
         2,
-        [mockAddress],
+        [mockAccount2Address],
         1,
         false,
       );
@@ -539,23 +556,25 @@ describe('EarnController', () => {
       // Assertion on second call since the first is part of controller setup.
       expect(
         mockedStakingApiService.getPooledStakingEligibility,
-      ).toHaveBeenNthCalledWith(2, [mockAddress]);
+      ).toHaveBeenNthCalledWith(2, [mockAccount1Address]);
     });
 
-    it('fetches staking eligibility using options.address', async () => {
+    it('fetches staking eligibility using options.address override', async () => {
       const { controller } = setupController();
-      await controller.refreshStakingEligibility({ address: mockAddress });
+      await controller.refreshStakingEligibility({
+        address: mockAccount2Address,
+      });
 
       // Assertion on second call since the first is part of controller setup.
       expect(
         mockedStakingApiService.getPooledStakingEligibility,
-      ).toHaveBeenNthCalledWith(2, [mockAddress]);
+      ).toHaveBeenNthCalledWith(2, [mockAccount2Address]);
     });
   });
 
   describe('subscription handlers', () => {
     const firstAccount = createMockInternalAccount({
-      address: mockAddress,
+      address: mockAccount1Address,
     });
 
     it('updates vault data when network changes', () => {

--- a/packages/earn-controller/src/EarnController.ts
+++ b/packages/earn-controller/src/EarnController.ts
@@ -28,6 +28,7 @@ import {
 
 import type {
   RefreshPooledStakesOptions,
+  RefreshPooledStakingDataOptions,
   RefreshStakingEligibilityOptions,
 } from './types';
 
@@ -447,18 +448,23 @@ export class EarnController extends BaseController<
    * This method allows partial success, meaning some data may update while other requests fail.
    * All errors are collected and thrown as a single error message.
    *
-   * @param resetCache - Control whether the BE cache should be invalidated.
+   * @param options - Optional arguments
+   * @param [options.resetCache] - Control whether the BE cache should be invalidated (optional).
+   * @param [options.address] - The address to refresh pooled stakes for (optional).
    * @returns A promise that resolves when all possible data has been updated
    * @throws {Error} If any of the refresh operations fail, with concatenated error messages
    */
-  async refreshPooledStakingData(resetCache = false): Promise<void> {
+  async refreshPooledStakingData({
+    resetCache,
+    address,
+  }: RefreshPooledStakingDataOptions = {}): Promise<void> {
     const errors: Error[] = [];
 
     await Promise.all([
-      this.refreshPooledStakes({ resetCache }).catch((error) => {
+      this.refreshPooledStakes({ resetCache, address }).catch((error) => {
         errors.push(error);
       }),
-      this.refreshStakingEligibility().catch((error) => {
+      this.refreshStakingEligibility({ address }).catch((error) => {
         errors.push(error);
       }),
       this.refreshPooledStakingVaultMetadata().catch((error) => {

--- a/packages/earn-controller/src/EarnController.ts
+++ b/packages/earn-controller/src/EarnController.ts
@@ -255,15 +255,14 @@ export class EarnController extends BaseController<
     this.messagingSystem.subscribe(
       'AccountsController:selectedAccountChange',
       (account) => {
+        const address = account?.address;
         /**
          * TEMP: There's a race condition where the account state isn't updated immediately.
          * Until this has been fixed, we rely on the event payload for the latest account instead of #getCurrentAccount().
          * Issue: https://github.com/MetaMask/accounts-planning/issues/887
          */
-        this.refreshStakingEligibility({ address: account?.address }).catch(
-          console.error,
-        );
-        this.refreshPooledStakes().catch(console.error);
+        this.refreshStakingEligibility({ address }).catch(console.error);
+        this.refreshPooledStakes({ address }).catch(console.error);
       },
     );
   }

--- a/packages/earn-controller/src/types.ts
+++ b/packages/earn-controller/src/types.ts
@@ -1,3 +1,8 @@
 export type RefreshStakingEligibilityOptions = {
   address?: string;
 };
+
+export type RefreshPooledStakesOptions = {
+  resetCache?: boolean;
+  address?: string;
+};

--- a/packages/earn-controller/src/types.ts
+++ b/packages/earn-controller/src/types.ts
@@ -6,3 +6,8 @@ export type RefreshPooledStakesOptions = {
   resetCache?: boolean;
   address?: string;
 };
+
+export type RefreshPooledStakingDataOptions = {
+  resetCache?: boolean;
+  address?: string;
+};

--- a/packages/earn-controller/src/types.ts
+++ b/packages/earn-controller/src/types.ts
@@ -1,0 +1,3 @@
+export type RefreshStakingEligibilityOptions = {
+  address?: string;
+};


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This PR updates a few earn-controller methods to have an options bag argument. It also updates the `selectedAccountChange` subscription handler to pass the `account.address` from the event payload into the underlying methods instead of relying on `getSelectedAccount`.

### Why is this needed?
Recently, a [race condition](https://github.com/MetaMask/accounts-planning/issues/887) was discovered in the `accounts-controller` that causes a discrepancy between the account data in the `selectAccountChange` event payload and what's retrieved using `getSelectedAccount`. 

The `selectAccountChange` event payload has the accurate account state and is now passed into `refreshStakingEligibility` and `refreshPooledStakes` to ensure they have the latest account data to work with. 

Once the issue has been resolved and the `getSelectedAccount` account data **and** the `selectAccountChange` data are the same these overrides won't be necessary and can likely be removed.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Jira ticket: [STAKE-964: Fix geo-block race condition for fresh app installs](https://consensyssoftware.atlassian.net/browse/STAKE-964)

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/earn-controller`

- **CHANGED**: Refactored `refreshPooledStakingData` and `refreshPooledStakes` methods to have a single options bag parameter instead of optional positional parameters. The available options are now `{ resetCache?: boolean, address?: string }`.
- **CHANGED**: Refactored `refreshStakingEligibility` to have a single options bag parameter instead of optional positional parameters. The available option is now `{ address?: string }`.
- **CHANGED**: `AccountsController:selectedAccountChange` subscription handler now pass the `account.address` from the event payload into `refreshStakingEligibility` and `refreshPooledStakes`. This ensure that those underlying method have the most accurate data to work with.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
