### PR TITLE
feat: STAKE-1005: refresh staking data when staking txs are confirmed

### DIFF
--- a/packages/earn-controller/package.json
+++ b/packages/earn-controller/package.json
@@ -56,6 +56,7 @@
     "@metamask/accounts-controller": "^27.0.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/network-controller": "^23.2.0",
+    "@metamask/transaction-controller": "^53.0.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/earn-controller/tsconfig.build.json
+++ b/packages/earn-controller/tsconfig.build.json
@@ -14,6 +14,9 @@
     },
     {
       "path": "../accounts-controller/tsconfig.build.json"
+    },
+    {
+      "path": "../transaction-controller/tsconfig.build.json"
     }
   ],
   "include": ["../../types", "./src"]

--- a/packages/earn-controller/tsconfig.json
+++ b/packages/earn-controller/tsconfig.json
@@ -13,6 +13,9 @@
     },
     {
       "path": "../accounts-controller"
+    },
+    {
+      "path": "../transaction-controller"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2962,6 +2962,7 @@ __metadata:
     "@metamask/controller-utils": "npm:^11.7.0"
     "@metamask/network-controller": "npm:^23.2.0"
     "@metamask/stake-sdk": "npm:^1.0.0"
+    "@metamask/transaction-controller": "npm:^53.0.0"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"
     jest: "npm:^27.5.1"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This PR updates the `EarnController` to refresh a user's pooled-staking data when a staking transaction is confirmed. Non-staking transaction types are ignored.

- Added a new subscription to the `TransactionController:transactionConfirmed` event has been added.
- Added `@metamask/transaction-controller` has been added as a dev dependency.
- Added related tests.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
Jira ticket: [[Earn-Controller] Refresh staking data when staking transactions are confirmed](https://consensyssoftware.atlassian.net/browse/STAKE-1005)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
