### PR TITLE
fix: use zero address as native address instead of assetId

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **BREAKING:** Use zero address as solana's default native address instead of assetId
+- **BREAKING:** Use zero address as solana's default native address instead of assetId ([#5799](https://github.com/MetaMask/core/pull/5799))
 
 ## [24.0.0]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **BREAKING:** Use zero address as solana's default native address instead of assetId
+
 ## [24.0.0]
 
 ### Added

--- a/packages/bridge-controller/src/constants/tokens.ts
+++ b/packages/bridge-controller/src/constants/tokens.ts
@@ -27,7 +27,6 @@ export type SwapsTokenObject = {
 };
 
 const DEFAULT_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
-const DEFAULT_SOLANA_TOKEN_ADDRESS = `${SolScope.Mainnet}/slip44:501`;
 
 const CURRENCY_SYMBOLS = {
   ARBITRUM: 'ETH',
@@ -134,7 +133,7 @@ const BASE_SWAPS_TOKEN_OBJECT = {
 const SOLANA_SWAPS_TOKEN_OBJECT = {
   symbol: CURRENCY_SYMBOLS.SOL,
   name: 'Solana',
-  address: DEFAULT_SOLANA_TOKEN_ADDRESS,
+  address: DEFAULT_TOKEN_ADDRESS,
   decimals: 9,
   iconUrl: '',
 } as const;


### PR DESCRIPTION
## Explanation

`getNativeAssetForChainId` returns the assetId for SOL instead of a recognized native token address. This can cause duplicate SOL tokens to appear in the clients. This updates the address to the ZeroAddress, which clients use for native assets

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
