### PR TITLE
Stop throwing an error if `verifyingContract` field in EIP712 payloads is undefined or not a string

### DIFF
--- a/packages/signature-controller/src/utils/validation.test.ts
+++ b/packages/signature-controller/src/utils/validation.test.ts
@@ -311,6 +311,24 @@ describe('Validation Utils', () => {
             );
           });
 
+          it('does not throw if external origin in request and verifying contract is not present', () => {
+            const data = JSON.parse(DATA_TYPED_MOCK);
+            delete data.domain.verifyingContract;
+
+            expect(() =>
+              validateTypedSignatureRequest({
+                currentChainId: CHAIN_ID_MOCK,
+                internalAccounts: ['0x1234', INTERNAL_ACCOUNT_MOCK],
+                messageData: {
+                  data,
+                  from: '0x3244e191f1b4903970224322180f1fbbc415696b',
+                },
+                request: { origin: ORIGIN_MOCK } as OriginalRequest,
+                version,
+              }),
+            ).not.toThrow();
+          });
+
           it('throws if external origin in message params and verifying contract is internal account', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
             data.domain.verifyingContract = INTERNAL_ACCOUNT_MOCK;

--- a/packages/signature-controller/src/utils/validation.ts
+++ b/packages/signature-controller/src/utils/validation.ts
@@ -220,10 +220,12 @@ function validateVerifyingContract({
   internalAccounts: Hex[];
   origin: string | undefined;
 }) {
-  const verifyingContract = data?.domain?.verifyingContract as Hex;
+  const verifyingContract = data?.domain?.verifyingContract;
   const isExternal = origin && origin !== ORIGIN_METAMASK;
 
   if (
+    verifyingContract &&
+    typeof verifyingContract === 'string' &&
     isExternal &&
     internalAccounts.some(
       (internalAccount) =>


### PR DESCRIPTION
## Explanation
It seems we've broken some dapps that rely on EIP712 / `eth_signTypedData_v4` signatures which don't include `verifyingContract` as part of their payload.

## References

See: https://github.com/MetaMask/metamask-extension/issues/31607

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
