### PR TITLE
refactor: descriptive caip25CaveatBuilder unsupported scopes 

### DIFF
--- a/packages/chain-agnostic-permission/src/caip25Permission.test.ts
+++ b/packages/chain-agnostic-permission/src/caip25Permission.test.ts
@@ -744,7 +744,7 @@ describe('caip25CaveatBuilder', () => {
       });
     }).toThrow(
       new Error(
-        `${Caip25EndowmentPermissionName} error: Received scopeString value(s) for caveat of type "${Caip25CaveatType}" that are not supported by the wallet.`,
+        `${Caip25EndowmentPermissionName} error: Received scopeString value(s): eip155:1, bip122:000000000019d6689c085ae165831e93, eip155:5, bip122:12a765e31ffd4059bada1e25190f6e98 for caveat of type "${Caip25CaveatType}" that are not supported by the wallet.`,
       ),
     );
   });

--- a/packages/chain-agnostic-permission/src/caip25Permission.ts
+++ b/packages/chain-agnostic-permission/src/caip25Permission.ts
@@ -220,23 +220,20 @@ export const caip25CaveatBuilder = ({
         }
       };
 
-      const allRequiredScopesSupported = Object.keys(requiredScopes).every(
+      const unsupportedScopes = Object.keys({
+        ...requiredScopes,
+        ...optionalScopes,
+      }).filter(
         (scopeString) =>
-          isSupportedScopeString(scopeString, {
+          !isSupportedScopeString(scopeString, {
             isEvmChainIdSupported,
             isNonEvmScopeSupported,
           }),
       );
-      const allOptionalScopesSupported = Object.keys(optionalScopes).every(
-        (scopeString) =>
-          isSupportedScopeString(scopeString, {
-            isEvmChainIdSupported,
-            isNonEvmScopeSupported,
-          }),
-      );
-      if (!allRequiredScopesSupported || !allOptionalScopesSupported) {
+
+      if (unsupportedScopes.length > 0) {
         throw new Error(
-          `${Caip25EndowmentPermissionName} error: Received scopeString value(s) for caveat of type "${Caip25CaveatType}" that are not supported by the wallet.`,
+          `${Caip25EndowmentPermissionName} error: Received scopeString value(s): ${unsupportedScopes.join(', ')} for caveat of type "${Caip25CaveatType}" that are not supported by the wallet.`,
         );
       }
 


### PR DESCRIPTION

## Explanation
Currently the exception thrown by `caip25CaveatBuilder` `validator` doesn't reference the unsupported scopes that caused it. With this change we list all the scopes that failed validation on the exception message when throwing it.  

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
Fixes https://github.com/MetaMask/MetaMask-planning/issues/4855

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
