### PR TITLE
fix: Update origin in Snap requests

### DIFF
--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update origin used for `SnapController:handleRequest` ([#5616](https://github.com/MetaMask/core/pull/5616))
+
 ## [11.0.0]
 
 ### Changed

--- a/packages/profile-sync-controller/src/controllers/authentication/auth-snap-requests.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/auth-snap-requests.ts
@@ -14,7 +14,7 @@ const snapId = 'npm:@metamask/message-signing-snap' as SnapId;
 export function createSnapPublicKeyRequest(): SnapRPCRequest {
   return {
     snapId,
-    origin: '',
+    origin: 'metamask',
     handler: 'onRpcRequest' as any,
     request: {
       method: 'getPublicKey',
@@ -33,7 +33,7 @@ export function createSnapSignMessageRequest(
 ): SnapRPCRequest {
   return {
     snapId,
-    origin: '',
+    origin: 'metamask',
     handler: 'onRpcRequest' as any,
     request: {
       method: 'signMessage',


### PR DESCRIPTION
## Explanation

We are making a change to the SnapController to more strictly validate the `origin` parameter. This disallows empty string which was previously allowed. This PR updates the `profile-sync-controller` to comply with these new requirements.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
