### PR TITLE
fix: add optional account for fetching historical prices

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added optional`account` parameter to `fetchHistoricalPricesForAsset` method in `MultichainAssetsRatesController` ([#5833](https://github.com/MetaMask/core/pull/5833))
 - Updated `TokenListController` `fetchTokenList` method to bail if cache is valid ([#5804](https://github.com/MetaMask/core/pull/5804))
   - also cleaned up internal state update logic
 - Bump `@metamask/controller-utils` to `^11.9.0` ([#5812](https://github.com/MetaMask/core/pull/5812))

--- a/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
+++ b/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
@@ -353,9 +353,13 @@ export class MultichainAssetsRatesController extends StaticIntervalPollingContro
    * Fetches historical prices for the current account
    *
    * @param asset - The asset to fetch historical prices for.
+   * @param account - optional account to fetch historical prices for
    * @returns The historical prices.
    */
-  async fetchHistoricalPricesForAsset(asset: CaipAssetType): Promise<void> {
+  async fetchHistoricalPricesForAsset(
+    asset: CaipAssetType,
+    account?: InternalAccount,
+  ): Promise<void> {
     const releaseLock = await this.#mutex.acquire();
     return (async () => {
       const currentCaipCurrency =
@@ -373,9 +377,11 @@ export class MultichainAssetsRatesController extends StaticIntervalPollingContro
         return;
       }
 
-      const selectedAccount = this.messagingSystem.call(
-        'AccountsController:getSelectedMultichainAccount',
-      );
+      const selectedAccount =
+        account ??
+        this.messagingSystem.call(
+          'AccountsController:getSelectedMultichainAccount',
+        );
       try {
         const historicalPricesResponse = await this.#handleSnapRequest({
           snapId: selectedAccount?.metadata.snap?.id as SnapId,


### PR DESCRIPTION
## Explanation

PR to add an optional account to fetchHistoricalPricesForAsset to be used instead of accountsController getSelectedMultichainAccount.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
