### PR TITLE
chore: Remove obsolete workaround

### DIFF
--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove obsolete `eth_getBlockByNumber` error handling for load balancer errors ([#5808](https://github.com/MetaMask/core/pull/5808))
+
 ### Fixed
 
 - Improved handling of HTTP status codes to prevent unnecessary circuit breaker triggers ([#5798](https://github.com/MetaMask/core/pull/5798))

--- a/packages/network-controller/src/rpc-service/rpc-service.test.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.test.ts
@@ -861,36 +861,6 @@ describe('RpcService', () => {
       });
     });
 
-    it('interprets a "Not Found" response for eth_getBlockByNumber as an empty result', async () => {
-      const endpointUrl = 'https://rpc.example.chain';
-      nock(endpointUrl)
-        .post('/', {
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'eth_getBlockByNumber',
-          params: ['0x999999999', false],
-        })
-        .reply(200, 'Not Found');
-      const service = new RpcService({
-        fetch,
-        btoa,
-        endpointUrl,
-      });
-
-      const response = await service.request({
-        id: 1,
-        jsonrpc: '2.0',
-        method: 'eth_getBlockByNumber',
-        params: ['0x999999999', false],
-      });
-
-      expect(response).toStrictEqual({
-        id: 1,
-        jsonrpc: '2.0',
-        result: null,
-      });
-    });
-
     it('calls the onDegraded callback if the endpoint takes more than 5 seconds to respond', async () => {
       const endpointUrl = 'https://rpc.example.chain';
       nock(endpointUrl)

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -379,10 +379,7 @@ export class RpcService implements AbstractRpcService {
     );
 
     try {
-      return await this.#executePolicy<Params, Result>(
-        jsonRpcRequest,
-        completeFetchOptions,
-      );
+      return await this.#executePolicy<Result>(completeFetchOptions);
     } catch (error) {
       if (
         this.#policy.circuitBreakerPolicy.state === CircuitState.Open &&
@@ -462,7 +459,6 @@ export class RpcService implements AbstractRpcService {
   /**
    * Makes the request using the Cockatiel policy that this service creates.
    *
-   * @param jsonRpcRequest - The JSON-RPC request to send to the endpoint.
    * @param fetchOptions - The options for `fetch`; will be combined with the
    * fetch options passed to the constructor
    * @returns The decoded JSON-RPC response from the endpoint.
@@ -472,12 +468,7 @@ export class RpcService implements AbstractRpcService {
    * @throws A generic error if the response HTTP status is not 2xx but also not
    * 405, 429, 503, or 504.
    */
-  async #executePolicy<
-    Params extends JsonRpcParams,
-    Result extends Json,
-    Request extends JsonRpcRequest = JsonRpcRequest<Params>,
-  >(
-    jsonRpcRequest: Request,
+  async #executePolicy<Result extends Json>(
     fetchOptions: FetchOptions,
   ): Promise<JsonRpcResponse<Result> | JsonRpcResponse<null>> {
     return await this.#policy.execute(async () => {

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -500,29 +500,15 @@ export class RpcService implements AbstractRpcService {
         });
       }
 
-      const text = await response.text();
-
-      if (
-        jsonRpcRequest.method === 'eth_getBlockByNumber' &&
-        text === 'Not Found'
-      ) {
-        return {
-          id: jsonRpcRequest.id,
-          jsonrpc: jsonRpcRequest.jsonrpc,
-          result: null,
-        };
-      }
-
       // Type annotation: We assume that if this response is valid JSON, it's a
       // valid JSON-RPC response.
       let json: JsonRpcResponse<Result>;
       try {
-        json = JSON.parse(text);
+        json = await response.json();
       } catch (error) {
         if (error instanceof SyntaxError) {
           throw rpcErrors.internal({
             message: 'Could not parse response as it is not valid JSON',
-            data: text,
           });
         } else {
           throw error;


### PR DESCRIPTION
## Explanation

An error case was added to our network middleware long ago to workaround load balancer errors that we encountered with Infura at the time. These errors were fixed long ago, so this workaround is no longer needed.

I [checked with the Infura team](https://consensys.slack.com/archives/CV90KPED9/p1747252611880119), and they confirmed that this case should no longer be possible for Infura RPC endpoints.

Removing this check allowed me to update how we're parsing the response body as well. We're now using `response.json()` rather than parsing the raw body as text. As a consequence of this, we no longer have the raw text to attach to parsing errors, but this seems OK to remove given that we don't reference it anywhere, and the full response can be seen in devtools in a development environment.

## References

This workaround was originally introduced here: https://github.com/MetaMask/eth-json-rpc-infura/blame/7871c8ee5acf6c738b6bfa43dfaadc02d7f00509/src/index.js#L13C52-L13C59

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
