### PR TITLE
fix: add logic to properly rate limit snap install requests

### DIFF
--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -50,6 +50,7 @@
     "@metamask/base-controller": "^8.0.1",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/utils": "^11.2.0",
+    "@metamask/controller-utils": "^11.8.0",
     "nanoid": "^3.3.8"
   },
   "devDependencies": {

--- a/packages/approval-controller/src/ApprovalController.ts
+++ b/packages/approval-controller/src/ApprovalController.ts
@@ -32,6 +32,15 @@ const stateMetadata = {
   approvalFlows: { persist: false, anonymous: false },
 };
 
+const SnapApprovalTypes = new Set([
+  'wallet_installSnap',
+  'wallet_updateSnap',
+  'wallet_installSnapResult',
+]);
+
+const getAlreadyPendingSnapInstallFlowMessage = (origin: string) =>
+  `Snap installation flow already pending for origin ${origin}. Please wait.`;
+
 const getAlreadyPendingMessage = (origin: string, type: string) =>
   `Request of type '${type}' already pending for origin ${origin}. Please wait.`;
 
@@ -916,6 +925,8 @@ export class ApprovalController extends BaseController<
   ): Promise<unknown | AddResult> {
     this.#validateAddParams(id, origin, type, requestData, requestState);
 
+    this.#checkForSnapInstallFlow(id, type, origin, requestData || {});
+
     if (
       !this.#typesExcludedFromRateLimiting.includes(type) &&
       this.has({ origin, type })
@@ -1106,6 +1117,41 @@ export class ApprovalController extends BaseController<
           console.info('Failed to end flow', { id: opts.flowToEnd, error });
         }
       }
+    }
+  }
+
+  #checkForSnapInstallFlow(
+    id: string,
+    type: string,
+    origin: string,
+    requestData: Record<string, Json>,
+  ) {
+    const pendingApprovals = Object.values(this.state.pendingApprovals);
+    const isSnapApproval = SnapApprovalTypes.has(type);
+    const isSnapConnectApproval =
+      type === 'wallet_requestPermissions' &&
+      Boolean(
+        (requestData?.permissions as Record<string, unknown>)?.wallet_snap,
+      );
+
+    if (!isSnapApproval && !isSnapConnectApproval) {
+      return;
+    }
+
+    const hasSomeSnapInstallFlows = pendingApprovals.some(
+      (approval) =>
+        approval.id === id &&
+        (SnapApprovalTypes.has(approval.type) ||
+          Boolean(
+            (approval.requestData?.permissions as Record<string, unknown>)
+              ?.wallet_snap,
+          )),
+    );
+
+    if (hasSomeSnapInstallFlows) {
+      throw rpcErrors.resourceUnavailable(
+        getAlreadyPendingSnapInstallFlowMessage(origin),
+      );
     }
   }
 }

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -169,6 +169,9 @@ export enum ApprovalType {
   WalletConnect = 'wallet_connect',
   WalletRequestPermissions = 'wallet_requestPermissions',
   WatchAsset = 'wallet_watchAsset',
+  WalletInstallSnap = 'wallet_installSnap',
+  WalletUpdateSnap = 'wallet_updateSnap',
+  WalletInstallSnapResult = 'wallet_installSnapResult',
 }
 
 /**


### PR DESCRIPTION
## Explanation

* What is the current state of things and why does it need to change? The approval controller doesn't properly block multiple snap install requests from the same origin. One can technically open up to 3 install flows at once (connect to snap A, proceed to install step, connect to snap B, proceed to install-result step for snap A, proceed to install-result for snap B, connect to snap C).
* What is the solution your changes offer and how does it work? Add logic to treat `wallet_installSnap`, `wallet_updateSnap`, `wallet_installSnapResult` as one.
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain? The snap installation flow is comprised of multiple requests, hence why this probably slipped through the cracks.
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so? Added snap approval types to controller-utils (for use in the client).

## References

Are there any issues that this pull request is tied to? No
Are there other links that reviewers should consult to understand these changes better? These changes are necessary to complete this PR: https://github.com/MetaMask/metamask-extension/pull/33040

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
