### PR TITLE
fix: validation of EIP-7702 contract signatures with odd-length chain ID

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix EIP-7702 contract signature validation on chains with odd-length hexadecimal ID ([#5563](https://github.com/MetaMask/core/pull/5563))
 - Fix simulation of type-4 transactions ([#5552](https://github.com/MetaMask/core/pull/5552))
 
 ## [52.2.0]

--- a/packages/transaction-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.test.ts
@@ -192,6 +192,32 @@ describe('Feature Flags Utils', () => {
         ),
       ).toStrictEqual([ADDRESS_2_MOCK]);
     });
+
+    it('validates signature using padded chain ID', () => {
+      const chainId = '0x539' as const;
+
+      isValidSignatureMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+      mockFeatureFlags({
+        [FEATURE_FLAG_EIP_7702]: {
+          contracts: {
+            [chainId]: [{ address: ADDRESS_MOCK, signature: SIGNATURE_MOCK }],
+          },
+        },
+      });
+
+      getEIP7702ContractAddresses(
+        chainId,
+        controllerMessenger,
+        PUBLIC_KEY_MOCK,
+      );
+
+      expect(isValidSignatureMock).toHaveBeenCalledWith(
+        [ADDRESS_MOCK, `0x0539`],
+        SIGNATURE_MOCK,
+        PUBLIC_KEY_MOCK,
+      );
+    });
   });
 
   describe('getEIP7702UpgradeContractAddress', () => {

--- a/packages/transaction-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.ts
@@ -1,6 +1,7 @@
 import { createModuleLogger, type Hex } from '@metamask/utils';
 
 import { isValidSignature } from './signature';
+import { padHexToEvenLength } from './utils';
 import { projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
 
@@ -112,7 +113,7 @@ export function getEIP7702ContractAddresses(
   return contracts
     .filter((contract) =>
       isValidSignature(
-        [contract.address, chainId],
+        [contract.address, padHexToEvenLength(chainId) as Hex],
         contract.signature,
         publicKey,
       ),


### PR DESCRIPTION
## Explanation

Pad chain ID with leading zero if odd-length in order to prevent signature validation from silently failing.

## References

Relates to [#31388](https://github.com/MetaMask/metamask-extension/issues/31388)

## Changelog

See `CHANGELOG.md`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
