### PR TITLE
fix: ensure no duplicate accounts are persisted

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -229,7 +229,7 @@
     "jest/no-conditional-in-test": 8
   },
   "packages/keyring-controller/src/KeyringController.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 5,
+    "@typescript-eslint/no-unsafe-enum-comparison": 4,
     "@typescript-eslint/no-unused-vars": 1
   },
   "packages/keyring-controller/tests/mocks/mockKeyring.ts": {

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Ensure no duplicate accounts are peristed ([#5710](https://github.com/MetaMask/core/pull/5710))
+- Ensure no duplicate accounts are persisted ([#5710](https://github.com/MetaMask/core/pull/5710))
 
 ## [21.0.3]
 

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure no duplicate accounts are peristed ([#5710](https://github.com/MetaMask/core/pull/5710))
+
 ## [21.0.3]
 
 ### Changed

--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 93.85,
+      branches: 93.67,
       functions: 100,
-      lines: 98.93,
-      statements: 98.94,
+      lines: 98.92,
+      statements: 98.93,
     },
   },
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -260,6 +260,21 @@ describe('KeyringController', () => {
         );
       });
     });
+
+    it('should throw error if the account is duplicated', async () => {
+      jest
+        .spyOn(HdKeyring.prototype, 'addAccounts')
+        .mockResolvedValue(['0x123']);
+      jest.spyOn(HdKeyring.prototype, 'getAccounts').mockReturnValue(['0x123']);
+      await withController(async ({ controller }) => {
+        jest
+          .spyOn(HdKeyring.prototype, 'getAccounts')
+          .mockReturnValue(['0x123', '0x123']);
+        await expect(controller.addNewAccount()).rejects.toThrow(
+          KeyringControllerError.DuplicatedAccount,
+        );
+      });
+    });
   });
 
   describe('addNewAccountForKeyring', () => {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Current checks for duplicate accounts only work for imported private keys, and only enforced when creating and restoring keyrings. That is, we don't have proper checks in place to avoid duplicates, and the few checks we have are locking out users instead of ensuring no duplicate is persisted in the vault altogether.

More info on the issue referenced below.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Fixes https://github.com/MetaMask/core/issues/5411

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
