### PR TITLE
feat(KeyringController): add `exportEncryptionKey` method to export vault key

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add method `exportEncryptionKey` ([#5984](https://github.com/MetaMask/core/pull/5984))
+
+### Changed
+
+- Make salt optional with method `submitEncryptionKey` ([#5984](https://github.com/MetaMask/core/pull/5984))
+
 ## [22.0.2]
 
 ### Fixed

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -3303,6 +3303,36 @@ describe('KeyringController', () => {
     });
   });
 
+  describe('exportEncryptionKey', () => {
+    it('should export encryption key and unlock', async () => {
+      await withController(
+        { cacheEncryptionKey: true },
+        async ({ controller }) => {
+          const encryptionKey = await controller.exportEncryptionKey();
+          expect(encryptionKey).toBeDefined();
+
+          await controller.setLocked();
+
+          await controller.submitEncryptionKey(encryptionKey);
+
+          expect(controller.isUnlocked()).toBe(true);
+        },
+      );
+    });
+
+    it('should throw error if controller is locked', async () => {
+      await withController(
+        { cacheEncryptionKey: true },
+        async ({ controller }) => {
+          await controller.setLocked();
+          await expect(controller.exportEncryptionKey()).rejects.toThrow(
+            KeyringControllerError.EncryptionKeyNotSet,
+          );
+        },
+      );
+    });
+  });
+
   describe('verifySeedPhrase', () => {
     it('should return current seedphrase', async () => {
       await withController(async ({ controller }) => {

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -3326,7 +3326,7 @@ describe('KeyringController', () => {
         async ({ controller }) => {
           await controller.setLocked();
           await expect(controller.exportEncryptionKey()).rejects.toThrow(
-            KeyringControllerError.EncryptionKeyNotSet,
+            KeyringControllerError.ControllerLocked,
           );
         },
       );

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -3331,6 +3331,28 @@ describe('KeyringController', () => {
         },
       );
     });
+
+    it('should export key after password change', async () => {
+      await withController(
+        { cacheEncryptionKey: true },
+        async ({ controller }) => {
+          await controller.changePassword('new password');
+          const encryptionKey = await controller.exportEncryptionKey();
+          expect(encryptionKey).toBeDefined();
+        },
+      );
+    });
+
+    it('should export key after password change to the same password', async () => {
+      await withController(
+        { cacheEncryptionKey: true },
+        async ({ controller }) => {
+          await controller.changePassword(password);
+          const encryptionKey = await controller.exportEncryptionKey();
+          expect(encryptionKey).toBeDefined();
+        },
+      );
+    });
   });
 
   describe('verifySeedPhrase', () => {

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -3332,6 +3332,14 @@ describe('KeyringController', () => {
       );
     });
 
+    it('should throw error if encryptionKey is not set', async () => {
+      await withController(async ({ controller }) => {
+        await expect(controller.exportEncryptionKey()).rejects.toThrow(
+          KeyringControllerError.EncryptionKeyNotSet,
+        );
+      });
+    });
+
     it('should export key after password change', async () => {
       await withController(
         { cacheEncryptionKey: true },

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -528,6 +528,20 @@ function assertIsExportableKeyEncryptor(
 }
 
 /**
+ * Assert that the encryption key is set.
+ *
+ * @param encryptionKey - The encryption key to check.
+ * @throws If the encryption key is not set.
+ */
+function assertIsEncryptionKeySet(
+  encryptionKey: string | undefined,
+): asserts encryptionKey is string {
+  if (!encryptionKey) {
+    throw new Error(KeyringControllerError.EncryptionKeyNotSet);
+  }
+}
+
+/**
  * Assert that the provided password is a valid non-empty string.
  *
  * @param password - The password to check.
@@ -1469,6 +1483,16 @@ export class KeyringController extends BaseController<
       // since the controller is already unlocked.
       console.error('Failed to update vault during login:', error);
     }
+  }
+
+  /**
+   * Exports the vault encryption key.
+   *
+   * @returns The vault encryption key.
+   */
+  async exportEncryptionKey(): Promise<string> {
+    assertIsEncryptionKeySet(this.state.encryptionKey);
+    return this.state.encryptionKey;
   }
 
   /**

--- a/packages/keyring-controller/src/constants.ts
+++ b/packages/keyring-controller/src/constants.ts
@@ -36,4 +36,5 @@ export enum KeyringControllerError {
   NoHdKeyring = 'KeyringController - No HD Keyring found',
   ControllerLockRequired = 'KeyringController - attempt to update vault during a non mutually exclusive operation',
   LastAccountInPrimaryKeyring = 'KeyringController - Last account in primary keyring cannot be removed',
+  EncryptionKeyNotSet = 'KeyringController - Encryption key not set',
 }

--- a/packages/keyring-controller/src/constants.ts
+++ b/packages/keyring-controller/src/constants.ts
@@ -4,6 +4,7 @@ export enum KeyringControllerError {
   UnsafeDirectKeyringAccess = 'KeyringController - Returning keyring instances is unsafe',
   WrongPasswordType = 'KeyringController - Password must be of type string.',
   InvalidEmptyPassword = 'KeyringController - Password cannot be empty.',
+  EncryptionKeyNotSet = 'KeyringController - Encryption key not set.',
   NoFirstAccount = 'KeyringController - First Account not found.',
   DuplicatedAccount = 'KeyringController - The account you are trying to import is a duplicate',
   VaultError = 'KeyringController - Cannot unlock without a previous vault.',

--- a/packages/keyring-controller/src/constants.ts
+++ b/packages/keyring-controller/src/constants.ts
@@ -4,7 +4,6 @@ export enum KeyringControllerError {
   UnsafeDirectKeyringAccess = 'KeyringController - Returning keyring instances is unsafe',
   WrongPasswordType = 'KeyringController - Password must be of type string.',
   InvalidEmptyPassword = 'KeyringController - Password cannot be empty.',
-  EncryptionKeyNotSet = 'KeyringController - Encryption key not set.',
   NoFirstAccount = 'KeyringController - First Account not found.',
   DuplicatedAccount = 'KeyringController - The account you are trying to import is a duplicate',
   VaultError = 'KeyringController - Cannot unlock without a previous vault.',


### PR DESCRIPTION
## Explanation

Keyring Controller:
* Add method `controller.exportEncryptionKey` to export vault key.
* Change method `controller.submitEncryptionKey` to have an optional salt.
  * If the salt is provided, the controller will check that it is consistent with the locally stored salt.
  * If the salt is not provided, this check is omitted.
  * Before, the salt was mandatory, but it might not be required in the case of unlocking the vault during vault recovery.

This feature is relevant for resolving an audit finding with the seedless onboarding controller.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

Previously, seedless onboarding was backing up the keyring password to allow for vault recovery after a password change. Now we backup the keyring encryption key.

See the [ADR](https://github.com/MetaMask/decisions/pull/85) for more details.
This is part of the implementation of option 6.

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
