### PR TITLE
fix: use gas limit from simulation response

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix type-4 gas estimation ([#5790](https://github.com/MetaMask/core/pull/5790))
+
 ## [55.0.1]
 
 ### Changed

--- a/packages/transaction-controller/src/api/simulation-api.ts
+++ b/packages/transaction-controller/src/api/simulation-api.ts
@@ -188,7 +188,10 @@ export type SimulationResponseTransaction = {
     tokenFees: SimulationResponseTokenFee[];
   }[];
 
-  /** The total gas used by the transaction. */
+  /** Required `gasLimit` for the transaction. */
+  gasLimit?: Hex;
+
+  /** Total gas used by the transaction. */
   gasUsed?: Hex;
 
   /** Return value of the transaction, such as the balance if calling balanceOf. */

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -617,7 +617,7 @@ describe('gas', () => {
         simulateTransactionsMock.mockResolvedValueOnce({
           transactions: [
             {
-              gasUsed: toHex(SIMULATE_GAS_MOCK) as Hex,
+              gasLimit: toHex(SIMULATE_GAS_MOCK) as Hex,
             },
           ],
         } as SimulationResponse);

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -405,13 +405,13 @@ async function simulateGas({
     },
   });
 
-  const gasUsed = response?.transactions?.[0].gasUsed;
+  const gasLimit = response?.transactions?.[0].gasLimit;
 
-  if (!gasUsed) {
+  if (!gasLimit) {
     throw new Error('No simulated gas returned');
   }
 
-  return gasUsed;
+  return gasLimit;
 }
 
 /**


### PR DESCRIPTION
## Explanation

When simulating gas for type-4 transactions, use `gasLimit` rather than `gasUsed` from simulation response.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
