### PR TITLE
feat: use new api field for protocol name

### DIFF
--- a/packages/assets-controllers/src/DeFiPositionsController/__fixtures__/mock-responses.ts
+++ b/packages/assets-controllers/src/DeFiPositionsController/__fixtures__/mock-responses.ts
@@ -14,6 +14,7 @@ export const MOCK_DEFI_RESPONSE_MULTI_CHAIN: DefiPositionResponse[] = [
     chainId: 1,
     productId: 'a-token',
     chainName: 'ethereum',
+    protocolDisplayName: 'Aave V3',
     metadata: {
       groupPositions: true,
     },
@@ -54,6 +55,7 @@ export const MOCK_DEFI_RESPONSE_MULTI_CHAIN: DefiPositionResponse[] = [
     chainId: 8453,
     productId: 'a-token',
     chainName: 'base',
+    protocolDisplayName: 'Aave V3',
     metadata: {
       groupPositions: true,
     },
@@ -100,6 +102,7 @@ export const MOCK_DEFI_RESPONSE_FAILED_ENTRY: DefiPositionResponse[] = [
     chainId: 1,
     productId: 'variable-debt-token',
     chainName: 'ethereum',
+    protocolDisplayName: 'Aave V3',
     metadata: {
       groupPositions: true,
     },
@@ -118,6 +121,7 @@ export const MOCK_DEFI_RESPONSE_FAILED_ENTRY: DefiPositionResponse[] = [
     chainId: 1,
     productId: 'a-token',
     chainName: 'ethereum',
+    protocolDisplayName: 'Aave V3',
     metadata: {
       groupPositions: true,
     },
@@ -164,6 +168,7 @@ export const MOCK_DEFI_RESPONSE_NO_PRICES: DefiPositionResponse[] = [
     chainId: 1,
     productId: 'a-token',
     chainName: 'ethereum',
+    protocolDisplayName: 'Aave V3',
     metadata: {
       groupPositions: true,
     },
@@ -233,6 +238,7 @@ export const MOCK_DEFI_RESPONSE_BORROW: DefiPositionResponse[] = [
     chainId: 1,
     productId: 'a-token',
     chainName: 'ethereum',
+    protocolDisplayName: 'Aave V3',
     metadata: {
       groupPositions: true,
     },
@@ -296,6 +302,7 @@ export const MOCK_DEFI_RESPONSE_BORROW: DefiPositionResponse[] = [
     chainId: 1,
     productId: 'variable-debt-token',
     chainName: 'ethereum',
+    protocolDisplayName: 'Aave V3',
     metadata: {
       groupPositions: true,
     },
@@ -342,6 +349,7 @@ export const MOCK_DEFI_RESPONSE_COMPLEX: DefiPositionResponse[] = [
     chainId: 1,
     productId: 'a-token',
     chainName: 'ethereum',
+    protocolDisplayName: 'Aave V3',
     metadata: {
       groupPositions: true,
     },
@@ -405,6 +413,7 @@ export const MOCK_DEFI_RESPONSE_COMPLEX: DefiPositionResponse[] = [
     chainId: 1,
     productId: 'variable-debt-token',
     chainName: 'ethereum',
+    protocolDisplayName: 'Aave V3',
     metadata: {
       groupPositions: true,
     },
@@ -446,6 +455,7 @@ export const MOCK_DEFI_RESPONSE_COMPLEX: DefiPositionResponse[] = [
     chainId: 1,
     productId: 'wst-eth',
     chainName: 'ethereum',
+    protocolDisplayName: 'Lido',
     success: true,
     tokens: [
       {
@@ -498,6 +508,7 @@ export const MOCK_DEFI_RESPONSE_COMPLEX: DefiPositionResponse[] = [
     chainId: 8453,
     productId: 'pool',
     chainName: 'base',
+    protocolDisplayName: 'Uniswap V3',
     success: true,
     tokens: [
       {

--- a/packages/assets-controllers/src/DeFiPositionsController/fetch-positions.ts
+++ b/packages/assets-controllers/src/DeFiPositionsController/fetch-positions.ts
@@ -6,6 +6,7 @@ type ProtocolDetails = {
   chainId: number;
   protocolId: string;
   productId: string;
+  protocolDisplayName: string;
   name: string;
   description: string;
   iconUrl: string;

--- a/packages/assets-controllers/src/DeFiPositionsController/group-defi-positions.test.ts
+++ b/packages/assets-controllers/src/DeFiPositionsController/group-defi-positions.test.ts
@@ -64,7 +64,7 @@ describe('groupDeFiPositions', () => {
         protocols: {
           'aave-v3': {
             protocolDetails: {
-              name: 'AaveV3',
+              name: 'Aave V3',
               iconUrl: 'https://cryptologos.cc/logos/aave-aave-logo.png',
             },
             aggregatedMarketValue: 540,
@@ -209,7 +209,7 @@ describe('groupDeFiPositions', () => {
         protocols: {
           'uniswap-v3': {
             protocolDetails: {
-              name: 'UniswapV3',
+              name: 'Uniswap V3',
               iconUrl:
                 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png',
             },

--- a/packages/assets-controllers/src/DeFiPositionsController/group-defi-positions.ts
+++ b/packages/assets-controllers/src/DeFiPositionsController/group-defi-positions.ts
@@ -1,6 +1,5 @@
 import { toHex } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
-import { upperFirst, camelCase } from 'lodash';
 
 import type {
   DefiPositionResponse,
@@ -52,7 +51,8 @@ export function groupDeFiPositions(
       continue;
     }
 
-    const { chainId, protocolId, iconUrl, positionType } = position;
+    const { chainId, protocolId, iconUrl, positionType, protocolDisplayName } =
+      position;
 
     const chain = toHex(chainId);
 
@@ -68,7 +68,7 @@ export function groupDeFiPositions(
     if (!chainData.protocols[protocolId]) {
       chainData.protocols[protocolId] = {
         protocolDetails: {
-          name: upperFirst(camelCase(protocolId)),
+          name: protocolDisplayName,
           iconUrl,
         },
         aggregatedMarketValue: 0,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Use the protocol display name value from the API instead of building it internally.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
If you're making any consumer-facing changes, list those changes here as if you were updating a changelog, using the template below as a guide.

(CATEGORY is one of BREAKING, ADDED, CHANGED, DEPRECATED, REMOVED, or FIXED. For security-related issues, follow the Security Advisory process.)

Please take care to name the exact pieces of the API you've added or changed (e.g. types, interfaces, functions, or methods).

If there are any breaking changes, make sure to offer a solution for consumers to follow once they upgrade to the changes.

Finally, if you're only making changes to development scripts or tests, you may replace the template below with "None".
-->

They are internal changes, no need to add them to changelog.

### `@metamask/assets-controllers`

- **CHANGED**: DeFi protocol name is now received from the API

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [X] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
