### PR TITLE
fix: Preferences controller: initialise smartAccountOptIn with true value

### DIFF
--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Initialise preference smartAccountOptIn with true value ([#6040](https://github.com/MetaMask/core/pull/6040))
+
 ## [18.3.0]
 
 ### Added

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -26,7 +26,7 @@ describe('PreferencesController', () => {
       securityAlertsEnabled: false,
       isMultiAccountBalancesEnabled: true,
       showTestNetworks: false,
-      smartAccountOptIn: false,
+      smartAccountOptIn: true,
       smartAccountOptInForAccounts: [],
       isIpfsGatewayEnabled: true,
       useTransactionSimulations: true,
@@ -561,9 +561,9 @@ describe('PreferencesController', () => {
 
   it('should set smartAccountOptIn', () => {
     const controller = setupPreferencesController();
-    expect(controller.state.smartAccountOptIn).toBe(false);
-    controller.setSmartAccountOptIn(true);
     expect(controller.state.smartAccountOptIn).toBe(true);
+    controller.setSmartAccountOptIn(false);
+    expect(controller.state.smartAccountOptIn).toBe(false);
   });
 
   it('should set smartAccountOptInForAccounts', () => {

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -251,7 +251,7 @@ export function getDefaultPreferencesState(): PreferencesState {
     },
     privacyMode: false,
     dismissSmartAccountSuggestionEnabled: false,
-    smartAccountOptIn: false,
+    smartAccountOptIn: true,
     smartAccountOptInForAccounts: [],
   };
 }


### PR DESCRIPTION
## Explanation

Preferences controller: initialise smartAccountOptIn with true value

## References

Related to https://github.com/MetaMask/MetaMask-planning/issues/5235

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [X] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
