### PR TITLE
fix(accounts-controller): fix Snap account's metadata update when Snaps during wallet reset flow

### DIFF
--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Prevent use of `undefined` Snap during `SnapController:stateChange` ([#5884](https://github.com/MetaMask/core/pull/5884))
+  - We were assuming that the Snap will always be defined, but this might not always be true.
 - Populate `.options.entropySource` for new `InternalAccount`s before publishing `:accountAdded` ([#5841](https://github.com/MetaMask/core/pull/5841))
 
 ## [29.0.0]

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -325,9 +325,7 @@ describe('AccountsController', () => {
             status: SnapStatus.Running,
           },
         },
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any as SnapControllerState;
+      } as unknown as SnapControllerState;
       const { accountsController } = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -371,9 +369,7 @@ describe('AccountsController', () => {
             status: SnapStatus.Running,
           },
         },
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any as SnapControllerState;
+      } as unknown as SnapControllerState;
       const { accountsController } = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -417,9 +413,7 @@ describe('AccountsController', () => {
             status: SnapStatus.Running,
           },
         },
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any as SnapControllerState;
+      } as unknown as SnapControllerState;
       const { accountsController } = setupAccountsController({
         initialState: {
           internalAccounts: {
@@ -463,9 +457,7 @@ describe('AccountsController', () => {
             status: SnapStatus.Running,
           },
         },
-        // TODO: Replace `any` with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any as SnapControllerState;
+      } as unknown as SnapControllerState;
       const mockStateChange = jest.fn();
       const { accountsController } = setupAccountsController({
         initialState: {
@@ -494,6 +486,48 @@ describe('AccountsController', () => {
       messenger.publish('SnapController:stateChange', mockSnapChangeState, []);
       expect(updatedAccount.metadata.snap?.enabled).toBe(true);
       expect(mockStateChange).not.toHaveBeenCalled();
+    });
+
+    it('considers the Snap disabled if it cannot be found on the SnapController state', () => {
+      const messenger = buildMessenger();
+      const mockSnapAccount = createMockInternalAccount({
+        id: 'mock-id',
+        name: 'Snap Account 1',
+        address: '0x0',
+        keyringType: KeyringTypes.snap,
+        snap: {
+          id: 'mock-snap',
+          name: 'mock-snap-name',
+          enabled: true, // This Snap was enabled initially.
+        },
+      });
+      const mockSnapChangeState = {
+        snaps: {
+          // No `mock-snap` on the state, the Snap will be considered "disabled".
+        },
+      } as unknown as SnapControllerState;
+      const { accountsController } = setupAccountsController({
+        initialState: {
+          internalAccounts: {
+            accounts: {
+              [mockSnapAccount.id]: mockSnapAccount,
+            },
+            selectedAccount: mockSnapAccount.id,
+          },
+        },
+        messenger,
+      });
+
+      // Initial state
+      const account = accountsController.getAccountExpect(mockSnapAccount.id);
+      expect(account.metadata.snap?.enabled).toBe(true);
+
+      // The Snap 'mock-snap' won't be found, so we will automatically consider it disabled.
+      messenger.publish('SnapController:stateChange', mockSnapChangeState, []);
+      const updatedAccount = accountsController.getAccountExpect(
+        mockSnapAccount.id,
+      );
+      expect(updatedAccount.metadata.snap?.enabled).toBe(false);
     });
   });
 

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -996,18 +996,24 @@ export class AccountsController extends BaseController<
    * @param snapState - The new SnapControllerState.
    */
   #handleOnSnapStateChange(snapState: SnapControllerState) {
-    // only check if snaps changed in status
+    // Only check if Snaps changed in status.
     const { snaps } = snapState;
 
     const accounts: { id: string; enabled: boolean }[] = [];
     for (const account of this.listMultichainAccounts()) {
       if (account.metadata.snap) {
-        const snap: Snap = snaps[account.metadata.snap.id as SnapId];
-        const enabled = snap.enabled && !snap.blocked;
-        const metadata = account.metadata.snap;
+        const snap = snaps[account.metadata.snap.id as SnapId];
 
-        if (metadata.enabled !== enabled) {
-          accounts.push({ id: account.id, enabled });
+        if (snap) {
+          const enabled = snap.enabled && !snap.blocked;
+          const metadata = account.metadata.snap;
+
+          if (metadata.enabled !== enabled) {
+            accounts.push({ id: account.id, enabled });
+          }
+        } else {
+          // If Snap could not be found on the state, we consider it disabled.
+          accounts.push({ id: account.id, enabled: false });
         }
       }
     }

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -32,7 +32,6 @@ import type {
   SnapStateChange,
 } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
-import type { Snap } from '@metamask/snaps-utils';
 import { type CaipChainId, isCaipChainId } from '@metamask/utils';
 import type { WritableDraft } from 'immer/dist/internal.js';
 


### PR DESCRIPTION
## Explanation

We assume the `snap` will always be defined, but they could be deleted/reloaded during some flows. To prevent using an `undefined` `snap` here, we check if it's defined first, if not, we consider it to be disabled.

## References

- https://github.com/MetaMask/metamask-mobile/issues/15628

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
