### PR TITLE
feat: implement solana snap onClientRequest

### DIFF
--- a/packages/bridge-controller/src/index.ts
+++ b/packages/bridge-controller/src/index.ts
@@ -129,3 +129,5 @@ export {
 } from './selectors';
 
 export { DEFAULT_FEATURE_FLAG_CONFIG } from './constants/bridge';
+
+export { getBridgeFeatureFlags } from './utils/feature-flags';

--- a/packages/bridge-controller/src/types.ts
+++ b/packages/bridge-controller/src/types.ts
@@ -65,6 +65,7 @@ export type ChainConfiguration = {
   refreshRate?: number;
   topAssets?: string[];
   isUnifiedUIEnabled?: boolean;
+  isSnapConfirmationEnabled?: boolean;
 };
 
 export type L1GasFees = {

--- a/packages/bridge-controller/src/utils/feature-flags.ts
+++ b/packages/bridge-controller/src/utils/feature-flags.ts
@@ -4,7 +4,6 @@ import { DEFAULT_FEATURE_FLAG_CONFIG } from '../constants/bridge';
 import type {
   FeatureFlagsPlatformConfig,
   ChainConfiguration,
-  BridgeControllerMessenger,
 } from '../types';
 
 export const formatFeatureFlags = (
@@ -37,12 +36,14 @@ export const processFeatureFlags = (
 /**
  * Gets the bridge feature flags from the remote feature flag controller
  *
- * @param messenger - The messenger instance
+ * @param messenger - Any messenger with access to RemoteFeatureFlagController:getState
  * @returns The bridge feature flags
  */
-export function getBridgeFeatureFlags(
-  messenger: BridgeControllerMessenger,
-): FeatureFlagsPlatformConfig {
+export function getBridgeFeatureFlags<
+  T extends {
+    call(action: 'RemoteFeatureFlagController:getState'): any;
+  },
+>(messenger: T): FeatureFlagsPlatformConfig {
   // This will return the bridgeConfig for the current platform even without specifying the platform
   const remoteFeatureFlagControllerState = messenger.call(
     'RemoteFeatureFlagController:getState',

--- a/packages/bridge-status-controller/src/types.ts
+++ b/packages/bridge-status-controller/src/types.ts
@@ -24,6 +24,7 @@ import type {
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetStateAction,
 } from '@metamask/network-controller';
+import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type { HandleSnapRequest } from '@metamask/snaps-controllers';
 import type {
   TransactionControllerGetStateAction,
@@ -335,7 +336,8 @@ type AllowedActions =
   | BridgeControllerAction<BridgeBackgroundAction.GET_BRIDGE_ERC20_ALLOWANCE>
   | BridgeControllerAction<BridgeBackgroundAction.TRACK_METAMETRICS_EVENT>
   | GetGasFeeState
-  | AccountsControllerGetAccountByAddressAction;
+  | AccountsControllerGetAccountByAddressAction
+  | RemoteFeatureFlagControllerGetStateAction;
 
 /**
  * The external events available to the BridgeStatusController.

--- a/packages/bridge-status-controller/src/utils/transaction.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.ts
@@ -154,3 +154,26 @@ export const getKeyringRequest = (
     },
   };
 };
+
+export const getClientRequest = (
+  quoteResponse: Omit<QuoteResponse<string>, 'approval'> & QuoteMetadata,
+  selectedAccount: AccountsControllerState['internalAccounts']['accounts'][string],
+) => {
+  const clientReqId = uuid();
+
+  return {
+    origin: 'metamask',
+    snapId: selectedAccount.metadata.snap?.id as never,
+    handler: 'onClientRequest' as never,
+    request: {
+      id: clientReqId,
+      jsonrpc: '2.0',
+      method: 'signAndSendTransactionWithoutConfirmation',
+      params: {
+        account: { address: selectedAccount.address },
+        transaction: quoteResponse.trade,
+        scope: SolScope.Mainnet,
+      },
+    },
+  };
+};


### PR DESCRIPTION
## Explanation

Deprecates the solana snap confirmation page by implementing onClientRequest. Retains ability to fallback to onKeyringRequest through a LaunchDarkly feature flag on the chain level.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
Mobile PR: Related to https://github.com/MetaMask/metamask-mobile/pull/16293)
## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
