### PR TITLE
feat: remove `isAccountSyncingEnabled` `env` property from `UserStorageController` constructor

### DIFF
--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove `isAccountSyncingEnabled` `env` property from `UserStorageController` constructor ([#5629](https://github.com/MetaMask/core/pull/5629))
+
 ## [11.0.1]
 
 ### Changed

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Remove `isAccountSyncingEnabled` `env` property from `UserStorageController` constructor ([#5629](https://github.com/MetaMask/core/pull/5629))
+### Removed
+
+- **BREAKING:** Remove `isAccountSyncingEnabled` `env` property from `UserStorageController` constructor ([#5629](https://github.com/MetaMask/core/pull/5629))
 
 ## [11.0.1]
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -703,12 +703,9 @@ describe('user-storage/user-storage-controller - syncInternalAccountsWithUserSto
       arrangeMocks();
     const controller = new UserStorageController({
       messenger,
-      env: {
-        // We're only verifying that calling this controller method will call the integration module
-        // The actual implementation is tested in the integration tests
-        // This is done to prevent creating unnecessary nock instances in this test
-        isAccountSyncingEnabled: false,
-      },
+      // We're only verifying that calling this controller method will call the integration module
+      // The actual implementation is tested in the integration tests
+      // This is done to prevent creating unnecessary nock instances in this test
       config: {
         accountSyncing: {
           onAccountAdded: jest.fn(),
@@ -764,18 +761,14 @@ describe('user-storage/user-storage-controller - saveInternalAccountToUserStorag
     const { messenger, mockSaveInternalAccountToUserStorage } = arrangeMocks();
     const controller = new UserStorageController({
       messenger,
-      env: {
-        // We're only verifying that calling this controller method will call the integration module
-        // The actual implementation is tested in the integration tests
-        // This is done to prevent creating unnecessary nock instances in this test
-        isAccountSyncingEnabled: false,
-      },
+      // We're only verifying that calling this controller method will call the integration module
+      // The actual implementation is tested in the integration tests
+      // This is done to prevent creating unnecessary nock instances in this test
     });
 
     mockSaveInternalAccountToUserStorage.mockImplementation(
       async (
         _internalAccount,
-        _config,
         {
           getMessenger = jest.fn(),
           getUserStorageControllerInstance = jest.fn(),
@@ -911,11 +904,9 @@ describe('user-storage/user-storage-controller - account syncing edge cases', ()
     const messengerMocks = mockUserStorageMessenger();
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      env: {
-        isAccountSyncingEnabled: false,
-      },
     });
 
+    await controller.disableProfileSyncing();
     await controller.syncInternalAccountsWithUserStorage();
 
     // Should not have called the account syncing module
@@ -928,9 +919,6 @@ describe('user-storage/user-storage-controller - account syncing edge cases', ()
 
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      env: {
-        isAccountSyncingEnabled: true,
-      },
     });
 
     await controller.syncInternalAccountsWithUserStorage();
@@ -944,9 +932,6 @@ describe('user-storage/user-storage-controller - account syncing edge cases', ()
 
     const controller = new UserStorageController({
       messenger: messengerMocks.messenger,
-      env: {
-        isAccountSyncingEnabled: false,
-      },
     });
 
     const mockSetStorage = jest.spyOn(controller, 'performSetStorage');

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -283,7 +283,6 @@ export default class UserStorageController extends BaseController<
   // This is replaced with the actual value in the constructor
   // We will remove this once the feature will be released
   readonly #env = {
-    isAccountSyncingEnabled: false,
     isNetworkSyncingEnabled: false,
   };
 
@@ -342,7 +341,6 @@ export default class UserStorageController extends BaseController<
     state?: UserStorageControllerState;
     config?: ControllerConfig;
     env?: {
-      isAccountSyncingEnabled?: boolean;
       isNetworkSyncingEnabled?: boolean;
     };
     nativeScryptCrypto?: NativeScrypt;
@@ -354,7 +352,6 @@ export default class UserStorageController extends BaseController<
       state: { ...defaultState, ...state },
     });
 
-    this.#env.isAccountSyncingEnabled = Boolean(env?.isAccountSyncingEnabled);
     this.#env.isNetworkSyncingEnabled = Boolean(env?.isNetworkSyncingEnabled);
     this.#config = config;
 
@@ -391,15 +388,10 @@ export default class UserStorageController extends BaseController<
     this.#nativeScryptCrypto = nativeScryptCrypto;
 
     // Account Syncing
-    if (this.#env.isAccountSyncingEnabled) {
-      setupAccountSyncingSubscriptions(
-        { isAccountSyncingEnabled: true },
-        {
-          getUserStorageControllerInstance: () => this,
-          getMessenger: () => this.messagingSystem,
-        },
-      );
-    }
+    setupAccountSyncingSubscriptions({
+      getUserStorageControllerInstance: () => this,
+      getMessenger: () => this.messagingSystem,
+    });
 
     // Network Syncing
     if (this.#env.isNetworkSyncingEnabled) {
@@ -718,7 +710,6 @@ export default class UserStorageController extends BaseController<
 
     await syncInternalAccountsWithUserStorage(
       {
-        isAccountSyncingEnabled: this.#env.isAccountSyncingEnabled,
         maxNumberOfAccountsToAdd:
           this.#config?.accountSyncing?.maxNumberOfAccountsToAdd,
         onAccountAdded: () =>
@@ -747,14 +738,10 @@ export default class UserStorageController extends BaseController<
   async saveInternalAccountToUserStorage(
     internalAccount: InternalAccount,
   ): Promise<void> {
-    await saveInternalAccountToUserStorage(
-      internalAccount,
-      { isAccountSyncingEnabled: this.#env.isAccountSyncingEnabled },
-      {
-        getMessenger: () => this.messagingSystem,
-        getUserStorageControllerInstance: () => this,
-      },
-    );
+    await saveInternalAccountToUserStorage(internalAccount, {
+      getMessenger: () => this.messagingSystem,
+      getUserStorageControllerInstance: () => this,
+    });
   }
 
   async syncNetworks() {

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/controller-integration.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/controller-integration.ts
@@ -7,7 +7,7 @@ import {
   getInternalAccountsList,
   getUserStorageAccountsList,
 } from './sync-utils';
-import type { AccountSyncingConfig, AccountSyncingOptions } from './types';
+import type { AccountSyncingOptions } from './types';
 import {
   isInternalAccountFromPrimarySRPHdKeyring,
   isNameDefaultAccountName,
@@ -19,20 +19,16 @@ import { USER_STORAGE_FEATURE_NAMES } from '../../../shared/storage-schema';
  * Saves an individual internal account to the user storage.
  *
  * @param internalAccount - The internal account to save
- * @param config - parameters used for saving the internal account
  * @param options - parameters used for saving the internal account
  */
 export async function saveInternalAccountToUserStorage(
   internalAccount: InternalAccount,
-  config: AccountSyncingConfig,
   options: AccountSyncingOptions,
 ): Promise<void> {
-  const { isAccountSyncingEnabled } = config;
   const { getUserStorageControllerInstance } = options;
 
   if (
-    !isAccountSyncingEnabled ||
-    !canPerformAccountSyncing(config, options) ||
+    !canPerformAccountSyncing(options) ||
     !isEvmAccountType(internalAccount.type) ||
     !(await isInternalAccountFromPrimarySRPHdKeyring(internalAccount, options))
   ) {
@@ -62,19 +58,12 @@ export async function saveInternalAccountToUserStorage(
 /**
  * Saves the list of internal accounts to the user storage.
  *
- * @param config - parameters used for saving the list of internal accounts
  * @param options - parameters used for saving the list of internal accounts
  */
 export async function saveInternalAccountsListToUserStorage(
-  config: AccountSyncingConfig,
   options: AccountSyncingOptions,
 ): Promise<void> {
-  const { isAccountSyncingEnabled } = config;
   const { getUserStorageControllerInstance } = options;
-
-  if (!isAccountSyncingEnabled) {
-    return;
-  }
 
   const internalAccountsList = await getInternalAccountsList(options);
 
@@ -95,7 +84,7 @@ export async function saveInternalAccountsListToUserStorage(
   );
 }
 
-type SyncInternalAccountsWithUserStorageConfig = AccountSyncingConfig & {
+type SyncInternalAccountsWithUserStorageConfig = {
   maxNumberOfAccountsToAdd?: number;
   onAccountAdded?: () => void;
   onAccountNameUpdated?: () => void;
@@ -117,9 +106,7 @@ export async function syncInternalAccountsWithUserStorage(
   config: SyncInternalAccountsWithUserStorageConfig,
   options: AccountSyncingOptions,
 ): Promise<void> {
-  const { isAccountSyncingEnabled } = config;
-
-  if (!canPerformAccountSyncing(config, options) || !isAccountSyncingEnabled) {
+  if (!canPerformAccountSyncing(options)) {
     return;
   }
 
@@ -139,10 +126,7 @@ export async function syncInternalAccountsWithUserStorage(
     const userStorageAccountsList = await getUserStorageAccountsList(options);
 
     if (!userStorageAccountsList || !userStorageAccountsList.length) {
-      await saveInternalAccountsListToUserStorage(
-        { isAccountSyncingEnabled },
-        options,
-      );
+      await saveInternalAccountsListToUserStorage(options);
       await getUserStorageControllerInstance().setHasAccountSyncingSyncedAtLeastOnce(
         true,
       );

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/setup-subscriptions.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/setup-subscriptions.test.ts
@@ -2,7 +2,6 @@ import { setupAccountSyncingSubscriptions } from './setup-subscriptions';
 
 describe('user-storage/account-syncing/setup-subscriptions - setupAccountSyncingSubscriptions', () => {
   it('should subscribe to accountAdded and accountRenamed events', () => {
-    const config = { isAccountSyncingEnabled: true };
     const options = {
       getMessenger: jest.fn().mockReturnValue({
         subscribe: jest.fn(),
@@ -14,7 +13,7 @@ describe('user-storage/account-syncing/setup-subscriptions - setupAccountSyncing
       }),
     };
 
-    setupAccountSyncingSubscriptions(config, options);
+    setupAccountSyncingSubscriptions(options);
 
     expect(options.getMessenger().subscribe).toHaveBeenCalledWith(
       'AccountsController:accountAdded',

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/setup-subscriptions.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/setup-subscriptions.ts
@@ -1,15 +1,13 @@
 import { saveInternalAccountToUserStorage } from './controller-integration';
 import { canPerformAccountSyncing } from './sync-utils';
-import type { AccountSyncingConfig, AccountSyncingOptions } from './types';
+import type { AccountSyncingOptions } from './types';
 
 /**
  * Initialize and setup events to listen to for account syncing
  *
- * @param config - configuration parameters
  * @param options - parameters used for initializing and enabling account syncing
  */
 export function setupAccountSyncingSubscriptions(
-  config: AccountSyncingConfig,
   options: AccountSyncingOptions,
 ) {
   const { getMessenger, getUserStorageControllerInstance } = options;
@@ -17,32 +15,34 @@ export function setupAccountSyncingSubscriptions(
   getMessenger().subscribe(
     'AccountsController:accountAdded',
 
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     async (account) => {
       if (
-        !canPerformAccountSyncing(config, options) ||
+        !canPerformAccountSyncing(options) ||
         !getUserStorageControllerInstance().state
           .hasAccountSyncingSyncedAtLeastOnce
       ) {
         return;
       }
 
-      await saveInternalAccountToUserStorage(account, config, options);
+      await saveInternalAccountToUserStorage(account, options);
     },
   );
 
   getMessenger().subscribe(
     'AccountsController:accountRenamed',
 
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     async (account) => {
       if (
-        !canPerformAccountSyncing(config, options) ||
+        !canPerformAccountSyncing(options) ||
         !getUserStorageControllerInstance().state
           .hasAccountSyncingSyncedAtLeastOnce
       ) {
         return;
       }
 
-      await saveInternalAccountToUserStorage(account, config, options);
+      await saveInternalAccountToUserStorage(account, options);
     },
   );
 }

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/sync-utils.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/sync-utils.test.ts
@@ -6,18 +6,16 @@ import {
   getInternalAccountsList,
   getUserStorageAccountsList,
 } from './sync-utils';
-import type { AccountSyncingConfig, AccountSyncingOptions } from './types';
+import type { AccountSyncingOptions } from './types';
 
 describe('user-storage/account-syncing/sync-utils', () => {
   describe('canPerformAccountSyncing', () => {
     const arrangeMocks = ({
-      isAccountSyncingEnabled = true,
       isProfileSyncingEnabled = true,
       isAccountSyncingInProgress = false,
       messengerCallControllerAndAction = 'AuthenticationController:isSignedIn',
       messengerCallCallback = () => true,
     }) => {
-      const config: AccountSyncingConfig = { isAccountSyncingEnabled };
       const options: AccountSyncingOptions = {
         getMessenger: jest.fn().mockReturnValue({
           call: jest
@@ -36,7 +34,7 @@ describe('user-storage/account-syncing/sync-utils', () => {
         }),
       };
 
-      return { config, options };
+      return { options };
     };
 
     const failureCases = [
@@ -49,20 +47,19 @@ describe('user-storage/account-syncing/sync-utils', () => {
           messengerCallCallback: () => false,
         },
       ],
-      ['account syncing is not enabled', { isAccountSyncingEnabled: false }],
       ['account syncing is in progress', { isAccountSyncingInProgress: true }],
     ] as const;
 
     it.each(failureCases)('returns false if %s', (_message, mocks) => {
-      const { config, options } = arrangeMocks(mocks);
+      const { options } = arrangeMocks(mocks);
 
-      expect(canPerformAccountSyncing(config, options)).toBe(false);
+      expect(canPerformAccountSyncing(options)).toBe(false);
     });
 
     it('returns true if all conditions are met', () => {
-      const { config, options } = arrangeMocks({});
+      const { options } = arrangeMocks({});
 
-      expect(canPerformAccountSyncing(config, options)).toBe(true);
+      expect(canPerformAccountSyncing(options)).toBe(true);
     });
   });
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/sync-utils.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/sync-utils.ts
@@ -1,25 +1,18 @@
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
-import type {
-  AccountSyncingConfig,
-  AccountSyncingOptions,
-  UserStorageAccount,
-} from './types';
+import type { AccountSyncingOptions, UserStorageAccount } from './types';
 import { mapInternalAccountsListToPrimarySRPHdKeyringInternalAccountsList } from './utils';
 import { USER_STORAGE_FEATURE_NAMES } from '../../../shared/storage-schema';
 
 /**
  * Checks if account syncing can be performed based on a set of conditions
  *
- * @param config - configuration parameters
  * @param options - parameters used for checking if account syncing can be performed
  * @returns Returns true if account syncing can be performed, false otherwise.
  */
 export function canPerformAccountSyncing(
-  config: AccountSyncingConfig,
   options: AccountSyncingOptions,
 ): boolean {
-  const { isAccountSyncingEnabled } = config;
   const { getMessenger, getUserStorageControllerInstance } = options;
 
   const { isProfileSyncingEnabled, isAccountSyncingInProgress } =
@@ -31,7 +24,6 @@ export function canPerformAccountSyncing(
   if (
     !isProfileSyncingEnabled ||
     !isAuthEnabled ||
-    !isAccountSyncingEnabled ||
     isAccountSyncingInProgress
   ) {
     return false;

--- a/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/types.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/account-syncing/types.ts
@@ -21,10 +21,6 @@ export type UserStorageAccount = {
   nlu?: number;
 };
 
-export type AccountSyncingConfig = {
-  isAccountSyncingEnabled: boolean;
-};
-
 export type AccountSyncingOptions = {
   getUserStorageControllerInstance: () => UserStorageController;
   getMessenger: () => UserStorageControllerMessenger;


### PR DESCRIPTION
## Explanation

Since account syncing is now enabled by default in both clients, we are removing the possibility to control `isAccountSyncingEnabled` from the `UserStorageController` contructor `env` property.

In a subsequent PR, we'll introduce a new `isAccountSyncingEnabled` state property, and expose a way to toggle it from the clients. For now, all clients dispatch account syncing depending on if `isProfileSyncingEnabled` is `true`, so we can do this change in another PR without risking to break anything.
The UTs flagged with `it.todo` in the PR will then be updated using this new state property.

This change is **BREAKING**, and the clients need to remove the `isAccountSyncingEnabled` property from `UserStorageController` `env` when instantiating the controller.

## References

Related to: https://consensyssoftware.atlassian.net/browse/IDENTITY-82
Extension test drive PR (CI ✅): https://github.com/MetaMask/metamask-extension/pull/31884

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
