### PR TITLE
Feat/bulk scan phishing controller

### DIFF
--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `bulkScanUrls` method to `PhishingController` for scanning multiple URLs for phishing in bulk ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
-- Add `BulkPhishingDetectionScanResponse` type for bulk URL scan results ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
-- Add `PHISHING_DETECTION_BULK_SCAN_ENDPOINT` constant ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
+- Add `bulkScanUrls` method to `PhishingController` for scanning multiple URLs for phishing in bulk ([#5682](https://github.com/MetaMask/core/pull/5682))
+- Add `BulkPhishingDetectionScanResponse` type for bulk URL scan results ([#5682](https://github.com/MetaMask/core/pull/5682))
+- Add `PHISHING_DETECTION_BULK_SCAN_ENDPOINT` constant ([#5682](https://github.com/MetaMask/core/pull/5682))
 
 ### Changed
 

--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `bulkScanUrls` method to `PhishingController` for scanning multiple URLs for phishing in bulk ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
+- Add `BulkPhishingDetectionScanResponse` type for bulk URL scan results ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
+- Add `PHISHING_DETECTION_BULK_SCAN_ENDPOINT` constant ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
+
 ### Changed
 
 - Bump `@metamask/controller-utils` to `^11.7.0` ([#5583](https://github.com/MetaMask/core/pull/5583))

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -2730,7 +2730,8 @@ describe('PhishingController', () => {
 
       // Mock responses for each batch
       const mockBatch1Response: BulkPhishingDetectionScanResponse = {
-        results: batch1.reduce<Record<string, PhishingDetectionScanResult>>((acc, url) => {
+        results: batch1.reduce<Record<string, PhishingDetectionScanResult>>(
+          (acc, url) => {
             acc[url] = {
               domainName: url.replace('https://', ''),
               recommendedAction: RecommendedAction.None,
@@ -2743,7 +2744,8 @@ describe('PhishingController', () => {
       };
 
       const mockBatch2Response: BulkPhishingDetectionScanResponse = {
-        results: batch2.reduce<Record<string, PhishingDetectionScanResult>>((acc, url) => {
+        results: batch2.reduce<Record<string, PhishingDetectionScanResult>>(
+          (acc, url) => {
             acc[url] = {
               domainName: url.replace('https://', ''),
               recommendedAction: RecommendedAction.None,

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -15,6 +15,8 @@ import {
   C2_DOMAIN_BLOCKLIST_ENDPOINT,
   PHISHING_DETECTION_BASE_URL,
   PHISHING_DETECTION_SCAN_ENDPOINT,
+  PHISHING_DETECTION_BULK_SCAN_ENDPOINT,
+  type BulkPhishingDetectionScanResponse,
 } from './PhishingController';
 import { formatHostnameToUrl } from './tests/utils';
 import type { PhishingDetectionScanResult } from './types';
@@ -2584,6 +2586,247 @@ describe('PhishingController', () => {
 
       const response = await controller.scanUrl(urlWithAuth);
       expect(response).toMatchObject(mockResponse);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('bulkScanUrls', () => {
+    let controller: PhishingController;
+    let clock: sinon.SinonFakeTimers;
+    const testUrls: string[] = [
+      'https://example1.com',
+      'https://example2.com',
+      'https://example3.com',
+    ];
+    const mockResponse: BulkPhishingDetectionScanResponse = {
+      results: {
+        'https://example1.com': {
+          domainName: 'example1.com',
+          recommendedAction: RecommendedAction.None,
+        },
+        'https://example2.com': {
+          domainName: 'example2.com',
+          recommendedAction: RecommendedAction.Block,
+        },
+        'https://example3.com': {
+          domainName: 'example3.com',
+          recommendedAction: RecommendedAction.None,
+        },
+      },
+      errors: {},
+    };
+
+    beforeEach(() => {
+      controller = getPhishingController();
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should return the scan results for multiple URLs', async () => {
+      const scope = nock(PHISHING_DETECTION_BASE_URL)
+        .post(`/${PHISHING_DETECTION_BULK_SCAN_ENDPOINT}`, {
+          urls: testUrls,
+        })
+        .reply(200, mockResponse);
+
+      const response = await controller.bulkScanUrls(testUrls);
+      expect(response).toStrictEqual(mockResponse);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('should handle empty URL arrays', async () => {
+      const response = await controller.bulkScanUrls([]);
+      expect(response).toStrictEqual({
+        results: {},
+        errors: {},
+      });
+    });
+
+    it('should enforce maximum URL limit', async () => {
+      const tooManyUrls = Array(251).fill('https://example.com');
+      const response = await controller.bulkScanUrls(tooManyUrls);
+      expect(response).toStrictEqual({
+        results: {},
+        errors: {
+          too_many_urls: 'Maximum of 250 URLs allowed per request',
+        },
+      });
+    });
+
+    it('should validate URL length', async () => {
+      const longUrl = `https://example.com/${'a'.repeat(2048)}`;
+      const response = await controller.bulkScanUrls([longUrl]);
+      expect(response).toStrictEqual({
+        results: {},
+        errors: {
+          [longUrl]: 'URL length must not exceed 2048 characters',
+        },
+      });
+    });
+
+    it.each([
+      [400, 'Bad Request'],
+      [401, 'Unauthorized'],
+      [403, 'Forbidden'],
+      [404, 'Not Found'],
+      [500, 'Internal Server Error'],
+      [502, 'Bad Gateway'],
+      [503, 'Service Unavailable'],
+      [504, 'Gateway Timeout'],
+    ])(
+      'should return an error response on %i status code',
+      async (statusCode, statusText) => {
+        const scope = nock(PHISHING_DETECTION_BASE_URL)
+          .post(`/${PHISHING_DETECTION_BULK_SCAN_ENDPOINT}`, {
+            urls: testUrls,
+          })
+          .reply(statusCode);
+
+        const response = await controller.bulkScanUrls(testUrls);
+        expect(response).toStrictEqual({
+          results: {},
+          errors: {
+            api_error: `${statusCode} ${statusText}`,
+          },
+        });
+        expect(scope.isDone()).toBe(true);
+      },
+    );
+
+    it('should handle timeouts correctly', async () => {
+      const scope = nock(PHISHING_DETECTION_BASE_URL)
+        .post(`/${PHISHING_DETECTION_BULK_SCAN_ENDPOINT}`, {
+          urls: testUrls,
+        })
+        .delayConnection(20000)
+        .reply(200, {});
+
+      const promise = controller.bulkScanUrls(testUrls);
+      clock.tick(15000);
+      const response = await promise;
+      expect(response).toStrictEqual({
+        results: {},
+        errors: {
+          network_error: 'timeout of 15000ms exceeded',
+        },
+      });
+      expect(scope.isDone()).toBe(false);
+    });
+
+    it('should process URLs in batches when more than 50 URLs are provided', async () => {
+      const batchSize = 50;
+      const totalUrls = 120;
+      const manyUrls = Array(totalUrls)
+        .fill(0)
+        .map((_, i) => `https://example${i}.com`);
+
+      // Expected batches
+      const batch1 = manyUrls.slice(0, batchSize);
+      const batch2 = manyUrls.slice(batchSize, 2 * batchSize);
+      const batch3 = manyUrls.slice(2 * batchSize);
+
+      // Mock responses for each batch
+      const mockBatch1Response: BulkPhishingDetectionScanResponse = {
+        results: batch1.reduce<Record<string, PhishingDetectionScanResult>>((acc, url) => {
+            acc[url] = {
+              domainName: url.replace('https://', ''),
+              recommendedAction: RecommendedAction.None,
+            };
+            return acc;
+          },
+          {},
+        ),
+        errors: {},
+      };
+
+      const mockBatch2Response: BulkPhishingDetectionScanResponse = {
+        results: batch2.reduce<Record<string, PhishingDetectionScanResult>>((acc, url) => {
+            acc[url] = {
+              domainName: url.replace('https://', ''),
+              recommendedAction: RecommendedAction.None,
+            };
+            return acc;
+          },
+          {},
+        ),
+        errors: {},
+      };
+
+      const mockBatch3Response: BulkPhishingDetectionScanResponse = {
+        results: batch3.reduce<Record<string, PhishingDetectionScanResult>>((acc, url) => {
+            acc[url] = {
+              domainName: url.replace('https://', ''),
+              recommendedAction: RecommendedAction.None,
+            };
+            return acc;
+          },
+          {},
+        ),
+        errors: {},
+      };
+
+      // Setup nock to handle all three batch requests
+      const scope1 = nock(PHISHING_DETECTION_BASE_URL)
+        .post(`/${PHISHING_DETECTION_BULK_SCAN_ENDPOINT}`, {
+          urls: batch1,
+        })
+        .reply(200, mockBatch1Response);
+
+      const scope2 = nock(PHISHING_DETECTION_BASE_URL)
+        .post(`/${PHISHING_DETECTION_BULK_SCAN_ENDPOINT}`, {
+          urls: batch2,
+        })
+        .reply(200, mockBatch2Response);
+
+      const scope3 = nock(PHISHING_DETECTION_BASE_URL)
+        .post(`/${PHISHING_DETECTION_BULK_SCAN_ENDPOINT}`, {
+          urls: batch3,
+        })
+        .reply(200, mockBatch3Response);
+
+      const response = await controller.bulkScanUrls(manyUrls);
+
+      // Verify all scopes were called
+      expect(scope1.isDone()).toBe(true);
+      expect(scope2.isDone()).toBe(true);
+      expect(scope3.isDone()).toBe(true);
+
+      // Check all results were merged correctly
+      const combinedResults = {
+        ...mockBatch1Response.results,
+        ...mockBatch2Response.results,
+        ...mockBatch3Response.results,
+      };
+
+      expect(Object.keys(response.results)).toHaveLength(totalUrls);
+      expect(response.results).toStrictEqual(combinedResults);
+    });
+
+    it('should handle mixed results with both successful scans and errors', async () => {
+      const mixedResponse: BulkPhishingDetectionScanResponse = {
+        results: {
+          'https://example1.com': {
+            domainName: 'example1.com',
+            recommendedAction: RecommendedAction.None,
+          },
+        },
+        errors: {
+          'https://example2.com': 'Failed to process URL',
+          'https://example3.com': 'Domain not found',
+        },
+      };
+
+      const scope = nock(PHISHING_DETECTION_BASE_URL)
+        .post(`/${PHISHING_DETECTION_BULK_SCAN_ENDPOINT}`, {
+          urls: testUrls,
+        })
+        .reply(200, mixedResponse);
+
+      const response = await controller.bulkScanUrls(testUrls);
+      expect(response).toStrictEqual(mixedResponse);
       expect(scope.isDone()).toBe(true);
     });
   });

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -2651,7 +2651,7 @@ describe('PhishingController', () => {
       expect(response).toStrictEqual({
         results: {},
         errors: {
-          too_many_urls: 'Maximum of 250 URLs allowed per request',
+          too_many_urls: ['Maximum of 250 URLs allowed per request'],
         },
       });
     });
@@ -2662,7 +2662,7 @@ describe('PhishingController', () => {
       expect(response).toStrictEqual({
         results: {},
         errors: {
-          [longUrl]: 'URL length must not exceed 2048 characters',
+          [longUrl]: ['URL length must not exceed 2048 characters'],
         },
       });
     });
@@ -2689,7 +2689,7 @@ describe('PhishingController', () => {
         expect(response).toStrictEqual({
           results: {},
           errors: {
-            api_error: `${statusCode} ${statusText}`,
+            api_error: [`${statusCode} ${statusText}`],
           },
         });
         expect(scope.isDone()).toBe(true);
@@ -2710,7 +2710,7 @@ describe('PhishingController', () => {
       expect(response).toStrictEqual({
         results: {},
         errors: {
-          network_error: 'timeout of 15000ms exceeded',
+          network_error: ['timeout of 15000ms exceeded'],
         },
       });
       expect(scope.isDone()).toBe(false);
@@ -2817,8 +2817,8 @@ describe('PhishingController', () => {
           },
         },
         errors: {
-          'https://example2.com': 'Failed to process URL',
-          'https://example3.com': 'Domain not found',
+          'https://example2.com': ['Failed to process URL'],
+          'https://example3.com': ['Domain not found'],
         },
       };
 

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -2756,7 +2756,8 @@ describe('PhishingController', () => {
       };
 
       const mockBatch3Response: BulkPhishingDetectionScanResponse = {
-        results: batch3.reduce<Record<string, PhishingDetectionScanResult>>((acc, url) => {
+        results: batch3.reduce<Record<string, PhishingDetectionScanResult>>(
+          (acc, url) => {
             acc[url] = {
               domainName: url.replace('https://', ''),
               recommendedAction: RecommendedAction.None,

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -705,7 +705,12 @@ export class PhishingController extends BaseController<
     // Merge results and errors from all batches
     batchResults.forEach((batchResponse) => {
       Object.assign(combinedResponse.results, batchResponse.results);
-      Object.assign(combinedResponse.errors, batchResponse.errors);
+      Object.entries(batchResponse.errors).forEach(([key, messages]) => {
+        combinedResponse.errors[key] = [
+          ...(combinedResponse.errors[key] || []),
+          ...messages,
+        ];
+      });
     });
 
     return combinedResponse;

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -627,7 +627,7 @@ export class PhishingController extends BaseController<
       return {
         domainName: '',
         recommendedAction: RecommendedAction.None,
-        fetchError: 'error fetching phishing detection results',
+        fetchError: 'timeout of 8000ms exceeded',
       };
     } else if ('error' in apiResponse) {
       return {
@@ -735,6 +735,8 @@ export class PhishingController extends BaseController<
         if (!res.ok) {
           return {
             error: `${res.status} ${res.statusText}`,
+            status: res.status,
+            statusText: res.statusText,
           };
         }
 
@@ -750,7 +752,17 @@ export class PhishingController extends BaseController<
       return {
         results: {},
         errors: {
-          network_error: 'error fetching bulk scan results',
+          network_error: 'timeout of 15000ms exceeded',
+        },
+      };
+    }
+
+    // Handle HTTP error responses
+    if ('error' in apiResponse && 'status' in apiResponse && 'statusText' in apiResponse) {
+      return {
+        results: {},
+        errors: {
+          api_error: `${apiResponse.status} ${apiResponse.statusText}`,
         },
       };
     }

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -660,10 +660,8 @@ export class PhishingController extends BaseController<
       };
     }
 
-    // API has a limit of 50 URLs per request, but we can handle up to 250 by batching
-    const MAX_URLS_PER_BATCH = 50;
+    // we are arbitrarily limiting the number of URLs to 250
     const MAX_TOTAL_URLS = 250;
-
     if (urls.length > MAX_TOTAL_URLS) {
       return {
         results: {},
@@ -685,7 +683,8 @@ export class PhishingController extends BaseController<
       }
     }
 
-    // Split URLs into batches of 50
+    // The API has a limit of 50 URLs per request, so we batch the requests
+    const MAX_URLS_PER_BATCH = 50;
     const batches: string[][] = [];
     for (let i = 0; i < urls.length; i += MAX_URLS_PER_BATCH) {
       batches.push(urls.slice(i, i + MAX_URLS_PER_BATCH));

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -746,7 +746,7 @@ export class PhishingController extends BaseController<
         return data;
       },
       true,
-      15000, // Increased timeout for bulk requests
+      15000,
     );
 
     // Handle timeout or network errors

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -289,7 +289,7 @@ export type PhishingControllerMessenger = RestrictedMessenger<
 
 export type BulkPhishingDetectionScanResponse = {
   results: Record<string, PhishingDetectionScanResult>;
-  errors: Record<string, string>;
+  errors: Record<string, string[]>;
 };
 
 /**
@@ -666,7 +666,9 @@ export class PhishingController extends BaseController<
       return {
         results: {},
         errors: {
-          too_many_urls: `Maximum of ${MAX_TOTAL_URLS} URLs allowed per request`,
+          too_many_urls: [
+            `Maximum of ${MAX_TOTAL_URLS} URLs allowed per request`,
+          ],
         },
       };
     }
@@ -677,7 +679,7 @@ export class PhishingController extends BaseController<
         return {
           results: {},
           errors: {
-            [url]: `URL length must not exceed ${MAX_URL_LENGTH} characters`,
+            [url]: [`URL length must not exceed ${MAX_URL_LENGTH} characters`],
           },
         };
       }
@@ -752,17 +754,21 @@ export class PhishingController extends BaseController<
       return {
         results: {},
         errors: {
-          network_error: 'timeout of 15000ms exceeded',
+          network_error: ['timeout of 15000ms exceeded'],
         },
       };
     }
 
     // Handle HTTP error responses
-    if ('error' in apiResponse && 'status' in apiResponse && 'statusText' in apiResponse) {
+    if (
+      'error' in apiResponse &&
+      'status' in apiResponse &&
+      'statusText' in apiResponse
+    ) {
       return {
         results: {},
         errors: {
-          api_error: `${apiResponse.status} ${apiResponse.statusText}`,
+          api_error: [`${apiResponse.status} ${apiResponse.statusText}`],
         },
       };
     }
@@ -815,7 +821,6 @@ export class PhishingController extends BaseController<
     }
 
     // TODO: Either fix this lint violation or explain why it's necessary to ignore.
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { eth_phishing_detect_config, ...partialState } =
       stalelistResponse.data;
 

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -627,7 +627,7 @@ export class PhishingController extends BaseController<
       return {
         domainName: '',
         recommendedAction: RecommendedAction.None,
-        fetchError: 'timeout of 8000ms exceeded',
+        fetchError: 'error fetching phishing detection results',
       };
     } else if ('error' in apiResponse) {
       return {
@@ -750,14 +750,7 @@ export class PhishingController extends BaseController<
       return {
         results: {},
         errors: {
-          network_error: 'timeout of 15000ms exceeded',
-        },
-      };
-    } else if ('error' in apiResponse) {
-      return {
-        results: {},
-        errors: {
-          api_error: apiResponse.error,
+          network_error: 'error fetching bulk scan results',
         },
       };
     }

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -287,13 +287,6 @@ export type PhishingControllerMessenger = RestrictedMessenger<
   never
 >;
 
-/**
- * @type BulkPhishingDetectionScanResponse
- *
- * Response from the bulk phishing detection scan API
- * @property results - Map of URLs to scan results
- * @property errors - Map of URLs to error messages
- */
 export type BulkPhishingDetectionScanResponse = {
   results: Record<string, PhishingDetectionScanResult>;
   errors: Record<string, string>;

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -287,6 +287,13 @@ export type PhishingControllerMessenger = RestrictedMessenger<
   never
 >;
 
+/**
+ * @type BulkPhishingDetectionScanResponse
+ *
+ * Response for bulk phishing detection scan requests
+ * @property results - Record of domain names and their corresponding phishing detection scan results
+ * @property errors - Record of domain names and their corresponding errors
+ */
 export type BulkPhishingDetectionScanResponse = {
   results: Record<string, PhishingDetectionScanResult>;
   errors: Record<string, string[]>;

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -37,6 +37,7 @@ export const C2_DOMAIN_BLOCKLIST_ENDPOINT = '/v1/request-blocklist';
 export const PHISHING_DETECTION_BASE_URL =
   'https://dapp-scanning.api.cx.metamask.io';
 export const PHISHING_DETECTION_SCAN_ENDPOINT = 'scan';
+export const PHISHING_DETECTION_BULK_SCAN_ENDPOINT = 'bulk-scan';
 
 export const C2_DOMAIN_BLOCKLIST_REFRESH_INTERVAL = 5 * 60; // 5 mins in seconds
 export const HOTLIST_REFRESH_INTERVAL = 5 * 60; // 5 mins in seconds
@@ -285,6 +286,18 @@ export type PhishingControllerMessenger = RestrictedMessenger<
   never,
   never
 >;
+
+/**
+ * @type BulkPhishingDetectionScanResponse
+ *
+ * Response from the bulk phishing detection scan API
+ * @property results - Map of URLs to scan results
+ * @property errors - Map of URLs to error messages
+ */
+export type BulkPhishingDetectionScanResponse = {
+  results: Record<string, PhishingDetectionScanResult>;
+  errors: Record<string, string>;
+};
 
 /**
  * Controller that manages community-maintained lists of approved and unapproved website origins.
@@ -635,6 +648,129 @@ export class PhishingController extends BaseController<
       domainName: hostname,
       recommendedAction: apiResponse.recommendedAction,
     } as PhishingDetectionScanResult;
+  };
+
+  /**
+   * Scan multiple URLs for phishing in bulk. It will only scan the hostnames of the URLs.
+   * It also only supports web URLs.
+   *
+   * @param urls - The URLs to scan.
+   * @returns A mapping of URLs to their phishing detection scan results and errors.
+   */
+  bulkScanUrls = async (
+    urls: string[],
+  ): Promise<BulkPhishingDetectionScanResponse> => {
+    if (!urls || urls.length === 0) {
+      return {
+        results: {},
+        errors: {},
+      };
+    }
+
+    // API has a limit of 50 URLs per request, but we can handle up to 250 by batching
+    const MAX_URLS_PER_BATCH = 50;
+    const MAX_TOTAL_URLS = 250;
+
+    if (urls.length > MAX_TOTAL_URLS) {
+      return {
+        results: {},
+        errors: {
+          too_many_urls: `Maximum of ${MAX_TOTAL_URLS} URLs allowed per request`,
+        },
+      };
+    }
+
+    const MAX_URL_LENGTH = 2048;
+    for (const url of urls) {
+      if (url.length > MAX_URL_LENGTH) {
+        return {
+          results: {},
+          errors: {
+            [url]: `URL length must not exceed ${MAX_URL_LENGTH} characters`,
+          },
+        };
+      }
+    }
+
+    // Split URLs into batches of 50
+    const batches: string[][] = [];
+    for (let i = 0; i < urls.length; i += MAX_URLS_PER_BATCH) {
+      batches.push(urls.slice(i, i + MAX_URLS_PER_BATCH));
+    }
+
+    // Process each batch in parallel
+    const batchResults = await Promise.all(
+      batches.map((batchUrls) => this.#processBatch(batchUrls)),
+    );
+
+    // Combine all batch results
+    const combinedResponse: BulkPhishingDetectionScanResponse = {
+      results: {},
+      errors: {},
+    };
+    // Merge results and errors from all batches
+    batchResults.forEach((batchResponse) => {
+      Object.assign(combinedResponse.results, batchResponse.results);
+      Object.assign(combinedResponse.errors, batchResponse.errors);
+    });
+
+    return combinedResponse;
+  };
+
+  /**
+   * Process a batch of URLs (up to 50) for phishing detection.
+   *
+   * @param urls - A batch of URLs to scan.
+   * @returns The scan results and errors for this batch.
+   */
+  readonly #processBatch = async (
+    urls: string[],
+  ): Promise<BulkPhishingDetectionScanResponse> => {
+    const apiResponse = await safelyExecuteWithTimeout(
+      async () => {
+        const res = await fetch(
+          `${PHISHING_DETECTION_BASE_URL}/${PHISHING_DETECTION_BULK_SCAN_ENDPOINT}`,
+          {
+            method: 'POST',
+            headers: {
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ urls }),
+          },
+        );
+
+        if (!res.ok) {
+          return {
+            error: `${res.status} ${res.statusText}`,
+          };
+        }
+
+        const data = await res.json();
+        return data;
+      },
+      true,
+      15000, // Increased timeout for bulk requests
+    );
+
+    // Handle timeout or network errors
+    if (!apiResponse) {
+      return {
+        results: {},
+        errors: {
+          network_error: 'timeout of 15000ms exceeded',
+        },
+      };
+    } else if ('error' in apiResponse) {
+      return {
+        results: {},
+        errors: {
+          api_error: apiResponse.error,
+        },
+      };
+    }
+
+    return apiResponse as BulkPhishingDetectionScanResponse;
   };
 
   /**

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -288,11 +288,12 @@ export type PhishingControllerMessenger = RestrictedMessenger<
 >;
 
 /**
- * @type BulkPhishingDetectionScanResponse
+ * BulkPhishingDetectionScanResponse
  *
  * Response for bulk phishing detection scan requests
- * @property results - Record of domain names and their corresponding phishing detection scan results
- * @property errors - Record of domain names and their corresponding errors
+ * results - Record of domain names and their corresponding phishing detection scan results
+ *
+ * errors - Record of domain names and their corresponding errors
  */
 export type BulkPhishingDetectionScanResponse = {
   results: Record<string, PhishingDetectionScanResult>;


### PR DESCRIPTION
# Add bulk URL phishing scanning capability to PhishingController

## Explanation

The PhishingController currently supports scanning single URLs for phishing detection, but there are cases where we need to check multiple URLs at once for efficiency. This PR adds a new `bulkScanUrls` method that allows scanning up to 250 URLs in a single operation, improving performance when multiple URLs need to be checked.

The implementation includes:
- A new `bulkScanUrls` method that can process up to 250 URLs (in batches of 50)
- URL validation for length and quantity limits
- Error handling for API errors, timeouts, and validation failures
- Parallel processing of URL batches for improved performance

## References

* Implements new bulk scan API endpoint functionality
* Related to improved phishing detection performance

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes