### PR TITLE
fix(rpc-service): handle 405 and 429 status codes without triggering circuit breaker

### DIFF
--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved handling of HTTP status codes to prevent unnecessary circuit breaker triggers ([#5767](https://github.com/MetaMask/core/pull/5767))
+  - 405 (Method Not Allowed) now returns a JSON-RPC error with code -32601 (Method not found)
+  - 429 (Too Many Requests) now returns a JSON-RPC error with code -32005 (Request rate limit exceeded)
+  - Added retry delay information in 429 error responses when available via Retry-After header
+  - These status codes no longer trigger the circuit breaker, preventing unnecessary failover to backup endpoints
+
 ## [23.4.0]
 
 ### Added


### PR DESCRIPTION
## Explanation
This PR improves the handling of HTTP status codes in the RPC service by properly handling 405 (Method Not Allowed) and 429 (Too Many Requests) responses without triggering the circuit breaker. Instead of throwing errors for these status codes, we now return appropriate JSON-RPC error responses.

### Changes
- Added handling for 405 status code, returning a JSON-RPC error with code -32601 (Method not found)
- Added handling for 429 status code, returning a JSON-RPC error with code -32005 (Request rate limit exceeded)
- Included retry delay information in the 429 error response when available

### Why
Previously, these status codes would trigger the circuit breaker, which could lead to unnecessary failover to backup endpoints. These status codes represent expected error conditions that should be handled gracefully without triggering the circuit breaker.

### Testing
- [ ] Test with 405 response to verify proper error handling
- [ ] Test with 429 response to verify proper error handling and retry delay information
- [ ] Verify circuit breaker is not triggered for these status codes

## References

* Fixes https://github.com/MetaMask/core/issues/5766

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
