### PR TITLE
feat: support incoming transaction polling only when viewing activity

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove incoming transactions when calling `wipeTransactions` ([#5986](https://github.com/MetaMask/core/pull/5986))
+- Poll immediately when calling `startIncomingTransactionPolling` ([#5986](https://github.com/MetaMask/core/pull/5986))
+
 ## [58.0.0]
 
 ### Changed

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1161,6 +1161,19 @@ describe('TransactionController', () => {
 
       expect(transactions).toHaveLength(0);
     });
+
+    it('updates state when helper emits update event', async () => {
+      const { controller } = setupController();
+
+      jest.mocked(methodDataHelperMock.hub.on).mock.calls[0][1]({
+        fourBytePrefix: '0x12345678',
+        methodData: METHOD_DATA_MOCK,
+      });
+
+      expect(controller.state.methodData).toStrictEqual({
+        '0x12345678': METHOD_DATA_MOCK,
+      });
+    });
   });
 
   describe('estimateGas', () => {
@@ -3391,17 +3404,23 @@ describe('TransactionController', () => {
       expect(controller.state.transactions[0].id).toBe('4');
     });
 
-    it('updates state when helper emits update event', async () => {
-      const { controller } = setupController();
-
-      jest.mocked(methodDataHelperMock.hub.on).mock.calls[0][1]({
-        fourBytePrefix: '0x12345678',
-        methodData: METHOD_DATA_MOCK,
+    it('removes incoming transactions to specified account', async () => {
+      const { controller } = setupController({
+        options: {
+          state: {
+            transactions: [
+              { ...TRANSACTION_META_MOCK, type: TransactionType.incoming },
+            ],
+          },
+        },
+        updateToInitialState: true,
       });
 
-      expect(controller.state.methodData).toStrictEqual({
-        '0x12345678': METHOD_DATA_MOCK,
-      });
+      expect(controller.state.transactions).toHaveLength(1);
+
+      controller.wipeTransactions({ address: ACCOUNT_2_MOCK });
+
+      expect(controller.state.transactions).toHaveLength(0);
     });
   });
 

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1711,7 +1711,7 @@ export class TransactionController extends BaseController<
     }
 
     const newTransactions = this.state.transactions.filter(
-      ({ chainId: txChainId, txParams }) => {
+      ({ chainId: txChainId, txParams, type }) => {
         const isMatchingNetwork = !chainId || chainId === txChainId;
 
         if (!isMatchingNetwork) {
@@ -1719,7 +1719,10 @@ export class TransactionController extends BaseController<
         }
 
         const isMatchingAddress =
-          !address || txParams.from?.toLowerCase() === address.toLowerCase();
+          !address ||
+          txParams.from?.toLowerCase() === address.toLowerCase() ||
+          (type === TransactionType.incoming &&
+            txParams.to?.toLowerCase() === address.toLowerCase());
 
         return !isMatchingAddress;
       },

--- a/packages/transaction-controller/src/helpers/IncomingTransactionHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/IncomingTransactionHelper.test.ts
@@ -351,6 +351,8 @@ describe('IncomingTransactionHelper', () => {
 
       helper.start();
 
+      await flushPromises();
+
       expect(jest.getTimerCount()).toBe(1);
     });
 
@@ -361,6 +363,9 @@ describe('IncomingTransactionHelper', () => {
       });
 
       helper.start();
+
+      await flushPromises();
+
       helper.start();
 
       expect(jest.getTimerCount()).toBe(1);

--- a/packages/transaction-controller/src/helpers/IncomingTransactionHelper.ts
+++ b/packages/transaction-controller/src/helpers/IncomingTransactionHelper.ts
@@ -111,13 +111,13 @@ export class IncomingTransactionHelper {
 
     const interval = this.#getInterval();
 
-    log('Starting polling', { interval });
+    log('Started polling', { interval });
 
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    this.#timeoutId = setTimeout(() => this.#onInterval(), interval);
     this.#isRunning = true;
 
-    log('Started polling');
+    this.#onInterval().catch((error) => {
+      log('Initial polling failed', error);
+    });
   }
 
   stop() {


### PR DESCRIPTION
## Explanation

Support the clients polling incoming transactions only when viewing the transaction activity list.

Specifically:

- Delete incoming transactions when calling `wipeTransactions` method.
- Poll immediately when calling `startIncomingTransactionPolling` method.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
