### PR TITLE
ci: GH action to remind developers to add release notes in CHANGELOG.md

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,18 @@
+name: Check Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  check_changelog:
+    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@fd5f71cd6cb3c64e4fab7db56ce6b53c75732f95
+    with:
+      base-branch: main
+      head-ref: ${{ github.head_ref }}
+      labels: ${{ toJSON(github.event.pull_request.labels) }}
+      repo: ${{ github.repository }}
+    secrets:
+      gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Explanation

This PR introduces a new CI workflow that enforces the inclusion of a CHANGELOG entry for any changes made by developers.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/3678

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
