### PR TITLE
fix(accounts-controller): do not fire events during `update` blocks

### DIFF
--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -777,11 +777,8 @@ describe('AccountsController', () => {
 
         const accounts = accountsController.listMultichainAccounts();
 
-        expect(accounts).toStrictEqual([
-          setLastSelectedAsAny(mockAccount),
-        ]);
+        expect(accounts).toStrictEqual([setLastSelectedAsAny(mockAccount)]);
       });
-
 
       it('increment the default account number when adding an account', async () => {
         const messenger = buildMessenger();
@@ -1520,9 +1517,6 @@ describe('AccountsController', () => {
         expect(selectedAccount.id).toStrictEqual(expectedSelectedId);
       },
     );
-
-    it('handles Snap keyring not available', () => {
-    });
   });
 
   describe('onSnapKeyringEvents', () => {

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -464,7 +464,7 @@ describe('AccountsController', () => {
       expect(listMultichainAccountsSpy).toHaveBeenCalled();
     });
 
-    it('not update state when only keyring is unlocked without any keyrings', async () => {
+    it('does not update state when only keyring is unlocked without any keyrings', async () => {
       const messenger = buildMessenger();
       const { accountsController } = setupAccountsController({
         initialState: {
@@ -652,7 +652,7 @@ describe('AccountsController', () => {
         ]);
       });
 
-      it('handle the event when a Snap deleted the account before the it was added', async () => {
+      it('handles the event when a Snap deleted the account before it was added', async () => {
         mockUUIDWithNormalAccounts([mockAccount]);
 
         const messenger = buildMessenger();
@@ -719,6 +719,69 @@ describe('AccountsController', () => {
           setLastSelectedAsAny(mockAccount4),
         ]);
       });
+
+      it('handles the event when a Snap keyring has been deleted', async () => {
+        mockUUIDWithNormalAccounts([mockAccount]);
+
+        const messenger = buildMessenger();
+        messenger.registerActionHandler(
+          'KeyringController:getKeyringsByType',
+          // The Snap keyring will be treated as undefined
+          mockGetKeyringByType.mockReturnValue([]),
+        );
+
+        const mockNewKeyringState = {
+          isUnlocked: true,
+          keyrings: [
+            {
+              type: KeyringTypes.hd,
+              accounts: [mockAccount.address],
+            },
+            {
+              type: KeyringTypes.snap,
+              // Since the Snap keyring will be mocked as "unavailable", this account won't be added
+              // to the state (like if the Snap did remove it right before the keyring controller
+              // state change got triggered).
+              accounts: [mockAccount3.address],
+            },
+          ],
+          keyringsMetadata: [
+            {
+              id: 'mock-id',
+              name: 'mock-name',
+            },
+            {
+              id: 'mock-id2',
+              name: 'mock-name2',
+            },
+          ],
+        };
+
+        const { accountsController } = setupAccountsController({
+          initialState: {
+            internalAccounts: {
+              accounts: {
+                [mockAccount.id]: mockAccount,
+              },
+              selectedAccount: mockAccount.id,
+            },
+          },
+          messenger,
+        });
+
+        messenger.publish(
+          'KeyringController:stateChange',
+          mockNewKeyringState,
+          [],
+        );
+
+        const accounts = accountsController.listMultichainAccounts();
+
+        expect(accounts).toStrictEqual([
+          setLastSelectedAsAny(mockAccount),
+        ]);
+      });
+
 
       it('increment the default account number when adding an account', async () => {
         const messenger = buildMessenger();
@@ -994,7 +1057,9 @@ describe('AccountsController', () => {
 
         // First call is 'KeyringController:stateChange'
         expect(messengerSpy).toHaveBeenNthCalledWith(
-          2,
+          // 1. KeyringController:stateChange
+          // 2. AccountsController:stateChange
+          3,
           'AccountsController:accountAdded',
           setLastSelectedAsAny(mockAccount2),
         );
@@ -1298,7 +1363,9 @@ describe('AccountsController', () => {
 
         // First call is 'KeyringController:stateChange'
         expect(messengerSpy).toHaveBeenNthCalledWith(
-          2,
+          // 1. KeyringController:stateChange
+          // 2. AccountsController:stateChange
+          3,
           'AccountsController:accountRemoved',
           mockAccount3.id,
         );
@@ -1453,6 +1520,9 @@ describe('AccountsController', () => {
         expect(selectedAccount.id).toStrictEqual(expectedSelectedId);
       },
     );
+
+    it('handles Snap keyring not available', () => {
+    });
   });
 
   describe('onSnapKeyringEvents', () => {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -537,6 +537,10 @@ export class AccountsController extends BaseController<
       {} as Record<string, InternalAccount>,
     );
 
+    const lastSelectedAccount = this.#getLastSelectedAccount(
+      Object.values(accounts),
+    );
+
     this.update((currentState) => {
       currentState.internalAccounts.accounts = accounts;
 
@@ -545,23 +549,22 @@ export class AccountsController extends BaseController<
           currentState.internalAccounts.selectedAccount
         ]
       ) {
-        const lastSelectedAccount = this.#getLastSelectedAccount(
-          Object.values(accounts),
-        );
-
         if (lastSelectedAccount) {
           currentState.internalAccounts.selectedAccount =
             lastSelectedAccount.id;
           currentState.internalAccounts.accounts[
             lastSelectedAccount.id
           ].metadata.lastSelected = this.#getLastSelectedIndex();
-          this.#publishAccountChangeEvent(lastSelectedAccount);
         } else {
           // It will be undefined if there are no accounts
           currentState.internalAccounts.selectedAccount = '';
         }
       }
     });
+
+    if (lastSelectedAccount) {
+      this.#publishAccountChangeEvent(lastSelectedAccount);
+    }
   }
 
   /**

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -533,9 +533,8 @@ export class AccountsController extends BaseController<
       {} as Record<string, InternalAccount>,
     );
 
-    const lastSelectedAccount = this.#getLastSelectedAccount(
-      Object.values(accounts),
-    );
+    const { selectedAccount: previouslySelectedAccount } =
+      this.state.internalAccounts;
 
     this.update((state) => {
       state.internalAccounts.accounts = accounts;
@@ -548,7 +547,8 @@ export class AccountsController extends BaseController<
       );
     });
 
-    if (this.state.internalAccounts.selectedAccount) {
+    const { selectedAccount } = this.state.internalAccounts;
+    if (selectedAccount && selectedAccount !== previouslySelectedAccount) {
       this.#publishAccountChangeEvent(this.getSelectedAccount());
     }
   }

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -34,6 +34,7 @@ import type {
 import type { SnapId } from '@metamask/snaps-sdk';
 import type { Snap } from '@metamask/snaps-utils';
 import { type CaipChainId, isCaipChainId } from '@metamask/utils';
+import type { WritableDraft } from 'immer/dist/internal.js';
 
 import type { MultichainNetworkControllerNetworkDidChangeEvent } from './types';
 import {
@@ -202,11 +203,6 @@ export type AccountsControllerMessenger = RestrictedMessenger<
   AllowedActions['type'],
   AllowedEvents['type']
 >;
-
-type AddressAndKeyringTypeObject = {
-  address: string;
-  type: string;
-};
 
 const accountsControllerMetadata = {
   internalAccounts: {
@@ -466,9 +462,9 @@ export class AccountsController extends BaseController<
     };
 
     this.update((currentState) => {
-      // Do not remove this comment - This error is flaky: Comment out or restore the `ts-expect-error` directive below as needed.
+      // FIXME: Do not remove this comment - This error is flaky: Comment out or restore the `ts-expect-error` directive below as needed.
       // See: https://github.com/MetaMask/utils/issues/168
-      // // @ts-expect-error Known issue - `Json` causes recursive error in immer `Draft`/`WritableDraft` types
+      // @ts-expect-error Known issue - `Json` causes recursive error in immer `Draft`/`WritableDraft` types
       currentState.internalAccounts.accounts[accountId] = internalAccount;
     });
 
@@ -541,29 +537,19 @@ export class AccountsController extends BaseController<
       Object.values(accounts),
     );
 
-    this.update((currentState) => {
-      currentState.internalAccounts.accounts = accounts;
+    this.update((state) => {
+      state.internalAccounts.accounts = accounts;
 
-      if (
-        !currentState.internalAccounts.accounts[
-          currentState.internalAccounts.selectedAccount
-        ]
-      ) {
-        if (lastSelectedAccount) {
-          currentState.internalAccounts.selectedAccount =
-            lastSelectedAccount.id;
-          currentState.internalAccounts.accounts[
-            lastSelectedAccount.id
-          ].metadata.lastSelected = this.#getLastSelectedIndex();
-        } else {
-          // It will be undefined if there are no accounts
-          currentState.internalAccounts.selectedAccount = '';
-        }
-      }
+      // Now check if the previously selected account has been deleted and pick a
+      // new one if neeed.
+      this.#reSelectAccountIfNeeded(
+        state,
+        state.internalAccounts.selectedAccount,
+      );
     });
 
-    if (lastSelectedAccount) {
-      this.#publishAccountChangeEvent(lastSelectedAccount);
+    if (this.state.internalAccounts.selectedAccount) {
+      this.#publishAccountChangeEvent(this.getSelectedAccount());
     }
   }
 
@@ -616,23 +602,34 @@ export class AccountsController extends BaseController<
   }
 
   /**
+   * Get Snap keyring from the keyring controller.
+   *
+   * @returns The Snap keyring if available.
+   */
+  #getSnapKeyring(): SnapKeyring | undefined {
+    const [snapKeyring] = this.messagingSystem.call(
+      'KeyringController:getKeyringsByType',
+      SnapKeyring.type,
+    );
+
+    // Snap keyring is not available until the first account is created in the keyring
+    // controller, so this might be undefined.
+    return snapKeyring as SnapKeyring | undefined;
+  }
+
+  /**
    * Returns a list of internal accounts created using the SnapKeyring.
    *
    * @returns A promise that resolves to an array of InternalAccount objects.
    */
   async #listSnapAccounts(): Promise<InternalAccount[]> {
-    const [snapKeyring] = this.messagingSystem.call(
-      'KeyringController:getKeyringsByType',
-      SnapKeyring.type,
-    );
-    // snap keyring is not available until the first account is created in the keyring controller
-    if (!snapKeyring) {
+    const keyring = this.#getSnapKeyring();
+
+    if (!keyring) {
       return [];
     }
 
-    const snapAccounts = (snapKeyring as SnapKeyring).listAccounts();
-
-    return snapAccounts;
+    return keyring.listAccounts();
   }
 
   /**
@@ -715,158 +712,208 @@ export class AccountsController extends BaseController<
    * Handles changes in the keyring state, specifically when new accounts are added or removed.
    *
    * @param keyringState - The new state of the keyring controller.
+   * @param keyringState.isUnlocked - True if the keyrings are unlocked, false otherwise.
+   * @param keyringState.keyrings - List of all keyrings.
    */
-  #handleOnKeyringStateChange(keyringState: KeyringControllerState): void {
-    // check if there are any new accounts added
-    // TODO: change when accountAdded event is added to the keyring controller
+  #handleOnKeyringStateChange({
+    isUnlocked,
+    keyrings,
+  }: KeyringControllerState): void {
+    // TODO: Change when accountAdded event is added to the keyring controller.
 
     // We check for keyrings length to be greater than 0 because the extension client may try execute
     // submit password twice and clear the keyring state.
     // https://github.com/MetaMask/KeyringController/blob/2d73a4deed8d013913f6ef0c9f5c0bb7c614f7d3/src/KeyringController.ts#L910
-    if (keyringState.isUnlocked && keyringState.keyrings.length > 0) {
-      const updatedNormalKeyringAddresses: AddressAndKeyringTypeObject[] = [];
-      const updatedSnapKeyringAddresses: AddressAndKeyringTypeObject[] = [];
+    if (!isUnlocked || keyrings.length === 0) {
+      return;
+    }
 
-      for (const keyring of keyringState.keyrings) {
-        if (keyring.type === KeyringTypes.snap) {
-          updatedSnapKeyringAddresses.push(
-            ...keyring.accounts.map((address) => {
-              return {
-                address,
-                type: keyring.type,
-              };
-            }),
-          );
+    // State patches.
+    const generatePatch = () => {
+      return {
+        previous: {} as Record<string, InternalAccount>,
+        added: [] as {
+          account?: InternalAccount; // This one is optional, cause we cannot get the account before doing the state update.
+          address: string;
+          type: string;
+        }[],
+        updated: [] as InternalAccount[],
+        removed: [] as InternalAccount[],
+      };
+    };
+    const patches = {
+      snap: generatePatch(),
+      normal: generatePatch(),
+    };
+
+    // Gets the patch object based on the keyring type (since Snap accounts and other accounts
+    // are hanlded differently).
+    const patchOf = (type: string) => {
+      if (type === KeyringTypes.snap) {
+        return patches.snap;
+      }
+      return patches.normal;
+    };
+
+    // Create a map (with lower-cased addresses) of all existing accounts.
+    for (const account of this.listMultichainAccounts()) {
+      const address = account.address.toLowerCase();
+      const patch = patchOf(account.metadata.keyring.type);
+      patch.previous[address] = account;
+    }
+
+    // Go over all keyring changes and create patches out of it.
+    const addresses = new Set<string>();
+    for (const keyring of keyrings) {
+      const patch = patchOf(keyring.type);
+
+      // Lower-case all addresses to use them with the `previous` map.
+      const keyringAddresses = keyring.accounts.map((address) =>
+        address.toLowerCase(),
+      );
+
+      for (const accountAddress of keyring.accounts) {
+        const address = accountAddress.toLowerCase();
+        const account = patch.previous[address];
+
+        if (account) {
+          // If the account exists before, this might be an update.
+          patch.updated.push(account);
         } else {
-          updatedNormalKeyringAddresses.push(
-            ...keyring.accounts.map((address) => {
-              return {
-                address,
-                type: keyring.type,
-              };
-            }),
+          // Otherwise, that's a new account.
+          patch.added.push({
+            address,
+            type: keyring.type,
+          });
+        }
+
+        // Keep track of those address to check for removed accounts later.
+        addresses.add(address);
+      }
+    }
+
+    // We might have accounts associated with removed keyrings, so we iterate
+    // over all previous known accounts and check against the keyring addresses.
+    for (const patch of [patches.snap, patches.normal]) {
+      for (const [address, account] of Object.entries(patch.previous)) {
+        // If a previous address is not part of the new addesses, then it got removed.
+        if (!addresses.has(address)) {
+          patch.removed.push(account);
+        }
+      }
+    }
+
+    // The currently selected account might get deleted during the update, so keep track
+    // of it before doing any change.
+    const previouslySelectedAccount =
+      this.state.internalAccounts.selectedAccount;
+
+    this.update((state) => {
+      const { internalAccounts } = state;
+
+      for (const patch of [patches.snap, patches.normal]) {
+        for (const account of patch.removed) {
+          delete internalAccounts.accounts[account.id];
+        }
+
+        for (const added of patch.added) {
+          const account = this.#getInternalAccountFromAddressAndType(
+            added.address,
+            added.type,
+          );
+
+          if (account) {
+            // NOTE: We now save the account for later, to publish events.
+            added.account = account;
+
+            // Re-compute the list of accounts everytime, so we can make sure new names
+            // are also considered.
+            const accounts = Object.values(
+              internalAccounts.accounts,
+            ) as InternalAccount[];
+
+            // Get next account name available for this given keyring.
+            const name = this.getNextAvailableAccountName(
+              account.metadata.keyring.type,
+              accounts,
+            );
+
+            // If it's the first account, we need to select it.
+            const lastSelected =
+              accounts.length === 0 ? this.#getLastSelectedIndex() : 0;
+
+            internalAccounts.accounts[account.id] = {
+              ...account,
+              metadata: {
+                ...account.metadata,
+                name,
+                importTime: Date.now(),
+                lastSelected,
+              },
+            };
+          }
+        }
+      }
+
+      // Now check if the previously selected account has been deleted and pick a
+      // new one if neeed.
+      this.#reSelectAccountIfNeeded(state, previouslySelectedAccount);
+    });
+
+    // Now publish events
+    const { accounts } = this.state.internalAccounts;
+    for (const patch of [patches.snap, patches.normal]) {
+      for (const account of patch.removed) {
+        this.messagingSystem.publish(
+          'AccountsController:accountRemoved',
+          account.id,
+        );
+      }
+
+      for (const { account } of patch.added) {
+        // Check if the account has really been added to the state.
+        if (account && accounts[account.id]) {
+          this.messagingSystem.publish(
+            'AccountsController:accountAdded',
+            accounts[account.id],
           );
         }
       }
 
-      const { previousNormalInternalAccounts, previousSnapInternalAccounts } =
-        this.listMultichainAccounts().reduce(
-          (accumulator, account) => {
-            if (account.metadata.keyring.type === KeyringTypes.snap) {
-              accumulator.previousSnapInternalAccounts.push(account);
-            } else {
-              accumulator.previousNormalInternalAccounts.push(account);
-            }
-            return accumulator;
-          },
-          {
-            previousNormalInternalAccounts: [] as InternalAccount[],
-            previousSnapInternalAccounts: [] as InternalAccount[],
-          },
-        );
+      // NOTE: Since we also track "updated" accounts with our patches, we could fire a new event
+      // like `accountUpdated` (we would still need to check if anything really changed on the account).
+    }
+  }
 
-      const addedAccounts: AddressAndKeyringTypeObject[] = [];
-      const deletedAccounts: InternalAccount[] = [];
+  /**
+   * Fixup the currently selected account (on a writable draft).
+   *
+   * @param state - The writable state draft.
+   * @param lastSelectedAccountId - The last selected account ID (prior to the update). If not defined, the last selected one will be selected.
+   */
+  #reSelectAccountIfNeeded(
+    state: WritableDraft<AccountsControllerState>,
+    lastSelectedAccountId: string,
+  ) {
+    const { internalAccounts } = state;
 
-      // snap account ids are random uuid while normal accounts
-      // are determininistic based on the address
+    // If the account no longer exists (or none is selected), we need to re-select another one.
+    if (!internalAccounts.accounts[lastSelectedAccountId]) {
+      const accounts = Object.values(
+        internalAccounts.accounts,
+      ) as InternalAccount[];
 
-      // ^NOTE: This will be removed when normal accounts also implement internal accounts
-      // finding all the normal accounts that were added
-      for (const account of updatedNormalKeyringAddresses) {
-        if (
-          !this.state.internalAccounts.accounts[
-            getUUIDFromAddressOfNormalAccount(account.address)
-          ]
-        ) {
-          addedAccounts.push(account);
-        }
+      // Get the lastly selected account (according to the current accounts).
+      const lastSelectedAccount = this.#getLastSelectedAccount(accounts);
+      if (lastSelectedAccount) {
+        internalAccounts.selectedAccount = lastSelectedAccount.id;
+        internalAccounts.accounts[
+          lastSelectedAccount.id
+        ].metadata.lastSelected = this.#getLastSelectedIndex();
+      } else {
+        // It will be undefined if there are no accounts.
+        internalAccounts.selectedAccount = '';
       }
-
-      // finding all the snap accounts that were added
-      for (const account of updatedSnapKeyringAddresses) {
-        if (
-          !previousSnapInternalAccounts.find(
-            (internalAccount: InternalAccount) =>
-              internalAccount.address.toLowerCase() ===
-              account.address.toLowerCase(),
-          )
-        ) {
-          addedAccounts.push(account);
-        }
-      }
-
-      // finding all the normal accounts that were deleted
-      for (const account of previousNormalInternalAccounts) {
-        if (
-          !updatedNormalKeyringAddresses.find(
-            ({ address }) =>
-              address.toLowerCase() === account.address.toLowerCase(),
-          )
-        ) {
-          deletedAccounts.push(account);
-        }
-      }
-
-      // finding all the snap accounts that were deleted
-      for (const account of previousSnapInternalAccounts) {
-        if (
-          !updatedSnapKeyringAddresses.find(
-            ({ address }) =>
-              address.toLowerCase() === account.address.toLowerCase(),
-          )
-        ) {
-          deletedAccounts.push(account);
-        }
-      }
-
-      this.update((currentState) => {
-        if (deletedAccounts.length > 0) {
-          for (const account of deletedAccounts) {
-            currentState.internalAccounts.accounts = this.#handleAccountRemoved(
-              currentState.internalAccounts.accounts,
-              account.id,
-            );
-          }
-        }
-
-        if (addedAccounts.length > 0) {
-          for (const account of addedAccounts) {
-            currentState.internalAccounts.accounts =
-              this.#handleNewAccountAdded(
-                currentState.internalAccounts.accounts,
-                account,
-              );
-          }
-        }
-
-        // We don't use list accounts because it is not the updated state yet.
-        const existingAccounts = Object.values(
-          currentState.internalAccounts.accounts,
-        );
-
-        // handle if the selected account was deleted
-        if (
-          !currentState.internalAccounts.accounts[
-            this.state.internalAccounts.selectedAccount
-          ]
-        ) {
-          const lastSelectedAccount =
-            this.#getLastSelectedAccount(existingAccounts);
-
-          if (lastSelectedAccount) {
-            currentState.internalAccounts.selectedAccount =
-              lastSelectedAccount.id;
-            currentState.internalAccounts.accounts[
-              lastSelectedAccount.id
-            ].metadata.lastSelected = this.#getLastSelectedIndex();
-            this.#publishAccountChangeEvent(lastSelectedAccount);
-          } else {
-            // It will be undefined if there are no accounts
-            currentState.internalAccounts.selectedAccount = '';
-          }
-        }
-      });
     }
   }
 
@@ -1003,65 +1050,33 @@ export class AccountsController extends BaseController<
   }
 
   /**
-   * Handles the addition of a new account to the controller.
+   * Get an internal account given an address and a keyring type.
+   *
    * If the account is not a Snap Keyring account, generates an internal account for it and adds it to the controller.
    * If the account is a Snap Keyring account, retrieves the account from the keyring and adds it to the controller.
    *
-   * @param accountsState - AccountsController accounts state that is to be mutated.
-   * @param account - The address and keyring type object of the new account.
-   * @returns The updated AccountsController accounts state.
+   * @param address - The address of the new account.
+   * @param type - The keyring type of the new account.
+   * @returns The newly generated/retrieved internal account.
    */
-  #handleNewAccountAdded(
-    accountsState: AccountsControllerState['internalAccounts']['accounts'],
-    account: AddressAndKeyringTypeObject,
-  ): AccountsControllerState['internalAccounts']['accounts'] {
-    let newAccount: InternalAccount;
-    if (account.type !== KeyringTypes.snap) {
-      newAccount = this.#generateInternalAccountForNonSnapAccount(
-        account.address,
-        account.type,
-      );
-    } else {
-      const [snapKeyring] = this.messagingSystem.call(
-        'KeyringController:getKeyringsByType',
-        SnapKeyring.type,
-      );
+  #getInternalAccountFromAddressAndType(
+    address: string,
+    type: string,
+  ): InternalAccount | undefined {
+    if (type === KeyringTypes.snap) {
+      const keyring = this.#getSnapKeyring();
 
-      newAccount = (snapKeyring as SnapKeyring).getAccountByAddress(
-        account.address,
-      ) as InternalAccount;
-
-      // The snap deleted the account before the keyring controller could add it
-      if (!newAccount) {
-        return accountsState;
+      // We need the Snap keyring to retrieve the account from its address.
+      if (!keyring) {
+        return undefined;
       }
+
+      // This might be undefined if the Snap deleted the account before
+      // reaching that point.
+      return keyring.getAccountByAddress(address);
     }
 
-    const isFirstAccount = Object.keys(accountsState).length === 0;
-
-    // Get next account name available for this given keyring
-    const accountName = this.getNextAvailableAccountName(
-      newAccount.metadata.keyring.type,
-      Object.values(accountsState),
-    );
-
-    const newAccountWithUpdatedMetadata = {
-      ...newAccount,
-      metadata: {
-        ...newAccount.metadata,
-        name: accountName,
-        importTime: Date.now(),
-        lastSelected: isFirstAccount ? this.#getLastSelectedIndex() : 0,
-      },
-    };
-    accountsState[newAccount.id] = newAccountWithUpdatedMetadata;
-
-    this.messagingSystem.publish(
-      'AccountsController:accountAdded',
-      newAccountWithUpdatedMetadata,
-    );
-
-    return accountsState;
+    return this.#generateInternalAccountForNonSnapAccount(address, type);
   }
 
   #publishAccountChangeEvent(account: InternalAccount) {
@@ -1075,27 +1090,6 @@ export class AccountsController extends BaseController<
       'AccountsController:selectedAccountChange',
       account,
     );
-  }
-
-  /**
-   * Handles the removal of an account from the internal accounts list.
-   *
-   * @param accountsState - AccountsController accounts state that is to be mutated.
-   * @param accountId - The ID of the account to be removed.
-   * @returns The updated AccountsController state.
-   */
-  #handleAccountRemoved(
-    accountsState: AccountsControllerState['internalAccounts']['accounts'],
-    accountId: string,
-  ): AccountsControllerState['internalAccounts']['accounts'] {
-    delete accountsState[accountId];
-
-    this.messagingSystem.publish(
-      'AccountsController:accountRemoved',
-      accountId,
-    );
-
-    return accountsState;
   }
 
   /**

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -460,23 +460,24 @@ export class AccountsController extends BaseController<
       throw new Error('Account name already exists');
     }
 
+    const internalAccount = {
+      ...account,
+      metadata: { ...account.metadata, ...metadata },
+    };
+
     this.update((currentState) => {
-      const internalAccount = {
-        ...account,
-        metadata: { ...account.metadata, ...metadata },
-      };
       // Do not remove this comment - This error is flaky: Comment out or restore the `ts-expect-error` directive below as needed.
       // See: https://github.com/MetaMask/utils/issues/168
       // // @ts-expect-error Known issue - `Json` causes recursive error in immer `Draft`/`WritableDraft` types
       currentState.internalAccounts.accounts[accountId] = internalAccount;
-
-      if (metadata.name) {
-        this.messagingSystem.publish(
-          'AccountsController:accountRenamed',
-          internalAccount,
-        );
-      }
     });
+
+    if (metadata.name) {
+      this.messagingSystem.publish(
+        'AccountsController:accountRenamed',
+        internalAccount,
+      );
+    }
   }
 
   /**

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -767,12 +767,8 @@ export class AccountsController extends BaseController<
     for (const keyring of keyrings) {
       const patch = patchOf(keyring.type);
 
-      // Lower-case all addresses to use them with the `previous` map.
-      const keyringAddresses = keyring.accounts.map((address) =>
-        address.toLowerCase(),
-      );
-
       for (const accountAddress of keyring.accounts) {
+        // Lower-case address to use it in the `previous` map.
         const address = accountAddress.toLowerCase();
         const account = patch.previous[address];
 


### PR DESCRIPTION
## Explanation

Events should be fired after making a state update. Otherwise we could end up with race conditions like some other component react to `AccountsController:accountAdded` and try to call `getAccount(account.id)`, it might not the same value compared to the `account` being passed during the event (since the state update has not been persisted yet).

This PR now moves all events firing after the state update.

It also includes a small refactor of the `KeyringController:stateChange` handler (which made the new events firing logic, a bit easier).

## References

N/A

## Changelog

TODO

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
