### PR TITLE
Export `SwappableTokenSearchParams` from index

### DIFF
--- a/packages/token-search-discovery-controller/CHANGELOG.md
+++ b/packages/token-search-discovery-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Export `SwappableTokenSearchParams` from root of package for use by clients ([#5654](https://github.com/MetaMask/core/pull/5654))
+- Export `SwappableTokenSearchParams` type ([#5654](https://github.com/MetaMask/core/pull/5654))
 
 ## [3.0.0]
 

--- a/packages/token-search-discovery-controller/CHANGELOG.md
+++ b/packages/token-search-discovery-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export `SwappableTokenSearchParams` from root of package for use by clients ([#5654](https://github.com/MetaMask/core/pull/5654))
+
 ## [3.0.0]
 
 ### Added

--- a/packages/token-search-discovery-controller/src/index.ts
+++ b/packages/token-search-discovery-controller/src/index.ts
@@ -11,6 +11,7 @@ export type {
   TopGainersParams,
   TopLosersParams,
   BlueChipParams,
+  SwappableTokenSearchParams,
 } from './types';
 
 export { AbstractTokenSearchApiService } from './token-search-api-service/abstract-token-search-api-service';


### PR DESCRIPTION
## Explanation

`SwappableTokenSearchParams` is needed by clients to do proper type checking on params passed to the controller.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
