### PR TITLE
Enable `noUncheckedIndexedAccess` Across Monorepo for Enhanced Type Safety

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "esModuleInterop": true,
     "module": "Node16",
     "moduleResolution": "Node16",
-    "noEmit": true
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true
   },
   "references": [
     { "path": "./packages/accounts-controller" },

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM"],
     "module": "Node16",
     "moduleResolution": "Node16",
+    "noUncheckedIndexedAccess": true,
     /**
      * Here we ensure that TypeScript resolves `@metamask/*` imports to the
      * uncompiled source code for packages that live in this repo.


### PR DESCRIPTION
### Description

This PR addresses #4729  by enabling the `noUncheckedIndexedAccess` TypeScript compiler option across the entire monorepo.

**Changes Implemented:**

* Set `"noUncheckedIndexedAccess": true` in the root `tsconfig.json` to enforce stricter type checking at the project level.
* Updated `tsconfig.packages.json` to propagate this setting to all packages within the monorepo.
