### PR TITLE
fix case where internal accounts can be undefined

### DIFF
--- a/packages/chain-agnostic-permission/CHANGELOG.md
+++ b/packages/chain-agnostic-permission/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
 - `isInternalAccountInPermittedAccountIds` now returns `false` when passed an `InternalAccount` in which `scopes` is `undefined` ([#6000](https://github.com/MetaMask/core/pull/6000))
 
 ## [0.7.1]

--- a/packages/chain-agnostic-permission/CHANGELOG.md
+++ b/packages/chain-agnostic-permission/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `isInternalAccountInPermittedAccountIds` now returns `false` when passed an `InternalAccount` in which `scopes` is `undefined` ([#6000](https://github.com/MetaMask/core/pull/6000))
+
 ## [0.7.1]
 
 ### Changed

--- a/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-accounts.test.ts
+++ b/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-accounts.test.ts
@@ -554,6 +554,29 @@ describe('CAIP-25 eth_accounts adapters', () => {
   });
 
   describe('isInternalAccountInPermittedAccountIds', () => {
+    it('returns false if the internal account has no scopes', () => {
+      const result = isInternalAccountInPermittedAccountIds(
+        // @ts-expect-error partial internal account
+        {
+          scopes: [],
+          address: '0xdeadbeef',
+        },
+        [],
+      );
+      expect(result).toBe(false);
+    });
+
+    it('returns false if internal account does not have a scopes property', () => {
+      const result = isInternalAccountInPermittedAccountIds(
+        // @ts-expect-error partial internal account
+        {
+          address: '0xdeadbeef',
+        },
+        [],
+      );
+      expect(result).toBe(false);
+    });
+
     it('returns false if there are no permitted account ids', () => {
       const result = isInternalAccountInPermittedAccountIds(
         // @ts-expect-error partial internal account

--- a/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-accounts.ts
+++ b/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-accounts.ts
@@ -375,7 +375,7 @@ export function isInternalAccountInPermittedAccountIds(
   permittedAccounts: CaipAccountId[],
 ): boolean {
   // temporary fix for the issue where the internal account has no scopes and or scopes is undefined
-  // TODO: remove this once the bug is fixed (link to issue: TODO)
+  // TODO: remove this once the bug is fixed (tracked here: https://github.com/MetaMask/accounts-planning/issues/941)
   // there is currently a bug where an account associated with a snap can fail to add scopes to the internal account in time
   // before we attempt to access this state
   if (!internalAccount?.scopes?.length) {

--- a/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-accounts.ts
+++ b/packages/chain-agnostic-permission/src/adapters/caip-permission-adapter-accounts.ts
@@ -374,6 +374,14 @@ export function isInternalAccountInPermittedAccountIds(
   internalAccount: InternalAccount,
   permittedAccounts: CaipAccountId[],
 ): boolean {
+  // temporary fix for the issue where the internal account has no scopes and or scopes is undefined
+  // TODO: remove this once the bug is fixed (link to issue: TODO)
+  // there is currently a bug where an account associated with a snap can fail to add scopes to the internal account in time
+  // before we attempt to access this state
+  if (!internalAccount?.scopes?.length) {
+    return false;
+  }
+
   const parsedInteralAccountScopes = internalAccount.scopes.map((scope) => {
     return parseScopeString(scope);
   });


### PR DESCRIPTION
## Explanation
Temporary fix for the issue where the internal account has no scopes and or scopes is undefined
there is currently a bug where an account associated with a snap can fail to add scopes to the internal account in time
before we attempt to access this state

## References

For example:

* Fixes https://github.com/MetaMask/metamask-extension/issues/32451
* [Sentry Error](https://metamask.sentry.io/issues/6683351210/?project=273505)
* Slack thread: https://consensys.slack.com/archives/C08T784K955/p1750172591818219


## Changelog

## @metamask/chain-agnostic-permission

*CHANGED*: `isInternalAccountInPermittedAccountIds` now returns false when passed an `InternalAccount` where `scopes` is `undefined`

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
