### PR TITLE
fix: include origin in 7702 transaction

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` to `^11.8.0` ([#5765](https://github.com/MetaMask/core/pull/5765))
 
+### Fixed
+
+- Validate correct origin in EIP-7702 transaction ([#5771](https://github.com/MetaMask/core/pull/5771))
+
 ## [55.0.0]
 
 ### Added

--- a/packages/transaction-controller/src/utils/batch.test.ts
+++ b/packages/transaction-controller/src/utils/batch.test.ts
@@ -58,6 +58,7 @@ const TRANSACTION_SIGNATURE_MOCK = '0xabc';
 const TRANSACTION_SIGNATURE_2_MOCK = '0xdef';
 const ERROR_MESSAGE_MOCK = 'Test error';
 const SECURITY_ALERT_ID_MOCK = '123-456';
+const ORIGIN_MOCK = 'test.com';
 const UPGRADE_CONTRACT_ADDRESS_MOCK =
   '0xfedfedfedfedfedfedfedfedfedfedfedfedfedf';
 
@@ -127,6 +128,7 @@ describe('Batch Utils', () => {
         request: {
           from: FROM_MOCK,
           networkClientId: NETWORK_CLIENT_ID_MOCK,
+          origin: ORIGIN_MOCK,
           requireApproval: true,
           transactions: [
             {
@@ -230,6 +232,7 @@ describe('Batch Utils', () => {
         },
         expect.objectContaining({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
+          origin: ORIGIN_MOCK,
           requireApproval: true,
         }),
       );

--- a/packages/transaction-controller/src/utils/batch.ts
+++ b/packages/transaction-controller/src/utils/batch.ts
@@ -231,10 +231,11 @@ async function addTransactionBatchWith7702(
     batchId: batchIdOverride,
     from,
     networkClientId,
+    origin,
     requireApproval,
+    securityAlertId,
     transactions,
     validateSecurity,
-    securityAlertId,
   } = userRequest;
 
   const chainId = getChainId(networkClientId);
@@ -325,10 +326,10 @@ async function addTransactionBatchWith7702(
     batchId,
     nestedTransactions,
     networkClientId,
+    origin,
     requireApproval,
     securityAlertResponse,
     type: TransactionType.batch,
-    origin,
   });
 
   // Wait for the transaction to be published.


### PR DESCRIPTION
## Explanation

Include `origin` in call to `addTransaction` from EIP-7702 batch transaction.

Wasn't causing a linting error as `origin` is default global variable.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
