### PR TITLE
feat: add `Monad Testnet` to `network-controller` and `controller-utils` 

### DIFF
--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -50,6 +50,7 @@ export const TESTNET_TICKER_SYMBOLS = {
   LINEA_GOERLI: 'LineaETH',
   LINEA_SEPOLIA: 'LineaETH',
   MEGAETH_TESTNET: 'MegaETH',
+  MONAD_TESTNET: 'MON',
 };
 
 /**
@@ -57,6 +58,7 @@ export const TESTNET_TICKER_SYMBOLS = {
  */
 export const BUILT_IN_CUSTOM_NETWORKS_RPC = {
   MEGAETH_TESTNET: 'https://carrot.megaeth.com/rpc',
+  MONAD_TESTNET: 'https://testnet-rpc.monad.xyz',
 };
 
 /**
@@ -110,6 +112,13 @@ export const BUILT_IN_NETWORKS = {
     ticker: NetworksTicker['megaeth-testnet'],
     rpcPrefs: {
       blockExplorerUrl: BlockExplorerUrl['megaeth-testnet'],
+    },
+  },
+  [NetworkType['monad-testnet']]: {
+    chainId: ChainId['monad-testnet'],
+    ticker: NetworksTicker['monad-testnet'],
+    rpcPrefs: {
+      blockExplorerUrl: BlockExplorerUrl['monad-testnet'],
     },
   },
   [NetworkType.rpc]: {

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -18,6 +18,7 @@ export type InfuraNetworkType =
  */
 export const CustomNetworkType = {
   'megaeth-testnet': 'megaeth-testnet',
+  'monad-testnet': 'monad-testnet',
 } as const;
 export type CustomNetworkType =
   (typeof CustomNetworkType)[keyof typeof CustomNetworkType];
@@ -76,6 +77,7 @@ export enum BuiltInNetworkName {
   LineaMainnet = 'linea-mainnet',
   Aurora = 'aurora',
   MegaETHTestnet = 'megaeth-testnet',
+  MonadTestnet = 'monad-testnet',
 }
 
 /**
@@ -92,6 +94,7 @@ export const ChainId = {
   [BuiltInNetworkName.LineaSepolia]: '0xe705', // toHex(59141)
   [BuiltInNetworkName.LineaMainnet]: '0xe708', // toHex(59144)
   [BuiltInNetworkName.MegaETHTestnet]: '0x18c6', // toHex(6342)
+  [BuiltInNetworkName.MonadTestnet]: '0x279f', // toHex(10143)
 } as const;
 export type ChainId = (typeof ChainId)[keyof typeof ChainId];
 
@@ -109,6 +112,7 @@ export enum NetworksTicker {
   'linea-sepolia' = 'LineaETH',
   'linea-mainnet' = 'ETH',
   'megaeth-testnet' = 'MegaETH',
+  'monad-testnet' = 'MON',
   // TODO: Either fix this lint violation or explain why it's necessary to ignore.
   // eslint-disable-next-line @typescript-eslint/naming-convention
   rpc = '',
@@ -122,6 +126,7 @@ export const BlockExplorerUrl = {
   [BuiltInNetworkName.LineaSepolia]: 'https://sepolia.lineascan.build',
   [BuiltInNetworkName.LineaMainnet]: 'https://lineascan.build',
   [BuiltInNetworkName.MegaETHTestnet]: 'https://megaexplorer.xyz',
+  [BuiltInNetworkName.MonadTestnet]: 'https://testnet.monadexplorer.com',
 } as const satisfies Record<BuiltInNetworkType, string>;
 export type BlockExplorerUrl =
   (typeof BlockExplorerUrl)[keyof typeof BlockExplorerUrl];
@@ -134,6 +139,7 @@ export const NetworkNickname = {
   [BuiltInNetworkName.LineaSepolia]: 'Linea Sepolia',
   [BuiltInNetworkName.LineaMainnet]: 'Linea',
   [BuiltInNetworkName.MegaETHTestnet]: 'Mega Testnet',
+  [BuiltInNetworkName.MonadTestnet]: 'Monad Testnet',
 } as const satisfies Record<BuiltInNetworkType, string>;
 export type NetworkNickname =
   (typeof NetworkNickname)[keyof typeof NetworkNickname];

--- a/packages/network-controller/src/types.ts
+++ b/packages/network-controller/src/types.ts
@@ -1,4 +1,5 @@
-import type { ChainId, InfuraNetworkType } from '@metamask/controller-utils';
+import { ChainId } from '@metamask/controller-utils';
+import type { InfuraNetworkType } from '@metamask/controller-utils';
 import type { BlockTracker as BaseBlockTracker } from '@metamask/eth-block-tracker';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { Hex } from '@metamask/utils';
@@ -57,4 +58,4 @@ export type NetworkClientConfiguration =
 /**
  * The Chain ID representing the additional networks to be included as default.
  */
-export type AdditionalDefaultNetwork = (typeof ChainId)['megaeth-testnet'];
+export type AdditionalDefaultNetwork = typeof ChainId['megaeth-testnet'] | typeof ChainId['monad-testnet'];


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->


We are adding Monad Testnet as default network on `Network Controller` default state - `networkConfigurationsByChainId` with the constants and type from the latest `controller-utils`

### Changes:

- Refactor `Network Controller` methods`getDefaultCustomNetworkConfigurationsByChainId` to build the configuration from `CustomNetworkType` instead of hardcode network 1 by 1

- Add `Monad Testnet` info into `controller-utils`
- 
## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
