### PR TITLE
fix: use password instead of key when upgrading vault

### DIFF
--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2270,7 +2270,9 @@ export class KeyringController extends BaseController<
    */
   #updateVault(): Promise<boolean> {
     return this.#withVaultLock(async () => {
-      const { encryptionKey, encryptionSalt } = this.state;
+      const { encryptionKey, encryptionSalt, vault } = this.state;
+      const useCachedKey =
+        encryptionKey && vault && this.#encryptor.isVaultUpdated?.(vault);
 
       if (!this.#password && !encryptionKey) {
         throw new Error(KeyringControllerError.MissingCredentials);
@@ -2289,7 +2291,7 @@ export class KeyringController extends BaseController<
       if (this.#cacheEncryptionKey) {
         assertIsExportableKeyEncryptor(this.#encryptor);
 
-        if (encryptionKey) {
+        if (useCachedKey) {
           const key = await this.#encryptor.importKey(encryptionKey);
           const vaultJSON = await this.#encryptor.encryptWithKey(
             key,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Alternative proposal to https://github.com/MetaMask/core/pull/5593 to invalidate the encryption key when the vault encryption needs to be updated.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
