### PR TITLE
chore: Remove preference smartAccountOptInForAccounts as it is not going to be used

### DIFF
--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed un-used preference `smartAccountOptInForAccounts` [#6079](https://github.com/MetaMask/core/pull/6079)
+
 ## [18.4.1]
 
 ### Changed

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -27,7 +27,6 @@ describe('PreferencesController', () => {
       isMultiAccountBalancesEnabled: true,
       showTestNetworks: false,
       smartAccountOptIn: true,
-      smartAccountOptInForAccounts: [],
       isIpfsGatewayEnabled: true,
       useTransactionSimulations: true,
       useMultiRpcMigration: true,
@@ -564,13 +563,6 @@ describe('PreferencesController', () => {
     expect(controller.state.smartAccountOptIn).toBe(true);
     controller.setSmartAccountOptIn(false);
     expect(controller.state.smartAccountOptIn).toBe(false);
-  });
-
-  it('should set smartAccountOptInForAccounts', () => {
-    const controller = setupPreferencesController();
-    expect(controller.state.smartAccountOptInForAccounts).toHaveLength(0);
-    controller.setSmartAccountOptInForAccounts(['0x1', '0x2']);
-    expect(controller.state.smartAccountOptInForAccounts[0]).toBe('0x1');
   });
 });
 

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -141,10 +141,6 @@ export type PreferencesState = {
    * User to opt in for smart account upgrade for all user accounts.
    */
   smartAccountOptIn: boolean;
-  /**
-   * User to opt in for smart account upgrade for specific accounts.
-   */
-  smartAccountOptInForAccounts: Hex[];
 };
 
 const metadata = {
@@ -169,7 +165,6 @@ const metadata = {
   privacyMode: { persist: true, anonymous: true },
   dismissSmartAccountSuggestionEnabled: { persist: true, anonymous: true },
   smartAccountOptIn: { persist: true, anonymous: true },
-  smartAccountOptInForAccounts: { persist: true, anonymous: true },
 };
 
 const name = 'PreferencesController';
@@ -252,7 +247,6 @@ export function getDefaultPreferencesState(): PreferencesState {
     privacyMode: false,
     dismissSmartAccountSuggestionEnabled: false,
     smartAccountOptIn: true,
-    smartAccountOptInForAccounts: [],
   };
 }
 
@@ -628,18 +622,6 @@ export class PreferencesController extends BaseController<
   setSmartAccountOptIn(smartAccountOptIn: boolean) {
     this.update((state) => {
       state.smartAccountOptIn = smartAccountOptIn;
-    });
-  }
-
-  /**
-   * Add account to list of accounts for which user has optedin
-   * smart account upgrade.
-   *
-   * @param accounts - accounts for which user wants to optin for smart account upgrade
-   */
-  setSmartAccountOptInForAccounts(accounts: Hex[] = []): void {
-    this.update((state) => {
-      state.smartAccountOptInForAccounts = accounts;
     });
   }
 }

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -9,7 +9,6 @@ import type {
   KeyringControllerState,
   KeyringControllerStateChangeEvent,
 } from '@metamask/keyring-controller';
-import type { Hex } from '@metamask/utils';
 
 import { ETHERSCAN_SUPPORTED_CHAIN_IDS } from './constants';
 


### PR DESCRIPTION
## Explanation

Remove preference smartAccountOptInForAccounts as it is not going to be used

## References

* Related to [#67890](https://github.com/MetaMask/MetaMask-planning/issues/5262)

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [X] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
