### PR TITLE
chore: sends transaction update events

### DIFF
--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
@@ -755,7 +755,7 @@ describe('MultichainTransactionsController', () => {
     expect(finalTransactions[0]).toBe(mainnetTransaction);
   });
 
-  it('publishes transactionFinalized event when transaction is confirmed', async () => {
+  it('publishes transactionConfirmed event when transaction is confirmed', async () => {
     const { messenger } = setupController();
 
     const confirmedTransaction = {
@@ -775,7 +775,7 @@ describe('MultichainTransactionsController', () => {
     await waitForAllPromises();
 
     expect(publishSpy).toHaveBeenCalledWith(
-      'MultichainTransactionsController:transactionFinalized',
+      'MultichainTransactionsController:transactionConfirmed',
       confirmedTransaction,
     );
   });
@@ -825,7 +825,7 @@ describe('MultichainTransactionsController', () => {
     await waitForAllPromises();
 
     expect(publishSpy).not.toHaveBeenCalledWith(
-      'MultichainTransactionsController:transactionFinalized',
+      'MultichainTransactionsController:transactionConfirmed',
       expect.anything(),
     );
     expect(publishSpy).not.toHaveBeenCalledWith(
@@ -866,7 +866,7 @@ describe('MultichainTransactionsController', () => {
     await waitForAllPromises();
 
     expect(publishSpy).toHaveBeenCalledWith(
-      'MultichainTransactionsController:transactionFinalized',
+      'MultichainTransactionsController:transactionConfirmed',
       transactions[0],
     );
     expect(publishSpy).toHaveBeenCalledWith(

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
@@ -20,7 +20,7 @@ import type { KeyringControllerGetStateAction } from '@metamask/keyring-controll
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { KeyringClient } from '@metamask/keyring-snap-client';
 import type { HandleSnapRequest } from '@metamask/snaps-controllers';
-import type { AccountId, SnapId } from '@metamask/snaps-sdk';
+import type { SnapId } from '@metamask/snaps-sdk';
 import { HandlerType } from '@metamask/snaps-utils';
 import {
   KnownCaipNamespace,

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
@@ -67,6 +67,22 @@ export function getDefaultMultichainTransactionsControllerState(): MultichainTra
 }
 
 /**
+ * Event emitted when a transaction is finalized.
+ */
+export type MultichainTransactionsControllerTransactionFinalizedEvent = {
+  type: `${typeof controllerName}:transactionFinalized`;
+  payload: [Transaction];
+};
+
+/**
+ * Event emitted when a transaction is submitted.
+ */
+export type MultichainTransactionsControllerTransactionSubmittedEvent = {
+  type: `${typeof controllerName}:transactionSubmitted`;
+  payload: [Transaction];
+};
+
+/**
  * Returns the state of the {@link MultichainTransactionsController}.
  */
 export type MultichainTransactionsControllerGetStateAction =
@@ -94,17 +110,9 @@ export type MultichainTransactionsControllerActions =
  * Events emitted by {@link MultichainTransactionsController}.
  */
 export type MultichainTransactionsControllerEvents =
-  MultichainTransactionsControllerStateChange;
-
-export type MultichainTransactionsControllerTransactionFinalizedEvent = {
-  type: `${typeof controllerName}:transactionFinalized`;
-  payload: [Transaction];
-};
-
-export type MultichainTransactionsControllerTransactionSubmittedEvent = {
-  type: `${typeof controllerName}:transactionSubmitted`;
-  payload: [Transaction];
-};
+  | MultichainTransactionsControllerStateChange
+  | MultichainTransactionsControllerTransactionFinalizedEvent
+  | MultichainTransactionsControllerTransactionSubmittedEvent;
 
 /**
  * Messenger type for the MultichainTransactionsController.
@@ -131,9 +139,7 @@ export type AllowedActions =
 export type AllowedEvents =
   | AccountsControllerAccountAddedEvent
   | AccountsControllerAccountRemovedEvent
-  | AccountsControllerAccountTransactionsUpdatedEvent
-  | MultichainTransactionsControllerTransactionFinalizedEvent
-  | MultichainTransactionsControllerTransactionSubmittedEvent;
+  | AccountsControllerAccountTransactionsUpdatedEvent;
 
 /**
  * {@link MultichainTransactionsController}'s metadata.

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
@@ -415,7 +415,6 @@ export class MultichainTransactionsController extends BaseController<
 
         filteredNewTransactions.forEach((tx) => {
           transactions.set(tx.id, tx);
-          this.#publishTransactionUpdateEvent(tx);
         });
 
         // Sorted by timestamp (newest first). If the timestamp is not provided, those
@@ -437,6 +436,17 @@ export class MultichainTransactionsController extends BaseController<
         },
       );
     });
+
+    // After we update the state, publish the events for new/updated transactions
+    Object.entries(transactionsUpdate.transactions).forEach(
+      ([_, newTransactions]) => {
+        const filteredNewTransactions =
+          this.#filterTransactions(newTransactions);
+        filteredNewTransactions.forEach((tx) => {
+          this.#publishTransactionUpdateEvent(tx);
+        });
+      },
+    );
   }
 
   /**

--- a/packages/multichain-transactions-controller/src/index.ts
+++ b/packages/multichain-transactions-controller/src/index.ts
@@ -6,6 +6,6 @@ export type {
   MultichainTransactionsControllerStateChange,
   MultichainTransactionsControllerGetStateAction,
   MultichainTransactionsControllerTransactionSubmittedEvent,
-  MultichainTransactionsControllerTransactionFinalizedEvent,
+  MultichainTransactionsControllerTransactionConfirmedEvent,
 } from './MultichainTransactionsController';
 export { MultichainNetwork, MultichainNativeAsset } from './constants';

--- a/packages/multichain-transactions-controller/src/index.ts
+++ b/packages/multichain-transactions-controller/src/index.ts
@@ -3,5 +3,9 @@ export type {
   MultichainTransactionsControllerState,
   PaginationOptions,
   TransactionStateEntry,
+  MultichainTransactionsControllerStateChange,
+  MultichainTransactionsControllerGetStateAction,
+  MultichainTransactionsControllerTransactionSubmittedEvent,
+  MultichainTransactionsControllerTransactionFinalizedEvent,
 } from './MultichainTransactionsController';
 export { MultichainNetwork, MultichainNativeAsset } from './constants';


### PR DESCRIPTION
## Explanation

We are sending two events `transactionFinalized` and `transactionSubmitted` in order to track these in the client, and send out the necessary metrics.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
