### PR TITLE
chore: remove private syntax in transaction controller

### DIFF
--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -668,160 +668,102 @@ export class TransactionController extends BaseController<
 > {
   readonly #afterAdd: AfterAddHook;
 
-  readonly #internalEvents = new EventEmitter();
-
-  private readonly isHistoryDisabled: boolean;
-
-  private readonly isSwapsDisabled: boolean;
-
-  private readonly isSendFlowHistoryDisabled: boolean;
-
-  private readonly isTxParamsGasFeeUpdatesEnabled: (
+  readonly #afterSign: (
     transactionMeta: TransactionMeta,
+    signedTx: TypedTransaction,
   ) => boolean;
 
-  private readonly approvingTransactionIds: Set<string> = new Set();
+  readonly #approvingTransactionIds: Set<string> = new Set();
 
-  readonly #methodDataHelper: MethodDataHelper;
+  readonly #beforeCheckPendingTransaction: (
+    transactionMeta: TransactionMeta,
+  ) => Promise<boolean>;
 
-  private readonly gasFeeFlows: GasFeeFlow[];
+  readonly #beforePublish: (
+    transactionMeta: TransactionMeta,
+  ) => Promise<boolean>;
 
-  private readonly getSavedGasFees: (chainId: Hex) => SavedGasFees | undefined;
+  readonly #gasFeeFlows: GasFeeFlow[];
 
-  private readonly getNetworkState: () => NetworkState;
+  readonly #getAdditionalSignArguments: (
+    transactionMeta: TransactionMeta,
+  ) => (TransactionMeta | undefined)[];
 
-  private readonly getCurrentAccountEIP1559Compatibility: () => Promise<boolean>;
+  readonly #getCurrentAccountEIP1559Compatibility: () => Promise<boolean>;
 
-  private readonly getCurrentNetworkEIP1559Compatibility: (
+  readonly #getCurrentNetworkEIP1559Compatibility: (
     networkClientId?: NetworkClientId,
   ) => Promise<boolean>;
 
-  private readonly getGasFeeEstimates: (
-    options: FetchGasFeeEstimateOptions,
-  ) => Promise<GasFeeState>;
-
-  private readonly getPermittedAccounts?: (
-    origin?: string,
-  ) => Promise<string[]>;
-
-  private readonly getExternalPendingTransactions: (
+  readonly #getExternalPendingTransactions: (
     address: string,
     chainId?: string,
   ) => NonceTrackerTransaction[];
 
-  readonly #incomingTransactionHelper: IncomingTransactionHelper;
+  readonly #getGasFeeEstimates: (
+    options: FetchGasFeeEstimateOptions,
+  ) => Promise<GasFeeState>;
 
-  private readonly layer1GasFeeFlows: Layer1GasFeeFlow[];
+  readonly #getNetworkState: () => NetworkState;
+
+  readonly #getPermittedAccounts?: (origin?: string) => Promise<string[]>;
+
+  readonly #getSavedGasFees: (chainId: Hex) => SavedGasFees | undefined;
+
+  readonly #incomingTransactionHelper: IncomingTransactionHelper;
 
   readonly #incomingTransactionOptions: IncomingTransactionOptions & {
     etherscanApiKeysByChainId?: Record<Hex, string>;
   };
 
-  private readonly securityProviderRequest?: SecurityProviderRequest;
+  readonly #internalEvents = new EventEmitter();
 
-  readonly #pendingTransactionOptions: PendingTransactionOptions;
-
-  readonly #publishBatchHook?: PublishBatchHook;
-
-  readonly #publicKeyEIP7702?: Hex;
-
-  private readonly signAbortCallbacks: Map<string, () => void> = new Map();
-
-  readonly #trace: TraceCallback;
-
-  readonly #transactionHistoryLimit: number;
+  readonly #isAutomaticGasFeeUpdateEnabled: (
+    transactionMeta: TransactionMeta,
+  ) => boolean;
 
   readonly #isFirstTimeInteractionEnabled: () => boolean;
 
+  readonly #isHistoryDisabled: boolean;
+
+  readonly #isSendFlowHistoryDisabled: boolean;
+
   readonly #isSimulationEnabled: () => boolean;
 
-  readonly #testGasFeeFlows: boolean;
+  readonly #isSwapsDisabled: boolean;
 
-  private readonly afterSign: (
-    transactionMeta: TransactionMeta,
-    signedTx: TypedTransaction,
-  ) => boolean;
+  readonly #layer1GasFeeFlows: Layer1GasFeeFlow[];
 
-  private readonly beforeCheckPendingTransaction: (
-    transactionMeta: TransactionMeta,
-  ) => Promise<boolean>;
+  readonly #methodDataHelper: MethodDataHelper;
 
-  private readonly beforePublish: (
-    transactionMeta: TransactionMeta,
-  ) => Promise<boolean>;
+  readonly #multichainTrackingHelper: MultichainTrackingHelper;
 
-  private readonly publish: (
+  readonly #pendingTransactionOptions: PendingTransactionOptions;
+
+  readonly #publicKeyEIP7702?: Hex;
+
+  readonly #publish: (
     transactionMeta: TransactionMeta,
     rawTx: string,
   ) => Promise<{ transactionHash?: string }>;
 
-  private readonly getAdditionalSignArguments: (
-    transactionMeta: TransactionMeta,
-  ) => (TransactionMeta | undefined)[];
+  readonly #publishBatchHook?: PublishBatchHook;
 
-  private failTransaction(
-    transactionMeta: TransactionMeta,
-    error: Error,
-    actionId?: string,
-  ) {
-    let newTransactionMeta: TransactionMeta;
+  readonly #securityProviderRequest?: SecurityProviderRequest;
 
-    try {
-      newTransactionMeta = this.#updateTransactionInternal(
-        {
-          transactionId: transactionMeta.id,
-          note: 'TransactionController#failTransaction - Add error message and set status to failed',
-          skipValidation: true,
-        },
-        (draftTransactionMeta) => {
-          draftTransactionMeta.status = TransactionStatus.failed;
-
-          (
-            draftTransactionMeta as TransactionMeta & {
-              status: TransactionStatus.failed;
-            }
-          ).error = normalizeTxError(error);
-        },
-      );
-    } catch (err: unknown) {
-      log('Failed to mark transaction as failed', err);
-
-      newTransactionMeta = {
-        ...transactionMeta,
-        status: TransactionStatus.failed,
-        error: normalizeTxError(error),
-      };
-    }
-
-    this.messagingSystem.publish(`${controllerName}:transactionFailed`, {
-      actionId,
-      error: error.message,
-      transactionMeta: newTransactionMeta,
-    });
-
-    this.onTransactionStatusChange(newTransactionMeta);
-
-    this.messagingSystem.publish(
-      `${controllerName}:transactionFinished`,
-      newTransactionMeta,
-    );
-
-    this.#internalEvents.emit(
-      `${transactionMeta.id}:finished`,
-      newTransactionMeta,
-    );
-  }
-
-  readonly #multichainTrackingHelper: MultichainTrackingHelper;
-
-  /**
-   * Method used to sign transactions
-   */
-  sign?: (
+  readonly #sign?: (
     transaction: TypedTransaction,
     from: string,
     transactionMeta?: TransactionMeta,
   ) => Promise<TypedTransaction>;
