### PR TITLE
fix: revert PreferenceController changes

### DIFF
--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Deprecate preference `smartAccountOptInForAccounts` and function `setSmartAccountOptInForAccounts` ([#6087](https://github.com/MetaMask/core/pull/6087))
+
 ## [18.4.1]
 
 ### Changed

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Deprecated
 
 - Deprecate preference `smartAccountOptInForAccounts` and function `setSmartAccountOptInForAccounts` ([#6087](https://github.com/MetaMask/core/pull/6087))
 

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Removed un-used preference `smartAccountOptInForAccounts` [#6079](https://github.com/MetaMask/core/pull/6079)
-
 ## [18.4.1]
 
 ### Changed

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -27,6 +27,7 @@ describe('PreferencesController', () => {
       isMultiAccountBalancesEnabled: true,
       showTestNetworks: false,
       smartAccountOptIn: true,
+      smartAccountOptInForAccounts: [],
       isIpfsGatewayEnabled: true,
       useTransactionSimulations: true,
       useMultiRpcMigration: true,
@@ -563,6 +564,13 @@ describe('PreferencesController', () => {
     expect(controller.state.smartAccountOptIn).toBe(true);
     controller.setSmartAccountOptIn(false);
     expect(controller.state.smartAccountOptIn).toBe(false);
+  });
+
+  it('should set smartAccountOptInForAccounts', () => {
+    const controller = setupPreferencesController();
+    expect(controller.state.smartAccountOptInForAccounts).toHaveLength(0);
+    controller.setSmartAccountOptInForAccounts(['0x1', '0x2']);
+    expect(controller.state.smartAccountOptInForAccounts[0]).toBe('0x1');
   });
 });
 

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -9,6 +9,7 @@ import type {
   KeyringControllerState,
   KeyringControllerStateChangeEvent,
 } from '@metamask/keyring-controller';
+import type { Hex } from '@metamask/utils';
 
 import { ETHERSCAN_SUPPORTED_CHAIN_IDS } from './constants';
 
@@ -140,6 +141,10 @@ export type PreferencesState = {
    * User to opt in for smart account upgrade for all user accounts.
    */
   smartAccountOptIn: boolean;
+  /**
+   * User to opt in for smart account upgrade for specific accounts.
+   */
+  smartAccountOptInForAccounts: Hex[];
 };
 
 const metadata = {
@@ -164,6 +169,7 @@ const metadata = {
   privacyMode: { persist: true, anonymous: true },
   dismissSmartAccountSuggestionEnabled: { persist: true, anonymous: true },
   smartAccountOptIn: { persist: true, anonymous: true },
+  smartAccountOptInForAccounts: { persist: true, anonymous: true },
 };
 
 const name = 'PreferencesController';
@@ -246,6 +252,7 @@ export function getDefaultPreferencesState(): PreferencesState {
     privacyMode: false,
     dismissSmartAccountSuggestionEnabled: false,
     smartAccountOptIn: true,
+    smartAccountOptInForAccounts: [],
   };
 }
 
@@ -621,6 +628,18 @@ export class PreferencesController extends BaseController<
   setSmartAccountOptIn(smartAccountOptIn: boolean) {
     this.update((state) => {
       state.smartAccountOptIn = smartAccountOptIn;
+    });
+  }
+
+  /**
+   * Add account to list of accounts for which user has optedin
+   * smart account upgrade.
+   *
+   * @param accounts - accounts for which user wants to optin for smart account upgrade
+   */
+  setSmartAccountOptInForAccounts(accounts: Hex[] = []): void {
+    this.update((state) => {
+      state.smartAccountOptInForAccounts = accounts;
     });
   }
 }

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -143,6 +143,7 @@ export type PreferencesState = {
   smartAccountOptIn: boolean;
   /**
    * User to opt in for smart account upgrade for specific accounts.
+   *
    * @deprecated This preference is deprecated and will be removed in the future.
    */
   smartAccountOptInForAccounts: Hex[];

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -143,6 +143,7 @@ export type PreferencesState = {
   smartAccountOptIn: boolean;
   /**
    * User to opt in for smart account upgrade for specific accounts.
+   * @deprecated This preference is deprecated and will be removed in the future.
    */
   smartAccountOptInForAccounts: Hex[];
 };
@@ -636,6 +637,7 @@ export class PreferencesController extends BaseController<
    * smart account upgrade.
    *
    * @param accounts - accounts for which user wants to optin for smart account upgrade
+   * @deprecated This method is deprecated and will be removed in the future.
    */
   setSmartAccountOptInForAccounts(accounts: Hex[] = []): void {
     this.update((state) => {


### PR DESCRIPTION
## Explanation

Revert PreferenceController changes to remove preference `smartAccountOptInForAccounts` and rather add `@deprecated` tag to it.

## References

* Related to https://github.com/MetaMask/MetaMask-planning/issues/5262

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [X] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
