### PR TITLE
feat: use feature flags for gas estimation buffers 

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Configure gas estimation buffers using feature flags ([#5637](https://github.com/MetaMask/core/pull/5637))
 - Update error codes for duplicate batch ID and batch size limit errors ([#5635](https://github.com/MetaMask/core/pull/5635))
 
 ### Fixed

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1200,6 +1200,7 @@ describe('TransactionController', () => {
         estimatedGas: gasMock,
         blockGasLimit: blockGasLimitMock,
         simulationFails: simulationFailsMock,
+        isUpgradeWithDataToSelf: false,
       });
 
       addGasBufferMock.mockReturnValue(expectedEstimatedGas);

--- a/packages/transaction-controller/src/constants.ts
+++ b/packages/transaction-controller/src/constants.ts
@@ -32,11 +32,6 @@ export const CHAIN_IDS = {
   MEGAETH_TESTNET: '0x18c6',
 } as const;
 
-export const GAS_BUFFER_CHAIN_OVERRIDES = {
-  [CHAIN_IDS.OPTIMISM]: 1,
-  [CHAIN_IDS.OPTIMISM_SEPOLIA]: 1,
-};
-
 /** Extract of the Wrapped ERC-20 ABI required for simulation. */
 export const ABI_SIMULATION_ERC20_WRAPPED = [
   {

--- a/packages/transaction-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.test.ts
@@ -4,8 +4,6 @@ import type { Hex } from '@metamask/utils';
 
 import type { TransactionControllerFeatureFlags } from './feature-flags';
 import {
-  FEATURE_FLAG_EIP_7702,
-  FEATURE_FLAG_TRANSACTIONS,
   getAcceleratedPollingParams,
   getBatchSizeLimit,
   getEIP7702ContractAddresses,
@@ -14,6 +12,7 @@ import {
   getGasFeeRandomisation,
   getGasEstimateFallback,
   getGasEstimateBuffer,
+  FeatureFlag,
 } from './feature-flags';
 import { isValidSignature } from './signature';
 import type { TransactionControllerMessenger } from '..';
@@ -83,7 +82,7 @@ describe('Feature Flags Utils', () => {
   describe('getEIP7702SupportedChains', () => {
     it('returns value from remote feature flag controller', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_EIP_7702]: {
+        [FeatureFlag.EIP7702]: {
           supportedChains: [CHAIN_ID_MOCK, CHAIN_ID_2_MOCK],
         },
       });
@@ -103,7 +102,7 @@ describe('Feature Flags Utils', () => {
   describe('getEIP7702ContractAddresses', () => {
     it('returns value from remote feature flag controller', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_EIP_7702]: {
+        [FeatureFlag.EIP7702]: {
           contracts: {
             [CHAIN_ID_MOCK]: [
               { address: ADDRESS_MOCK, signature: SIGNATURE_MOCK },
@@ -136,7 +135,7 @@ describe('Feature Flags Utils', () => {
 
     it('returns empty array if chain ID not found', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_EIP_7702]: {
+        [FeatureFlag.EIP7702]: {
           contracts: {
             [CHAIN_ID_2_MOCK]: [
               { address: ADDRESS_MOCK, signature: SIGNATURE_MOCK },
@@ -159,7 +158,7 @@ describe('Feature Flags Utils', () => {
       isValidSignatureMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
 
       mockFeatureFlags({
-        [FEATURE_FLAG_EIP_7702]: {
+        [FeatureFlag.EIP7702]: {
           contracts: {
             [CHAIN_ID_MOCK]: [
               { address: ADDRESS_MOCK, signature: SIGNATURE_MOCK },
@@ -182,7 +181,7 @@ describe('Feature Flags Utils', () => {
       isValidSignatureMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
 
       mockFeatureFlags({
-        [FEATURE_FLAG_EIP_7702]: {
+        [FeatureFlag.EIP7702]: {
           contracts: {
             [CHAIN_ID_MOCK]: [
               { address: ADDRESS_MOCK, signature: undefined as never },
@@ -207,7 +206,7 @@ describe('Feature Flags Utils', () => {
       isValidSignatureMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
 
       mockFeatureFlags({
-        [FEATURE_FLAG_EIP_7702]: {
+        [FeatureFlag.EIP7702]: {
           contracts: {
             [chainId]: [{ address: ADDRESS_MOCK, signature: SIGNATURE_MOCK }],
           },
@@ -231,7 +230,7 @@ describe('Feature Flags Utils', () => {
   describe('getEIP7702UpgradeContractAddress', () => {
     it('returns first contract address for chain', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_EIP_7702]: {
+        [FeatureFlag.EIP7702]: {
           contracts: {
             [CHAIN_ID_MOCK]: [
               { address: ADDRESS_MOCK, signature: SIGNATURE_MOCK },
@@ -264,7 +263,7 @@ describe('Feature Flags Utils', () => {
 
     it('returns undefined if empty contract addresses', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_EIP_7702]: {
+        [FeatureFlag.EIP7702]: {
           contracts: {
             [CHAIN_ID_MOCK]: [],
           },
@@ -284,7 +283,7 @@ describe('Feature Flags Utils', () => {
       isValidSignatureMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
 
       mockFeatureFlags({
-        [FEATURE_FLAG_EIP_7702]: {
+        [FeatureFlag.EIP7702]: {
           contracts: {
             [CHAIN_ID_MOCK]: [
               { address: ADDRESS_MOCK, signature: SIGNATURE_MOCK },
@@ -307,7 +306,7 @@ describe('Feature Flags Utils', () => {
   describe('getBatchSizeLimit', () => {
     it('returns value from remote feature flag controller', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
+        [FeatureFlag.Transactions]: {
           batchSizeLimit: 5,
         },
       });
@@ -338,7 +337,7 @@ describe('Feature Flags Utils', () => {
 
     it('returns values from chain-specific config when available', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
+        [FeatureFlag.Transactions]: {
           acceleratedPolling: {
             perChainConfig: {
               [CHAIN_ID_MOCK]: {
@@ -363,7 +362,7 @@ describe('Feature Flags Utils', () => {
 
     it('returns default values from feature flag when no chain-specific config', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
+        [FeatureFlag.Transactions]: {
           acceleratedPolling: {
             defaultCountMax: 15,
             defaultIntervalMs: 4000,
@@ -384,7 +383,7 @@ describe('Feature Flags Utils', () => {
 
     it('uses chain-specific over default values', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
+        [FeatureFlag.Transactions]: {
           acceleratedPolling: {
             defaultCountMax: 15,
             defaultIntervalMs: 4000,
@@ -411,7 +410,7 @@ describe('Feature Flags Utils', () => {
 
     it('uses defaults if chain not found in perChainConfig', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
+        [FeatureFlag.Transactions]: {
           acceleratedPolling: {
             defaultCountMax: 15,
             defaultIntervalMs: 4000,
@@ -438,7 +437,7 @@ describe('Feature Flags Utils', () => {
 
     it('merges partial chain-specific config with defaults', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
+        [FeatureFlag.Transactions]: {
           acceleratedPolling: {
             defaultCountMax: 15,
             defaultIntervalMs: 4000,
@@ -476,7 +475,7 @@ describe('Feature Flags Utils', () => {
 
     it('returns values from feature flags when set', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
+        [FeatureFlag.Transactions]: {
           gasFeeRandomisation: {
             randomisedGasFeeDigits: {
               [CHAIN_ID_MOCK]: 3,
@@ -498,7 +497,7 @@ describe('Feature Flags Utils', () => {
 
     it('returns empty randomisedGasFeeDigits if not set in feature flags', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
+        [FeatureFlag.Transactions]: {
           gasFeeRandomisation: {
             preservedNumberOfDigits: 2,
           },
@@ -515,7 +514,7 @@ describe('Feature Flags Utils', () => {
   describe('getGasEstimateFallback', () => {
     it('returns gas estimate fallback for specific chain ID from remote feature flag controller', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
+        [FeatureFlag.Transactions]: {
           gasEstimateFallback: {
             perChainConfig: {
               [CHAIN_ID_MOCK]: {
@@ -537,7 +536,7 @@ describe('Feature Flags Utils', () => {
 
     it('returns default gas estimate fallback if specific chain ID is not found', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
+        [FeatureFlag.Transactions]: {
           gasEstimateFallback: {
             default: {
               fixed: undefined,
@@ -559,10 +558,8 @@ describe('Feature Flags Utils', () => {
   describe('getGasBufferEstimate', () => {
     it('returns default if no chain ID override', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
-          gasEstimateBuffer: {
-            default: GAS_BUFFER_MOCK,
-          },
+        [FeatureFlag.GasBuffer]: {
+          default: GAS_BUFFER_MOCK,
         },
       });
 
@@ -576,13 +573,11 @@ describe('Feature Flags Utils', () => {
 
     it('returns chain ID override if defined', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
-          gasEstimateBuffer: {
-            default: GAS_BUFFER_MOCK,
-            perChainConfig: {
-              [CHAIN_ID_MOCK]: {
-                buffer: GAS_BUFFER_2_MOCK,
-              },
+        [FeatureFlag.GasBuffer]: {
+          default: GAS_BUFFER_MOCK,
+          perChainConfig: {
+            [CHAIN_ID_MOCK]: {
+              buffer: GAS_BUFFER_2_MOCK,
             },
           },
         },
@@ -598,14 +593,12 @@ describe('Feature Flags Utils', () => {
 
     it('returns eip7702 buffer if defined', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {
-          gasEstimateBuffer: {
-            default: GAS_BUFFER_MOCK,
-            perChainConfig: {
-              [CHAIN_ID_MOCK]: {
-                buffer: GAS_BUFFER_2_MOCK,
-                eip7702: GAS_BUFFER_3_MOCK,
-              },
+        [FeatureFlag.GasBuffer]: {
+          default: GAS_BUFFER_MOCK,
+          perChainConfig: {
+            [CHAIN_ID_MOCK]: {
+              buffer: GAS_BUFFER_2_MOCK,
+              eip7702: GAS_BUFFER_3_MOCK,
             },
           },
         },
@@ -621,7 +614,7 @@ describe('Feature Flags Utils', () => {
 
     it('returns no buffer if not defined', () => {
       mockFeatureFlags({
-        [FEATURE_FLAG_TRANSACTIONS]: {},
+        [FeatureFlag.GasBuffer]: {},
       });
 
       expect(

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -18,7 +18,6 @@ import {
 } from './gas';
 import type { SimulationResponse } from './simulation-api';
 import { simulateTransactions } from './simulation-api';
-import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import { TransactionEnvelopeType, type TransactionMeta } from '../types';
 import type { AuthorizationList } from '../types';

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -159,10 +159,7 @@ describe('gas', () => {
       GAS_ESTIMATE_FALLBACK_MULTIPLIER_MOCK,
     );
 
-    getGasEstimateBufferMock.mockReturnValue({
-      buffer: 1.5,
-      eip7702: 2.0,
-    });
+    getGasEstimateBufferMock.mockReturnValue(1.5);
   });
 
   describe('updateGas', () => {
@@ -280,31 +277,6 @@ describe('gas', () => {
         await updateGas(updateGasRequest);
 
         expect(updateGasRequest.txMeta.txParams.gas).toBe(toHex(GAS_MOCK));
-        expect(updateGasRequest.txMeta.originalGasEstimate).toBe(
-          updateGasRequest.txMeta.txParams.gas,
-        );
-      });
-
-      it('using eip7702 buffer if transaction is type 4 with data to self', async () => {
-        mockQuery({
-          getBlockByNumberResponse: { gasLimit: toHex(BLOCK_GAS_LIMIT_MOCK) },
-          estimateGasResponse: toHex(GAS_MOCK),
-        });
-
-        updateGasRequest.txMeta.txParams.authorizationList =
-          AUTHORIZATION_LIST_MOCK;
-
-        updateGasRequest.txMeta.txParams.to =
-          TRANSACTION_META_MOCK.txParams.from;
-
-        updateGasRequest.txMeta.txParams.type = TransactionEnvelopeType.setCode;
-
-        await updateGas(updateGasRequest);
-
-        expect(updateGasRequest.txMeta.txParams.gas).toBe(
-          toHex(GAS_MOCK * 2.0),
-        );
-
         expect(updateGasRequest.txMeta.originalGasEstimate).toBe(
           updateGasRequest.txMeta.txParams.gas,
         );

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -209,7 +209,8 @@ export function addGasBuffer(
 async function getGas(
   request: UpdateGasRequest,
 ): Promise<[string, TransactionMeta['simulationFails']?, string?]> {
-  const { chainId, isSimulationEnabled, messenger, txMeta } = request;
+  const { chainId, isCustomNetwork, isSimulationEnabled, messenger, txMeta } =
+    request;
   const { disableGasBuffer } = txMeta;
 
   if (txMeta.txParams.gas) {
@@ -249,12 +250,12 @@ async function getGas(
     return [estimatedGas, simulationFails, estimatedGas];
   }
 
-  const { buffer, eip7702 } = getGasEstimateBuffer(chainId, messenger);
-
-  log('Configured buffers', { buffer, eip7702 });
-
-  const bufferMultiplier =
-    isUpgradeWithDataToSelf && eip7702 ? eip7702 : buffer;
+  const bufferMultiplier = getGasEstimateBuffer({
+    chainId,
+    isCustomRPC: isCustomNetwork,
+    isUpgradeWithDataToSelf,
+    messenger,
+  });
 
   log('Buffer', bufferMultiplier);
 

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -10,9 +10,8 @@ import type { Hex } from '@metamask/utils';
 import { add0x, createModuleLogger, remove0x } from '@metamask/utils';
 
 import { DELEGATION_PREFIX } from './eip7702';
-import { getGasEstimateFallback } from './feature-flags';
+import { getGasEstimateBuffer, getGasEstimateFallback } from './feature-flags';
 import { simulateTransactions } from './simulation-api';
-import { GAS_BUFFER_CHAIN_OVERRIDES } from '../constants';
 import { projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import {
@@ -123,8 +122,8 @@ export async function estimateGas({
 
   const isUpgradeWithDataToSelf =
     txParams.type === TransactionEnvelopeType.setCode &&
-    authorizationList?.length &&
-    data &&
+    Boolean(authorizationList?.length) &&
+    Boolean(data) &&
     data !== '0x' &&
     from?.toLowerCase() === to?.toLowerCase();
 
@@ -155,6 +154,7 @@ export async function estimateGas({
   return {
     blockGasLimit,
     estimatedGas,
+    isUpgradeWithDataToSelf,
     simulationFails,
   };
 }
@@ -209,7 +209,7 @@ export function addGasBuffer(
 async function getGas(
   request: UpdateGasRequest,
 ): Promise<[string, TransactionMeta['simulationFails']?, string?]> {
-  const { chainId, isCustomNetwork, isSimulationEnabled, txMeta } = request;
+  const { chainId, isSimulationEnabled, messenger, txMeta } = request;
   const { disableGasBuffer } = txMeta;
 
   if (txMeta.txParams.gas) {
@@ -222,35 +222,51 @@ async function getGas(
     return [FIXED_GAS, undefined, FIXED_GAS];
   }
 
-  const { blockGasLimit, estimatedGas, simulationFails } = await estimateGas({
+  const {
+    blockGasLimit,
+    estimatedGas,
+    isUpgradeWithDataToSelf,
+    simulationFails,
+  } = await estimateGas({
     chainId: request.chainId,
     ethQuery: request.ethQuery,
     isSimulationEnabled,
-    messenger: request.messenger,
+    messenger,
     txParams: txMeta.txParams,
   });
 
-  if (isCustomNetwork || simulationFails) {
-    log(
-      isCustomNetwork
-        ? 'Using original estimate as custom network'
-        : 'Using original fallback estimate as simulation failed',
-    );
+  log('Original estimated gas', estimatedGas);
+
+  if (simulationFails) {
+    log('Using original fallback estimate as simulation failed');
+  }
+
+  if (disableGasBuffer) {
+    log('Gas buffer disabled');
+  }
+
+  if (simulationFails || disableGasBuffer) {
     return [estimatedGas, simulationFails, estimatedGas];
   }
 
-  let finalGas = estimatedGas;
+  const { buffer, eip7702 } = getGasEstimateBuffer(chainId, messenger);
 
-  if (!disableGasBuffer) {
-    const bufferMultiplier =
-      GAS_BUFFER_CHAIN_OVERRIDES[
-        chainId as keyof typeof GAS_BUFFER_CHAIN_OVERRIDES
-      ] ?? DEFAULT_GAS_MULTIPLIER;
+  log('Configured buffers', { buffer, eip7702 });
 
-    finalGas = addGasBuffer(estimatedGas, blockGasLimit, bufferMultiplier);
-  }
+  const bufferMultiplier =
+    isUpgradeWithDataToSelf && eip7702 ? eip7702 : buffer;
 
-  return [finalGas, simulationFails, estimatedGas];
+  log('Buffer', bufferMultiplier);
+
+  const bufferedGas = addGasBuffer(
+    estimatedGas,
+    blockGasLimit,
+    bufferMultiplier,
+  );
+
+  log('Buffered gas', bufferedGas);
+
+  return [bufferedGas, simulationFails, estimatedGas];
 }
 
 /**


### PR DESCRIPTION
## Explanation

Use feature flags to configure the gas estimation buffers, including support for specific chain and type-4 buffers.

```js
[FeatureFlag.GasBuffer]?: {
    /** Fallback buffer for all chains and transactions. */
    default?: number;

    /**
     * Buffer for included network RPCs only and not those added by user.
     * Takes priority over `default`.
     */
    included?: number;

    /** Buffers for specific chains. */
    perChainConfig?: {
      [chainId: Hex]: {
        /**
         * Buffer for the chain for all transactions.
         * Takes priority over non-chain `included`.
         */
        base?: number;

        /**
         * Buffer if network RPC is included and not added by user.
         * Takes priority over `base`.
         */
        included?: number;

        /**
         * Buffer for the chain for EIP-7702 / type 4 transactions only.
         * Only if `data` included and `to` matches `from`.
         * Takes priority over `included` and `base`.
         */
        eip7702?: number;
      };
    };
  };
```

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
