### PR TITLE
fix: do not throw error when encryption upgrade fails during login

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/base-controller` from ^8.0.0 to ^8.0.1 ([#5722](https://github.com/MetaMask/core/pull/5722))
 
+### Fixed
+
+- The vault encryption upgrade fails grecefully during login ([#5740](https://github.com/MetaMask/core/pull/5740))
+
 ## [21.0.4]
 
 ### Fixed

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The vault encryption upgrade fails grecefully during login ([#5740](https://github.com/MetaMask/core/pull/5740))
+- The vault encryption upgrade fails gracefully during login ([#5740](https://github.com/MetaMask/core/pull/5740))
 
 ## [21.0.4]
 

--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,7 +17,7 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 93.67,
+      branches: 93.64,
       functions: 100,
       lines: 98.92,
       statements: 98.93,

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2681,8 +2681,8 @@ describe('KeyringController', () => {
               },
               async ({ controller, encryptor }) => {
                 jest.spyOn(encryptor, 'isVaultUpdated').mockReturnValue(false);
-                const encryptSpy = jest.spyOn(encryptor, 'encrypt');
-                jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
+                const encryptSpy = jest.spyOn(encryptor, 'encryptWithDetail');
+                jest.spyOn(encryptor, 'decryptWithKey').mockResolvedValueOnce([
                   {
                     type: KeyringTypes.hd,
                     data: {

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2671,6 +2671,41 @@ describe('KeyringController', () => {
           );
         });
 
+        it('should unlock the wallet if the state has a duplicate account and the encryption parameters are outdated', async () => {
+          stubKeyringClassWithAccount(MockKeyring, '0x123');
+          // @ts-expect-error HdKeyring is not yet compatible with Keyring type.
+          stubKeyringClassWithAccount(HdKeyring, '0x123');
+          await withController(
+            {
+              skipVaultCreation: true,
+              cacheEncryptionKey,
+              state: { vault: 'my vault' },
+              keyringBuilders: [keyringBuilderFactory(MockKeyring)],
+            },
+            async ({ controller, encryptor, messenger }) => {
+              const unlockListener = jest.fn();
+              messenger.subscribe('KeyringController:unlock', unlockListener);
+              jest.spyOn(encryptor, 'isVaultUpdated').mockReturnValue(false);
+              jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
+                {
+                  type: KeyringTypes.hd,
+                  data: {},
+                },
+                {
+                  type: MockKeyring.type,
+                  data: {},
+                },
+              ]);
+
+              await controller.submitPassword(password);
+
+              expect(controller.state.keyrings).toHaveLength(2);
+              expect(controller.state.isUnlocked).toBe(true);
+              expect(unlockListener).toHaveBeenCalledTimes(1);
+            },
+          );
+        });
+
         cacheEncryptionKey &&
           it('should upgrade the vault encryption if the key encryptor has different parameters', async () => {
             await withController(
@@ -2694,42 +2729,6 @@ describe('KeyringController', () => {
                 await controller.submitPassword(password);
 
                 expect(encryptSpy).toHaveBeenCalledTimes(1);
-              },
-            );
-          });
-
-        !cacheEncryptionKey &&
-          it('should unlock the wallet if the state has a duplicate account and the encryption parameters are outdated', async () => {
-            stubKeyringClassWithAccount(MockKeyring, '0x123');
-            // @ts-expect-error HdKeyring is not yet compatible with Keyring type.
-            stubKeyringClassWithAccount(HdKeyring, '0x123');
-            await withController(
-              {
-                skipVaultCreation: true,
-                cacheEncryptionKey,
-                state: { vault: 'my vault' },
-                keyringBuilders: [keyringBuilderFactory(MockKeyring)],
-              },
-              async ({ controller, encryptor, messenger }) => {
-                const unlockListener = jest.fn();
-                messenger.subscribe('KeyringController:unlock', unlockListener);
-                jest.spyOn(encryptor, 'isVaultUpdated').mockReturnValue(false);
-                jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
-                  {
-                    type: KeyringTypes.hd,
-                    data: {},
-                  },
-                  {
-                    type: MockKeyring.type,
-                    data: {},
-                  },
-                ]);
-
-                await controller.submitPassword(password);
-
-                expect(controller.state.keyrings).toHaveLength(2);
-                expect(controller.state.isUnlocked).toBe(true);
-                expect(unlockListener).toHaveBeenCalledTimes(1);
               },
             );
           });

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2681,8 +2681,8 @@ describe('KeyringController', () => {
               },
               async ({ controller, encryptor }) => {
                 jest.spyOn(encryptor, 'isVaultUpdated').mockReturnValue(false);
-                const encryptSpy = jest.spyOn(encryptor, 'encryptWithDetail');
-                jest.spyOn(encryptor, 'decryptWithKey').mockResolvedValueOnce([
+                const encryptSpy = jest.spyOn(encryptor, 'encrypt');
+                jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
                   {
                     type: KeyringTypes.hd,
                     data: {
@@ -2694,6 +2694,42 @@ describe('KeyringController', () => {
                 await controller.submitPassword(password);
 
                 expect(encryptSpy).toHaveBeenCalledTimes(1);
+              },
+            );
+          });
+
+        !cacheEncryptionKey &&
+          it('should unlock the wallet if the state has a duplicate account and the encryption parameters are outdated', async () => {
+            stubKeyringClassWithAccount(MockKeyring, '0x123');
+            // @ts-expect-error HdKeyring is not yet compatible with Keyring type.
+            stubKeyringClassWithAccount(HdKeyring, '0x123');
+            await withController(
+              {
+                skipVaultCreation: true,
+                cacheEncryptionKey,
+                state: { vault: 'my vault' },
+                keyringBuilders: [keyringBuilderFactory(MockKeyring)],
+              },
+              async ({ controller, encryptor, messenger }) => {
+                const unlockListener = jest.fn();
+                messenger.subscribe('KeyringController:unlock', unlockListener);
+                jest.spyOn(encryptor, 'isVaultUpdated').mockReturnValue(false);
+                jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
+                  {
+                    type: KeyringTypes.hd,
+                    data: {},
+                  },
+                  {
+                    type: MockKeyring.type,
+                    data: {},
+                  },
+                ]);
+
+                await controller.submitPassword(password);
+
+                expect(controller.state.keyrings).toHaveLength(2);
+                expect(controller.state.isUnlocked).toBe(true);
+                expect(unlockListener).toHaveBeenCalledTimes(1);
               },
             );
           });

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1452,7 +1452,7 @@ export class KeyringController extends BaseController<
 
     try {
       // If there are stronger encryption params available, we
-      // can attempt to upgrade the vault encryption params.
+      // can attempt to upgrade the vault.
       await this.#withRollback(async () =>
         this.#upgradeVaultEncryptionParams(),
       );

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1445,10 +1445,22 @@ export class KeyringController extends BaseController<
    * @returns Promise resolving when the operation completes.
    */
   async submitPassword(password: string): Promise<void> {
-    return this.#withRollback(async () => {
+    await this.#withRollback(async () => {
       this.#keyrings = await this.#unlockKeyrings(password);
       this.#setUnlocked();
     });
+
+    try {
+      // If there are stronger encryption params available, we
+      // can attempt to upgrade the vault encryption params.
+      await this.#withRollback(async () =>
+        this.#upgradeVaultEncryptionParams(),
+      );
+    } catch (error) {
+      // We don't want to throw an error if the upgrade fails
+      // since the controller is already unlocked.
+      console.error('Failed to upgrade vault encryption params:', error);
+    }
   }
 
   /**
@@ -2175,7 +2187,7 @@ export class KeyringController extends BaseController<
     encryptionKey?: string,
     encryptionSalt?: string,
   ): Promise<EthKeyring[]> {
-    return this.#withVaultLock(async ({ releaseLock }) => {
+    return this.#withVaultLock(async () => {
       const encryptedVault = this.state.vault;
       if (!encryptedVault) {
         throw new Error(KeyringControllerError.VaultError);
@@ -2252,19 +2264,6 @@ export class KeyringController extends BaseController<
           state.encryptionSalt = updatedState.encryptionSalt;
         }
       });
-
-      if (
-        this.#password &&
-        (!this.#cacheEncryptionKey || !encryptionKey) &&
-        this.#encryptor.isVaultUpdated &&
-        !this.#encryptor.isVaultUpdated(encryptedVault)
-      ) {
-        // The lock needs to be released before persisting the keyrings
-        // to avoid deadlock
-        releaseLock();
-        // Re-encrypt the vault with safer method if one is available
-        await this.#updateVault();
-      }
 
       return this.#keyrings;
     });
@@ -2354,6 +2353,24 @@ export class KeyringController extends BaseController<
 
       return true;
     });
+  }
+
+  /**
+   * Upgrade the vault encryption parameters if needed.
+   *
+   * @returns A promise resolving to `void`.
+   */
+  async #upgradeVaultEncryptionParams(): Promise<void> {
+    const { vault } = this.state;
+
+    if (
+      vault &&
+      this.#password &&
+      this.#encryptor.isVaultUpdated &&
+      !this.#encryptor.isVaultUpdated(vault)
+    ) {
+      await this.#updateVault();
+    }
   }
 
   /**

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2361,6 +2361,7 @@ export class KeyringController extends BaseController<
    * @returns A promise resolving to `void`.
    */
   async #upgradeVaultEncryptionParams(): Promise<void> {
+    this.#assertControllerMutexIsLocked();
     const { vault } = this.state;
 
     if (


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
There's a mechanism in KeyringController to upgrade the vault encryption parameters during a successful login to ensure users always use the safest encryption available without needing additional actions for the vault to be upgraded.

However, when the vault encryption upgrade fails during login, we don't want to interrupt and rollback the entire operation. We can move the vault upgrade to a standalone, mutually exclusive operation that can fail gracefully.

This fix can be tested on extension with this draft PR (instructions included): https://github.com/MetaMask/metamask-extension/pull/32438

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Fixes https://github.com/MetaMask/core/issues/5745

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
