### PR TITLE
feat: generate EIP-7702 gas fee tokens

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `isEIP7702GasFeeTokensEnabled` constructor callback ([#5706](https://github.com/MetaMask/core/pull/5706))
+
 ## [54.4.0]
 
 ### Changed
@@ -18,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add optional `isEIP7702GasFeeTokensEnabled` constructor callback ([#5706](https://github.com/MetaMask/core/pull/5706))
 - Add optional `gasTransfer` property to `GasFeeToken` ([#5681](https://github.com/MetaMask/core/pull/5681))
 
 ### Changed

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add optional `isEIP7702GasFeeTokensEnabled` constructor callback ([#5706](https://github.com/MetaMask/core/pull/5706))
 - Add optional `gasTransfer` property to `GasFeeToken` ([#5681](https://github.com/MetaMask/core/pull/5681))
 
 ### Changed

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2371,6 +2371,48 @@ describe('TransactionController', () => {
           expect.any(Object),
         );
       });
+
+      it('with authorization list if in transaction params', async () => {
+        getSimulationDataMock.mockResolvedValueOnce(
+          SIMULATION_DATA_RESULT_MOCK,
+        );
+
+        const { controller } = setupController();
+
+        await controller.addTransaction(
+          {
+            authorizationList: [
+              {
+                address: ACCOUNT_2_MOCK,
+                chainId: CHAIN_ID_MOCK,
+                nonce: toHex(NONCE_MOCK),
+                r: '0x1',
+                s: '0x2',
+                yParity: '0x1',
+              },
+            ],
+            from: ACCOUNT_MOCK,
+            to: ACCOUNT_MOCK,
+          },
+          {
+            networkClientId: NETWORK_CLIENT_ID_MOCK,
+          },
+        );
+
+        await flushPromises();
+
+        expect(getSimulationDataMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authorizationList: [
+              {
+                address: ACCOUNT_2_MOCK,
+                from: ACCOUNT_MOCK,
+              },
+            ],
+          }),
+          expect.any(Object),
+        );
+      });
     });
 
     describe('updates gas fee tokens', () => {

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2197,6 +2197,8 @@ describe('TransactionController', () => {
           },
           {
             blockTime: undefined,
+            senderCode: undefined,
+            use7702Fees: false,
           },
         );
 
@@ -2277,9 +2279,12 @@ describe('TransactionController', () => {
 
         await flushPromises();
 
-        expect(getSimulationDataMock).toHaveBeenCalledWith(expect.any(Object), {
-          senderCode: DELEGATION_PREFIX + ACCOUNT_2_MOCK.slice(2),
-        });
+        expect(getSimulationDataMock).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.objectContaining({
+            senderCode: DELEGATION_PREFIX + ACCOUNT_2_MOCK.slice(2),
+          }),
+        );
       });
     });
 
@@ -6857,6 +6862,8 @@ describe('TransactionController', () => {
         },
         {
           blockTime: 123,
+          senderCode: undefined,
+          use7702Fees: false,
         },
       );
     });
@@ -6896,6 +6903,8 @@ describe('TransactionController', () => {
         },
         {
           blockTime: 123,
+          senderCode: undefined,
+          use7702Fees: false,
         },
       );
     });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -352,7 +352,7 @@ export type TransactionControllerOptions = {
 
   /** Whether simulation should return EIP-7702 gas fee tokens. */
   isEIP7702GasFeeTokensEnabled?: (
-    transactionMeta?: TransactionMeta,
+    transactionMeta: TransactionMeta,
   ) => Promise<boolean>;
 
   /** Whether the first time interaction check is enabled. */

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -4241,8 +4241,16 @@ export class TransactionController extends BaseController<
     transactionMeta: TransactionMeta;
   }) {
     const { chainId, delegationAddress, txParams } = transactionMeta;
-    const { data, from, to, value } = txParams;
-    const authorizationAddress = txParams?.authorizationList?.[0]?.address;
+
+    const {
+      authorizationList: authorizationListRequest,
+      data,
+      from,
+      to,
+      value,
+    } = txParams;
+
+    const authorizationAddress = authorizationListRequest?.[0]?.address;
 
     const senderCode =
       authorizationAddress &&
@@ -4257,9 +4265,12 @@ export class TransactionController extends BaseController<
 
     let authorizationList:
       | GetSimulationDataRequest['authorizationList']
-      | undefined;
+      | undefined = authorizationListRequest?.map((authorization) => ({
+      address: authorization.address,
+      from: from as Hex,
+    }));
 
-    if (use7702Fees && !delegationAddress) {
+    if (use7702Fees && !delegationAddress && !authorizationList) {
       authorizationList = this.#getSimulationAuthorizationList({
         chainId,
         from: from as Hex,

--- a/packages/transaction-controller/src/api/simulation-api.ts
+++ b/packages/transaction-controller/src/api/simulation-api.ts
@@ -12,6 +12,14 @@ const ENDPOINT_NETWORKS = 'networks';
 
 /** Single transaction to simulate in a simulation API request.  */
 export type SimulationRequestTransaction = {
+  authorizationList?: {
+    /** Address of a smart contract that contains the code to be set. */
+    address: Hex;
+
+    /** Address of the account being upgraded. */
+    from: Hex;
+  }[];
+
   /** Data to send with the transaction. */
   data?: Hex;
 
@@ -65,11 +73,14 @@ export type SimulationRequest = {
    * Whether to include available token fees.
    */
   suggestFees?: {
-    /* Whether to include the native transfer if available. */
-    withTransfer?: boolean;
+    /* Whether to estimate gas for the transaction being submitted via a delegation. */
+    with7702?: boolean;
 
     /* Whether to include the gas fee of the token transfer. */
     withFeeTransfer?: boolean;
+
+    /* Whether to include the native transfer if available. */
+    withTransfer?: boolean;
   };
 
   /**

--- a/packages/transaction-controller/src/utils/batch.test.ts
+++ b/packages/transaction-controller/src/utils/batch.test.ts
@@ -1,7 +1,12 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 
-import { addTransactionBatch, isAtomicBatchSupported } from './batch';
 import {
+  ERROR_MESSAGE_NO_UPGRADE_CONTRACT,
+  addTransactionBatch,
+  isAtomicBatchSupported,
+} from './batch';
+import {
+  ERROR_MESSGE_PUBLIC_KEY,
   doesChainSupportEIP7702,
   generateEIP7702BatchTransaction,
   isAccountUpgradedToEIP7702,
@@ -371,9 +376,7 @@ describe('Batch Utils', () => {
 
       await expect(
         addTransactionBatch({ ...request, publicKeyEIP7702: undefined }),
-      ).rejects.toThrow(
-        rpcErrors.internal('EIP-7702 public key not specified'),
-      );
+      ).rejects.toThrow(rpcErrors.internal(ERROR_MESSGE_PUBLIC_KEY));
     });
 
     it('throws if account upgraded to unsupported contract', async () => {
@@ -399,7 +402,7 @@ describe('Batch Utils', () => {
       getEIP7702UpgradeContractAddressMock.mockReturnValueOnce(undefined);
 
       await expect(addTransactionBatch(request)).rejects.toThrow(
-        rpcErrors.internal('Upgrade contract address not found'),
+        rpcErrors.internal(ERROR_MESSAGE_NO_UPGRADE_CONTRACT),
       );
     });
 
@@ -1159,9 +1162,7 @@ describe('Batch Utils', () => {
           messenger: MESSENGER_MOCK,
           publicKeyEIP7702: undefined,
         }),
-      ).rejects.toThrow(
-        rpcErrors.internal('EIP-7702 public key not specified'),
-      );
+      ).rejects.toThrow(rpcErrors.internal(ERROR_MESSGE_PUBLIC_KEY));
     });
 
     it('does not throw if error getting provider', async () => {

--- a/packages/transaction-controller/src/utils/eip7702.ts
+++ b/packages/transaction-controller/src/utils/eip7702.ts
@@ -21,6 +21,7 @@ import type {
 export const DELEGATION_PREFIX = '0xef0100';
 export const BATCH_FUNCTION_NAME = 'execute';
 export const CALLS_SIGNATURE = '(address,uint256,bytes)[]';
+export const ERROR_MESSGE_PUBLIC_KEY = 'EIP-7702 public key not specified';
 
 const UNSUPPORTED_PARAMS = [
   'gas',

--- a/packages/transaction-controller/src/utils/simulation.test.ts
+++ b/packages/transaction-controller/src/utils/simulation.test.ts
@@ -49,6 +49,7 @@ const TOKEN_ID_MOCK = '0x5' as Hex;
 const OTHER_TOKEN_ID_MOCK = '0x6' as Hex;
 const ERROR_CODE_MOCK = 123;
 const ERROR_MESSAGE_MOCK = 'Test Error';
+const SENDER_CODE_MOCK = '0x1234' as Hex;
 
 // Regression test – leading zero in user address
 const USER_ADDRESS_WITH_LEADING_ZERO =
@@ -263,6 +264,34 @@ describe('Simulation Utils', () => {
   });
 
   describe('getSimulationData', () => {
+    it('includes code override in request if senderCode provided', async () => {
+      await getSimulationData(REQUEST_MOCK, { senderCode: SENDER_CODE_MOCK });
+
+      expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          overrides: {
+            [REQUEST_MOCK.from]: {
+              code: SENDER_CODE_MOCK,
+            },
+          },
+        }),
+      );
+    });
+
+    it('includes with7702 in request if use7702Fees set', async () => {
+      await getSimulationData(REQUEST_MOCK, { use7702Fees: true });
+
+      expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          suggestFees: expect.objectContaining({
+            with7702: true,
+          }),
+        }),
+      );
+    });
+
     describe('returns native balance change', () => {
       it.each([
         ['increased', BALANCE_1_MOCK, BALANCE_2_MOCK, false],

--- a/packages/transaction-controller/src/utils/simulation.ts
+++ b/packages/transaction-controller/src/utils/simulation.ts
@@ -11,6 +11,7 @@ import type {
   SimulationResponse,
   SimulationResponseCallTrace,
   SimulationResponseTransaction,
+  SimulationRequest,
 } from '../api/simulation-api';
 import {
   ABI_SIMULATION_ERC20_WRAPPED,
@@ -42,6 +43,7 @@ export enum SupportedToken {
 type ABI = Fragment[];
 
 export type GetSimulationDataRequest = {
+  authorizationList?: SimulationRequestTransaction['authorizationList'];
   chainId: Hex;
   data?: Hex;
   from: Hex;
@@ -65,6 +67,7 @@ type ParsedEvent = {
 type GetSimulationDataOptions = {
   blockTime?: number;
   senderCode?: Hex;
+  use7702Fees?: boolean;
 };
 
 const log = createModuleLogger(projectLogger, 'simulation');
@@ -122,12 +125,24 @@ export async function getSimulationData(
   options: GetSimulationDataOptions = {},
 ): Promise<GetSimulationDataResult> {
   const { chainId, from, to, value, data } = request;
-  const { blockTime, senderCode } = options;
+  const { use7702Fees } = options;
 
-  log('Getting simulation data', request);
+  log('Getting simulation data', { request, options });
 
   try {
-    const response = await simulateTransactions(chainId, {
+    const response = await baseRequest({
+      chainId,
+      from,
+      options,
+      params: {
+        suggestFees: {
+          withFeeTransfer: true,
+          withTransfer: true,
+          ...(use7702Fees ? { with7702: true } : {}),
+        },
+        withCallTrace: true,
+        withLogs: true,
+      },
       transactions: [
         {
           data,
@@ -136,24 +151,6 @@ export async function getSimulationData(
           value,
         },
       ],
-      suggestFees: {
-        withTransfer: true,
-        withFeeTransfer: true,
-      },
-      withCallTrace: true,
-      withLogs: true,
-      ...(blockTime && {
-        blockOverrides: {
-          time: toHex(blockTime),
-        },
-      }),
-      ...(senderCode && {
-        overrides: {
-          [from]: {
-            code: senderCode,
-          },
-        },
-      }),
     });
 
     const transactionError = response.transactions?.[0]?.error;
@@ -356,8 +353,7 @@ async function getTokenBalanceChanges(
   events: ParsedEvent[],
   options: GetSimulationDataOptions,
 ): Promise<SimulationTokenBalanceChange[]> {
-  const { from } = request;
-  const { blockTime, senderCode } = options;
+  const { chainId, from } = request;
   const balanceTxs = getTokenBalanceTransactions(request, events);
 
   log('Generated balance transactions', [...balanceTxs.after.values()]);
@@ -372,20 +368,11 @@ async function getTokenBalanceChanges(
     return [];
   }
 
-  const response = await simulateTransactions(request.chainId as Hex, {
+  const response = await baseRequest({
+    chainId,
+    from,
+    options,
     transactions,
-    ...(blockTime && {
-      blockOverrides: {
-        time: toHex(blockTime),
-      },
-    }),
-    ...(senderCode && {
-      overrides: {
-        [from]: {
-          code: senderCode,
-        },
-      },
-    }),
   });
 
   log('Balance simulation response', response);
@@ -752,4 +739,51 @@ function getGasFeeTokens(response: SimulationResponse): GasFeeToken[] {
     symbol: tokenFee.token.symbol,
     tokenAddress: tokenFee.token.address,
   }));
+}
+
+/**
+ * Base request to simulation API.
+ *
+ * @param request - The request object.
+ * @param request.chainId - Chain ID of the transaction.
+ * @param request.from - Address of the sender.
+ * @param request.options - Options for the simulation.
+ * @param request.params - Additional parameters for the request.
+ * @param request.transactions - Transactions to simulate.
+ * @returns The simulation response.
+ */
+async function baseRequest({
+  chainId,
+  from,
+  options,
+  params,
+  transactions,
+}: {
+  chainId: Hex;
+  from: Hex;
+  options: GetSimulationDataOptions;
+  params?: Partial<SimulationRequest>;
+  transactions: SimulationRequestTransaction[];
+}): Promise<SimulationResponse> {
+  const { blockTime, senderCode } = options;
+
+  return await simulateTransactions(chainId as Hex, {
+    transactions,
+    ...params,
+    ...(blockTime && {
+      blockOverrides: {
+        ...params?.blockOverrides,
+        time: toHex(blockTime),
+      },
+    }),
+    ...(senderCode && {
+      overrides: {
+        ...params?.overrides,
+        [from]: {
+          ...params?.overrides?.[from],
+          code: senderCode,
+        },
+      },
+    }),
+  });
 }

--- a/packages/transaction-controller/src/utils/simulation.ts
+++ b/packages/transaction-controller/src/utils/simulation.ts
@@ -124,7 +124,7 @@ export async function getSimulationData(
   request: GetSimulationDataRequest,
   options: GetSimulationDataOptions = {},
 ): Promise<GetSimulationDataResult> {
-  const { chainId, from, to, value, data } = request;
+  const { authorizationList, chainId, from, to, value, data } = request;
   const { use7702Fees } = options;
 
   log('Getting simulation data', { request, options });
@@ -145,6 +145,7 @@ export async function getSimulationData(
       },
       transactions: [
         {
+          authorizationList,
           data,
           from,
           to,


### PR DESCRIPTION
## Explanation

Include `authorizationList` and `with7702` properties in simulation request to return EIP-7702 gas fee tokens, and include upgrade gas.

Add optional `isEIP7702GasFeeTokensEnabled` property to constructor.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