+
+  readonly #signAbortCallbacks: Map<string, () => void> = new Map();
+
+  readonly #testGasFeeFlows: boolean;
+
+  readonly #trace: TraceCallback;
+
+  readonly #transactionHistoryLimit: number;
 
   /**
    * Constructs a TransactionController.
@@ -833,7 +775,6 @@ export class TransactionController extends BaseController<
       disableHistory,
       disableSendFlowHistory,
       disableSwaps,
-      isAutomaticGasFeeUpdateEnabled,
       getCurrentAccountEIP1559Compatibility,
       getCurrentNetworkEIP1559Compatibility,
       getExternalPendingTransactions,
@@ -842,7 +783,9 @@ export class TransactionController extends BaseController<
       getNetworkState,
       getPermittedAccounts,
       getSavedGasFees,
+      hooks,
       incomingTransactions = {},
+      isAutomaticGasFeeUpdateEnabled,
       isFirstTimeInteractionEnabled,
       isSimulationEnabled,
       messenger,
@@ -854,7 +797,6 @@ export class TransactionController extends BaseController<
       testGasFeeFlows,
       trace,
       transactionHistoryLimit = 40,
-      hooks,
     } = options;
 
     super({
@@ -868,45 +810,45 @@ export class TransactionController extends BaseController<
     });
 
     this.messagingSystem = messenger;
-    this.isTxParamsGasFeeUpdatesEnabled =
-      isAutomaticGasFeeUpdateEnabled ?? ((_txMeta: TransactionMeta) => false);
-    this.getNetworkState = getNetworkState;
-    this.isSendFlowHistoryDisabled = disableSendFlowHistory ?? false;
-    this.isHistoryDisabled = disableHistory ?? false;
-    this.isSwapsDisabled = disableSwaps ?? false;
-    this.#isFirstTimeInteractionEnabled =
-      isFirstTimeInteractionEnabled ?? (() => true);
-    this.#isSimulationEnabled = isSimulationEnabled ?? (() => true);
-    this.getSavedGasFees = getSavedGasFees ?? ((_chainId) => undefined);
-    this.getCurrentAccountEIP1559Compatibility =
-      getCurrentAccountEIP1559Compatibility ?? (() => Promise.resolve(true));
-    this.getCurrentNetworkEIP1559Compatibility =
-      getCurrentNetworkEIP1559Compatibility;
-    this.getGasFeeEstimates =
-      getGasFeeEstimates || (() => Promise.resolve({} as GasFeeState));
-    this.getPermittedAccounts = getPermittedAccounts;
-    this.getExternalPendingTransactions =
-      getExternalPendingTransactions ?? (() => []);
-    this.securityProviderRequest = securityProviderRequest;
-    this.#incomingTransactionOptions = incomingTransactions;
-    this.#pendingTransactionOptions = pendingTransactions;
-    this.#publishBatchHook = hooks?.publishBatch;
-    this.#publicKeyEIP7702 = publicKeyEIP7702;
-    this.#transactionHistoryLimit = transactionHistoryLimit;
-    this.sign = sign;
-    this.#testGasFeeFlows = testGasFeeFlows === true;
-    this.#trace = trace ?? (((_request, fn) => fn?.()) as TraceCallback);
 
     this.#afterAdd = hooks?.afterAdd ?? (() => Promise.resolve({}));
-    this.afterSign = hooks?.afterSign ?? (() => true);
-    this.beforeCheckPendingTransaction =
+    this.#afterSign = hooks?.afterSign ?? (() => true);
+    this.#beforeCheckPendingTransaction =
       /* istanbul ignore next */
       hooks?.beforeCheckPendingTransaction ?? (() => Promise.resolve(true));
-    this.beforePublish = hooks?.beforePublish ?? (() => Promise.resolve(true));
-    this.getAdditionalSignArguments =
+    this.#beforePublish = hooks?.beforePublish ?? (() => Promise.resolve(true));
+    this.#getAdditionalSignArguments =
       hooks?.getAdditionalSignArguments ?? (() => []);
-    this.publish =
+    this.#getCurrentAccountEIP1559Compatibility =
+      getCurrentAccountEIP1559Compatibility ?? (() => Promise.resolve(true));
+    this.#getCurrentNetworkEIP1559Compatibility =
+      getCurrentNetworkEIP1559Compatibility;
+    this.#getExternalPendingTransactions =
+      getExternalPendingTransactions ?? (() => []);
+    this.#getGasFeeEstimates =
+      getGasFeeEstimates || (() => Promise.resolve({} as GasFeeState));
+    this.#getNetworkState = getNetworkState;
+    this.#getPermittedAccounts = getPermittedAccounts;
+    this.#getSavedGasFees = getSavedGasFees ?? ((_chainId) => undefined);
+    this.#incomingTransactionOptions = incomingTransactions;
+    this.#isAutomaticGasFeeUpdateEnabled =
+      isAutomaticGasFeeUpdateEnabled ?? ((_txMeta: TransactionMeta) => false);
+    this.#isFirstTimeInteractionEnabled =
+      isFirstTimeInteractionEnabled ?? (() => true);
+    this.#isHistoryDisabled = disableHistory ?? false;
+    this.#isSendFlowHistoryDisabled = disableSendFlowHistory ?? false;
+    this.#isSimulationEnabled = isSimulationEnabled ?? (() => true);
+    this.#isSwapsDisabled = disableSwaps ?? false;
+    this.#pendingTransactionOptions = pendingTransactions;
+    this.#publicKeyEIP7702 = publicKeyEIP7702;
+    this.#publish =
       hooks?.publish ?? (() => Promise.resolve({ transactionHash: undefined }));
+    this.#publishBatchHook = hooks?.publishBatch;
+    this.#securityProviderRequest = securityProviderRequest;
+    this.#sign = sign;
+    this.#testGasFeeFlows = testGasFeeFlows === true;
+    this.#trace = trace ?? (((_request, fn) => fn?.()) as TraceCallback);
+    this.#transactionHistoryLimit = transactionHistoryLimit;
 
     const findNetworkClientIdByChainId = (chainId: Hex) => {
       return this.messagingSystem.call(
@@ -936,18 +878,18 @@ export class TransactionController extends BaseController<
         );
       },
     });
-    this.#multichainTrackingHelper.initialize();
 
-    this.gasFeeFlows = this.#getGasFeeFlows();
-    this.layer1GasFeeFlows = this.#getLayer1GasFeeFlows();
+    this.#multichainTrackingHelper.initialize();
+    this.#gasFeeFlows = this.#getGasFeeFlows();
+    this.#layer1GasFeeFlows = this.#getLayer1GasFeeFlows();
 
     const gasFeePoller = new GasFeePoller({
       findNetworkClientIdByChainId,
-      gasFeeFlows: this.gasFeeFlows,
-      getGasFeeControllerEstimates: this.getGasFeeEstimates,
+      gasFeeFlows: this.#gasFeeFlows,
+      getGasFeeControllerEstimates: this.#getGasFeeEstimates,
       getProvider: (networkClientId) => this.#getProvider({ networkClientId }),
       getTransactions: () => this.state.transactions,
-      layer1GasFeeFlows: this.layer1GasFeeFlows,
+      layer1GasFeeFlows: this.#layer1GasFeeFlows,
       messenger: this.messagingSystem,
       onStateChange: (listener) => {
         this.messagingSystem.subscribe(
@@ -991,7 +933,7 @@ export class TransactionController extends BaseController<
       isEnabled: this.#incomingTransactionOptions.isEnabled,
       queryEntireHistory: this.#incomingTransactionOptions.queryEntireHistory,
       remoteTransactionSource: new AccountsApiRemoteTransactionSource(),
-      trimTransactions: this.trimTransactionsForState.bind(this),
+      trimTransactions: this.#trimTransactionsForState.bind(this),
       updateCache,
       updateTransactions: this.#incomingTransactionOptions.updateTransactions,
     });
@@ -1019,7 +961,7 @@ export class TransactionController extends BaseController<
       getTransactions: () => this.state.transactions,
     });
 
-    this.onBootCleanup();
+    this.#onBootCleanup();
     this.#checkForPendingTransactionAndStartPolling();
     this.#registerActionHandlers();
   }
