### PR TITLE
fix: throw error when creating HD keyring with duplicate account

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -230,7 +230,7 @@
     "jest/no-conditional-in-test": 8
   },
   "packages/keyring-controller/src/KeyringController.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 5,
+    "@typescript-eslint/no-unsafe-enum-comparison": 6,
     "@typescript-eslint/no-unused-vars": 1
   },
   "packages/keyring-controller/tests/mocks/mockKeyring.ts": {

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `#checkForDuplicate` is now checking duplicate accounts also for HD keyring ([#5675](https://github.com/MetaMask/core/pull/5675))
+
 ## [21.0.3]
 
 ### Changed

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- `#checkForDuplicate` is now checking duplicate accounts also for HD keyring ([#5675](https://github.com/MetaMask/core/pull/5675))
+
+- Now check for duplicated addresses when creating new HD keyrings ([#5675](https://github.com/MetaMask/core/pull/5675))
+  - This will prevent creating a new HD keyring when one of its accounts got already imported (using a raw private key).
 
 ## [21.0.3]
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2574,7 +2574,7 @@ export class KeyringController extends BaseController<
    * Checks for duplicate keypairs, using the the first account in the given
    * array. Rejects if a duplicate is found.
    *
-   * Only supports 'Simple Key Pair'.
+   * Only supports 'Simple Key Pair' and 'HD Key Tree'.
    *
    * @param type - The key pair type to check for.
    * @param newAccountArray - Array of new accounts.

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2587,7 +2587,8 @@ export class KeyringController extends BaseController<
     const accounts = await this.#getAccountsFromKeyrings();
 
     switch (type) {
-      case KeyringTypes.simple: {
+      case KeyringTypes.simple:
+      case KeyringTypes.hd: {
         const isIncluded = Boolean(
           accounts.find(
             (key) =>


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Currently, we are not checking whether the HD keyring account being added by importing SRP is a duplicate. This creates the possibility of adding the same account first to the simple keyring and then again with import HD keyring.

This PR adds a duplicate account check when adding an HD keyring, preventing this situation.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Used by ([#3121](https://github.com/MetaMask/metamask-extension/pull/32121))
* Fixes #5411 

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
