### PR TITLE
Add fallback to sequential hook when `publishBatchHook` returns empty

### DIFF
--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1742,7 +1742,7 @@ export type PublishBatchHookRequest = {
 export type PublishBatchHookResult =
   | {
       /** Result data for each transaction in the batch. */
-      results: {
+      results?: {
         /** Hash of the transaction on the network. */
         transactionHash: Hex;
       }[];

--- a/packages/transaction-controller/src/utils/batch.test.ts
+++ b/packages/transaction-controller/src/utils/batch.test.ts
@@ -117,6 +117,23 @@ const TRANSACTIONS_BATCH_MOCK = [
   },
 ];
 
+const PUBLISH_BATCH_HOOK_PARAMS = {
+  from: FROM_MOCK,
+  networkClientId: NETWORK_CLIENT_ID_MOCK,
+  transactions: [
+    {
+      id: TRANSACTION_ID_MOCK,
+      params: TRANSACTION_BATCH_PARAMS_MOCK,
+      signedTx: TRANSACTION_SIGNATURE_MOCK,
+    },
+    {
+      id: TRANSACTION_ID_2_MOCK,
+      params: TRANSACTION_BATCH_PARAMS_MOCK,
+      signedTx: TRANSACTION_SIGNATURE_2_MOCK,
+    },
+  ],
+};
+
 /**
  * Mocks the `ApprovalController:addRequest` action for the `requestApproval` function in `batch.ts`.
  *
@@ -816,22 +833,9 @@ describe('Batch Utils', () => {
         await flushPromises();
 
         expect(publishBatchHook).toHaveBeenCalledTimes(1);
-        expect(publishBatchHook).toHaveBeenCalledWith({
-          from: FROM_MOCK,
-          networkClientId: NETWORK_CLIENT_ID_MOCK,
-          transactions: [
-            {
-              id: TRANSACTION_ID_MOCK,
-              params: TRANSACTION_BATCH_PARAMS_MOCK,
-              signedTx: TRANSACTION_SIGNATURE_MOCK,
-            },
-            {
-              id: TRANSACTION_ID_2_MOCK,
-              params: TRANSACTION_BATCH_PARAMS_MOCK,
-              signedTx: TRANSACTION_SIGNATURE_2_MOCK,
-            },
-          ],
-        });
+        expect(publishBatchHook).toHaveBeenCalledWith(
+          PUBLISH_BATCH_HOOK_PARAMS,
+        );
       });
 
       it('resolves individual publish hooks with transaction hashes from publish batch hook', async () => {
@@ -1319,22 +1323,9 @@ describe('Batch Utils', () => {
       const assertSequentialPublishBatchHookCalled = () => {
         expect(sequentialPublishBatchHookMock).toHaveBeenCalledTimes(1);
         expect(sequentialPublishBatchHook).toHaveBeenCalledTimes(1);
-        expect(sequentialPublishBatchHook).toHaveBeenCalledWith({
-          from: FROM_MOCK,
-          networkClientId: NETWORK_CLIENT_ID_MOCK,
-          transactions: [
-            {
-              id: TRANSACTION_ID_MOCK,
-              params: TRANSACTION_BATCH_PARAMS_MOCK,
-              signedTx: TRANSACTION_SIGNATURE_MOCK,
-            },
-            {
-              id: TRANSACTION_ID_2_MOCK,
-              params: TRANSACTION_BATCH_PARAMS_MOCK,
-              signedTx: TRANSACTION_SIGNATURE_2_MOCK,
-            },
-          ],
-        });
+        expect(sequentialPublishBatchHook).toHaveBeenCalledWith(
+          PUBLISH_BATCH_HOOK_PARAMS,
+        );
       };
 
       it('throws if simulation is not supported', async () => {
@@ -1455,6 +1446,45 @@ describe('Batch Utils', () => {
         );
 
         assertSequentialPublishBatchHookCalled();
+
+        const result = await resultPromise;
+        expect(result?.batchId).toMatch(/^0x[0-9a-f]{32}$/u);
+      });
+
+      it('falls back sequentialPublishBatchHook when publishBatchHook returns empty results', async () => {
+        const { approve } = mockRequestApproval(MESSENGER_MOCK, {
+          state: 'approved',
+        });
+        mockSequentialPublishBatchHookResults();
+        setupSequentialPublishBatchHookMock(() => sequentialPublishBatchHook);
+        const publishBatchHookMock = jest
+          .fn()
+          .mockResolvedValue({ results: {} });
+
+        const resultPromise = addTransactionBatch({
+          ...request,
+          publishBatchHook: publishBatchHookMock,
+          messenger: MESSENGER_MOCK,
+          request: {
+            ...request.request,
+            origin: ORIGIN_MOCK,
+            disable7702: true,
+            disableHook: false,
+            disableSequential: false,
+          },
+        }).catch(() => {
+          // Intentionally empty
+        });
+
+        await flushPromises();
+        approve();
+        await executePublishHooks();
+
+        assertSequentialPublishBatchHookCalled();
+        expect(publishBatchHookMock).toHaveBeenCalledTimes(1);
+        expect(publishBatchHookMock).toHaveBeenCalledWith(
+          PUBLISH_BATCH_HOOK_PARAMS,
+        );
 
         const result = await resultPromise;
         expect(result?.batchId).toMatch(/^0x[0-9a-f]{32}$/u);


### PR DESCRIPTION
## Explanation
This PR aims to add a fallback mechanism to use the sequential hook when `publishBatchHook` returns empty. This will help us to handle case when `publishBatchHook` is defined by the client as it's for smart transaction but smart transaction is disabled.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes https://github.com/MetaMask/MetaMask-planning/issues/5301

# Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
