### PR TITLE
fix: use number as expected bridge ChainId type

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Calculate EVM token exchange rates accurately in `selectExchangeRateByChainIdAndAddress` when the `marketData` conversion rate is in the native currency ([#6030](https://github.com/MetaMask/core/pull/6030))
 - Convert `trade.value` to decimal when calculating relayer fee ([#6039](https://github.com/MetaMask/core/pull/6039))
+- Revert QuoteResponse ChainId schema to expect a number instead of strings
 
 ## [33.0.1]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Calculate EVM token exchange rates accurately in `selectExchangeRateByChainIdAndAddress` when the `marketData` conversion rate is in the native currency ([#6030](https://github.com/MetaMask/core/pull/6030))
 - Convert `trade.value` to decimal when calculating relayer fee ([#6039](https://github.com/MetaMask/core/pull/6039))
-- Revert QuoteResponse ChainId schema to expect a number instead of strings
+- Revert QuoteResponse ChainId schema to expect a number instead of a string ([#6045](https://github.com/MetaMask/core/pull/6045))
 
 ## [33.0.1]
 

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -2,7 +2,7 @@ import type { BigNumber } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
 import type { StateMetadata } from '@metamask/base-controller';
-import type { ChainId, TraceCallback } from '@metamask/controller-utils';
+import type { TraceCallback } from '@metamask/controller-utils';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 import type { NetworkClientId } from '@metamask/network-controller';
 import { StaticIntervalPollingController } from '@metamask/polling-controller';

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -584,7 +584,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     const l1GasFeePromises = Promise.allSettled(
       quotes.map(async (quoteResponse) => {
         const { quote, trade, approval } = quoteResponse;
-        const chainId = numberToHex(Number(quote.srcChainId)) as ChainId;
+        const chainId = numberToHex(quote.srcChainId);
 
         const getTxParams = (txData: TxData) => ({
           from: txData.from,

--- a/packages/bridge-controller/src/utils/validators.ts
+++ b/packages/bridge-controller/src/utils/validators.ts
@@ -42,7 +42,7 @@ const HexStringSchema = define<string>('HexString', (v: unknown) =>
 export const truthyString = (s: string) => Boolean(s?.length);
 const TruthyDigitStringSchema = pattern(string(), /^\d+$/u);
 
-const ChainIdSchema = union([number(), TruthyDigitStringSchema]);
+const ChainIdSchema = number();
 
 export const BridgeAssetSchema = type({
   /**

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Set event property `gas_included` to quote's `gasIncluded` value ([#6030](https://github.com/MetaMask/core/pull/6030))
+- Set StatusResponse ChainId schema to expect a number instead of a string ([#6045](https://github.com/MetaMask/core/pull/6045))
 
 ## [32.0.0]
 

--- a/packages/bridge-status-controller/src/bridge-status-controller.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.ts
@@ -494,7 +494,7 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
         const bridgeHistoryItem = this.state.txHistory[txMetaId];
 
         const hexSourceChainId = numberToHex(
-          Number(bridgeHistoryItem.quote.srcChainId),
+          bridgeHistoryItem.quote.srcChainId,
         );
 
         return (

--- a/packages/bridge-status-controller/src/utils/__snapshots__/validators.test.ts.snap
+++ b/packages/bridge-status-controller/src/utils/__snapshots__/validators.test.ts.snap
@@ -39,7 +39,7 @@ Array [
   Array [
     "Bridge status validation failed",
     Object {
-      "destChain.chainId": "[across] Expected a string, but received: undefined",
+      "destChain.chainId": "[across] Expected a number, but received: undefined",
     },
   ],
 ]

--- a/packages/bridge-status-controller/src/utils/bridge-status.ts
+++ b/packages/bridge-status-controller/src/utils/bridge-status.ts
@@ -68,8 +68,8 @@ export const getStatusRequestWithSrcTxHash = (
     bridgeId,
     srcTxHash,
     bridge: bridges[0],
-    srcChainId: Number(srcChainId),
-    destChainId: Number(destChainId),
+    srcChainId,
+    destChainId,
     quote,
     refuel: Boolean(refuel),
   };

--- a/packages/bridge-status-controller/src/utils/transaction.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.ts
@@ -27,8 +27,8 @@ export const getStatusRequestParams = (
   return {
     bridgeId: quoteResponse.quote.bridgeId,
     bridge: quoteResponse.quote.bridges[0],
-    srcChainId: Number(quoteResponse.quote.srcChainId),
-    destChainId: Number(quoteResponse.quote.destChainId),
+    srcChainId: quoteResponse.quote.srcChainId,
+    destChainId: quoteResponse.quote.destChainId,
     quote: quoteResponse.quote,
     refuel: Boolean(quoteResponse.quote.refuel),
   };

--- a/packages/bridge-status-controller/src/utils/validators.test.ts
+++ b/packages/bridge-status-controller/src/utils/validators.test.ts
@@ -25,7 +25,7 @@ const BridgeTxStatusResponses = {
       },
     },
     destChain: {
-      chainId: '10',
+      chainId: 10,
       token: {},
     },
   },
@@ -110,7 +110,7 @@ const BridgeTxStatusResponses = {
       },
     },
     destChain: {
-      chainId: '42161',
+      chainId: 42161,
       txHash:
         '0x3a494e672717f9b1f2b64a48a19985842d82d0747400fccebebc7a4e99c8eaab',
       amount: '4926701727965948',
@@ -152,7 +152,7 @@ const BridgeTxStatusResponses = {
       },
     },
     destChain: {
-      chainId: '42161',
+      chainId: 42161,
       txHash:
         '0x3a494e672717f9b1f2b64a48a19985842d82d0747400fccebebc7a4e99c8eaab',
       amount: '4926701727965948',

--- a/packages/bridge-status-controller/src/utils/validators.ts
+++ b/packages/bridge-status-controller/src/utils/validators.ts
@@ -12,7 +12,7 @@ import {
   StructError,
 } from '@metamask/superstruct';
 
-const ChainIdSchema = union([number(), string()]);
+const ChainIdSchema = number();
 
 const EmptyObjectSchema = object({});
 


### PR DESCRIPTION
## Explanation

Undoing type change for ChainId. Was changed to `number | string` in an earlier PR, but bridge-api only returns `number`. The earlier change is causing type errors in clients

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
