### PR TITLE
feat: added 'private key sync` feature to the controller

### DIFF
--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
@@ -93,6 +93,7 @@ const MOCK_KEYRING_ID = 'mock-keyring-id';
 const MOCK_SEED_PHRASE = stringToBytes(
   'horror pink muffin canal young photo magnet runway start elder patch until',
 );
+const MOCK_PRIVATE_KEY = stringToBytes('0xdeadbeef');
 
 const MOCK_AUTH_PUB_KEY = 'A09CwPHdl/qo2AjBOHen5d4QORaLedxOrSdgReq8IhzQ';
 const MOCK_AUTH_PUB_KEY_OUTDATED =
@@ -1009,7 +1010,7 @@ describe('SeedlessOnboardingController', () => {
     });
   });
 
-  describe('addNewSeedPhraseBackup', () => {
+  describe('addNewSecretData', () => {
     const MOCK_PASSWORD = 'mock-password';
     const NEW_KEY_RING_1 = {
       id: 'new-keyring-1',
@@ -1050,9 +1051,12 @@ describe('SeedlessOnboardingController', () => {
     it('should throw an error if the controller is locked', async () => {
       await withController(async ({ controller }) => {
         await expect(
-          controller.addNewSeedPhraseBackup(
+          controller.addNewSecretData(
             NEW_KEY_RING_1.seedPhrase,
-            NEW_KEY_RING_1.id,
+            SecretType.Mnemonic,
+            {
+              keyringId: NEW_KEY_RING_1.id,
+            },
           ),
         ).rejects.toThrow(
           SeedlessOnboardingControllerErrorMessage.ControllerLocked,
@@ -1081,9 +1085,12 @@ describe('SeedlessOnboardingController', () => {
 
           // encrypt and store the secret data
           const mockSecretDataAdd = handleMockSecretDataAdd();
-          await controller.addNewSeedPhraseBackup(
+          await controller.addNewSecretData(
             NEW_KEY_RING_1.seedPhrase,
-            NEW_KEY_RING_1.id,
+            SecretType.Mnemonic,
+            {
+              keyringId: NEW_KEY_RING_1.id,
+            },
           );
 
           expect(mockSecretDataAdd.isDone()).toBe(true);
@@ -1116,9 +1123,12 @@ describe('SeedlessOnboardingController', () => {
 
           // encrypt and store the secret data
           const mockSecretDataAdd = handleMockSecretDataAdd();
-          await controller.addNewSeedPhraseBackup(
+          await controller.addNewSecretData(
             NEW_KEY_RING_1.seedPhrase,
-            NEW_KEY_RING_1.id,
+            SecretType.Mnemonic,
+            {
+              keyringId: NEW_KEY_RING_1.id,
+            },
           );
 
           expect(mockSecretDataAdd.isDone()).toBe(true);
@@ -1135,9 +1145,12 @@ describe('SeedlessOnboardingController', () => {
 
           // add another seed phrase backup
           const mockSecretDataAdd2 = handleMockSecretDataAdd();
-          await controller.addNewSeedPhraseBackup(
+          await controller.addNewSecretData(
             NEW_KEY_RING_2.seedPhrase,
-            NEW_KEY_RING_2.id,
+            SecretType.Mnemonic,
+            {
+              keyringId: NEW_KEY_RING_2.id,
+            },
           );
 
           expect(mockSecretDataAdd2.isDone()).toBe(true);
@@ -1170,6 +1183,37 @@ describe('SeedlessOnboardingController', () => {
       );
     });
 
+    it('should be able to add Private key backup', async () => {
+      await withController(
+        {
+          state: getMockInitialControllerState({
+            withMockAuthenticatedUser: true,
+            withMockAuthPubKey: true,
+            vault: MOCK_VAULT,
+            vaultEncryptionKey: MOCK_VAULT_ENCRYPTION_KEY,
+            vaultEncryptionSalt: MOCK_VAULT_ENCRYPTION_SALT,
+          }),
+        },
+        async ({ controller, toprfClient }) => {
+          mockFetchAuthPubKey(
+            toprfClient,
+            base64ToBytes(controller.state.authPubKey as string),
+          );
+
+          await controller.submitPassword(MOCK_PASSWORD);
+
+          // encrypt and store the secret data
+          const mockSecretDataAdd = handleMockSecretDataAdd();
+          await controller.addNewSecretData(
+            MOCK_PRIVATE_KEY,
+            SecretType.PrivateKey,
+          );
+
+          expect(mockSecretDataAdd.isDone()).toBe(true);
+        },
+      );
+    });
+
     it('should throw an error if failed to parse vault data', async () => {
       await withController(
         {
@@ -1193,9 +1237,12 @@ describe('SeedlessOnboardingController', () => {
             .spyOn(encryptor, 'decryptWithKey')
             .mockResolvedValueOnce('{ "foo": "bar"');
           await expect(
-            controller.addNewSeedPhraseBackup(
+            controller.addNewSecretData(
               NEW_KEY_RING_1.seedPhrase,
-              NEW_KEY_RING_1.id,
+              SecretType.Mnemonic,
+              {
+                keyringId: NEW_KEY_RING_1.id,
+              },
             ),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.InvalidVaultData,
@@ -1238,9 +1285,12 @@ describe('SeedlessOnboardingController', () => {
           );
 
           await expect(
-            controller.addNewSeedPhraseBackup(
+            controller.addNewSecretData(
               NEW_KEY_RING_2.seedPhrase,
-              NEW_KEY_RING_2.id,
+              SecretType.Mnemonic,
+              {
+                keyringId: NEW_KEY_RING_2.id,
+              },
             ),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.MissingCredentials,
@@ -1276,9 +1326,12 @@ describe('SeedlessOnboardingController', () => {
           });
 
           await expect(
-            controller.addNewSeedPhraseBackup(
+            controller.addNewSecretData(
               NEW_KEY_RING_1.seedPhrase,
-              NEW_KEY_RING_1.id,
+              SecretType.Mnemonic,
+              {
+                keyringId: NEW_KEY_RING_1.id,
+              },
             ),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.ExpiredCredentials,
@@ -1321,9 +1374,12 @@ describe('SeedlessOnboardingController', () => {
           );
 
           await expect(
-            controller.addNewSeedPhraseBackup(
+            controller.addNewSecretData(
               NEW_KEY_RING_2.seedPhrase,
-              NEW_KEY_RING_2.id,
+              SecretType.Mnemonic,
+              {
+                keyringId: NEW_KEY_RING_2.id,
+              },
             ),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.WrongPasswordType,
@@ -1368,9 +1424,12 @@ describe('SeedlessOnboardingController', () => {
             .spyOn(encryptor, 'decryptWithKey')
             .mockResolvedValueOnce({ foo: 'bar' });
           await expect(
-            controller.addNewSeedPhraseBackup(
+            controller.addNewSecretData(
               NEW_KEY_RING_2.seedPhrase,
-              NEW_KEY_RING_2.id,
+              SecretType.Mnemonic,
+              {
+                keyringId: NEW_KEY_RING_2.id,
+              },
             ),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.InvalidVaultData,
@@ -1378,9 +1437,12 @@ describe('SeedlessOnboardingController', () => {
 
           jest.spyOn(encryptor, 'decryptWithKey').mockResolvedValueOnce('null');
           await expect(
-            controller.addNewSeedPhraseBackup(
+            controller.addNewSecretData(
               NEW_KEY_RING_2.seedPhrase,
-              NEW_KEY_RING_2.id,
+              SecretType.Mnemonic,
+              {
+                keyringId: NEW_KEY_RING_2.id,
+              },
             ),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.VaultDataError,
@@ -1425,9 +1487,12 @@ describe('SeedlessOnboardingController', () => {
             .spyOn(encryptor, 'decryptWithKey')
             .mockResolvedValueOnce(MOCK_VAULT);
           await expect(
-            controller.addNewSeedPhraseBackup(
+            controller.addNewSecretData(
               NEW_KEY_RING_2.seedPhrase,
-              NEW_KEY_RING_2.id,
+              SecretType.Mnemonic,
+              {
+                keyringId: NEW_KEY_RING_2.id,
+              },
             ),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.VaultDataError,
@@ -1451,9 +1516,12 @@ describe('SeedlessOnboardingController', () => {
           mockFetchAuthPubKey(toprfClient, base64ToBytes(MOCK_AUTH_PUB_KEY));
           await controller.submitPassword(MOCK_PASSWORD);
           await expect(
-            controller.addNewSeedPhraseBackup(
+            controller.addNewSecretData(
               NEW_KEY_RING_1.seedPhrase,
-              NEW_KEY_RING_1.id,
+              SecretType.Mnemonic,
+              {
+                keyringId: NEW_KEY_RING_1.id,
+              },
             ),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.OutdatedPassword,
@@ -1461,12 +1529,40 @@ describe('SeedlessOnboardingController', () => {
         },
       );
     });
+
+    it('should throw an error if `KeyringId` is missing when adding new Mnemonic (SRP)', async () => {
+      await withController(
+        {
+          state: getMockInitialControllerState({
+            withMockAuthenticatedUser: true,
+            withMockAuthPubKey: true,
+            vault: MOCK_VAULT,
+            vaultEncryptionKey: MOCK_VAULT_ENCRYPTION_KEY,
+            vaultEncryptionSalt: MOCK_VAULT_ENCRYPTION_SALT,
+          }),
+        },
+        async ({ controller, toprfClient }) => {
+          mockFetchAuthPubKey(
+            toprfClient,
+            base64ToBytes(controller.state.authPubKey as string),
+          );
+
+          await controller.submitPassword(MOCK_PASSWORD);
+
+          await expect(
+            controller.addNewSecretData(MOCK_SEED_PHRASE, SecretType.Mnemonic),
+          ).rejects.toThrow(
+            SeedlessOnboardingControllerErrorMessage.MissingKeyringId,
+          );
+        },
+      );
+    });
   });
 
-  describe('fetchAndRestoreSeedPhrase', () => {
+  describe('fetchAllSecretData', () => {
     const MOCK_PASSWORD = 'mock-password';
 
-    it('should be able to restore and login with a seed phrase from metadata', async () => {
+    it('should be able to fetch secret data from metadata store', async () => {
       await withController(
         {
           state: getMockInitialControllerState({
@@ -1483,16 +1579,27 @@ describe('SeedlessOnboardingController', () => {
           const mockSecretDataGet = handleMockSecretDataGet({
             status: 200,
             body: createMockSecretDataGetResponse(
-              [MOCK_SEED_PHRASE],
+              [
+                {
+                  data: MOCK_SEED_PHRASE,
+                  type: SecretType.Mnemonic,
+                },
+                {
+                  data: MOCK_PRIVATE_KEY,
+                  type: SecretType.PrivateKey,
+                },
+              ],
               MOCK_PASSWORD,
             ),
           });
-          const secretData =
-            await controller.fetchAllSeedPhrases(MOCK_PASSWORD);
+          const secretData = await controller.fetchAllSecretData(MOCK_PASSWORD);
 
           expect(mockSecretDataGet.isDone()).toBe(true);
           expect(secretData).toBeDefined();
-          expect(secretData).toStrictEqual([MOCK_SEED_PHRASE]);
+          expect(secretData).toStrictEqual({
+            mnemonic: [MOCK_SEED_PHRASE],
+            privateKey: [MOCK_PRIVATE_KEY],
+          });
 
           expect(controller.state.vault).toBeDefined();
           expect(controller.state.vault).not.toBe(initialState.vault);
@@ -1541,19 +1648,21 @@ describe('SeedlessOnboardingController', () => {
               MOCK_PASSWORD,
             ),
           });
-          const secretData =
-            await controller.fetchAllSeedPhrases(MOCK_PASSWORD);
+          const secretData = await controller.fetchAllSecretData(MOCK_PASSWORD);
 
           expect(mockSecretDataGet.isDone()).toBe(true);
           expect(secretData).toBeDefined();
 
           // `fetchAndRestoreSeedPhraseMetadata` should sort the seed phrases by timestamp in ascending order and return the seed phrases in the correct order
           // the seed phrases are sorted in ascending order, so the oldest seed phrase is the first item in the array
-          expect(secretData).toStrictEqual([
-            stringToBytes('seedPhrase1'),
-            stringToBytes('seedPhrase2'),
-            stringToBytes('seedPhrase3'),
-          ]);
+          expect(secretData).toStrictEqual({
+            mnemonic: [
+              stringToBytes('seedPhrase1'),
+              stringToBytes('seedPhrase2'),
+              stringToBytes('seedPhrase3'),
+            ],
+            privateKey: [],
+          });
 
           // verify the vault data
           const { encryptedMockVault } = await createMockVault(
@@ -1600,12 +1709,14 @@ describe('SeedlessOnboardingController', () => {
               MOCK_PASSWORD,
             ),
           });
-          const secretData =
-            await controller.fetchAllSeedPhrases(MOCK_PASSWORD);
+          const secretData = await controller.fetchAllSecretData(MOCK_PASSWORD);
 
           expect(mockSecretDataGet.isDone()).toBe(true);
           expect(secretData).toBeDefined();
-          expect(secretData).toStrictEqual([MOCK_SEED_PHRASE]);
+          expect(secretData).toStrictEqual({
+            mnemonic: [MOCK_SEED_PHRASE],
+            privateKey: [],
+          });
 
           expect(controller.state.vault).toBeDefined();
           expect(controller.state.vault).not.toBe(initialState.vault);
@@ -1672,11 +1783,14 @@ describe('SeedlessOnboardingController', () => {
             ),
           });
 
-          const secretData = await controller.fetchAllSeedPhrases();
+          const secretData = await controller.fetchAllSecretData();
 
           expect(mockSecretDataGet.isDone()).toBe(true);
           expect(secretData).toBeDefined();
-          expect(secretData).toStrictEqual([MOCK_SEED_PHRASE]);
+          expect(secretData).toStrictEqual({
+            mnemonic: [MOCK_SEED_PHRASE],
+            privateKey: [],
+          });
         },
       );
     });
@@ -1696,7 +1810,7 @@ describe('SeedlessOnboardingController', () => {
             );
 
           await expect(
-            controller.fetchAllSeedPhrases('INCORRECT_PASSWORD'),
+            controller.fetchAllSecretData('INCORRECT_PASSWORD'),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.LoginFailedError,
           );
@@ -1719,7 +1833,7 @@ describe('SeedlessOnboardingController', () => {
             .mockRejectedValueOnce(new Error('Failed to decrypt data'));
 
           await expect(
-            controller.fetchAllSeedPhrases('INCORRECT_PASSWORD'),
+            controller.fetchAllSecretData('INCORRECT_PASSWORD'),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.FailedToFetchSeedPhraseMetadata,
           );
@@ -1743,7 +1857,7 @@ describe('SeedlessOnboardingController', () => {
               stringToBytes(JSON.stringify({ key: 'value' })),
             ]);
           await expect(
-            controller.fetchAllSeedPhrases(MOCK_PASSWORD),
+            controller.fetchAllSecretData(MOCK_PASSWORD),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.FailedToFetchSeedPhraseMetadata,
           );
@@ -1771,7 +1885,7 @@ describe('SeedlessOnboardingController', () => {
           );
 
           await expect(
-            controller.fetchAllSeedPhrases(MOCK_PASSWORD),
+            controller.fetchAllSecretData(MOCK_PASSWORD),
           ).rejects.toStrictEqual(
             new RecoveryError(
               SeedlessOnboardingControllerErrorMessage.TooManyLoginAttempts,
@@ -1814,7 +1928,7 @@ describe('SeedlessOnboardingController', () => {
           );
 
           await expect(
-            controller.fetchAllSeedPhrases(MOCK_PASSWORD),
+            controller.fetchAllSecretData(MOCK_PASSWORD),
           ).rejects.toStrictEqual(
             new RecoveryError(
               SeedlessOnboardingControllerErrorMessage.TooManyLoginAttempts,
@@ -1848,7 +1962,7 @@ describe('SeedlessOnboardingController', () => {
             );
 
           await expect(
-            controller.fetchAllSeedPhrases(MOCK_PASSWORD),
+            controller.fetchAllSecretData(MOCK_PASSWORD),
           ).rejects.toStrictEqual(
             new RecoveryError(
               SeedlessOnboardingControllerErrorMessage.IncorrectPassword,
@@ -1873,7 +1987,7 @@ describe('SeedlessOnboardingController', () => {
             );
 
           await expect(
-            controller.fetchAllSeedPhrases(MOCK_PASSWORD),
+            controller.fetchAllSecretData(MOCK_PASSWORD),
           ).rejects.toStrictEqual(
             new RecoveryError(
               SeedlessOnboardingControllerErrorMessage.LoginFailedError,
@@ -2382,7 +2496,7 @@ describe('SeedlessOnboardingController', () => {
               data: [],
             },
           });
-          await controller.fetchAllSeedPhrases(MOCK_PASSWORD);
+          await controller.fetchAllSecretData(MOCK_PASSWORD);
 
           expect(mockSecretDataGet.isDone()).toBe(true);
           expect(controller.state.vault).toBeUndefined();
@@ -2435,8 +2549,12 @@ describe('SeedlessOnboardingController', () => {
           // mock the secret data add
           const mockSecretDataAdd = handleMockSecretDataAdd();
           await expect(
-            // @ts-expect-error Intentionally passing wrong password type
-            controller.createToprfKeyAndBackupSeedPhrase(123, MOCK_SEED_PHRASE),
+            controller.createToprfKeyAndBackupSeedPhrase(
+              // @ts-expect-error Intentionally passing wrong password type
+              123,
+              MOCK_SEED_PHRASE,
+              'MOCK_KEYRING_ID',
+            ),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.WrongPasswordType,
           );
@@ -2469,10 +2587,9 @@ describe('SeedlessOnboardingController', () => {
           controller.setLocked();
 
           await expect(
-            controller.addNewSeedPhraseBackup(
-              MOCK_SEED_PHRASE,
-              MOCK_KEYRING_ID,
-            ),
+            controller.addNewSecretData(MOCK_SEED_PHRASE, SecretType.Mnemonic, {
+              keyringId: MOCK_KEYRING_ID,
+            }),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.ControllerLocked,
           );
@@ -2499,10 +2616,9 @@ describe('SeedlessOnboardingController', () => {
           baseMessenger.publish('KeyringController:lock');
 
           await expect(
-            controller.addNewSeedPhraseBackup(
-              MOCK_SEED_PHRASE,
-              MOCK_KEYRING_ID,
-            ),
+            controller.addNewSecretData(MOCK_SEED_PHRASE, SecretType.Mnemonic, {
+              keyringId: MOCK_KEYRING_ID,
+            }),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.ControllerLocked,
           );
@@ -2519,10 +2635,9 @@ describe('SeedlessOnboardingController', () => {
         },
         async ({ controller, baseMessenger }) => {
           await expect(
-            controller.addNewSeedPhraseBackup(
-              MOCK_SEED_PHRASE,
-              MOCK_KEYRING_ID,
-            ),
+            controller.addNewSecretData(MOCK_SEED_PHRASE, SecretType.Mnemonic, {
+              keyringId: MOCK_KEYRING_ID,
+            }),
           ).rejects.toThrow(
             SeedlessOnboardingControllerErrorMessage.ControllerLocked,
           );
@@ -2665,8 +2780,8 @@ describe('SeedlessOnboardingController', () => {
     });
 
     it('should be able to parse the array of Mixed SecretMetadata', () => {
-      const MOCK_PRIVATE_KEY = 'private-key-1';
-      const secret1 = new SecretMetadata<string>(MOCK_PRIVATE_KEY, {
+      const mockPrivKeyString = '0xdeadbeef';
+      const secret1 = new SecretMetadata<string>(mockPrivKeyString, {
         type: SecretType.PrivateKey,
       });
       const secret2 = new SecretMetadata<Uint8Array>(MOCK_SEED_PHRASE, {
@@ -2678,15 +2793,15 @@ describe('SeedlessOnboardingController', () => {
       const parsedSecrets =
         SecretMetadata.parseSecretsFromMetadataStore(secrets);
       expect(parsedSecrets).toHaveLength(2);
-      expect(parsedSecrets[0].data).toBe(MOCK_PRIVATE_KEY);
+      expect(parsedSecrets[0].data).toBe(mockPrivKeyString);
       expect(parsedSecrets[0].type).toBe(SecretType.PrivateKey);
       expect(parsedSecrets[1].data).toStrictEqual(MOCK_SEED_PHRASE);
       expect(parsedSecrets[1].type).toBe(SecretType.Mnemonic);
     });
 
     it('should be able to filter the array of SecretMetadata by type', () => {
-      const MOCK_PRIVATE_KEY = 'MOCK_PRIVATE_KEY';
-      const secret1 = new SecretMetadata<string>(MOCK_PRIVATE_KEY, {
+      const mockPrivKeyString = '0xdeadbeef';
+      const secret1 = new SecretMetadata<string>(mockPrivKeyString, {
         type: SecretType.PrivateKey,
       });
       const secret2 = new SecretMetadata<Uint8Array>(MOCK_SEED_PHRASE, {
@@ -2712,7 +2827,7 @@ describe('SeedlessOnboardingController', () => {
       );
 
       expect(privateKeySecrets).toHaveLength(1);
-      expect(privateKeySecrets[0].data).toBe(MOCK_PRIVATE_KEY);
+      expect(privateKeySecrets[0].data).toBe(mockPrivKeyString);
       expect(privateKeySecrets[0].type).toBe(SecretType.PrivateKey);
     });
   });

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -257,11 +257,14 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
         });
 
       // encrypt and store the seed phrase backup
-      await this.#encryptAndStoreSeedPhraseBackup({
-        keyringId,
-        seedPhrase,
+      await this.#encryptAndStoreSecretData({
+        data: seedPhrase,
+        type: SecretType.Mnemonic,
         encKey,
         authKeyPair,
+        options: {
+          keyringId,
+        },
       });
 
       // store/persist the encryption key shares
@@ -282,45 +285,55 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
   }
 
   /**
-   * Add a new seed phrase backup to the metadata store.
+   * encrypt and add a new secret data to the metadata store.
    *
-   * @param seedPhrase - The seed phrase to backup.
-   * @param keyringId - The keyring id of the backup seed phrase.
+   * @param data - The data to add.
+   * @param type - The type of the secret data.
+   * @param options - Optional options object, which includes optional data to be added to the metadata store.
+   * @param options.keyringId - The keyring id of the backup keyring (SRP).
    * @returns A promise that resolves to the success of the operation.
    */
-  async addNewSeedPhraseBackup(
-    seedPhrase: Uint8Array,
-    keyringId: string,
+  async addNewSecretData(
+    data: Uint8Array,
+    type: SecretType,
+    options?: {
+      keyringId?: string;
+    },
   ): Promise<void> {
     return await this.#withControllerLock(async () => {
       this.#assertIsUnlocked();
+
       await this.#assertPasswordInSync({
         skipCache: true,
         skipLock: true, // skip lock since we already have the lock
       });
+
       // verify the password and unlock the vault
       const { toprfEncryptionKey, toprfAuthKeyPair } =
         await this.#unlockVaultAndGetBackupEncKey();
 
       // encrypt and store the seed phrase backup
-      await this.#encryptAndStoreSeedPhraseBackup({
-        keyringId,
-        seedPhrase,
+      await this.#encryptAndStoreSecretData({
+        data,
+        type,
         encKey: toprfEncryptionKey,
         authKeyPair: toprfAuthKeyPair,
+        options,
       });
     });
   }
 
   /**
-   * Fetches all encrypted seed phrases and metadata for user's account from the metadata store.
+   * Fetches all encrypted secret data and metadata for user's account from the metadata store.
    *
-   * Decrypts the seed phrases and returns the decrypted seed phrases using the recovered encryption key from the password.
+   * Decrypts the secret data and returns the decrypted secret data using the recovered encryption key from the password.
    *
    * @param password - The optional password used to create new wallet and seedphrase. If not provided, `cached Encryption Key` will be used.
-   * @returns A promise that resolves to the seed phrase metadata.
+   * @returns A promise that resolves to the secret data.
    */
-  async fetchAllSeedPhrases(password?: string): Promise<Uint8Array[]> {
+  async fetchAllSecretData(
+    password?: string,
+  ): Promise<Record<SecretType, Uint8Array[]>> {
     // assert that the user is authenticated before fetching the seed phrases
     this.#assertIsAuthenticatedUser(this.state);
 
@@ -359,11 +372,18 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
           });
         }
 
-        const secrets = SecretMetadata.parseSecretsFromMetadataStore(
-          secretData,
-          SecretType.Mnemonic,
-        );
-        return secrets.map((secret) => secret.data);
+        const result: Record<SecretType, Uint8Array[]> = {
+          mnemonic: [],
+          privateKey: [],
+        };
+        const secrets =
+          SecretMetadata.parseSecretsFromMetadataStore(secretData);
+
+        secrets.forEach((secret) => {
+          result[secret.type].push(secret.data);
+        });
+
+        return result;
       } catch (error) {
         log('Error fetching seed phrase metadata', error);
         throw new Error(
@@ -797,34 +817,58 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
    * Encrypt and store the seed phrase backup in the metadata store.
    *
    * @param params - The parameters for encrypting and storing the seed phrase backup.
-   * @param params.keyringId - The keyring id of the backup seed phrase.
-   * @param params.seedPhrase - The seed phrase to store.
+   * @param params.data - The seed phrase to store.
+   * @param params.type - The type of the secret data.
    * @param params.encKey - The encryption key to store.
    * @param params.authKeyPair - The authentication key pair to store.
+   * @param params.options - Optional options object, which includes optional data to be added to the metadata store.
+   * @param params.options.keyringId - The keyring id of the backup keyring (SRP).
    *
    * @returns A promise that resolves to the success of the operation.
    */
-  async #encryptAndStoreSeedPhraseBackup(params: {
-    keyringId: string;
-    seedPhrase: Uint8Array;
+  async #encryptAndStoreSecretData(params: {
+    data: Uint8Array;
+    type: SecretType;
     encKey: Uint8Array;
     authKeyPair: KeyPair;
+    options?: {
+      keyringId?: string;
+    };
   }): Promise<void> {
-    try {
-      const { keyringId, seedPhrase, encKey, authKeyPair } = params;
+    const { options, data, encKey, authKeyPair, type } = params;
 
-      const seedPhraseMetadata = new SecretMetadata(seedPhrase);
-      const secretData = seedPhraseMetadata.toBytes();
-      await this.#withPersistedSeedPhraseBackupsState(async () => {
-        await this.toprfClient.addSecretDataItem({
-          encKey,
-          secretData,
-          authKeyPair,
+    const seedPhraseMetadata = new SecretMetadata(data, {
+      type,
+    });
+    const secretData = seedPhraseMetadata.toBytes();
+
+    const keyringId = options?.keyringId as string;
+    if (type === SecretType.Mnemonic && !keyringId) {
+      throw new Error(
+        SeedlessOnboardingControllerErrorMessage.MissingKeyringId,
+      );
+    }
+
+    try {
+      if (type === SecretType.Mnemonic) {
+        await this.#withPersistedSeedPhraseBackupsState(async () => {
+          await this.toprfClient.addSecretDataItem({
+            encKey,
+            secretData,
+            authKeyPair,
+          });
+          return {
+            keyringId,
+            seedPhrase: data,
+          };
         });
-        return {
-          keyringId,
-          seedPhrase,
-        };
+        return;
+      }
+
+      await this.toprfClient.addSecretDataItem({
+        encKey,
+        secretData,
+        authKeyPair,
       });
     } catch (error) {
       log('Error encrypting and storing seed phrase backup', error);

--- a/packages/seedless-onboarding-controller/src/constants.ts
+++ b/packages/seedless-onboarding-controller/src/constants.ts
@@ -39,6 +39,7 @@ export enum SeedlessOnboardingControllerErrorMessage {
   VaultDataError = `${controllerName} - The decrypted vault has an unexpected shape.`,
   VaultError = `${controllerName} - Cannot unlock without a previous vault.`,
   InvalidSecretMetadata = `${controllerName} - Invalid secret metadata`,
+  MissingKeyringId = `${controllerName} - Keyring ID is required to store SRP backups.`,
   FailedToEncryptAndStoreSeedPhraseBackup = `${controllerName} - Failed to encrypt and store seed phrase backup`,
   FailedToFetchSeedPhraseMetadata = `${controllerName} - Failed to fetch seed phrase metadata`,
   FailedToChangePassword = `${controllerName} - Failed to change password`,

--- a/packages/seedless-onboarding-controller/src/index.ts
+++ b/packages/seedless-onboarding-controller/src/index.ts
@@ -19,5 +19,6 @@ export {
   Web3AuthNetwork,
   SeedlessOnboardingControllerErrorMessage,
   AuthConnection,
+  SecretType,
 } from './constants';
 export { RecoveryError } from './errors';

--- a/packages/seedless-onboarding-controller/tests/mocks/toprf.ts
+++ b/packages/seedless-onboarding-controller/tests/mocks/toprf.ts
@@ -1,4 +1,5 @@
 import { MockToprfEncryptorDecryptor } from './toprfEncryptor';
+import type { SecretType } from '../../src/constants';
 
 export const TOPRF_BASE_URL = /https:\/\/node-[1-5]\.dev-node\.web3auth\.io/u;
 
@@ -74,7 +75,9 @@ export const MULTIPLE_MOCK_SECRET_METADATA = [
  * @returns The mock secret data get response
  */
 export function createMockSecretDataGetResponse<
-  T extends Uint8Array | { data: Uint8Array; timestamp: number },
+  T extends
+    | Uint8Array
+    | { data: Uint8Array; timestamp?: number; type?: SecretType },
 >(secretDataArr: T[], password: string) {
   const mockToprfEncryptor = new MockToprfEncryptorDecryptor();
   const ids: string[] = [];
@@ -82,16 +85,19 @@ export function createMockSecretDataGetResponse<
   const encryptedSecretData = secretDataArr.map((secretData) => {
     let b64SecretData: string;
     let timestamp = Date.now();
+    let type: SecretType | undefined;
     if (secretData instanceof Uint8Array) {
       b64SecretData = Buffer.from(secretData).toString('base64');
     } else {
       b64SecretData = Buffer.from(secretData.data).toString('base64');
-      timestamp = secretData.timestamp;
+      timestamp = secretData.timestamp || Date.now();
+      type = secretData.type;
     }
 
     const metadata = JSON.stringify({
       data: b64SecretData,
       timestamp,
+      type,
     });
 
     return mockToprfEncryptor.encrypt(


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Added `Private Key` sync feature to the `SeedlessOnboardingController`.
- `PrivateKey` will be encrypted and added to the metadata store (similar to the `SRP backups`)
- Upon rehydration, both `Mnemonics` (Seed phrases) and `Private Keys` will be decrypted and returned in bytes.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
