### PR TITLE
fix: Add `userFeeLevel` as `dappSuggested` initially when `txParams` contains gas values for `legacy` transactions

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Fixed
 
 - Add `userFeeLevel` as `dappSuggested` initially when `txParams` contains gas values ([#5821](https://github.com/MetaMask/core/pull/5821))
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `userFeeLevel` as `dappSuggested` initially when `txParams` contains gas values ([#5821](https://github.com/MetaMask/core/pull/5821))
+
 ## [56.1.0]
 
 ### Added

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Add `userFeeLevel` as `dappSuggested` initially when `txParams` contains gas values ([#5821](https://github.com/MetaMask/core/pull/5821))
+- Fix `userFeeLevel` as `dappSuggested` initially when dApp suggested gas values for legacy transactions ([#5821](https://github.com/MetaMask/core/pull/5821))
 
 ## [56.1.0]
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -81,6 +81,7 @@ import {
   TransactionEnvelopeType,
   TransactionStatus,
   TransactionType,
+  UserFeeLevel,
   WalletDevice,
 } from './types';
 import { addTransactionBatch } from './utils/batch';
@@ -1786,11 +1787,13 @@ describe('TransactionController', () => {
               networkClientId: NETWORK_CLIENT_ID_MOCK,
             },
           );
-          expect(
-            controller.state.transactions[0]?.dappSuggestedGasFees?.[
-              gasPropName
-            ],
-          ).toBe(mockGasValue);
+          const transactionMeta = controller.state.transactions[0];
+          expect(transactionMeta?.dappSuggestedGasFees?.[gasPropName]).toBe(
+            mockGasValue,
+          );
+          expect(transactionMeta?.userFeeLevel).toBe(
+            UserFeeLevel.DAPP_SUGGESTED,
+          );
         },
       );
     });

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1729,6 +1729,7 @@ describe('TransactionController', () => {
         time: expect.any(Number),
         txParams: expect.anything(),
         userEditedGasLimit: false,
+        userFeeLevel: undefined,
         type: TransactionType.simpleSend,
         verifiedOnBlockchain: expect.any(Boolean),
       };

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1729,7 +1729,6 @@ describe('TransactionController', () => {
         time: expect.any(Number),
         txParams: expect.anything(),
         userEditedGasLimit: false,
-        userFeeLevel: undefined,
         type: TransactionType.simpleSend,
         verifiedOnBlockchain: expect.any(Boolean),
       };
@@ -1791,9 +1790,6 @@ describe('TransactionController', () => {
           const transactionMeta = controller.state.transactions[0];
           expect(transactionMeta?.dappSuggestedGasFees?.[gasPropName]).toBe(
             mockGasValue,
-          );
-          expect(transactionMeta?.userFeeLevel).toBe(
-            UserFeeLevel.DAPP_SUGGESTED,
           );
         },
       );

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -81,7 +81,6 @@ import {
   TransactionEnvelopeType,
   TransactionStatus,
   TransactionType,
-  UserFeeLevel,
   WalletDevice,
 } from './types';
 import { addTransactionBatch } from './utils/batch';

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1787,10 +1787,11 @@ describe('TransactionController', () => {
               networkClientId: NETWORK_CLIENT_ID_MOCK,
             },
           );
-          const transactionMeta = controller.state.transactions[0];
-          expect(transactionMeta?.dappSuggestedGasFees?.[gasPropName]).toBe(
-            mockGasValue,
-          );
+          expect(
+            controller.state.transactions[0]?.dappSuggestedGasFees?.[
+              gasPropName
+            ],
+          ).toBe(mockGasValue);
         },
       );
     });

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -118,11 +118,12 @@ import type {
   GasFeeEstimateLevel as GasFeeEstimateLevelType,
 } from './types';
 import {
+  GasFeeEstimateLevel,
   TransactionEnvelopeType,
   TransactionType,
   TransactionStatus,
   SimulationErrorCode,
-  GasFeeEstimateLevel,
+  UserFeeLevel,
 } from './types';
 import {
   addTransactionBatch,
@@ -1219,6 +1220,9 @@ export class TransactionController extends BaseController<
           txParams,
           type: transactionType,
           userEditedGasLimit: false,
+          userFeeLevel: dappSuggestedGasFees
+            ? UserFeeLevel.DAPP_SUGGESTED
+            : undefined,
           verifiedOnBlockchain: false,
         };
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1220,9 +1220,6 @@ export class TransactionController extends BaseController<
           txParams,
           type: transactionType,
           userEditedGasLimit: false,
-          userFeeLevel: dappSuggestedGasFees
-            ? UserFeeLevel.DAPP_SUGGESTED
-            : undefined,
           verifiedOnBlockchain: false,
         };
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -123,7 +123,6 @@ import {
   TransactionType,
   TransactionStatus,
   SimulationErrorCode,
-  UserFeeLevel,
 } from './types';
 import {
   addTransactionBatch,

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -487,14 +487,6 @@ describe('gas-fees', () => {
     });
 
     describe('sets userFeeLevel', () => {
-      it('to undefined if not eip1559', async () => {
-        updateGasFeeRequest.eip1559 = false;
-
-        await updateGasFees(updateGasFeeRequest);
-
-        expect(updateGasFeeRequest.txMeta.userFeeLevel).toBeUndefined();
-      });
-
       it('to saved userFeeLevel if saved gas fees defined', async () => {
         updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;
         updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -283,12 +283,7 @@ function getGasPrice(request: GetGasFeeRequest): string | undefined {
  * @returns The user fee level.
  */
 function getUserFeeLevel(request: GetGasFeeRequest): UserFeeLevel | undefined {
-  const { eip1559, initialParams, savedGasFees, suggestedGasFees, txMeta } =
-    request;
-
-  if (!eip1559) {
-    return undefined;
-  }
+  const { initialParams, savedGasFees, suggestedGasFees, txMeta } = request;
 
   if (savedGasFees) {
     return UserFeeLevel.CUSTOM;


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR aims to add `userFeeLevel` as `dappSuggested` initially when `txParams` contains gas values also for `legacy` transactions.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Issue found while implementing gas modal: https://github.com/MetaMask/metamask-mobile/pull/15234

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [X] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
