### PR TITLE
feat: add general settings to core PreferencesController

### DIFF
--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -49,6 +49,12 @@ describe('PreferencesController', () => {
       },
       privacyMode: false,
       dismissSmartAccountSuggestionEnabled: false,
+      currentLocale: 'en',
+      theme: 'auto',
+      useBlockie: false,
+      currentCurrency: 'USD',
+      showNativeTokenAsMainBalance: false,
+      hideZeroBalanceTokens: false,
     });
   });
 
@@ -571,6 +577,48 @@ describe('PreferencesController', () => {
     expect(controller.state.smartAccountOptInForAccounts).toHaveLength(0);
     controller.setSmartAccountOptInForAccounts(['0x1', '0x2']);
     expect(controller.state.smartAccountOptInForAccounts[0]).toBe('0x1');
+  });
+
+  it('should set currentLocale', () => {
+    const controller = setupPreferencesController();
+    expect(controller.state.currentLocale).toBe('en');
+    controller.setCurrentLocale('es');
+    expect(controller.state.currentLocale).toBe('es');
+  });
+
+  it('should set theme', () => {
+    const controller = setupPreferencesController();
+    expect(controller.state.theme).toBe('auto');
+    controller.setTheme('dark');
+    expect(controller.state.theme).toBe('dark');
+  });
+
+  it('should set useBlockie', () => {
+    const controller = setupPreferencesController();
+    expect(controller.state.useBlockie).toBe(false);
+    controller.setUseBlockie(true);
+    expect(controller.state.useBlockie).toBe(true);
+  });
+
+  it('should set currentCurrency', () => {
+    const controller = setupPreferencesController();
+    expect(controller.state.currentCurrency).toBe('USD');
+    controller.setCurrentCurrency('EUR');
+    expect(controller.state.currentCurrency).toBe('EUR');
+  });
+
+  it('should set showNativeTokenAsMainBalance', () => {
+    const controller = setupPreferencesController();
+    expect(controller.state.showNativeTokenAsMainBalance).toBe(false);
+    controller.setShowNativeTokenAsMainBalance(true);
+    expect(controller.state.showNativeTokenAsMainBalance).toBe(true);
+  });
+
+  it('should set hideZeroBalanceTokens', () => {
+    const controller = setupPreferencesController();
+    expect(controller.state.hideZeroBalanceTokens).toBe(false);
+    controller.setHideZeroBalanceTokens(true);
+    expect(controller.state.hideZeroBalanceTokens).toBe(true);
   });
 });
 

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -147,6 +147,30 @@ export type PreferencesState = {
    * @deprecated This preference is deprecated and will be removed in the future.
    */
   smartAccountOptInForAccounts: Hex[];
+  /**
+   * The user's preferred language locale
+   */
+  currentLocale: string;
+  /**
+   * The user's preferred theme (light, dark, or auto)
+   */
+  theme: string;
+  /**
+   * Whether to use blockie identicons instead of jazzicons
+   */
+  useBlockie: boolean;
+  /**
+   * The user's preferred currency for conversion rates
+   */
+  currentCurrency: string;
+  /**
+   * Whether to show native token as the main balance
+   */
+  showNativeTokenAsMainBalance: boolean;
+  /**
+   * Whether to hide tokens with zero balance
+   */
+  hideZeroBalanceTokens: boolean;
 };
 
 const metadata = {
@@ -172,6 +196,12 @@ const metadata = {
   dismissSmartAccountSuggestionEnabled: { persist: true, anonymous: true },
   smartAccountOptIn: { persist: true, anonymous: true },
   smartAccountOptInForAccounts: { persist: true, anonymous: true },
+  currentLocale: { persist: true, anonymous: true },
+  theme: { persist: true, anonymous: true },
+  useBlockie: { persist: true, anonymous: true },
+  currentCurrency: { persist: true, anonymous: true },
+  showNativeTokenAsMainBalance: { persist: true, anonymous: true },
+  hideZeroBalanceTokens: { persist: true, anonymous: true },
 };
 
 const name = 'PreferencesController';
@@ -255,6 +285,12 @@ export function getDefaultPreferencesState(): PreferencesState {
     dismissSmartAccountSuggestionEnabled: false,
     smartAccountOptIn: true,
     smartAccountOptInForAccounts: [],
+    currentLocale: 'en',
+    theme: 'auto',
+    useBlockie: false,
+    currentCurrency: 'USD',
+    showNativeTokenAsMainBalance: false,
+    hideZeroBalanceTokens: false,
   };
 }
 
