### PR TITLE
fix: update gasLimit to be passed as Hex string or undefined

### DIFF
--- a/packages/earn-controller/src/EarnController.test.ts
+++ b/packages/earn-controller/src/EarnController.test.ts
@@ -1651,8 +1651,7 @@ describe('EarnController', () => {
           to: '0x123',
           data: '0x456',
           value: '0',
-
-          gasLimit: '100000',
+          gasLimit: 100000,
         };
         const mockLendingContract = {
           encodeDepositTransactionData: jest
@@ -1669,8 +1668,9 @@ describe('EarnController', () => {
           },
         }));
 
+        const addTransactionFn = jest.fn().mockResolvedValue('successfulhash');
         const { controller } = await setupController({
-          addTransactionFn: jest.fn().mockResolvedValue('successfulhash'),
+          addTransactionFn,
         });
 
         const result = await controller.executeLendingDeposit({
@@ -1687,6 +1687,73 @@ describe('EarnController', () => {
           mockLendingContract.encodeDepositTransactionData,
         ).toHaveBeenCalledWith('100', mockAccount1Address, {});
         expect(result).toBe('successfulhash');
+
+        expect(addTransactionFn).toHaveBeenCalledWith(
+          {
+            ...mockTransactionData,
+            value: '0',
+            chainId: '0x1',
+            gasLimit: toHex(mockTransactionData.gasLimit),
+          },
+          {
+            networkClientId: '1',
+          },
+        );
+      });
+
+      it('executes lending deposit transaction with 0 gasLimit', async () => {
+        const mockTransactionData = {
+          to: '0x123',
+          data: '0x456',
+          value: '0',
+          gasLimit: 0,
+        };
+        const mockLendingContract = {
+          encodeDepositTransactionData: jest
+            .fn()
+            .mockResolvedValue(mockTransactionData),
+        };
+        (EarnSdk.create as jest.Mock).mockImplementation(() => ({
+          contracts: {
+            lending: {
+              aave: {
+                '0x123': mockLendingContract,
+              },
+            },
+          },
+        }));
+        const addTransactionFn = jest.fn().mockResolvedValue('successfulhash');
+
+        const { controller } = await setupController({
+          addTransactionFn,
+        });
+
+        const result = await controller.executeLendingDeposit({
+          amount: '100',
+          protocol: 'aave' as LendingMarket['protocol'],
+          underlyingTokenAddress: '0x123',
+          gasOptions: {},
+          txOptions: {
+            networkClientId: '1',
+          },
+        });
+
+        expect(
+          mockLendingContract.encodeDepositTransactionData,
+        ).toHaveBeenCalledWith('100', mockAccount1Address, {});
+        expect(result).toBe('successfulhash');
+
+        expect(addTransactionFn).toHaveBeenCalledWith(
+          {
+            ...mockTransactionData,
+            value: '0',
+            chainId: '0x1',
+            gasLimit: undefined,
+          },
+          {
+            networkClientId: '1',
+          },
+        );
       });
 
       it('handles error when encodeDepositTransactionData throws', async () => {
@@ -1742,7 +1809,7 @@ describe('EarnController', () => {
           to: '0x123',
           data: '0x456',
           value: '0',
-          gasLimit: '100000',
+          gasLimit: 100000,
         };
         const mockLendingContract = {
           encodeDepositTransactionData: jest
@@ -1787,7 +1854,7 @@ describe('EarnController', () => {
           to: '0x123',
           data: '0x456',
           value: '0',
-          gasLimit: '100000',
+          gasLimit: 100000,
         };
 
         const mockLendingContract = {
@@ -1806,8 +1873,9 @@ describe('EarnController', () => {
           },
         }));
 
+        const addTransactionFn = jest.fn().mockResolvedValue('successfulhash');
         const { controller } = await setupController({
-          addTransactionFn: jest.fn().mockResolvedValue('successfulhash'),
+          addTransactionFn,
         });
 
         const result = await controller.executeLendingWithdraw({
@@ -1824,6 +1892,73 @@ describe('EarnController', () => {
           mockLendingContract.encodeWithdrawTransactionData,
         ).toHaveBeenCalledWith('100', mockAccount1Address, {});
         expect(result).toBe('successfulhash');
+        expect(addTransactionFn).toHaveBeenCalledWith(
+          {
+            ...mockTransactionData,
+            value: '0',
+            chainId: '0x1',
+            gasLimit: toHex(mockTransactionData.gasLimit),
+          },
+          {
+            networkClientId: '1',
+          },
+        );
+      });
+
+      it('executes lending withdraw transaction with 0 gasLimit', async () => {
+        const mockTransactionData = {
+          to: '0x123',
+          data: '0x456',
+          value: '0',
+          gasLimit: 0,
+        };
+
+        const mockLendingContract = {
+          encodeWithdrawTransactionData: jest
+            .fn()
+            .mockResolvedValue(mockTransactionData),
+        };
+
+        (EarnSdk.create as jest.Mock).mockImplementation(() => ({
+          contracts: {
+            lending: {
+              aave: {
+                '0x123': mockLendingContract,
+              },
+            },
+          },
+        }));
+
+        const addTransactionFn = jest.fn().mockResolvedValue('successfulhash');
+        const { controller } = await setupController({
+          addTransactionFn,
+        });
+
+        const result = await controller.executeLendingWithdraw({
+          amount: '100',
+          protocol: 'aave' as LendingMarket['protocol'],
+          underlyingTokenAddress: '0x123',
+          gasOptions: {},
+          txOptions: {
+            networkClientId: '1',
+          },
+        });
+
+        expect(
+          mockLendingContract.encodeWithdrawTransactionData,
+        ).toHaveBeenCalledWith('100', mockAccount1Address, {});
+        expect(result).toBe('successfulhash');
+        expect(addTransactionFn).toHaveBeenCalledWith(
+          {
+            ...mockTransactionData,
+            value: '0',
+            chainId: '0x1',
+            gasLimit: undefined,
+          },
+          {
+            networkClientId: '1',
+          },
+        );
       });
 
       it('handles transaction data not found', async () => {
@@ -1846,7 +1981,7 @@ describe('EarnController', () => {
           to: '0x123',
           data: '0x456',
           value: '0',
-          gasLimit: '100000',
+          gasLimit: 100000,
         };
         const mockLendingContract = {
           encodeWithdrawTransactionData: jest
@@ -1891,7 +2026,7 @@ describe('EarnController', () => {
           to: '0x123',
           data: '0x456',
           value: '0',
-          gasLimit: '100000',
+          gasLimit: 100000,
         };
 
         const mockLendingContract = {
@@ -1910,8 +2045,9 @@ describe('EarnController', () => {
           },
         }));
 
+        const addTransactionFn = jest.fn().mockResolvedValue('successfulhash');
         const { controller } = await setupController({
-          addTransactionFn: jest.fn().mockResolvedValue('successfulhash'),
+          addTransactionFn,
         });
 
         const result = await controller.executeLendingTokenApprove({
@@ -1928,6 +2064,73 @@ describe('EarnController', () => {
           mockLendingContract.encodeUnderlyingTokenApproveTransactionData,
         ).toHaveBeenCalledWith('100', mockAccount1Address, {});
         expect(result).toBe('successfulhash');
+        expect(addTransactionFn).toHaveBeenCalledWith(
+          {
+            ...mockTransactionData,
+            value: '0',
+            chainId: '0x1',
+            gasLimit: toHex(mockTransactionData.gasLimit),
+          },
+          {
+            networkClientId: '1',
+          },
+        );
+      });
+
+      it('executes lending token approve transaction with 0 gasLimit', async () => {
+        const mockTransactionData = {
+          to: '0x123',
+          data: '0x456',
+          value: '0',
+          gasLimit: 0,
+        };
+
+        const mockLendingContract = {
+          encodeUnderlyingTokenApproveTransactionData: jest
+            .fn()
+            .mockResolvedValue(mockTransactionData),
+        };
+
+        (EarnSdk.create as jest.Mock).mockImplementation(() => ({
+          contracts: {
+            lending: {
+              aave: {
+                '0x123': mockLendingContract,
+              },
+            },
+          },
+        }));
+
+        const addTransactionFn = jest.fn().mockResolvedValue('successfulhash');
+        const { controller } = await setupController({
+          addTransactionFn,
+        });
+
+        const result = await controller.executeLendingTokenApprove({
+          amount: '100',
+          protocol: 'aave' as LendingMarket['protocol'],
+          underlyingTokenAddress: '0x123',
+          gasOptions: {},
+          txOptions: {
+            networkClientId: '1',
+          },
+        });
+
+        expect(
+          mockLendingContract.encodeUnderlyingTokenApproveTransactionData,
+        ).toHaveBeenCalledWith('100', mockAccount1Address, {});
+        expect(result).toBe('successfulhash');
+        expect(addTransactionFn).toHaveBeenCalledWith(
+          {
+            ...mockTransactionData,
+            value: '0',
+            chainId: '0x1',
+            gasLimit: undefined,
+          },
+          {
+            networkClientId: '1',
+          },
+        );
       });
 
       it('handles transaction data not found', async () => {
@@ -1950,7 +2153,7 @@ describe('EarnController', () => {
           to: '0x123',
           data: '0x456',
           value: '0',
-          gasLimit: '100000',
+          gasLimit: 100000,
         };
         const mockLendingContract = {
           encodeUnderlyingTokenApproveTransactionData: jest

--- a/packages/earn-controller/src/EarnController.ts
+++ b/packages/earn-controller/src/EarnController.ts
@@ -942,12 +942,16 @@ export class EarnController extends BaseController<
       throw new Error('Selected network client id not found');
     }
 
+    const gasLimit = !transactionData.gasLimit
+      ? undefined
+      : toHex(transactionData.gasLimit);
+
     const txHash = await this.#addTransactionFn(
       {
         ...transactionData,
         value: transactionData.value.toString(),
         chainId: toHex(this.#getCurrentChainId()),
-        gasLimit: String(transactionData.gasLimit),
+        gasLimit,
       },
       {
         ...txOptions,
@@ -1007,12 +1011,16 @@ export class EarnController extends BaseController<
       throw new Error('Selected network client id not found');
     }
 
+    const gasLimit = !transactionData.gasLimit
+      ? undefined
+      : toHex(transactionData.gasLimit);
+
     const txHash = await this.#addTransactionFn(
       {
         ...transactionData,
         value: transactionData.value.toString(),
         chainId: toHex(this.#getCurrentChainId()),
-        gasLimit: String(transactionData.gasLimit),
+        gasLimit,
       },
       {
         ...txOptions,
@@ -1072,12 +1080,16 @@ export class EarnController extends BaseController<
       throw new Error('Selected network client id not found');
     }
 
+    const gasLimit = !transactionData.gasLimit
+      ? undefined
+      : toHex(transactionData.gasLimit);
+
     const txHash = await this.#addTransactionFn(
       {
         ...transactionData,
         value: transactionData.value.toString(),
         chainId: toHex(this.#getCurrentChainId()),
-        gasLimit: String(transactionData.gasLimit),
+        gasLimit,
       },
       {
         ...txOptions,


### PR DESCRIPTION
- For any contract method that uses a gasLimit, allow gasOptions.gasLimit to be set to 'none' and translate that to setting gasLimit undefined in addTransaction params
- In the case that there is a gasLimit convert it to Hex string

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
