### PR TITLE
fix: validate destWalletAddress when bridging to or from Solana

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING** Require `destWalletAddress` in `isValidQuoteRequest` if bridging to or from Solana
 - **BREAKING:** Bump peer dependency `@metamask/assets-controllers` from `^69.0.0` to `^70.0.0` ([#6061](https://github.com/MetaMask/core/pull/6061))
 - **BREAKING:** Bump peer dependency `@metamask/snaps-controllers` from `^12.0.0` to `^14.0.0` ([#6035](https://github.com/MetaMask/core/pull/6035))
 - **BREAKING** Remove `isSnapConfirmationEnabled` feature flag from `ChainConfigurationSchema` validation ([#6077](https://github.com/MetaMask/core/pull/6077))

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING** Require `destWalletAddress` in `isValidQuoteRequest` if bridging to or from Solana
+- **BREAKING** Require `destWalletAddress` in `isValidQuoteRequest` if bridging to or from Solana ([#6091](https://github.com/MetaMask/core/pull/6091))
 - **BREAKING:** Bump peer dependency `@metamask/assets-controllers` from `^69.0.0` to `^70.0.0` ([#6061](https://github.com/MetaMask/core/pull/6061))
 - **BREAKING:** Bump peer dependency `@metamask/snaps-controllers` from `^12.0.0` to `^14.0.0` ([#6035](https://github.com/MetaMask/core/pull/6035))
 - **BREAKING** Remove `isSnapConfirmationEnabled` feature flag from `ChainConfigurationSchema` validation ([#6077](https://github.com/MetaMask/core/pull/6077))

--- a/packages/bridge-controller/src/__snapshots__/bridge-controller.test.ts.snap
+++ b/packages/bridge-controller/src/__snapshots__/bridge-controller.test.ts.snap
@@ -562,6 +562,32 @@ Array [
   Array [
     "SnapController:handleRequest",
     Object {
+      "handler": "onProtocolRequest",
+      "origin": "metamask",
+      "request": Object {
+        "jsonrpc": "2.0",
+        "method": " ",
+        "params": Object {
+          "request": Object {
+            "id": "test-uuid-1234",
+            "jsonrpc": "2.0",
+            "method": "getMinimumBalanceForRentExemption",
+            "params": Array [
+              0,
+              Object {
+                "commitment": "confirmed",
+              },
+            ],
+          },
+          "scope": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        },
+      },
+      "snapId": "npm:@metamask/solana-snap",
+    },
+  ],
+  Array [
+    "SnapController:handleRequest",
+    Object {
       "handler": "onRpcRequest",
       "origin": "metamask",
       "request": Object {
@@ -717,6 +743,7 @@ Object {
   "quoteRequest": Object {
     "destChainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
     "destTokenAddress": "123d1",
+    "destWalletAddress": "SolanaWalletAddres1234",
     "insufficientBal": false,
     "slippage": 0.5,
     "srcChainId": "0x1",
@@ -745,6 +772,7 @@ Object {
   "quoteRequest": Object {
     "destChainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
     "destTokenAddress": "123d1",
+    "destWalletAddress": "SolanaWalletAddres1234",
     "insufficientBal": false,
     "slippage": 0.5,
     "srcChainId": "0x1",

--- a/packages/bridge-controller/src/utils/quote.ts
+++ b/packages/bridge-controller/src/utils/quote.ts
@@ -5,7 +5,7 @@ import {
 } from '@metamask/controller-utils';
 import { BigNumber } from 'bignumber.js';
 
-import { isNativeAddress } from './bridge';
+import { isNativeAddress, isSolanaChainId } from './bridge';
 import type {
   ExchangeRate,
   GenericQuoteRequest,
@@ -28,6 +28,18 @@ export const isValidQuoteRequest = (
   ];
   if (requireAmount) {
     stringFields.push('srcTokenAmount');
+  }
+  // If bridging and one of the chains is solana, require the dest wallet address
+  if (
+    partialRequest.destChainId &&
+    partialRequest.srcChainId &&
+    isSolanaChainId(partialRequest.destChainId) ===
+      !isSolanaChainId(partialRequest.srcChainId)
+  ) {
+    stringFields.push('destWalletAddress');
+    if (!partialRequest.destWalletAddress) {
+      return false;
+    }
   }
   const numberFields = [];
   // if slippage is defined, require it to be a number


### PR DESCRIPTION
## Explanation

**BREAKING** Require `destWalletAddress` in `isValidQuoteRequest` if bridging to or from Solana. This prevents getQuote network calls from being made if the user has not selected a destination wallet address

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes: https://github.com/MetaMask/metamask-extension/issues/32700 , https://github.com/MetaMask/metamask-extension/issues/32771

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
