### PR TITLE
Integrate RNS Registry into EnsController

### DIFF
--- a/packages/controller-utils/src/constants.ts
+++ b/packages/controller-utils/src/constants.ts
@@ -194,4 +194,5 @@ export const CHAIN_ID_TO_ETHERS_NETWORK_NAME_MAP: Record<
   [ChainId['linea-sepolia']]: BuiltInNetworkName.LineaSepolia,
   [ChainId['linea-mainnet']]: BuiltInNetworkName.LineaMainnet,
   [ChainId.aurora]: BuiltInNetworkName.Aurora,
+  [ChainId['rootstock-mainnet']]: BuiltInNetworkName.RootstockMainnet,
 };

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -80,6 +80,7 @@ export enum BuiltInNetworkName {
   MegaETHTestnet = 'megaeth-testnet',
   MonadTestnet = 'monad-testnet',
   BaseMainnet = 'base-mainnet',
+  RootstockMainnet = 'rootstock-mainnet',
 }
 
 /**
@@ -98,6 +99,7 @@ export const ChainId = {
   [BuiltInNetworkName.MegaETHTestnet]: '0x18c6', // toHex(6342)
   [BuiltInNetworkName.MonadTestnet]: '0x279f', // toHex(10143)
   [BuiltInNetworkName.BaseMainnet]: '0x2105', // toHex(8453)
+  [BuiltInNetworkName.RootstockMainnet]: '0x1e', // toHex(30)
 } as const;
 export type ChainId = (typeof ChainId)[keyof typeof ChainId];
 

--- a/packages/ens-controller/src/EnsController.ts
+++ b/packages/ens-controller/src/EnsController.ts
@@ -38,6 +38,8 @@ export const DEFAULT_ENS_NETWORK_MAP: Record<number, Hex> = {
   17000: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
   // Sepolia
   11155111: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+  // Rootstock Mainnet
+  30: '0xcb868aeabd31e2b66f74e9a55cf064abb31a4ad5',
 };
 
 /**


### PR DESCRIPTION
## Explanation

This PR adds the RNS Registry address to the `EnsController` package. This enhancement enables the resolution of `.rsk` domains in the Rootstock-compatible version of MetaMask.

**Why:**

By including the RNS Registry address, users will be able to resolve human-readable domain names (e.g., `alice.rsk`) directly in MetaMask when interacting with dApps built on Rootstock. This improves the user experience and provides native support for domain name resolution within the Rootstock ecosystem.

**Note:**

We are aware that additional changes are required in MetaMask to fully support RNS resolution. However, this PR represents the first step toward enabling complete RNS integration within the wallet.

**Further Reading:**

- Learn more about RNS and how it works in the Rootstock ecosystem:  
  [Rootstock - RNS Overview](https://dev.rootstock.io/concepts/rif-suite/rns/)

- General information about Rootstock:  
  [Rootstock Developer Portal](https://dev.rootstock.io/)

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
