### PR TITLE
fix: update active network based on account's namespace

### DIFF
--- a/packages/multichain-network-controller/CHANGELOG.md
+++ b/packages/multichain-network-controller/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The `AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS` now includes non-EVM testnets ([#5589](https://github.com/MetaMask/core/pull/5589))
+
+### Fixed
+
 - Fix the condition to update the active network based on the `AccountsController:selectedAccountChange` event ([#5642](https://github.com/MetaMask/core/pull/5642))
 
 ## [0.3.0]

--- a/packages/multichain-network-controller/CHANGELOG.md
+++ b/packages/multichain-network-controller/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The `AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS` now includes non-EVM testnets ([#5589](https://github.com/MetaMask/core/pull/5589))
+- Fix the condition to update the active network based on the `AccountsController:selectedAccountChange` event ([#5642](https://github.com/MetaMask/core/pull/5642))
 
 ## [0.3.0]
 

--- a/packages/multichain-network-controller/src/MultichainNetworkController.test.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController.test.ts
@@ -441,8 +441,7 @@ describe('MultichainNetworkController', () => {
       expect(controller.state.isEvmSelected).toBe(false);
     });
 
-    it('does not change the active network if the network is part of the account scopes', async () => {
-      // By default, Solana is selected and active
+    it('does not change the active network if the network is part of the account scope', async () => {
       const { controller, triggerSelectedAccountChange } = setupController({
         options: {
           state: {
@@ -452,16 +451,13 @@ describe('MultichainNetworkController', () => {
         },
       });
 
-      // Solana is currently active
       expect(controller.state.isEvmSelected).toBe(false);
       expect(controller.state.selectedMultichainNetworkChainId).toBe(
         SolScope.Devnet,
       );
 
-      // Switching to Bitcoin account
       triggerSelectedAccountChange(SolAccountType.DataAccount);
 
-      // Bitcoin is now the selected network
       expect(controller.state.selectedMultichainNetworkChainId).toBe(
         SolScope.Devnet,
       );

--- a/packages/multichain-network-controller/src/MultichainNetworkController.test.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController.test.ts
@@ -440,6 +440,33 @@ describe('MultichainNetworkController', () => {
       );
       expect(controller.state.isEvmSelected).toBe(false);
     });
+
+    it('does not change the active network if the network is part of the account scopes', async () => {
+      // By default, Solana is selected and active
+      const { controller, triggerSelectedAccountChange } = setupController({
+        options: {
+          state: {
+            isEvmSelected: false,
+            selectedMultichainNetworkChainId: SolScope.Devnet,
+          },
+        },
+      });
+
+      // Solana is currently active
+      expect(controller.state.isEvmSelected).toBe(false);
+      expect(controller.state.selectedMultichainNetworkChainId).toBe(
+        SolScope.Devnet,
+      );
+
+      // Switching to Bitcoin account
+      triggerSelectedAccountChange(SolAccountType.DataAccount);
+
+      // Bitcoin is now the selected network
+      expect(controller.state.selectedMultichainNetworkChainId).toBe(
+        SolScope.Devnet,
+      );
+      expect(controller.state.isEvmSelected).toBe(false);
+    });
   });
 
   describe('removeEvmNetwork', () => {

--- a/packages/multichain-network-controller/src/MultichainNetworkController.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController.ts
@@ -232,7 +232,7 @@ export class MultichainNetworkController extends BaseController<
 
     // Handle switching to non-EVM network
     if (scopes.includes(this.state.selectedMultichainNetworkChainId)) {
-      // No need to update if already on the same non-EVM network
+      // No need to update if the account's scope includes the active network
       this.update((state) => {
         state.isEvmSelected = false;
       });

--- a/packages/multichain-network-controller/src/MultichainNetworkController.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController.ts
@@ -2,11 +2,7 @@ import { BaseController } from '@metamask/base-controller';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { NetworkClientId } from '@metamask/network-controller';
-import {
-  type CaipChainId,
-  isCaipChainId,
-  parseCaipChainId,
-} from '@metamask/utils';
+import { type CaipChainId, isCaipChainId } from '@metamask/utils';
 
 import {
   AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,

--- a/packages/multichain-network-controller/src/MultichainNetworkController.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController.ts
@@ -2,7 +2,11 @@ import { BaseController } from '@metamask/base-controller';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { NetworkClientId } from '@metamask/network-controller';
-import { type CaipChainId, isCaipChainId } from '@metamask/utils';
+import {
+  type CaipChainId,
+  isCaipChainId,
+  parseCaipChainId,
+} from '@metamask/utils';
 
 import {
   AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
@@ -48,11 +52,10 @@ export class MultichainNetworkController extends BaseController<
       state: {
         ...getDefaultMultichainNetworkControllerState(),
         ...state,
-        multichainNetworkConfigurationsByChainId: {
-          // We can keep the current network as a hardcoded value
-          // since it is not expected to add/remove networks yet.
-          ...AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
-        },
+        // We can keep the current network as a hardcoded value
+        // since it is not expected to add/remove networks yet.
+        multichainNetworkConfigurationsByChainId:
+          AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
       },
     });
 
@@ -233,10 +236,15 @@ export class MultichainNetworkController extends BaseController<
 
     // Handle switching to non-EVM network
     const nonEvmChainId = getChainIdForNonEvmAddress(accountAddress);
-    const isSameNonEvmNetwork =
-      nonEvmChainId === this.state.selectedMultichainNetworkChainId;
+    const { namespace: selectedNetworkNamespace } = parseCaipChainId(
+      this.state.selectedMultichainNetworkChainId,
+    );
+    const { namespace: selectAccountNetworkNamespace } =
+      parseCaipChainId(nonEvmChainId);
+    const isSameNonEvmNamespace =
+      selectedNetworkNamespace === selectAccountNetworkNamespace;
 
-    if (isSameNonEvmNetwork) {
+    if (isSameNonEvmNamespace) {
       // No need to update if already on the same non-EVM network
       this.update((state) => {
         state.isEvmSelected = false;

--- a/packages/multichain-network-controller/src/MultichainNetworkController.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController.ts
@@ -216,7 +216,7 @@ export class MultichainNetworkController extends BaseController<
    * @param account - The account that was changed
    */
   #handleOnSelectedAccountChange(account: InternalAccount) {
-    const { type: accountType, address: accountAddress } = account;
+    const { type: accountType, address: accountAddress, scopes } = account;
     const isEvmAccount = isEvmAccountType(accountType);
 
     // Handle switching to EVM network
@@ -235,16 +235,7 @@ export class MultichainNetworkController extends BaseController<
     }
 
     // Handle switching to non-EVM network
-    const nonEvmChainId = getChainIdForNonEvmAddress(accountAddress);
-    const { namespace: selectedNetworkNamespace } = parseCaipChainId(
-      this.state.selectedMultichainNetworkChainId,
-    );
-    const { namespace: selectAccountNetworkNamespace } =
-      parseCaipChainId(nonEvmChainId);
-    const isSameNonEvmNamespace =
-      selectedNetworkNamespace === selectAccountNetworkNamespace;
-
-    if (isSameNonEvmNamespace) {
+    if (scopes.includes(this.state.selectedMultichainNetworkChainId)) {
       // No need to update if already on the same non-EVM network
       this.update((state) => {
         state.isEvmSelected = false;
@@ -252,6 +243,7 @@ export class MultichainNetworkController extends BaseController<
       return;
     }
 
+    const nonEvmChainId = getChainIdForNonEvmAddress(accountAddress);
     this.update((state) => {
       state.selectedMultichainNetworkChainId = nonEvmChainId;
       state.isEvmSelected = false;

--- a/packages/multichain-network-controller/tests/utils.ts
+++ b/packages/multichain-network-controller/tests/utils.ts
@@ -1,4 +1,7 @@
 import {
+  EthScope,
+  BtcScope,
+  SolScope,
   BtcAccountType,
   EthAccountType,
   SolAccountType,
@@ -51,7 +54,7 @@ export const createMockInternalAccount = ({
   importTime?: number;
   lastSelected?: number;
 } = {}): InternalAccount => {
-  let methods;
+  let methods, scopes;
 
   switch (type) {
     case EthAccountType.Eoa:
@@ -63,6 +66,7 @@ export const createMockInternalAccount = ({
         EthMethod.SignTypedDataV3,
         EthMethod.SignTypedDataV4,
       ];
+      scopes = [EthScope.Eoa];
       break;
     case EthAccountType.Erc4337:
       methods = [
@@ -70,12 +74,15 @@ export const createMockInternalAccount = ({
         EthMethod.PrepareUserOperation,
         EthMethod.SignUserOperation,
       ];
+      scopes = [EthScope.Mainnet];
       break;
     case BtcAccountType.P2wpkh:
       methods = [BtcMethod.SendBitcoin];
+      scopes = [BtcScope.Mainnet];
       break;
     case SolAccountType.DataAccount:
       methods = [SolMethod.SendAndConfirmTransaction];
+      scopes = [SolScope.Mainnet, SolScope.Devnet];
       break;
     default:
       throw new Error(`Unknown account type: ${type as string}`);
@@ -87,6 +94,7 @@ export const createMockInternalAccount = ({
     options: {},
     methods,
     type,
+    scopes,
     metadata: {
       name,
       keyring: { type: keyringType },


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR introduces two small changes,

1. Remove object de-structuring on controller constructor
2. Fix the condition to update the active network based on the account event

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes https://github.com/MetaMask/accounts-planning/issues/857

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

```
### Changed
- Fix the condition to update the active network based on the account event.
```

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
