### PR TITLE
throw error in caveat validator when caip25:endowment permission caveat when no scopes are requested

### DIFF
--- a/packages/chain-agnostic-permission/src/caip25Permission.test.ts
+++ b/packages/chain-agnostic-permission/src/caip25Permission.test.ts
@@ -913,7 +913,7 @@ describe('caip25CaveatBuilder', () => {
       });
     }).toThrow(
       new Error(
-        `${Caip25EndowmentPermissionName} error: Received no scopes requested for caveat of type "${Caip25CaveatType}".`,
+        `${Caip25EndowmentPermissionName} error: Received no scopes for caveat of type "${Caip25CaveatType}".`,
       ),
     );
   });

--- a/packages/chain-agnostic-permission/src/caip25Permission.test.ts
+++ b/packages/chain-agnostic-permission/src/caip25Permission.test.ts
@@ -900,6 +900,24 @@ describe('caip25CaveatBuilder', () => {
     ).toBeUndefined();
   });
 
+  it('throws an error if both requiredScopes and optionalScopes are empty', () => {
+    expect(() => {
+      validator({
+        type: Caip25CaveatType,
+        value: {
+          requiredScopes: {},
+          optionalScopes: {},
+          sessionProperties: {},
+          isMultichainOrigin: true,
+        },
+      });
+    }).toThrow(
+      new Error(
+        `${Caip25EndowmentPermissionName} error: Received no scopes requested for caveat of type "${Caip25CaveatType}".`,
+      ),
+    );
+  });
+
   describe('permission merger', () => {
     describe('incremental request an existing scope (requiredScopes), and 2 whole new scopes (optionalScopes) with accounts', () => {
       it('should return merged scope with previously existing chain and accounts, plus new requested chains with new accounts', () => {

--- a/packages/chain-agnostic-permission/src/caip25Permission.ts
+++ b/packages/chain-agnostic-permission/src/caip25Permission.ts
@@ -205,7 +205,7 @@ export const caip25CaveatBuilder = ({
         Object.keys(optionalScopes).length === 0
       ) {
         throw new Error(
-          `${Caip25EndowmentPermissionName} error: Received no scopes requested for caveat of type "${Caip25CaveatType}".`,
+          `${Caip25EndowmentPermissionName} error: Received no scopes for caveat of type "${Caip25CaveatType}".`,
         );
       }
 

--- a/packages/chain-agnostic-permission/src/caip25Permission.ts
+++ b/packages/chain-agnostic-permission/src/caip25Permission.ts
@@ -200,6 +200,15 @@ export const caip25CaveatBuilder = ({
       assertIsInternalScopesObject(requiredScopes);
       assertIsInternalScopesObject(optionalScopes);
 
+      if (
+        Object.keys(requiredScopes).length === 0 &&
+        Object.keys(optionalScopes).length === 0
+      ) {
+        throw new Error(
+          `${Caip25EndowmentPermissionName} error: Received no scopes requested for caveat of type "${Caip25CaveatType}".`,
+        );
+      }
+
       const isEvmChainIdSupported = (chainId: Hex) => {
         try {
           findNetworkClientIdByChainId(chainId);


### PR DESCRIPTION
## Explanation

We need to add further caveat validation to throw when no scopes are requested in either `requiredScopes` or `optionalScopes`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
See this thread: https://consensys.slack.com/archives/C089Q8CQZHT/p1742825693477409

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->
### `@metamask/chain-agnostic-permission`

- **ADDED**: **BREAKING** Validation check in `caip25CaveatBuilder` to prevent creating permission requests with no scopes. This ensures that all CAIP-25 permission requests must specify at least one scope in either `requiredScopes` or `optionalScopes`.

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
