### PR TITLE
poc: confirmation intents

### DIFF
--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -237,6 +237,25 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     );
   }
 
+  async fetchQuotes(requests: GenericQuoteRequest[]) {
+    return await Promise.all(
+      requests.map(async (request) => {
+        const quotes = await fetchBridgeQuotes(
+          request,
+          null as never,
+          this.#clientId,
+          this.#fetchFn,
+          this.#config.customBridgeApiBaseUrl ?? BRIDGE_PROD_API_BASE_URL,
+        );
+
+        const quotesWithL1GasFees = await this.#appendL1GasFees(quotes);
+        const quotesWithSolanaFees = await this.#appendSolanaFees(quotes);
+
+        return quotesWithL1GasFees ?? quotesWithSolanaFees ?? quotes;
+      }),
+    );
+  }
+
   _executePoll = async (pollingInput: BridgePollingInput) => {
     await this.#fetchBridgeQuotes(pollingInput);
   };

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -120,6 +120,7 @@ import type {
   AfterSimulateHook,
   BeforeSignHook,
   TransactionContainerType,
+  TransactionAsset,
 } from './types';
 import {
   GasFeeEstimateLevel,
@@ -1106,6 +1107,7 @@ export class TransactionController extends BaseController<
    * @param txParams - Standard parameters for an Ethereum transaction.
    * @param options - Additional options to control how the transaction is added.
    * @param options.actionId - Unique ID to prevent duplicate requests.
+   * @param options.assets - Assets required by the transaction.
    * @param options.batchId - A custom ID for the batch this transaction belongs to.
    * @param options.deviceConfirmedOn - An enum to indicate what device confirmed the transaction.
    * @param options.disableGasBuffer - Whether to disable the gas estimation buffer.
@@ -1128,6 +1130,7 @@ export class TransactionController extends BaseController<
     txParams: TransactionParams,
     options: {
       actionId?: string;
+      assets?: TransactionAsset[];
       batchId?: Hex;
       deviceConfirmedOn?: WalletDevice;
       disableGasBuffer?: boolean;
@@ -1151,6 +1154,7 @@ export class TransactionController extends BaseController<
 
     const {
       actionId,
+      assets,
       batchId,
       deviceConfirmedOn,
       disableGasBuffer,
@@ -1244,6 +1248,7 @@ export class TransactionController extends BaseController<
       : {
           // Add actionId to txMeta to check if same actionId is seen again
           actionId,
+          assets,
           batchId,
           chainId,
           dappSuggestedGasFees,

--- a/packages/transaction-controller/src/hooks/ExtraTransactionsPublishHook.ts
+++ b/packages/transaction-controller/src/hooks/ExtraTransactionsPublishHook.ts
@@ -93,8 +93,8 @@ export class ExtraTransactionsPublishHook {
       }));
 
     const transactions: TransactionBatchSingleRequest[] = [
-      firstTransaction,
       ...extraTransactions,
+      firstTransaction,
     ];
 
     log('Adding transaction batch', {
@@ -107,9 +107,10 @@ export class ExtraTransactionsPublishHook {
       from,
       networkClientId,
       transactions,
-      disable7702: true,
-      disableHook: false,
+      disable7702: false,
+      disableHook: true,
       disableSequential: true,
+      requireApproval: false,
     });
 
     return resultPromise.promise;

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -69,6 +69,7 @@ export type {
   SimulationError,
   SimulationToken,
   SimulationTokenBalanceChange,
+  TransactionAsset,
   TransactionBatchMeta,
   TransactionBatchRequest,
   TransactionBatchResult,

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -39,6 +39,8 @@ export type TransactionMeta = {
    */
   actionId?: string;
 
+  assets?: TransactionAsset[];
+
   /**
    * Base fee of the block as a hex value, introduced in EIP-1559.
    */
@@ -1877,3 +1879,8 @@ export type BeforeSignHook = (request: {
     }
   | undefined
 >;
+
+export type TransactionAsset = {
+  address: Hex;
+  amount: Hex;
+};

--- a/packages/transaction-controller/src/utils/eip7702.ts
+++ b/packages/transaction-controller/src/utils/eip7702.ts
@@ -131,16 +131,6 @@ export function generateEIP7702BatchTransaction(
       (param) => transaction[param] !== undefined,
     );
 
-    if (unsupported.length) {
-      const errorData = unsupported
-        .map((param) => `${param}: ${transaction[param]}`)
-        .join(', ');
-
-      throw new Error(
-        `EIP-7702 batch transactions do not support gas parameters per call - ${errorData}`,
-      );
-    }
-
     return [
       to ?? '0x0000000000000000000000000000000000000000',
       value ?? '0x0',


### PR DESCRIPTION
## Explanation

Core changes required for confirmation intents POC. See [#34097](https://github.com/MetaMask/metamask-extension/pull/34097).

Includes:

- New `fetchQuotes` method in `BridgeController` to retrieve multiple sets of quotes simultaneously.
- New `assets` property in `addTransaction` options and `TransactionMeta`.
- Updated EIP-7702 batch support to re-use existing nonce and invoke `onPublish` callback.
- Updated `batchTransactions` to be processed after existing transaction. 

## References

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
