### PR TITLE
fix: Fix `userLevelFee` to be `medium` instead of `dappSuggested` when `gasPrice` is suggested

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Validate correct origin in EIP-7702 transaction ([#5771](https://github.com/MetaMask/core/pull/5771))
-- Set `userLevelFee` to be `medium` instead of `dappSuggested` when gasPrice is suggested ([#5773](https://github.com/MetaMask/core/5773))
+- Set `userLevelFee` to `medium` instead of `dappSuggested` when gasPrice is suggested ([#5773](https://github.com/MetaMask/core/5773))
 
 ## [55.0.0]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Validate correct origin in EIP-7702 transaction ([#5771](https://github.com/MetaMask/core/pull/5771))
+- Set `userLevelFee` to be `medium` instead of `dappSuggested` when gasPrice is suggested ([#5773](https://github.com/MetaMask/core/5773))
 
 ## [55.0.0]
 

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -254,6 +254,17 @@ describe('gas-fees', () => {
         );
       });
 
+      it('to medium if no request maxFeePerGas or maxPriorityFeePerGas but suggested gasPrice available', async () => {
+        delete updateGasFeeRequest.txMeta.txParams.maxFeePerGas;
+        delete updateGasFeeRequest.txMeta.txParams.maxPriorityFeePerGas;
+        
+        mockGasFeeFlowMockResponse(FLOW_RESPONSE_GAS_PRICE_MOCK);
+      
+        await updateGasFees(updateGasFeeRequest);
+      
+        expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(UserFeeLevel.MEDIUM);
+      });
+
       it('to suggested medium maxFeePerGas if request gas price and request maxPriorityFeePerGas', async () => {
         updateGasFeeRequest.txMeta.txParams.gasPrice = '0x456';
         updateGasFeeRequest.txMeta.txParams.maxPriorityFeePerGas = '0x789';

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -257,12 +257,14 @@ describe('gas-fees', () => {
       it('to medium if no request maxFeePerGas or maxPriorityFeePerGas but suggested gasPrice available', async () => {
         delete updateGasFeeRequest.txMeta.txParams.maxFeePerGas;
         delete updateGasFeeRequest.txMeta.txParams.maxPriorityFeePerGas;
-        
+
         mockGasFeeFlowMockResponse(FLOW_RESPONSE_GAS_PRICE_MOCK);
-      
+
         await updateGasFees(updateGasFeeRequest);
-      
-        expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(UserFeeLevel.MEDIUM);
+
+        expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(
+          UserFeeLevel.MEDIUM,
+        );
       });
 
       it('to suggested medium maxFeePerGas if request gas price and request maxPriorityFeePerGas', async () => {

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -313,6 +313,14 @@ function getUserFeeLevel(request: GetGasFeeRequest): UserFeeLevel | undefined {
     return UserFeeLevel.MEDIUM;
   }
 
+  if (
+    !initialParams.maxFeePerGas &&
+    !initialParams.maxPriorityFeePerGas &&
+    suggestedGasFees.gasPrice
+  ) {
+    return UserFeeLevel.MEDIUM;
+  }
+
   if (txMeta.origin === ORIGIN_METAMASK) {
     return UserFeeLevel.MEDIUM;
   }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR aims to fix `userLevelFee` to be settled to `medium` instead of `dappSuggested` fallback when `gasPrice` is suggested.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [X] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
