### PR TITLE
fix: cancel upgrade error code

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` to `^11.9.0` ([#5812](https://github.com/MetaMask/core/pull/5812))
 
+### Fixed
+
+- Throw correct error code if upgrade rejected ([#5814](https://github.com/MetaMask/core/pull/5814))
+
 ## [56.0.0]
 
 ### Changed

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -4165,7 +4165,7 @@ export class TransactionController extends BaseController<
   #isRejectError(error: Error & { code?: number }) {
     return [
       errorCodes.provider.userRejectedRequest,
-      errorCodes.rpc.methodNotSupported,
+      ErrorCode.RejectedUpgrade,
     ].includes(error.code as number);
   }
 

--- a/packages/transaction-controller/src/utils/validation.ts
+++ b/packages/transaction-controller/src/utils/validation.ts
@@ -16,6 +16,7 @@ import {
 export enum ErrorCode {
   DuplicateBundleId = 5720,
   BundleTooLarge = 5740,
+  RejectedUpgrade = 5750,
 }
 
 const TRANSACTION_ENVELOPE_TYPES_FEE_MARKET = [


### PR DESCRIPTION
## Explanation

Throw the correct error code from `addTransaction` if an EIP-7702 upgrade is rejected.

## References

Relates to [#32956](https://github.com/MetaMask/metamask-extension/issues/32956)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
