### PR TITLE
fix: Prevent circuit break for HTTP 4XX errors

### DIFF
--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `HttpError` class for errors representing non-200 HTTP responses ([#5809](https://github.com/MetaMask/core/pull/5809))
+
 ### Changed
 
-- Improved circuit breaker behavior to only consider specific error codes as service failures ([#5798](https://github.com/MetaMask/core/pull/5798))
+- Improved circuit breaker behavior to no longer consider HTTP 4XX responses as service failures ([#5798](https://github.com/MetaMask/core/pull/5798), [#5809](https://github.com/MetaMask/core/pull/5809))
   - Changed from using `handleAll` to `handleWhen(isServiceFailure)` in circuit breaker policy
   - This ensures that expected error responses (like 405 Method Not Allowed and 429 Rate Limited) don't trigger the circuit breaker
-  - Only considers as service failures:
-    - Errors that have a numeric code property with value -32603 (Internal error)
-    - Errors that don't meet the criteria for having a numeric code property
-  - With more precise type checking for the error object structure
 
 ## [11.8.0]
 

--- a/packages/controller-utils/src/create-service-policy.ts
+++ b/packages/controller-utils/src/create-service-policy.ts
@@ -134,12 +134,10 @@ const isServiceFailure = (error: unknown) => {
   if (
     typeof error === 'object' &&
     error !== null &&
-    'code' in error &&
-    typeof error.code === 'number'
+    'httpStatus' in error &&
+    typeof error.httpStatus === 'number'
   ) {
-    const { code } = error;
-    // Only consider errors with code -32603 (internal error) as service failures
-    return code === -32603;
+    return error.httpStatus >= 500;
   }
 
   // If the error is not an object, or doesn't have a numeric code property,

--- a/packages/controller-utils/src/index.test.ts
+++ b/packages/controller-utils/src/index.test.ts
@@ -25,6 +25,7 @@ describe('@metamask/controller-utils', () => {
         "handleFetch",
         "hexToBN",
         "hexToText",
+        "HttpError",
         "isNonEmptyArray",
         "isPlainObject",
         "isSafeChainId",

--- a/packages/controller-utils/src/index.ts
+++ b/packages/controller-utils/src/index.ts
@@ -29,6 +29,7 @@ export {
   handleFetch,
   hexToBN,
   hexToText,
+  HttpError,
   isNonEmptyArray,
   isPlainObject,
   isSafeChainId,

--- a/packages/controller-utils/src/util.test.ts
+++ b/packages/controller-utils/src/util.test.ts
@@ -354,6 +354,26 @@ describe('util', () => {
     expect(toSmartContract4).toBe(true);
   });
 
+  describe('HttpError', () => {
+    it('stores the status as an instance variable', () => {
+      const httpError = new util.HttpError(500);
+
+      expect(httpError.httpStatus).toBe(500);
+    });
+
+    it('has the expected default message', () => {
+      const httpError = new util.HttpError(500);
+
+      expect(httpError.message).toBe(`Fetch failed with status '500'`);
+    });
+
+    it('allows setting a custom message', () => {
+      const httpError = new util.HttpError(500, 'custom message');
+
+      expect(httpError.message).toBe('custom message');
+    });
+  });
+
   describe('successfulFetch', () => {
     beforeEach(() => {
       nock(SOME_API).get(/.+/u).reply(200, { foo: 'bar' }).persist();
@@ -369,6 +389,12 @@ describe('util', () => {
     it('should throw error for an unsuccessful fetch', async () => {
       await expect(util.successfulFetch(SOME_FAILING_API)).rejects.toThrow(
         `Fetch failed with status '500' for request '${SOME_FAILING_API}'`,
+      );
+    });
+
+    it('throws an HttpError', async () => {
+      await expect(util.successfulFetch(SOME_FAILING_API)).rejects.toThrow(
+        util.HttpError,
       );
     });
   });

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -365,6 +365,24 @@ export function isSmartContractCode(code: string) {
 }
 
 /**
+ * An error representing a non-200 HTTP response.
+ */
+export class HttpError extends Error {
+  public httpStatus: number;
+
+  /**
+   * Construct an HTTP error.
+   *
+   * @param status - The HTTP response status.
+   * @param message - The error message.
+   */
+  constructor(status: number, message?: string) {
+    super(message || `Fetch failed with status '${status}'`);
+    this.httpStatus = status;
+  }
+}
+
+/**
  * Execute fetch and verify that the response was successful.
  *
  * @param request - Request information.
@@ -377,10 +395,9 @@ export async function successfulFetch(
 ) {
   const response = await fetch(request, options);
   if (!response.ok) {
-    throw new Error(
-      `Fetch failed with status '${response.status}' for request '${String(
-        request,
-      )}'`,
+    throw new HttpError(
+      response.status,
+      `Fetch failed with status '${response.status}' for request '${String(request)}'`,
     );
   }
   return response;

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -13,10 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Improved handling of HTTP status codes to prevent unnecessary circuit breaker triggers ([#5798](https://github.com/MetaMask/core/pull/5798))
-  - 405 (Method Not Allowed) continues to throw JSON-RPC error with code -32601 (Method not found)
-  - 429 (Too Many Requests) now throws JSON-RPC error with code -32005 (Request rate limit exceeded) instead of a generic internal error
-  - These errors are filtered by the circuit breaker's `handleWhen` policy to prevent unnecessary failover to backup endpoints
+- Improved handling of HTTP status codes to prevent unnecessary circuit breaker triggers ([#5798](https://github.com/MetaMask/core/pull/5798), [#5809](https://github.com/MetaMask/core/pull/5809))
+  - HTTP 4XX responses (e.g. rate limit errors) will no longer trigger the circuit breaker policy.
 
 ## [23.4.0]
 

--- a/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
@@ -364,27 +364,6 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
           await expect(promiseForResult).rejects.toThrow(errorMessage);
         });
       });
-
-      // TODO: Add tests for failover behavior when the RPC endpoint returns a 405 or 429 response without opening a circuit breaker
-      // testsForRpcFailoverBehavior({
-      //   providerType,
-      //   requestToCall: {
-      //     method,
-      //     params: [],
-      //   },
-      //   getRequestToMock: () => ({
-      //     method,
-      //     params: [],
-      //   }),
-      //   failure: {
-      //     httpStatus,
-      //   },
-      //   isRetriableFailure: false,
-      //   getExpectedError: () =>
-      //     expect.objectContaining({
-      //       message: errorMessage,
-      //     }),
-      // });
     },
   );
 
@@ -432,6 +411,10 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
       getExpectedError: () =>
         expect.objectContaining({
           message: errorMessage,
+        }),
+      getExpectedBreakError: () =>
+        expect.objectContaining({
+          message: `Fetch failed with status '500'`,
         }),
     });
   });
@@ -527,6 +510,12 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
         getExpectedError: () =>
           expect.objectContaining({
             message: expect.stringContaining(errorMessage),
+          }),
+        getExpectedBreakError: () =>
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `Fetch failed with status '${httpStatus}'`,
+            ),
           }),
       });
     },

--- a/packages/network-controller/tests/provider-api-tests/block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-param.ts
@@ -454,30 +454,6 @@ export function testsForRpcMethodSupportingBlockParam(
             await expect(promiseForResult).rejects.toThrow(errorMessage);
           });
         });
-
-        // TODO: Add tests for failover behavior when the RPC endpoint returns a 405 or 429 response without opening a circuit breaker
-        // testsForRpcFailoverBehavior({
-        //   providerType,
-        //   requestToCall: {
-        //     method,
-        //     params: buildMockParams({ blockParam, blockParamIndex }),
-        //   },
-        //   getRequestToMock: (request: MockRequest, blockNumber: Hex) => {
-        //     return buildRequestWithReplacedBlockParam(
-        //       request,
-        //       blockParamIndex,
-        //       blockNumber,
-        //     );
-        //   },
-        //   failure: {
-        //     httpStatus,
-        //   },
-        //   isRetriableFailure: false,
-        //   getExpectedError: () =>
-        //     expect.objectContaining({
-        //       message: errorMessage,
-        //     }),
-        // });
       },
     );
 
@@ -541,6 +517,10 @@ export function testsForRpcMethodSupportingBlockParam(
         getExpectedError: () =>
           expect.objectContaining({
             message: errorMessage,
+          }),
+        getExpectedBreakError: () =>
+          expect.objectContaining({
+            message: `Fetch failed with status '500'`,
           }),
       });
     });
@@ -668,7 +648,13 @@ export function testsForRpcMethodSupportingBlockParam(
           isRetriableFailure: true,
           getExpectedError: () =>
             expect.objectContaining({
-              message: expect.stringContaining(errorMessage),
+              message: expect.stringContaining(`Gateway timeout`),
+            }),
+          getExpectedBreakError: () =>
+            expect.objectContaining({
+              message: expect.stringContaining(
+                `Fetch failed with status '${httpStatus}'`,
+              ),
             }),
         });
       },

--- a/packages/network-controller/tests/provider-api-tests/no-block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/no-block-param.ts
@@ -320,27 +320,6 @@ export function testsForRpcMethodAssumingNoBlockParam(
           await expect(promiseForResult).rejects.toThrow(errorMessage);
         });
       });
-
-      // TODO: Add tests for failover behavior when the RPC endpoint returns a 405 or 429 response without opening a circuit breaker
-      // testsForRpcFailoverBehavior({
-      //   providerType,
-      //   requestToCall: {
-      //     method,
-      //     params: [],
-      //   },
-      //   getRequestToMock: () => ({
-      //     method,
-      //     params: [],
-      //   }),
-      //   failure: {
-      //     httpStatus,
-      //   },
-      //   isRetriableFailure: false,
-      //   getExpectedError: () =>
-      //     expect.objectContaining({
-      //       message: errorMessage,
-      //     }),
-      // });
     },
   );
 
@@ -388,6 +367,10 @@ export function testsForRpcMethodAssumingNoBlockParam(
       getExpectedError: () =>
         expect.objectContaining({
           message: errorMessage,
+        }),
+      getExpectedBreakError: () =>
+        expect.objectContaining({
+          message: `Fetch failed with status '500'`,
         }),
     });
   });
@@ -483,6 +466,12 @@ export function testsForRpcMethodAssumingNoBlockParam(
         getExpectedError: () =>
           expect.objectContaining({
             message: expect.stringContaining(errorMessage),
+          }),
+        getExpectedBreakError: () =>
+          expect.objectContaining({
+            message: expect.stringContaining(
+              `Fetch failed with status '${httpStatus}'`,
+            ),
           }),
       });
     },

--- a/packages/network-controller/tests/provider-api-tests/rpc-failover.ts
+++ b/packages/network-controller/tests/provider-api-tests/rpc-failover.ts
@@ -16,6 +16,8 @@ import { buildRootMessenger } from '../helpers';
  * @param args.failure - The failure mock response to use.
  * @param args.isRetriableFailure - Whether the failure gets retried.
  * @param args.getExpectedError - Factory returning the expected error.
+ * @param args.getExpectedBreakError - Factory returning the expected error
+ * upon circuit break. Defaults to using `getExpectedError`.
  */
 export function testsForRpcFailoverBehavior({
   providerType,
@@ -24,6 +26,7 @@ export function testsForRpcFailoverBehavior({
   failure,
   isRetriableFailure,
   getExpectedError,
+  getExpectedBreakError = getExpectedError,
 }: {
   providerType: ProviderType;
   requestToCall: MockRequest;
@@ -31,6 +34,7 @@ export function testsForRpcFailoverBehavior({
   failure: MockResponse | Error | string;
   isRetriableFailure: boolean;
   getExpectedError: (url: string) => Error | jest.Constructable;
+  getExpectedBreakError?: (url: string) => Error | jest.Constructable;
 }) {
   const blockNumber = '0x100';
   const backoffDuration = 100;
@@ -199,7 +203,7 @@ export function testsForRpcFailoverBehavior({
                     chainId,
                     endpointUrl: rpcUrl,
                     failoverEndpointUrl,
-                    error: getExpectedError(rpcUrl),
+                    error: getExpectedBreakError(rpcUrl),
                   },
                 );
               },
@@ -295,7 +299,7 @@ export function testsForRpcFailoverBehavior({
                 ).toHaveBeenNthCalledWith(2, {
                   chainId,
                   endpointUrl: failoverEndpointUrl,
-                  error: getExpectedError(failoverEndpointUrl),
+                  error: getExpectedBreakError(failoverEndpointUrl),
                 });
               },
             );


### PR DESCRIPTION
## Explanation

The "create-service-policy" utility (specifically the circuit breaker) has been updated to handle fetch errors rather than RPC errors.

This utility was recently updated to handle the JSON-RPC "Internal error" response, but this is only expected for one specific place where this utility is used (the RPC service). Additionally, there remained some cases that would still inappropriately trigger the circuit break policy (i.e. there were some "internal errors" that don't indicate service failure).

The utility will now consider all network errors and HTTP 5XX errors as indicative of service failure. HTTP 4XX errors will no longer trigger the circuit breaker.

To accomodate these changes, the RPC service now only handles the fetch request and response parsing inside the policy execution phase. The step where errors are parsed and converted to JSON-RPC errors has been moved to _outside_ the execute step. Effectively this has the same functional result for users of the service, but it makes the policy much simpler.

## References

Related:
* https://github.com/MetaMask/core/pull/5798
* https://github.com/MetaMask/core/issues/5766

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
