### PR TITLE
Disable default schema validation in UserStorageController

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -635,6 +635,7 @@ export default class UserStorageController extends BaseController<
   ): Promise<void> {
     return await this.#userStorage.deleteAllFeatureItems(path, {
       nativeScryptCrypto: this.#nativeScryptCrypto,
+      validateAgainstSchema: false,
       entropySourceId,
     });
   }
@@ -657,6 +658,7 @@ export default class UserStorageController extends BaseController<
   ): Promise<void> {
     return await this.#userStorage.batchDeleteItems(path, values, {
       nativeScryptCrypto: this.#nativeScryptCrypto,
+      validateAgainstSchema: false,
       entropySourceId,
     });
   }


### PR DESCRIPTION

## Explanation

*   **What is the current state of things and why does it need to change?**
    Currently, public `UserStorageController` methods that interact with the storage SDK implicitly enforce schema validation (`validateAgainstSchema: true`) without providing an option to override this behavior. This default is not suitable for all scenarios, as some consumers may need to store data that does not conform to a predefined schema or manage schema validation externally.

*   **What is the solution your changes offer and how does it work?**
    This PR updates all relevant public `UserStorageController` methods to set `validateAgainstSchema: false` by default when calling the underlying storage SDK. This change provides greater flexibility, allowing consumers to store data without mandatory schema validation, aligning with use cases where schema enforcement is not required or handled elsewhere.

*   **Are there any changes whose purpose might not obvious to those unfamiliar with the domain?**
    The `performDeleteStorageAllFeatureEntries` and `performBatchDeleteStorage` methods previously did not include the `validateAgainstSchema` parameter. This PR adds it with the value `false` to ensure consistent behavior across all public storage operations.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
