### PR TITLE
fix: don't poll for swap status

### DIFF
--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/bridge-controller` peer dependency to `^25.0.1` ([#5811](https://github.com/MetaMask/core/pull/5811))
 - Bump `@metamask/controller-utils` to `^11.9.0` ([#5812](https://github.com/MetaMask/core/pull/5812))
 
+### Fixed
+
+- Don't start or restart getTxStatus polling if transaction is a swap ([#5829](https://github.com/MetaMask/core/pull/5829))
+
 ## [21.0.0]
 
 ### Changed

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Don't start or restart getTxStatus polling if transaction is a swap ([#5829](https://github.com/MetaMask/core/pull/5829))
+- Don't start or restart getTxStatus polling if transaction is a swap ([#5831](https://github.com/MetaMask/core/pull/5831))
 
 ## [21.0.0]
 

--- a/packages/bridge-status-controller/src/bridge-status-controller.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.test.ts
@@ -398,6 +398,38 @@ const MockTxHistory = {
       completionTime: undefined,
     },
   }),
+  getPendingSwap: ({
+    txMetaId = 'swapTxMetaId1',
+    srcTxHash = '0xsrcTxHash1',
+    account = '0xaccount1',
+    srcChainId = 42161,
+    destChainId = 42161,
+  } = {}): Record<string, BridgeHistoryItem> => ({
+    [txMetaId]: {
+      txMetaId,
+      quote: getMockQuote({ srcChainId, destChainId }),
+      startTime: 1729964825189,
+      estimatedProcessingTimeInSeconds: 15,
+      slippagePercentage: 0,
+      account,
+      status: MockStatusResponse.getPending({
+        srcTxHash,
+        srcChainId,
+      }),
+      targetContractAddress: '0x23981fC34e69eeDFE2BD9a0a9fCb0719Fe09DbFC',
+      initialDestAssetBalance: undefined,
+      pricingData: {
+        amountSent: '1.234',
+        amountSentInUsd: undefined,
+        quotedGasInUsd: undefined,
+        quotedReturnInUsd: undefined,
+      },
+      approvalTxId: undefined,
+      isStxEnabled: false,
+      hasApprovalTx: false,
+      completionTime: undefined,
+    },
+  }),
   getComplete: ({
     txMetaId = 'bridgeTxMetaId1',
     srcTxHash = '0xsrcTxHash1',
@@ -606,6 +638,7 @@ describe('BridgeStatusController', () => {
           txHistory: {
             ...MockTxHistory.getPending(),
             ...MockTxHistory.getUnknown(),
+            ...MockTxHistory.getPendingSwap(),
           },
         },
         clientId: BridgeClientId.EXTENSION,


### PR DESCRIPTION
## Explanation

After a swap is submitted the status controller keeps calling getTxStatus. This is unnecessary and can cause clients to keep polling until the user clears their activity log
 
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
