### PR TITLE
fix: fail gracefully when L1 gas fees are not available

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove `error_message` property from QuotesRequested event payload ([#5900](https://github.com/MetaMask/core/pull/5900))
-- Fail gracefully when `TransactionController.getLayer1GasFee` returns `undefined` ([#5910](https://github.com/MetaMask/core/pull/5910))
-- Filter out quote if an error is thrown during L1 gas fee calculation ([#5910](https://github.com/MetaMask/core/pull/5910))
+- Fail gracefully when fee calculations return invalid value or throw errors
+  - Filter out single quote if `TransactionController.getLayer1GasFee` returns `undefined` ([#5910](https://github.com/MetaMask/core/pull/5910))
+  - Filter out single quote if an error is thrown by `getLayer1GasFee` ([#5910](https://github.com/MetaMask/core/pull/5910))
+  - Filter out single quote if an error is thrown by Solana snap's `getFeeForTransaction` method ([#5910](https://github.com/MetaMask/core/pull/5910))
 
 ## [32.0.0]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove `error_message` property from QuotesRequested event payload ([#5900](https://github.com/MetaMask/core/pull/5900))
+- Fail gracefully when `TransactionController.getLayer1GasFee` returns `undefined` ([#5910](https://github.com/MetaMask/core/pull/5910))
+- Filter out quote if an error is thrown during L1 gas fee calculation ([#5910](https://github.com/MetaMask/core/pull/5910))
 
 ## [32.0.0]
 

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -1,5 +1,10 @@
 import { Contract } from '@ethersproject/contracts';
-import { SolScope } from '@metamask/keyring-api';
+import {
+  EthAccountType,
+  EthScope,
+  SolAccountType,
+  SolScope,
+} from '@metamask/keyring-api';
 import type { Hex } from '@metamask/utils';
 import { bigIntToHex } from '@metamask/utils';
 import nock from 'nock';
@@ -666,6 +671,10 @@ describe('BridgeController', function () {
         // eslint-disable-next-line jest/no-conditional-in-test
         if (actionType === 'AccountsController:getSelectedMultichainAccount') {
           return {
+            type: SolAccountType.DataAccount,
+            id: 'account1',
+            scopes: [SolScope.Mainnet],
+            methods: [],
             address: '0x123',
             metadata: {
               snap: {
@@ -673,11 +682,16 @@ describe('BridgeController', function () {
                 name: 'Solana Snap',
                 enabled: true,
               },
-            } as never,
+              name: 'Account 1',
+              importTime: 1717334400,
+              keyring: {
+                type: 'Keyring',
+              },
+            },
             options: {
               scope: 'mainnet',
             },
-          } as never;
+          };
         }
         // eslint-disable-next-line jest/no-conditional-in-test
         if (actionType === 'NetworkController:getNetworkClientById') {
@@ -1253,18 +1267,49 @@ describe('BridgeController', function () {
             isSnapAccount
           ) {
             return {
+              type: SolAccountType.DataAccount,
+              id: 'account1',
+              scopes: [SolScope.Mainnet],
+              methods: [],
               address: '0x123',
               metadata: {
+                name: 'Account 1',
+                importTime: 1717334400,
+                keyring: {
+                  type: 'Keyring',
+                },
                 snap: {
                   id: 'npm:@metamask/solana-snap',
                   name: 'Solana Snap',
                   enabled: true,
                 },
-              } as never,
+              },
               options: {
                 scope: 'mainnet',
               },
-            } as never;
+            };
+          }
+          // eslint-disable-next-line jest/no-conditional-in-test
+          if (
+            actionType === 'AccountsController:getSelectedMultichainAccount'
+          ) {
+            return {
+              type: EthAccountType.Eoa,
+              id: 'account1',
+              scopes: [EthScope.Eoa],
+              methods: [],
+              address: '0x123',
+              metadata: {
+                name: 'Account 1',
+                importTime: 1717334400,
+                keyring: {
+                  type: 'Keyring',
+                },
+              },
+              options: {
+                scope: 'mainnet',
+              },
+            };
           }
           // eslint-disable-next-line jest/no-conditional-in-test
           if (actionType === 'SnapController:handleRequest') {

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -201,6 +201,10 @@ describe('BridgeController', function () {
   };
 
   it('updateBridgeQuoteRequestParams should update the quoteRequest state', async function () {
+    messengerMock.call.mockReturnValue({
+      currentCurrency: 'usd',
+    } as never);
+
     await bridgeController.updateBridgeQuoteRequestParams(
       { srcChainId: 1 },
       metricsContext,

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -1259,12 +1259,14 @@ describe('BridgeController', function () {
     [
       'should append solanaFees for Solana quotes',
       mockBridgeQuotesSolErc20 as unknown as QuoteResponse[],
+      2,
       '5000',
       solanaSnapCalls,
     ],
     [
       'should not append solanaFees if selected account is not a snap',
       mockBridgeQuotesSolErc20 as unknown as QuoteResponse[],
+      2,
       undefined,
       [],
       false,
@@ -1275,6 +1277,7 @@ describe('BridgeController', function () {
         ...mockBridgeQuotesSolErc20,
         ...mockBridgeQuotesErc20Native,
       ] as unknown as QuoteResponse[],
+      8,
       undefined,
       mixedQuotesSnapCalls,
     ],
@@ -1283,6 +1286,7 @@ describe('BridgeController', function () {
     async (
       _testTitle: string,
       quoteResponse: QuoteResponse[],
+      expectedQuotesLength: number,
       expectedFees: string | undefined,
       expectedSnapCalls: typeof solanaSnapCalls,
       isSnapAccount = true,
@@ -1415,6 +1419,8 @@ describe('BridgeController', function () {
       );
 
       expect(snapCalls).toMatchObject(expectedSnapCalls);
+
+      expect(quotes).toHaveLength(expectedQuotesLength);
     },
   );
 

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -6,7 +6,7 @@ import type { ChainId, TraceCallback } from '@metamask/controller-utils';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 import type { NetworkClientId } from '@metamask/network-controller';
 import { StaticIntervalPollingController } from '@metamask/polling-controller';
-import type { TransactionParams } from '@metamask/transaction-controller';
+import type { TransactionController } from '@metamask/transaction-controller';
 import type { CaipAssetType } from '@metamask/utils';
 import { numberToHex, type Hex } from '@metamask/utils';
 
@@ -145,10 +145,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
 
   readonly #clientId: string;
 
-  readonly #getLayer1GasFee: (params: {
-    transactionParams: TransactionParams;
-    chainId: ChainId;
-  }) => Promise<string>;
+  readonly #getLayer1GasFee: typeof TransactionController.prototype.getLayer1GasFee;
 
   readonly #fetchFn: FetchFunction;
 
@@ -179,10 +176,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     messenger: BridgeControllerMessenger;
     state?: Partial<BridgeControllerState>;
     clientId: BridgeClientId;
-    getLayer1GasFee: (params: {
-      transactionParams: TransactionParams;
-      chainId: ChainId;
-    }) => Promise<string>;
+    getLayer1GasFee: typeof TransactionController.prototype.getLayer1GasFee;
     fetchFn: FetchFunction;
     config?: {
       customBridgeApiBaseUrl?: string;

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -606,16 +606,16 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
       }),
     );
 
-    const quotesWithL1GasFees: (QuoteResponse & L1GasFees)[] = [];
-
-    (await l1GasFeePromises).forEach((result) => {
+    const quotesWithL1GasFees = (await l1GasFeePromises).reduce<
+      (QuoteResponse & L1GasFees)[]
+    >((acc, result) => {
       if (result.status === 'fulfilled' && result.value) {
-        quotesWithL1GasFees.push(result.value);
-      }
-      if (result.status === 'rejected') {
+        acc.push(result.value);
+      } else if (result.status === 'rejected') {
         console.error('Error calculating L1 gas fees for quote', result.reason);
       }
-    });
+      return acc;
+    }, []);
 
     return quotesWithL1GasFees;
   };
@@ -680,16 +680,16 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
       }),
     );
 
-    const quotesWithSolanaFees: (QuoteResponse & SolanaFees)[] = [];
-
-    (await solanaFeePromises).forEach((result) => {
+    const quotesWithSolanaFees = (await solanaFeePromises).reduce<
+      (QuoteResponse & SolanaFees)[]
+    >((acc, result) => {
       if (result.status === 'fulfilled' && result.value) {
-        quotesWithSolanaFees.push(result.value);
-      }
-      if (result.status === 'rejected') {
+        acc.push(result.value);
+      } else if (result.status === 'rejected') {
         console.error('Error calculating solana fees for quote', result.reason);
       }
-    });
+      return acc;
+    }, []);
 
     return quotesWithSolanaFees;
   };

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -612,6 +612,9 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
       if (result.status === 'fulfilled' && result.value) {
         quotesWithL1GasFees.push(result.value);
       }
+      if (result.status === 'rejected') {
+        console.error('Error calculating L1 gas fees for quote', result.reason);
+      }
     });
 
     return quotesWithL1GasFees;


### PR DESCRIPTION
## Explanation

This fixes L1 and Solana fee calculations in the BridgeController such that some quotes can be returned if exceptions are thrown by dependencies (snap and RPCs). 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References
Fixes https://consensyssoftware.atlassian.net/browse/MMS-2568
<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
