### PR TITLE
fix: Fix sending native token to smart account

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `addTransaction` function to correctly identify a transaction as a `simpleSend` type when the recipient is a smart account ([#5800](https://github.com/MetaMask/core/pull/5800))
+
 ## [56.1.0]
 
 ### Added

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `addTransaction` function to correctly identify a transaction as a `simpleSend` type when the recipient is a smart account ([#5800](https://github.com/MetaMask/core/pull/5800))
+- Fix `addTransaction` function to correctly identify a transaction as a `simpleSend` type when the recipient is a smart account ([#5822](https://github.com/MetaMask/core/pull/5822))
 
 ## [56.1.0]
 

--- a/packages/transaction-controller/src/utils/transaction-type.test.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.test.ts
@@ -1,9 +1,9 @@
 import EthQuery from '@metamask/eth-query';
 
+import { DELEGATION_PREFIX } from './eip7702';
 import { determineTransactionType } from './transaction-type';
 import { FakeProvider } from '../../../../tests/fake-provider';
 import { TransactionType } from '../types';
-import { DELEGATION_PREFIX } from './eip7702';
 
 describe('determineTransactionType', () => {
   const FROM_MOCK = '0x9e';
@@ -106,24 +106,25 @@ describe('determineTransactionType', () => {
 
   it('does not identify contract codes with DELEGATION_PREFIX as contract addresses', async () => {
     class MockEthQuery extends EthQuery {
+      // TODO: Replace `any` with type
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       getCode(_to: any, cb: any) {
-        // Return a code starting with the DELEGATION_PREFIX
-        cb(null, DELEGATION_PREFIX + '1234567890abcdef');
+        cb(null, `${DELEGATION_PREFIX}1234567890abcdef`);
       }
     }
-    
+
     const result = await determineTransactionType(
       {
         to: '0x9e673399f795D01116e9A8B2dD2F156705131ee9',
         data: '0xabd',
         from: FROM_MOCK,
       },
-      new MockEthQuery(new FakeProvider())
+      new MockEthQuery(new FakeProvider()),
     );
-    
+
     expect(result).toMatchObject({
       type: TransactionType.simpleSend,
-      getCodeResponse: DELEGATION_PREFIX + '1234567890abcdef',
+      getCodeResponse: `${DELEGATION_PREFIX}1234567890abcdef`,
     });
   });
 

--- a/packages/transaction-controller/src/utils/transaction-type.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.ts
@@ -11,6 +11,7 @@ import {
 
 import type { InferTransactionTypeResult, TransactionParams } from '../types';
 import { TransactionType } from '../types';
+import { DELEGATION_PREFIX } from './eip7702';
 
 export const ESTIMATE_GAS_ERROR = 'eth_estimateGas rpc method error';
 
@@ -146,7 +147,9 @@ async function readAddressAsContract(
   }
 
   const isContractAddress = contractCode
-    ? contractCode !== '0x' && contractCode !== '0x0'
+    ? contractCode !== '0x' &&
+      contractCode !== '0x0' &&
+      !contractCode.startsWith(DELEGATION_PREFIX)
     : false;
   return { contractCode, isContractAddress };
 }

--- a/packages/transaction-controller/src/utils/transaction-type.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.ts
@@ -9,9 +9,9 @@ import {
   abiFiatTokenV2,
 } from '@metamask/metamask-eth-abis';
 
+import { DELEGATION_PREFIX } from './eip7702';
 import type { InferTransactionTypeResult, TransactionParams } from '../types';
 import { TransactionType } from '../types';
-import { DELEGATION_PREFIX } from './eip7702';
 
 export const ESTIMATE_GAS_ERROR = 'eth_estimateGas rpc method error';
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR aims to fix where the `addTransaction` function incorrectly identifies a transaction as a `simpleSend` type when the recipient is a smart account.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Fixes https://github.com/MetaMask/MetaMask-planning/issues/4920
* Extension PR: https://github.com/MetaMask/metamask-extension/pull/33013

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
