### PR TITLE
feat: remove unused action handlers

### DIFF
--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -11,13 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Add new public method `setIsBackupAndSyncFeatureEnabled` to `UserStorageController` ([#5636](https://github.com/MetaMask/core/pull/5636))
   - This replaces `enableProfileSyncing` and `disableProfileSyncing` and will be used as the main method to enable and disable backup and sync features from now on.
-- Add new `isAccountSyncingEnabled` state property to `UserStorageController` ([#5636](https://github.com/MetaMask/core/pull/5636))
+- **BREAKING:** Add new `isAccountSyncingEnabled` state property to `UserStorageController` ([#5636](https://github.com/MetaMask/core/pull/5636))
   - This property is `true` by default.
 
 ### Removed
 
 - **BREAKING:** Remove `isAccountSyncingEnabled` `env` property from `UserStorageController` constructor ([#5629](https://github.com/MetaMask/core/pull/5629))
-- **BREAKING:** Remove unused action handlers: `enableProfileSyncing`, `disableProfileSyncing`, `syncInternalAccountsWithUserStorage` and `saveInternalAccountToUserStorage`. ([#5638](https://github.com/MetaMask/core/pull/5638))
+- **BREAKING:** Remove unused action handlers: `setIsBackupAndSyncFeatureEnabled`, `syncInternalAccountsWithUserStorage` and `saveInternalAccountToUserStorage`. ([#5638](https://github.com/MetaMask/core/pull/5638))
   - These actions should not be callable through the messaging system.
 
 ## [11.0.1]

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **BREAKING:** Remove `isAccountSyncingEnabled` `env` property from `UserStorageController` constructor ([#5629](https://github.com/MetaMask/core/pull/5629))
-- **BREAKING:** Remove unused action handlers: `enableProfileSyncing`, `disableProfileSyncing`, `syncInternalAccountsWithUserStorage` and `saveInternalAccountToUserStorage`. ([]())
+- **BREAKING:** Remove unused action handlers: `enableProfileSyncing`, `disableProfileSyncing`, `syncInternalAccountsWithUserStorage` and `saveInternalAccountToUserStorage`. ([#5638](https://github.com/MetaMask/core/pull/5638))
   - These actions should not be callable through the messaging system.
 
 ## [11.0.1]

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **BREAKING:** Remove `isAccountSyncingEnabled` `env` property from `UserStorageController` constructor ([#5629](https://github.com/MetaMask/core/pull/5629))
+- **BREAKING:** Remove unused action handlers: `enableProfileSyncing`, `disableProfileSyncing`, `syncInternalAccountsWithUserStorage` and `saveInternalAccountToUserStorage`. ([]())
+  - These actions should not be callable through the messaging system.
 
 ## [11.0.1]
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -186,10 +186,6 @@ type ActionsObj = CreateActionsObj<
   | 'performDeleteStorage'
   | 'performBatchDeleteStorage'
   | 'getStorageKey'
-  | 'enableProfileSyncing'
-  | 'disableProfileSyncing'
-  | 'syncInternalAccountsWithUserStorage'
-  | 'saveInternalAccountToUserStorage'
 >;
 export type UserStorageControllerGetStateAction = ControllerGetStateAction<
   typeof controllerName,
@@ -211,14 +207,6 @@ export type UserStorageControllerPerformDeleteStorage =
 export type UserStorageControllerPerformBatchDeleteStorage =
   ActionsObj['performBatchDeleteStorage'];
 export type UserStorageControllerGetStorageKey = ActionsObj['getStorageKey'];
-export type UserStorageControllerEnableProfileSyncing =
-  ActionsObj['enableProfileSyncing'];
-export type UserStorageControllerDisableProfileSyncing =
-  ActionsObj['disableProfileSyncing'];
-export type UserStorageControllerSyncInternalAccountsWithUserStorage =
-  ActionsObj['syncInternalAccountsWithUserStorage'];
-export type UserStorageControllerSaveInternalAccountToUserStorage =
-  ActionsObj['saveInternalAccountToUserStorage'];
 
 export type AllowedActions =
   // Keyring Requests
@@ -442,26 +430,6 @@ export default class UserStorageController extends BaseController<
     this.messagingSystem.registerActionHandler(
       'UserStorageController:getStorageKey',
       this.getStorageKey.bind(this),
-    );
-
-    this.messagingSystem.registerActionHandler(
-      'UserStorageController:enableProfileSyncing',
-      this.enableProfileSyncing.bind(this),
-    );
-
-    this.messagingSystem.registerActionHandler(
-      'UserStorageController:disableProfileSyncing',
-      this.disableProfileSyncing.bind(this),
-    );
-
-    this.messagingSystem.registerActionHandler(
-      'UserStorageController:syncInternalAccountsWithUserStorage',
-      this.syncInternalAccountsWithUserStorage.bind(this),
-    );
-
-    this.messagingSystem.registerActionHandler(
-      'UserStorageController:saveInternalAccountToUserStorage',
-      this.saveInternalAccountToUserStorage.bind(this),
     );
   }
 


### PR DESCRIPTION
## Explanation

This PR removes unused `UserStorageController` action handlers: `setIsBackupAndSyncFeatureEnabled`, `syncInternalAccountsWithUserStorage` and `saveInternalAccountToUserStorage`, as they should not be callable through the messaging system.

This is a **BREAKING** change, although no other Controller should use them at the moment.

## References

Fixes: https://consensyssoftware.atlassian.net/browse/IDENTITY-84
Extension test drive PR (CI ✅): https://github.com/MetaMask/metamask-extension/pull/31945

## Changelog

View CHANGELOG.md changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