@@ -1060,7 +1002,7 @@ export class TransactionController extends BaseController<
       getEthQuery: (networkClientId) => this.#getEthQuery({ networkClientId }),
       getInternalAccounts: this.#getInternalAccounts.bind(this),
       getTransaction: (transactionId) =>
-        this.getTransactionOrThrow(transactionId),
+        this.#getTransactionOrThrow(transactionId),
       messenger: this.messagingSystem,
       publishBatchHook: this.#publishBatchHook,
       publicKeyEIP7702: this.#publicKeyEIP7702,
@@ -1172,7 +1114,7 @@ export class TransactionController extends BaseController<
     const permittedAddresses =
       origin === undefined
         ? undefined
-        : await this.getPermittedAccounts?.(origin);
+        : await this.#getPermittedAccounts?.(origin);
 
     const selectedAddress = this.#getSelectedAccount().address;
     const internalAccounts = this.#getInternalAccounts();
@@ -1194,7 +1136,7 @@ export class TransactionController extends BaseController<
     ).catch(() => undefined);
 
     const isEIP1559Compatible =
-      await this.getEIP1559Compatibility(networkClientId);
+      await this.#getEIP1559Compatibility(networkClientId);
 
     validateTxParams(txParams, isEIP1559Compatible, chainId);
 
@@ -1216,7 +1158,7 @@ export class TransactionController extends BaseController<
       );
     }
 
-    const dappSuggestedGasFees = this.generateDappSuggestedGasFees(
+    const dappSuggestedGasFees = this.#generateDappSuggestedGasFees(
       txParams,
       origin,
     );
@@ -1226,7 +1168,7 @@ export class TransactionController extends BaseController<
 
     const delegationAddress = await delegationAddressPromise;
 
-    const existingTransactionMeta = this.getTransactionWithActionId(actionId);
+    const existingTransactionMeta = this.#getTransactionWithActionId(actionId);
 
     // If a request to add a transaction with the same actionId is submitted again, a new transaction will not be created for it.
     let addedTransactionMeta: TransactionMeta = existingTransactionMeta
@@ -1271,7 +1213,7 @@ export class TransactionController extends BaseController<
     await this.#trace(
       { name: 'Estimate Gas Properties', parentContext: traceContext },
       (context) =>
-        this.updateGasProperties(addedTransactionMeta, {
+        this.#updateGasProperties(addedTransactionMeta, {
           traceContext: context,
         }),
     );
