### PR TITLE
fix: confusing error message when using wrong password

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed wrong error message thrown when using the wrong password ([#1234](https://github.com/MetaMask/core/pull/1234))
+
 ## [21.0.2]
 
 ### Changed

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed wrong error message thrown when using the wrong password ([#1234](https://github.com/MetaMask/core/pull/1234))
+- Fixed wrong error message thrown when using the wrong password ([#5627](https://github.com/MetaMask/core/pull/5627))
 
 ## [21.0.2]
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2526,174 +2526,91 @@ describe('KeyringController', () => {
   describe('submitPassword', () => {
     [false, true].map((cacheEncryptionKey) =>
       describe(`when cacheEncryptionKey is ${cacheEncryptionKey}`, () => {
-        it('should submit password and decrypt', async () => {
-          await withController(
-            { cacheEncryptionKey },
-            async ({ controller, initialState }) => {
-              await controller.submitPassword(password);
-              expect(controller.state).toStrictEqual(initialState);
-            },
-          );
-        });
-
-        it('should emit KeyringController:unlock event', async () => {
-          await withController(
-            { cacheEncryptionKey },
-            async ({ controller, messenger }) => {
-              const listener = sinon.spy();
-              messenger.subscribe('KeyringController:unlock', listener);
-              await controller.submitPassword(password);
-              expect(listener.called).toBe(true);
-            },
-          );
-        });
-
-        it('should unlock also with unsupported keyrings', async () => {
-          await withController(
-            {
-              cacheEncryptionKey,
-              skipVaultCreation: true,
-              state: { vault: 'my vault' },
-            },
-            async ({ controller, encryptor }) => {
-              jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
-                {
-                  type: 'UnsupportedKeyring',
-                  data: '0x1234',
-                },
-              ]);
-
-              await controller.submitPassword(password);
-
-              expect(controller.state.isUnlocked).toBe(true);
-            },
-          );
-        });
-
-        it('should throw error if vault unlocked has an unexpected shape', async () => {
-          await withController(
-            {
-              cacheEncryptionKey,
-              skipVaultCreation: true,
-              state: { vault: 'my vault' },
-            },
-            async ({ controller, encryptor }) => {
-              jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
-                {
-                  foo: 'bar',
-                },
-              ]);
-
-              await expect(controller.submitPassword(password)).rejects.toThrow(
-                KeyringControllerError.VaultDataError,
-              );
-            },
-          );
-        });
-
-        it('should throw error if vault is missing', async () => {
-          await withController(
-            { skipVaultCreation: true },
-            async ({ controller }) => {
-              await expect(controller.submitPassword(password)).rejects.toThrow(
-                KeyringControllerError.VaultError,
-              );
-            },
-          );
-        });
-
-        it('should unlock succesfully when the controller is instantiated with an existing `keyringsMetadata`', async () => {
-          await withController(
-            {
-              cacheEncryptionKey,
-              state: { keyringsMetadata: [], vault: 'my vault' },
-              skipVaultCreation: true,
-            },
-            async ({ controller, encryptor }) => {
-              jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
-                {
-                  type: KeyringTypes.hd,
-                  data: {
-                    accounts: ['0x123'],
-                  },
-                },
-              ]);
-
-              await controller.submitPassword(password);
-
-              expect(controller.state.keyringsMetadata).toHaveLength(1);
-            },
-          );
-        });
-
-        it('should throw an error when the controller is instantiated with an existing `keyringsMetadata` with too many objects', async () => {
-          await withController(
-            {
-              cacheEncryptionKey,
-              state: {
-                keyringsMetadata: [
-                  { id: '123', name: '' },
-                  { id: '456', name: '' },
-                ],
-                vault: 'my vault',
+        describe('when using the correct password', () => {
+          it('should submit password and decrypt', async () => {
+            await withController(
+              { cacheEncryptionKey },
+              async ({ controller, initialState }) => {
+                await controller.submitPassword(password);
+                expect(controller.state).toStrictEqual(initialState);
               },
-              skipVaultCreation: true,
-            },
-            async ({ controller, encryptor }) => {
-              jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
-                {
-                  type: KeyringTypes.hd,
-                  data: {
-                    accounts: ['0x123'],
-                  },
-                },
-              ]);
+            );
+          });
 
-              await expect(controller.submitPassword(password)).rejects.toThrow(
-                KeyringControllerError.KeyringMetadataLengthMismatch,
-              );
-            },
-          );
-        });
+          it('should emit KeyringController:unlock event', async () => {
+            await withController(
+              { cacheEncryptionKey },
+              async ({ controller, messenger }) => {
+                const listener = sinon.spy();
+                messenger.subscribe('KeyringController:unlock', listener);
+                await controller.submitPassword(password);
+                expect(listener.called).toBe(true);
+              },
+            );
+          });
 
-        cacheEncryptionKey &&
-          it('should upgrade the vault encryption if the key encryptor has different parameters', async () => {
+          it('should unlock also with unsupported keyrings', async () => {
             await withController(
               {
-                skipVaultCreation: true,
                 cacheEncryptionKey,
+                skipVaultCreation: true,
                 state: { vault: 'my vault' },
               },
               async ({ controller, encryptor }) => {
-                jest.spyOn(encryptor, 'isVaultUpdated').mockReturnValue(false);
-                const encryptSpy = jest.spyOn(encryptor, 'encryptWithDetail');
-                jest.spyOn(encryptor, 'decryptWithKey').mockResolvedValueOnce([
+                jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
                   {
-                    type: KeyringTypes.hd,
-                    data: {
-                      accounts: ['0x123'],
-                    },
+                    type: 'UnsupportedKeyring',
+                    data: '0x1234',
                   },
                 ]);
 
                 await controller.submitPassword(password);
 
-                expect(encryptSpy).toHaveBeenCalledTimes(1);
+                expect(controller.state.isUnlocked).toBe(true);
               },
             );
           });
 
-        !cacheEncryptionKey &&
-          it('should upgrade the vault encryption if the generic encryptor has different parameters', async () => {
+          it('should throw error if vault unlocked has an unexpected shape', async () => {
             await withController(
               {
-                skipVaultCreation: true,
                 cacheEncryptionKey,
+                skipVaultCreation: true,
                 state: { vault: 'my vault' },
               },
               async ({ controller, encryptor }) => {
-                jest.spyOn(encryptor, 'isVaultUpdated').mockReturnValue(false);
-                const encryptSpy = jest.spyOn(encryptor, 'encrypt');
+                jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
+                  {
+                    foo: 'bar',
+                  },
+                ]);
+
+                await expect(
+                  controller.submitPassword(password),
+                ).rejects.toThrow(KeyringControllerError.VaultDataError);
+              },
+            );
+          });
+
+          it('should throw error if vault is missing', async () => {
+            await withController(
+              { skipVaultCreation: true },
+              async ({ controller }) => {
+                await expect(
+                  controller.submitPassword(password),
+                ).rejects.toThrow(KeyringControllerError.VaultError);
+              },
+            );
+          });
+
+          it('should unlock succesfully when the controller is instantiated with an existing `keyringsMetadata`', async () => {
+            await withController(
+              {
+                cacheEncryptionKey,
+                state: { keyringsMetadata: [], vault: 'my vault' },
+                skipVaultCreation: true,
+              },
+              async ({ controller, encryptor }) => {
                 jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
                   {
                     type: KeyringTypes.hd,
@@ -2705,35 +2622,145 @@ describe('KeyringController', () => {
 
                 await controller.submitPassword(password);
 
-                expect(encryptSpy).toHaveBeenCalledTimes(1);
+                expect(controller.state.keyringsMetadata).toHaveLength(1);
               },
             );
           });
 
-        !cacheEncryptionKey &&
-          it('should throw error if password is of wrong type', async () => {
+          it('should throw an error when the controller is instantiated with an existing `keyringsMetadata` with too many objects', async () => {
             await withController(
-              { cacheEncryptionKey },
+              {
+                cacheEncryptionKey,
+                state: {
+                  keyringsMetadata: [
+                    { id: '123', name: '' },
+                    { id: '456', name: '' },
+                  ],
+                  vault: 'my vault',
+                },
+                skipVaultCreation: true,
+              },
+              async ({ controller, encryptor }) => {
+                jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
+                  {
+                    type: KeyringTypes.hd,
+                    data: {
+                      accounts: ['0x123'],
+                    },
+                  },
+                ]);
+
+                await expect(
+                  controller.submitPassword(password),
+                ).rejects.toThrow(
+                  KeyringControllerError.KeyringMetadataLengthMismatch,
+                );
+              },
+            );
+          });
+
+          cacheEncryptionKey &&
+            it('should upgrade the vault encryption if the key encryptor has different parameters', async () => {
+              await withController(
+                {
+                  skipVaultCreation: true,
+                  cacheEncryptionKey,
+                  state: { vault: 'my vault' },
+                },
+                async ({ controller, encryptor }) => {
+                  jest
+                    .spyOn(encryptor, 'isVaultUpdated')
+                    .mockReturnValue(false);
+                  const encryptSpy = jest.spyOn(encryptor, 'encryptWithDetail');
+                  jest
+                    .spyOn(encryptor, 'decryptWithKey')
+                    .mockResolvedValueOnce([
+                      {
+                        type: KeyringTypes.hd,
+                        data: {
+                          accounts: ['0x123'],
+                        },
+                      },
+                    ]);
+
+                  await controller.submitPassword(password);
+
+                  expect(encryptSpy).toHaveBeenCalledTimes(1);
+                },
+              );
+            });
+
+          !cacheEncryptionKey &&
+            it('should upgrade the vault encryption if the generic encryptor has different parameters', async () => {
+              await withController(
+                {
+                  skipVaultCreation: true,
+                  cacheEncryptionKey,
+                  state: { vault: 'my vault' },
+                },
+                async ({ controller, encryptor }) => {
+                  jest
+                    .spyOn(encryptor, 'isVaultUpdated')
+                    .mockReturnValue(false);
+                  const encryptSpy = jest.spyOn(encryptor, 'encrypt');
+                  jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
+                    {
+                      type: KeyringTypes.hd,
+                      data: {
+                        accounts: ['0x123'],
+                      },
+                    },
+                  ]);
+
+                  await controller.submitPassword(password);
+
+                  expect(encryptSpy).toHaveBeenCalledTimes(1);
+                },
+              );
+            });
+
+          !cacheEncryptionKey &&
+            it('should throw error if password is of wrong type', async () => {
+              await withController(
+                { cacheEncryptionKey },
+                async ({ controller }) => {
+                  await expect(
+                    // @ts-expect-error we are testing the case of a user using
+                    // the wrong password type
+                    controller.submitPassword(12341234),
+                  ).rejects.toThrow(KeyringControllerError.WrongPasswordType);
+                },
+              );
+            });
+
+          cacheEncryptionKey &&
+            it('should set encryptionKey and encryptionSalt in state', async () => {
+              // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
+              withController({ cacheEncryptionKey }, async ({ controller }) => {
+                await controller.submitPassword(password);
+                expect(controller.state.encryptionKey).toBeDefined();
+                expect(controller.state.encryptionSalt).toBeDefined();
+              });
+            });
+        });
+
+        describe('when using the wrong password', () => {
+          it('should throw error', async () => {
+            await withController(
+              {
+                skipVaultCreation: true,
+                cacheEncryptionKey,
+                state: { vault: 'my vault' },
+              },
               async ({ controller }) => {
                 await expect(
-                  // @ts-expect-error we are testing the case of a user using
-                  // the wrong password type
-                  controller.submitPassword(12341234),
-                ).rejects.toThrow(KeyringControllerError.WrongPasswordType);
+                  controller.submitPassword('wrong password'),
+                ).rejects.toThrow('Incorrect password.');
               },
             );
           });
-
-        cacheEncryptionKey &&
-          it('should set encryptionKey and encryptionSalt in state', async () => {
-            // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            withController({ cacheEncryptionKey }, async ({ controller }) => {
-              await controller.submitPassword(password);
-              expect(controller.state.encryptionKey).toBeDefined();
-              expect(controller.state.encryptionSalt).toBeDefined();
-            });
-          });
+        });
       }),
     );
   });

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2234,7 +2234,7 @@ export class KeyringController extends BaseController<
       await this.#restoreSerializedKeyrings(vault);
 
       // The keyrings array and the keyringsMetadata array should
-      // always be the same length while the controller is unlocked.
+      // always have the same length while the controller is unlocked.
       if (this.#keyrings.length !== this.#keyringsMetadata.length) {
         throw new Error(KeyringControllerError.KeyringMetadataLengthMismatch);
       }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2155,10 +2155,6 @@ export class KeyringController extends BaseController<
     for (const serializedKeyring of serializedKeyrings) {
       await this.#restoreKeyring(serializedKeyring);
     }
-
-    if (this.#keyrings.length !== this.#keyringsMetadata.length) {
-      throw new Error(KeyringControllerError.KeyringMetadataLengthMismatch);
-    }
   }
 
   /**
@@ -2236,6 +2232,13 @@ export class KeyringController extends BaseController<
       }
 
       await this.#restoreSerializedKeyrings(vault);
+
+      // The keyrings array and the keyringsMetadata array should
+      // always be the same length while the controller is unlocked.
+      if (this.#keyrings.length !== this.#keyringsMetadata.length) {
+        throw new Error(KeyringControllerError.KeyringMetadataLengthMismatch);
+      }
+
       const updatedKeyrings = await this.#getUpdatedKeyrings();
 
       this.update((state) => {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
When calling `submitPassword` with the wrong password, a confusing error is shown instead of `Incorrect password`. This is due to the recently added metadata length check in `#restoreSerializedKeyrings`, which doesn't match the correct behavior when `isUnlocked = true`.

We can move the metadata length check to `#unlockKeyrings`, so that it will be skipped everytime the controller is locked

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Related to https://github.com/MetaMask/metamask-extension/issues/31373

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->
Changelog updated in the PR

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
