### PR TITLE
chore: pin changelog-check workflow to safe commit to prevent breakages

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -6,8 +6,9 @@ on:
 
 jobs:
   check_changelog:
-    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@91e349d177db2c569e03c7aa69d2acb404b62f75
+    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@5af9094a52045afa865077e2ccfb854f41bb4789
     with:
+      action-sha: 5af9094a52045afa865077e2ccfb854f41bb4789
       base-branch: ${{ github.event.pull_request.base.ref }}
       head-ref: ${{ github.head_ref }}
       labels: ${{ toJSON(github.event.pull_request.labels) }}

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   check_changelog:
-    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@5af9094a52045afa865077e2ccfb854f41bb4789
+    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@85fffce169c0fd35028ecde6b38dfb3f932882ec
     with:
-      action-sha: 5af9094a52045afa865077e2ccfb854f41bb4789
+      action-sha: 85fffce169c0fd35028ecde6b38dfb3f932882ec
       base-branch: ${{ github.event.pull_request.base.ref }}
       head-ref: ${{ github.head_ref }}
       labels: ${{ toJSON(github.event.pull_request.labels) }}


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR updates the changelog-check workflow to use commit [85fffce169c0fd35028ecde6b38dfb3f932882ec](https://github.com/MetaMask/github-tools/commit/85fffce169c0fd35028ecde6b38dfb3f932882ec), which pins a safe version and prevents breaking changes in the shared workflow from affecting this repo. The change that adds this protection was introduced in [this commit](https://github.com/MetaMask/github-tools/commit/4e692425299b2beb849e6b9316f940f9a528541c).

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
