### PR TITLE
chore: remove LD flag check for isSnapConfirmationEnabled

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Bump peer dependency `@metamask/assets-controllers` from `^69.0.0` to `^70.0.0` ([#6061](https://github.com/MetaMask/core/pull/6061))
 - **BREAKING:** Bump peer dependency `@metamask/snaps-controllers` from `^12.0.0` to `^14.0.0` ([#6035](https://github.com/MetaMask/core/pull/6035))
+- **BREAKING** Remove `isSnapConfirmationEnabled` feature flag from `ChainConfigurationSchema` validation ([#6077](https://github.com/MetaMask/core/pull/6077))
 - Bump `@metamask/controller-utils` from `^11.10.0` to `^11.11.0` ([#6069](https://github.com/MetaMask/core/pull/6069))
 - Bump `@metamask/utils` from `^11.2.0` to `^11.4.2` ([#6054](https://github.com/MetaMask/core/pull/6054))
 

--- a/packages/bridge-controller/src/utils/feature-flags.test.ts
+++ b/packages/bridge-controller/src/utils/feature-flags.test.ts
@@ -40,7 +40,6 @@ describe('feature-flags', () => {
           '1151111081099710': {
             isActiveSrc: true,
             isActiveDest: true,
-            isSnapConfirmationEnabled: false,
           },
         },
       };
@@ -80,7 +79,6 @@ describe('feature-flags', () => {
           'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
             isActiveSrc: true,
             isActiveDest: true,
-            isSnapConfirmationEnabled: false,
           },
         },
       });

--- a/packages/bridge-controller/src/utils/validators.ts
+++ b/packages/bridge-controller/src/utils/validators.ts
@@ -82,7 +82,6 @@ export const ChainConfigurationSchema = type({
   refreshRate: optional(number()),
   topAssets: optional(array(string())),
   isUnifiedUIEnabled: optional(boolean()),
-  isSnapConfirmationEnabled: optional(boolean()),
 });
 
 /**

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING** Submit Solana transactions using `onClientRequest` RPC call by default, which hides the Snap confirmation page from clients. Clients will need to remove conditional redirect the the confirmation page on tx submission ([#6077](https://github.com/MetaMask/core/pull/6077))
 - Bump `@metamask/controller-utils` from `^11.10.0` to `^11.11.0` ([#6069](https://github.com/MetaMask/core/pull/6069))
 - Bump `@metamask/utils` from `^11.2.0` to `^11.4.2` ([#6054](https://github.com/MetaMask/core/pull/6054))
 

--- a/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
+++ b/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
@@ -2182,9 +2182,6 @@ Array [
     "AccountsController:getSelectedMultichainAccount",
   ],
   Array [
-    "RemoteFeatureFlagController:getState",
-  ],
-  Array [
     "SnapController:handleRequest",
     Object {
       "handler": "onClientRequest",
@@ -2247,9 +2244,6 @@ Array [
   ],
   Array [
     "AccountsController:getSelectedMultichainAccount",
-  ],
-  Array [
-    "RemoteFeatureFlagController:getState",
   ],
   Array [
     "SnapController:handleRequest",
@@ -2481,9 +2475,6 @@ Array [
     "AccountsController:getSelectedMultichainAccount",
   ],
   Array [
-    "RemoteFeatureFlagController:getState",
-  ],
-  Array [
     "SnapController:handleRequest",
     Object {
       "handler": "onClientRequest",
@@ -2546,9 +2537,6 @@ Array [
   ],
   Array [
     "AccountsController:getSelectedMultichainAccount",
-  ],
-  Array [
-    "RemoteFeatureFlagController:getState",
   ],
   Array [
     "SnapController:handleRequest",

--- a/packages/bridge-status-controller/src/bridge-status-controller.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.test.ts
@@ -524,19 +524,6 @@ const getMessengerMock = ({
             },
           ],
         };
-      } else if (method === 'RemoteFeatureFlagController:getState') {
-        return {
-          remoteFeatureFlags: {
-            bridgeConfig: {
-              support: true,
-              chains: {
-                [ChainId.SOLANA]: {
-                  isSnapConfirmationEnabled: false,
-                },
-              },
-            },
-          },
-        };
       }
       return null;
     }),
@@ -1469,20 +1456,6 @@ describe('BridgeStatusController', () => {
 
     it('should successfully submit a transaction', async () => {
       mockMessengerCall.mockReturnValueOnce(mockSolanaAccount);
-      // Mock the RemoteFeatureFlagController:getState call that happens in getBridgeFeatureFlags
-      mockMessengerCall.mockReturnValueOnce({
-        remoteFeatureFlags: {
-          cacheTimestamp: 1234567890,
-          bridgeConfig: {
-            support: true,
-            chains: {
-              [ChainId.SOLANA]: {
-                isSnapConfirmationEnabled: true,
-              },
-            },
-          },
-        },
-      });
       mockMessengerCall.mockResolvedValueOnce('signature');
       mockMessengerCall.mockReturnValueOnce(mockSolanaAccount);
 
@@ -1506,19 +1479,6 @@ describe('BridgeStatusController', () => {
         metadata: { snap: undefined },
       };
       mockMessengerCall.mockReturnValueOnce(accountWithoutSnap);
-      // Mock the RemoteFeatureFlagController:getState call that happens in getBridgeFeatureFlags
-      mockMessengerCall.mockReturnValueOnce({
-        remoteFeatureFlags: {
-          bridgeConfig: {
-            support: true,
-            chains: {
-              [ChainId.SOLANA]: {
-                isSnapConfirmationEnabled: false,
-              },
-            },
-          },
-        },
-      });
       mockMessengerCall.mockReturnValueOnce(accountWithoutSnap);
 
       const { controller, startPollingForBridgeTxStatusSpy } =
@@ -1549,19 +1509,6 @@ describe('BridgeStatusController', () => {
 
     it('should handle snap controller errors', async () => {
       mockMessengerCall.mockReturnValueOnce(mockSolanaAccount);
-      // Mock the RemoteFeatureFlagController:getState call that happens in getBridgeFeatureFlags
-      mockMessengerCall.mockReturnValueOnce({
-        remoteFeatureFlags: {
-          bridgeConfig: {
-            support: true,
-            chains: {
-              [ChainId.SOLANA]: {
-                isSnapConfirmationEnabled: false,
-              },
-            },
-          },
-        },
-      });
       mockMessengerCall.mockRejectedValueOnce(new Error('Snap error'));
 
       const { controller, startPollingForBridgeTxStatusSpy } =
@@ -1708,19 +1655,6 @@ describe('BridgeStatusController', () => {
 
     it('should successfully submit a transaction', async () => {
       mockMessengerCall.mockReturnValueOnce(mockSolanaAccount);
-      // Mock the RemoteFeatureFlagController:getState call that happens in getBridgeFeatureFlags
-      mockMessengerCall.mockReturnValueOnce({
-        remoteFeatureFlags: {
-          bridgeConfig: {
-            support: true,
-            chains: {
-              [ChainId.SOLANA]: {
-                isSnapConfirmationEnabled: false,
-              },
-            },
-          },
-        },
-      });
       mockMessengerCall.mockResolvedValueOnce({
         signature: 'signature',
       });
@@ -1775,19 +1709,6 @@ describe('BridgeStatusController', () => {
 
     it('should handle snap controller errors', async () => {
       mockMessengerCall.mockReturnValueOnce(mockSolanaAccount);
-      // Mock the RemoteFeatureFlagController:getState call that happens in getBridgeFeatureFlags
-      mockMessengerCall.mockReturnValueOnce({
-        remoteFeatureFlags: {
-          bridgeConfig: {
-            support: true,
-            chains: {
-              [ChainId.SOLANA]: {
-                isSnapConfirmationEnabled: false,
-              },
-            },
-          },
-        },
-      });
       mockMessengerCall.mockRejectedValueOnce(new Error('Snap error'));
 
       const { controller, startPollingForBridgeTxStatusSpy } =

--- a/packages/bridge-status-controller/src/bridge-status-controller.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.ts
@@ -13,12 +13,10 @@ import {
   getActionType,
   formatChainIdToCaip,
   isCrossChain,
-  getBridgeFeatureFlags,
   isHardwareWallet,
 } from '@metamask/bridge-controller';
 import type { TraceCallback } from '@metamask/controller-utils';
 import { toHex } from '@metamask/controller-utils';
-import { SolScope } from '@metamask/keyring-api';
 import { StaticIntervalPollingController } from '@metamask/polling-controller';
 import type {
   TransactionController,
@@ -66,7 +64,6 @@ import {
   findAndUpdateTransactionsInBatch,
   getAddTransactionBatchParams,
   getClientRequest,
-  getKeyringRequest,
   getStatusRequestParams,
   getUSDTAllowanceResetTx,
   handleLineaDelay,
@@ -600,11 +597,7 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
       );
     }
 
-    const bridgeFeatureFlags = getBridgeFeatureFlags(this.messagingSystem);
-    const request = bridgeFeatureFlags?.chains?.[SolScope.Mainnet]
-      ?.isSnapConfirmationEnabled
-      ? getKeyringRequest(quoteResponse, selectedAccount)
-      : getClientRequest(quoteResponse, selectedAccount);
+    const request = getClientRequest(quoteResponse, selectedAccount);
     const requestResponse = (await this.messagingSystem.call(
       'SnapController:handleRequest',
       request,

--- a/packages/bridge-status-controller/src/utils/transaction.test.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.test.ts
@@ -17,7 +17,6 @@ import {
   getTxMetaFields,
   handleSolanaTxResponse,
   handleLineaDelay,
-  getKeyringRequest,
   getClientRequest,
   toBatchTxParams,
 } from './transaction';
@@ -999,109 +998,6 @@ describe('Bridge Status Controller Transaction Utils', () => {
 
       // Verify that no timer was set
       expect(jest.getTimerCount()).toBe(0);
-    });
-  });
-
-  describe('getKeyringRequest', () => {
-    it('should generate a valid keyring request', () => {
-      const mockQuoteResponse: Omit<QuoteResponse<string>, 'approval'> &
-        QuoteMetadata = {
-        quote: {
-          bridgeId: 'bridge1',
-          bridges: ['bridge1'],
-          srcChainId: ChainId.SOLANA,
-          destChainId: ChainId.POLYGON,
-          srcTokenAmount: '1000000000',
-          destTokenAmount: '2000000000000000000',
-          srcAsset: {
-            address: 'solanaNativeAddress',
-            decimals: 9,
-            symbol: 'SOL',
-          },
-          destAsset: {
-            address: '0x0000000000000000000000000000000000000000',
-            decimals: 18,
-            symbol: 'MATIC',
-          },
-          steps: ['step1'],
-          feeData: {
-            [FeeType.METABRIDGE]: {
-              amount: '100000000',
-            },
-          },
-        },
-        estimatedProcessingTimeInSeconds: 300,
-        trade: 'ABCD',
-        // QuoteMetadata fields
-        sentAmount: {
-          amount: '1.0',
-          valueInCurrency: '100',
-          usd: '100',
-        },
-        toTokenAmount: {
-          amount: '2.0',
-          valueInCurrency: '3600',
-          usd: '3600',
-        },
-        swapRate: '2.0',
-        totalNetworkFee: {
-          amount: '0.1',
-          valueInCurrency: '10',
-          usd: '10',
-        },
-        totalMaxNetworkFee: {
-          amount: '0.15',
-          valueInCurrency: '15',
-          usd: '15',
-        },
-        gasFee: {
-          amount: '0.05',
-          valueInCurrency: '5',
-          usd: '5',
-        },
-        adjustedReturn: {
-          valueInCurrency: '3585',
-          usd: '3585',
-        },
-        cost: {
-          valueInCurrency: '0.1',
-          usd: '0.1',
-        },
-      } as never;
-
-      const mockAccount = {
-        id: 'test-account-id',
-        address: '0x123456',
-        metadata: {
-          snap: { id: 'test-snap-id' },
-        },
-      } as never;
-
-      const result = getKeyringRequest(mockQuoteResponse, mockAccount);
-
-      expect(result).toMatchObject({
-        origin: 'metamask',
-        snapId: 'test-snap-id',
-        handler: 'onKeyringRequest',
-        request: {
-          id: expect.any(String),
-          jsonrpc: '2.0',
-          method: 'keyring_submitRequest',
-          params: {
-            request: {
-              params: {
-                account: { address: '0x123456' },
-                transaction: 'ABCD',
-                scope: SolScope.Mainnet,
-              },
-              method: 'signAndSendTransaction',
-            },
-            id: expect.any(String),
-            account: 'test-account-id',
-            scope: SolScope.Mainnet,
-          },
-        },
-      });
     });
   });
 

--- a/packages/bridge-status-controller/src/utils/transaction.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.ts
@@ -177,38 +177,6 @@ export const handleLineaDelay = async (
   }
 };
 
-export const getKeyringRequest = (
-  quoteResponse: Omit<QuoteResponse<string>, 'approval'> & QuoteMetadata,
-  selectedAccount: AccountsControllerState['internalAccounts']['accounts'][string],
-) => {
-  const keyringReqId = uuid();
-  const snapRequestId = uuid();
-
-  return {
-    origin: 'metamask',
-    snapId: selectedAccount.metadata.snap?.id as never,
-    handler: 'onKeyringRequest' as never,
-    request: {
-      id: keyringReqId,
-      jsonrpc: '2.0',
-      method: 'keyring_submitRequest',
-      params: {
-        request: {
-          params: {
-            account: { address: selectedAccount.address },
-            transaction: quoteResponse.trade,
-            scope: SolScope.Mainnet,
-          },
-          method: 'signAndSendTransaction',
-        },
-        id: snapRequestId,
-        account: selectedAccount.id,
-        scope: SolScope.Mainnet,
-      },
-    },
-  };
-};
-
 export const getClientRequest = (
   quoteResponse: Omit<QuoteResponse<string>, 'approval'> & QuoteMetadata,
   selectedAccount: AccountsControllerState['internalAccounts']['accounts'][string],


### PR DESCRIPTION
## Explanation

**BREAKING** Submit Solana transactions using `onClientRequest` RPC call by default, which hides the Snap confirmation page from clients. Clients will need to remove conditional redirect the the confirmation page on tx submission

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes https://github.com/MetaMask/metamask-extension/issues/34148

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
