### PR TITLE
fix: use scopes to retrieve chain ID

### DIFF
--- a/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.ts
@@ -23,7 +23,7 @@ import {
 } from '../types';
 import {
   checkIfSupportedCaipChainId,
-  getChainIdForNonEvmAddress,
+  getChainIdForNonEvm,
   convertEvmCaipToHexChainId,
   isEvmCaipChainId,
 } from '../utils';
@@ -255,7 +255,7 @@ export class MultichainNetworkController extends BaseController<
    * @param account - The account that was changed
    */
   #handleOnSelectedAccountChange(account: InternalAccount) {
-    const { type: accountType, address: accountAddress, scopes } = account;
+    const { type: accountType, scopes } = account;
     const isEvmAccount = isEvmAccountType(accountType);
 
     // Handle switching to EVM network
@@ -282,7 +282,7 @@ export class MultichainNetworkController extends BaseController<
       return;
     }
 
-    const nonEvmChainId = getChainIdForNonEvmAddress(accountAddress);
+    const nonEvmChainId = getChainIdForNonEvm(scopes);
     this.update((state) => {
       state.selectedMultichainNetworkChainId = nonEvmChainId;
       state.isEvmSelected = false;

--- a/packages/multichain-network-controller/src/api/accounts-api.ts
+++ b/packages/multichain-network-controller/src/api/accounts-api.ts
@@ -50,6 +50,10 @@ export const MULTICHAIN_ACCOUNTS_CLIENT_ID =
  */
 export const MULTICHAIN_ALLOWED_ACTIVE_NETWORK_SCOPES = [
   String(BtcScope.Mainnet),
+  String(BtcScope.Testnet),
+  String(BtcScope.Testnet4),
+  String(BtcScope.Signet),
+  String(BtcScope.Regtest),
   String(SolScope.Mainnet),
   String(EthScope.Mainnet),
   String(EthScope.Testnet),

--- a/packages/multichain-network-controller/src/constants.ts
+++ b/packages/multichain-network-controller/src/constants.ts
@@ -11,7 +11,9 @@ import type {
 
 export const BTC_NATIVE_ASSET = `${BtcScope.Mainnet}/slip44:0`;
 export const BTC_TESTNET_NATIVE_ASSET = `${BtcScope.Testnet}/slip44:0`;
+export const BTC_TESTNET4_NATIVE_ASSET = `${BtcScope.Testnet4}/slip44:0`;
 export const BTC_SIGNET_NATIVE_ASSET = `${BtcScope.Signet}/slip44:0`;
+export const BTC_REGTEST_NATIVE_ASSET = `${BtcScope.Regtest}/slip44:0`;
 export const SOL_NATIVE_ASSET = `${SolScope.Mainnet}/slip44:501`;
 export const SOL_TESTNET_NATIVE_ASSET = `${SolScope.Testnet}/slip44:501`;
 export const SOL_DEVNET_NATIVE_ASSET = `${SolScope.Devnet}/slip44:501`;
@@ -35,10 +37,22 @@ export const AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS: Record<
     nativeCurrency: BTC_TESTNET_NATIVE_ASSET,
     isEvm: false,
   },
+  [BtcScope.Testnet4]: {
+    chainId: BtcScope.Testnet4,
+    name: 'Bitcoin Testnet4',
+    nativeCurrency: BTC_TESTNET4_NATIVE_ASSET,
+    isEvm: false,
+  },
   [BtcScope.Signet]: {
     chainId: BtcScope.Signet,
-    name: 'Bitcoin Signet',
+    name: 'Bitcoin Mutinynet',
     nativeCurrency: BTC_SIGNET_NATIVE_ASSET,
+    isEvm: false,
+  },
+  [BtcScope.Regtest]: {
+    chainId: BtcScope.Regtest,
+    name: 'Bitcoin Regtest',
+    nativeCurrency: BTC_REGTEST_NATIVE_ASSET,
     isEvm: false,
   },
   [SolScope.Mainnet]: {
@@ -68,7 +82,9 @@ export const AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS: Record<
  */
 export const NON_EVM_TESTNET_IDS: CaipChainId[] = [
   BtcScope.Testnet,
+  BtcScope.Testnet4,
   BtcScope.Signet,
+  BtcScope.Regtest,
   SolScope.Testnet,
   SolScope.Devnet,
 ];
@@ -122,7 +138,9 @@ export const MULTICHAIN_NETWORK_CONTROLLER_METADATA = {
 export const MULTICHAIN_NETWORK_TICKER: Record<CaipChainId, string> = {
   [BtcScope.Mainnet]: 'BTC',
   [BtcScope.Testnet]: 'tBTC',
+  [BtcScope.Testnet4]: 'tBTC',
   [BtcScope.Signet]: 'sBTC',
+  [BtcScope.Regtest]: 'rBTC',
   [SolScope.Mainnet]: 'SOL',
   [SolScope.Testnet]: 'tSOL',
   [SolScope.Devnet]: 'dSOL',
@@ -135,7 +153,9 @@ export const MULTICHAIN_NETWORK_TICKER: Record<CaipChainId, string> = {
 export const MULTICHAIN_NETWORK_DECIMAL_PLACES: Record<CaipChainId, number> = {
   [BtcScope.Mainnet]: 8,
   [BtcScope.Testnet]: 8,
+  [BtcScope.Testnet4]: 8,
   [BtcScope.Signet]: 8,
+  [BtcScope.Regtest]: 8,
   [SolScope.Mainnet]: 5,
   [SolScope.Testnet]: 5,
   [SolScope.Devnet]: 5,

--- a/packages/multichain-network-controller/src/types.ts
+++ b/packages/multichain-network-controller/src/types.ts
@@ -34,7 +34,9 @@ export type MultichainNetworkMetadata = {
 export type SupportedCaipChainId =
   | BtcScope.Mainnet
   | BtcScope.Testnet
+  | BtcScope.Testnet4
   | BtcScope.Signet
+  | BtcScope.Regtest
   | SolScope.Mainnet
   | SolScope.Testnet
   | SolScope.Devnet;

--- a/packages/multichain-network-controller/src/utils.test.ts
+++ b/packages/multichain-network-controller/src/utils.test.ts
@@ -11,7 +11,7 @@ import {
   isEvmCaipChainId,
   toEvmCaipChainId,
   convertEvmCaipToHexChainId,
-  getChainIdForNonEvmAddress,
+  getChainIdForNonEvm,
   checkIfSupportedCaipChainId,
   toMultichainNetworkConfiguration,
   toMultichainNetworkConfigurationsByChainId,
@@ -22,12 +22,12 @@ describe('utils', () => {
   describe('getChainIdForNonEvmAddress', () => {
     it('returns Solana chain ID for Solana addresses', () => {
       const solanaAddress = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
-      expect(getChainIdForNonEvmAddress(solanaAddress)).toBe(SolScope.Mainnet);
+      expect(getChainIdForNonEvm(solanaAddress)).toBe(SolScope.Mainnet);
     });
 
     it('returns Bitcoin chain ID for non-Solana addresses', () => {
       const bitcoinAddress = 'bc1qzqc2aqlw8nwa0a05ehjkk7dgt8308ac7kzw9a6';
-      expect(getChainIdForNonEvmAddress(bitcoinAddress)).toBe(BtcScope.Mainnet);
+      expect(getChainIdForNonEvm(bitcoinAddress)).toBe(BtcScope.Mainnet);
     });
   });
 

--- a/packages/multichain-network-controller/src/utils.ts
+++ b/packages/multichain-network-controller/src/utils.ts
@@ -31,17 +31,27 @@ export function isEvmCaipChainId(chainId: CaipChainId): boolean {
 /**
  * Returns the chain id of the non-EVM network based on the account address.
  *
- * @param address - The address to check.
+ * @param scopes - The scopes to check.
  * @returns The caip chain id of the non-EVM network.
  */
-export function getChainIdForNonEvmAddress(
-  address: string,
-): SupportedCaipChainId {
-  // This condition is not the most robust. Once we support more networks, we will need to update this logic.
-  if (isSolanaAddress(address)) {
-    return SolScope.Mainnet;
+export function getChainIdForNonEvm(scopes: string[]): SupportedCaipChainId {
+  const solanaScope = Object.values(SolScope).find((scope) =>
+    scopes.includes(scope),
+  );
+  if (solanaScope) {
+    return solanaScope;
   }
-  return BtcScope.Mainnet;
+
+  const bitcoinScope = Object.values(BtcScope).find((scope) =>
+    scopes.includes(scope),
+  );
+  if (bitcoinScope) {
+    return bitcoinScope;
+  }
+
+  throw new Error(
+    `Unsupported scope: ${scopes.join(', ')}. Only Solana and Bitcoin are supported.`,
+  );
 }
 
 /**


### PR DESCRIPTION
## Explanation

We currently use the address to identify what network the account belongs to, yet that method is incorrect as:
- accounts span multiple networks 
- addresses can be the same on different networks.

The current implementation leads to a bug where the network will always be Mainnet for Solana and Bitcoin, preventing testnets to work. It would also fail to work on EVM networks if this function was used.

The solution, using scopes, fixes the problem for Bitcoin and introduces no regression for Solana.

## References

* Fixes [#12345
* Related to #67890](https://consensyssoftware.atlassian.net/browse/NWNT-397


## Changelog

Fix bug where network is not switched to testnets when creating a new Solana or Bitcoin account.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
