### PR TITLE
feat: persist access token and metadata access token in seedless controller

### DIFF
--- a/packages/seedless-onboarding-controller/src/constants.ts
+++ b/packages/seedless-onboarding-controller/src/constants.ts
@@ -33,6 +33,8 @@ export enum SeedlessOnboardingControllerErrorMessage {
   InsufficientAuthToken = `${controllerName} - Insufficient auth token`,
   InvalidRefreshToken = `${controllerName} - Invalid refresh token`,
   InvalidRevokeToken = `${controllerName} - Invalid revoke token`,
+  InvalidAccessToken = `${controllerName} - Invalid access token`,
+  InvalidMetadataAccessToken = `${controllerName} - Invalid metadata access token`,
   MissingCredentials = `${controllerName} - Cannot unlock vault without password and encryption key`,
   ExpiredCredentials = `${controllerName} - Encryption key and salt provided are expired`,
   InvalidEmptyPassword = `${controllerName} - Password cannot be empty.`,

--- a/packages/seedless-onboarding-controller/src/types.ts
+++ b/packages/seedless-onboarding-controller/src/types.ts
@@ -158,6 +158,18 @@ export type SeedlessOnboardingControllerState =
        * The encrypted keyring encryption key used to encrypt the keyring vault.
        */
       encryptedKeyringEncryptionKey?: string;
+
+      /**
+       * The access token used for pairing with profile sync auth service and to access other services.
+       */
+      accessToken?: string;
+
+      /**
+       * The metadata access token used to access the metadata service.
+       *
+       * This token is used to access the metadata service before the vault is created or unlocked.
+       */
+      metadataAccessToken?: string;
     };
 
 // Actions
@@ -320,6 +332,10 @@ export type VaultData = {
    * The revoke token to revoke refresh token and get new refresh token and new revoke token.
    */
   revokeToken: string;
+  /**
+   * The access token used for pairing with profile sync auth service and to access other services.
+   */
+  accessToken: string;
 };
 
 export type SecretDataType = Uint8Array | string | number;


### PR DESCRIPTION

## Explanation

- This update introduces two new tokens, accessToken and metadataAccessToken, to the SeedlessOnboardingController. 

- These tokens are essential for pairing with the profile sync auth service and accessing the metadata service before the vault is created or unlocked.

-  The changes include updates to the controller state, methods for handling these tokens, and corresponding tests to ensure proper functionality and error handling when tokens are missing. 

- Additionally, the vault data structure has been modified to include the new accessToken. Tests have been added to verify the correct behavior of the controller with respect to these tokens.


<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
