### PR TITLE
feat(accounts-controller): Add `entropySource` to new `InternalAccount`

### DIFF
--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
-- Populate `.options.entropySource` for new `InternalAccounts` before publishing ([#5841](https://github.com/MetaMask/core/pull/5841))
+- Populate `.options.entropySource` for new `InternalAccount`s before publishing `:accountAdded` ([#5841](https://github.com/MetaMask/core/pull/5841))
 
 ## [29.0.0]
 

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Populate `.options.entropySource` for new `InternalAccounts` before publishing ([#5841](https://github.com/MetaMask/core/pull/5841))
+
 ## [29.0.0]
 
 ### Changed

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -7,9 +7,9 @@ import type {
 } from '@metamask/keyring-api';
 import {
   BtcAccountType,
+  BtcScope,
   EthAccountType,
   EthScope,
-  BtcScope,
 } from '@metamask/keyring-api';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
@@ -17,8 +17,8 @@ import type { NetworkClientId } from '@metamask/network-controller';
 import type { SnapControllerState } from '@metamask/snaps-controllers';
 import { SnapStatus } from '@metamask/snaps-utils';
 import type { CaipChainId } from '@metamask/utils';
-import * as uuid from 'uuid';
 import type { V4Options } from 'uuid';
+import * as uuid from 'uuid';
 
 import type {
   AccountsControllerActions,
@@ -56,9 +56,7 @@ const mockGetState = jest.fn();
 const mockAccount: InternalAccount = {
   id: 'mock-id',
   address: '0x123',
-  options: {
-    entropySource: 'mock-id',
-  },
+  options: {},
   methods: [...ETH_EOA_METHODS],
   type: EthAccountType.Eoa,
   scopes: [EthScope.Eoa],
@@ -74,9 +72,7 @@ const mockAccount: InternalAccount = {
 const mockAccount2: InternalAccount = {
   id: 'mock-id2',
   address: '0x1234',
-  options: {
-    entropySource: 'mock-id',
-  },
+  options: {},
   methods: [...ETH_EOA_METHODS],
   type: EthAccountType.Eoa,
   scopes: [EthScope.Eoa],
@@ -91,9 +87,7 @@ const mockAccount2: InternalAccount = {
 const mockAccount3: InternalAccount = {
   id: 'mock-id3',
   address: '0x3333',
-  options: {
-    entropySource: 'mock-id',
-  },
+  options: {},
   methods: [...ETH_EOA_METHODS],
   type: EthAccountType.Eoa,
   scopes: [EthScope.Eoa],
@@ -184,6 +178,29 @@ function setLastSelectedAsAny(account: InternalAccount): InternalAccount {
   deepClonedAccount.metadata.lastSelected = expect.any(Number);
   deepClonedAccount.metadata.importTime = expect.any(Number);
   return deepClonedAccount;
+}
+
+/**
+ * Sets the `entropySource` property of the given `account` to the specified
+ * keyringId value.
+ *
+ * @param account - The account to modify.
+ * @param keyringId - The keyring ID to set as entropySource.
+ * @returns The modified account.
+ */
+function populateEntropySource(
+  account: InternalAccount,
+  keyringId: string,
+): InternalAccount {
+  return JSON.parse(
+    JSON.stringify({
+      ...account,
+      options: {
+        ...account.options,
+        entropySource: keyringId,
+      },
+    }),
+  ) as InternalAccount;
 }
 
 /**
@@ -627,7 +644,7 @@ describe('AccountsController', () => {
 
         expect(accounts).toStrictEqual([
           mockAccount,
-          setLastSelectedAsAny(mockAccount2),
+          setLastSelectedAsAny(populateEntropySource(mockAccount2, 'mock-id')),
         ]);
       });
 
@@ -701,9 +718,6 @@ describe('AccountsController', () => {
               address: mockAccount3.address,
               keyringType: mockAccount3.metadata.keyring.type as KeyringTypes,
               snap: mockAccount3.metadata.snap,
-              options: {
-                entropySource: 'mock-id2',
-              },
             }),
           ),
         ]);
@@ -886,7 +900,7 @@ describe('AccountsController', () => {
               address: mockAccount3.address,
               keyringType: KeyringTypes.hd,
               options: {
-                entropySource: mockAccount3.options.entropySource,
+                entropySource: 'mock-id',
               },
             }),
           ),
@@ -954,7 +968,7 @@ describe('AccountsController', () => {
             address: mockAccount3.address,
             keyringType: KeyringTypes.hd,
             options: {
-              entropySource: mockAccount3.options.entropySource,
+              entropySource: 'mock-id',
             },
           }),
         ]);
@@ -1058,7 +1072,7 @@ describe('AccountsController', () => {
 
         expect(accounts).toStrictEqual([
           mockAccount,
-          setLastSelectedAsAny(mockAccount2),
+          setLastSelectedAsAny(populateEntropySource(mockAccount2, 'mock-id')),
         ]);
         expect(accountsController.getSelectedAccount().id).toBe(mockAccount.id);
       });
@@ -1107,7 +1121,7 @@ describe('AccountsController', () => {
           // 2. AccountsController:stateChange
           3,
           'AccountsController:accountAdded',
-          setLastSelectedAsAny(mockAccount2),
+          setLastSelectedAsAny(populateEntropySource(mockAccount2, 'mock-id')),
         );
       });
     });
@@ -2059,9 +2073,6 @@ describe('AccountsController', () => {
           address: mockSnapAccount2.address,
           keyringType: KeyringTypes.snap,
           snap: mockSnapAccount2.metadata.snap,
-          options: {
-            entropySource: 'mock-id',
-          },
         }),
       ];
 
@@ -2134,9 +2145,6 @@ describe('AccountsController', () => {
           address: mockSnapAccount2.address,
           keyringType: KeyringTypes.snap,
           snap: mockSnapAccount2.metadata.snap,
-          options: {
-            entropySource: 'mock-id',
-          },
         }),
       ];
 
@@ -3057,27 +3065,18 @@ describe('AccountsController', () => {
       name: 'Account 2',
       address: '0x555',
       keyringType: KeyringTypes.simple,
-      options: {
-        entropySource: 'mock-id2',
-      },
     });
     const mockSimpleKeyring2 = createMockInternalAccount({
       id: 'mock-id3',
       name: 'Account 3',
       address: '0x666',
       keyringType: KeyringTypes.simple,
-      options: {
-        entropySource: 'mock-id2',
-      },
     });
     const mockSimpleKeyring3 = createMockInternalAccount({
       id: 'mock-id4',
       name: 'Account 4',
       address: '0x777',
       keyringType: KeyringTypes.simple,
-      options: {
-        entropySource: 'mock-id2',
-      },
     });
 
     const mockNewKeyringStateWith = (simpleAddressess: string[]) => {

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -703,7 +703,7 @@ describe('AccountsController', () => {
               snap: mockAccount3.metadata.snap,
               options: {
                 entropySource: 'mock-id2',
-              }
+              },
             }),
           ),
         ]);

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -56,7 +56,9 @@ const mockGetState = jest.fn();
 const mockAccount: InternalAccount = {
   id: 'mock-id',
   address: '0x123',
-  options: {},
+  options: {
+    entropySource: 'mock-id',
+  },
   methods: [...ETH_EOA_METHODS],
   type: EthAccountType.Eoa,
   scopes: [EthScope.Eoa],
@@ -72,7 +74,9 @@ const mockAccount: InternalAccount = {
 const mockAccount2: InternalAccount = {
   id: 'mock-id2',
   address: '0x1234',
-  options: {},
+  options: {
+    entropySource: 'mock-id',
+  },
   methods: [...ETH_EOA_METHODS],
   type: EthAccountType.Eoa,
   scopes: [EthScope.Eoa],
@@ -87,7 +91,9 @@ const mockAccount2: InternalAccount = {
 const mockAccount3: InternalAccount = {
   id: 'mock-id3',
   address: '0x3333',
-  options: {},
+  options: {
+    entropySource: 'mock-id',
+  },
   methods: [...ETH_EOA_METHODS],
   type: EthAccountType.Eoa,
   scopes: [EthScope.Eoa],
@@ -695,6 +701,9 @@ describe('AccountsController', () => {
               address: mockAccount3.address,
               keyringType: mockAccount3.metadata.keyring.type as KeyringTypes,
               snap: mockAccount3.metadata.snap,
+              options: {
+                entropySource: 'mock-id2',
+              }
             }),
           ),
         ]);
@@ -876,6 +885,9 @@ describe('AccountsController', () => {
               name: 'Account 3',
               address: mockAccount3.address,
               keyringType: KeyringTypes.hd,
+              options: {
+                entropySource: mockAccount3.options.entropySource,
+              },
             }),
           ),
         ]);
@@ -941,7 +953,9 @@ describe('AccountsController', () => {
             name: 'Account 3',
             address: mockAccount3.address,
             keyringType: KeyringTypes.hd,
-            options: {},
+            options: {
+              entropySource: mockAccount3.options.entropySource,
+            },
           }),
         ]);
       });
@@ -1407,6 +1421,9 @@ describe('AccountsController', () => {
         name: 'Account 1',
         address: '0x456',
         keyringType: KeyringTypes.hd,
+        options: {
+          entropySource: 'mock-id',
+        },
       });
 
       mockUUIDWithNormalAccounts([
@@ -2042,6 +2059,9 @@ describe('AccountsController', () => {
           address: mockSnapAccount2.address,
           keyringType: KeyringTypes.snap,
           snap: mockSnapAccount2.metadata.snap,
+          options: {
+            entropySource: 'mock-id',
+          },
         }),
       ];
 
@@ -2114,6 +2134,9 @@ describe('AccountsController', () => {
           address: mockSnapAccount2.address,
           keyringType: KeyringTypes.snap,
           snap: mockSnapAccount2.metadata.snap,
+          options: {
+            entropySource: 'mock-id',
+          },
         }),
       ];
 
@@ -3034,18 +3057,27 @@ describe('AccountsController', () => {
       name: 'Account 2',
       address: '0x555',
       keyringType: KeyringTypes.simple,
+      options: {
+        entropySource: 'mock-id2',
+      },
     });
     const mockSimpleKeyring2 = createMockInternalAccount({
       id: 'mock-id3',
       name: 'Account 3',
       address: '0x666',
       keyringType: KeyringTypes.simple,
+      options: {
+        entropySource: 'mock-id2',
+      },
     });
     const mockSimpleKeyring3 = createMockInternalAccount({
       id: 'mock-id4',
       name: 'Account 4',
       address: '0x777',
       keyringType: KeyringTypes.simple,
+      options: {
+        entropySource: 'mock-id2',
+      },
     });
 
     const mockNewKeyringStateWith = (simpleAddressess: string[]) => {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -906,7 +906,9 @@ export class AccountsController extends BaseController<
               },
               options: {
                 ...account.options,
-                entropySource: added.entropySource,
+                ...(added.type === KeyringTypes.hd
+                  ? { entropySource: added.entropySource }
+                  : {}),
               },
             };
 

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -791,6 +791,7 @@ export class AccountsController extends BaseController<
         added: [] as {
           address: string;
           type: string;
+          entropySource: string;
         }[],
         updated: [] as InternalAccount[],
         removed: [] as InternalAccount[],
@@ -836,6 +837,7 @@ export class AccountsController extends BaseController<
           patch.added.push({
             address,
             type: keyring.type,
+            entropySource: keyring.metadata.id,
           });
         }
 
@@ -901,6 +903,10 @@ export class AccountsController extends BaseController<
                 name,
                 importTime: Date.now(),
                 lastSelected,
+              },
+              options: {
+                ...account.options,
+                entropySource: added.entropySource,
               },
             };
 

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -791,7 +791,7 @@ export class AccountsController extends BaseController<
         added: [] as {
           address: string;
           type: string;
-          entropySource: string;
+          options: InternalAccount['options'];
         }[],
         updated: [] as InternalAccount[],
         removed: [] as InternalAccount[],
@@ -837,7 +837,11 @@ export class AccountsController extends BaseController<
           patch.added.push({
             address,
             type: keyring.type,
-            entropySource: keyring.metadata.id,
+            // Automatically injects `entropySource` for HD accounts only.
+            options:
+              keyring.type === KeyringTypes.hd
+                ? { entropySource: keyring.metadata.id }
+                : {},
           });
         }
 
@@ -906,9 +910,7 @@ export class AccountsController extends BaseController<
               },
               options: {
                 ...account.options,
-                ...(added.type === KeyringTypes.hd
-                  ? { entropySource: added.entropySource }
-                  : {}),
+                ...added.options,
               },
             };
 


### PR DESCRIPTION
## Explanation

`AccountsController:accountAdded` events were missing the `.options.entropySource` property, causing account syncing to misbehave, registering new accounts to the primary SRP instead of the actual SRP used to add the account.

We now add the `entropySource` to these new `InternalAccount`s based on the `keyring` that was used to create them.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
Relates to #5618
Relates to #5725
Relates to #5753

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
