### PR TITLE
Rename team-solana label to team-new-networks

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -44,7 +44,7 @@
   "metamask/signature-controller": "team-confirmations",
   "metamask/transaction-controller": "team-confirmations",
   "metamask/user-operation-controller": "team-confirmations",
-  "metamask/multichain-transactions-controller": "team-solana,team-accounts",
+  "metamask/multichain-transactions-controller": "team-new-networks,team-accounts",
   "metamask/token-search-discovery-controller": "team-portfolio",
   "metamask/earn-controller": "team-earn",
   "metamask/error-reporting-service": "team-wallet-framework",


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

The `team-solana` issue label in the extension and mobile repos has been renamed to `team-new-networks`. The `create-update-issues` workflow uses this to know which teams to assign to tickets representing controller upgrades. Updating this label in `teams.json` ensures that this workflow won't break when a new major version of `@metamask/multichain-transactions-controller` is released.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Noticed in Slack.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
