### PR TITLE
fix: discard duplicate accounts on unlock

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -273,7 +273,6 @@
     "import-x/order": 1
   },
   "packages/multichain/src/adapters/caip-permission-adapter-eth-accounts.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 1,
     "jsdoc/tag-lines": 5
   },
   "packages/multichain/src/adapters/caip-permission-adapter-permittedChains.test.ts": {
@@ -338,7 +337,7 @@
     "jsdoc/require-returns": 1
   },
   "packages/multichain/src/scope/supported.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 6
+    "@typescript-eslint/no-unsafe-enum-comparison": 3
   },
   "packages/multichain/src/scope/validation.ts": {
     "jsdoc/tag-lines": 2

--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -273,6 +273,7 @@
     "import-x/order": 1
   },
   "packages/multichain/src/adapters/caip-permission-adapter-eth-accounts.ts": {
+    "@typescript-eslint/no-unsafe-enum-comparison": 1,
     "jsdoc/tag-lines": 5
   },
   "packages/multichain/src/adapters/caip-permission-adapter-permittedChains.test.ts": {
@@ -337,7 +338,7 @@
     "jsdoc/require-returns": 1
   },
   "packages/multichain/src/scope/supported.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 3
+    "@typescript-eslint/no-unsafe-enum-comparison": 6
   },
   "packages/multichain/src/scope/validation.ts": {
     "jsdoc/tag-lines": 2

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The metadata is now stored in each keyring object in the `state.keyrings` array.
   - When updating to this version, we recommend removing the `keyringsMetadata` state and all state referencing a keyring ID with a migration. New metadata will be generated for each keyring automatically after the update.
 
+### Fixed
+
+- Keyrings with duplicate accounts are skipped as unsupported on unlock ([#5725](https://github.com/MetaMask/core/pull/5725))
+
 ## [21.0.6]
 
 ### Changed

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Keyrings with duplicate accounts are skipped as unsupported on unlock ([#5725](https://github.com/MetaMask/core/pull/5725))
 
+### Fixed
+
+- Discard keyrings with duplicate accounts when unlock the wallet ([#5775](https://github.com/MetaMask/core/pull/5775))
+
 ## [21.0.6]
 
 ### Changed

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -15,11 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Keyrings with duplicate accounts are skipped as unsupported on unlock ([#5725](https://github.com/MetaMask/core/pull/5725))
-
-### Fixed
-
-- Discard keyrings with duplicate accounts when unlock the wallet ([#5775](https://github.com/MetaMask/core/pull/5775))
+- Keyrings with duplicate accounts are skipped as unsupported on unlock ([#5775](https://github.com/MetaMask/core/pull/5775))
 
 ## [21.0.6]
 

--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,7 +17,7 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 93.71,
+      branches: 94.11,
       functions: 100,
       lines: 98.93,
       statements: 98.93,

--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,7 +17,7 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.25,
+      branches: 94.31,
       functions: 100,
       lines: 98.79,
       statements: 98.8,

--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.11,
+      branches: 93.1,
       functions: 100,
-      lines: 98.93,
-      statements: 98.93,
+      lines: 98.64,
+      statements: 98.65,
     },
   },
 

--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 93.1,
+      branches: 94.25,
       functions: 100,
-      lines: 98.64,
-      statements: 98.65,
+      lines: 98.79,
+      statements: 98.8,
     },
   },
 

--- a/packages/keyring-controller/jest.config.js
+++ b/packages/keyring-controller/jest.config.js
@@ -17,10 +17,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.25,
+      branches: 93.71,
       functions: 100,
-      lines: 98.79,
-      statements: 98.8,
+      lines: 98.93,
+      statements: 98.93,
     },
   },
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -3036,6 +3036,33 @@ describe('KeyringController', () => {
         });
 
         !cacheEncryptionKey &&
+          it('should not upgrade the vault encryption if the generic encryptor has the same parameters', async () => {
+            await withController(
+              {
+                skipVaultCreation: true,
+                cacheEncryptionKey,
+                state: { vault: 'my vault' },
+              },
+              async ({ controller, encryptor }) => {
+                jest.spyOn(encryptor, 'isVaultUpdated').mockReturnValue(true);
+                const encryptSpy = jest.spyOn(encryptor, 'encrypt');
+                jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
+                  {
+                    type: KeyringTypes.hd,
+                    data: {
+                      accounts: ['0x123'],
+                    },
+                  },
+                ]);
+
+                await controller.submitPassword(password);
+
+                expect(encryptSpy).toHaveBeenCalledTimes(1);
+              },
+            );
+          });
+
+        !cacheEncryptionKey &&
           it('should throw error if password is of wrong type', async () => {
             await withController(
               { cacheEncryptionKey },

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2951,6 +2951,7 @@ describe('KeyringController', () => {
               await controller.submitPassword(password);
 
               expect(controller.state.keyrings).toHaveLength(1);
+              expect(unlockListener).toHaveBeenCalledTimes(1);
             },
           );
         });

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -3067,33 +3067,6 @@ describe('KeyringController', () => {
         });
 
         !cacheEncryptionKey &&
-          it('should not upgrade the vault encryption if the generic encryptor has the same parameters', async () => {
-            await withController(
-              {
-                skipVaultCreation: true,
-                cacheEncryptionKey,
-                state: { vault: 'my vault' },
-              },
-              async ({ controller, encryptor }) => {
-                jest.spyOn(encryptor, 'isVaultUpdated').mockReturnValue(true);
-                const encryptSpy = jest.spyOn(encryptor, 'encrypt');
-                jest.spyOn(encryptor, 'decrypt').mockResolvedValueOnce([
-                  {
-                    type: KeyringTypes.hd,
-                    data: {
-                      accounts: ['0x123'],
-                    },
-                  },
-                ]);
-
-                await controller.submitPassword(password);
-
-                expect(encryptSpy).toHaveBeenCalledTimes(1);
-              },
-            );
-          });
-
-        !cacheEncryptionKey &&
           it('should throw error if password is of wrong type', async () => {
             await withController(
               { cacheEncryptionKey },

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2923,7 +2923,7 @@ describe('KeyringController', () => {
           );
         });
 
-        it('should unlock the wallet also if encryption parameters are outdated the vault upgrade fails', async () => {
+        it('should unlock the wallet also if encryption parameters are outdated and the vault upgrade fails', async () => {
           await withController(
             {
               skipVaultCreation: true,
@@ -2976,7 +2976,7 @@ describe('KeyringController', () => {
 
               await controller.submitPassword(password);
 
-              expect(controller.state.keyrings).toHaveLength(1);
+              expect(controller.state.keyrings).toHaveLength(1); // Second keyring will be skipped as "unsupported".
               expect(unlockListener).toHaveBeenCalledTimes(1);
             },
           );

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2321,6 +2321,7 @@ export class KeyringController extends BaseController<
 
       this.update((state) => {
         state.keyrings = updatedKeyrings;
+        state.keyringsMetadata = this.#keyringsMetadata.slice();
         if (updatedState.encryptionKey || updatedState.encryptionSalt) {
           state.encryptionKey = updatedState.encryptionKey;
           state.encryptionSalt = updatedState.encryptionSalt;
@@ -2600,6 +2601,11 @@ export class KeyringController extends BaseController<
     } catch (error) {
       console.error(error);
       this.#unsupportedKeyrings.push(serialized);
+      if (this.#keyringsMetadata.length > this.#keyrings.length) {
+        // There was already a metadata entry for the keyring, so
+        // we need to remove it
+        this.#keyringsMetadata.splice(this.#keyrings.length, 1);
+      }
       return undefined;
     }
   }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2596,6 +2596,14 @@ export class KeyringController extends BaseController<
         keyring,
         metadata,
       });
+      try {
+        await this.#assertNoDuplicateAccounts();
+      } catch (error) {
+        // If the keyring includes duplicated accounts, we need to remove it
+        // from the keyrings array
+        this.#keyrings.pop();
+        throw error;
+      }
       return { keyring, metadata, newMetadata };
     } catch (error) {
       console.error(error);

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2321,7 +2321,6 @@ export class KeyringController extends BaseController<
 
       this.update((state) => {
         state.keyrings = updatedKeyrings;
-        state.keyringsMetadata = this.#keyringsMetadata.slice();
         if (updatedState.encryptionKey || updatedState.encryptionSalt) {
           state.encryptionKey = updatedState.encryptionKey;
           state.encryptionSalt = updatedState.encryptionSalt;
@@ -2601,11 +2600,6 @@ export class KeyringController extends BaseController<
     } catch (error) {
       console.error(error);
       this.#unsupportedKeyrings.push(serialized);
-      if (this.#keyringsMetadata.length > this.#keyrings.length) {
-        // There was already a metadata entry for the keyring, so
-        // we need to remove it
-        this.#keyringsMetadata.splice(this.#keyrings.length, 1);
-      }
       return undefined;
     }
   }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2432,13 +2432,18 @@ export class KeyringController extends BaseController<
    * Retrieves all the accounts from keyrings instances
    * that are currently in memory.
    *
+   * @param additionalKeyrings - Additional keyrings to include in the search.
    * @returns A promise resolving to an array of accounts.
    */
-  async #getAccountsFromKeyrings(): Promise<string[]> {
-    const keyrings = this.#keyrings;
+  async #getAccountsFromKeyrings(
+    additionalKeyrings: EthKeyring[] = [],
+  ): Promise<string[]> {
+    const keyrings = this.#keyrings.map(({ keyring }) => keyring);
 
     const keyringArrays = await Promise.all(
-      keyrings.map(async ({ keyring }) => keyring.getAccounts()),
+      [...keyrings, ...additionalKeyrings].map(async (keyring) =>
+        keyring.getAccounts(),
+      ),
     );
     const addresses = keyringArrays.reduce((res, arr) => {
       return res.concat(arr);
@@ -2584,6 +2589,7 @@ export class KeyringController extends BaseController<
       let newMetadata = false;
       let metadata = serializedMetadata;
       const keyring = await this.#createKeyring(type, data);
+      await this.#assertNoDuplicateAccounts([keyring]);
       // If metadata is missing, assume the data is from an installation before
       // we had keyring metadata.
       if (!metadata) {
@@ -2596,14 +2602,6 @@ export class KeyringController extends BaseController<
         keyring,
         metadata,
       });
-      try {
-        await this.#assertNoDuplicateAccounts();
-      } catch (error) {
-        // If the keyring includes duplicated accounts, we need to remove it
-        // from the keyrings array
-        this.#keyrings.pop();
-        throw error;
-      }
       return { keyring, metadata, newMetadata };
     } catch (error) {
       console.error(error);
@@ -2656,10 +2654,13 @@ export class KeyringController extends BaseController<
   /**
    * Assert that there are no duplicate accounts in the keyrings.
    *
+   * @param additionalKeyrings - Additional keyrings to include in the check.
    * @throws If there are duplicate accounts.
    */
-  async #assertNoDuplicateAccounts(): Promise<void> {
-    const accounts = await this.#getAccountsFromKeyrings();
+  async #assertNoDuplicateAccounts(
+    additionalKeyrings: EthKeyring[] = [],
+  ): Promise<void> {
+    const accounts = await this.#getAccountsFromKeyrings(additionalKeyrings);
 
     if (new Set(accounts).size !== accounts.length) {
       throw new Error(KeyringControllerError.DuplicatedAccount);


### PR DESCRIPTION
Dependent on:
- https://github.com/MetaMask/core/pull/5725

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
It is no longer possible to persist duplicates in the vault, though users that already have duplicates will see them in the accounts list, and won't be able to do any action with their vault. These changes aim to discard duplicates, moving the keyring including a duplicate account to the unsupported array.

Can be tested on extension with https://github.com/MetaMask/metamask-extension/pull/32621

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
