### PR TITLE
seedless controller: store encrypted password locally

### DIFF
--- a/packages/seedless-onboarding-controller/CHANGELOG.md
+++ b/packages/seedless-onboarding-controller/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - check for token expired in toprf call, refresh token and retry if expired
   - `submitPassword` revoke refresh token and replace with new one after password submit to prevent malicious use if refresh token leak in persisted state
 - Removed `recoveryRatelimitCache` from the controller state. ([#5976](https://github.com/MetaMask/core/pull/5976)).
+- Changed `recoverCurrentDevicePassword` to no longer persist passwords in the backup store. ([#5988](https://github.com/MetaMask/core/pull/5988))
 
 ## [1.0.0]
 

--- a/packages/seedless-onboarding-controller/src/constants.ts
+++ b/packages/seedless-onboarding-controller/src/constants.ts
@@ -50,4 +50,5 @@ export enum SeedlessOnboardingControllerErrorMessage {
   OutdatedPassword = `${controllerName} - Outdated password`,
   CouldNotRecoverPassword = `${controllerName} - Could not recover password`,
   SRPNotBackedUpError = `${controllerName} - SRP not backed up`,
+  EncryptedPasswordNotSet = `${controllerName} - Encrypted password not set`,
 }

--- a/packages/seedless-onboarding-controller/src/types.ts
+++ b/packages/seedless-onboarding-controller/src/types.ts
@@ -148,6 +148,11 @@ export type SeedlessOnboardingControllerState =
        * This is temporarily stored in state during authentication and then persisted in the vault.
        */
       revokeToken?: string;
+
+      /**
+       * The encrypted password used to encrypt the vault.
+       */
+      encryptedPassword?: string;
     };
 
 // Actions


### PR DESCRIPTION
## Explanation

Resolves https://github.com/MetaMask/decisions/pull/85. Implements Option 7.

Stores encrypted password locally instead of writing it to the backup store.
Resolves an audit finding as mentioned in the above referenced ADR.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