@@ -1279,8 +1221,8 @@ export class TransactionController extends BaseController<
     // Checks if a transaction already exists with a given actionId
     if (!existingTransactionMeta) {
       // Set security provider response
-      if (method && this.securityProviderRequest) {
-        const securityProviderResponse = await this.securityProviderRequest(
+      if (method && this.#securityProviderRequest) {
+        const securityProviderResponse = await this.#securityProviderRequest(
           addedTransactionMeta,
           method,
         );
@@ -1288,11 +1230,11 @@ export class TransactionController extends BaseController<
           securityProviderResponse;
       }
 
-      if (!this.isSendFlowHistoryDisabled) {
+      if (!this.#isSendFlowHistoryDisabled) {
         addedTransactionMeta.sendFlowHistory = sendFlowHistory ?? [];
       }
       // Initial history push
-      if (!this.isHistoryDisabled) {
+      if (!this.#isHistoryDisabled) {
         addedTransactionMeta = addInitialHistorySnapshot(addedTransactionMeta);
       }
 
@@ -1301,13 +1243,13 @@ export class TransactionController extends BaseController<
         transactionType,
         swaps,
         {
-          isSwapsDisabled: this.isSwapsDisabled,
+          isSwapsDisabled: this.#isSwapsDisabled,
           cancelTransaction: this.#rejectTransaction.bind(this),
           messenger: this.messagingSystem,
         },
       );
 
-      this.addMetadata(addedTransactionMeta);
+      this.#addMetadata(addedTransactionMeta);
 
       if (requireApproval !== false) {
         this.#updateSimulationData(addedTransactionMeta, {
@@ -1335,7 +1277,7 @@ export class TransactionController extends BaseController<
     }
 
     return {
-      result: this.processApproval(addedTransactionMeta, {
+      result: this.#processApproval(addedTransactionMeta, {
         actionId,
         isExisting: Boolean(existingTransactionMeta),
         publishHook,
@@ -1459,7 +1401,7 @@ export class TransactionController extends BaseController<
     transactionType: TransactionType;
   }) {
     // If transaction is found for same action id, do not create a new transaction.
-    if (this.getTransactionWithActionId(actionId)) {
+    if (this.#getTransactionWithActionId(actionId)) {
       return;
     }
 
@@ -1471,14 +1413,14 @@ export class TransactionController extends BaseController<
 
     log(`Creating ${label} transaction`, transactionId, gasValues);
 
-    const transactionMeta = this.getTransaction(transactionId);
+    const transactionMeta = this.#getTransaction(transactionId);
     /* istanbul ignore next */
     if (!transactionMeta) {
       return;
     }
 
     /* istanbul ignore next */
-    if (!this.sign) {
+    if (!this.#sign) {
       throw new Error('No sign method defined.');
     }
 
@@ -1496,12 +1438,12 @@ export class TransactionController extends BaseController<
       newTxParams,
     );
 
-    const signedTx = await this.sign(
+    const signedTx = await this.#sign(
       unsignedEthTx,
       transactionMeta.txParams.from,
     );
 
-    const transactionMetaWithRsv = this.updateTransactionMetaRSV(
+    const transactionMetaWithRsv = this.#updateTransactionMetaRSV(
       transactionMeta,
       signedTx,
     );
@@ -1535,14 +1477,14 @@ export class TransactionController extends BaseController<
       type: transactionType,
     };
 
-    const hash = await this.publishTransactionForRetry(ethQuery, {
+    const hash = await this.#publishTransactionForRetry(ethQuery, {
       ...newTransactionMeta,
       origin: label,
     });
 
     newTransactionMeta.hash = hash;
 
-    this.addMetadata(newTransactionMeta);
+    this.#addMetadata(newTransactionMeta);
 
     // speedUpTransaction has no approval request, so we assume the user has already approved the transaction
     this.messagingSystem.publish(`${controllerName}:transactionApproved`, {
@@ -1646,7 +1588,7 @@ export class TransactionController extends BaseController<
         'updateSecurityAlertResponse: securityAlertResponse should not be null',
       );
     }
-    const transactionMeta = this.getTransaction(transactionId);
+    const transactionMeta = this.#getTransaction(transactionId);
     if (!transactionMeta) {
       throw new Error(
         `Cannot update security alert response as no transaction metadata found`,
@@ -1700,7 +1642,7 @@ export class TransactionController extends BaseController<
     );
 
     this.update((state) => {
-      state.transactions = this.trimTransactionsForState(newTransactions);
+      state.transactions = this.#trimTransactionsForState(newTransactions);
     });
   }
 
@@ -1717,7 +1659,7 @@ export class TransactionController extends BaseController<
     baseFeePerGas: Hex,
   ) {
     // Run validation and add external transaction to state.
-    const newTransactionMeta = this.addExternalTransaction(transactionMeta);
+    const newTransactionMeta = this.#addExternalTransaction(transactionMeta);
 
     try {
       const transactionId = newTransactionMeta.id;
@@ -1740,10 +1682,10 @@ export class TransactionController extends BaseController<
         updatedTransactionMeta,
         `${controllerName}:confirmExternalTransaction - Add external transaction`,
       );
-      this.onTransactionStatusChange(updatedTransactionMeta);
+      this.#onTransactionStatusChange(updatedTransactionMeta);
 
       // Intentional given potential duration of process.
-      this.updatePostBalance(updatedTransactionMeta).catch((error) => {
+      this.#updatePostBalance(updatedTransactionMeta).catch((error) => {
         /* istanbul ignore next */
         log('Error while updating post balance', error);
         throw error;
@@ -1771,13 +1713,13 @@ export class TransactionController extends BaseController<
     currentSendFlowHistoryLength: number,
     sendFlowHistoryToAdd: SendFlowHistoryEntry[],
   ): TransactionMeta {
-    if (this.isSendFlowHistoryDisabled) {
+    if (this.#isSendFlowHistoryDisabled) {
       throw new Error(
         'Send flow history is disabled for the current transaction controller',
       );
     }
 
-    const transactionMeta = this.getTransaction(transactionID);
+    const transactionMeta = this.#getTransaction(transactionID);
 
     if (!transactionMeta) {
       throw new Error(
@@ -1802,7 +1744,7 @@ export class TransactionController extends BaseController<
       );
     }
 
-    return this.getTransaction(transactionID) as TransactionMeta;
+    return this.#getTransaction(transactionID) as TransactionMeta;
   }
 
   /**
@@ -1851,7 +1793,7 @@ export class TransactionController extends BaseController<
       userFeeLevel?: string;
     },
   ): TransactionMeta {
-    const transactionMeta = this.getTransaction(transactionId);
+    const transactionMeta = this.#getTransaction(transactionId);
 
     if (!transactionMeta) {
       throw new Error(
@@ -1894,7 +1836,7 @@ export class TransactionController extends BaseController<
       `${controllerName}:updateTransactionGasFees - gas values updated`,
     );
 
-    return this.getTransaction(transactionId) as TransactionMeta;
+    return this.#getTransaction(transactionId) as TransactionMeta;
   }
 
   /**
@@ -1919,7 +1861,7 @@ export class TransactionController extends BaseController<
       maxPriorityFeePerGas?: string;
     },
   ): TransactionMeta {
-    const transactionMeta = this.getTransaction(transactionId);
+    const transactionMeta = this.#getTransaction(transactionId);
 
     if (!transactionMeta) {
       throw new Error(
@@ -1952,7 +1894,7 @@ export class TransactionController extends BaseController<
       `${controllerName}:updatePreviousGasParams - Previous gas values updated`,
     );
 
-    return this.getTransaction(transactionId) as TransactionMeta;
+    return this.#getTransaction(transactionId) as TransactionMeta;
   }
 
   async getNonceLock(
@@ -2002,7 +1944,7 @@ export class TransactionController extends BaseController<
       value?: string;
     },
   ) {
-    const transactionMeta = this.getTransaction(txId);
+    const transactionMeta = this.#getTransaction(txId);
 
     if (!transactionMeta) {
       throw new Error(
@@ -2043,7 +1985,7 @@ export class TransactionController extends BaseController<
     updatedTransaction.type = type;
 
     await updateTransactionLayer1GasFee({
-      layer1GasFeeFlows: this.layer1GasFeeFlows,
+      layer1GasFeeFlows: this.#layer1GasFeeFlows,
       messenger: this.messagingSystem,
       provider,
       transactionMeta: updatedTransaction,
@@ -2054,7 +1996,7 @@ export class TransactionController extends BaseController<
       `Update Editable Params for ${txId}`,
     );
 
-    return this.getTransaction(txId);
+    return this.#getTransaction(txId);
   }
 
   /**
@@ -2064,7 +2006,7 @@ export class TransactionController extends BaseController<
    * @param isActive - The active state.
    */
   setTransactionActive(transactionId: string, isActive: boolean) {
-    const transactionMeta = this.getTransaction(transactionId);
+    const transactionMeta = this.#getTransaction(transactionId);
 
     if (!transactionMeta) {
       throw new Error(`Transaction with id ${transactionId} not found`);
@@ -2110,11 +2052,11 @@ export class TransactionController extends BaseController<
     const initialTxAsEthTx = prepareTransaction(chainId, initialTx);
     const initialTxAsSerializedHex = serializeTransaction(initialTxAsEthTx);
 
-    if (this.approvingTransactionIds.has(initialTxAsSerializedHex)) {
+    if (this.#approvingTransactionIds.has(initialTxAsSerializedHex)) {
       return '';
     }
 
-    this.approvingTransactionIds.add(initialTxAsSerializedHex);
+    this.#approvingTransactionIds.add(initialTxAsSerializedHex);
 
     let rawTransactions, nonceLock;
     try {
@@ -2137,7 +2079,7 @@ export class TransactionController extends BaseController<
       rawTransactions = await Promise.all(
         listOfTxParams.map((txParams) => {
           txParams.nonce = nonce;
-          return this.signExternalTransaction(txParams.chainId, txParams);
+          return this.#signExternalTransaction(txParams.chainId, txParams);
         }),
       );
     } catch (err) {
@@ -2147,7 +2089,7 @@ export class TransactionController extends BaseController<
       throw err;
     } finally {
       nonceLock?.releaseLock();
-      this.approvingTransactionIds.delete(initialTxAsSerializedHex);
+      this.#approvingTransactionIds.delete(initialTxAsSerializedHex);
     }
     return rawTransactions;
   }
@@ -2173,7 +2115,7 @@ export class TransactionController extends BaseController<
       type,
     } = request;
 
-    const transactionMeta = this.getTransaction(transactionId);
+    const transactionMeta = this.#getTransaction(transactionId);
 
     if (!transactionMeta) {
       throw new Error(
@@ -2371,13 +2313,13 @@ export class TransactionController extends BaseController<
     // Guaranteed as the default gas fee flow matches all transactions.
     const gasFeeFlow = getGasFeeFlow(
       transactionMeta,
-      this.gasFeeFlows,
+      this.#gasFeeFlows,
       this.messagingSystem,
     ) as GasFeeFlow;
 
     const ethQuery = new EthQuery(provider);
 
-    const gasFeeControllerData = await this.getGasFeeEstimates({
+    const gasFeeControllerData = await this.#getGasFeeEstimates({
       networkClientId,
     });
 
@@ -2413,7 +2355,7 @@ export class TransactionController extends BaseController<
     });
 
     return await getTransactionLayer1GasFee({
-      layer1GasFeeFlows: this.layer1GasFeeFlows,
+      layer1GasFeeFlows: this.#layer1GasFeeFlows,
       messenger: this.messagingSystem,
       provider,
       transactionMeta: {
@@ -2423,11 +2365,11 @@ export class TransactionController extends BaseController<
     });
   }
 
-  private async signExternalTransaction(
+  async #signExternalTransaction(
     chainId: Hex,
     transactionParams: TransactionParams,
   ): Promise<string> {
-    if (!this.sign) {
+    if (!this.#sign) {
       throw new Error('No sign method defined.');
     }
 
@@ -2450,7 +2392,7 @@ export class TransactionController extends BaseController<
       updatedTransactionParams,
     );
 
-    const signedTransaction = await this.sign(unsignedTransaction, from);
+    const signedTransaction = await this.#sign(unsignedTransaction, from);
     const rawTransaction = serializeTransaction(signedTransaction);
 
     return rawTransaction;
@@ -2464,7 +2406,7 @@ export class TransactionController extends BaseController<
       ({ status }) => status !== TransactionStatus.unapproved,
     );
     this.update((state) => {
-      state.transactions = this.trimTransactionsForState(transactions);
+      state.transactions = this.#trimTransactionsForState(transactions);
     });
   }
 
@@ -2475,13 +2417,13 @@ export class TransactionController extends BaseController<
    * @param transactionId - The ID of the transaction to stop signing.
    */
   abortTransactionSigning(transactionId: string) {
-    const transactionMeta = this.getTransaction(transactionId);
+    const transactionMeta = this.#getTransaction(transactionId);
 
     if (!transactionMeta) {
       throw new Error(`Cannot abort signing as no transaction metadata found`);
     }
 
-    const abortCallback = this.signAbortCallbacks.get(transactionId);
+    const abortCallback = this.#signAbortCallbacks.get(transactionId);
 
     if (!abortCallback) {
       throw new Error(
@@ -2491,7 +2433,7 @@ export class TransactionController extends BaseController<
 
     abortCallback();
 
-    this.signAbortCallbacks.delete(transactionId);
+    this.#signAbortCallbacks.delete(transactionId);
   }
 
   /**
@@ -2625,23 +2567,23 @@ export class TransactionController extends BaseController<
     });
   }
 
-  private addMetadata(transactionMeta: TransactionMeta) {
+  #addMetadata(transactionMeta: TransactionMeta) {
     validateTxParams(transactionMeta.txParams);
     this.update((state) => {
-      state.transactions = this.trimTransactionsForState([
+      state.transactions = this.#trimTransactionsForState([
         ...state.transactions,
         transactionMeta,
       ]);
     });
   }
 
-  private async updateGasProperties(
+  async #updateGasProperties(
     transactionMeta: TransactionMeta,
     { traceContext }: { traceContext?: TraceContext } = {},
   ) {
     const isEIP1559Compatible =
       transactionMeta.txParams.type !== TransactionEnvelopeType.legacy &&
-      (await this.getEIP1559Compatibility(transactionMeta.networkClientId));
+      (await this.#getEIP1559Compatibility(transactionMeta.networkClientId));
 
     const { networkClientId } = transactionMeta;
     const ethQuery = this.#getEthQuery({ networkClientId });
@@ -2660,9 +2602,9 @@ export class TransactionController extends BaseController<
         await updateGasFees({
           eip1559: isEIP1559Compatible,
           ethQuery,
-          gasFeeFlows: this.gasFeeFlows,
-          getGasFeeEstimates: this.getGasFeeEstimates,
-          getSavedGasFees: this.getSavedGasFees.bind(this),
+          gasFeeFlows: this.#gasFeeFlows,
+          getGasFeeEstimates: this.#getGasFeeEstimates,
+          getSavedGasFees: this.#getSavedGasFees.bind(this),
           messenger: this.messagingSystem,
           txMeta: transactionMeta,
         }),
@@ -2672,7 +2614,7 @@ export class TransactionController extends BaseController<
       { name: 'Update Layer 1 Gas Fees', parentContext: traceContext },
       async () =>
         await updateTransactionLayer1GasFee({
-          layer1GasFeeFlows: this.layer1GasFeeFlows,
+          layer1GasFeeFlows: this.#layer1GasFeeFlows,
           messenger: this.messagingSystem,
           provider,
           transactionMeta,
@@ -2680,12 +2622,12 @@ export class TransactionController extends BaseController<
     );
   }
 
-  private onBootCleanup() {
+  #onBootCleanup() {
     this.clearUnapprovedTransactions();
-    this.failIncompleteTransactions();
+    this.#failIncompleteTransactions();
   }
 
-  private failIncompleteTransactions() {
+  #failIncompleteTransactions() {
     const incompleteTransactions = this.state.transactions.filter(
       (transaction) =>
         [TransactionStatus.approved, TransactionStatus.signed].includes(
@@ -2694,14 +2636,14 @@ export class TransactionController extends BaseController<
     );
 
     for (const transactionMeta of incompleteTransactions) {
-      this.failTransaction(
+      this.#failTransaction(
         transactionMeta,
         new Error('Transaction incomplete at startup'),
       );
     }
   }
 
-  private async processApproval(
+  async #processApproval(
     transactionMeta: TransactionMeta,
     {
       actionId,
@@ -2721,11 +2663,11 @@ export class TransactionController extends BaseController<
   ): Promise<string> {
     const transactionId = transactionMeta.id;
     let resultCallbacks: AcceptResultCallbacks | undefined;
-    const { meta, isCompleted } = this.isTransactionCompleted(transactionId);
+    const { meta, isCompleted } = this.#isTransactionCompleted(transactionId);
 
     const finishedPromise = isCompleted
       ? Promise.resolve(meta)
-      : this.waitForTransactionFinished(transactionId);
+      : this.#waitForTransactionFinished(transactionId);
 
     if (meta && !isExisting && !isCompleted) {
       try {
@@ -2733,7 +2675,7 @@ export class TransactionController extends BaseController<
           const acceptResult = await this.#trace(
             { name: 'Await Approval', parentContext: traceContext },
             (context) =>
-              this.requestApproval(transactionMeta, {
+              this.#requestApproval(transactionMeta, {
                 shouldShowRequest,
                 traceContext: context,
               }),
@@ -2763,10 +2705,10 @@ export class TransactionController extends BaseController<
         }
 
         const { isCompleted: isTxCompleted } =
-          this.isTransactionCompleted(transactionId);
+          this.#isTransactionCompleted(transactionId);
 
         if (!isTxCompleted) {
-          const approvalResult = await this.approveTransaction(
+          const approvalResult = await this.#approveTransaction(
             transactionId,
             traceContext,
             publishHook,
@@ -2777,7 +2719,7 @@ export class TransactionController extends BaseController<
           ) {
             resultCallbacks.success();
           }
-          const updatedTransactionMeta = this.getTransaction(
+          const updatedTransactionMeta = this.#getTransaction(
             transactionId,
           ) as TransactionMeta;
           this.messagingSystem.publish(
@@ -2792,13 +2734,13 @@ export class TransactionController extends BaseController<
         const error = rawError as Error & { code?: number; data?: Json };
 
         const { isCompleted: isTxCompleted } =
-          this.isTransactionCompleted(transactionId);
+          this.#isTransactionCompleted(transactionId);
 
         if (!isTxCompleted) {
           if (this.#isRejectError(error)) {
             this.#rejectTransactionAndThrow(transactionId, actionId, error);
           } else {
-            this.failTransaction(meta, error, actionId);
+            this.#failTransaction(meta, error, actionId);
           }
         }
       }
@@ -2839,7 +2781,7 @@ export class TransactionController extends BaseController<
    * @param publishHookOverride - Custom logic to publish the transaction.
    * @returns The state of the approval.
    */
-  private async approveTransaction(
+  async #approveTransaction(
     transactionId: string,
     traceContext?: unknown,
     publishHookOverride?: PublishHook,
@@ -2847,31 +2789,34 @@ export class TransactionController extends BaseController<
     let clearApprovingTransactionId: (() => void) | undefined;
     let clearNonceLock: (() => void) | undefined;
 
-    let transactionMeta = this.getTransactionOrThrow(transactionId);
+    let transactionMeta = this.#getTransactionOrThrow(transactionId);
 
     log('Approving transaction', transactionMeta);
 
     try {
-      if (!this.sign) {
-        this.failTransaction(
+      if (!this.#sign) {
+        this.#failTransaction(
           transactionMeta,
           new Error('No sign method defined.'),
         );
         return ApprovalState.NotApproved;
       } else if (!transactionMeta.chainId) {
-        this.failTransaction(transactionMeta, new Error('No chainId defined.'));
+        this.#failTransaction(
+          transactionMeta,
+          new Error('No chainId defined.'),
+        );
         return ApprovalState.NotApproved;
       }
 
-      if (this.approvingTransactionIds.has(transactionId)) {
+      if (this.#approvingTransactionIds.has(transactionId)) {
         log('Skipping approval as signing in progress', transactionId);
         return ApprovalState.NotApproved;
       }
 
-      this.approvingTransactionIds.add(transactionId);
+      this.#approvingTransactionIds.add(transactionId);
 
       clearApprovingTransactionId = () =>
-        this.approvingTransactionIds.delete(transactionId);
+        this.#approvingTransactionIds.delete(transactionId);
 
       const [nonce, releaseNonce] = await getNextNonce(
         transactionMeta,
@@ -2904,14 +2849,14 @@ export class TransactionController extends BaseController<
         },
       );
 
-      this.onTransactionStatusChange(transactionMeta);
+      this.#onTransactionStatusChange(transactionMeta);
 
       const rawTx = await this.#trace(
         { name: 'Sign', parentContext: traceContext },
         () => this.#signTransaction(transactionMeta),
       );
 
-      if (!(await this.beforePublish(transactionMeta))) {
+      if (!(await this.#beforePublish(transactionMeta))) {
         log('Skipping publishing transaction based on hook');
         this.messagingSystem.publish(
           `${controllerName}:transactionPublishingSkipped`,
@@ -2960,7 +2905,7 @@ export class TransactionController extends BaseController<
       await this.#trace(
         { name: 'Publish', parentContext: traceContext },
         async () => {
-          const publishHook = publishHookOverride ?? this.publish;
+          const publishHook = publishHookOverride ?? this.#publish;
 
           ({ transactionHash: hash } = await publishHook(
             transactionMeta,
@@ -2968,7 +2913,7 @@ export class TransactionController extends BaseController<
           ));
 
           if (hash === undefined) {
-            hash = await this.publishTransaction(ethQuery, {
+            hash = await this.#publishTransaction(ethQuery, {
               ...transactionMeta,
               rawTx,
             });
@@ -3004,12 +2949,12 @@ export class TransactionController extends BaseController<
       );
       this.#internalEvents.emit(`${transactionId}:finished`, transactionMeta);
 
-      this.onTransactionStatusChange(transactionMeta);
+      this.#onTransactionStatusChange(transactionMeta);
       return ApprovalState.Approved;
       // TODO: Replace `any` with type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
-      this.failTransaction(transactionMeta, error);
+      this.#failTransaction(transactionMeta, error);
       return ApprovalState.NotApproved;
     } finally {
       clearApprovingTransactionId?.();
@@ -3017,7 +2962,7 @@ export class TransactionController extends BaseController<
     }
   }
 
-  private async publishTransaction(
+  async #publishTransaction(
     ethQuery: EthQuery,
     transactionMeta: TransactionMeta,
     { skipSubmitHistory }: { skipSubmitHistory?: boolean } = {},
@@ -3042,7 +2987,7 @@ export class TransactionController extends BaseController<
    * @param error - The error that caused the rejection.
    */
   #rejectTransaction(transactionId: string, actionId?: string, error?: Error) {
-    const transactionMeta = this.getTransaction(transactionId);
+    const transactionMeta = this.#getTransaction(transactionId);
 
     if (!transactionMeta) {
       return;
@@ -3071,7 +3016,7 @@ export class TransactionController extends BaseController<
       actionId,
     });
 
-    this.onTransactionStatusChange(updatedTransactionMeta);
+    this.#onTransactionStatusChange(updatedTransactionMeta);
   }
 
   /**
@@ -3088,7 +3033,7 @@ export class TransactionController extends BaseController<
    * @param transactions - The transactions to be applied to the state.
    * @returns The trimmed list of transactions.
    */
-  private trimTransactionsForState(
+  #trimTransactionsForState(
     transactions: TransactionMeta[],
   ): TransactionMeta[] {
     const nonceNetworkSet = new Set();
@@ -3107,7 +3052,7 @@ export class TransactionController extends BaseController<
             return true;
           } else if (
             nonceNetworkSet.size < this.#transactionHistoryLimit ||
-            !this.isFinalState(status)
+            !this.#isFinalState(status)
           ) {
             nonceNetworkSet.add(key);
             return true;
@@ -3127,7 +3072,7 @@ export class TransactionController extends BaseController<
    * @param status - The transaction status.
    * @returns Whether the transaction is in a final state.
    */
-  private isFinalState(status: TransactionStatus): boolean {
+  #isFinalState(status: TransactionStatus): boolean {
     return (
       status === TransactionStatus.rejected ||
       status === TransactionStatus.confirmed ||
@@ -3141,7 +3086,7 @@ export class TransactionController extends BaseController<
    * @param status - The transaction status.
    * @returns Whether the transaction is in a final state.
    */
-  private isLocalFinalState(status: TransactionStatus): boolean {
+  #isLocalFinalState(status: TransactionStatus): boolean {
     return [
       TransactionStatus.confirmed,
       TransactionStatus.failed,
@@ -3150,14 +3095,14 @@ export class TransactionController extends BaseController<
     ].includes(status);
   }
 
-  private async requestApproval(
+  async #requestApproval(
     txMeta: TransactionMeta,
     {
       shouldShowRequest,
       traceContext,
     }: { shouldShowRequest: boolean; traceContext?: TraceContext },
   ): Promise<AddResult> {
-    const id = this.getApprovalId(txMeta);
+    const id = this.#getApprovalId(txMeta);
     const { origin } = txMeta;
     const type = ApprovalType.Transaction;
     const requestData = { txId: txMeta.id };
@@ -3181,18 +3126,18 @@ export class TransactionController extends BaseController<
     )) as Promise<AddResult>;
   }
 
-  private getTransaction(
+  #getTransaction(
     transactionId: string,
   ): Readonly<TransactionMeta> | undefined {
     const { transactions } = this.state;
     return transactions.find(({ id }) => id === transactionId);
   }
 
-  private getTransactionOrThrow(
+  #getTransactionOrThrow(
     transactionId: string,
     errorMessagePrefix = 'TransactionController',
   ): Readonly<TransactionMeta> {
-    const txMeta = this.getTransaction(transactionId);
+    const txMeta = this.#getTransaction(transactionId);
     if (!txMeta) {
       throw new Error(
         `${errorMessagePrefix}: No transaction found with id ${transactionId}`,
@@ -3201,21 +3146,21 @@ export class TransactionController extends BaseController<
     return txMeta;
   }
 
-  private getApprovalId(txMeta: TransactionMeta) {
+  #getApprovalId(txMeta: TransactionMeta) {
     return String(txMeta.id);
   }
 
-  private isTransactionCompleted(transactionId: string): {
+  #isTransactionCompleted(transactionId: string): {
     meta?: TransactionMeta;
     isCompleted: boolean;
   } {
-    const transaction = this.getTransaction(transactionId);
+    const transaction = this.#getTransaction(transactionId);
 
     if (!transaction) {
       return { meta: undefined, isCompleted: false };
     }
 
-    const isCompleted = this.isLocalFinalState(transaction.status);
+    const isCompleted = this.#isLocalFinalState(transaction.status);
 
     return { meta: transaction, isCompleted };
   }
@@ -3264,7 +3209,7 @@ export class TransactionController extends BaseController<
     }).provider;
   }
 
-  private onIncomingTransactions(transactions: TransactionMeta[]) {
+  #onIncomingTransactions(transactions: TransactionMeta[]) {
     if (!transactions.length) {
       return;
     }
@@ -3282,7 +3227,7 @@ export class TransactionController extends BaseController<
     this.update((state) => {
       const { transactions: currentTransactions } = state;
 
-      state.transactions = this.trimTransactionsForState([
+      state.transactions = this.#trimTransactionsForState([
         ...finalTransactions,
         ...currentTransactions,
       ]);
@@ -3300,7 +3245,7 @@ export class TransactionController extends BaseController<
     );
   }
 
-  private generateDappSuggestedGasFees(
+  #generateDappSuggestedGasFees(
     txParams: TransactionParams,
     origin?: string,
   ): DappSuggestedGasFees | undefined {
@@ -3344,7 +3289,7 @@ export class TransactionController extends BaseController<
    * @param transactionMeta - Nominated external transaction to be added to state.
    * @returns The new transaction.
    */
-  private addExternalTransaction(transactionMeta: TransactionMeta) {
+  #addExternalTransaction(transactionMeta: TransactionMeta) {
     const { chainId } = transactionMeta;
     const { transactions } = this.state;
     const fromAddress = transactionMeta?.txParams?.from;
@@ -3368,12 +3313,12 @@ export class TransactionController extends BaseController<
 
     // Make sure provided external transaction has non empty history array
     const newTransactionMeta =
-      (transactionMeta.history ?? []).length === 0 && !this.isHistoryDisabled
+      (transactionMeta.history ?? []).length === 0 && !this.#isHistoryDisabled
         ? addInitialHistorySnapshot(transactionMeta)
         : transactionMeta;
 
     this.update((state) => {
-      state.transactions = this.trimTransactionsForState([
+      state.transactions = this.#trimTransactionsForState([
         ...state.transactions,
         newTransactionMeta,
       ]);
@@ -3389,7 +3334,7 @@ export class TransactionController extends BaseController<
    * @param transactionId - Used to identify original transaction.
    */
   #markNonceDuplicatesDropped(transactionId: string) {
-    const transactionMeta = this.getTransaction(transactionId);
+    const transactionMeta = this.#getTransaction(transactionId);
     if (!transactionMeta) {
       return;
     }
@@ -3428,7 +3373,7 @@ export class TransactionController extends BaseController<
         sameNonceTransactionIds.includes(transaction.id) &&
         transaction.status !== TransactionStatus.failed
       ) {
-        this.setTransactionStatusDropped(transaction);
+        this.#setTransactionStatusDropped(transaction);
       }
     }
   }
@@ -3438,7 +3383,7 @@ export class TransactionController extends BaseController<
    *
    * @param transactionMeta - TransactionMeta of transaction to be marked as dropped.
    */
-  private setTransactionStatusDropped(transactionMeta: TransactionMeta) {
+  #setTransactionStatusDropped(transactionMeta: TransactionMeta) {
     const updatedTransactionMeta = {
       ...transactionMeta,
       status: TransactionStatus.dropped as const,
@@ -3450,7 +3395,7 @@ export class TransactionController extends BaseController<
       updatedTransactionMeta,
       'TransactionController#setTransactionStatusDropped - Transaction dropped',
     );
-    this.onTransactionStatusChange(updatedTransactionMeta);
+    this.#onTransactionStatusChange(updatedTransactionMeta);
   }
 
   /**
@@ -3459,13 +3404,13 @@ export class TransactionController extends BaseController<
    * @param actionId - Unique ID to prevent duplicate requests
    * @returns the filtered transaction
    */
-  private getTransactionWithActionId(actionId?: string) {
+  #getTransactionWithActionId(actionId?: string) {
     return this.state.transactions.find(
       (transaction) => actionId && transaction.actionId === actionId,
     );
   }
 
-  private async waitForTransactionFinished(
+  async #waitForTransactionFinished(
     transactionId: string,
   ): Promise<TransactionMeta> {
     return new Promise((resolve) => {
@@ -3483,7 +3428,7 @@ export class TransactionController extends BaseController<
    * @param signedTx - The encompassing type for all transaction types containing r, s, and v values.
    * @returns The updated TransactionMeta object.
    */
-  private updateTransactionMetaRSV(
+  #updateTransactionMetaRSV(
     transactionMeta: TransactionMeta,
     signedTx: TypedTransaction,
   ): TransactionMeta {
@@ -3502,12 +3447,12 @@ export class TransactionController extends BaseController<
     return transactionMetaWithRsv;
   }
 
-  private async getEIP1559Compatibility(networkClientId?: NetworkClientId) {
+  async #getEIP1559Compatibility(networkClientId?: NetworkClientId) {
     const currentNetworkIsEIP1559Compatible =
-      await this.getCurrentNetworkEIP1559Compatibility(networkClientId);
+      await this.#getCurrentNetworkEIP1559Compatibility(networkClientId);
 
     const currentAccountIsEIP1559Compatible =
-      await this.getCurrentAccountEIP1559Compatibility();
+      await this.#getCurrentAccountEIP1559Compatibility();
 
     return (
       currentNetworkIsEIP1559Compatible && currentAccountIsEIP1559Compatible
@@ -3540,21 +3485,21 @@ export class TransactionController extends BaseController<
       finalTxParams,
     );
 
-    this.approvingTransactionIds.add(transactionMeta.id);
+    this.#approvingTransactionIds.add(transactionMeta.id);
 
     const signedTx = await new Promise<TypedTransaction>((resolve, reject) => {
-      this.sign?.(
+      this.#sign?.(
         unsignedEthTx,
         from,
-        ...this.getAdditionalSignArguments(transactionMeta),
+        ...this.#getAdditionalSignArguments(transactionMeta),
       ).then(resolve, reject);
 
-      this.signAbortCallbacks.set(transactionMeta.id, () =>
+      this.#signAbortCallbacks.set(transactionMeta.id, () =>
         reject(new Error('Signing aborted by user')),
       );
     });
 
-    this.signAbortCallbacks.delete(transactionMeta.id);
+    this.#signAbortCallbacks.delete(transactionMeta.id);
 
     if (!signedTx) {
       log('Skipping signed status as no signed transaction');
@@ -3562,7 +3507,7 @@ export class TransactionController extends BaseController<
     }
 
     const transactionMetaFromHook = cloneDeep(transactionMeta);
-    if (!this.afterSign(transactionMetaFromHook, signedTx)) {
+    if (!this.#afterSign(transactionMetaFromHook, signedTx)) {
       this.updateTransaction(
         transactionMetaFromHook,
         'TransactionController#signTransaction - Update after sign',
@@ -3574,7 +3519,7 @@ export class TransactionController extends BaseController<
     }
 
     const transactionMetaWithRsv = {
-      ...this.updateTransactionMetaRSV(transactionMetaFromHook, signedTx),
+      ...this.#updateTransactionMetaRSV(transactionMetaFromHook, signedTx),
       status: TransactionStatus.signed as const,
       txParams: finalTxParams,
     };
@@ -3584,7 +3529,7 @@ export class TransactionController extends BaseController<
       'TransactionController#approveTransaction - Transaction signed',
     );
 
-    this.onTransactionStatusChange(transactionMetaWithRsv);
+    this.#onTransactionStatusChange(transactionMetaWithRsv);
 
     const rawTx = serializeTransaction(signedTx);
 
@@ -3600,13 +3545,13 @@ export class TransactionController extends BaseController<
     return rawTx;
   }
 
-  private onTransactionStatusChange(transactionMeta: TransactionMeta) {
+  #onTransactionStatusChange(transactionMeta: TransactionMeta) {
     this.messagingSystem.publish(`${controllerName}:transactionStatusUpdated`, {
       transactionMeta,
     });
   }
 
-  private getNonceTrackerTransactions(
+  #getNonceTrackerTransactions(
     statuses: TransactionStatus[],
     address: string,
     chainId: string,
@@ -3629,16 +3574,16 @@ export class TransactionController extends BaseController<
       transactionMeta,
     );
 
-    this.onTransactionStatusChange(transactionMeta);
+    this.#onTransactionStatusChange(transactionMeta);
 
     // Intentional given potential duration of process.
-    this.updatePostBalance(transactionMeta).catch((error) => {
+    this.#updatePostBalance(transactionMeta).catch((error) => {
       log('Error while updating post balance', error);
       throw error;
     });
   }
 
-  private async updatePostBalance(transactionMeta: TransactionMeta) {
+  async #updatePostBalance(transactionMeta: TransactionMeta) {
     try {
       const { networkClientId, type } = transactionMeta;
 
@@ -3651,7 +3596,7 @@ export class TransactionController extends BaseController<
       const { updatedTransactionMeta, approvalTransactionMeta } =
         await updatePostTransactionBalance(transactionMeta, {
           ethQuery,
-          getTransaction: this.getTransaction.bind(this),
+          getTransaction: this.#getTransaction.bind(this),
           updateTransaction: this.updateTransaction.bind(this),
         });
 
@@ -3687,7 +3632,7 @@ export class TransactionController extends BaseController<
         this,
         chainId,
       ),
-      getConfirmedTransactions: this.getNonceTrackerTransactions.bind(
+      getConfirmedTransactions: this.#getNonceTrackerTransactions.bind(
         this,
         [TransactionStatus.confirmed],
         chainId,
@@ -3721,12 +3666,12 @@ export class TransactionController extends BaseController<
         }),
       messenger: this.messagingSystem,
       publishTransaction: (_ethQuery, transactionMeta) =>
-        this.publishTransaction(_ethQuery, transactionMeta, {
+        this.#publishTransaction(_ethQuery, transactionMeta, {
           skipSubmitHistory: true,
         }),
       hooks: {
         beforeCheckPendingTransaction:
-          this.beforeCheckPendingTransaction.bind(this),
+          this.#beforeCheckPendingTransaction.bind(this),
       },
     });
 
@@ -3748,7 +3693,7 @@ export class TransactionController extends BaseController<
   ) {
     incomingTransactionHelper.hub.on(
       'transactions',
-      this.onIncomingTransactions.bind(this),
+      this.#onIncomingTransactions.bind(this),
     );
   }
 
@@ -3771,12 +3716,12 @@ export class TransactionController extends BaseController<
 
     pendingTransactionTracker.hub.on(
       'transaction-dropped',
-      this.setTransactionStatusDropped.bind(this),
+      this.#setTransactionStatusDropped.bind(this),
     );
 
     pendingTransactionTracker.hub.on(
       'transaction-failed',
-      this.failTransaction.bind(this),
+      this.#failTransaction.bind(this),
     );
 
     pendingTransactionTracker.hub.on(
@@ -3786,7 +3731,7 @@ export class TransactionController extends BaseController<
   }
 
   #getNonceTrackerPendingTransactions(chainId: string, address: string) {
-    const standardPendingTransactions = this.getNonceTrackerTransactions(
+    const standardPendingTransactions = this.#getNonceTrackerTransactions(
       [
         TransactionStatus.approved,
         TransactionStatus.signed,
@@ -3796,21 +3741,21 @@ export class TransactionController extends BaseController<
       chainId,
     );
 
-    const externalPendingTransactions = this.getExternalPendingTransactions(
+    const externalPendingTransactions = this.#getExternalPendingTransactions(
       address,
       chainId,
     );
     return [...standardPendingTransactions, ...externalPendingTransactions];
   }
 
-  private async publishTransactionForRetry(
+  async #publishTransactionForRetry(
     ethQuery: EthQuery,
     transactionMeta: TransactionMeta,
   ): Promise<string> {
     try {
-      return await this.publishTransaction(ethQuery, transactionMeta);
+      return await this.#publishTransaction(ethQuery, transactionMeta);
     } catch (error: unknown) {
-      if (this.isTransactionAlreadyConfirmedError(error as Error)) {
+      if (this.#isTransactionAlreadyConfirmedError(error as Error)) {
         throw new Error('Previous transaction is already confirmed');
       }
       throw error;
@@ -3826,7 +3771,7 @@ export class TransactionController extends BaseController<
   // TODO: Replace `any` with type
   // Some networks are returning original error in the data field
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private isTransactionAlreadyConfirmedError(error: any): boolean {
+  #isTransactionAlreadyConfirmedError(error: any): boolean {
     return (
       error?.message?.includes('nonce too low') ||
       error?.data?.message?.includes('nonce too low')
@@ -3899,7 +3844,7 @@ export class TransactionController extends BaseController<
         );
       }
 
-      const shouldSkipHistory = this.isHistoryDisabled || skipHistory;
+      const shouldSkipHistory = this.#isHistoryDisabled || skipHistory;
 
       if (!shouldSkipHistory) {
         transactionMeta = updateTransactionHistory(
@@ -3910,7 +3855,7 @@ export class TransactionController extends BaseController<
       state.transactions[index] = transactionMeta;
     });
 
-    const transactionMeta = this.getTransaction(
+    const transactionMeta = this.#getTransaction(
       transactionId,
     ) as TransactionMeta;
 
@@ -3975,7 +3920,7 @@ export class TransactionController extends BaseController<
       const isFirstTimeInteraction =
         count === undefined ? undefined : count === 0;
 
-      const finalTransactionMeta = this.getTransaction(transactionId);
+      const finalTransactionMeta = this.#getTransaction(transactionId);
 
       /* istanbul ignore if */
       if (!finalTransactionMeta) {
@@ -4076,7 +4021,7 @@ export class TransactionController extends BaseController<
       }
     }
 
-    const finalTransactionMeta = this.getTransaction(transactionId);
+    const finalTransactionMeta = this.#getTransaction(transactionId);
 
     /* istanbul ignore if */
     if (!finalTransactionMeta) {
@@ -4122,7 +4067,7 @@ export class TransactionController extends BaseController<
           txMeta,
           gasFeeEstimates,
           gasFeeEstimatesLoaded,
-          isTxParamsGasFeeUpdatesEnabled: this.isTxParamsGasFeeUpdatesEnabled,
+          isTxParamsGasFeeUpdatesEnabled: this.#isAutomaticGasFeeUpdateEnabled,
           layer1GasFee,
         });
       },
@@ -4145,7 +4090,7 @@ export class TransactionController extends BaseController<
     const { chainId, networkClientId, origin, rawTx, txParams } =
       transactionMeta;
 
-    const { networkConfigurationsByChainId } = this.getNetworkState();
+    const { networkConfigurationsByChainId } = this.#getNetworkState();
     const networkConfiguration = networkConfigurationsByChainId[chainId as Hex];
 
     const endpoint = networkConfiguration?.rpcEndpoints.find(
@@ -4211,7 +4156,7 @@ export class TransactionController extends BaseController<
         ({ id }) => id !== transactionId,
       );
 
-      state.transactions = this.trimTransactionsForState(transactions);
+      state.transactions = this.#trimTransactionsForState(transactions);
     });
   }
 
@@ -4237,5 +4182,58 @@ export class TransactionController extends BaseController<
     }
 
     throw error;
+  }
+
+  #failTransaction(
+    transactionMeta: TransactionMeta,
+    error: Error,
+    actionId?: string,
+  ) {
+    let newTransactionMeta: TransactionMeta;
+
+    try {
+      newTransactionMeta = this.#updateTransactionInternal(
+        {
+          transactionId: transactionMeta.id,
+          note: 'TransactionController#failTransaction - Add error message and set status to failed',
+          skipValidation: true,
+        },
+        (draftTransactionMeta) => {
+          draftTransactionMeta.status = TransactionStatus.failed;
+
+          (
+            draftTransactionMeta as TransactionMeta & {
+              status: TransactionStatus.failed;
+            }
+          ).error = normalizeTxError(error);
+        },
+      );
+    } catch (err: unknown) {
+      log('Failed to mark transaction as failed', err);
+
+      newTransactionMeta = {
+        ...transactionMeta,
+        status: TransactionStatus.failed,
+        error: normalizeTxError(error),
+      };
+    }
+
+    this.messagingSystem.publish(`${controllerName}:transactionFailed`, {
+      actionId,
+      error: error.message,
+      transactionMeta: newTransactionMeta,
+    });
+
+    this.#onTransactionStatusChange(newTransactionMeta);
+
+    this.messagingSystem.publish(
+      `${controllerName}:transactionFinished`,
+      newTransactionMeta,
+    );
+
+    this.#internalEvents.emit(
+      `${transactionMeta.id}:finished`,
+      newTransactionMeta,
+    );
   }
 }


### PR DESCRIPTION
## Explanation

Remove `private` syntax in favour of `#`, plus sort all property definitions and assignments.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
