### PR TITLE
fix: hardcode support for ethereum mainnet temporarily until we refac…

### DIFF
--- a/packages/earn-controller/src/EarnController.test.ts
+++ b/packages/earn-controller/src/EarnController.test.ts
@@ -39,6 +39,10 @@ jest.mock('@metamask/stake-sdk', () => ({
     getVaultDailyApys: jest.fn(),
     getVaultApyAverages: jest.fn(),
   })),
+  ChainId: {
+    ETHEREUM: 1,
+    HOLESKY: 17000,
+  },
 }));
 
 /**
@@ -378,7 +382,9 @@ describe('EarnController', () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it('reinitializes SDK when network changes', () => {
+    // TEMP: We're hardcoding ETH mainnet since we can't rely on the network picker anymore.
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('reinitializes SDK when network changes', () => {
       const { messenger } = setupController();
 
       messenger.publish(

--- a/packages/earn-controller/src/EarnController.ts
+++ b/packages/earn-controller/src/EarnController.ts
@@ -24,6 +24,7 @@ import {
   type VaultData,
   type VaultDailyApy,
   type VaultApyAverages,
+  ChainId,
 } from '@metamask/stake-sdk';
 import {
   TransactionType,
@@ -353,16 +354,19 @@ export class EarnController extends BaseController<
   }
 
   #getCurrentChainId(): number {
-    const { selectedNetworkClientId } = this.messagingSystem.call(
-      'NetworkController:getState',
-    );
-    const {
-      configuration: { chainId },
-    } = this.messagingSystem.call(
-      'NetworkController:getNetworkClientById',
-      selectedNetworkClientId,
-    );
-    return convertHexToDecimal(chainId);
+    // const { selectedNetworkClientId } = this.messagingSystem.call(
+    //   'NetworkController:getState',
+    // );
+    // const {
+    //   configuration: { chainId },
+    // } = this.messagingSystem.call(
+    //   'NetworkController:getNetworkClientById',
+    //   selectedNetworkClientId,
+    // );
+    // return convertHexToDecimal(chainId);
+
+    // TEMP: Until we update our data-fetching and storage solution to not depend on single selected network.
+    return ChainId.ETHEREUM;
   }
 
   /**


### PR DESCRIPTION
…tor controller to not rely on active network

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Temporary workaround to hardcode Ethereum mainnet (`1`) as the selected chainId. We cannot rely on the active network state from the `NetworkController` since we need to be able to fetch data for one or more chains regardless of the active network. 

There should be no regressions since Ethereum mainnet is the only supported `chainId` for pooled-staking anyway.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Jira ticket: [STAKE-1010: Staked ETH info not loaded in ETH token page until user has selected 'Ethereum' in network picker](https://consensyssoftware.atlassian.net/browse/STAKE-1010)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
