### PR TITLE
fix: cache incoming transaction timestamps

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix incoming transaction support with `queryEntireHistory` set to `false` ([#5582](https://github.com/MetaMask/core/pull/5582))
+
 ## [54.0.0]
 
 ### Added

--- a/packages/transaction-controller/src/helpers/AccountsApiRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/helpers/AccountsApiRemoteTransactionSource.ts
@@ -18,6 +18,8 @@ import type {
 } from '../types';
 import { TransactionStatus, TransactionType } from '../types';
 
+const RECENT_HISTORY_DURATION_MS = 1000 * 60 * 60 * 24; // 1 Day
+
 export const SUPPORTED_CHAIN_IDS: Hex[] = [
   CHAIN_IDS.MAINNET,
   CHAIN_IDS.POLYGON,
@@ -84,32 +86,49 @@ export class AccountsApiRemoteTransactionSource
 
     const cursor = this.#getCacheCursor(cache, SUPPORTED_CHAIN_IDS, address);
 
+    const timestamp = this.#getCacheTimestamp(
+      cache,
+      SUPPORTED_CHAIN_IDS,
+      address,
+    );
+
     if (cursor) {
       log('Using cached cursor', cursor);
+    } else if (timestamp) {
+      log('Using cached timestamp', timestamp);
+    } else {
+      log('No cached cursor or timestamp found');
     }
 
-    return await this.#queryTransactions(request, SUPPORTED_CHAIN_IDS, cursor);
+    return await this.#queryTransactions(
+      request,
+      SUPPORTED_CHAIN_IDS,
+      cursor,
+      timestamp,
+    );
   }
 
   async #queryTransactions(
     request: RemoteTransactionSourceRequest,
     chainIds: Hex[],
     cursor?: string,
+    timestamp?: number,
   ): Promise<TransactionResponse[]> {
-    const { address, queryEntireHistory, updateCache } = request;
+    const { address, queryEntireHistory } = request;
     const transactions: TransactionResponse[] = [];
 
     let hasNextPage = true;
     let currentCursor = cursor;
     let pageCount = 0;
 
-    const startTimestamp =
-      queryEntireHistory || cursor
-        ? undefined
-        : this.#getTimestampSeconds(Date.now());
-
     while (hasNextPage) {
       try {
+        const startTimestamp = this.#getStartTimestamp({
+          cursor: currentCursor,
+          queryEntireHistory,
+          timestamp,
+        });
+
         const response = await getAccountTransactions({
           address,
           chainIds,
@@ -127,15 +146,12 @@ export class AccountsApiRemoteTransactionSource
         hasNextPage = response?.pageInfo?.hasNextPage;
         currentCursor = response?.pageInfo?.cursor;
 
-        if (currentCursor) {
-          // eslint-disable-next-line no-loop-func
-          updateCache((cache) => {
-            const key = this.#getCacheKey(chainIds, address);
-            cache[key] = currentCursor;
-
-            log('Updated cache', { key, newCursor: currentCursor });
-          });
-        }
+        this.#updateCache({
+          chainIds,
+          cursor: currentCursor,
+          request,
+          startTimestamp,
+        });
       } catch (error) {
         log('Error while fetching transactions', error);
         break;
@@ -248,7 +264,64 @@ export class AccountsApiRemoteTransactionSource
     };
   }
 
-  #getCacheKey(chainIds: Hex[], address: Hex): string {
+  #updateCache({
+    chainIds,
+    cursor,
+    request,
+    startTimestamp,
+  }: {
+    chainIds: Hex[];
+    cursor?: string;
+    request: RemoteTransactionSourceRequest;
+    startTimestamp?: number;
+  }) {
+    if (!cursor && !startTimestamp) {
+      log('Cache not updated');
+      return;
+    }
+
+    const { address, updateCache } = request;
+    const cursorCacheKey = this.#getCursorCacheKey(chainIds, address);
+    const timestampCacheKey = this.#getTimestampCacheKey(chainIds, address);
+
+    updateCache((cache) => {
+      if (cursor) {
+        cache[cursorCacheKey] = cursor;
+        delete cache[timestampCacheKey];
+
+        log('Updated cursor in cache', { cursorCacheKey, newCursor: cursor });
+      } else {
+        cache[timestampCacheKey] = startTimestamp;
+
+        log('Updated timestamp in cache', {
+          timestampCacheKey,
+          newTimestamp: startTimestamp,
+        });
+      }
+    });
+  }
+
+  #getStartTimestamp({
+    cursor,
+    queryEntireHistory,
+    timestamp,
+  }: {
+    cursor?: string;
+    queryEntireHistory: boolean;
+    timestamp?: number;
+  }): number | undefined {
+    if (queryEntireHistory || cursor) {
+      return undefined;
+    }
+
+    if (timestamp) {
+      return timestamp;
+    }
+
+    return this.#getTimestampSeconds(Date.now() - RECENT_HISTORY_DURATION_MS);
+  }
+
+  #getCursorCacheKey(chainIds: Hex[], address: Hex): string {
     return `accounts-api#${chainIds.join(',')}#${address}`;
   }
 
@@ -257,8 +330,21 @@ export class AccountsApiRemoteTransactionSource
     chainIds: Hex[],
     address: Hex,
   ): string | undefined {
-    const key = this.#getCacheKey(chainIds, address);
+    const key = this.#getCursorCacheKey(chainIds, address);
     return cache[key] as string | undefined;
+  }
+
+  #getTimestampCacheKey(chainIds: Hex[], address: Hex): string {
+    return `accounts-api#timestamp#${chainIds.join(',')}#${address}`;
+  }
+
+  #getCacheTimestamp(
+    cache: Record<string, unknown>,
+    chainIds: Hex[],
+    address: Hex,
+  ): number | undefined {
+    const key = this.#getTimestampCacheKey(chainIds, address);
+    return cache[key] as number | undefined;
   }
 
   #getTimestampSeconds(timestampMs: number): number {

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -922,7 +922,7 @@ export interface RemoteTransactionSourceRequest {
   address: Hex;
 
   /**
-   * Numerical cache to optimize fetching transactions.
+   * Cache to optimize fetching transactions.
    */
   cache: Record<string, unknown>;
 


### PR DESCRIPTION
## Explanation

If `queryEntireHistory` is `false`, query incoming transactions from the last 24 hours.

If no cursor is returned, cache the `startTimestamp` and use that in subsequent queries until a cursor is available.

## References

Fixes [#30902](https://github.com/MetaMask/metamask-extension/issues/30902)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
