### PR TITLE
fix(rpc-service): improve error handling for HTTP status codes

### DIFF
--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved error handling in RPC service with more specific error types ([#5843](https://github.com/MetaMask/core/pull/5843)):
+  - 401 responses now throw an "Unauthorized" error
+  - 402/404/5xx responses now throw a "Resource Unavailable" error
+  - 405/501 responses now throw a "Method Not Found" error
+  - 429 responses now throw a "Rate Limiting" error
+  - Other 4xx responses now throw an "Invalid Request" error
+  - Invalid JSON responses now throw a "Parse" error
+
 ## [23.5.0]
 
 ### Changed

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -12,9 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling in RPC service with more specific error types ([#5843](https://github.com/MetaMask/core/pull/5843)):
   - 401 responses now throw an "Unauthorized" error
   - 402/404/5xx responses now throw a "Resource Unavailable" error
-  - 501 responses now throw a "Method Not Found" error
   - 429 responses now throw a "Rate Limiting" error
-  - Other 4xx responses now throw an "Invalid Request" error
+  - Other 4xx responses now throw a generic HTTP client error
   - Invalid JSON responses now throw a "Parse" error
 
 ## [23.5.0]

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling in RPC service with more specific error types ([#5843](https://github.com/MetaMask/core/pull/5843)):
   - 401 responses now throw an "Unauthorized" error
   - 402/404/5xx responses now throw a "Resource Unavailable" error
-  - 405/501 responses now throw a "Method Not Found" error
+  - 501 responses now throw a "Method Not Found" error
   - 429 responses now throw a "Rate Limiting" error
   - Other 4xx responses now throw an "Invalid Request" error
   - Invalid JSON responses now throw a "Parse" error

--- a/packages/network-controller/src/rpc-service/rpc-service-chain.test.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service-chain.test.ts
@@ -193,22 +193,22 @@ describe('RpcServiceChain', () => {
       };
       // Retry the first endpoint until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Retry the first endpoint again, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Retry the first endpoint for a third time, until max retries is hit.
       // The circuit will break on the last time, and the second endpoint will
       // be retried, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
@@ -315,22 +315,22 @@ describe('RpcServiceChain', () => {
       // Retry the first endpoint until max retries is hit.
       await expect(
         rpcServiceChain.request(jsonRpcRequest, fetchOptions),
-      ).rejects.toThrow('Gateway timeout');
+      ).rejects.toThrow('RPC endpoint server error (HTTP 503)');
       // Retry the first endpoint again, until max retries is hit.
       await expect(
         rpcServiceChain.request(jsonRpcRequest, fetchOptions),
-      ).rejects.toThrow('Gateway timeout');
+      ).rejects.toThrow('RPC endpoint server error (HTTP 503)');
       // Retry the first endpoint for a third time, until max retries is hit.
       // The circuit will break on the last time, and the second endpoint will
       // be retried, until max retries is hit.
       await expect(
         rpcServiceChain.request(jsonRpcRequest, fetchOptions),
-      ).rejects.toThrow('Gateway timeout');
+      ).rejects.toThrow('RPC endpoint server error (HTTP 503)');
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       await expect(
         rpcServiceChain.request(jsonRpcRequest, fetchOptions),
-      ).rejects.toThrow('Gateway timeout');
+      ).rejects.toThrow('RPC endpoint server error (HTTP 503)');
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       // The circuit will break on the last time, and the third endpoint will
@@ -415,22 +415,22 @@ describe('RpcServiceChain', () => {
       };
       // Retry the first endpoint until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Retry the first endpoint again, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Retry the first endpoint for a third time, until max retries is hit.
       // The circuit will break on the last time, and the second endpoint will
       // be retried, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
@@ -530,22 +530,22 @@ describe('RpcServiceChain', () => {
       };
       // Retry the first endpoint until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Retry the first endpoint again, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Retry the first endpoint for a third time, until max retries is hit.
       // The circuit will break on the last time, and the second endpoint will
       // be retried, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
@@ -645,22 +645,22 @@ describe('RpcServiceChain', () => {
       };
       // Retry the first endpoint until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Retry the first endpoint again, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Retry the first endpoint for a third time, until max retries is hit.
       // The circuit will break on the last time, and the second endpoint will
       // be retried, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'Gateway timeout',
+        'RPC endpoint server error (HTTP 503)',
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.

--- a/packages/network-controller/src/rpc-service/rpc-service-chain.test.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service-chain.test.ts
@@ -195,7 +195,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -205,7 +205,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -217,7 +217,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -228,7 +228,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -342,7 +342,7 @@ describe('RpcServiceChain', () => {
       ).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -354,7 +354,7 @@ describe('RpcServiceChain', () => {
       ).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -368,7 +368,7 @@ describe('RpcServiceChain', () => {
       ).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -381,7 +381,7 @@ describe('RpcServiceChain', () => {
       ).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -473,7 +473,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -483,7 +483,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -495,7 +495,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -506,7 +506,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -612,7 +612,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -622,7 +622,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -634,7 +634,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -645,7 +645,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -751,7 +751,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -761,7 +761,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -773,7 +773,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },
@@ -784,7 +784,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint server error (HTTP 503)',
+          message: 'RPC endpoint not found or unavailable',
           data: {
             httpStatus: 503,
           },

--- a/packages/network-controller/src/rpc-service/rpc-service-chain.test.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service-chain.test.ts
@@ -195,7 +195,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -205,7 +205,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -217,7 +217,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -228,7 +228,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -342,7 +342,7 @@ describe('RpcServiceChain', () => {
       ).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -354,7 +354,7 @@ describe('RpcServiceChain', () => {
       ).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -368,7 +368,7 @@ describe('RpcServiceChain', () => {
       ).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -381,7 +381,7 @@ describe('RpcServiceChain', () => {
       ).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -473,7 +473,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -483,7 +483,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -495,7 +495,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -506,7 +506,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -612,7 +612,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -622,7 +622,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -634,7 +634,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -645,7 +645,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -751,7 +751,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -761,7 +761,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -773,7 +773,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },
@@ -784,7 +784,7 @@ describe('RpcServiceChain', () => {
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
         expect.objectContaining({
           code: -32002,
-          message: 'RPC endpoint not found or unavailable',
+          message: 'RPC endpoint not found or unavailable.',
           data: {
             httpStatus: 503,
           },

--- a/packages/network-controller/src/rpc-service/rpc-service-chain.test.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service-chain.test.ts
@@ -193,22 +193,46 @@ describe('RpcServiceChain', () => {
       };
       // Retry the first endpoint until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Retry the first endpoint again, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Retry the first endpoint for a third time, until max retries is hit.
       // The circuit will break on the last time, and the second endpoint will
       // be retried, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
@@ -415,22 +439,46 @@ describe('RpcServiceChain', () => {
       };
       // Retry the first endpoint until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Retry the first endpoint again, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Retry the first endpoint for a third time, until max retries is hit.
       // The circuit will break on the last time, and the second endpoint will
       // be retried, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
@@ -530,22 +578,46 @@ describe('RpcServiceChain', () => {
       };
       // Retry the first endpoint until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Retry the first endpoint again, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Retry the first endpoint for a third time, until max retries is hit.
       // The circuit will break on the last time, and the second endpoint will
       // be retried, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
@@ -645,22 +717,46 @@ describe('RpcServiceChain', () => {
       };
       // Retry the first endpoint until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Retry the first endpoint again, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Retry the first endpoint for a third time, until max retries is hit.
       // The circuit will break on the last time, and the second endpoint will
       // be retried, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       await expect(rpcServiceChain.request(jsonRpcRequest)).rejects.toThrow(
-        'RPC endpoint server error (HTTP 503)',
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
       );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.

--- a/packages/network-controller/src/rpc-service/rpc-service-chain.test.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service-chain.test.ts
@@ -339,22 +339,54 @@ describe('RpcServiceChain', () => {
       // Retry the first endpoint until max retries is hit.
       await expect(
         rpcServiceChain.request(jsonRpcRequest, fetchOptions),
-      ).rejects.toThrow('RPC endpoint server error (HTTP 503)');
+      ).rejects.toThrow(
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
+      );
       // Retry the first endpoint again, until max retries is hit.
       await expect(
         rpcServiceChain.request(jsonRpcRequest, fetchOptions),
-      ).rejects.toThrow('RPC endpoint server error (HTTP 503)');
+      ).rejects.toThrow(
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
+      );
       // Retry the first endpoint for a third time, until max retries is hit.
       // The circuit will break on the last time, and the second endpoint will
       // be retried, until max retries is hit.
       await expect(
         rpcServiceChain.request(jsonRpcRequest, fetchOptions),
-      ).rejects.toThrow('RPC endpoint server error (HTTP 503)');
+      ).rejects.toThrow(
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
+      );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       await expect(
         rpcServiceChain.request(jsonRpcRequest, fetchOptions),
-      ).rejects.toThrow('RPC endpoint server error (HTTP 503)');
+      ).rejects.toThrow(
+        expect.objectContaining({
+          code: -32002,
+          message: 'RPC endpoint server error (HTTP 503)',
+          data: {
+            httpStatus: 503,
+          },
+        }),
+      );
       // Try the first endpoint, see that the circuit is broken, and retry the
       // second endpoint, until max retries is hit.
       // The circuit will break on the last time, and the third endpoint will

--- a/packages/network-controller/src/rpc-service/rpc-service-chain.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service-chain.ts
@@ -99,11 +99,11 @@ export class RpcServiceChain implements RpcServiceRequestable {
    * @param fetchOptions - An options bag for {@link fetch} which further
    * specifies the request.
    * @returns The decoded JSON-RPC response from the endpoint.
-   * @throws A "method not found" error if the response status is 405.
-   * @throws A rate limiting error if the response HTTP status is 429.
-   * @throws A timeout error if the response HTTP status is 503 or 504.
-   * @throws A generic error if the response HTTP status is not 2xx but also not
-   * 405, 429, 503, or 504.
+   * @throws A 401 error if the response status is 401.
+   * @throws A "rate limiting" error if the response HTTP status is 429.
+   * @throws A "resource unavailable" error if the response status is 402, 404, or any 5xx.
+   * @throws A generic HTTP client error (-32100) for any other 4xx status codes.
+   * @throws A "parse" error if the response is not valid JSON.
    */
   async request<Params extends JsonRpcParams, Result extends Json>(
     jsonRpcRequest: JsonRpcRequest<Params> & { method: 'eth_getBlockByNumber' },
@@ -122,11 +122,11 @@ export class RpcServiceChain implements RpcServiceRequestable {
    * @param fetchOptions - An options bag for {@link fetch} which further
    * specifies the request.
    * @returns The decoded JSON-RPC response from the endpoint.
-   * @throws A "method not found" error if the response status is 405.
-   * @throws A rate limiting error if the response HTTP status is 429.
-   * @throws A timeout error if the response HTTP status is 503 or 504.
-   * @throws A generic error if the response HTTP status is not 2xx but also not
-   * 405, 429, 503, or 504.
+   * @throws A 401 error if the response status is 401.
+   * @throws A "rate limiting" error if the response HTTP status is 429.
+   * @throws A "resource unavailable" error if the response status is 402, 404, or any 5xx.
+   * @throws A generic HTTP client error (-32100) for any other 4xx status codes.
+   * @throws A "parse" error if the response is not valid JSON.
    */
   async request<Params extends JsonRpcParams, Result extends Json>(
     jsonRpcRequest: JsonRpcRequest<Params>,

--- a/packages/network-controller/src/rpc-service/rpc-service.test.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.test.ts
@@ -345,7 +345,15 @@ describe('RpcService', () => {
           method: 'eth_chainId',
           params: [],
         });
-        await expect(promise).rejects.toThrow('Unauthorized.');
+        await expect(promise).rejects.toThrow(
+          expect.objectContaining({
+            code: -33100,
+            message: 'Unauthorized.',
+            data: {
+              httpStatus: 401,
+            },
+          }),
+        );
       });
 
       it('does not forward the request to a failover service if given one', async () => {
@@ -431,7 +439,13 @@ describe('RpcService', () => {
             params: [],
           });
           await expect(promise).rejects.toThrow(
-            `RPC endpoint server error (HTTP ${httpStatus})`,
+            expect.objectContaining({
+              code: -32002,
+              message: `RPC endpoint server error (HTTP ${httpStatus})`,
+              data: {
+                httpStatus,
+              },
+            }),
           );
         });
 
@@ -517,7 +531,13 @@ describe('RpcService', () => {
           params: [],
         });
         await expect(promise).rejects.toThrow(
-          'The method does not exist / is not available.',
+          expect.objectContaining({
+            code: -32601,
+            message: 'The method does not exist / is not available.',
+            data: {
+              httpStatus: 501,
+            },
+          }),
         );
       });
 
@@ -601,7 +621,15 @@ describe('RpcService', () => {
           method: 'eth_chainId',
           params: [],
         });
-        await expect(promise).rejects.toThrow('Request is being rate limited.');
+        await expect(promise).rejects.toThrow(
+          expect.objectContaining({
+            code: -32005,
+            message: 'Request is being rate limited.',
+            data: {
+              httpStatus: 429,
+            },
+          }),
+        );
       });
 
       it('does not forward the request to a failover service if given one', async () => {
@@ -689,7 +717,13 @@ describe('RpcService', () => {
           params: [],
         });
         await expect(promise).rejects.toThrow(
-          'The JSON sent is not a valid Request object.',
+          expect.objectContaining({
+            code: -32600,
+            message: 'The JSON sent is not a valid Request object.',
+            data: {
+              httpStatus: 403,
+            },
+          }),
         );
       });
 

--- a/packages/network-controller/src/rpc-service/rpc-service.test.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.test.ts
@@ -315,7 +315,7 @@ describe('RpcService', () => {
           getClock: () => clock,
           httpStatus,
           expectedError: rpcErrors.internal({
-            message: 'RPC endpoint not found or unavailable',
+            message: 'RPC endpoint not found or unavailable.',
           }),
           expectedOnBreakError: new HttpError(httpStatus),
         });
@@ -441,7 +441,7 @@ describe('RpcService', () => {
           await expect(promise).rejects.toThrow(
             expect.objectContaining({
               code: -32002,
-              message: 'RPC endpoint not found or unavailable',
+              message: 'RPC endpoint not found or unavailable.',
               data: {
                 httpStatus,
               },
@@ -506,97 +506,6 @@ describe('RpcService', () => {
         });
       },
     );
-
-    describe('if the endpoint has a 501 response', () => {
-      it('throws a method not found error without retrying the request', async () => {
-        const endpointUrl = 'https://rpc.example.chain';
-        nock(endpointUrl)
-          .post('/', {
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'eth_unknownMethod',
-            params: [],
-          })
-          .reply(501);
-        const service = new RpcService({
-          fetch,
-          btoa,
-          endpointUrl,
-        });
-
-        const promise = service.request({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'eth_unknownMethod',
-          params: [],
-        });
-        await expect(promise).rejects.toThrow(
-          expect.objectContaining({
-            code: -32601,
-            message: 'The method does not exist / is not available.',
-            data: {
-              httpStatus: 501,
-            },
-          }),
-        );
-      });
-
-      it('does not forward the request to a failover service if given one', async () => {
-        const endpointUrl = 'https://rpc.example.chain';
-        nock(endpointUrl)
-          .post('/', {
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'eth_unknownMethod',
-            params: [],
-          })
-          .reply(501);
-        const failoverService = buildMockRpcService();
-        const service = new RpcService({
-          fetch,
-          btoa,
-          endpointUrl,
-          failoverService,
-        });
-
-        const jsonRpcRequest = {
-          id: 1,
-          jsonrpc: '2.0' as const,
-          method: 'eth_unknownMethod',
-          params: [],
-        };
-        await ignoreRejection(service.request(jsonRpcRequest));
-        expect(failoverService.request).not.toHaveBeenCalled();
-      });
-
-      it('does not call onBreak', async () => {
-        const endpointUrl = 'https://rpc.example.chain';
-        nock(endpointUrl)
-          .post('/', {
-            id: 1,
-            jsonrpc: '2.0',
-            method: 'eth_unknownMethod',
-            params: [],
-          })
-          .reply(501);
-        const onBreakListener = jest.fn();
-        const service = new RpcService({
-          fetch,
-          btoa,
-          endpointUrl,
-        });
-        service.onBreak(onBreakListener);
-
-        const promise = service.request({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'eth_unknownMethod',
-          params: [],
-        });
-        await ignoreRejection(promise);
-        expect(onBreakListener).not.toHaveBeenCalled();
-      });
-    });
 
     describe('if the endpoint has a 429 response', () => {
       it('throws a rate-limiting error without retrying the request', async () => {
@@ -718,8 +627,8 @@ describe('RpcService', () => {
         });
         await expect(promise).rejects.toThrow(
           expect.objectContaining({
-            code: -32600,
-            message: 'The JSON sent is not a valid Request object.',
+            code: -32100,
+            message: 'HTTP client error.',
             data: {
               httpStatus: 403,
             },

--- a/packages/network-controller/src/rpc-service/rpc-service.test.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.test.ts
@@ -308,7 +308,7 @@ describe('RpcService', () => {
       });
     });
 
-    describe.each([503, 504])(
+    describe.each([502, 503, 504])(
       'if the endpoint has a %d response',
       (httpStatus) => {
         testsForRetriableResponses({
@@ -413,7 +413,7 @@ describe('RpcService', () => {
       });
     });
 
-    describe.each([402, 404])(
+    describe.each([402, 404, 500, 501, 505, 506, 507, 508, 510, 511])(
       'if the endpoint has a %d response',
       (httpStatus) => {
         it('throws a resource unavailable error without retrying the request', async () => {

--- a/packages/network-controller/src/rpc-service/rpc-service.test.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.test.ts
@@ -315,7 +315,7 @@ describe('RpcService', () => {
           getClock: () => clock,
           httpStatus,
           expectedError: rpcErrors.internal({
-            message: `RPC endpoint server error (HTTP ${httpStatus})`,
+            message: 'RPC endpoint not found or unavailable',
           }),
           expectedOnBreakError: new HttpError(httpStatus),
         });
@@ -441,7 +441,7 @@ describe('RpcService', () => {
           await expect(promise).rejects.toThrow(
             expect.objectContaining({
               code: -32002,
-              message: `RPC endpoint server error (HTTP ${httpStatus})`,
+              message: 'RPC endpoint not found or unavailable',
               data: {
                 httpStatus,
               },

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -252,7 +252,9 @@ export class RpcService implements AbstractRpcService {
           error.message.includes('not valid JSON') ||
           // Ignore server overload errors
           ('httpStatus' in error &&
-            (error.httpStatus === 503 || error.httpStatus === 504)) ||
+            (error.httpStatus === 502 ||
+              error.httpStatus === 503 ||
+              error.httpStatus === 504)) ||
           (hasProperty(error, 'code') &&
             (error.code === 'ETIMEDOUT' || error.code === 'ECONNRESET'))
         );

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -337,7 +337,7 @@ export class RpcService implements AbstractRpcService {
    * specifies the request.
    * @returns The decoded JSON-RPC response from the endpoint.
    * @throws A 401 error if the response status is 401.
-   * @throws A "method not found" error if the response status is 405 or 501.
+   * @throws A "method not found" error if the response status is 501.
    * @throws A "rate limiting" error if the response HTTP status is 429.
    * @throws A "resource unavailable" error if the response status is 402, 404, or any 5xx.
    * @throws An "invalid request" error for any other 4xx status codes.
@@ -362,7 +362,7 @@ export class RpcService implements AbstractRpcService {
    * specifies the request.
    * @returns The decoded JSON-RPC response from the endpoint.
    * @throws A 401 error if the response status is 401.
-   * @throws A "method not found" error if the response status is 405 or 501.
+   * @throws A "method not found" error if the response status is 501.
    * @throws A "rate limiting" error if the response HTTP status is 429.
    * @throws A "resource unavailable" error if the response status is 402, 404, or any 5xx.
    * @throws An "invalid request" error for any other 4xx status codes.
@@ -467,7 +467,7 @@ export class RpcService implements AbstractRpcService {
    * fetch options passed to the constructor
    * @returns The decoded JSON-RPC response from the endpoint.
    * @throws A 401 error if the response status is 401.
-   * @throws A "method not found" error if the response status is 405 or 501.
+   * @throws A "method not found" error if the response status is 501.
    * @throws A "rate limiting" error if the response HTTP status is 429.
    * @throws A "resource unavailable" error if the response status is 402, 404, or any 5xx.
    * @throws An "invalid request" error for any other 4xx status codes.
@@ -493,15 +493,7 @@ export class RpcService implements AbstractRpcService {
             httpStatus: status,
           });
         }
-        if (status === 402 || status === 404) {
-          throw rpcErrors.resourceUnavailable({
-            message: `RPC endpoint server error (HTTP ${status})`,
-            data: {
-              httpStatus: status,
-            },
-          });
-        }
-        if (status === 405 || status === 501) {
+        if (status === 501) {
           throw rpcErrors.methodNotFound({
             data: {
               httpStatus: status,
@@ -516,13 +508,9 @@ export class RpcService implements AbstractRpcService {
             },
           });
         }
-        if (status >= 500 && status < 600) {
-          const message =
-            status === 503 || status === 504
-              ? 'Gateway timeout. The request took too long to process. This can happen when querying logs over too wide a block range.'
-              : `RPC endpoint server error (HTTP ${status})`;
+        if (status >= 500 || status === 402 || status === 404) {
           throw rpcErrors.resourceUnavailable({
-            message,
+            message: `RPC endpoint server error (HTTP ${status})`,
             data: {
               httpStatus: status,
             },

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -339,7 +339,7 @@ export class RpcService implements AbstractRpcService {
    * @throws A 401 error if the response status is 401.
    * @throws A "rate limiting" error if the response HTTP status is 429.
    * @throws A "resource unavailable" error if the response status is 402, 404, or any 5xx.
-   * @throws An "invalid request" error for any other 4xx status codes.
+   * @throws A generic HTTP client error (-32100) for any other 4xx status codes.
    * @throws A "parse" error if the response is not valid JSON.
    */
   async request<Params extends JsonRpcParams, Result extends Json>(
@@ -363,7 +363,7 @@ export class RpcService implements AbstractRpcService {
    * @throws A 401 error if the response status is 401.
    * @throws A "rate limiting" error if the response HTTP status is 429.
    * @throws A "resource unavailable" error if the response status is 402, 404, or any 5xx.
-   * @throws An "invalid request" error for any other 4xx status codes.
+   * @throws A generic HTTP client error (-32100) for any other 4xx status codes.
    * @throws A "parse" error if the response is not valid JSON.
    */
   async request<Params extends JsonRpcParams, Result extends Json>(
@@ -467,7 +467,7 @@ export class RpcService implements AbstractRpcService {
    * @throws A 401 error if the response status is 401.
    * @throws A "rate limiting" error if the response HTTP status is 429.
    * @throws A "resource unavailable" error if the response status is 402, 404, or any 5xx.
-   * @throws An "invalid request" error for any other 4xx status codes.
+   * @throws A generic HTTP client error (-32100) for any other 4xx status codes.
    * @throws A "parse" error if the response is not valid JSON.
    */
   async #processRequest<Result extends Json>(

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -510,7 +510,7 @@ export class RpcService implements AbstractRpcService {
         }
         if (status >= 500 || status === 402 || status === 404) {
           throw rpcErrors.resourceUnavailable({
-            message: `RPC endpoint server error (HTTP ${status})`,
+            message: 'RPC endpoint not found or unavailable',
             data: {
               httpStatus: status,
             },

--- a/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
@@ -337,7 +337,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
   });
 
   describe.each([
-    [405, 'The method does not exist / is not available.'],
+    [405, 'The JSON sent is not a valid Request object.'],
     [429, 'Request is being rate limited.'],
   ])(
     'if the RPC endpoint returns a %d response',
@@ -422,7 +422,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
   describe.each([503, 504])(
     'if the RPC endpoint returns a %d response',
     (httpStatus) => {
-      const errorMessage = 'Gateway timeout';
+      const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
 
       it('retries the request up to 5 times until there is a 200 response', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {

--- a/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
@@ -367,59 +367,61 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
     },
   );
 
-  describe('if the RPC endpoint returns a 5xx response that is not 503, or 504', () => {
-    const httpStatus = 500;
-    const errorMessage = 'RPC endpoint not found or unavailable.';
+  describe.each([500, 501, 505, 506, 507, 508, 510, 511])(
+    'if the RPC endpoint returns a %d response',
+    (httpStatus) => {
+      const errorMessage = 'RPC endpoint not found or unavailable.';
 
-    it('throws a generic, undescriptive error', async () => {
-      await withMockedCommunications({ providerType }, async (comms) => {
-        const request = { method };
+      it('throws a generic, undescriptive error', async () => {
+        await withMockedCommunications({ providerType }, async (comms) => {
+          const request = { method };
 
-        // The first time a block-cacheable request is made, the latest block
-        // number is retrieved through the block tracker first. It doesn't
-        // matter what this is — it's just used as a cache key.
-        comms.mockNextBlockTrackerRequest();
-        comms.mockRpcCall({
-          request,
-          response: {
-            httpStatus,
-          },
+          // The first time a block-cacheable request is made, the latest block
+          // number is retrieved through the block tracker first. It doesn't
+          // matter what this is — it's just used as a cache key.
+          comms.mockNextBlockTrackerRequest();
+          comms.mockRpcCall({
+            request,
+            response: {
+              httpStatus,
+            },
+          });
+          const promiseForResult = withNetworkClient(
+            { providerType },
+            async ({ makeRpcCall }) => makeRpcCall(request),
+          );
+
+          await expect(promiseForResult).rejects.toThrow(errorMessage);
         });
-        const promiseForResult = withNetworkClient(
-          { providerType },
-          async ({ makeRpcCall }) => makeRpcCall(request),
-        );
-
-        await expect(promiseForResult).rejects.toThrow(errorMessage);
       });
-    });
 
-    testsForRpcFailoverBehavior({
-      providerType,
-      requestToCall: {
-        method,
-        params: [],
-      },
-      getRequestToMock: () => ({
-        method,
-        params: [],
-      }),
-      failure: {
-        httpStatus,
-      },
-      isRetriableFailure: false,
-      getExpectedError: () =>
-        expect.objectContaining({
-          message: errorMessage,
+      testsForRpcFailoverBehavior({
+        providerType,
+        requestToCall: {
+          method,
+          params: [],
+        },
+        getRequestToMock: () => ({
+          method,
+          params: [],
         }),
-      getExpectedBreakError: () =>
-        expect.objectContaining({
-          message: `Fetch failed with status '${httpStatus}'`,
-        }),
-    });
-  });
+        failure: {
+          httpStatus,
+        },
+        isRetriableFailure: false,
+        getExpectedError: () =>
+          expect.objectContaining({
+            message: errorMessage,
+          }),
+        getExpectedBreakError: () =>
+          expect.objectContaining({
+            message: `Fetch failed with status '${httpStatus}'`,
+          }),
+      });
+    },
+  );
 
-  describe.each([503, 504])(
+  describe.each([502, 503, 504])(
     'if the RPC endpoint returns a %d response',
     (httpStatus) => {
       const errorMessage = 'RPC endpoint not found or unavailable.';

--- a/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
@@ -337,7 +337,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
   });
 
   describe.each([
-    [405, 'The JSON sent is not a valid Request object.'],
+    [405, 'HTTP client error.'],
     [429, 'Request is being rate limited.'],
   ])(
     'if the RPC endpoint returns a %d response',
@@ -369,7 +369,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
 
   describe('if the RPC endpoint returns a 5xx response that is not 503, or 504', () => {
     const httpStatus = 500;
-    const errorMessage = 'RPC endpoint not found or unavailable';
+    const errorMessage = 'RPC endpoint not found or unavailable.';
 
     it('throws a generic, undescriptive error', async () => {
       await withMockedCommunications({ providerType }, async (comms) => {
@@ -422,7 +422,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
   describe.each([503, 504])(
     'if the RPC endpoint returns a %d response',
     (httpStatus) => {
-      const errorMessage = 'RPC endpoint not found or unavailable';
+      const errorMessage = 'RPC endpoint not found or unavailable.';
 
       it('retries the request up to 5 times until there is a 200 response', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {

--- a/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
@@ -367,9 +367,9 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
     },
   );
 
-  describe('if the RPC endpoint returns a response that is not 405, 429, 503, or 504', () => {
+  describe('if the RPC endpoint returns a 5xx response that is not 503, or 504', () => {
     const httpStatus = 500;
-    const errorMessage = `Non-200 status code: '${httpStatus}'`;
+    const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
 
     it('throws a generic, undescriptive error', async () => {
       await withMockedCommunications({ providerType }, async (comms) => {
@@ -414,7 +414,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
         }),
       getExpectedBreakError: () =>
         expect.objectContaining({
-          message: `Fetch failed with status '500'`,
+          message: `Fetch failed with status '${httpStatus}'`,
         }),
     });
   });

--- a/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-hash-in-response.ts
@@ -369,7 +369,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
 
   describe('if the RPC endpoint returns a 5xx response that is not 503, or 504', () => {
     const httpStatus = 500;
-    const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
+    const errorMessage = 'RPC endpoint not found or unavailable';
 
     it('throws a generic, undescriptive error', async () => {
       await withMockedCommunications({ providerType }, async (comms) => {
@@ -422,7 +422,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
   describe.each([503, 504])(
     'if the RPC endpoint returns a %d response',
     (httpStatus) => {
-      const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
+      const errorMessage = 'RPC endpoint not found or unavailable';
 
       it('retries the request up to 5 times until there is a 200 response', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {

--- a/packages/network-controller/tests/provider-api-tests/block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-param.ts
@@ -414,7 +414,7 @@ export function testsForRpcMethodSupportingBlockParam(
     });
 
     describe.each([
-      [405, 'The method does not exist / is not available.'],
+      [405, 'The JSON sent is not a valid Request object.'],
       [429, 'Request is being rate limited.'],
     ])(
       'if the RPC endpoint returns a %d response',
@@ -528,7 +528,7 @@ export function testsForRpcMethodSupportingBlockParam(
     describe.each([503, 504])(
       'if the RPC endpoint returns a %d response',
       (httpStatus) => {
-        const errorMessage = 'Gateway timeout';
+        const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
 
         it('retries the request up to 5 times until there is a 200 response', async () => {
           await withMockedCommunications({ providerType }, async (comms) => {
@@ -628,7 +628,6 @@ export function testsForRpcMethodSupportingBlockParam(
             await expect(promiseForResult).rejects.toThrow(errorMessage);
           });
         });
-
         testsForRpcFailoverBehavior({
           providerType,
           requestToCall: {
@@ -648,7 +647,9 @@ export function testsForRpcMethodSupportingBlockParam(
           isRetriableFailure: true,
           getExpectedError: () =>
             expect.objectContaining({
-              message: expect.stringContaining(`Gateway timeout`),
+              message: expect.stringContaining(
+                `RPC endpoint server error (HTTP ${httpStatus})`,
+              ),
             }),
           getExpectedBreakError: () =>
             expect.objectContaining({

--- a/packages/network-controller/tests/provider-api-tests/block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-param.ts
@@ -414,7 +414,7 @@ export function testsForRpcMethodSupportingBlockParam(
     });
 
     describe.each([
-      [405, 'The JSON sent is not a valid Request object.'],
+      [405, 'HTTP client error.'],
       [429, 'Request is being rate limited.'],
     ])(
       'if the RPC endpoint returns a %d response',
@@ -459,7 +459,7 @@ export function testsForRpcMethodSupportingBlockParam(
 
     describe('if the RPC endpoint returns a 5xx response that is not 503, or 504', () => {
       const httpStatus = 500;
-      const errorMessage = 'RPC endpoint not found or unavailable';
+      const errorMessage = 'RPC endpoint not found or unavailable.';
 
       it('throws a generic, undescriptive error', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {
@@ -528,7 +528,7 @@ export function testsForRpcMethodSupportingBlockParam(
     describe.each([503, 504])(
       'if the RPC endpoint returns a %d response',
       (httpStatus) => {
-        const errorMessage = 'RPC endpoint not found or unavailable';
+        const errorMessage = 'RPC endpoint not found or unavailable.';
 
         it('retries the request up to 5 times until there is a 200 response', async () => {
           await withMockedCommunications({ providerType }, async (comms) => {
@@ -648,7 +648,7 @@ export function testsForRpcMethodSupportingBlockParam(
           getExpectedError: () =>
             expect.objectContaining({
               message: expect.stringContaining(
-                'RPC endpoint not found or unavailable',
+                'RPC endpoint not found or unavailable.',
               ),
             }),
           getExpectedBreakError: () =>

--- a/packages/network-controller/tests/provider-api-tests/block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-param.ts
@@ -457,9 +457,9 @@ export function testsForRpcMethodSupportingBlockParam(
       },
     );
 
-    describe('if the RPC endpoint returns a response that is not 405, 429, 503, or 504', () => {
+    describe('if the RPC endpoint returns a 5xx response that is not 503, or 504', () => {
       const httpStatus = 500;
-      const errorMessage = `Non-200 status code: '${httpStatus}'`;
+      const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
 
       it('throws a generic, undescriptive error', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {
@@ -520,7 +520,7 @@ export function testsForRpcMethodSupportingBlockParam(
           }),
         getExpectedBreakError: () =>
           expect.objectContaining({
-            message: `Fetch failed with status '500'`,
+            message: `Fetch failed with status '${httpStatus}'`,
           }),
       });
     });

--- a/packages/network-controller/tests/provider-api-tests/block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/block-param.ts
@@ -459,7 +459,7 @@ export function testsForRpcMethodSupportingBlockParam(
 
     describe('if the RPC endpoint returns a 5xx response that is not 503, or 504', () => {
       const httpStatus = 500;
-      const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
+      const errorMessage = 'RPC endpoint not found or unavailable';
 
       it('throws a generic, undescriptive error', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {
@@ -528,7 +528,7 @@ export function testsForRpcMethodSupportingBlockParam(
     describe.each([503, 504])(
       'if the RPC endpoint returns a %d response',
       (httpStatus) => {
-        const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
+        const errorMessage = 'RPC endpoint not found or unavailable';
 
         it('retries the request up to 5 times until there is a 200 response', async () => {
           await withMockedCommunications({ providerType }, async (comms) => {
@@ -648,7 +648,7 @@ export function testsForRpcMethodSupportingBlockParam(
           getExpectedError: () =>
             expect.objectContaining({
               message: expect.stringContaining(
-                `RPC endpoint server error (HTTP ${httpStatus})`,
+                'RPC endpoint not found or unavailable',
               ),
             }),
           getExpectedBreakError: () =>

--- a/packages/network-controller/tests/provider-api-tests/no-block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/no-block-param.ts
@@ -293,7 +293,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
   });
 
   describe.each([
-    [405, 'The method does not exist / is not available.'],
+    [405, 'The JSON sent is not a valid Request object.'],
     [429, 'Request is being rate limited.'],
   ])(
     'if the RPC endpoint returns a %d response',
@@ -378,7 +378,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
   describe.each([503, 504])(
     'if the RPC endpoint returns a %d response',
     (httpStatus) => {
-      const errorMessage = 'Gateway timeout';
+      const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
 
       it('retries the request up to 5 times until there is a 200 response', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {

--- a/packages/network-controller/tests/provider-api-tests/no-block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/no-block-param.ts
@@ -323,59 +323,61 @@ export function testsForRpcMethodAssumingNoBlockParam(
     },
   );
 
-  describe('if the RPC endpoint returns a 5xx response that is not 503, or 504', () => {
-    const httpStatus = 500;
-    const errorMessage = 'RPC endpoint not found or unavailable.';
+  describe.each([500, 501, 505, 506, 507, 508, 510, 511])(
+    'if the RPC endpoint returns a %d response',
+    (httpStatus) => {
+      const errorMessage = 'RPC endpoint not found or unavailable.';
 
-    it('throws a generic, undescriptive error', async () => {
-      await withMockedCommunications({ providerType }, async (comms) => {
-        const request = { method };
+      it('throws a generic, undescriptive error', async () => {
+        await withMockedCommunications({ providerType }, async (comms) => {
+          const request = { method };
 
-        // The first time a block-cacheable request is made, the latest block
-        // number is retrieved through the block tracker first. It doesn't
-        // matter what this is — it's just used as a cache key.
-        comms.mockNextBlockTrackerRequest();
-        comms.mockRpcCall({
-          request,
-          response: {
-            httpStatus,
-          },
+          // The first time a block-cacheable request is made, the latest block
+          // number is retrieved through the block tracker first. It doesn't
+          // matter what this is — it's just used as a cache key.
+          comms.mockNextBlockTrackerRequest();
+          comms.mockRpcCall({
+            request,
+            response: {
+              httpStatus,
+            },
+          });
+          const promiseForResult = withNetworkClient(
+            { providerType },
+            async ({ makeRpcCall }) => makeRpcCall(request),
+          );
+
+          await expect(promiseForResult).rejects.toThrow(errorMessage);
         });
-        const promiseForResult = withNetworkClient(
-          { providerType },
-          async ({ makeRpcCall }) => makeRpcCall(request),
-        );
-
-        await expect(promiseForResult).rejects.toThrow(errorMessage);
       });
-    });
 
-    testsForRpcFailoverBehavior({
-      providerType,
-      requestToCall: {
-        method,
-        params: [],
-      },
-      getRequestToMock: () => ({
-        method,
-        params: [],
-      }),
-      failure: {
-        httpStatus,
-      },
-      isRetriableFailure: false,
-      getExpectedError: () =>
-        expect.objectContaining({
-          message: errorMessage,
+      testsForRpcFailoverBehavior({
+        providerType,
+        requestToCall: {
+          method,
+          params: [],
+        },
+        getRequestToMock: () => ({
+          method,
+          params: [],
         }),
-      getExpectedBreakError: () =>
-        expect.objectContaining({
-          message: `Fetch failed with status '${httpStatus}'`,
-        }),
-    });
-  });
+        failure: {
+          httpStatus,
+        },
+        isRetriableFailure: false,
+        getExpectedError: () =>
+          expect.objectContaining({
+            message: errorMessage,
+          }),
+        getExpectedBreakError: () =>
+          expect.objectContaining({
+            message: `Fetch failed with status '${httpStatus}'`,
+          }),
+      });
+    },
+  );
 
-  describe.each([503, 504])(
+  describe.each([502, 503, 504])(
     'if the RPC endpoint returns a %d response',
     (httpStatus) => {
       const errorMessage = 'RPC endpoint not found or unavailable.';

--- a/packages/network-controller/tests/provider-api-tests/no-block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/no-block-param.ts
@@ -325,7 +325,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
 
   describe('if the RPC endpoint returns a 5xx response that is not 503, or 504', () => {
     const httpStatus = 500;
-    const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
+    const errorMessage = 'RPC endpoint not found or unavailable';
 
     it('throws a generic, undescriptive error', async () => {
       await withMockedCommunications({ providerType }, async (comms) => {
@@ -378,7 +378,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
   describe.each([503, 504])(
     'if the RPC endpoint returns a %d response',
     (httpStatus) => {
-      const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
+      const errorMessage = 'RPC endpoint not found or unavailable';
 
       it('retries the request up to 5 times until there is a 200 response', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {

--- a/packages/network-controller/tests/provider-api-tests/no-block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/no-block-param.ts
@@ -323,9 +323,9 @@ export function testsForRpcMethodAssumingNoBlockParam(
     },
   );
 
-  describe('if the RPC endpoint returns a response that is not 405, 429, 503, or 504', () => {
+  describe('if the RPC endpoint returns a 5xx response that is not 503, or 504', () => {
     const httpStatus = 500;
-    const errorMessage = `Non-200 status code: '${httpStatus}'`;
+    const errorMessage = `RPC endpoint server error (HTTP ${httpStatus})`;
 
     it('throws a generic, undescriptive error', async () => {
       await withMockedCommunications({ providerType }, async (comms) => {
@@ -370,7 +370,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
         }),
       getExpectedBreakError: () =>
         expect.objectContaining({
-          message: `Fetch failed with status '500'`,
+          message: `Fetch failed with status '${httpStatus}'`,
         }),
     });
   });

--- a/packages/network-controller/tests/provider-api-tests/no-block-param.ts
+++ b/packages/network-controller/tests/provider-api-tests/no-block-param.ts
@@ -293,7 +293,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
   });
 
   describe.each([
-    [405, 'The JSON sent is not a valid Request object.'],
+    [405, 'HTTP client error.'],
     [429, 'Request is being rate limited.'],
   ])(
     'if the RPC endpoint returns a %d response',
@@ -325,7 +325,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
 
   describe('if the RPC endpoint returns a 5xx response that is not 503, or 504', () => {
     const httpStatus = 500;
-    const errorMessage = 'RPC endpoint not found or unavailable';
+    const errorMessage = 'RPC endpoint not found or unavailable.';
 
     it('throws a generic, undescriptive error', async () => {
       await withMockedCommunications({ providerType }, async (comms) => {
@@ -378,7 +378,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
   describe.each([503, 504])(
     'if the RPC endpoint returns a %d response',
     (httpStatus) => {
-      const errorMessage = 'RPC endpoint not found or unavailable';
+      const errorMessage = 'RPC endpoint not found or unavailable.';
 
       it('retries the request up to 5 times until there is a 200 response', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Improves error handling in the RPC service by making it more specific and consistent. The changes include:

- Clarifies error handling for different HTTP status codes:
  - 401: Unauthorized error
  - 402/404/5xx: Resource unavailable error
  - 429: Rate limiting error
  - Other 4xx responses now throw a generic HTTP client error
  - Invalid JSON: Parse error

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes https://github.com/MetaMask/core/issues/5844

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
