### PR TITLE
feat(stake-959): adding hoodi testnet config to controllers

### DIFF
--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.10.0]
+
+### Added
+
+- Add `Hoodi` (testnet for ethereum) to list of test networks supported.
+
 ## [11.9.0]
 
 ### Added

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/controller-utils",
-  "version": "11.9.0",
+  "version": "11.10.0",
   "description": "Data and convenience functions shared by multiple packages",
   "keywords": [
     "MetaMask",

--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -50,6 +50,7 @@ export const TESTNET_TICKER_SYMBOLS = {
   LINEA_GOERLI: 'LineaETH',
   LINEA_SEPOLIA: 'LineaETH',
   MEGAETH_TESTNET: 'MegaETH',
+  HOODI: 'HoodiETH'
 };
 
 /**
@@ -124,6 +125,13 @@ export const BUILT_IN_NETWORKS = {
       blockExplorerUrl: BlockExplorerUrl['monad-testnet'],
     },
   },
+  [NetworkType.hoodi]: {
+    chainId: ChainId.hoodi,
+    ticker: NetworksTicker.hoodi,
+    rpcPrefs: {
+      blockExplorerUrl: BlockExplorerUrl.hoodi,
+    },
+  },
   [NetworkType.rpc]: {
     chainId: undefined,
     blockExplorerUrl: undefined,
@@ -186,4 +194,5 @@ export const CHAIN_ID_TO_ETHERS_NETWORK_NAME_MAP: Record<
   [ChainId['linea-sepolia']]: BuiltInNetworkName.LineaSepolia,
   [ChainId['linea-mainnet']]: BuiltInNetworkName.LineaMainnet,
   [ChainId.aurora]: BuiltInNetworkName.Aurora,
+  [ChainId.hoodi]: BuiltInNetworkName.Hoodi
 };

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -8,6 +8,7 @@ export const InfuraNetworkType = {
   'linea-goerli': 'linea-goerli',
   'linea-sepolia': 'linea-sepolia',
   'linea-mainnet': 'linea-mainnet',
+  hoodi: 'hoodi'
 } as const;
 
 export type InfuraNetworkType =
@@ -78,6 +79,7 @@ export enum BuiltInNetworkName {
   Aurora = 'aurora',
   MegaETHTestnet = 'megaeth-testnet',
   MonadTestnet = 'monad-testnet',
+  Hoodi = 'hoodi'
 }
 
 /**
@@ -95,6 +97,7 @@ export const ChainId = {
   [BuiltInNetworkName.LineaMainnet]: '0xe708', // toHex(59144)
   [BuiltInNetworkName.MegaETHTestnet]: '0x18c6', // toHex(6342)
   [BuiltInNetworkName.MonadTestnet]: '0x279f', // toHex(10143)
+  [BuiltInNetworkName.Hoodi]: '0x88A10' // toHex('560048')
 } as const;
 export type ChainId = (typeof ChainId)[keyof typeof ChainId];
 
@@ -113,6 +116,7 @@ export enum NetworksTicker {
   'linea-mainnet' = 'ETH',
   'megaeth-testnet' = 'MegaETH',
   'monad-testnet' = 'MON',
+  hoodi = 'HoodiETH',
   // TODO: Either fix this lint violation or explain why it's necessary to ignore.
   // eslint-disable-next-line @typescript-eslint/naming-convention
   rpc = '',
@@ -127,6 +131,7 @@ export const BlockExplorerUrl = {
   [BuiltInNetworkName.LineaMainnet]: 'https://lineascan.build',
   [BuiltInNetworkName.MegaETHTestnet]: 'https://megaexplorer.xyz',
   [BuiltInNetworkName.MonadTestnet]: 'https://testnet.monadexplorer.com',
+  [BuiltInNetworkName.Hoodi]: 'https://hoodi.etherscan.io'
 } as const satisfies Record<BuiltInNetworkType, string>;
 export type BlockExplorerUrl =
   (typeof BlockExplorerUrl)[keyof typeof BlockExplorerUrl];
@@ -140,6 +145,7 @@ export const NetworkNickname = {
   [BuiltInNetworkName.LineaMainnet]: 'Linea',
   [BuiltInNetworkName.MegaETHTestnet]: 'Mega Testnet',
   [BuiltInNetworkName.MonadTestnet]: 'Monad Testnet',
+  [BuiltInNetworkName.Hoodi]: 'Hoodi',
 } as const satisfies Record<BuiltInNetworkType, string>;
 export type NetworkNickname =
   (typeof NetworkNickname)[keyof typeof NetworkNickname];

--- a/packages/name-controller/CHANGELOG.md
+++ b/packages/name-controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.0]
+
+### Added
+
+- Add `Hoodi` (testnet for ethereum) to list of test networks supported.
+
 ### Changed
 
 - Bump `@metamask/base-controller` from ^8.0.0 to ^8.0.1 ([#5722](https://github.com/MetaMask/core/pull/5722))

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/name-controller",
-  "version": "8.0.3",
+  "version": "8.1.0",
   "description": "Stores and suggests names for values such as Ethereum addresses",
   "keywords": [
     "MetaMask",

--- a/packages/name-controller/src/constants.ts
+++ b/packages/name-controller/src/constants.ts
@@ -21,6 +21,7 @@ export const CHAIN_IDS = {
   MOONBEAM_TESTNET: '0x507',
   MOONRIVER: '0x505',
   GNOSIS: '0x64',
+  HOODI: '0x88A10'
 } as const;
 
 const DEFAULT_ETHERSCAN_DOMAIN = 'etherscan.io';
@@ -38,6 +39,10 @@ export const ETHERSCAN_SUPPORTED_NETWORKS = {
   [CHAIN_IDS.SEPOLIA]: {
     domain: DEFAULT_ETHERSCAN_DOMAIN,
     subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-sepolia`,
+  },
+  [CHAIN_IDS.HOODI]: {
+    domain: DEFAULT_ETHERSCAN_DOMAIN,
+    subdomain: `${DEFAULT_ETHERSCAN_SUBDOMAIN_PREFIX}-hoodi`
   },
   [CHAIN_IDS.LINEA_GOERLI]: {
     domain: 'lineascan.build',

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [23.6.0]
+
+### Added
+
+- Add `Hoodi` (testnet for ethereum) to list of test networks supported.
+
 ## [23.5.0]
 
 ### Changed

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-controller",
-  "version": "23.5.0",
+  "version": "23.6.0",
   "description": "Provides an interface to the currently selected network via a MetaMask-compatible provider object",
   "keywords": [
     "MetaMask",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^8.0.1",
-    "@metamask/controller-utils": "^11.9.0",
+    "@metamask/controller-utils": "^11.10.0",
     "@metamask/eth-block-tracker": "^11.0.3",
     "@metamask/eth-json-rpc-infura": "^10.1.1",
     "@metamask/eth-json-rpc-middleware": "^16.0.1",

--- a/packages/network-controller/tests/helpers.ts
+++ b/packages/network-controller/tests/helpers.ts
@@ -54,6 +54,7 @@ export const INFURA_NETWORKS = [
   InfuraNetworkType.sepolia,
   InfuraNetworkType['linea-mainnet'],
   InfuraNetworkType['linea-sepolia'],
+  InfuraNetworkType.hoodi
 ];
 
 /**

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [18.1.0]
+
+### Added
+
+- Add `Hoodi` (testnet for ethereum) to list of test networks supported.
+
+
 ### Changed
 
 - Bump `@metamask/controller-utils` to `^11.9.0` ([#5812](https://github.com/MetaMask/core/pull/5812))

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -219,6 +219,7 @@ export function getDefaultPreferencesState(): PreferencesState {
       [ETHERSCAN_SUPPORTED_CHAIN_IDS.MOONBEAM_TESTNET]: true,
       [ETHERSCAN_SUPPORTED_CHAIN_IDS.MOONRIVER]: true,
       [ETHERSCAN_SUPPORTED_CHAIN_IDS.GNOSIS]: true,
+      [ETHERSCAN_SUPPORTED_CHAIN_IDS.HOODI]: true,
     },
     showTestNetworks: false,
     useNftDetection: false,

--- a/packages/preferences-controller/src/constants.ts
+++ b/packages/preferences-controller/src/constants.ts
@@ -19,4 +19,5 @@ export const ETHERSCAN_SUPPORTED_CHAIN_IDS = {
   MOONBEAM_TESTNET: '0x507',
   MOONRIVER: '0x505',
   GNOSIS: '0x64',
+  HOODI: '0x88A10'
 } as const;

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [56.3.0]
+
+- Add `Hoodi` (testnet for ethereum) to list of test networks supported.
+
 ## [56.2.0]
 
 ### Added

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "56.2.0",
+  "version": "56.3.0",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",

--- a/packages/transaction-controller/src/constants.ts
+++ b/packages/transaction-controller/src/constants.ts
@@ -30,6 +30,7 @@ export const CHAIN_IDS = {
   SCROLL: '0x82750',
   SCROLL_SEPOLIA: '0x8274f',
   MEGAETH_TESTNET: '0x18c6',
+  HOODI: '0x88A10'
 } as const;
 
 /** Extract of the Wrapped ERC-20 ABI required for simulation. */


### PR DESCRIPTION
## Explanation

This PR aims to add [hoodi](https://github.com/eth-clients/hoodi) testnet configuration to the current list of supported testnets by Metamask.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
