### PR TITLE
fix: Rename `enableTxParamsGasFeeUpdates` to `isAutomaticGasFeeUpdateEnabled` and also callback

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip `origin` validation for `batch` transaction type ([#5586](https://github.com/MetaMask/core/pull/5586))
 - **BREAKING:** `enableTxParamsGasFeeUpdates` now expects a callback function instead of a boolean.
   - This callback is invoked before performing `txParams` gas fee updates. The update will proceed only if the callback returns a truthy value.
+  - If not set it will default to return `false`.
 
 ## [53.0.0]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Skip `origin` validation for `batch` transaction type ([#5586](https://github.com/MetaMask/core/pull/5586))
-- **BREAKING:** `enableTxParamsGasFeeUpdates` now expects a callback function instead of a boolean.
+- **BREAKING:** `enableTxParamsGasFeeUpdates` is renamed to `isAutomaticGasFeeUpdateEnabled` now expects a callback function instead of a boolean.
   - This callback is invoked before performing `txParams` gas fee updates. The update will proceed only if the callback returns a truthy value.
   - If not set it will default to return `false`.
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Skip `origin` validation for `batch` transaction type ([#5586](https://github.com/MetaMask/core/pull/5586))
+- **BREAKING:** `enableTxParamsGasFeeUpdates` now expects a callback function instead of a boolean.
+  - This callback is invoked before performing `txParams` gas fee updates. The update will proceed only if the callback returns a truthy value.
 
 ## [53.0.0]
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -294,7 +294,9 @@ export type TransactionControllerOptions = {
    * Callback to determine whether gas fee updates should be enabled for a given transaction.
    * Returns true to enable updates, false to disable them.
    */
-  isAutomaticGasFeeUpdateEnabled?: (transactionMeta: TransactionMeta) => boolean;
+  isAutomaticGasFeeUpdateEnabled?: (
+    transactionMeta: TransactionMeta,
+  ) => boolean;
 
   /** Whether or not the account supports EIP-1559. */
   getCurrentAccountEIP1559Compatibility?: () => Promise<boolean>;

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -294,7 +294,7 @@ export type TransactionControllerOptions = {
    * Callback to determine whether gas fee updates should be enabled for a given transaction.
    * Returns true to enable updates, false to disable them.
    */
-  enableTxParamsGasFeeUpdates: (transactionMeta: TransactionMeta) => boolean;
+  enableTxParamsGasFeeUpdates?: (transactionMeta: TransactionMeta) => boolean;
 
   /** Whether or not the account supports EIP-1559. */
   getCurrentAccountEIP1559Compatibility?: () => Promise<boolean>;

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -290,8 +290,11 @@ export type TransactionControllerOptions = {
   /** Whether to disable additional processing on swaps transactions. */
   disableSwaps: boolean;
 
-  /** Whether to enable gas fee updates. */
-  enableTxParamsGasFeeUpdates?: boolean;
+  /**
+   * Callback to determine whether gas fee updates should be enabled for a given transaction.
+   * Returns true to enable updates, false to disable them.
+   */
+  enableTxParamsGasFeeUpdates: (transactionMeta: TransactionMeta) => boolean;
 
   /** Whether or not the account supports EIP-1559. */
   getCurrentAccountEIP1559Compatibility?: () => Promise<boolean>;
@@ -657,7 +660,9 @@ export class TransactionController extends BaseController<
 
   private readonly isSendFlowHistoryDisabled: boolean;
 
-  private readonly isTxParamsGasFeeUpdatesEnabled: boolean;
+  private readonly isTxParamsGasFeeUpdatesEnabled: (
+    transactionMeta: TransactionMeta,
+  ) => boolean;
 
   private readonly approvingTransactionIds: Set<string> = new Set();
 
@@ -847,7 +852,8 @@ export class TransactionController extends BaseController<
     });
 
     this.messagingSystem = messenger;
-    this.isTxParamsGasFeeUpdatesEnabled = enableTxParamsGasFeeUpdates ?? false;
+    this.isTxParamsGasFeeUpdatesEnabled =
+      enableTxParamsGasFeeUpdates ?? ((_txMeta: TransactionMeta) => false);
     this.getNetworkState = getNetworkState;
     this.isSendFlowHistoryDisabled = disableSendFlowHistory ?? false;
     this.isHistoryDisabled = disableHistory ?? false;

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -294,7 +294,7 @@ export type TransactionControllerOptions = {
    * Callback to determine whether gas fee updates should be enabled for a given transaction.
    * Returns true to enable updates, false to disable them.
    */
-  enableTxParamsGasFeeUpdates?: (transactionMeta: TransactionMeta) => boolean;
+  isAutomaticGasFeeUpdateEnabled?: (transactionMeta: TransactionMeta) => boolean;
 
   /** Whether or not the account supports EIP-1559. */
   getCurrentAccountEIP1559Compatibility?: () => Promise<boolean>;
@@ -817,7 +817,7 @@ export class TransactionController extends BaseController<
       disableHistory,
       disableSendFlowHistory,
       disableSwaps,
-      enableTxParamsGasFeeUpdates,
+      isAutomaticGasFeeUpdateEnabled,
       getCurrentAccountEIP1559Compatibility,
       getCurrentNetworkEIP1559Compatibility,
       getExternalPendingTransactions,
@@ -853,7 +853,7 @@ export class TransactionController extends BaseController<
 
     this.messagingSystem = messenger;
     this.isTxParamsGasFeeUpdatesEnabled =
-      enableTxParamsGasFeeUpdates ?? ((_txMeta: TransactionMeta) => false);
+      isAutomaticGasFeeUpdateEnabled ?? ((_txMeta: TransactionMeta) => false);
     this.getNetworkState = getNetworkState;
     this.isSendFlowHistoryDisabled = disableSendFlowHistory ?? false;
     this.isHistoryDisabled = disableHistory ?? false;

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -223,6 +223,7 @@ const setupController = async (
     disableHistory: false,
     disableSendFlowHistory: false,
     disableSwaps: false,
+    enableTxParamsGasFeeUpdates: () => true,
     getCurrentNetworkEIP1559Compatibility: async (
       networkClientId?: NetworkClientId,
     ) => {

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -223,7 +223,7 @@ const setupController = async (
     disableHistory: false,
     disableSendFlowHistory: false,
     disableSwaps: false,
-    enableTxParamsGasFeeUpdates: () => true,
+    isAutomaticGasFeeUpdateEnabled: () => true,
     getCurrentNetworkEIP1559Compatibility: async (
       networkClientId?: NetworkClientId,
     ) => {

--- a/packages/transaction-controller/src/helpers/AccountsApiRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/helpers/AccountsApiRemoteTransactionSource.ts
@@ -19,14 +19,14 @@ import type {
 import { TransactionStatus, TransactionType } from '../types';
 
 export const SUPPORTED_CHAIN_IDS: Hex[] = [
-  '0x1',
-  '0x89',
-  '0x38',
-  '0x7a69',
-  '0x19',
-  '0xa',
-  '0xa4b1',
-  '0x7a69',
+  CHAIN_IDS.MAINNET,
+  CHAIN_IDS.POLYGON,
+  CHAIN_IDS.BSC,
+  CHAIN_IDS.LINEA_MAINNET,
+  CHAIN_IDS.BASE,
+  CHAIN_IDS.OPTIMISM,
+  CHAIN_IDS.ARBITRUM,
+  CHAIN_IDS.SCROLL,
 ];
 
 const log = createModuleLogger(

--- a/packages/transaction-controller/src/helpers/AccountsApiRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/helpers/AccountsApiRemoteTransactionSource.ts
@@ -19,14 +19,14 @@ import type {
 import { TransactionStatus, TransactionType } from '../types';
 
 export const SUPPORTED_CHAIN_IDS: Hex[] = [
-  CHAIN_IDS.MAINNET,
-  CHAIN_IDS.POLYGON,
-  CHAIN_IDS.BSC,
-  CHAIN_IDS.LINEA_MAINNET,
-  CHAIN_IDS.BASE,
-  CHAIN_IDS.OPTIMISM,
-  CHAIN_IDS.ARBITRUM,
-  CHAIN_IDS.SCROLL,
+  '0x1',
+  '0x89',
+  '0x38',
+  '0x7a69',
+  '0x19',
+  '0xa',
+  '0xa4b1',
+  '0x7a69',
 ];
 
 const log = createModuleLogger(

--- a/packages/transaction-controller/src/helpers/GasFeePoller.test.ts
+++ b/packages/transaction-controller/src/helpers/GasFeePoller.test.ts
@@ -371,7 +371,7 @@ describe('updateTransactionGasFees', () => {
     updateTransactionGasFees({
       txMeta,
       gasFeeEstimates: FEE_MARKET_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-      isTxParamsGasFeeUpdatesEnabled: true,
+      isTxParamsGasFeeUpdatesEnabled: () => true,
     });
 
     expect(txMeta.gasFeeEstimates).toBe(FEE_MARKET_GAS_FEE_ESTIMATES_MOCK);
@@ -385,7 +385,7 @@ describe('updateTransactionGasFees', () => {
     updateTransactionGasFees({
       txMeta,
       gasFeeEstimatesLoaded: true,
-      isTxParamsGasFeeUpdatesEnabled: true,
+      isTxParamsGasFeeUpdatesEnabled: () => true,
     });
 
     expect(txMeta.gasFeeEstimatesLoaded).toBe(true);
@@ -393,7 +393,7 @@ describe('updateTransactionGasFees', () => {
     updateTransactionGasFees({
       txMeta,
       gasFeeEstimatesLoaded: false,
-      isTxParamsGasFeeUpdatesEnabled: true,
+      isTxParamsGasFeeUpdatesEnabled: () => true,
     });
 
     expect(txMeta.gasFeeEstimatesLoaded).toBe(false);
@@ -408,14 +408,14 @@ describe('updateTransactionGasFees', () => {
     updateTransactionGasFees({
       txMeta,
       layer1GasFee: layer1GasFeeMock,
-      isTxParamsGasFeeUpdatesEnabled: true,
+      isTxParamsGasFeeUpdatesEnabled: () => true,
     });
 
     expect(txMeta.layer1GasFee).toBe(layer1GasFeeMock);
   });
 
   describe('does not update txParams gas values', () => {
-    it('if isTxParamsGasFeeUpdatesEnabled is false', () => {
+    it('if isTxParamsGasFeeUpdatesEnabled callback returns false', () => {
       const prevMaxFeePerGas = '0x987654321';
       const prevMaxPriorityFeePerGas = '0x98765432';
       const userFeeLevel = UserFeeLevel.MEDIUM;
@@ -432,11 +432,10 @@ describe('updateTransactionGasFees', () => {
       updateTransactionGasFees({
         txMeta,
         gasFeeEstimates: FEE_MARKET_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-        isTxParamsGasFeeUpdatesEnabled: false,
+        isTxParamsGasFeeUpdatesEnabled: () => false,
       });
 
       expect(txMeta.txParams.maxFeePerGas).toBe(prevMaxFeePerGas);
-
       expect(txMeta.txParams.maxPriorityFeePerGas).toBe(
         prevMaxPriorityFeePerGas,
       );
@@ -468,7 +467,7 @@ describe('updateTransactionGasFees', () => {
       updateTransactionGasFees({
         txMeta,
         gasFeeEstimates: FEE_MARKET_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-        isTxParamsGasFeeUpdatesEnabled: true,
+        isTxParamsGasFeeUpdatesEnabled: () => true,
       });
 
       expect(txMeta.txParams.maxFeePerGas).toBe(
@@ -500,16 +499,31 @@ describe('updateTransactionGasFees', () => {
       updateTransactionGasFees({
         txMeta,
         gasFeeEstimates: FEE_MARKET_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-        isTxParamsGasFeeUpdatesEnabled: true,
+        isTxParamsGasFeeUpdatesEnabled: () => true,
       });
 
       expect(txMeta.txParams.maxFeePerGas).toBe(
         FEE_MARKET_GAS_FEE_ESTIMATES_MOCK[userFeeLevel].maxFeePerGas,
       );
-
       expect(txMeta.txParams.maxPriorityFeePerGas).toBe(
         FEE_MARKET_GAS_FEE_ESTIMATES_MOCK[userFeeLevel].maxPriorityFeePerGas,
       );
+    });
+
+    it('calls isTxParamsGasFeeUpdatesEnabled with transaction meta', () => {
+      const mockCallback = jest.fn(() => true);
+      const txMeta = {
+        ...TRANSACTION_META_MOCK,
+        userFeeLevel: GasFeeEstimateLevel.Low,
+      };
+
+      updateTransactionGasFees({
+        txMeta,
+        gasFeeEstimates: FEE_MARKET_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
+        isTxParamsGasFeeUpdatesEnabled: mockCallback,
+      });
+
+      expect(mockCallback).toHaveBeenCalledWith(txMeta);
     });
 
     describe('EIP-1559 compatible chains', () => {
@@ -522,14 +536,13 @@ describe('updateTransactionGasFees', () => {
         updateTransactionGasFees({
           txMeta,
           gasFeeEstimates: FEE_MARKET_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-          isTxParamsGasFeeUpdatesEnabled: true,
+          isTxParamsGasFeeUpdatesEnabled: () => true,
         });
 
         expect(txMeta.txParams.maxFeePerGas).toBe(
           FEE_MARKET_GAS_FEE_ESTIMATES_MOCK[GasFeeEstimateLevel.Low]
             .maxFeePerGas,
         );
-
         expect(txMeta.txParams.maxPriorityFeePerGas).toBe(
           FEE_MARKET_GAS_FEE_ESTIMATES_MOCK[GasFeeEstimateLevel.Low]
             .maxPriorityFeePerGas,
@@ -545,7 +558,7 @@ describe('updateTransactionGasFees', () => {
         updateTransactionGasFees({
           txMeta,
           gasFeeEstimates: GAS_PRICE_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-          isTxParamsGasFeeUpdatesEnabled: true,
+          isTxParamsGasFeeUpdatesEnabled: () => true,
         });
 
         expect(txMeta.txParams.maxFeePerGas).toBe(
@@ -566,7 +579,7 @@ describe('updateTransactionGasFees', () => {
         updateTransactionGasFees({
           txMeta,
           gasFeeEstimates: LEGACY_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-          isTxParamsGasFeeUpdatesEnabled: true,
+          isTxParamsGasFeeUpdatesEnabled: () => true,
         });
 
         expect(txMeta.txParams.maxFeePerGas).toBe(
@@ -593,7 +606,7 @@ describe('updateTransactionGasFees', () => {
         updateTransactionGasFees({
           txMeta,
           gasFeeEstimates: FEE_MARKET_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-          isTxParamsGasFeeUpdatesEnabled: true,
+          isTxParamsGasFeeUpdatesEnabled: () => true,
         });
 
         expect(txMeta.txParams.gasPrice).toBe(
@@ -617,7 +630,7 @@ describe('updateTransactionGasFees', () => {
         updateTransactionGasFees({
           txMeta,
           gasFeeEstimates: GAS_PRICE_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-          isTxParamsGasFeeUpdatesEnabled: true,
+          isTxParamsGasFeeUpdatesEnabled: () => true,
         });
 
         expect(txMeta.txParams.gasPrice).toBe(
@@ -640,7 +653,7 @@ describe('updateTransactionGasFees', () => {
         updateTransactionGasFees({
           txMeta,
           gasFeeEstimates: LEGACY_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-          isTxParamsGasFeeUpdatesEnabled: true,
+          isTxParamsGasFeeUpdatesEnabled: () => true,
         });
 
         expect(txMeta.txParams.gasPrice).toBe(
@@ -666,7 +679,7 @@ describe('updateTransactionGasFees', () => {
       updateTransactionGasFees({
         txMeta,
         gasFeeEstimates: FEE_MARKET_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-        isTxParamsGasFeeUpdatesEnabled: true,
+        isTxParamsGasFeeUpdatesEnabled: () => true,
       });
 
       expect(txMeta.txParams.maxFeePerGas).toBe(
@@ -695,7 +708,7 @@ describe('updateTransactionGasFees', () => {
       updateTransactionGasFees({
         txMeta,
         gasFeeEstimates: LEGACY_GAS_FEE_ESTIMATES_MOCK as GasFeeEstimates,
-        isTxParamsGasFeeUpdatesEnabled: true,
+        isTxParamsGasFeeUpdatesEnabled: () => true,
       });
 
       expect(txMeta.txParams.gasPrice).toBe(
@@ -721,7 +734,7 @@ describe('updateTransactionGasFees', () => {
       updateTransactionGasFees({
         txMeta,
         gasFeeEstimates: undefined,
-        isTxParamsGasFeeUpdatesEnabled: true,
+        isTxParamsGasFeeUpdatesEnabled: () => true,
       });
 
       expect(txMeta.txParams.maxFeePerGas).toBe('0x123456');
@@ -737,7 +750,7 @@ describe('updateTransactionGasFees', () => {
         txMeta,
         gasFeeEstimates: undefined,
         gasFeeEstimatesLoaded: true,
-        isTxParamsGasFeeUpdatesEnabled: true,
+        isTxParamsGasFeeUpdatesEnabled: () => true,
       });
 
       expect(txMeta.gasFeeEstimates).toBeUndefined();

--- a/packages/transaction-controller/src/helpers/GasFeePoller.ts
+++ b/packages/transaction-controller/src/helpers/GasFeePoller.ts
@@ -339,15 +339,16 @@ export function updateTransactionGasFees({
   txMeta: TransactionMeta;
   gasFeeEstimates?: GasFeeEstimates;
   gasFeeEstimatesLoaded?: boolean;
-  isTxParamsGasFeeUpdatesEnabled: boolean;
+  isTxParamsGasFeeUpdatesEnabled: (transactionMeta: TransactionMeta) => boolean;
   layer1GasFee?: Hex;
 }): void {
   const userFeeLevel = txMeta.userFeeLevel as GasFeeEstimateLevel;
   const isUsingGasFeeEstimateLevel =
     Object.values(GasFeeEstimateLevel).includes(userFeeLevel);
   const { type: gasEstimateType } = gasFeeEstimates ?? {};
+  const shouldUpdateTxParamsGasFees = isTxParamsGasFeeUpdatesEnabled(txMeta);
 
-  if (isTxParamsGasFeeUpdatesEnabled && isUsingGasFeeEstimateLevel) {
+  if (shouldUpdateTxParamsGasFees && isUsingGasFeeEstimateLevel) {
     const isEIP1559Compatible =
       txMeta.txParams.type !== TransactionEnvelopeType.legacy;
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR aims to rename `enableTxParamsGasFeeUpdates` to `isAutomaticGasFeeUpdateEnabled` and make it a callback function instead of a boolean.
This callback is invoked before performing `txParams` gas fee updates. The update will proceed only if the callback returns a truthy value.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4595
Mobile update PR: https://github.com/MetaMask/metamask-mobile/pull/14470 (Not updated package yet since major update PR in review https://github.com/MetaMask/metamask-mobile/pull/14326 )
Extension update PR: 


## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [X] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
