### PR TITLE
feat: Add lendingWithdraw type to TransactionController and EarnController

### DIFF
--- a/packages/earn-controller/CHANGELOG.md
+++ b/packages/earn-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replace hardcoded `"lendingWithdraw"` in `LendingTransactionTypes` with `TransactionType.lendingWithdraw` ([#5936](https://github.com/MetaMask/core/pull/5936))
+
 ## [1.0.0]
 
 ### Added

--- a/packages/earn-controller/src/EarnController.ts
+++ b/packages/earn-controller/src/EarnController.ts
@@ -98,11 +98,11 @@ const stakingTransactionTypes = new Set<StakingTransactionTypes>([
 
 type LendingTransactionTypes =
   | TransactionType.lendingDeposit
-  | 'lendingWithdraw';
+  | TransactionType.lendingWithdraw;
 
 const lendingTransactionTypes = new Set<LendingTransactionTypes>([
   TransactionType.lendingDeposit,
-  'lendingWithdraw',
+  TransactionType.lendingWithdraw,
 ]);
 
 /**

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `lendingWithdraw` to `TransactionType` ([#5936](https://github.com/MetaMask/core/pull/5936))
+
 ### Fixed
 
 - Avoid coercing `publishBatchHook` to a boolean ([#5934](https://github.com/MetaMask/core/pull/5934))

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -679,6 +679,11 @@ export enum TransactionType {
   lendingDeposit = 'lendingDeposit',
 
   /**
+   * A transaction that withdraws tokens from a lending contract.
+   */
+  lendingWithdraw = 'lendingWithdraw',
+
+  /**
    * A transaction for personal sign.
    */
   personalSign = 'personal_sign',


### PR DESCRIPTION
### Changes
- Add `lendingWithdraw` type to `@metamask/transaction-controller`
- Replace hardcoded `"lendingWithdraw"` in `@metamask/earn-controller`