### PR TITLE
fix(multichain-network): temporarily restrict network activity to EVM

### DIFF
--- a/packages/multichain-network-controller/CHANGELOG.md
+++ b/packages/multichain-network-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Temporarily restrict `getNetworksWithTransactionActivityByAccounts` to EVM networks only while non-EVM network endpoint support is being completed. Full multi-chain support will be restored in the coming weeks ([#xxxx](https://github.com/MetaMask/core/pull/xxxx))
+
 ## [0.5.0]
 
 ### Added

--- a/packages/multichain-network-controller/CHANGELOG.md
+++ b/packages/multichain-network-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Temporarily restrict `getNetworksWithTransactionActivityByAccounts` to EVM networks only while non-EVM network endpoint support is being completed. Full multi-chain support will be restored in the coming weeks ([#xxxx](https://github.com/MetaMask/core/pull/xxxx))
+- Updated to restrict `getNetworksWithTransactionActivityByAccounts` to EVM networks only while non-EVM network endpoint support is being completed. Full multi-chain support will be restored in the coming weeks ([#xxxx](https://github.com/MetaMask/core/pull/xxxx))
 
 ## [0.5.0]
 

--- a/packages/multichain-network-controller/CHANGELOG.md
+++ b/packages/multichain-network-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated to restrict `getNetworksWithTransactionActivityByAccounts` to EVM networks only while non-EVM network endpoint support is being completed. Full multi-chain support will be restored in the coming weeks ([#xxxx](https://github.com/MetaMask/core/pull/xxxx))
+- Updated to restrict `getNetworksWithTransactionActivityByAccounts` to EVM networks only while non-EVM network endpoint support is being completed. Full multi-chain support will be restored in the coming weeks ([#5677](https://github.com/MetaMask/core/pull/5677))
 
 ## [0.5.0]
 

--- a/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.test.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.test.ts
@@ -575,10 +575,8 @@ describe('MultichainNetworkController', () => {
 
   describe('getNetworksWithTransactionActivityByAccounts', () => {
     const MOCK_EVM_ADDRESS = '0x1234567890123456789012345678901234567890';
-    const MOCK_SOLANA_ADDRESS = 'solana123';
     const MOCK_EVM_CHAIN_1 = '1';
     const MOCK_EVM_CHAIN_137 = '137';
-    const MOCK_SOLANA_CHAIN = '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
 
     it('returns empty object when no accounts exist', async () => {
       const { controller, messenger } = setupController({
@@ -634,60 +632,6 @@ describe('MultichainNetworkController', () => {
         [MOCK_EVM_ADDRESS]: {
           namespace: KnownCaipNamespace.Eip155,
           activeChains: [MOCK_EVM_CHAIN_1, MOCK_EVM_CHAIN_137],
-        },
-      });
-    });
-
-    it('formats network activity for mixed EVM and non-EVM accounts', async () => {
-      const mockResponse: ActiveNetworksResponse = {
-        activeNetworks: [
-          `${KnownCaipNamespace.Eip155}:${MOCK_EVM_CHAIN_1}:${MOCK_EVM_ADDRESS}`,
-          `${KnownCaipNamespace.Solana}:${MOCK_SOLANA_CHAIN}:${MOCK_SOLANA_ADDRESS}`,
-        ],
-      };
-
-      const mockNetworkService = createMockNetworkService(mockResponse);
-      await mockNetworkService.fetchNetworkActivity([
-        `${KnownCaipNamespace.Eip155}:${MOCK_EVM_CHAIN_1}:${MOCK_EVM_ADDRESS}`,
-        `${KnownCaipNamespace.Solana}:${MOCK_SOLANA_CHAIN}:${MOCK_SOLANA_ADDRESS}`,
-      ]);
-
-      const { controller, messenger } = setupController({
-        mockNetworkService,
-      });
-
-      messenger.registerActionHandler(
-        'AccountsController:listMultichainAccounts',
-        () => [
-          createMockInternalAccount({
-            type: EthAccountType.Eoa,
-            address: MOCK_EVM_ADDRESS,
-            scopes: [EthScope.Eoa],
-          }),
-          createMockInternalAccount({
-            type: SolAccountType.DataAccount,
-            address: MOCK_SOLANA_ADDRESS,
-            scopes: [SolScope.Mainnet],
-          }),
-        ],
-      );
-
-      const result =
-        await controller.getNetworksWithTransactionActivityByAccounts();
-
-      expect(mockNetworkService.fetchNetworkActivity).toHaveBeenCalledWith([
-        `${KnownCaipNamespace.Eip155}:0:${MOCK_EVM_ADDRESS}`,
-        `${KnownCaipNamespace.Solana}:${MOCK_SOLANA_CHAIN}:${MOCK_SOLANA_ADDRESS}`,
-      ]);
-
-      expect(result).toStrictEqual({
-        [MOCK_EVM_ADDRESS]: {
-          namespace: KnownCaipNamespace.Eip155,
-          activeChains: [MOCK_EVM_CHAIN_1],
-        },
-        [MOCK_SOLANA_ADDRESS]: {
-          namespace: KnownCaipNamespace.Solana,
-          activeChains: [MOCK_SOLANA_CHAIN],
         },
       });
     });

--- a/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.ts
@@ -163,7 +163,7 @@ export class MultichainNetworkController extends BaseController<
    */
   async getNetworksWithTransactionActivityByAccounts(): Promise<ActiveNetworksByAddress> {
     // TODO: We are filtering out non-EVN accounts for now
-    // Support for non-EVM networks will be added in sometime this month
+    // Support for non-EVM networks will be added in the coming weeks
     const evmAccounts = this.messagingSystem
       .call('AccountsController:listMultichainAccounts')
       .filter((account) => isEvmAccountType(account.type));

--- a/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.ts
@@ -162,14 +162,17 @@ export class MultichainNetworkController extends BaseController<
    * @returns A promise that resolves to the active networks for the available addresses
    */
   async getNetworksWithTransactionActivityByAccounts(): Promise<ActiveNetworksByAddress> {
-    const accounts = this.messagingSystem.call(
-      'AccountsController:listMultichainAccounts',
-    );
-    if (!accounts || accounts.length === 0) {
+    // TODO: We are filtering out non-EVN accounts for now
+    // Support for non-EVM networks will be added in sometime this month
+    const evmAccounts = this.messagingSystem
+      .call('AccountsController:listMultichainAccounts')
+      .filter((account) => isEvmAccountType(account.type));
+
+    if (!evmAccounts || evmAccounts.length === 0) {
       return this.state.networksWithTransactionActivity;
     }
 
-    const formattedAccounts = accounts
+    const formattedAccounts = evmAccounts
       .map((account: InternalAccount) => toAllowedCaipAccountIds(account))
       .flat();
 

--- a/packages/multichain-network-controller/src/MultichainNetworkService/MultichainNetworkService.test.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkService/MultichainNetworkService.test.ts
@@ -1,4 +1,4 @@
-import type { CaipAccountId } from '@metamask/utils';
+import { KnownCaipNamespace, type CaipAccountId } from '@metamask/utils';
 
 import { MultichainNetworkService } from './MultichainNetworkService';
 import {
@@ -10,9 +10,12 @@ import {
 
 describe('MultichainNetworkService', () => {
   const mockFetch = jest.fn();
+  const MOCK_EVM_ADDRESS = '0x1234567890123456789012345678901234567890';
+  const MOCK_EVM_CHAIN_1 = '1';
+  const MOCK_EVM_CHAIN_137 = '137';
   const validAccountIds: CaipAccountId[] = [
-    'eip155:1:0x1234567890123456789012345678901234567890',
-    'solana:1:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    `${KnownCaipNamespace.Eip155}:${MOCK_EVM_CHAIN_1}:${MOCK_EVM_ADDRESS}`,
+    `${KnownCaipNamespace.Eip155}:${MOCK_EVM_CHAIN_137}:${MOCK_EVM_ADDRESS}`,
   ];
 
   describe('constructor', () => {
@@ -27,7 +30,10 @@ describe('MultichainNetworkService', () => {
   describe('fetchNetworkActivity', () => {
     it('makes request with correct URL and headers', async () => {
       const mockResponse: ActiveNetworksResponse = {
-        activeNetworks: ['eip155:1:0x1234567890123456789012345678901234567890'],
+        activeNetworks: [
+          `${KnownCaipNamespace.Eip155}:${MOCK_EVM_CHAIN_1}:${MOCK_EVM_ADDRESS}`,
+          `${KnownCaipNamespace.Eip155}:${MOCK_EVM_CHAIN_137}:${MOCK_EVM_ADDRESS}`,
+        ],
       };
 
       mockFetch.mockResolvedValueOnce({


### PR DESCRIPTION
## Explanation

This PR temporarily restricts the `getNetworksWithTransactionActivityByAccounts` method to EVM networks only. This change is necessary because:

1. The non-EVM network endpoint support is still being completed and needs additional work
2. We want to ensure reliable functionality for EVM networks while non-EVM support is being finalized
3. This allows us to maintain stable service for our primary use case (EVM networks) while API platform team completes the full multi-chain implementation

### Technical Details
- Added a filter to exclude non-EVM accounts from network activity checks
- Updated the `CHANGELOG` to reflect this temporary limitation
- This is an interim solution that will be reverted once non-EVM endpoint support is complete (expected in the coming weeks)

## References

- Related to [#4469](https://github.com/MetaMask/MetaMask-planning/issues/4469)
- Builds upon [#5551](https://github.com/MetaMask/core/pull/5551)

## Changelog

### `@metamask/multichain-network-controller`

- **CHANGED**: `getNetworksWithTransactionActivityByAccounts` to only support EVM networks only for now

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
