### PR TITLE
feat: add optional `getFailoverRpcs` function to the `NetworkController` constructor

### DIFF
--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added an optional `getFailoverRpcs` parameter to `NetworkControllerOptions` constructor options.
+  - This allows platforms to provide and inject failover RPCs for different chainID's
+
 ## [23.5.1]
 
 ### Changed


### PR DESCRIPTION
## Explanation

Allows our clients to provide the failover RPCs.

This was our clients control the list of failover RPCs (filled in via env vars). and ensures that all new users using default networks (networks enabled by default) also contain failover RPCs.

## References

https://consensyssoftware.atlassian.net/browse/MMASSETS-893

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
