### PR TITLE
feat: update active networks to fetch on transaction confirmation

### DIFF
--- a/packages/multichain-network-controller/CHANGELOG.md
+++ b/packages/multichain-network-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add automatic network activity refresh when transactions are confirmed ([#6017](https://github.com/MetaMask/core/pull/6017))
+  - Listen to `TransactionController:transactionConfirmed` events
+  - Automatically call `getNetworksWithTransactionActivityByAccounts()` with a 30-second delay to allow blockchain indexing services to process new transactions
+  - Add error handling for failed network activity refresh attempts
+
 ## [0.9.0]
 
 ### Changed

--- a/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.test.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.test.ts
@@ -648,7 +648,6 @@ describe('MultichainNetworkController', () => {
     const MOCK_EVM_ADDRESS = '0x1234567890123456789012345678901234567890';
 
     it('calls getNetworksWithTransactionActivityByAccounts when transaction is confirmed', async () => {
-      // Mock setTimeout to execute immediately
       jest
         .spyOn(global, 'setTimeout')
         .mockImplementation((callback: () => void) => {
@@ -661,7 +660,6 @@ describe('MultichainNetworkController', () => {
         mockNetworkService,
       });
 
-      // Setup accounts controller mock
       messenger.registerActionHandler(
         'AccountsController:listMultichainAccounts',
         () => [
@@ -673,19 +671,16 @@ describe('MultichainNetworkController', () => {
         ],
       );
 
-      // Spy on the method
       const getNetworksWithTransactionActivitySpy = jest.spyOn(
         controller,
         'getNetworksWithTransactionActivityByAccounts',
       );
 
-      // Publish the transaction confirmed event
       messenger.publish('TransactionController:transactionConfirmed', {
         id: 'test-transaction-id',
         status: 'confirmed',
       } as Record<string, unknown>);
 
-      // Wait for promises to resolve
       await Promise.resolve();
 
       expect(getNetworksWithTransactionActivitySpy).toHaveBeenCalled();
@@ -698,7 +693,6 @@ describe('MultichainNetworkController', () => {
         mockNetworkService,
       });
 
-      // Setup accounts controller mock
       messenger.registerActionHandler(
         'AccountsController:listMultichainAccounts',
         () => [
@@ -710,17 +704,16 @@ describe('MultichainNetworkController', () => {
         ],
       );
 
-      // Spy on the method and make it throw an error
       const getNetworksWithTransactionActivitySpy = jest
         .spyOn(controller, 'getNetworksWithTransactionActivityByAccounts')
         .mockRejectedValue(new Error('Network error'));
 
-      // Spy on console.error to verify error handling
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
-        .mockImplementation(() => {});
+        .mockImplementation(() => {
+          // no op
+        });
 
-      // Mock setTimeout to execute immediately but still allow the error to propagate
       const setTimeoutSpy = jest
         .spyOn(global, 'setTimeout')
         .mockImplementation((callback: () => void) => {
@@ -729,13 +722,11 @@ describe('MultichainNetworkController', () => {
           return 0 as unknown as NodeJS.Timeout;
         });
 
-      // Publish the transaction confirmed event
       messenger.publish('TransactionController:transactionConfirmed', {
         id: 'test-transaction-id',
         status: 'confirmed',
       } as Record<string, unknown>);
 
-      // Wait for the setImmediate callback to execute
       await new Promise(setImmediate);
       await new Promise(setImmediate);
 
@@ -745,7 +736,6 @@ describe('MultichainNetworkController', () => {
         expect.any(Error),
       );
 
-      // Restore mocks
       setTimeoutSpy.mockRestore();
       consoleErrorSpy.mockRestore();
       getNetworksWithTransactionActivitySpy.mockRestore();

--- a/packages/multichain-network-controller/src/types.ts
+++ b/packages/multichain-network-controller/src/types.ts
@@ -186,10 +186,17 @@ export type AccountsControllerSelectedAccountChangeEvent = {
   payload: [InternalAccount];
 };
 
+export type TransactionControllerTransactionConfirmedEvent = {
+  type: `TransactionController:transactionConfirmed`;
+  payload: [transactionMeta: Record<string, unknown>];
+};
+
 /**
  * Events that this controller is allowed to subscribe.
  */
-export type AllowedEvents = AccountsControllerSelectedAccountChangeEvent;
+export type AllowedEvents =
+  | AccountsControllerSelectedAccountChangeEvent
+  | TransactionControllerTransactionConfirmedEvent;
 
 export type MultichainNetworkControllerAllowedActions =
   | MultichainNetworkControllerActions


### PR DESCRIPTION
## Explanation

We need to fetch and update the new transaction activity when a new transaction has just finished

## References

Related to [#4469](https://github.com/MetaMask/MetaMask-planning/issues/4469)

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
