### PR TITLE
feat: add lock & operations queue handler for UserStorageController

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/setup-subscriptions.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/setup-subscriptions.ts
@@ -16,7 +16,7 @@ export function setupAccountSyncingSubscriptions(
 
   getMessenger().subscribe(
     'AccountsController:accountAdded',
-
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     async (account) => {
       if (
         !canPerformAccountSyncing(config, options) ||
@@ -32,7 +32,7 @@ export function setupAccountSyncingSubscriptions(
 
   getMessenger().subscribe(
     'AccountsController:accountRenamed',
-
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     async (account) => {
       if (
         !canPerformAccountSyncing(config, options) ||


### PR DESCRIPTION
## Explanation

This PR introduces a new `lock`, `unlock`, `pendingOperations` and `executeWithLockHandling` approach for `UserStorageController`.

Any function wrapped with `executeWithLockHandling` with either be executed instantly or added to the `pendingOperations` queue if the controller has been locked with `lock`.
Calling `unlock` would then sequentially call every operation that has been added to the `pendingOperations` queue.

If one of the `pendingOperations` operation throws, then the queue is cleared and the execution is stopped.

## References

Related to: https://consensyssoftware.atlassian.net/browse/IDENTITY-70

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

### `@metamask/profile-sync-controller`

- **ADDED**: add lock & operations queue handler for `UserStorageController`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
