### PR TITLE
fix(create-package): remove unneeded ts-expect-error directives

### DIFF
--- a/scripts/create-package/cli.ts
+++ b/scripts/create-package/cli.ts
@@ -20,8 +20,6 @@ export default async function cli(
     // Disable --version. This is an internal tool and it doesn't have a version.
     .version(false)
     .usage('$0 [args]')
-    // @ts-expect-error: The CommandModule<T, U>[] signature does in fact exist,
-    // but it is missing from our yargs types.
     .command(commands)
     .strict()
     .check((args) => {
@@ -43,6 +41,5 @@ export default async function cli(
     .showHelpOnFail(false)
     .help()
     .alias('help', 'h')
-    // @ts-expect-error: This does in fact exist, but it is missing from our yargs types.
     .parseAsync();
 }


### PR DESCRIPTION
## Explanation

It seems those directives are not required anymore. If we keep them as is, invoking `yarn create-package ...` does fail with the following error:

```console
/path/to/core/node_modules/ts-node/src/index.ts:859
    return new TSError(diagnosticText, diagnosticCodes, diagnostics);
           ^
TSError: ⨯ Unable to compile TypeScript:
scripts/create-package/cli.ts:23:5 - error TS2578: Unused '@ts-expect-error' directive.

23     // @ts-expect-error: The CommandModule<T, U>[] signature does in fact exist,
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
scripts/create-package/cli.ts:46:5 - error TS2578: Unused '@ts-expect-error' directive.

46     // @ts-expect-error: This does in fact exist, but it is missing from our yargs types.
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    at createTSError (/path/to/core/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/path/to/core/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/path/to/core/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/path/to/core/node_modules/ts-node/src/index.ts:1433:41)
    at Module.m._compile (/path/to/core/node_modules/ts-node/src/index.ts:1617:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Object.require.extensions.<computed> [as .ts] (/path/to/core/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1019:12)
    at Module.require (node:internal/modules/cjs/loader:1231:19) {
  diagnosticCodes: [ 2578, 2578 ]
}
```

## References

N/A

## Changelog

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