@@ -643,6 +679,72 @@ export class PreferencesController extends BaseController<
   setSmartAccountOptInForAccounts(accounts: Hex[] = []): void {
     this.update((state) => {
       state.smartAccountOptInForAccounts = accounts;
+    });
+  }
+
+  /**
+   * Sets the user's preferred language locale
+   *
+   * @param currentLocale - The language locale (e.g., 'en', 'es', 'fr')
+   */
+  setCurrentLocale(currentLocale: string): void {
+    this.update((state) => {
+      state.currentLocale = currentLocale;
+    });
+  }
+
+  /**
+   * Sets the user's preferred theme
+   *
+   * @param theme - The theme preference ('light', 'dark', or 'auto')
+   */
+  setTheme(theme: string): void {
+    this.update((state) => {
+      state.theme = theme;
+    });
+  }
+
+  /**
+   * Sets whether to use blockie identicons instead of jazzicons
+   *
+   * @param useBlockie - Whether to use blockie identicons
+   */
+  setUseBlockie(useBlockie: boolean): void {
+    this.update((state) => {
+      state.useBlockie = useBlockie;
+    });
+  }
+
+  /**
+   * Sets the user's preferred currency for conversion rates
+   *
+   * @param currentCurrency - The currency code (e.g., 'USD', 'EUR', 'GBP')
+   */
+  setCurrentCurrency(currentCurrency: string): void {
+    this.update((state) => {
+      state.currentCurrency = currentCurrency;
+    });
+  }
+
+  /**
+   * Sets whether to show native token as the main balance
+   *
+   * @param showNativeTokenAsMainBalance - Whether to show native token as main balance
+   */
+  setShowNativeTokenAsMainBalance(showNativeTokenAsMainBalance: boolean): void {
+    this.update((state) => {
+      state.showNativeTokenAsMainBalance = showNativeTokenAsMainBalance;
+    });
+  }
+
+  /**
+   * Sets whether to hide tokens with zero balance
+   *
+   * @param hideZeroBalanceTokens - Whether to hide tokens with zero balance
+   */
+  setHideZeroBalanceTokens(hideZeroBalanceTokens: boolean): void {
+    this.update((state) => {
+      state.hideZeroBalanceTokens = hideZeroBalanceTokens;
     });
   }
 }


### PR DESCRIPTION
## Explanation

### Current State
MetaMask's general settings (theme, locale, currency, etc.) are currently managed differently across platforms:
- **Extension**: Stored in the extension's PreferencesController 
- **Mobile**: Managed through Redux state

This architectural difference creates challenges for implementing cross-platform settings synchronization, as there's no single source of truth for these preferences.

### Solution
This PR adds general settings properties to the core PreferencesController to establish a centralized foundation for settings sync:

- `currentLocale` - User's preferred language
- `theme` - UI theme preference (light/dark/auto)
- `useBlockie` - Identicon style preference
- `currentCurrency` - Display currency for fiat conversions
- `showNativeTokenAsMainBalance` - Balance display preference
- `hideZeroBalanceTokens` - Token list filtering preference

Each property includes:
- Appropriate default values
- Setter methods following existing patterns
- Full JSDoc documentation
- Comprehensive test coverage

### Next Steps
This lays the groundwork for unified settings management:
- **Extension**: Will be updated to consume these settings from the core controller instead of maintaining its own copies
- **Mobile**: Will bridge these settings from Redux state to the core controller for synchronization

This approach ensures all platforms use a consistent source of truth while maintaining backward compatibility during the transition.

## References

[IDENTITY-172](https://consensyssoftware.atlassian.net/browse/IDENTITY-172)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes