### PR TITLE
chore: remove `goerli` and `linea goerli` from `network-controller` as default network

### DIFF
--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -129,8 +129,8 @@ const mockNetworkConfigurations: Record<string, NetworkConfiguration> = {
   [InfuraNetworkType.mainnet]: buildInfuraNetworkConfiguration(
     InfuraNetworkType.mainnet,
   ),
-  [InfuraNetworkType.goerli]: buildInfuraNetworkConfiguration(
-    InfuraNetworkType.goerli,
+  [InfuraNetworkType.sepolia]: buildInfuraNetworkConfiguration(
+    InfuraNetworkType.sepolia,
   ),
   polygon: {
     blockExplorerUrls: ['https://polygonscan.com/'],
@@ -361,12 +361,12 @@ describe('TokenDetectionController', () => {
         async ({ controller, mockNetworkState, mockGetNetworkClientById }) => {
           mockNetworkState({
             ...getDefaultNetworkControllerState(),
-            selectedNetworkClientId: NetworkType.goerli,
+            selectedNetworkClientId: NetworkType.sepolia,
           });
           mockGetNetworkClientById(
             () =>
               ({
-                configuration: { chainId: '0x5' },
+                configuration: { chainId: ChainId.sepolia },
               }) as unknown as AutoManagedNetworkClient<CustomNetworkClientConfiguration>,
           );
           await controller.start();
@@ -1167,14 +1167,7 @@ describe('TokenDetectionController', () => {
             await advanceTime({ clock, duration: 1 });
 
             expect(mockTokens).toHaveBeenNthCalledWith(1, {
-              chainIds: [
-                '0x1',
-                '0x5',
-                '0xaa36a7',
-                '0xe704',
-                '0xe705',
-                '0xe708',
-              ],
+              chainIds: ['0x1', '0xaa36a7', '0xe705', '0xe708'],
               selectedAddress: secondSelectedAccount.address,
             });
           },
@@ -1667,7 +1660,7 @@ describe('TokenDetectionController', () => {
             mockTokenListGetState({
               ...getDefaultTokenListState(),
               tokensChainsCache: {
-                '0x5': {
+                [ChainId.sepolia]: {
                   timestamp: 0,
                   data: {
                     [sampleTokenA.address]: {
@@ -1686,7 +1679,7 @@ describe('TokenDetectionController', () => {
 
             triggerNetworkDidChange({
               ...getDefaultNetworkControllerState(),
-              selectedNetworkClientId: 'goerli',
+              selectedNetworkClientId: NetworkType.sepolia,
             });
             await advanceTime({ clock, duration: 1 });
 
@@ -2436,14 +2429,14 @@ describe('TokenDetectionController', () => {
           mockMultiChainAccountsService();
           mockNetworkState({
             ...getDefaultNetworkControllerState(),
-            selectedNetworkClientId: NetworkType.goerli,
+            selectedNetworkClientId: NetworkType.sepolia,
           });
           triggerPreferencesStateChange({
             ...getDefaultPreferencesState(),
             useTokenDetection: false,
           });
           await controller.detectTokens({
-            chainIds: ['0x5'],
+            chainIds: [ChainId.sepolia],
             selectedAddress: selectedAccount.address,
           });
           expect(callActionSpy).not.toHaveBeenCalledWith(
@@ -2753,7 +2746,7 @@ describe('TokenDetectionController', () => {
             useTokenDetection: false,
           });
           await controller.detectTokens({
-            chainIds: ['0x5'],
+            chainIds: [ChainId.sepolia],
             selectedAddress: selectedAccount.address,
           });
           expect(callActionSpy).not.toHaveBeenCalledWith(

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -957,16 +957,18 @@ describe('TokenListController', () => {
     nock(tokenService.TOKEN_END_POINT_API)
       .get(getTokensPath(ChainId.mainnet))
       .reply(200, sampleMainnetTokenList)
-      .get(getTokensPath(ChainId.goerli))
-      .reply(200, { error: 'ChainId 5 is not supported' })
+      .get(getTokensPath(ChainId.sepolia))
+      .reply(200, {
+        error: `ChainId ${convertHexToDecimal(ChainId.sepolia)} is not supported`,
+      })
       .get(getTokensPath(toHex(56)))
       .reply(200, sampleBinanceTokenList)
       .persist();
     const selectedCustomNetworkClientId = 'selectedCustomNetworkClientId';
     const messenger = getMessenger();
     const getNetworkClientById = buildMockGetNetworkClientById({
-      [InfuraNetworkType.goerli]: buildInfuraNetworkClientConfiguration(
-        InfuraNetworkType.goerli,
+      [InfuraNetworkType.sepolia]: buildInfuraNetworkClientConfiguration(
+        InfuraNetworkType.sepolia,
       ),
       [selectedCustomNetworkClientId]: buildCustomNetworkClientConfiguration({
         chainId: toHex(56),
@@ -996,7 +998,7 @@ describe('TokenListController', () => {
     messenger.publish(
       'NetworkController:stateChange',
       {
-        selectedNetworkClientId: InfuraNetworkType.goerli,
+        selectedNetworkClientId: InfuraNetworkType.sepolia,
         networkConfigurationsByChainId: {},
         networksMetadata: {},
         // @ts-expect-error This property isn't used and will get removed later.
@@ -1061,8 +1063,10 @@ describe('TokenListController', () => {
     nock(tokenService.TOKEN_END_POINT_API)
       .get(getTokensPath(ChainId.mainnet))
       .reply(200, sampleMainnetTokenList)
-      .get(getTokensPath(ChainId.goerli))
-      .reply(200, { error: 'ChainId 5 is not supported' })
+      .get(getTokensPath(ChainId.sepolia))
+      .reply(200, {
+        error: `ChainId ${convertHexToDecimal(ChainId.sepolia)} is not supported`,
+      })
       .get(getTokensPath(toHex(56)))
       .reply(200, sampleBinanceTokenList)
       .persist();
@@ -1083,7 +1087,7 @@ describe('TokenListController', () => {
     );
     const restrictedMessenger = getRestrictedMessenger(messenger);
     const controller = new TokenListController({
-      chainId: ChainId.goerli,
+      chainId: ChainId.sepolia,
       preventPollingOnNetworkRestart: true,
       messenger: restrictedMessenger,
       interval: 100,

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -1004,7 +1004,7 @@ describe('GasFeeController', () => {
         getIsEIP1559Compatible: jest.fn().mockResolvedValue(true),
         networkControllerState: {
           networksMetadata: {
-            goerli: {
+            'linea-sepolia': {
               EIPS: {
                 1559: true,
               },
@@ -1042,7 +1042,7 @@ describe('GasFeeController', () => {
         });
 
         await gasFeeController.fetchGasFeeEstimates({
-          networkClientId: 'goerli',
+          networkClientId: 'sepolia',
         });
 
         expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith({
@@ -1051,12 +1051,14 @@ describe('GasFeeController', () => {
           fetchGasEstimates,
           // TODO: Either fix this lint violation or explain why it's necessary to ignore.
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          fetchGasEstimatesUrl: 'https://some-eip-1559-endpoint/5',
+          fetchGasEstimatesUrl: `https://some-eip-1559-endpoint/${convertHexToDecimal(
+            ChainId.sepolia,
+          )}`,
           fetchLegacyGasPriceEstimates,
           // TODO: Either fix this lint violation or explain why it's necessary to ignore.
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           fetchLegacyGasPriceEstimatesUrl: `https://some-legacy-endpoint/${convertHexToDecimal(
-            ChainId.goerli,
+            ChainId.sepolia,
           )}`,
           fetchEthGasPriceEstimate,
           calculateTimeEstimate,
@@ -1070,12 +1072,12 @@ describe('GasFeeController', () => {
         it('should update the globally selected network state with a fetched set of estimates', async () => {
           await setupGasFeeController({
             ...getDefaultOptions(),
-            getChainId: jest.fn().mockReturnValue(ChainId.goerli),
+            getChainId: jest.fn().mockReturnValue(ChainId.sepolia),
             onNetworkDidChange: jest.fn(),
           });
 
           await gasFeeController.fetchGasFeeEstimates({
-            networkClientId: 'goerli',
+            networkClientId: 'sepolia',
           });
 
           expect(gasFeeController.state).toMatchObject(
@@ -1086,16 +1088,16 @@ describe('GasFeeController', () => {
         it('should update the gasFeeEstimatesByChainId state with a fetched set of estimates', async () => {
           await setupGasFeeController({
             ...getDefaultOptions(),
-            getChainId: jest.fn().mockReturnValue(ChainId.goerli),
+            getChainId: jest.fn().mockReturnValue(ChainId.sepolia),
             onNetworkDidChange: jest.fn(),
           });
 
           await gasFeeController.fetchGasFeeEstimates({
-            networkClientId: 'goerli',
+            networkClientId: 'sepolia',
           });
 
           expect(
-            gasFeeController.state.gasFeeEstimatesByChainId?.[ChainId.goerli],
+            gasFeeController.state.gasFeeEstimatesByChainId?.[ChainId.sepolia],
           ).toMatchObject(mockDetermineGasFeeCalculations);
         });
       });
@@ -1109,7 +1111,7 @@ describe('GasFeeController', () => {
           });
 
           await gasFeeController.fetchGasFeeEstimates({
-            networkClientId: 'goerli',
+            networkClientId: 'sepolia',
           });
 
           expect(gasFeeController.state).toMatchObject({
@@ -1127,11 +1129,11 @@ describe('GasFeeController', () => {
           });
 
           await gasFeeController.fetchGasFeeEstimates({
-            networkClientId: 'goerli',
+            networkClientId: 'sepolia',
           });
 
           expect(
-            gasFeeController.state.gasFeeEstimatesByChainId?.[ChainId.goerli],
+            gasFeeController.state.gasFeeEstimatesByChainId?.[ChainId.sepolia],
           ).toMatchObject(mockDetermineGasFeeCalculations);
         });
       });
@@ -1181,7 +1183,7 @@ describe('GasFeeController', () => {
         EIP1559APIEndpoint: 'https://some-eip-1559-endpoint/<chain_id>',
         networkControllerState: {
           networksMetadata: {
-            goerli: {
+            'linea-sepolia': {
               EIPS: {
                 1559: true,
               },
@@ -1200,7 +1202,7 @@ describe('GasFeeController', () => {
       });
 
       gasFeeController.startPolling({
-        networkClientId: 'goerli',
+        networkClientId: 'linea-sepolia',
       });
       await clock.tickAsync(0);
       expect(mockedDetermineGasFeeCalculations).toHaveBeenNthCalledWith(
@@ -1209,7 +1211,7 @@ describe('GasFeeController', () => {
           // TODO: Either fix this lint violation or explain why it's necessary to ignore.
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           fetchGasEstimatesUrl: `https://some-eip-1559-endpoint/${convertHexToDecimal(
-            ChainId.goerli,
+            ChainId['linea-sepolia'],
           )}`,
         }),
       );
@@ -1222,12 +1224,14 @@ describe('GasFeeController', () => {
           // TODO: Either fix this lint violation or explain why it's necessary to ignore.
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           fetchGasEstimatesUrl: `https://some-eip-1559-endpoint/${convertHexToDecimal(
-            ChainId.goerli,
+            ChainId['linea-sepolia'],
           )}`,
         }),
       );
       expect(
-        gasFeeController.state.gasFeeEstimatesByChainId?.['0x5'],
+        gasFeeController.state.gasFeeEstimatesByChainId?.[
+          ChainId['linea-sepolia']
+        ],
       ).toStrictEqual(buildMockGasFeeStateFeeMarket());
 
       gasFeeController.startPolling({

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -32,7 +32,7 @@ import * as URI from 'uri-js';
 import { v4 as uuidV4 } from 'uuid';
 
 import {
-  DeprecatedNetworks,
+  DEPRECATED_NETWORKS,
   INFURA_BLOCKED_KEY,
   NetworkStatus,
 } from './constants';
@@ -677,7 +677,7 @@ function getDefaultInfuraNetworkConfigurationsByChainId(): Record<
     const chainId = ChainId[infuraNetworkType];
 
     // Skip deprecated network as default network.
-    if (DeprecatedNetworks.has(chainId)) {
+    if (DEPRECATED_NETWORKS.has(chainId)) {
       return obj;
     }
 

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -32,7 +32,7 @@ import * as URI from 'uri-js';
 import { v4 as uuidV4 } from 'uuid';
 
 import {
-  DEPRECATED_NETWORKS,
+  DeprecatedNetworks,
   INFURA_BLOCKED_KEY,
   NetworkStatus,
 } from './constants';
@@ -677,7 +677,7 @@ function getDefaultInfuraNetworkConfigurationsByChainId(): Record<
     const chainId = ChainId[infuraNetworkType];
 
     // Skip deprecated network as default network.
-    if (DEPRECATED_NETWORKS.has(chainId)) {
+    if (DeprecatedNetworks.has(chainId)) {
       return obj;
     }
 

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -31,7 +31,11 @@ import { createSelector } from 'reselect';
 import * as URI from 'uri-js';
 import { v4 as uuidV4 } from 'uuid';
 
-import { DEPRECATED_NETWORKS, INFURA_BLOCKED_KEY, NetworkStatus } from './constants';
+import {
+  DEPRECATED_NETWORKS,
+  INFURA_BLOCKED_KEY,
+  NetworkStatus,
+} from './constants';
 import type {
   AutoManagedNetworkClient,
   ProxyWithAccessibleTarget,

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -31,7 +31,7 @@ import { createSelector } from 'reselect';
 import * as URI from 'uri-js';
 import { v4 as uuidV4 } from 'uuid';
 
-import { INFURA_BLOCKED_KEY, NetworkStatus } from './constants';
+import { DEPRECATED_NETWORKS, INFURA_BLOCKED_KEY, NetworkStatus } from './constants';
 import type {
   AutoManagedNetworkClient,
   ProxyWithAccessibleTarget,
@@ -671,6 +671,12 @@ function getDefaultInfuraNetworkConfigurationsByChainId(): Record<
     Record<Hex, NetworkConfiguration>
   >((obj, infuraNetworkType) => {
     const chainId = ChainId[infuraNetworkType];
+
+    // Skip deprecated network as default network.
+    if (DEPRECATED_NETWORKS.has(chainId)) {
+      return obj;
+    }
+
     const rpcEndpointUrl =
       // This ESLint rule mistakenly produces an error.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/packages/network-controller/src/constants.ts
+++ b/packages/network-controller/src/constants.ts
@@ -30,11 +30,11 @@ export enum NetworkStatus {
 export const INFURA_BLOCKED_KEY = 'countryBlocked';
 
 /**
- * A set of constant value for the deprecated networks.
+ * A set of deprecated network ChainId.
  * The network controller will exclude those the networks begin as default network,
  * without the need to remove the network from constant list of controller-utils.
  */
-export const DEPRECATED_NETWORKS = new Set<ChainId>([
+export const DeprecatedNetworks = new Set<ChainId>([
   ChainId[BuiltInNetworkName.Goerli],
   ChainId[BuiltInNetworkName.LineaGoerli],
 ]);

--- a/packages/network-controller/src/constants.ts
+++ b/packages/network-controller/src/constants.ts
@@ -32,4 +32,4 @@ export const INFURA_BLOCKED_KEY = 'countryBlocked';
  * The network controller will exclude those the networks begin as default network,
  * without the need to remove the network from constant list of controller-utils.
  */
-export const DeprecatedNetworks = new Set<string>(['0xe704', '0x5']);
+export const DEPRECATED_NETWORKS = new Set<string>(['0xe704', '0x5']);

--- a/packages/network-controller/src/constants.ts
+++ b/packages/network-controller/src/constants.ts
@@ -1,3 +1,5 @@
+import { BuiltInNetworkName, ChainId } from "@metamask/controller-utils";
+
 /**
  * Represents the availability state of the currently selected network.
  */
@@ -26,3 +28,14 @@ export enum NetworkStatus {
 }
 
 export const INFURA_BLOCKED_KEY = 'countryBlocked';
+
+
+/**
+ * A set of constant value for the deprecated networks.
+ * The network controller will exclude those the networks begin as default network,
+ * without the need to remove the network from constant list of controller-utils. 
+ */
+export const DEPRECATED_NETWORKS = new Set<ChainId>([
+  ChainId[BuiltInNetworkName.Goerli],
+  ChainId[BuiltInNetworkName.LineaGoerli]
+]);

--- a/packages/network-controller/src/constants.ts
+++ b/packages/network-controller/src/constants.ts
@@ -1,4 +1,4 @@
-import { BuiltInNetworkName, ChainId } from "@metamask/controller-utils";
+import { BuiltInNetworkName, ChainId } from '@metamask/controller-utils';
 
 /**
  * Represents the availability state of the currently selected network.
@@ -29,13 +29,12 @@ export enum NetworkStatus {
 
 export const INFURA_BLOCKED_KEY = 'countryBlocked';
 
-
 /**
  * A set of constant value for the deprecated networks.
  * The network controller will exclude those the networks begin as default network,
- * without the need to remove the network from constant list of controller-utils. 
+ * without the need to remove the network from constant list of controller-utils.
  */
 export const DEPRECATED_NETWORKS = new Set<ChainId>([
   ChainId[BuiltInNetworkName.Goerli],
-  ChainId[BuiltInNetworkName.LineaGoerli]
+  ChainId[BuiltInNetworkName.LineaGoerli],
 ]);

--- a/packages/network-controller/src/constants.ts
+++ b/packages/network-controller/src/constants.ts
@@ -1,5 +1,3 @@
-import { BuiltInNetworkName, ChainId } from '@metamask/controller-utils';
-
 /**
  * Represents the availability state of the currently selected network.
  */
@@ -34,7 +32,4 @@ export const INFURA_BLOCKED_KEY = 'countryBlocked';
  * The network controller will exclude those the networks begin as default network,
  * without the need to remove the network from constant list of controller-utils.
  */
-export const DeprecatedNetworks = new Set<ChainId>([
-  ChainId[BuiltInNetworkName.Goerli],
-  ChainId[BuiltInNetworkName.LineaGoerli],
-]);
+export const DeprecatedNetworks = new Set<string>(['0xe704', '0x5']);

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -143,6 +143,9 @@ const GENERIC_JSON_RPC_ERROR = rpcErrors.internal(
  */
 const FAKE_DATE_NOW_MS = 1732114339518;
 
+
+const infuraNetworks = [InfuraNetworkType['mainnet'], InfuraNetworkType['sepolia'], InfuraNetworkType['linea-mainnet'], InfuraNetworkType['linea-sepolia']];
+
 describe('NetworkController', () => {
   let uuidCounter = 0;
 
@@ -412,21 +415,6 @@ describe('NetworkController', () => {
                   },
                 ],
               },
-              "0x5": Object {
-                "blockExplorerUrls": Array [],
-                "chainId": "0x5",
-                "defaultRpcEndpointIndex": 0,
-                "name": "Goerli",
-                "nativeCurrency": "GoerliETH",
-                "rpcEndpoints": Array [
-                  Object {
-                    "failoverUrls": Array [],
-                    "networkClientId": "goerli",
-                    "type": "infura",
-                    "url": "https://goerli.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
               "0xaa36a7": Object {
                 "blockExplorerUrls": Array [],
                 "chainId": "0xaa36a7",
@@ -439,21 +427,6 @@ describe('NetworkController', () => {
                     "networkClientId": "sepolia",
                     "type": "infura",
                     "url": "https://sepolia.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xe704": Object {
-                "blockExplorerUrls": Array [],
-                "chainId": "0xe704",
-                "defaultRpcEndpointIndex": 0,
-                "name": "Linea Goerli",
-                "nativeCurrency": "LineaETH",
-                "rpcEndpoints": Array [
-                  Object {
-                    "failoverUrls": Array [],
-                    "networkClientId": "linea-goerli",
-                    "type": "infura",
-                    "url": "https://linea-goerli.infura.io/v3/{infuraProjectId}",
                   },
                 ],
               },
@@ -627,22 +600,22 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            selectedNetworkClientId: InfuraNetworkType.goerli,
+            selectedNetworkClientId: InfuraNetworkType.sepolia,
             networkConfigurationsByChainId: {
-              [ChainId.goerli]: {
+              [ChainId.sepolia]: {
                 blockExplorerUrls: ['https://block.explorer'],
-                chainId: ChainId.goerli,
+                chainId: ChainId.sepolia,
                 defaultBlockExplorerUrlIndex: 0,
                 defaultRpcEndpointIndex: 0,
-                name: 'Goerli',
-                nativeCurrency: 'GoerliETH',
+                name: 'Sepolia',
+                nativeCurrency: 'SepoliaETH',
                 rpcEndpoints: [
                   {
                     failoverUrls: ['https://failover.endpoint'],
-                    name: 'Goerli',
-                    networkClientId: InfuraNetworkType.goerli,
+                    name: 'Sepolia',
+                    networkClientId: InfuraNetworkType.sepolia,
                     type: RpcEndpointType.Infura,
-                    url: 'https://goerli.infura.io/v3/{infuraProjectId}',
+                    url: 'https://sepolia.infura.io/v3/{infuraProjectId}',
                   },
                 ],
               },
@@ -659,24 +632,24 @@ describe('NetworkController', () => {
           expect(controller.state).toMatchInlineSnapshot(`
             Object {
               "networkConfigurationsByChainId": Object {
-                "0x5": Object {
+                "0xaa36a7": Object {
                   "blockExplorerUrls": Array [
                     "https://block.explorer",
                   ],
-                  "chainId": "0x5",
+                  "chainId": "0xaa36a7",
                   "defaultBlockExplorerUrlIndex": 0,
                   "defaultRpcEndpointIndex": 0,
-                  "name": "Goerli",
-                  "nativeCurrency": "GoerliETH",
+                  "name": "Sepolia",
+                  "nativeCurrency": "SepoliaETH",
                   "rpcEndpoints": Array [
                     Object {
                       "failoverUrls": Array [
                         "https://failover.endpoint",
                       ],
-                      "name": "Goerli",
-                      "networkClientId": "goerli",
+                      "name": "Sepolia",
+                      "networkClientId": "sepolia",
                       "type": "infura",
-                      "url": "https://goerli.infura.io/v3/{infuraProjectId}",
+                      "url": "https://sepolia.infura.io/v3/{infuraProjectId}",
                     },
                   ],
                 },
@@ -689,7 +662,7 @@ describe('NetworkController', () => {
                   "status": "unknown",
                 },
               },
-              "selectedNetworkClientId": "goerli",
+              "selectedNetworkClientId": "sepolia",
             }
           `);
         },
@@ -726,7 +699,7 @@ describe('NetworkController', () => {
   });
 
   describe('initializeProvider', () => {
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.
@@ -886,7 +859,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       const infuraChainId = ChainId[infuraNetworkType];
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
 
@@ -989,10 +962,10 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.goerli,
+              selectedNetworkClientId: InfuraNetworkType.sepolia,
               networkConfigurationsByChainId: {
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
                 '0x1337': buildCustomNetworkConfiguration({
                   chainId: '0x1337',
@@ -1034,7 +1007,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.goerli) {
+              if (configuration.chainId === ChainId.sepolia) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -1272,32 +1245,6 @@ describe('NetworkController', () => {
             mockCreateNetworkClient().mockReturnValue(buildFakeClient());
 
             expect(controller.getNetworkClientRegistry()).toStrictEqual({
-              goerli: {
-                blockTracker: expect.anything(),
-                configuration: {
-                  chainId: '0x5',
-                  failoverRpcUrls: [],
-                  infuraProjectId,
-                  network: InfuraNetworkType.goerli,
-                  ticker: 'GoerliETH',
-                  type: NetworkClientType.Infura,
-                },
-                provider: expect.anything(),
-                destroy: expect.any(Function),
-              },
-              'linea-goerli': {
-                blockTracker: expect.anything(),
-                configuration: {
-                  type: NetworkClientType.Infura,
-                  failoverRpcUrls: [],
-                  infuraProjectId,
-                  chainId: '0xe704',
-                  ticker: 'LineaETH',
-                  network: InfuraNetworkType['linea-goerli'],
-                },
-                provider: expect.anything(),
-                destroy: expect.any(Function),
-              },
               'linea-mainnet': {
                 blockTracker: expect.anything(),
                 configuration: {
@@ -1454,7 +1401,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.
@@ -1862,8 +1809,8 @@ describe('NetworkController', () => {
               state: {
                 selectedNetworkClientId: 'AAAA-AAAA-AAAA-AAAA',
                 networkConfigurationsByChainId: {
-                  [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                    InfuraNetworkType.goerli,
+                  [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                    InfuraNetworkType.sepolia,
                   ),
                   '0x1337': buildCustomNetworkConfiguration({
                     chainId: '0x1337',
@@ -1896,7 +1843,7 @@ describe('NetworkController', () => {
                     beforeCompleting: () => {
                       // We are purposefully not awaiting this promise.
                       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                      controller.setProviderType(NetworkType.goerli);
+                      controller.setProviderType(NetworkType.sepolia);
                     },
                   },
                 ]),
@@ -1919,7 +1866,7 @@ describe('NetworkController', () => {
                   if (configuration.chainId === '0x1337') {
                     return fakeNetworkClients[0];
                   } else if (
-                    configuration.chainId === ChainId[InfuraNetworkType.goerli]
+                    configuration.chainId === ChainId[InfuraNetworkType.sepolia]
                   ) {
                     return fakeNetworkClients[1];
                   }
@@ -1938,7 +1885,7 @@ describe('NetworkController', () => {
               await controller.lookupNetwork();
 
               expect(
-                controller.state.networksMetadata[InfuraNetworkType.goerli]
+                controller.state.networksMetadata[InfuraNetworkType.sepolia]
                   .status,
               ).toBe('unknown');
             },
@@ -1953,8 +1900,8 @@ describe('NetworkController', () => {
               state: {
                 selectedNetworkClientId: 'AAAA-AAAA-AAAA-AAAA',
                 networkConfigurationsByChainId: {
-                  [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                    InfuraNetworkType.goerli,
+                  [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                    InfuraNetworkType.sepolia,
                   ),
                   '0x1337': buildCustomNetworkConfiguration({
                     chainId: '0x1337',
@@ -1991,7 +1938,7 @@ describe('NetworkController', () => {
                     beforeCompleting: () => {
                       // We are purposefully not awaiting this promise.
                       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                      controller.setProviderType(NetworkType.goerli);
+                      controller.setProviderType(NetworkType.sepolia);
                     },
                   },
                 ]),
@@ -2016,7 +1963,7 @@ describe('NetworkController', () => {
                   if (configuration.chainId === '0x1337') {
                     return fakeNetworkClients[0];
                   } else if (
-                    configuration.chainId === ChainId[InfuraNetworkType.goerli]
+                    configuration.chainId === ChainId[InfuraNetworkType.sepolia]
                   ) {
                     return fakeNetworkClients[1];
                   }
@@ -2036,7 +1983,7 @@ describe('NetworkController', () => {
               await controller.lookupNetwork();
 
               expect(
-                controller.state.networksMetadata[NetworkType.goerli]
+                controller.state.networksMetadata[NetworkType.sepolia]
                   .EIPS[1559],
               ).toBe(false);
               expect(
@@ -2055,8 +2002,8 @@ describe('NetworkController', () => {
               state: {
                 selectedNetworkClientId: 'AAAA-AAAA-AAAA-AAAA',
                 networkConfigurationsByChainId: {
-                  [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                    InfuraNetworkType.goerli,
+                  [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                    InfuraNetworkType.sepolia,
                   ),
                   '0x1337': buildCustomNetworkConfiguration({
                     chainId: '0x1337',
@@ -2089,7 +2036,7 @@ describe('NetworkController', () => {
                     beforeCompleting: () => {
                       // We are purposefully not awaiting this promise.
                       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                      controller.setProviderType(NetworkType.goerli);
+                      controller.setProviderType(NetworkType.sepolia);
                     },
                   },
                 ]),
@@ -2112,7 +2059,7 @@ describe('NetworkController', () => {
                   if (configuration.chainId === '0x1337') {
                     return fakeNetworkClients[0];
                   } else if (
-                    configuration.chainId === ChainId[InfuraNetworkType.goerli]
+                    configuration.chainId === ChainId[InfuraNetworkType.sepolia]
                   ) {
                     return fakeNetworkClients[1];
                   }
@@ -2278,7 +2225,7 @@ describe('NetworkController', () => {
   });
 
   describe('setProviderType', () => {
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       // False negative - this is a string.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       describe(`given the Infura network "${infuraNetworkType}"`, () => {
@@ -2404,9 +2351,9 @@ describe('NetworkController', () => {
         const fakeNetworkClient = buildFakeClient(fakeProvider);
         mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
 
-        await messenger.call('NetworkController:setProviderType', 'goerli');
+        await messenger.call('NetworkController:setProviderType', 'sepolia');
 
-        expect(controller.state.selectedNetworkClientId).toBe('goerli');
+        expect(controller.state.selectedNetworkClientId).toBe('sepolia');
       });
     });
   });
@@ -2426,7 +2373,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.
@@ -2948,7 +2895,7 @@ describe('NetworkController', () => {
   });
 
   describe('resetConnection', () => {
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       // False negative - this is a string.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       describe(`when the selected network client represents the Infura network "${infuraNetworkType}"`, () => {
@@ -3066,7 +3013,7 @@ describe('NetworkController', () => {
     // This is a string!
     // eslint-disable-next-line jest/valid-title
     describe(name, () => {
-      for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+      for (const infuraNetworkType of infuraNetworks) {
         const infuraChainId = ChainId[infuraNetworkType];
 
         // False negative - this is a string.
@@ -3181,7 +3128,7 @@ describe('NetworkController', () => {
     // This is a string!
     // eslint-disable-next-line jest/valid-title
     describe(name, () => {
-      for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+      for (const infuraNetworkType of infuraNetworks) {
         const infuraChainId = ChainId[infuraNetworkType];
 
         // False negative - this is a string.
@@ -3439,7 +3386,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraChainId = ChainId[infuraNetworkType];
 
@@ -3549,14 +3496,14 @@ describe('NetworkController', () => {
           const mainnetRpcEndpoint = buildInfuraRpcEndpoint(
             InfuraNetworkType.mainnet,
           );
-          const goerliRpcEndpoint = buildInfuraRpcEndpoint(
-            InfuraNetworkType.goerli,
+          const sepoliaRpcEndpoint = buildInfuraRpcEndpoint(
+            InfuraNetworkType.sepolia,
           );
           expect(() =>
             controller.addNetwork(
               buildAddNetworkFields({
                 chainId: ChainId.mainnet,
-                rpcEndpoints: [mainnetRpcEndpoint, goerliRpcEndpoint],
+                rpcEndpoints: [mainnetRpcEndpoint, sepoliaRpcEndpoint],
               }),
             ),
           ).toThrow(
@@ -3590,7 +3537,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraChainId = ChainId[infuraNetworkType];
 
@@ -3650,7 +3597,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       const infuraChainId = ChainId[infuraNetworkType];
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraNativeTokenName = NetworksTicker[infuraNetworkType];
@@ -4043,10 +3990,10 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.goerli,
+              selectedNetworkClientId: InfuraNetworkType.sepolia,
               networkConfigurationsByChainId: {
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -4712,7 +4659,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraChainId = ChainId[infuraNetworkType];
 
@@ -4870,9 +4817,9 @@ describe('NetworkController', () => {
     });
 
     it('throws (albeit for a different reason) if there are two or more different Infura RPC endpoints', async () => {
-      const [mainnetRpcEndpoint, goerliRpcEndpoint] = [
+      const [mainnetRpcEndpoint, sepoliaRpcEndpoint] = [
         buildInfuraRpcEndpoint(InfuraNetworkType.mainnet),
-        buildInfuraRpcEndpoint(InfuraNetworkType.goerli),
+        buildInfuraRpcEndpoint(InfuraNetworkType.sepolia),
       ];
       const networkConfigurationToUpdate = buildNetworkConfiguration({
         name: 'Mainnet',
@@ -4885,10 +4832,10 @@ describe('NetworkController', () => {
           state: buildNetworkControllerStateWithDefaultSelectedNetworkClientId({
             networkConfigurationsByChainId: {
               [ChainId.mainnet]: networkConfigurationToUpdate,
-              [ChainId.goerli]: buildNetworkConfiguration({
-                name: 'Goerli',
-                chainId: ChainId.goerli,
-                rpcEndpoints: [goerliRpcEndpoint],
+              [ChainId.sepolia]: buildNetworkConfiguration({
+                name: 'Sepolia',
+                chainId: ChainId.sepolia,
+                rpcEndpoints: [sepoliaRpcEndpoint],
               }),
             },
           }),
@@ -4897,11 +4844,11 @@ describe('NetworkController', () => {
           await expect(
             controller.updateNetwork(ChainId.mainnet, {
               ...networkConfigurationToUpdate,
-              rpcEndpoints: [mainnetRpcEndpoint, goerliRpcEndpoint],
+              rpcEndpoints: [mainnetRpcEndpoint, sepoliaRpcEndpoint],
             }),
           ).rejects.toThrow(
             new Error(
-              "Could not update network to point to same RPC endpoint as existing network for chain 0x5 ('Goerli')",
+              "Could not update network to point to same RPC endpoint as existing network for chain 0xaa36a7 ('Sepolia')",
             ),
           );
         },
@@ -5079,7 +5026,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       const infuraChainId = ChainId[infuraNetworkType];
       const infuraNativeTokenName = NetworksTicker[infuraNetworkType];
 
@@ -9009,7 +8956,7 @@ describe('NetworkController', () => {
       });
     });
 
-    const possibleInfuraNetworkTypes = Object.values(InfuraNetworkType);
+    const possibleInfuraNetworkTypes = infuraNetworks;
     possibleInfuraNetworkTypes.forEach(
       (infuraNetworkType, infuraNetworkTypeIndex) => {
         const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
@@ -11226,8 +11173,8 @@ describe('NetworkController', () => {
             state: {
               networkConfigurationsByChainId: {
                 '0x1337': networkConfigurationToUpdate,
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
                 '0x9999': buildCustomNetworkConfiguration({
                   chainId: '0x9999',
@@ -11245,7 +11192,7 @@ describe('NetworkController', () => {
           },
           async ({ controller }) => {
             const newRpcEndpoint = buildInfuraRpcEndpoint(
-              InfuraNetworkType.goerli,
+              InfuraNetworkType.sepolia,
             );
             await expect(() =>
               controller.updateNetwork('0x1337', {
@@ -11255,7 +11202,7 @@ describe('NetworkController', () => {
               }),
             ).rejects.toThrow(
               new Error(
-                "Could not update network to point to same RPC endpoint as existing network for chain 0x5 ('Goerli')",
+                "Could not update network to point to same RPC endpoint as existing network for chain 0xaa36a7 ('Sepolia')",
               ),
             );
           },
@@ -11836,7 +11783,7 @@ describe('NetworkController', () => {
     });
 
     describe('if nothing is being changed', () => {
-      for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+      for (const infuraNetworkType of infuraNetworks) {
         const infuraChainId = ChainId[infuraNetworkType];
 
         // This is a string.
@@ -12183,7 +12130,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // This is a string.
@@ -12286,11 +12233,11 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.goerli,
+              selectedNetworkClientId: InfuraNetworkType.sepolia,
               networkConfigurationsByChainId: {
                 '0x1337': buildCustomNetworkConfiguration(),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -12313,7 +12260,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.goerli,
+              selectedNetworkClientId: InfuraNetworkType.sepolia,
               networkConfigurationsByChainId: {
                 '0x1337': buildCustomNetworkConfiguration({
                   rpcEndpoints: [
@@ -12329,8 +12276,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -12364,11 +12311,11 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.goerli,
+              selectedNetworkClientId: InfuraNetworkType.sepolia,
               networkConfigurationsByChainId: {
                 '0x1337': buildCustomNetworkConfiguration(),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -12387,11 +12334,11 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.goerli,
+              selectedNetworkClientId: InfuraNetworkType.sepolia,
               networkConfigurationsByChainId: {
                 '0x1337': networkConfig,
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -12414,7 +12361,7 @@ describe('NetworkController', () => {
 
   describe('rollbackToPreviousProvider', () => {
     describe('when called not following any network switches', () => {
-      for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+      for (const infuraNetworkType of infuraNetworks) {
         // False negative - this is a string.
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         describe(`when the selected network client represents the Infura network "${infuraNetworkType}"`, () => {
@@ -12461,7 +12408,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of Object.values(InfuraNetworkType)) {
+    for (const infuraNetworkType of infuraNetworks) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.
@@ -13069,8 +13016,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -13079,7 +13026,7 @@ describe('NetworkController', () => {
             const fakeProvider = buildFakeProvider();
             const fakeNetworkClient = buildFakeClient(fakeProvider);
             mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
-            await controller.setActiveNetwork(InfuraNetworkType.goerli);
+            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
 
             const networkWillChange = waitForPublishedEvents({
               messenger,
@@ -13114,8 +13061,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -13124,7 +13071,7 @@ describe('NetworkController', () => {
             const fakeProvider = buildFakeProvider();
             const fakeNetworkClient = buildFakeClient(fakeProvider);
             mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
-            await controller.setActiveNetwork(InfuraNetworkType.goerli);
+            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
 
             const networkDidChange = waitForPublishedEvents({
               messenger,
@@ -13159,8 +13106,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -13173,7 +13120,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.goerli) {
+              if (configuration.chainId === ChainId.sepolia) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13184,9 +13131,9 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.goerli);
+            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
             expect(controller.state.selectedNetworkClientId).toBe(
-              InfuraNetworkType.goerli,
+              InfuraNetworkType.sepolia,
             );
 
             await controller.rollbackToPreviousProvider();
@@ -13213,8 +13160,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -13237,7 +13184,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.goerli) {
+              if (configuration.chainId === ChainId.sepolia) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13248,7 +13195,7 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.goerli);
+            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
             expect(
               controller.state.networksMetadata[
                 controller.state.selectedNetworkClientId
@@ -13298,8 +13245,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -13324,7 +13271,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.goerli) {
+              if (configuration.chainId === ChainId.sepolia) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13335,7 +13282,7 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.goerli);
+            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
 
             await controller.rollbackToPreviousProvider();
 
@@ -13367,8 +13314,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -13381,7 +13328,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.goerli) {
+              if (configuration.chainId === ChainId.sepolia) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13392,7 +13339,7 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.goerli);
+            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
             const networkClientBefore = controller.getSelectedNetworkClient();
             assert(networkClientBefore, 'Network client is somehow unset');
 
@@ -13423,8 +13370,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -13437,7 +13384,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.goerli) {
+              if (configuration.chainId === ChainId.sepolia) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13448,7 +13395,7 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.goerli);
+            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
 
             const promiseForInfuraIsUnblocked = waitForPublishedEvents({
               messenger,
@@ -13479,8 +13426,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -13510,7 +13457,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.goerli) {
+              if (configuration.chainId === ChainId.sepolia) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13521,9 +13468,9 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.goerli);
+            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
             expect(
-              controller.state.networksMetadata[InfuraNetworkType.goerli]
+              controller.state.networksMetadata[InfuraNetworkType.sepolia]
                 .status,
             ).toBe('unavailable');
 
@@ -13551,8 +13498,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.goerli]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.goerli,
+                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
+                  InfuraNetworkType.sepolia,
                 ),
               },
             },
@@ -13586,7 +13533,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.goerli) {
+              if (configuration.chainId === ChainId.sepolia) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13597,9 +13544,9 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.goerli);
+            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
             expect(
-              controller.state.networksMetadata[InfuraNetworkType.goerli]
+              controller.state.networksMetadata[InfuraNetworkType.sepolia]
                 .EIPS[1559],
             ).toBe(false);
 

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -34,6 +34,8 @@ import {
   buildNetworkControllerMessenger,
   buildRootMessenger,
   buildUpdateNetworkCustomRpcEndpointFields,
+  INFURA_NETWORKS,
+  TESTNET,
 } from './helpers';
 import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
 import type { FakeProviderStub } from '../../../tests/fake-provider';
@@ -142,26 +144,6 @@ const GENERIC_JSON_RPC_ERROR = rpcErrors.internal(
  * We are mocking/faking `Date.now` calls for test consistency
  */
 const FAKE_DATE_NOW_MS = 1732114339518;
-
-/**
- * A list of active InfuraNetworkType that are used in many tests
- */
-const INFURA_NEWORKS = [
-  InfuraNetworkType.mainnet,
-  InfuraNetworkType.sepolia,
-  InfuraNetworkType['linea-mainnet'],
-  InfuraNetworkType['linea-sepolia'],
-];
-
-/**
- * A object that contains the configuration for a network that begining used in many tests
- */
-const TESTNET = {
-  networkType: InfuraNetworkType.sepolia,
-  chainId: ChainId.sepolia,
-  name: 'Sepolia',
-  nativeCurrency: 'SepoliaETH',
-};
 
 describe('NetworkController', () => {
   let uuidCounter = 0;
@@ -686,7 +668,7 @@ describe('NetworkController', () => {
   });
 
   describe('initializeProvider', () => {
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.
@@ -846,7 +828,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
 
@@ -1388,7 +1370,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.
@@ -2211,7 +2193,7 @@ describe('NetworkController', () => {
   });
 
   describe('setProviderType', () => {
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       // False negative - this is a string.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       describe(`given the Infura network "${infuraNetworkType}"`, () => {
@@ -2364,7 +2346,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.
@@ -2886,7 +2868,7 @@ describe('NetworkController', () => {
   });
 
   describe('resetConnection', () => {
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       // False negative - this is a string.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       describe(`when the selected network client represents the Infura network "${infuraNetworkType}"`, () => {
@@ -3004,7 +2986,7 @@ describe('NetworkController', () => {
     // This is a string!
     // eslint-disable-next-line jest/valid-title
     describe(name, () => {
-      for (const infuraNetworkType of INFURA_NEWORKS) {
+      for (const infuraNetworkType of INFURA_NETWORKS) {
         const infuraChainId = ChainId[infuraNetworkType];
 
         // False negative - this is a string.
@@ -3119,7 +3101,7 @@ describe('NetworkController', () => {
     // This is a string!
     // eslint-disable-next-line jest/valid-title
     describe(name, () => {
-      for (const infuraNetworkType of INFURA_NEWORKS) {
+      for (const infuraNetworkType of INFURA_NETWORKS) {
         const infuraChainId = ChainId[infuraNetworkType];
 
         // False negative - this is a string.
@@ -3377,7 +3359,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraChainId = ChainId[infuraNetworkType];
 
@@ -3528,7 +3510,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraChainId = ChainId[infuraNetworkType];
 
@@ -3588,7 +3570,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraNativeTokenName = NetworksTicker[infuraNetworkType];
@@ -4650,7 +4632,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraChainId = ChainId[infuraNetworkType];
 
@@ -5017,7 +4999,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
       const infuraNativeTokenName = NetworksTicker[infuraNetworkType];
 
@@ -8947,7 +8929,7 @@ describe('NetworkController', () => {
       });
     });
 
-    const possibleInfuraNetworkTypes = INFURA_NEWORKS;
+    const possibleInfuraNetworkTypes = INFURA_NETWORKS;
     possibleInfuraNetworkTypes.forEach(
       (infuraNetworkType, infuraNetworkTypeIndex) => {
         const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
@@ -11772,7 +11754,7 @@ describe('NetworkController', () => {
     });
 
     describe('if nothing is being changed', () => {
-      for (const infuraNetworkType of INFURA_NEWORKS) {
+      for (const infuraNetworkType of INFURA_NETWORKS) {
         const infuraChainId = ChainId[infuraNetworkType];
 
         // This is a string.
@@ -12119,7 +12101,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // This is a string.
@@ -12350,7 +12332,7 @@ describe('NetworkController', () => {
 
   describe('rollbackToPreviousProvider', () => {
     describe('when called not following any network switches', () => {
-      for (const infuraNetworkType of INFURA_NEWORKS) {
+      for (const infuraNetworkType of INFURA_NETWORKS) {
         // False negative - this is a string.
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         describe(`when the selected network client represents the Infura network "${infuraNetworkType}"`, () => {
@@ -12397,7 +12379,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of INFURA_NEWORKS) {
+    for (const infuraNetworkType of INFURA_NETWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -529,21 +529,6 @@ describe('NetworkController', () => {
                     },
                   ],
                 },
-                "0x5": Object {
-                  "blockExplorerUrls": Array [],
-                  "chainId": "0x5",
-                  "defaultRpcEndpointIndex": 0,
-                  "name": "Goerli",
-                  "nativeCurrency": "GoerliETH",
-                  "rpcEndpoints": Array [
-                    Object {
-                      "failoverUrls": Array [],
-                      "networkClientId": "goerli",
-                      "type": "infura",
-                      "url": "https://goerli.infura.io/v3/{infuraProjectId}",
-                    },
-                  ],
-                },
                 "0xaa36a7": Object {
                   "blockExplorerUrls": Array [],
                   "chainId": "0xaa36a7",
@@ -556,21 +541,6 @@ describe('NetworkController', () => {
                       "networkClientId": "sepolia",
                       "type": "infura",
                       "url": "https://sepolia.infura.io/v3/{infuraProjectId}",
-                    },
-                  ],
-                },
-                "0xe704": Object {
-                  "blockExplorerUrls": Array [],
-                  "chainId": "0xe704",
-                  "defaultRpcEndpointIndex": 0,
-                  "name": "Linea Goerli",
-                  "nativeCurrency": "LineaETH",
-                  "rpcEndpoints": Array [
-                    Object {
-                      "failoverUrls": Array [],
-                      "networkClientId": "linea-goerli",
-                      "type": "infura",
-                      "url": "https://linea-goerli.infura.io/v3/{infuraProjectId}",
                     },
                   ],
                 },

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -146,17 +146,22 @@ const FAKE_DATE_NOW_MS = 1732114339518;
 /**
  * A list of active InfuraNetworkType that are used in many tests
  */
-const INFURA_NEWORKS = [InfuraNetworkType['mainnet'], InfuraNetworkType['sepolia'], InfuraNetworkType['linea-mainnet'], InfuraNetworkType['linea-sepolia']];
+const INFURA_NEWORKS = [
+  InfuraNetworkType.mainnet,
+  InfuraNetworkType.sepolia,
+  InfuraNetworkType['linea-mainnet'],
+  InfuraNetworkType['linea-sepolia'],
+];
 
 /**
  * A object that contains the configuration for a network that begining used in many tests
  */
 const TESTNET = {
-  networkType : InfuraNetworkType.sepolia,
+  networkType: InfuraNetworkType.sepolia,
   chainId: ChainId.sepolia,
   name: 'Sepolia',
   nativeCurrency: 'SepoliaETH',
-}
+};
 
 describe('NetworkController', () => {
   let uuidCounter = 0;
@@ -620,7 +625,7 @@ describe('NetworkController', () => {
                 defaultBlockExplorerUrlIndex: 0,
                 defaultRpcEndpointIndex: 0,
                 name: TESTNET.name,
-                nativeCurrency:  TESTNET.nativeCurrency,
+                nativeCurrency: TESTNET.nativeCurrency,
                 rpcEndpoints: [
                   {
                     failoverUrls: ['https://failover.endpoint'],
@@ -1897,8 +1902,7 @@ describe('NetworkController', () => {
               await controller.lookupNetwork();
 
               expect(
-                controller.state.networksMetadata[TESTNET.networkType]
-                  .status,
+                controller.state.networksMetadata[TESTNET.networkType].status,
               ).toBe('unknown');
             },
           );
@@ -2363,9 +2367,14 @@ describe('NetworkController', () => {
         const fakeNetworkClient = buildFakeClient(fakeProvider);
         mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
 
-        await messenger.call('NetworkController:setProviderType', TESTNET.networkType);
+        await messenger.call(
+          'NetworkController:setProviderType',
+          TESTNET.networkType,
+        );
 
-        expect(controller.state.selectedNetworkClientId).toBe(TESTNET.networkType);
+        expect(controller.state.selectedNetworkClientId).toBe(
+          TESTNET.networkType,
+        );
       });
     });
   });
@@ -11203,9 +11212,7 @@ describe('NetworkController', () => {
             },
           },
           async ({ controller }) => {
-            const newRpcEndpoint = buildInfuraRpcEndpoint(
-              TESTNET.networkType,
-            );
+            const newRpcEndpoint = buildInfuraRpcEndpoint(TESTNET.networkType);
             await expect(() =>
               controller.updateNetwork('0x1337', {
                 ...networkConfigurationToUpdate,
@@ -13482,8 +13489,7 @@ describe('NetworkController', () => {
             });
             await controller.setActiveNetwork(TESTNET.networkType);
             expect(
-              controller.state.networksMetadata[TESTNET.networkType]
-                .status,
+              controller.state.networksMetadata[TESTNET.networkType].status,
             ).toBe('unavailable');
 
             await controller.rollbackToPreviousProvider();
@@ -13558,8 +13564,7 @@ describe('NetworkController', () => {
             });
             await controller.setActiveNetwork(TESTNET.networkType);
             expect(
-              controller.state.networksMetadata[TESTNET.networkType]
-                .EIPS[1559],
+              controller.state.networksMetadata[TESTNET.networkType].EIPS[1559],
             ).toBe(false);
 
             await controller.rollbackToPreviousProvider();

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -143,8 +143,20 @@ const GENERIC_JSON_RPC_ERROR = rpcErrors.internal(
  */
 const FAKE_DATE_NOW_MS = 1732114339518;
 
+/**
+ * A list of active InfuraNetworkType that are used in many tests
+ */
+const INFURA_NEWORKS = [InfuraNetworkType['mainnet'], InfuraNetworkType['sepolia'], InfuraNetworkType['linea-mainnet'], InfuraNetworkType['linea-sepolia']];
 
-const infuraNetworks = [InfuraNetworkType['mainnet'], InfuraNetworkType['sepolia'], InfuraNetworkType['linea-mainnet'], InfuraNetworkType['linea-sepolia']];
+/**
+ * A object that contains the configuration for a network that begining used in many tests
+ */
+const TESTNET = {
+  networkType : InfuraNetworkType.sepolia,
+  chainId: ChainId.sepolia,
+  name: 'Sepolia',
+  nativeCurrency: 'SepoliaETH',
+}
 
 describe('NetworkController', () => {
   let uuidCounter = 0;
@@ -600,20 +612,20 @@ describe('NetworkController', () => {
       await withController(
         {
           state: {
-            selectedNetworkClientId: InfuraNetworkType.sepolia,
+            selectedNetworkClientId: TESTNET.networkType,
             networkConfigurationsByChainId: {
-              [ChainId.sepolia]: {
+              [TESTNET.chainId]: {
                 blockExplorerUrls: ['https://block.explorer'],
-                chainId: ChainId.sepolia,
+                chainId: TESTNET.chainId,
                 defaultBlockExplorerUrlIndex: 0,
                 defaultRpcEndpointIndex: 0,
-                name: 'Sepolia',
-                nativeCurrency: 'SepoliaETH',
+                name: TESTNET.name,
+                nativeCurrency:  TESTNET.nativeCurrency,
                 rpcEndpoints: [
                   {
                     failoverUrls: ['https://failover.endpoint'],
-                    name: 'Sepolia',
-                    networkClientId: InfuraNetworkType.sepolia,
+                    name: TESTNET.name,
+                    networkClientId: TESTNET.networkType,
                     type: RpcEndpointType.Infura,
                     url: 'https://sepolia.infura.io/v3/{infuraProjectId}',
                   },
@@ -699,7 +711,7 @@ describe('NetworkController', () => {
   });
 
   describe('initializeProvider', () => {
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.
@@ -859,7 +871,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
 
@@ -962,10 +974,10 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.sepolia,
+              selectedNetworkClientId: TESTNET.networkType,
               networkConfigurationsByChainId: {
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
                 '0x1337': buildCustomNetworkConfiguration({
                   chainId: '0x1337',
@@ -1007,7 +1019,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.sepolia) {
+              if (configuration.chainId === TESTNET.chainId) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -1401,7 +1413,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.
@@ -1809,8 +1821,8 @@ describe('NetworkController', () => {
               state: {
                 selectedNetworkClientId: 'AAAA-AAAA-AAAA-AAAA',
                 networkConfigurationsByChainId: {
-                  [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                    InfuraNetworkType.sepolia,
+                  [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                    TESTNET.networkType,
                   ),
                   '0x1337': buildCustomNetworkConfiguration({
                     chainId: '0x1337',
@@ -1843,7 +1855,7 @@ describe('NetworkController', () => {
                     beforeCompleting: () => {
                       // We are purposefully not awaiting this promise.
                       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                      controller.setProviderType(NetworkType.sepolia);
+                      controller.setProviderType(TESTNET.networkType);
                     },
                   },
                 ]),
@@ -1866,7 +1878,7 @@ describe('NetworkController', () => {
                   if (configuration.chainId === '0x1337') {
                     return fakeNetworkClients[0];
                   } else if (
-                    configuration.chainId === ChainId[InfuraNetworkType.sepolia]
+                    configuration.chainId === ChainId[TESTNET.networkType]
                   ) {
                     return fakeNetworkClients[1];
                   }
@@ -1885,7 +1897,7 @@ describe('NetworkController', () => {
               await controller.lookupNetwork();
 
               expect(
-                controller.state.networksMetadata[InfuraNetworkType.sepolia]
+                controller.state.networksMetadata[TESTNET.networkType]
                   .status,
               ).toBe('unknown');
             },
@@ -1900,8 +1912,8 @@ describe('NetworkController', () => {
               state: {
                 selectedNetworkClientId: 'AAAA-AAAA-AAAA-AAAA',
                 networkConfigurationsByChainId: {
-                  [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                    InfuraNetworkType.sepolia,
+                  [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                    TESTNET.networkType,
                   ),
                   '0x1337': buildCustomNetworkConfiguration({
                     chainId: '0x1337',
@@ -1938,7 +1950,7 @@ describe('NetworkController', () => {
                     beforeCompleting: () => {
                       // We are purposefully not awaiting this promise.
                       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                      controller.setProviderType(NetworkType.sepolia);
+                      controller.setProviderType(TESTNET.networkType);
                     },
                   },
                 ]),
@@ -1963,7 +1975,7 @@ describe('NetworkController', () => {
                   if (configuration.chainId === '0x1337') {
                     return fakeNetworkClients[0];
                   } else if (
-                    configuration.chainId === ChainId[InfuraNetworkType.sepolia]
+                    configuration.chainId === ChainId[TESTNET.networkType]
                   ) {
                     return fakeNetworkClients[1];
                   }
@@ -1983,7 +1995,7 @@ describe('NetworkController', () => {
               await controller.lookupNetwork();
 
               expect(
-                controller.state.networksMetadata[NetworkType.sepolia]
+                controller.state.networksMetadata[TESTNET.networkType]
                   .EIPS[1559],
               ).toBe(false);
               expect(
@@ -2002,8 +2014,8 @@ describe('NetworkController', () => {
               state: {
                 selectedNetworkClientId: 'AAAA-AAAA-AAAA-AAAA',
                 networkConfigurationsByChainId: {
-                  [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                    InfuraNetworkType.sepolia,
+                  [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                    TESTNET.networkType,
                   ),
                   '0x1337': buildCustomNetworkConfiguration({
                     chainId: '0x1337',
@@ -2036,7 +2048,7 @@ describe('NetworkController', () => {
                     beforeCompleting: () => {
                       // We are purposefully not awaiting this promise.
                       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                      controller.setProviderType(NetworkType.sepolia);
+                      controller.setProviderType(TESTNET.networkType);
                     },
                   },
                 ]),
@@ -2059,7 +2071,7 @@ describe('NetworkController', () => {
                   if (configuration.chainId === '0x1337') {
                     return fakeNetworkClients[0];
                   } else if (
-                    configuration.chainId === ChainId[InfuraNetworkType.sepolia]
+                    configuration.chainId === ChainId[TESTNET.networkType]
                   ) {
                     return fakeNetworkClients[1];
                   }
@@ -2225,7 +2237,7 @@ describe('NetworkController', () => {
   });
 
   describe('setProviderType', () => {
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       // False negative - this is a string.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       describe(`given the Infura network "${infuraNetworkType}"`, () => {
@@ -2351,9 +2363,9 @@ describe('NetworkController', () => {
         const fakeNetworkClient = buildFakeClient(fakeProvider);
         mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
 
-        await messenger.call('NetworkController:setProviderType', 'sepolia');
+        await messenger.call('NetworkController:setProviderType', TESTNET.networkType);
 
-        expect(controller.state.selectedNetworkClientId).toBe('sepolia');
+        expect(controller.state.selectedNetworkClientId).toBe(TESTNET.networkType);
       });
     });
   });
@@ -2373,7 +2385,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.
@@ -2895,7 +2907,7 @@ describe('NetworkController', () => {
   });
 
   describe('resetConnection', () => {
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       // False negative - this is a string.
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       describe(`when the selected network client represents the Infura network "${infuraNetworkType}"`, () => {
@@ -3013,7 +3025,7 @@ describe('NetworkController', () => {
     // This is a string!
     // eslint-disable-next-line jest/valid-title
     describe(name, () => {
-      for (const infuraNetworkType of infuraNetworks) {
+      for (const infuraNetworkType of INFURA_NEWORKS) {
         const infuraChainId = ChainId[infuraNetworkType];
 
         // False negative - this is a string.
@@ -3128,7 +3140,7 @@ describe('NetworkController', () => {
     // This is a string!
     // eslint-disable-next-line jest/valid-title
     describe(name, () => {
-      for (const infuraNetworkType of infuraNetworks) {
+      for (const infuraNetworkType of INFURA_NEWORKS) {
         const infuraChainId = ChainId[infuraNetworkType];
 
         // False negative - this is a string.
@@ -3386,7 +3398,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraChainId = ChainId[infuraNetworkType];
 
@@ -3496,14 +3508,14 @@ describe('NetworkController', () => {
           const mainnetRpcEndpoint = buildInfuraRpcEndpoint(
             InfuraNetworkType.mainnet,
           );
-          const sepoliaRpcEndpoint = buildInfuraRpcEndpoint(
-            InfuraNetworkType.sepolia,
+          const testnetRpcEndpoint = buildInfuraRpcEndpoint(
+            TESTNET.networkType,
           );
           expect(() =>
             controller.addNetwork(
               buildAddNetworkFields({
                 chainId: ChainId.mainnet,
-                rpcEndpoints: [mainnetRpcEndpoint, sepoliaRpcEndpoint],
+                rpcEndpoints: [mainnetRpcEndpoint, testnetRpcEndpoint],
               }),
             ),
           ).toThrow(
@@ -3537,7 +3549,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraChainId = ChainId[infuraNetworkType];
 
@@ -3597,7 +3609,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraNativeTokenName = NetworksTicker[infuraNetworkType];
@@ -3990,10 +4002,10 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.sepolia,
+              selectedNetworkClientId: TESTNET.networkType,
               networkConfigurationsByChainId: {
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -4659,7 +4671,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
       const infuraChainId = ChainId[infuraNetworkType];
 
@@ -4817,9 +4829,9 @@ describe('NetworkController', () => {
     });
 
     it('throws (albeit for a different reason) if there are two or more different Infura RPC endpoints', async () => {
-      const [mainnetRpcEndpoint, sepoliaRpcEndpoint] = [
+      const [mainnetRpcEndpoint, testnetRpcEndpoint] = [
         buildInfuraRpcEndpoint(InfuraNetworkType.mainnet),
-        buildInfuraRpcEndpoint(InfuraNetworkType.sepolia),
+        buildInfuraRpcEndpoint(TESTNET.networkType),
       ];
       const networkConfigurationToUpdate = buildNetworkConfiguration({
         name: 'Mainnet',
@@ -4832,10 +4844,10 @@ describe('NetworkController', () => {
           state: buildNetworkControllerStateWithDefaultSelectedNetworkClientId({
             networkConfigurationsByChainId: {
               [ChainId.mainnet]: networkConfigurationToUpdate,
-              [ChainId.sepolia]: buildNetworkConfiguration({
-                name: 'Sepolia',
-                chainId: ChainId.sepolia,
-                rpcEndpoints: [sepoliaRpcEndpoint],
+              [TESTNET.chainId]: buildNetworkConfiguration({
+                name: TESTNET.name,
+                chainId: TESTNET.chainId,
+                rpcEndpoints: [testnetRpcEndpoint],
               }),
             },
           }),
@@ -4844,11 +4856,11 @@ describe('NetworkController', () => {
           await expect(
             controller.updateNetwork(ChainId.mainnet, {
               ...networkConfigurationToUpdate,
-              rpcEndpoints: [mainnetRpcEndpoint, sepoliaRpcEndpoint],
+              rpcEndpoints: [mainnetRpcEndpoint, testnetRpcEndpoint],
             }),
           ).rejects.toThrow(
             new Error(
-              "Could not update network to point to same RPC endpoint as existing network for chain 0xaa36a7 ('Sepolia')",
+              `Could not update network to point to same RPC endpoint as existing network for chain ${TESTNET.chainId} ('${TESTNET.name}')`,
             ),
           );
         },
@@ -5026,7 +5038,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
       const infuraNativeTokenName = NetworksTicker[infuraNetworkType];
 
@@ -8956,7 +8968,7 @@ describe('NetworkController', () => {
       });
     });
 
-    const possibleInfuraNetworkTypes = infuraNetworks;
+    const possibleInfuraNetworkTypes = INFURA_NEWORKS;
     possibleInfuraNetworkTypes.forEach(
       (infuraNetworkType, infuraNetworkTypeIndex) => {
         const infuraNetworkNickname = NetworkNickname[infuraNetworkType];
@@ -11173,8 +11185,8 @@ describe('NetworkController', () => {
             state: {
               networkConfigurationsByChainId: {
                 '0x1337': networkConfigurationToUpdate,
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
                 '0x9999': buildCustomNetworkConfiguration({
                   chainId: '0x9999',
@@ -11192,7 +11204,7 @@ describe('NetworkController', () => {
           },
           async ({ controller }) => {
             const newRpcEndpoint = buildInfuraRpcEndpoint(
-              InfuraNetworkType.sepolia,
+              TESTNET.networkType,
             );
             await expect(() =>
               controller.updateNetwork('0x1337', {
@@ -11202,7 +11214,7 @@ describe('NetworkController', () => {
               }),
             ).rejects.toThrow(
               new Error(
-                "Could not update network to point to same RPC endpoint as existing network for chain 0xaa36a7 ('Sepolia')",
+                `Could not update network to point to same RPC endpoint as existing network for chain ${TESTNET.chainId} ('${TESTNET.name}')`,
               ),
             );
           },
@@ -11783,7 +11795,7 @@ describe('NetworkController', () => {
     });
 
     describe('if nothing is being changed', () => {
-      for (const infuraNetworkType of infuraNetworks) {
+      for (const infuraNetworkType of INFURA_NEWORKS) {
         const infuraChainId = ChainId[infuraNetworkType];
 
         // This is a string.
@@ -12130,7 +12142,7 @@ describe('NetworkController', () => {
       );
     });
 
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // This is a string.
@@ -12233,11 +12245,11 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.sepolia,
+              selectedNetworkClientId: TESTNET.networkType,
               networkConfigurationsByChainId: {
                 '0x1337': buildCustomNetworkConfiguration(),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -12260,7 +12272,7 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.sepolia,
+              selectedNetworkClientId: TESTNET.networkType,
               networkConfigurationsByChainId: {
                 '0x1337': buildCustomNetworkConfiguration({
                   rpcEndpoints: [
@@ -12276,8 +12288,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -12311,11 +12323,11 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.sepolia,
+              selectedNetworkClientId: TESTNET.networkType,
               networkConfigurationsByChainId: {
                 '0x1337': buildCustomNetworkConfiguration(),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -12334,11 +12346,11 @@ describe('NetworkController', () => {
         await withController(
           {
             state: {
-              selectedNetworkClientId: InfuraNetworkType.sepolia,
+              selectedNetworkClientId: TESTNET.networkType,
               networkConfigurationsByChainId: {
                 '0x1337': networkConfig,
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -12361,7 +12373,7 @@ describe('NetworkController', () => {
 
   describe('rollbackToPreviousProvider', () => {
     describe('when called not following any network switches', () => {
-      for (const infuraNetworkType of infuraNetworks) {
+      for (const infuraNetworkType of INFURA_NEWORKS) {
         // False negative - this is a string.
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         describe(`when the selected network client represents the Infura network "${infuraNetworkType}"`, () => {
@@ -12408,7 +12420,7 @@ describe('NetworkController', () => {
       });
     });
 
-    for (const infuraNetworkType of infuraNetworks) {
+    for (const infuraNetworkType of INFURA_NEWORKS) {
       const infuraChainId = ChainId[infuraNetworkType];
 
       // False negative - this is a string.
@@ -13016,8 +13028,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -13026,7 +13038,7 @@ describe('NetworkController', () => {
             const fakeProvider = buildFakeProvider();
             const fakeNetworkClient = buildFakeClient(fakeProvider);
             mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
-            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
+            await controller.setActiveNetwork(TESTNET.networkType);
 
             const networkWillChange = waitForPublishedEvents({
               messenger,
@@ -13061,8 +13073,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -13071,7 +13083,7 @@ describe('NetworkController', () => {
             const fakeProvider = buildFakeProvider();
             const fakeNetworkClient = buildFakeClient(fakeProvider);
             mockCreateNetworkClient().mockReturnValue(fakeNetworkClient);
-            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
+            await controller.setActiveNetwork(TESTNET.networkType);
 
             const networkDidChange = waitForPublishedEvents({
               messenger,
@@ -13106,8 +13118,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -13120,7 +13132,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.sepolia) {
+              if (configuration.chainId === TESTNET.chainId) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13131,9 +13143,9 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
+            await controller.setActiveNetwork(TESTNET.networkType);
             expect(controller.state.selectedNetworkClientId).toBe(
-              InfuraNetworkType.sepolia,
+              TESTNET.networkType,
             );
 
             await controller.rollbackToPreviousProvider();
@@ -13160,8 +13172,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -13184,7 +13196,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.sepolia) {
+              if (configuration.chainId === TESTNET.chainId) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13195,7 +13207,7 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
+            await controller.setActiveNetwork(TESTNET.networkType);
             expect(
               controller.state.networksMetadata[
                 controller.state.selectedNetworkClientId
@@ -13245,8 +13257,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -13271,7 +13283,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.sepolia) {
+              if (configuration.chainId === TESTNET.chainId) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13282,7 +13294,7 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
+            await controller.setActiveNetwork(TESTNET.networkType);
 
             await controller.rollbackToPreviousProvider();
 
@@ -13314,8 +13326,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -13328,7 +13340,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.sepolia) {
+              if (configuration.chainId === TESTNET.chainId) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13339,7 +13351,7 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
+            await controller.setActiveNetwork(TESTNET.networkType);
             const networkClientBefore = controller.getSelectedNetworkClient();
             assert(networkClientBefore, 'Network client is somehow unset');
 
@@ -13370,8 +13382,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -13384,7 +13396,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.sepolia) {
+              if (configuration.chainId === TESTNET.chainId) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13395,7 +13407,7 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
+            await controller.setActiveNetwork(TESTNET.networkType);
 
             const promiseForInfuraIsUnblocked = waitForPublishedEvents({
               messenger,
@@ -13426,8 +13438,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -13457,7 +13469,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.sepolia) {
+              if (configuration.chainId === TESTNET.chainId) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13468,9 +13480,9 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
+            await controller.setActiveNetwork(TESTNET.networkType);
             expect(
-              controller.state.networksMetadata[InfuraNetworkType.sepolia]
+              controller.state.networksMetadata[TESTNET.networkType]
                 .status,
             ).toBe('unavailable');
 
@@ -13498,8 +13510,8 @@ describe('NetworkController', () => {
                     }),
                   ],
                 }),
-                [ChainId.sepolia]: buildInfuraNetworkConfiguration(
-                  InfuraNetworkType.sepolia,
+                [TESTNET.chainId]: buildInfuraNetworkConfiguration(
+                  TESTNET.networkType,
                 ),
               },
             },
@@ -13533,7 +13545,7 @@ describe('NetworkController', () => {
               buildFakeClient(fakeProviders[1]),
             ];
             createNetworkClientMock.mockImplementation(({ configuration }) => {
-              if (configuration.chainId === ChainId.sepolia) {
+              if (configuration.chainId === TESTNET.chainId) {
                 return fakeNetworkClients[0];
               } else if (configuration.chainId === '0x1337') {
                 return fakeNetworkClients[1];
@@ -13544,9 +13556,9 @@ describe('NetworkController', () => {
                 )}`,
               );
             });
-            await controller.setActiveNetwork(InfuraNetworkType.sepolia);
+            await controller.setActiveNetwork(TESTNET.networkType);
             expect(
-              controller.state.networksMetadata[InfuraNetworkType.sepolia]
+              controller.state.networksMetadata[TESTNET.networkType]
                 .EIPS[1559],
             ).toBe(false);
 

--- a/packages/network-controller/tests/helpers.ts
+++ b/packages/network-controller/tests/helpers.ts
@@ -243,7 +243,7 @@ export function buildNetworkConfiguration(
       nativeCurrency: () => 'TOKEN',
       rpcEndpoints: () => [
         defaultRpcEndpointType === RpcEndpointType.Infura
-          ? buildInfuraRpcEndpoint(InfuraNetworkType['linea-goerli'])
+          ? buildInfuraRpcEndpoint(InfuraNetworkType.sepolia)
           : buildCustomRpcEndpoint({ url: 'https://test.endpoint' }),
       ],
     },

--- a/packages/network-controller/tests/helpers.ts
+++ b/packages/network-controller/tests/helpers.ts
@@ -45,6 +45,28 @@ export type RootMessenger = Messenger<
 >;
 
 /**
+ * A list of active InfuraNetworkType that are used in many tests
+ *
+ * TODO: Base this off of InfuraNetworkType when Goerli is removed.
+ */
+export const INFURA_NETWORKS = [
+  InfuraNetworkType.mainnet,
+  InfuraNetworkType.sepolia,
+  InfuraNetworkType['linea-mainnet'],
+  InfuraNetworkType['linea-sepolia'],
+];
+
+/**
+ * A object that contains the configuration for a network that begining used in many tests
+ */
+export const TESTNET = {
+  networkType: InfuraNetworkType.sepolia,
+  chainId: ChainId.sepolia,
+  name: 'Sepolia',
+  nativeCurrency: 'SepoliaETH',
+};
+
+/**
  * Build a root messenger that includes all events used by the network
  * controller.
  *
@@ -243,7 +265,7 @@ export function buildNetworkConfiguration(
       nativeCurrency: () => 'TOKEN',
       rpcEndpoints: () => [
         defaultRpcEndpointType === RpcEndpointType.Infura
-          ? buildInfuraRpcEndpoint(InfuraNetworkType.sepolia)
+          ? buildInfuraRpcEndpoint(TESTNET.networkType)
           : buildCustomRpcEndpoint({ url: 'https://test.endpoint' }),
       ],
     },

--- a/packages/network-controller/tests/provider-api-tests/shared-tests.ts
+++ b/packages/network-controller/tests/provider-api-tests/shared-tests.ts
@@ -287,7 +287,7 @@ export function testsForProviderType(providerType: ProviderType) {
       describe('net_version', () => {
         const networkArgs = {
           providerType,
-          infuraNetwork: providerType === 'infura' ? 'goerli' : undefined,
+          infuraNetwork: providerType === 'infura' ? 'sepolia' : undefined,
         } as const;
         it('hits the RPC endpoint', async () => {
           await withMockedCommunications(networkArgs, async (comms) => {

--- a/packages/network-controller/tests/provider-api-tests/shared-tests.ts
+++ b/packages/network-controller/tests/provider-api-tests/shared-tests.ts
@@ -4,6 +4,7 @@ import type { ProviderType } from './helpers';
 import { withMockedCommunications, withNetworkClient } from './helpers';
 import { testsForRpcMethodAssumingNoBlockParam } from './no-block-param';
 import { testsForRpcMethodNotHandledByMiddleware } from './not-handled-by-middleware';
+import { TESTNET } from '../helpers';
 
 /**
  * Constructs an error message that the Infura client would produce in the event
@@ -287,7 +288,8 @@ export function testsForProviderType(providerType: ProviderType) {
       describe('net_version', () => {
         const networkArgs = {
           providerType,
-          infuraNetwork: providerType === 'infura' ? 'sepolia' : undefined,
+          infuraNetwork:
+            providerType === 'infura' ? TESTNET.networkType : undefined,
         } as const;
         it('hits the RPC endpoint', async () => {
           await withMockedCommunications(networkArgs, async (comms) => {

--- a/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
+++ b/packages/selected-network-controller/tests/SelectedNetworkController.test.ts
@@ -218,11 +218,11 @@ describe('SelectedNetworkController', () => {
     it('can be instantiated with a state', () => {
       const { controller } = setup({
         state: {
-          domains: { networkClientId: 'goerli' },
+          domains: { networkClientId: 'sepolia' },
         },
       });
       expect(controller.state).toStrictEqual({
-        domains: { networkClientId: 'goerli' },
+        domains: { networkClientId: 'sepolia' },
       });
     });
 
@@ -298,7 +298,7 @@ describe('SelectedNetworkController', () => {
     describe('when a network is deleted from the network controller', () => {
       const initialDomains = {
         'not-deleted-network.com': 'linea-mainnet',
-        'deleted-network.com': 'goerli',
+        'deleted-network.com': 'sepolia',
       };
 
       const deleteNetwork = (
@@ -331,7 +331,7 @@ describe('SelectedNetworkController', () => {
 
         const networkControllerState = getDefaultNetworkControllerState();
         deleteNetwork(
-          '0x5',
+          '0xaa36a7',
           networkControllerState,
           messenger,
           mockNetworkControllerGetState,
@@ -352,7 +352,7 @@ describe('SelectedNetworkController', () => {
         };
 
         deleteNetwork(
-          '0x5',
+          '0xaa36a7',
           networkControllerState,
           messenger,
           mockNetworkControllerGetState,
@@ -398,7 +398,7 @@ describe('SelectedNetworkController', () => {
         });
 
         deleteNetwork(
-          '0x5',
+          '0xaa36a7',
           networkControllerState,
           messenger,
           mockNetworkControllerGetState,
@@ -415,7 +415,7 @@ describe('SelectedNetworkController', () => {
       it('redirects domains when the default rpc endpoint is switched', () => {
         const initialDomains = {
           'different-chain.com': 'mainnet',
-          'chain-with-new-default.com': 'goerli',
+          'chain-with-new-default.com': 'sepolia',
         };
 
         const { controller, messenger, mockNetworkControllerGetState } = setup({
@@ -425,7 +425,7 @@ describe('SelectedNetworkController', () => {
 
         const networkControllerState = getDefaultNetworkControllerState();
         const goerliNetwork =
-          networkControllerState.networkConfigurationsByChainId['0x5'];
+          networkControllerState.networkConfigurationsByChainId['0xaa36a7'];
 
         goerliNetwork.defaultRpcEndpointIndex =
           goerliNetwork.rpcEndpoints.push({
@@ -445,7 +445,7 @@ describe('SelectedNetworkController', () => {
           [
             {
               op: 'replace',
-              path: ['networkConfigurationsByChainId', '0x5'],
+              path: ['networkConfigurationsByChainId', '0xaa36a7'],
             },
           ],
         );
@@ -459,7 +459,7 @@ describe('SelectedNetworkController', () => {
       it('redirects domains when the default rpc endpoint is deleted and replaced', () => {
         const initialDomains = {
           'different-chain.com': 'mainnet',
-          'chain-with-new-default.com': 'goerli',
+          'chain-with-new-default.com': 'sepolia',
         };
 
         const { controller, messenger, mockNetworkControllerGetState } = setup({
@@ -469,7 +469,7 @@ describe('SelectedNetworkController', () => {
 
         const networkControllerState = getDefaultNetworkControllerState();
         const goerliNetwork =
-          networkControllerState.networkConfigurationsByChainId['0x5'];
+          networkControllerState.networkConfigurationsByChainId['0xaa36a7'];
 
         goerliNetwork.rpcEndpoints = [
           {
@@ -490,7 +490,7 @@ describe('SelectedNetworkController', () => {
           [
             {
               op: 'replace',
-              path: ['networkConfigurationsByChainId', '0x5'],
+              path: ['networkConfigurationsByChainId', '0xaa36a7'],
             },
           ],
         );

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -337,13 +337,15 @@ function waitForTransactionFinished(
 const MOCK_PREFERENCES = { state: { selectedAddress: 'foo' } };
 const INFURA_PROJECT_ID = 'testinfuraid';
 const HTTP_PROVIDERS = {
-  goerli: new HttpProvider('https://goerli.infura.io/v3/goerli-pid'),
+  sepolia: new HttpProvider('https://sepolia.infura.io/v3/sepolia-pid'),
   // TODO: Investigate and address why tests break when mainet has a different INFURA_PROJECT_ID
   mainnet: new HttpProvider(
     `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
   ),
   linea: new HttpProvider('https://linea.infura.io/v3/linea-pid'),
-  lineaGoerli: new HttpProvider('https://linea-g.infura.io/v3/linea-g-pid'),
+  lineaSepolia: new HttpProvider(
+    'https://linea-sepolia.infura.io/v3/linea-sepolia-pid',
+  ),
   custom: new HttpProvider(`http://127.0.0.123:456/ethrpc?apiKey=foobar`),
   palm: new HttpProvider('https://palm-mainnet.infura.io/v3/palm-pid'),
 };
@@ -357,13 +359,13 @@ type MockNetwork = {
 };
 
 const MOCK_NETWORK: MockNetwork = {
-  chainId: ChainId.goerli,
-  provider: HTTP_PROVIDERS.goerli,
-  blockTracker: buildMockBlockTracker('0x102833C', HTTP_PROVIDERS.goerli),
+  chainId: ChainId.sepolia,
+  provider: HTTP_PROVIDERS.sepolia,
+  blockTracker: buildMockBlockTracker('0x102833C', HTTP_PROVIDERS.sepolia),
   state: {
-    selectedNetworkClientId: NetworkType.goerli,
+    selectedNetworkClientId: NetworkType.sepolia,
     networksMetadata: {
-      [NetworkType.goerli]: {
+      [NetworkType.sepolia]: {
         EIPS: { 1559: false },
         status: NetworkStatus.Available,
       },
@@ -390,14 +392,14 @@ const MOCK_LINEA_MAINNET_NETWORK: MockNetwork = {
   subscribe: () => undefined,
 };
 
-const MOCK_LINEA_GOERLI_NETWORK: MockNetwork = {
-  chainId: ChainId['linea-goerli'],
-  provider: HTTP_PROVIDERS.lineaGoerli,
-  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.lineaGoerli),
+const MOCK_LINEA_SEPOLIA_NETWORK: MockNetwork = {
+  chainId: ChainId['linea-sepolia'],
+  provider: HTTP_PROVIDERS.lineaSepolia,
+  blockTracker: buildMockBlockTracker('0xA6EDFC', HTTP_PROVIDERS.lineaSepolia),
   state: {
-    selectedNetworkClientId: NetworkType['linea-goerli'],
+    selectedNetworkClientId: NetworkType['linea-sepolia'],
     networksMetadata: {
-      [NetworkType['linea-goerli']]: {
+      [NetworkType['linea-sepolia']]: {
         EIPS: { 1559: false },
         status: NetworkStatus.Available,
       },
@@ -1769,7 +1771,7 @@ describe('TransactionController', () => {
       const { controller, changeNetwork } = setupController({
         network: {
           state: {
-            selectedNetworkClientId: InfuraNetworkType.goerli,
+            selectedNetworkClientId: InfuraNetworkType.sepolia,
           },
         },
       });
@@ -1796,7 +1798,7 @@ describe('TransactionController', () => {
       const { controller, changeNetwork } = setupController({
         network: {
           state: {
-            selectedNetworkClientId: InfuraNetworkType.goerli,
+            selectedNetworkClientId: InfuraNetworkType.sepolia,
           },
         },
         mockNetworkClientConfigurationsByNetworkClientId: {
@@ -3265,7 +3267,7 @@ describe('TransactionController', () => {
 
     it('rejects unknown transaction', async () => {
       const { controller } = setupController({
-        network: MOCK_LINEA_GOERLI_NETWORK,
+        network: MOCK_LINEA_SEPOLIA_NETWORK,
       });
 
       await controller.stopTransaction('transactionIdMock', {
@@ -3292,7 +3294,7 @@ describe('TransactionController', () => {
 
     it('publishes transaction events', async () => {
       const { controller, messenger, mockTransactionApprovalRequest } =
-        setupController({ network: MOCK_LINEA_GOERLI_NETWORK });
+        setupController({ network: MOCK_LINEA_SEPOLIA_NETWORK });
 
       const approvedEventListener = jest.fn();
       const submittedEventListener = jest.fn();
@@ -5255,7 +5257,7 @@ describe('TransactionController', () => {
       const { controller, messenger } = setupController();
       messenger.registerActionHandler(
         'NetworkController:findNetworkClientIdByChainId',
-        () => 'goerli',
+        () => 'sepolia',
       );
 
       const mockTransactionParam = {

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -284,7 +284,7 @@ describe('TransactionController Integration', () => {
     it('should fail all approved transactions in state', async () => {
       mockNetwork({
         networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-          InfuraNetworkType.goerli,
+          InfuraNetworkType['linea-sepolia'],
         ),
         mocks: [
           buildEthBlockNumberRequestMock('0x1'),
@@ -313,7 +313,7 @@ describe('TransactionController Integration', () => {
           transactions: [
             {
               actionId: undefined,
-              chainId: '0x5',
+              chainId: '0xe705',
               dappSuggestedGasFees: undefined,
               deviceConfirmedOn: undefined,
               id: 'ecfe8c60-ba27-11ee-8643-dfd28279a442',
@@ -333,7 +333,7 @@ describe('TransactionController Integration', () => {
               userEditedGasLimit: false,
               verifiedOnBlockchain: false,
               type: TransactionType.simpleSend,
-              networkClientId: 'goerli',
+              networkClientId: 'linea-sepolia',
               simulationFails: undefined,
               originalGasEstimate: '0x5208',
               defaultGasEstimates: {
@@ -405,7 +405,7 @@ describe('TransactionController Integration', () => {
       it('should add a new unapproved transaction', async () => {
         mockNetwork({
           networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-            InfuraNetworkType.goerli,
+            InfuraNetworkType.sepolia,
           ),
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
@@ -420,7 +420,7 @@ describe('TransactionController Integration', () => {
             from: ACCOUNT_MOCK,
             to: ACCOUNT_2_MOCK,
           },
-          { networkClientId: 'goerli' },
+          { networkClientId: 'sepolia' },
         );
         expect(transactionController.state.transactions).toHaveLength(1);
         expect(transactionController.state.transactions[0].status).toBe(
@@ -432,7 +432,7 @@ describe('TransactionController Integration', () => {
       it('should be able to get to submitted state', async () => {
         mockNetwork({
           networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-            InfuraNetworkType.goerli,
+            InfuraNetworkType.sepolia,
           ),
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
@@ -444,11 +444,12 @@ describe('TransactionController Integration', () => {
             buildEthGasPriceRequestMock(),
             buildEthGetTransactionCountRequestMock(ACCOUNT_MOCK),
             buildEthSendRawTransactionRequestMock(
-              '0x02e2050101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
+              '0x02e583aa36a70101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
               '0x1',
             ),
           ],
         });
+
         const { transactionController, approvalController } =
           await setupController();
         const { result, transactionMeta } =
@@ -457,7 +458,7 @@ describe('TransactionController Integration', () => {
               from: ACCOUNT_MOCK,
               to: ACCOUNT_2_MOCK,
             },
-            { networkClientId: 'goerli' },
+            { networkClientId: 'sepolia' },
           );
 
         await approvalController.accept(transactionMeta.id);
@@ -475,7 +476,7 @@ describe('TransactionController Integration', () => {
       it('should be able to get to confirmed state', async () => {
         mockNetwork({
           networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-            InfuraNetworkType.goerli,
+            InfuraNetworkType.sepolia,
           ),
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
@@ -486,7 +487,7 @@ describe('TransactionController Integration', () => {
             buildEthGasPriceRequestMock(),
             buildEthGetTransactionCountRequestMock(ACCOUNT_MOCK),
             buildEthSendRawTransactionRequestMock(
-              '0x02e2050101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
+              '0x02e583aa36a70101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
               '0x1',
             ),
             buildEthBlockNumberRequestMock('0x3'),
@@ -502,7 +503,7 @@ describe('TransactionController Integration', () => {
               from: ACCOUNT_MOCK,
               to: ACCOUNT_2_MOCK,
             },
-            { networkClientId: 'goerli' },
+            { networkClientId: 'sepolia' },
           );
 
         await approvalController.accept(transactionMeta.id);
@@ -524,7 +525,7 @@ describe('TransactionController Integration', () => {
       it('should be able to send and confirm transactions on different chains', async () => {
         mockNetwork({
           networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-            InfuraNetworkType.goerli,
+            InfuraNetworkType['linea-sepolia'],
           ),
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
@@ -535,7 +536,7 @@ describe('TransactionController Integration', () => {
             buildEthGasPriceRequestMock(),
             buildEthGetTransactionCountRequestMock(ACCOUNT_MOCK),
             buildEthSendRawTransactionRequestMock(
-              '0x02e2050101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
+              '0x02e482e7050101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
               '0x1',
             ),
             buildEthBlockNumberRequestMock('0x3'),
@@ -571,7 +572,7 @@ describe('TransactionController Integration', () => {
             from: ACCOUNT_MOCK,
             to: ACCOUNT_2_MOCK,
           },
-          { networkClientId: 'goerli' },
+          { networkClientId: 'linea-sepolia' },
         );
         const secondTransaction = await transactionController.addTransaction(
           {
@@ -607,14 +608,14 @@ describe('TransactionController Integration', () => {
         );
         expect(
           transactionController.state.transactions[1].networkClientId,
-        ).toBe('goerli');
+        ).toBe('linea-sepolia');
         transactionController.destroy();
       });
 
       it('should be able to cancel a transaction', async () => {
         mockNetwork({
           networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-            InfuraNetworkType.goerli,
+            InfuraNetworkType.sepolia,
           ),
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
@@ -625,7 +626,7 @@ describe('TransactionController Integration', () => {
             buildEthGasPriceRequestMock(),
             buildEthGetTransactionCountRequestMock(ACCOUNT_MOCK),
             buildEthSendRawTransactionRequestMock(
-              '0x02e2050101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
+              '0x02e583aa36a7010101825208946bf137f335ea1b8f193b8f6ea92561a60d23a2078080c0808080',
               '0x1',
             ),
             buildEthBlockNumberRequestMock('0x3'),
@@ -633,7 +634,7 @@ describe('TransactionController Integration', () => {
             buildEthGetBlockByHashRequestMock('0x1'),
             buildEthBlockNumberRequestMock('0x3'),
             buildEthSendRawTransactionRequestMock(
-              '0x02e205010101825208946bf137f335ea1b8f193b8f6ea92561a60d23a2078080c0808080',
+              '0x02e583aa36a70101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
               '0x2',
             ),
             buildEthGetTransactionReceiptRequestMock('0x2', '0x1', '0x3'),
@@ -647,7 +648,7 @@ describe('TransactionController Integration', () => {
               from: ACCOUNT_MOCK,
               to: ACCOUNT_2_MOCK,
             },
-            { networkClientId: 'goerli' },
+            { networkClientId: 'sepolia' },
           );
 
         await approvalController.accept(transactionMeta.id);
@@ -667,7 +668,7 @@ describe('TransactionController Integration', () => {
       it('should be able to confirm a cancelled transaction and drop the original transaction', async () => {
         mockNetwork({
           networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-            InfuraNetworkType.goerli,
+            InfuraNetworkType.sepolia,
           ),
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
@@ -678,12 +679,12 @@ describe('TransactionController Integration', () => {
             buildEthGasPriceRequestMock(),
             buildEthGetTransactionCountRequestMock(ACCOUNT_MOCK),
             buildEthSendRawTransactionRequestMock(
-              '0x02e2050101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
+              '0x02e583aa36a70101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
               '0x1',
             ),
             buildEthBlockNumberRequestMock('0x3'),
             buildEthSendRawTransactionRequestMock(
-              '0x02e205010101825208946bf137f335ea1b8f193b8f6ea92561a60d23a2078080c0808080',
+              '0x02e583aa36a7010101825208946bf137f335ea1b8f193b8f6ea92561a60d23a2078080c0808080',
               '0x2',
             ),
             {
@@ -699,7 +700,7 @@ describe('TransactionController Integration', () => {
             buildEthGetTransactionReceiptRequestMock('0x2', '0x2', '0x4'),
             buildEthGetBlockByHashRequestMock('0x2'),
             buildEthSendRawTransactionRequestMock(
-              '0x02e2050101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
+              '0x02e583aa36a70101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
               '0x1',
             ),
           ],
@@ -712,7 +713,7 @@ describe('TransactionController Integration', () => {
               from: ACCOUNT_MOCK,
               to: ACCOUNT_2_MOCK,
             },
-            { networkClientId: 'goerli' },
+            { networkClientId: 'sepolia' },
           );
 
         await approvalController.accept(transactionMeta.id);
@@ -743,7 +744,7 @@ describe('TransactionController Integration', () => {
       it('should be able to get to speedup state and drop the original transaction', async () => {
         mockNetwork({
           networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-            InfuraNetworkType.goerli,
+            InfuraNetworkType.sepolia,
           ),
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
@@ -754,7 +755,7 @@ describe('TransactionController Integration', () => {
             buildEthGasPriceRequestMock(),
             buildEthGetTransactionCountRequestMock(ACCOUNT_MOCK),
             buildEthSendRawTransactionRequestMock(
-              '0x02e605018203e88203e88252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
+              '0x02e983aa36a7018203e88203e88252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
               '0x1',
             ),
             buildEthBlockNumberRequestMock('0x3'),
@@ -763,7 +764,7 @@ describe('TransactionController Integration', () => {
               response: { result: null },
             },
             buildEthSendRawTransactionRequestMock(
-              '0x02e6050182044c82044c8252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
+              '0x02e983aa36a70182044c82044c8252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
               '0x2',
             ),
             buildEthBlockNumberRequestMock('0x4'),
@@ -775,7 +776,7 @@ describe('TransactionController Integration', () => {
             buildEthGetTransactionReceiptRequestMock('0x2', '0x2', '0x4'),
             buildEthGetBlockByHashRequestMock('0x2'),
             buildEthSendRawTransactionRequestMock(
-              '0x02e605018203e88203e88252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
+              '0x02e983aa36a7018203e88203e88252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
               '0x1',
             ),
           ],
@@ -789,7 +790,7 @@ describe('TransactionController Integration', () => {
               to: ACCOUNT_2_MOCK,
               maxFeePerGas: '0x3e8',
             },
-            { networkClientId: 'goerli' },
+            { networkClientId: 'sepolia' },
           );
 
         await approvalController.accept(transactionMeta.id);
@@ -827,11 +828,11 @@ describe('TransactionController Integration', () => {
 
     describe('when transactions are added concurrently with different networkClientIds but on the same chainId', () => {
       it('should add each transaction with consecutive nonces', async () => {
-        const goerliNetworkClientConfiguration =
-          buildInfuraNetworkClientConfiguration(InfuraNetworkType.goerli);
+        const sepoliaNetworkClientConfiguration =
+          buildInfuraNetworkClientConfiguration(InfuraNetworkType.sepolia);
 
         mockNetwork({
-          networkClientConfiguration: goerliNetworkClientConfiguration,
+          networkClientConfiguration: sepoliaNetworkClientConfiguration,
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
             buildEthGetBlockByNumberRequestMock('0x1'),
@@ -841,7 +842,7 @@ describe('TransactionController Integration', () => {
             buildEthGasPriceRequestMock(),
             buildEthGetTransactionCountRequestMock(ACCOUNT_MOCK),
             buildEthSendRawTransactionRequestMock(
-              '0x02e2050101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
+              '0x02e583aa36a70101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
               '0x1',
             ),
             buildEthBlockNumberRequestMock('0x3'),
@@ -859,7 +860,7 @@ describe('TransactionController Integration', () => {
         mockNetwork({
           networkClientConfiguration: buildCustomNetworkClientConfiguration({
             rpcUrl: 'https://mock.rpc.url',
-            ticker: goerliNetworkClientConfiguration.ticker,
+            ticker: sepoliaNetworkClientConfiguration.ticker,
           }),
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
@@ -871,7 +872,7 @@ describe('TransactionController Integration', () => {
             buildEthGasPriceRequestMock(),
             buildEthGetTransactionCountRequestMock(ACCOUNT_MOCK),
             buildEthSendRawTransactionRequestMock(
-              '0x02e0050201018094e688b84b23f322a994a53dbf8e15fa82cdb711278080c0808080',
+              '0x02e383aa36a70201018094e688b84b23f322a994a53dbf8e15fa82cdb711278080c0808080',
               '0x1',
             ),
             buildEthBlockNumberRequestMock('0x3'),
@@ -889,29 +890,31 @@ describe('TransactionController Integration', () => {
           await setupController({
             getPermittedAccounts: async () => [ACCOUNT_MOCK],
           });
-        const existingGoerliNetworkConfiguration =
-          networkController.getNetworkConfigurationByChainId(ChainId.goerli);
+        const existingSepoliaNetworkConfiguration =
+          networkController.getNetworkConfigurationByChainId(ChainId.sepolia);
         assert(
-          existingGoerliNetworkConfiguration,
-          'Could not find network configuration for Goerli',
+          existingSepoliaNetworkConfiguration,
+          'Could not find network configuration for Sepolia',
         );
-        const updatedGoerliNetworkConfiguration =
-          await networkController.updateNetwork(ChainId.goerli, {
-            ...existingGoerliNetworkConfiguration,
+        const updatedSepoliaNetworkConfiguration =
+          await networkController.updateNetwork(ChainId.sepolia, {
+            ...existingSepoliaNetworkConfiguration,
             rpcEndpoints: [
-              ...existingGoerliNetworkConfiguration.rpcEndpoints,
+              ...existingSepoliaNetworkConfiguration.rpcEndpoints,
               buildUpdateNetworkCustomRpcEndpointFields({
                 url: 'https://mock.rpc.url',
               }),
             ],
           });
-        const otherGoerliRpcEndpoint =
-          updatedGoerliNetworkConfiguration.rpcEndpoints.find((rpcEndpoint) => {
-            return rpcEndpoint.url === 'https://mock.rpc.url';
-          });
+        const otherSepoliaRpcEndpoint =
+          updatedSepoliaNetworkConfiguration.rpcEndpoints.find(
+            (rpcEndpoint) => {
+              return rpcEndpoint.url === 'https://mock.rpc.url';
+            },
+          );
         assert(
-          otherGoerliRpcEndpoint,
-          'Could not find other Goerli RPC endpoint',
+          otherSepoliaRpcEndpoint,
+          'Could not find other Sepolia RPC endpoint',
         );
 
         const addTx1 = await transactionController.addTransaction(
@@ -919,7 +922,7 @@ describe('TransactionController Integration', () => {
             from: ACCOUNT_MOCK,
             to: ACCOUNT_2_MOCK,
           },
-          { networkClientId: 'goerli' },
+          { networkClientId: 'sepolia' },
         );
 
         const addTx2 = await transactionController.addTransaction(
@@ -928,7 +931,7 @@ describe('TransactionController Integration', () => {
             to: ACCOUNT_3_MOCK,
           },
           {
-            networkClientId: otherGoerliRpcEndpoint.networkClientId,
+            networkClientId: otherSepoliaRpcEndpoint.networkClientId,
           },
         );
 
@@ -953,7 +956,7 @@ describe('TransactionController Integration', () => {
       it('should add each transaction with consecutive nonces', async () => {
         mockNetwork({
           networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-            InfuraNetworkType.goerli,
+            InfuraNetworkType.sepolia,
           ),
           mocks: [
             buildEthBlockNumberRequestMock('0x1'),
@@ -966,14 +969,14 @@ describe('TransactionController Integration', () => {
             buildEthGetTransactionCountRequestMock(ACCOUNT_MOCK),
             buildEthGetTransactionCountRequestMock(ACCOUNT_MOCK),
             buildEthSendRawTransactionRequestMock(
-              '0x02e2050101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
+              '0x02e583aa36a70101018252089408f137f335ea1b8f193b8f6ea92561a60d23a2118080c0808080',
               '0x1',
             ),
             buildEthBlockNumberRequestMock('0x3'),
             buildEthGetTransactionReceiptRequestMock('0x1', '0x1', '0x3'),
             buildEthGetBlockByHashRequestMock('0x1'),
             buildEthSendRawTransactionRequestMock(
-              '0x02e20502010182520894e688b84b23f322a994a53dbf8e15fa82cdb711278080c0808080',
+              '0x02e583aa36a702010182520894e688b84b23f322a994a53dbf8e15fa82cdb711278080c0808080',
               '0x2',
             ),
             buildEthGetTransactionReceiptRequestMock('0x2', '0x2', '0x4'),
@@ -992,7 +995,7 @@ describe('TransactionController Integration', () => {
             from: ACCOUNT_MOCK,
             to: ACCOUNT_2_MOCK,
           },
-          { networkClientId: 'goerli' },
+          { networkClientId: 'sepolia' },
         );
 
         await advanceTime({ clock, duration: 1 });
@@ -1003,7 +1006,7 @@ describe('TransactionController Integration', () => {
             to: ACCOUNT_3_MOCK,
           },
           {
-            networkClientId: 'goerli',
+            networkClientId: 'sepolia',
           },
         );
 
@@ -1031,7 +1034,7 @@ describe('TransactionController Integration', () => {
   it('should start tracking when a new network is added', async () => {
     mockNetwork({
       networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-        InfuraNetworkType.goerli,
+        InfuraNetworkType.sepolia,
       ),
       mocks: [
         buildEthBlockNumberRequestMock('0x1'),
@@ -1058,27 +1061,30 @@ describe('TransactionController Integration', () => {
     const { networkController, transactionController } =
       await setupController();
 
-    const existingGoerliNetworkConfiguration =
-      networkController.getNetworkConfigurationByChainId(ChainId.goerli);
+    const existingSepoliaNetworkConfiguration =
+      networkController.getNetworkConfigurationByChainId(ChainId.sepolia);
     assert(
-      existingGoerliNetworkConfiguration,
-      'Could not find network configuration for Goerli',
+      existingSepoliaNetworkConfiguration,
+      'Could not find network configuration for Sepolia',
     );
-    const updatedGoerliNetworkConfiguration =
-      await networkController.updateNetwork(ChainId.goerli, {
-        ...existingGoerliNetworkConfiguration,
+    const updatedSepoliaNetworkConfiguration =
+      await networkController.updateNetwork(ChainId.sepolia, {
+        ...existingSepoliaNetworkConfiguration,
         rpcEndpoints: [
-          ...existingGoerliNetworkConfiguration.rpcEndpoints,
+          ...existingSepoliaNetworkConfiguration.rpcEndpoints,
           buildUpdateNetworkCustomRpcEndpointFields({
             url: 'https://mock.rpc.url',
           }),
         ],
       });
-    const otherGoerliRpcEndpoint =
-      updatedGoerliNetworkConfiguration.rpcEndpoints.find((rpcEndpoint) => {
+    const otherSepoliaRpcEndpoint =
+      updatedSepoliaNetworkConfiguration.rpcEndpoints.find((rpcEndpoint) => {
         return rpcEndpoint.url === 'https://mock.rpc.url';
       });
-    assert(otherGoerliRpcEndpoint, 'Could not find other Goerli RPC endpoint');
+    assert(
+      otherSepoliaRpcEndpoint,
+      'Could not find other Sepolia RPC endpoint',
+    );
 
     await transactionController.addTransaction(
       {
@@ -1086,13 +1092,13 @@ describe('TransactionController Integration', () => {
         to: ACCOUNT_3_MOCK,
       },
       {
-        networkClientId: otherGoerliRpcEndpoint.networkClientId,
+        networkClientId: otherSepoliaRpcEndpoint.networkClientId,
       },
     );
 
     expect(transactionController.state.transactions[0]).toStrictEqual(
       expect.objectContaining({
-        networkClientId: otherGoerliRpcEndpoint.networkClientId,
+        networkClientId: otherSepoliaRpcEndpoint.networkClientId,
       }),
     );
     transactionController.destroy();
@@ -1148,8 +1154,8 @@ describe('TransactionController Integration', () => {
     it('should call getNetworkClientRegistry on construction when feature flag is enabled', async () => {
       const getNetworkClientRegistrySpy = jest.fn().mockImplementation(() => {
         return {
-          [NetworkType.goerli]: {
-            configuration: BUILT_IN_NETWORKS[NetworkType.goerli],
+          [NetworkType.sepolia]: {
+            configuration: BUILT_IN_NETWORKS[NetworkType.sepolia],
           },
         };
       });
@@ -1267,7 +1273,7 @@ describe('TransactionController Integration', () => {
         await setupController();
       mockNetwork({
         networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-          InfuraNetworkType.goerli,
+          InfuraNetworkType.sepolia,
         ),
         mocks: [
           buildEthBlockNumberRequestMock('0x1'),
@@ -1277,7 +1283,7 @@ describe('TransactionController Integration', () => {
 
       mockNetwork({
         networkClientConfiguration: {
-          ...buildInfuraNetworkClientConfiguration(InfuraNetworkType.goerli),
+          ...buildInfuraNetworkClientConfiguration(InfuraNetworkType.sepolia),
           rpcUrl: 'https://mock.rpc.url',
           type: NetworkClientType.Custom,
         },
@@ -1287,34 +1293,34 @@ describe('TransactionController Integration', () => {
         ],
       });
 
-      const existingGoerliNetworkConfiguration =
-        networkController.getNetworkConfigurationByChainId(ChainId.goerli);
+      const existingSepoliaNetworkConfiguration =
+        networkController.getNetworkConfigurationByChainId(ChainId.sepolia);
       assert(
-        existingGoerliNetworkConfiguration,
-        'Could not find network configuration for Goerli',
+        existingSepoliaNetworkConfiguration,
+        'Could not find network configuration for Sepolia',
       );
-      const updatedGoerliNetworkConfiguration =
-        await networkController.updateNetwork(ChainId.goerli, {
-          ...existingGoerliNetworkConfiguration,
+      const updatedSepoliaNetworkConfiguration =
+        await networkController.updateNetwork(ChainId.sepolia, {
+          ...existingSepoliaNetworkConfiguration,
           rpcEndpoints: [
-            ...existingGoerliNetworkConfiguration.rpcEndpoints,
+            ...existingSepoliaNetworkConfiguration.rpcEndpoints,
             buildUpdateNetworkCustomRpcEndpointFields({
               url: 'https://mock.rpc.url',
             }),
           ],
         });
-      const otherGoerliRpcEndpoint =
-        updatedGoerliNetworkConfiguration.rpcEndpoints.find((rpcEndpoint) => {
+      const otherSepoliaRpcEndpoint =
+        updatedSepoliaNetworkConfiguration.rpcEndpoints.find((rpcEndpoint) => {
           return rpcEndpoint.url === 'https://mock.rpc.url';
         });
       assert(
-        otherGoerliRpcEndpoint,
-        'Could not find other Goerli RPC endpoint',
+        otherSepoliaRpcEndpoint,
+        'Could not find other Sepolia RPC endpoint',
       );
 
       const firstNonceLockPromise = transactionController.getNonceLock(
         ACCOUNT_MOCK,
-        'goerli',
+        'sepolia',
       );
       await advanceTime({ clock, duration: 1 });
 
@@ -1324,7 +1330,7 @@ describe('TransactionController Integration', () => {
 
       const secondNonceLockPromise = transactionController.getNonceLock(
         ACCOUNT_MOCK,
-        otherGoerliRpcEndpoint.networkClientId,
+        otherSepoliaRpcEndpoint.networkClientId,
       );
       const delay = () =>
         // TODO: Either fix this lint violation or explain why it's necessary to ignore.
@@ -1359,7 +1365,7 @@ describe('TransactionController Integration', () => {
 
       mockNetwork({
         networkClientConfiguration: buildInfuraNetworkClientConfiguration(
-          InfuraNetworkType.goerli,
+          InfuraNetworkType['linea-sepolia'],
         ),
         mocks: [
           buildEthBlockNumberRequestMock('0x1'),
@@ -1379,7 +1385,7 @@ describe('TransactionController Integration', () => {
 
       const firstNonceLockPromise = transactionController.getNonceLock(
         ACCOUNT_MOCK,
-        'goerli',
+        'linea-sepolia',
       );
       await advanceTime({ clock, duration: 1 });
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR is not to deprecated `goerli` and `linea goerli` , but just remove `goerli` and `linea goerli` from `network-controller` as default network, which will not impact to the reference of those network constants / type

Hence the mobile / extension no longer require to using patching or hardcode to remove the network for new installed user

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/network-controller`

- **CHANGED**: Remove `goerli` and `linea goerli` network as default network

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
