### PR TITLE
fix: handle incoming transactions with unknown chain

### DIFF
--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -4933,6 +4933,34 @@ describe('TransactionController', () => {
 
       expect(listener).toHaveBeenCalledTimes(0);
     });
+
+    it('ignores transactions with unrecognised chain ID', async () => {
+      const { controller } = setupController();
+
+      multichainTrackingHelperMock.getNetworkClient.mockImplementationOnce(
+        () => {
+          throw new Error('Unknown chain ID');
+        },
+      );
+
+      multichainTrackingHelperMock.getNetworkClient.mockImplementationOnce(
+        () =>
+          ({
+            id: NETWORK_CLIENT_ID_MOCK,
+          }) as never,
+      );
+
+      // TODO: Replace `any` with type
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (incomingTransactionHelperMock.hub.on as any).mock.calls[0][1]([
+        TRANSACTION_META_MOCK,
+        TRANSACTION_META_2_MOCK,
+      ]);
+
+      expect(controller.state.transactions).toStrictEqual([
+        { ...TRANSACTION_META_2_MOCK, networkClientId: NETWORK_CLIENT_ID_MOCK },
+      ]);
+    });
   });
 
   describe('on incoming transaction helper updateCache call', () => {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -3337,15 +3337,25 @@ export class TransactionController extends BaseController<
       return;
     }
 
-    const finalTransactions = transactions.map((tx) => {
-      const { chainId } = tx;
-      const networkClientId = this.#getNetworkClientId({ chainId });
+    const finalTransactions: TransactionMeta[] = [];
 
-      return {
-        ...tx,
-        networkClientId,
-      };
-    });
+    for (const tx of transactions) {
+      const { chainId } = tx;
+
+      try {
+        const networkClientId = this.#getNetworkClientId({ chainId });
+
+        finalTransactions.push({
+          ...tx,
+          networkClientId,
+        });
+      } catch (error) {
+        log('Failed to get network client ID for incoming transaction', {
+          chainId,
+          error,
+        });
+      }
+    }
 
     this.update((state) => {
       const { transactions: currentTransactions } = state;


### PR DESCRIPTION
## Explanation

Ignore incoming transactions with chain ID not recognised by `NetworkController`, as user has not added network.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
