### PR TITLE
fix: Remove lingering decimal in return of `gweiDecimalToWeiDecimal`

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `userFeeLevel` as `dappSuggested` initially when dApp suggested gas values for legacy transactions ([#5821](https://github.com/MetaMask/core/pull/5821))
 - Fix `addTransaction` function to correctly identify a transaction as a `simpleSend` type when the recipient is a smart account ([#5822](https://github.com/MetaMask/core/pull/5822))
+- Fix `gweiDecimalToWeiDecimal` function used in `RandomisedEstimationsGasFeeFlow` to prevent return WEI value with lingering decimal ([#5839](https://github.com/MetaMask/core/pull/5839))
 
 ## [56.1.0]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `userFeeLevel` as `dappSuggested` initially when dApp suggested gas values for legacy transactions ([#5821](https://github.com/MetaMask/core/pull/5821))
 - Fix `addTransaction` function to correctly identify a transaction as a `simpleSend` type when the recipient is a smart account ([#5822](https://github.com/MetaMask/core/pull/5822))
-- Fix `gweiDecimalToWeiDecimal` function used in `RandomisedEstimationsGasFeeFlow` to prevent return WEI value with lingering decimal ([#5839](https://github.com/MetaMask/core/pull/5839))
+- Fix gas fee randomisation with many decimal places ([#5839](https://github.com/MetaMask/core/pull/5839))
 
 ## [56.1.0]
 

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -585,28 +585,28 @@ describe('gweiDecimalToWeiDecimal', () => {
     expect(gweiDecimalToWeiDecimal('1.123456789123')).toBe('1123456789');
     expect(gweiDecimalToWeiDecimal(1.123456789123)).toBe('1123456789');
   });
-  
+
   it('handles small decimal values', () => {
     expect(gweiDecimalToWeiDecimal('0.000000001')).toBe('1');
     expect(gweiDecimalToWeiDecimal(0.000000001)).toBe('1');
     expect(gweiDecimalToWeiDecimal('0.00000001')).toBe('10');
   });
-  
+
   it('handles string values with leading zeros', () => {
     expect(gweiDecimalToWeiDecimal('00.1')).toBe('100000000');
     expect(gweiDecimalToWeiDecimal('01.5')).toBe('1500000000');
   });
-  
+
   it('handles string values with trailing zeros', () => {
     expect(gweiDecimalToWeiDecimal('1.500')).toBe('1500000000');
     expect(gweiDecimalToWeiDecimal('123.450000')).toBe('123450000000');
   });
-  
+
   it('handles extremely small values', () => {
     expect(gweiDecimalToWeiDecimal('0.000000000001')).toBe('0');
     expect(gweiDecimalToWeiDecimal(0.000000000001)).toBe('0');
   });
-  
+
   it('handles scientific notation inputs', () => {
     expect(gweiDecimalToWeiDecimal('1e-9')).toBe('1');
     expect(gweiDecimalToWeiDecimal(1e-9)).toBe('1');

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -580,4 +580,37 @@ describe('gweiDecimalToWeiDecimal', () => {
     expect(gweiDecimalToWeiDecimal('1000000')).toBe('1000000000000000');
     expect(gweiDecimalToWeiDecimal(1000000)).toBe('1000000000000000');
   });
+
+  it('handles values with many decimal places', () => {
+    expect(gweiDecimalToWeiDecimal('1.123456789123')).toBe('1123456789');
+    expect(gweiDecimalToWeiDecimal(1.123456789123)).toBe('1123456789');
+  });
+  
+  it('handles small decimal values', () => {
+    expect(gweiDecimalToWeiDecimal('0.000000001')).toBe('1');
+    expect(gweiDecimalToWeiDecimal(0.000000001)).toBe('1');
+    expect(gweiDecimalToWeiDecimal('0.00000001')).toBe('10');
+  });
+  
+  it('handles string values with leading zeros', () => {
+    expect(gweiDecimalToWeiDecimal('00.1')).toBe('100000000');
+    expect(gweiDecimalToWeiDecimal('01.5')).toBe('1500000000');
+  });
+  
+  it('handles string values with trailing zeros', () => {
+    expect(gweiDecimalToWeiDecimal('1.500')).toBe('1500000000');
+    expect(gweiDecimalToWeiDecimal('123.450000')).toBe('123450000000');
+  });
+  
+  it('handles extremely small values', () => {
+    expect(gweiDecimalToWeiDecimal('0.000000000001')).toBe('0');
+    expect(gweiDecimalToWeiDecimal(0.000000000001)).toBe('0');
+  });
+  
+  it('handles scientific notation inputs', () => {
+    expect(gweiDecimalToWeiDecimal('1e-9')).toBe('1');
+    expect(gweiDecimalToWeiDecimal(1e-9)).toBe('1');
+    expect(gweiDecimalToWeiDecimal('1e9')).toBe('1000000000000000000');
+    expect(gweiDecimalToWeiDecimal(1e9)).toBe('1000000000000000000');
+  });
 });

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -5,6 +5,7 @@ import {
   toHex,
 } from '@metamask/controller-utils';
 import type EthQuery from '@metamask/eth-query';
+import { BN } from 'bn.js';
 import type {
   FetchGasFeeEstimateOptions,
   GasFeeState,
@@ -126,12 +127,9 @@ export function gweiDecimalToWeiHex(value: string) {
  * // Returns "1500000000"
  */
 export function gweiDecimalToWeiDecimal(gweiDecimal: string | number): string {
-  const gwei =
-    typeof gweiDecimal === 'string' ? gweiDecimal : String(gweiDecimal);
+  const weiValue = Number(gweiDecimal) * 1e9;
 
-  const weiDecimal = Number(gwei) * 1e9;
-
-  return weiDecimal.toString();
+  return weiValue.toString().split('.')[0];
 }
 
 /**

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -5,7 +5,6 @@ import {
   toHex,
 } from '@metamask/controller-utils';
 import type EthQuery from '@metamask/eth-query';
-import { BN } from 'bn.js';
 import type {
   FetchGasFeeEstimateOptions,
   GasFeeState,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR aims to fix minor issue on `gweiDecimalToWeiDecimal` utility. 

If given value is more than 9 decimal places then generated WEI value will have decimal part which we don't expect / want in WEI value. 

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/4973

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [X] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
