### PR TITLE
Fix `getAllNamespacesFromCaip25CaveatValue` to return only reference when value is wallet namespaced

### DIFF
--- a/packages/chain-agnostic-permission/CHANGELOG.md
+++ b/packages/chain-agnostic-permission/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fix `getAllNamespacesFromCaip25CaveatValue` to return the reference instead of full scope when passed in values are `wallet` namespaced ([#5759](https://github.com/MetaMask/core/pull/5759))
 - Bump `@metamask/network-controller` to `^23.3.0` ([#5789](https://github.com/MetaMask/core/pull/5789))
 
 ## [0.5.0]

--- a/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-permittedChains.test.ts
+++ b/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-permittedChains.test.ts
@@ -684,7 +684,7 @@ describe('CAIP-25 permittedChains adapters', () => {
       expect(result).toStrictEqual(['eip155', 'bip122', 'solana', 'wallet']);
     });
 
-    it('returns only reference for wallet namespace scopes', () => {
+    it('returns only reference for `wallet:<namespace>` type scopes', () => {
       const result = getAllNamespacesFromCaip25CaveatValue({
         requiredScopes: {
           'wallet:eip155': { accounts: [] },

--- a/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-permittedChains.test.ts
+++ b/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-permittedChains.test.ts
@@ -684,24 +684,18 @@ describe('CAIP-25 permittedChains adapters', () => {
       expect(result).toStrictEqual(['eip155', 'bip122', 'solana', 'wallet']);
     });
 
-    it('returns full scopeString for wallet namespace scopes', () => {
+    it('returns only reference for wallet namespace scopes', () => {
       const result = getAllNamespacesFromCaip25CaveatValue({
         requiredScopes: {
           'wallet:eip155': { accounts: [] },
           'wallet:bip122': { accounts: [] },
         },
-        optionalScopes: {
-          wallet: { accounts: [] },
-        },
+        optionalScopes: {},
         sessionProperties: {},
         isMultichainOrigin: false,
       });
 
-      expect(result).toStrictEqual([
-        'wallet:eip155',
-        'wallet:bip122',
-        'wallet',
-      ]);
+      expect(result).toStrictEqual(['eip155', 'bip122']);
     });
 
     it('returns an empty array when given empty scope objects', () => {

--- a/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-permittedChains.ts
+++ b/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-permittedChains.ts
@@ -220,9 +220,9 @@ export function getAllNamespacesFromCaip25CaveatValue(
   const namespaceSet = new Set<CaipNamespace>();
 
   for (const scope of allScopes) {
-    const { namespace } = parseScopeString(scope);
+    const { namespace, reference } = parseScopeString(scope);
     if (namespace === KnownCaipNamespace.Wallet) {
-      namespaceSet.add(scope);
+      namespaceSet.add(reference ?? namespace);
     } else if (namespace) {
       namespaceSet.add(namespace);
     }


### PR DESCRIPTION
## Explanation

Fixes `getAllNamespacesFromCaip25CaveatValue` to return only the reference of the passed in scope string when it is `wallet` namespaced. I.e. `wallet:eip155` should return only `eip155` and an exact value of `wallet` should still return `wallet.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
