### PR TITLE
fix: Fix `yarn create-package`

### DIFF
--- a/scripts/create-package/cli.ts
+++ b/scripts/create-package/cli.ts
@@ -20,8 +20,6 @@ export default async function cli(
     // Disable --version. This is an internal tool and it doesn't have a version.
     .version(false)
     .usage('$0 [args]')
-    // @ts-expect-error: The CommandModule<T, U>[] signature does in fact exist,
-    // but it is missing from our yargs types.
     .command(commands)
     .strict()
     .check((args) => {
@@ -43,6 +41,5 @@ export default async function cli(
     .showHelpOnFail(false)
     .help()
     .alias('help', 'h')
-    // @ts-expect-error: This does in fact exist, but it is missing from our yargs types.
     .parseAsync();
 }


### PR DESCRIPTION
## Explanation

The `create-package` script was failing due to unused `ts-expect-error` directives. The directives became unused recently in #5810 after an update.

To test this, run `yarn create-package --help`. It should no longer throw an error.

## References

Broken since #5810

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
