### PR TITLE
feat: get scan from cache

### DIFF
--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `getScanResultFromCache` which allows getting scan results from the cache directly. ([#6023](https://github.com/MetaMask/core/pull/6023))
+
 ### Changed
 
 - **BREAKING**`scanUrl` hits the v2 endpoint now. Returns `hostname` instead of `domainName` now. ([#5981](https://github.com/MetaMask/core/pull/5981))

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -3025,6 +3025,38 @@ describe('PhishingController', () => {
       expect(nock.pendingMocks()).toHaveLength(0);
     });
   });
+
+  describe('getScanResultFromCache', () => {
+    it('returns the cached result for URLs that are in the cache', async () => {
+      const controller = getPhishingController();
+      const result = controller.getScanResultFromCache('https://example.com');
+      expect(result).toBeUndefined();
+      nock(PHISHING_DETECTION_BASE_URL)
+        .get(
+          `/${PHISHING_DETECTION_SCAN_ENDPOINT}?url=${encodeURIComponent('example.com')}`,
+        )
+        .reply(200, {
+          recommendedAction: RecommendedAction.None,
+        });
+
+      await controller.scanUrl('https://example.com');
+
+      const result2 = controller.getScanResultFromCache('https://example.com');
+      expect(result2).toBeDefined();
+    });
+
+    it('returns undefined for invalid URLs', async () => {
+      const controller = getPhishingController();
+      const result = controller.getScanResultFromCache('not-a-url');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined for URLs that are not in the cache', async () => {
+      const controller = getPhishingController();
+      const result = controller.getScanResultFromCache('https://example.com');
+      expect(result).toBeUndefined();
+    });
+  });
 });
 
 describe('URL Scan Cache', () => {

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -820,6 +820,22 @@ export class PhishingController extends BaseController<
   };
 
   /**
+   * Get a cached result if it exists and is not expired
+   *
+   * @param url - The URL to get the cached result for. You can pass in a full URL or just the hostname.
+   * @returns The cached scan result or undefined if not found or expired
+   */
+  getScanResultFromCache = (
+    url: string,
+  ): PhishingDetectionScanResult | undefined => {
+    const [hostname, ok] = getHostnameFromWebUrl(url);
+    if (!ok) {
+      return undefined;
+    }
+    return this.#urlScanCache.get(hostname);
+  };
+
+  /**
    * Process a batch of URLs (up to 50) for phishing detection.
    *
    * @param urls - A batch of URLs to scan.


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This introduces a new method for getting scan results from the cache directly. This will empower the extension to easily pull scan results and leverage the time-based caching logic that the controller has for the frontend.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
