### PR TITLE
feat: Create new `@metamask/messenger` package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,7 @@
 /packages/composable-controller        @MetaMask/core-platform
 /packages/controller-utils             @MetaMask/core-platform
 /packages/error-reporting-service      @MetaMask/core-platform
+/packages/messenger                    @MetaMask/core-platform
 /packages/sample-controllers           @MetaMask/core-platform
 /packages/polling-controller           @MetaMask/core-platform
 /packages/preferences-controller       @MetaMask/core-platform

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Each package in this repository has its own README where you can find installati
 - [`@metamask/keyring-controller`](packages/keyring-controller)
 - [`@metamask/logging-controller`](packages/logging-controller)
 - [`@metamask/message-manager`](packages/message-manager)
+- [`@metamask/messenger`](packages/messenger)
 - [`@metamask/multichain-api-middleware`](packages/multichain-api-middleware)
 - [`@metamask/multichain-network-controller`](packages/multichain-network-controller)
 - [`@metamask/multichain-transactions-controller`](packages/multichain-transactions-controller)
@@ -104,6 +105,7 @@ linkStyle default opacity:0.5
   keyring_controller(["@metamask/keyring-controller"]);
   logging_controller(["@metamask/logging-controller"]);
   message_manager(["@metamask/message-manager"]);
+  messenger(["@metamask/messenger"]);
   multichain_api_middleware(["@metamask/multichain-api-middleware"]);
   multichain_network_controller(["@metamask/multichain-network-controller"]);
   multichain_transactions_controller(["@metamask/multichain-transactions-controller"]);

--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Migrate `Messenger` class from `@metamask/base-controller` package
+
+[Unreleased]: https://github.com/MetaMask/core/

--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -9,6 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Migrate `Messenger` class from `@metamask/base-controller` package
+- Migrate `Messenger` class from `@metamask/base-controller` package ([#6127](https://github.com/MetaMask/core/pull/6127))
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/messenger/LICENSE
+++ b/packages/messenger/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2025 MetaMask
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE

--- a/packages/messenger/README.md
+++ b/packages/messenger/README.md
@@ -1,0 +1,17 @@
+# `@metamask/messenger`
+
+A type-safe message bus library.
+
+The `Messenger` class allows registering functions as 'actions' that can be called elsewhere, and it allows publishing and subscribing to events. Both actions and events are identified by namespaced strings.
+
+## Installation
+
+`yarn add @metamask/messenger`
+
+or
+
+`npm install @metamask/messenger`
+
+## Contributing
+
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).

--- a/packages/messenger/jest.config.js
+++ b/packages/messenger/jest.config.js
@@ -1,0 +1,26 @@
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+const merge = require('deepmerge');
+const path = require('path');
+
+const baseConfig = require('../../jest.config.packages');
+
+const displayName = path.basename(__dirname);
+
+module.exports = merge(baseConfig, {
+  // The display name when running multiple projects
+  displayName,
+
+  // An object that configures minimum threshold enforcement for coverage results
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+});

--- a/packages/messenger/package.json
+++ b/packages/messenger/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@metamask/messenger",
+  "version": "0.0.0",
+  "description": "A type-safe message bus library",
+  "keywords": [
+    "MetaMask",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/core/tree/main/packages/messenger#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/core/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/core.git"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",
+    "build:docs": "typedoc",
+    "changelog:update": "../../scripts/update-changelog.sh @metamask/messenger",
+    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/messenger",
+    "publish:preview": "yarn npm publish --tag preview",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
+    "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
+    "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+  },
+  "devDependencies": {
+    "@metamask/auto-changelog": "^3.4.4",
+    "@types/jest": "^27.4.1",
+    "deepmerge": "^4.2.2",
+    "immer": "^9.0.6",
+    "jest": "^27.5.1",
+    "sinon": "^9.2.4",
+    "ts-jest": "^27.1.4",
+    "typedoc": "^0.24.8",
+    "typedoc-plugin-missing-exports": "^2.0.0",
+    "typescript": "~5.2.2"
+  },
+  "engines": {
+    "node": "^18.18 || >=20"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -1,0 +1,727 @@
+import type { Patch } from 'immer';
+import sinon from 'sinon';
+
+import { Messenger } from './Messenger';
+
+describe('Messenger', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should allow registering and calling an action handler', () => {
+    type CountAction = { type: 'count'; handler: (increment: number) => void };
+    const messenger = new Messenger<CountAction, never>();
+
+    let count = 0;
+    messenger.registerActionHandler('count', (increment: number) => {
+      count += increment;
+    });
+    messenger.call('count', 1);
+
+    expect(count).toBe(1);
+  });
+
+  it('should allow registering and calling multiple different action handlers', () => {
+    // These 'Other' types are included to demonstrate that messenger generics can indeed be unions
+    // of actions and events from different modules.
+    type GetOtherState = {
+      type: `OtherController:getState`;
+      handler: () => { stuff: string };
+    };
+
+    type OtherStateChange = {
+      type: `OtherController:stateChange`;
+      payload: [{ stuff: string }, Patch[]];
+    };
+
+    type MessageAction =
+      | { type: 'concat'; handler: (message: string) => void }
+      | { type: 'reset'; handler: (initialMessage: string) => void };
+    const messenger = new Messenger<
+      MessageAction | GetOtherState,
+      OtherStateChange
+    >();
+
+    let message = '';
+    messenger.registerActionHandler('reset', (initialMessage: string) => {
+      message = initialMessage;
+    });
+
+    messenger.registerActionHandler('concat', (s: string) => {
+      message += s;
+    });
+
+    messenger.call('reset', 'hello');
+    messenger.call('concat', ', world');
+
+    expect(message).toBe('hello, world');
+  });
+
+  it('should allow registering and calling an action handler with no parameters', () => {
+    type IncrementAction = { type: 'increment'; handler: () => void };
+    const messenger = new Messenger<IncrementAction, never>();
+
+    let count = 0;
+    messenger.registerActionHandler('increment', () => {
+      count += 1;
+    });
+    messenger.call('increment');
+
+    expect(count).toBe(1);
+  });
+
+  it('should allow registering and calling an action handler with multiple parameters', () => {
+    type MessageAction = {
+      type: 'message';
+      handler: (to: string, message: string) => void;
+    };
+    const messenger = new Messenger<MessageAction, never>();
+
+    const messages: Record<string, string> = {};
+    messenger.registerActionHandler('message', (to, message) => {
+      messages[to] = message;
+    });
+    messenger.call('message', '0x123', 'hello');
+
+    expect(messages['0x123']).toBe('hello');
+  });
+
+  it('should allow registering and calling an action handler with a return value', () => {
+    type AddAction = { type: 'add'; handler: (a: number, b: number) => number };
+    const messenger = new Messenger<AddAction, never>();
+
+    messenger.registerActionHandler('add', (a, b) => {
+      return a + b;
+    });
+    const result = messenger.call('add', 5, 10);
+
+    expect(result).toBe(15);
+  });
+
+  it('should not allow registering multiple action handlers under the same name', () => {
+    type PingAction = { type: 'ping'; handler: () => void };
+    const messenger = new Messenger<PingAction, never>();
+
+    messenger.registerActionHandler('ping', () => undefined);
+
+    expect(() => {
+      messenger.registerActionHandler('ping', () => undefined);
+    }).toThrow('A handler for ping has already been registered');
+  });
+
+  it('should throw when calling unregistered action', () => {
+    type PingAction = { type: 'ping'; handler: () => void };
+    const messenger = new Messenger<PingAction, never>();
+
+    expect(() => {
+      messenger.call('ping');
+    }).toThrow('A handler for ping has not been registered');
+  });
+
+  it('should throw when calling an action that has been unregistered', () => {
+    type PingAction = { type: 'ping'; handler: () => void };
+    const messenger = new Messenger<PingAction, never>();
+
+    expect(() => {
+      messenger.call('ping');
+    }).toThrow('A handler for ping has not been registered');
+
+    let pingCount = 0;
+    messenger.registerActionHandler('ping', () => {
+      pingCount += 1;
+    });
+
+    messenger.unregisterActionHandler('ping');
+
+    expect(() => {
+      messenger.call('ping');
+    }).toThrow('A handler for ping has not been registered');
+    expect(pingCount).toBe(0);
+  });
+
+  it('should throw when calling an action after actions have been reset', () => {
+    type PingAction = { type: 'ping'; handler: () => void };
+    const messenger = new Messenger<PingAction, never>();
+
+    expect(() => {
+      messenger.call('ping');
+    }).toThrow('A handler for ping has not been registered');
+
+    let pingCount = 0;
+    messenger.registerActionHandler('ping', () => {
+      pingCount += 1;
+    });
+
+    messenger.clearActions();
+
+    expect(() => {
+      messenger.call('ping');
+    }).toThrow('A handler for ping has not been registered');
+    expect(pingCount).toBe(0);
+  });
+
+  it('should publish event to subscriber', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    messenger.subscribe('message', handler);
+    messenger.publish('message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBe(true);
+    expect(handler.callCount).toBe(1);
+  });
+
+  it('should allow publishing multiple different events to subscriber', () => {
+    type MessageEvent =
+      | { type: 'message'; payload: [string] }
+      | { type: 'ping'; payload: [] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const messageHandler = sinon.stub();
+    const pingHandler = sinon.stub();
+    messenger.subscribe('message', messageHandler);
+    messenger.subscribe('ping', pingHandler);
+
+    messenger.publish('message', 'hello');
+    messenger.publish('ping');
+
+    expect(messageHandler.calledWithExactly('hello')).toBe(true);
+    expect(messageHandler.callCount).toBe(1);
+    expect(pingHandler.calledWithExactly()).toBe(true);
+    expect(pingHandler.callCount).toBe(1);
+  });
+
+  it('should publish event with no payload to subscriber', () => {
+    type PingEvent = { type: 'ping'; payload: [] };
+    const messenger = new Messenger<never, PingEvent>();
+
+    const handler = sinon.stub();
+    messenger.subscribe('ping', handler);
+    messenger.publish('ping');
+
+    expect(handler.calledWithExactly()).toBe(true);
+    expect(handler.callCount).toBe(1);
+  });
+
+  it('should publish event with multiple payload parameters to subscriber', () => {
+    type MessageEvent = { type: 'message'; payload: [string, string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    messenger.subscribe('message', handler);
+    messenger.publish('message', 'hello', 'there');
+
+    expect(handler.calledWithExactly('hello', 'there')).toBe(true);
+    expect(handler.callCount).toBe(1);
+  });
+
+  it('should publish event once to subscriber even if subscribed multiple times', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    messenger.subscribe('message', handler);
+    messenger.subscribe('message', handler);
+    messenger.publish('message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBe(true);
+    expect(handler.callCount).toBe(1);
+  });
+
+  it('should publish event to many subscribers', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler1 = sinon.stub();
+    const handler2 = sinon.stub();
+    messenger.subscribe('message', handler1);
+    messenger.subscribe('message', handler2);
+    messenger.publish('message', 'hello');
+
+    expect(handler1.calledWithExactly('hello')).toBe(true);
+    expect(handler1.callCount).toBe(1);
+    expect(handler2.calledWithExactly('hello')).toBe(true);
+    expect(handler2.callCount).toBe(1);
+  });
+
+  describe('on first state change with an initial payload function registered', () => {
+    it('should publish event if selected payload differs', () => {
+      const state = {
+        propA: 1,
+        propB: 1,
+      };
+      type MessageEvent = {
+        type: 'complexMessage';
+        payload: [typeof state];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      messenger.registerInitialEventPayload({
+        eventType: 'complexMessage',
+        getPayload: () => [state],
+      });
+      const handler = sinon.stub();
+      messenger.subscribe('complexMessage', handler, (obj) => obj.propA);
+
+      state.propA += 1;
+      messenger.publish('complexMessage', state);
+
+      expect(handler.getCall(0)?.args).toStrictEqual([2, 1]);
+      expect(handler.callCount).toBe(1);
+    });
+
+    it('should not publish event if selected payload is the same', () => {
+      const state = {
+        propA: 1,
+        propB: 1,
+      };
+      type MessageEvent = {
+        type: 'complexMessage';
+        payload: [typeof state];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      messenger.registerInitialEventPayload({
+        eventType: 'complexMessage',
+        getPayload: () => [state],
+      });
+      const handler = sinon.stub();
+      messenger.subscribe('complexMessage', handler, (obj) => obj.propA);
+
+      messenger.publish('complexMessage', state);
+
+      expect(handler.callCount).toBe(0);
+    });
+  });
+
+  describe('on first state change without an initial payload function registered', () => {
+    it('should publish event if selected payload differs', () => {
+      const state = {
+        propA: 1,
+        propB: 1,
+      };
+      type MessageEvent = {
+        type: 'complexMessage';
+        payload: [typeof state];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      const handler = sinon.stub();
+      messenger.subscribe('complexMessage', handler, (obj) => obj.propA);
+
+      state.propA += 1;
+      messenger.publish('complexMessage', state);
+
+      expect(handler.getCall(0)?.args).toStrictEqual([2, undefined]);
+      expect(handler.callCount).toBe(1);
+    });
+
+    it('should publish event even when selected payload does not change', () => {
+      const state = {
+        propA: 1,
+        propB: 1,
+      };
+      type MessageEvent = {
+        type: 'complexMessage';
+        payload: [typeof state];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      const handler = sinon.stub();
+      messenger.subscribe('complexMessage', handler, (obj) => obj.propA);
+
+      messenger.publish('complexMessage', state);
+
+      expect(handler.getCall(0)?.args).toStrictEqual([1, undefined]);
+      expect(handler.callCount).toBe(1);
+    });
+
+    it('should not publish if selector returns undefined', () => {
+      const state = {
+        propA: undefined,
+        propB: 1,
+      };
+      type MessageEvent = {
+        type: 'complexMessage';
+        payload: [typeof state];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      const handler = sinon.stub();
+      messenger.subscribe('complexMessage', handler, (obj) => obj.propA);
+
+      messenger.publish('complexMessage', state);
+
+      expect(handler.callCount).toBe(0);
+    });
+  });
+
+  describe('on later state change', () => {
+    it('should call selector event handler with previous selector return value', () => {
+      type MessageEvent = {
+        type: 'complexMessage';
+        payload: [Record<string, unknown>];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+
+      const handler = sinon.stub();
+      messenger.subscribe('complexMessage', handler, (obj) => obj.prop1);
+      messenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
+      messenger.publish('complexMessage', { prop1: 'z', prop2: 'b' });
+
+      expect(handler.getCall(0).calledWithExactly('a', undefined)).toBe(true);
+      expect(handler.getCall(1).calledWithExactly('z', 'a')).toBe(true);
+      expect(handler.callCount).toBe(2);
+    });
+
+    it('should publish event with selector to subscriber', () => {
+      type MessageEvent = {
+        type: 'complexMessage';
+        payload: [Record<string, unknown>];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+
+      const handler = sinon.stub();
+      messenger.subscribe('complexMessage', handler, (obj) => obj.prop1);
+      messenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
+
+      expect(handler.calledWithExactly('a', undefined)).toBe(true);
+      expect(handler.callCount).toBe(1);
+    });
+
+    it('should not publish event with selector if selector return value is unchanged', () => {
+      type MessageEvent = {
+        type: 'complexMessage';
+        payload: [Record<string, unknown>];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+
+      const handler = sinon.stub();
+      messenger.subscribe('complexMessage', handler, (obj) => obj.prop1);
+      messenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
+      messenger.publish('complexMessage', { prop1: 'a', prop3: 'c' });
+
+      expect(handler.calledWithExactly('a', undefined)).toBe(true);
+      expect(handler.callCount).toBe(1);
+    });
+  });
+
+  it('should publish event to many subscribers with the same selector', () => {
+    type MessageEvent = {
+      type: 'complexMessage';
+      payload: [Record<string, unknown>];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler1 = sinon.stub();
+    const handler2 = sinon.stub();
+    const selector = sinon.fake((obj: Record<string, unknown>) => obj.prop1);
+    messenger.subscribe('complexMessage', handler1, selector);
+    messenger.subscribe('complexMessage', handler2, selector);
+    messenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
+    messenger.publish('complexMessage', { prop1: 'a', prop3: 'c' });
+
+    expect(handler1.calledWithExactly('a', undefined)).toBe(true);
+    expect(handler1.callCount).toBe(1);
+    expect(handler2.calledWithExactly('a', undefined)).toBe(true);
+    expect(handler2.callCount).toBe(1);
+    expect(
+      selector.getCall(0).calledWithExactly({ prop1: 'a', prop2: 'b' }),
+    ).toBe(true);
+
+    expect(
+      selector.getCall(1).calledWithExactly({ prop1: 'a', prop2: 'b' }),
+    ).toBe(true);
+
+    expect(
+      selector.getCall(2).calledWithExactly({ prop1: 'a', prop3: 'c' }),
+    ).toBe(true);
+
+    expect(
+      selector.getCall(3).calledWithExactly({ prop1: 'a', prop3: 'c' }),
+    ).toBe(true);
+    expect(selector.callCount).toBe(4);
+  });
+
+  it('should throw subscriber errors in a timeout', () => {
+    const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler = sinon.stub().throws(() => new Error('Example error'));
+    messenger.subscribe('message', handler);
+
+    expect(() => messenger.publish('message', 'hello')).not.toThrow();
+    expect(setTimeoutStub.callCount).toBe(1);
+    const onTimeout = setTimeoutStub.firstCall.args[0];
+    expect(() => onTimeout()).toThrow('Example error');
+  });
+
+  it('should continue calling subscribers when one throws', () => {
+    const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler1 = sinon.stub().throws(() => new Error('Example error'));
+    const handler2 = sinon.stub();
+    messenger.subscribe('message', handler1);
+    messenger.subscribe('message', handler2);
+
+    expect(() => messenger.publish('message', 'hello')).not.toThrow();
+
+    expect(handler1.calledWithExactly('hello')).toBe(true);
+    expect(handler1.callCount).toBe(1);
+    expect(handler2.calledWithExactly('hello')).toBe(true);
+    expect(handler2.callCount).toBe(1);
+    expect(setTimeoutStub.callCount).toBe(1);
+    const onTimeout = setTimeoutStub.firstCall.args[0];
+    expect(() => onTimeout()).toThrow('Example error');
+  });
+
+  it('should not call subscriber after unsubscribing', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    messenger.subscribe('message', handler);
+    messenger.unsubscribe('message', handler);
+    messenger.publish('message', 'hello');
+
+    expect(handler.callCount).toBe(0);
+  });
+
+  it('should not call subscriber with selector after unsubscribing', () => {
+    type MessageEvent = {
+      type: 'complexMessage';
+      payload: [Record<string, unknown>];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    const selector = sinon.fake((obj: Record<string, unknown>) => obj.prop1);
+    messenger.subscribe('complexMessage', handler, selector);
+    messenger.unsubscribe('complexMessage', handler);
+    messenger.publish('complexMessage', { prop1: 'a', prop2: 'b' });
+
+    expect(handler.callCount).toBe(0);
+    expect(selector.callCount).toBe(0);
+  });
+
+  it('should throw when unsubscribing when there are no subscriptions', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    expect(() => messenger.unsubscribe('message', handler)).toThrow(
+      'Subscription not found for event: message',
+    );
+  });
+
+  it('should throw when unsubscribing a handler that is not subscribed', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler1 = sinon.stub();
+    const handler2 = sinon.stub();
+    messenger.subscribe('message', handler1);
+
+    expect(() => messenger.unsubscribe('message', handler2)).toThrow(
+      'Subscription not found for event: message',
+    );
+  });
+
+  it('should not call subscriber after clearing event subscriptions', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    messenger.subscribe('message', handler);
+    messenger.clearEventSubscriptions('message');
+    messenger.publish('message', 'hello');
+
+    expect(handler.callCount).toBe(0);
+  });
+
+  it('should not throw when clearing event that has no subscriptions', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    expect(() => messenger.clearEventSubscriptions('message')).not.toThrow();
+  });
+
+  it('should not call subscriber after resetting subscriptions', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const messenger = new Messenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    messenger.subscribe('message', handler);
+    messenger.clearSubscriptions();
+    messenger.publish('message', 'hello');
+
+    expect(handler.callCount).toBe(0);
+  });
+
+  describe('registerMethodActionHandlers', () => {
+    it('should register action handlers for specified methods on the given messenger client', () => {
+      type TestActions =
+        | { type: 'TestService:getType'; handler: () => string }
+        | {
+            type: 'TestService:getCount';
+            handler: () => number;
+          };
+
+      const messenger = new Messenger<TestActions, never>();
+
+      class TestService {
+        name = 'TestService';
+
+        getType() {
+          return 'api';
+        }
+
+        getCount() {
+          return 42;
+        }
+      }
+
+      const service = new TestService();
+      const methodNames = ['getType', 'getCount'] as const;
+
+      messenger.registerMethodActionHandlers(service, methodNames);
+
+      const state = messenger.call('TestService:getType');
+      expect(state).toBe('api');
+
+      const count = messenger.call('TestService:getCount');
+      expect(count).toBe(42);
+    });
+
+    it('should bind action handlers to the given messenger client', () => {
+      type TestAction = {
+        type: 'TestService:getPrivateValue';
+        handler: () => string;
+      };
+      const messenger = new Messenger<TestAction, never>();
+
+      class TestService {
+        name = 'TestService';
+
+        privateValue = 'secret';
+
+        getPrivateValue() {
+          return this.privateValue;
+        }
+      }
+
+      const service = new TestService();
+      messenger.registerMethodActionHandlers(service, ['getPrivateValue']);
+
+      const result = messenger.call('TestService:getPrivateValue');
+      expect(result).toBe('secret');
+    });
+
+    it('should handle async methods', async () => {
+      type TestAction = {
+        type: 'TestService:fetchData';
+        handler: (id: string) => Promise<string>;
+      };
+      const messenger = new Messenger<TestAction, never>();
+
+      class TestService {
+        name = 'TestService';
+
+        async fetchData(id: string) {
+          return `data-${id}`;
+        }
+      }
+
+      const service = new TestService();
+      messenger.registerMethodActionHandlers(service, ['fetchData']);
+
+      const result = await messenger.call('TestService:fetchData', '123');
+      expect(result).toBe('data-123');
+    });
+
+    it('should not throw when given an empty methodNames array', () => {
+      type TestAction = { type: 'TestController:test'; handler: () => void };
+      const messenger = new Messenger<TestAction, never>();
+
+      class TestController {
+        name = 'TestController';
+      }
+
+      const controller = new TestController();
+      const methodNames: readonly string[] = [];
+
+      expect(() => {
+        messenger.registerMethodActionHandlers(
+          controller,
+          methodNames as never[],
+        );
+      }).not.toThrow();
+    });
+
+    it('should skip non-function properties', () => {
+      type TestAction = {
+        type: 'TestController:getValue';
+        handler: () => string;
+      };
+      const messenger = new Messenger<TestAction, never>();
+
+      class TestController {
+        name = 'TestController';
+
+        readonly nonFunction = 'not a function';
+
+        getValue() {
+          return 'test';
+        }
+      }
+
+      const controller = new TestController();
+      messenger.registerMethodActionHandlers(controller, ['getValue']);
+
+      // getValue should be registered
+      expect(messenger.call('TestController:getValue')).toBe('test');
+
+      // nonFunction should not be registered
+      expect(() => {
+        // @ts-expect-error - This is a test
+        messenger.call('TestController:nonFunction');
+      }).toThrow(
+        'A handler for TestController:nonFunction has not been registered',
+      );
+    });
+
+    it('should work with class inheritance', () => {
+      type TestActions =
+        | { type: 'ChildController:baseMethod'; handler: () => string }
+        | { type: 'ChildController:childMethod'; handler: () => string };
+
+      const messenger = new Messenger<TestActions, never>();
+
+      class BaseController {
+        name = 'BaseController';
+
+        baseMethod() {
+          return 'base method';
+        }
+      }
+
+      class ChildController extends BaseController {
+        name = 'ChildController';
+
+        childMethod() {
+          return 'child method';
+        }
+      }
+
+      const controller = new ChildController();
+      messenger.registerMethodActionHandlers(controller, [
+        'baseMethod',
+        'childMethod',
+      ]);
+
+      expect(messenger.call('ChildController:baseMethod')).toBe('base method');
+      expect(messenger.call('ChildController:childMethod')).toBe(
+        'child method',
+      );
+    });
+  });
+});

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -1,0 +1,480 @@
+import { RestrictedMessenger } from './RestrictedMessenger';
+
+export type ActionHandler<
+  Action extends ActionConstraint,
+  ActionType = Action['type'],
+> = (
+  ...args: ExtractActionParameters<Action, ActionType>
+) => ExtractActionResponse<Action, ActionType>;
+
+export type ExtractActionParameters<
+  Action extends ActionConstraint,
+  ActionType = Action['type'],
+> = Action extends {
+  type: ActionType;
+  handler: (...args: infer HandlerArgs) => unknown;
+}
+  ? HandlerArgs
+  : never;
+
+export type ExtractActionResponse<
+  Action extends ActionConstraint,
+  ActionType = Action['type'],
+> = Action extends {
+  type: ActionType;
+  handler: (...args: infer _) => infer HandlerReturnValue;
+}
+  ? HandlerReturnValue
+  : never;
+
+export type ExtractEventHandler<
+  Event extends EventConstraint,
+  EventType = Event['type'],
+> = Event extends {
+  type: EventType;
+  payload: infer Payload;
+}
+  ? Payload extends unknown[]
+    ? (...payload: Payload) => void
+    : never
+  : never;
+
+export type ExtractEventPayload<
+  Event extends EventConstraint,
+  EventType = Event['type'],
+> = Event extends {
+  type: EventType;
+  payload: infer Payload;
+}
+  ? Payload extends unknown[]
+    ? Payload
+    : never
+  : never;
+
+export type GenericEventHandler = (...args: unknown[]) => void;
+
+export type SelectorFunction<
+  Event extends EventConstraint,
+  EventType extends Event['type'],
+  ReturnValue,
+> = (...args: ExtractEventPayload<Event, EventType>) => ReturnValue;
+export type SelectorEventHandler<SelectorReturnValue> = (
+  newValue: SelectorReturnValue,
+  previousValue: SelectorReturnValue | undefined,
+) => void;
+
+export type ActionConstraint = {
+  type: string;
+  handler: ((...args: never) => unknown) | ((...args: never[]) => unknown);
+};
+export type EventConstraint = {
+  type: string;
+  payload: unknown[];
+};
+
+type EventSubscriptionMap<
+  Event extends EventConstraint,
+  ReturnValue = unknown,
+> = Map<
+  GenericEventHandler | SelectorEventHandler<ReturnValue>,
+  SelectorFunction<Event, Event['type'], ReturnValue> | undefined
+>;
+
+/**
+ * A namespaced string
+ *
+ * This type verifies that the string Name is prefixed by the string Name followed by a colon.
+ *
+ * @template Namespace - The namespace we're checking for.
+ * @template Name - The full string, including the namespace.
+ */
+export type NamespacedBy<
+  Namespace extends string,
+  Name extends string,
+> = Name extends `${Namespace}:${string}` ? Name : never;
+
+export type NotNamespacedBy<
+  Namespace extends string,
+  Name extends string,
+> = Name extends `${Namespace}:${string}` ? never : Name;
+
+export type NamespacedName<Namespace extends string = string> =
+  `${Namespace}:${string}`;
+
+type NarrowToNamespace<Name, Namespace extends string> = Name extends {
+  type: `${Namespace}:${string}`;
+}
+  ? Name
+  : never;
+
+type NarrowToAllowed<Name, Allowed extends string> = Name extends {
+  type: Allowed;
+}
+  ? Name
+  : never;
+
+/**
+ * A message broker for "actions" and "events".
+ *
+ * The messenger allows registering functions as 'actions' that can be called elsewhere,
+ * and it allows publishing and subscribing to events. Both actions and events are identified by
+ * unique strings.
+ *
+ * @template Action - A type union of all Action types.
+ * @template Event - A type union of all Event types.
+ */
+export class Messenger<
+  Action extends ActionConstraint,
+  Event extends EventConstraint,
+> {
+  readonly #actions = new Map<Action['type'], unknown>();
+
+  readonly #events = new Map<Event['type'], EventSubscriptionMap<Event>>();
+
+  /**
+   * A map of functions for getting the initial event payload.
+   *
+   * Used only for events that represent state changes.
+   */
+  readonly #initialEventPayloadGetters = new Map<
+    Event['type'],
+    () => ExtractEventPayload<Event, Event['type']>
+  >();
+
+  /**
+   * A cache of selector return values for their respective handlers.
+   */
+  readonly #eventPayloadCache = new Map<
+    GenericEventHandler,
+    unknown | undefined
+  >();
+
+  /**
+   * Register an action handler.
+   *
+   * This will make the registered function available to call via the `call` method.
+   *
+   * @param actionType - The action type. This is a unique identifier for this action.
+   * @param handler - The action handler. This function gets called when the `call` method is
+   * invoked with the given action type.
+   * @throws Will throw when a handler has been registered for this action type already.
+   * @template ActionType - A type union of Action type strings.
+   */
+  registerActionHandler<ActionType extends Action['type']>(
+    actionType: ActionType,
+    handler: ActionHandler<Action, ActionType>,
+  ) {
+    if (this.#actions.has(actionType)) {
+      throw new Error(
+        `A handler for ${actionType} has already been registered`,
+      );
+    }
+    this.#actions.set(actionType, handler);
+  }
+
+  /**
+   * Registers action handlers for a list of methods on a messenger client
+   *
+   * @param messengerClient - The object that is expected to make use of the messenger.
+   * @param methodNames - The names of the methods on the messenger client to register as action
+   * handlers
+   */
+  registerMethodActionHandlers<
+    MessengerClient extends { name: string },
+    MethodNames extends keyof MessengerClient & string,
+  >(messengerClient: MessengerClient, methodNames: readonly MethodNames[]) {
+    for (const methodName of methodNames) {
+      const method = messengerClient[methodName];
+      if (typeof method === 'function') {
+        const actionType = `${messengerClient.name}:${methodName}` as const;
+        this.registerActionHandler(actionType, method.bind(messengerClient));
+      }
+    }
+  }
+
+  /**
+   * Unregister an action handler.
+   *
+   * This will prevent this action from being called.
+   *
+   * @param actionType - The action type. This is a unique identifier for this action.
+   * @template ActionType - A type union of Action type strings.
+   */
+  unregisterActionHandler<ActionType extends Action['type']>(
+    actionType: ActionType,
+  ) {
+    this.#actions.delete(actionType);
+  }
+
+  /**
+   * Unregister all action handlers.
+   *
+   * This prevents all actions from being called.
+   */
+  clearActions() {
+    this.#actions.clear();
+  }
+
+  /**
+   * Call an action.
+   *
+   * This function will call the action handler corresponding to the given action type, passing
+   * along any parameters given.
+   *
+   * @param actionType - The action type. This is a unique identifier for this action.
+   * @param params - The action parameters. These must match the type of the parameters of the
+   * registered action handler.
+   * @throws Will throw when no handler has been registered for the given type.
+   * @template ActionType - A type union of Action type strings.
+   * @returns The action return value.
+   */
+  call<ActionType extends Action['type']>(
+    actionType: ActionType,
+    ...params: ExtractActionParameters<Action, ActionType>
+  ): ExtractActionResponse<Action, ActionType> {
+    const handler = this.#actions.get(actionType) as ActionHandler<
+      Action,
+      ActionType
+    >;
+    if (!handler) {
+      throw new Error(`A handler for ${actionType} has not been registered`);
+    }
+    return handler(...params);
+  }
+
+  /**
+   * Register a function for getting the initial payload for an event.
+   *
+   * This is used for events that represent a state change, where the payload is the state.
+   * Registering a function for getting the payload allows event selectors to have a point of
+   * comparison the first time state changes.
+   *
+   * @param args - The arguments to this function
+   * @param args.eventType - The event type to register a payload for.
+   * @param args.getPayload - A function for retrieving the event payload.
+   */
+  registerInitialEventPayload<EventType extends Event['type']>({
+    eventType,
+    getPayload,
+  }: {
+    eventType: EventType;
+    getPayload: () => ExtractEventPayload<Event, EventType>;
+  }) {
+    this.#initialEventPayloadGetters.set(eventType, getPayload);
+  }
+
+  /**
+   * Publish an event.
+   *
+   * Publishes the given payload to all subscribers of the given event type.
+   *
+   * Note that this method should never throw directly. Any errors from
+   * subscribers are captured and re-thrown in a timeout handler.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param payload - The event payload. The type of the parameters for each event handler must
+   * match the type of this payload.
+   * @template EventType - A type union of Event type strings.
+   */
+  publish<EventType extends Event['type']>(
+    eventType: EventType,
+    ...payload: ExtractEventPayload<Event, EventType>
+  ) {
+    const subscribers = this.#events.get(eventType);
+
+    if (subscribers) {
+      for (const [handler, selector] of subscribers.entries()) {
+        try {
+          if (selector) {
+            const previousValue = this.#eventPayloadCache.get(handler);
+            const newValue = selector(...payload);
+
+            if (newValue !== previousValue) {
+              this.#eventPayloadCache.set(handler, newValue);
+              handler(newValue, previousValue);
+            }
+          } else {
+            (handler as GenericEventHandler)(...payload);
+          }
+        } catch (error) {
+          // Throw error after timeout so that it is capured as a console error
+          // (and by Sentry) without interrupting the event publishing.
+          setTimeout(() => {
+            throw error;
+          });
+        }
+      }
+    }
+  }
+
+  /**
+   * Subscribe to an event.
+   *
+   * Registers the given function as an event handler for the given event type.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param handler - The event handler. The type of the parameters for this event handler must
+   * match the type of the payload for this event type.
+   * @template EventType - A type union of Event type strings.
+   */
+  subscribe<EventType extends Event['type']>(
+    eventType: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
+  ): void;
+
+  /**
+   * Subscribe to an event, with a selector.
+   *
+   * Registers the given handler function as an event handler for the given
+   * event type. When an event is published, its payload is first passed to the
+   * selector. The event handler is only called if the selector's return value
+   * differs from its last known return value.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param handler - The event handler. The type of the parameters for this event
+   * handler must match the return type of the selector.
+   * @param selector - The selector function used to select relevant data from
+   * the event payload. The type of the parameters for this selector must match
+   * the type of the payload for this event type.
+   * @template EventType - A type union of Event type strings.
+   * @template SelectorReturnValue - The selector return value.
+   */
+  subscribe<EventType extends Event['type'], SelectorReturnValue>(
+    eventType: EventType,
+    handler: SelectorEventHandler<SelectorReturnValue>,
+    selector: SelectorFunction<Event, EventType, SelectorReturnValue>,
+  ): void;
+
+  subscribe<EventType extends Event['type'], SelectorReturnValue>(
+    eventType: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
+    selector?: SelectorFunction<Event, EventType, SelectorReturnValue>,
+  ): void {
+    let subscribers = this.#events.get(eventType);
+    if (!subscribers) {
+      subscribers = new Map();
+      this.#events.set(eventType, subscribers);
+    }
+
+    subscribers.set(handler, selector);
+
+    if (selector) {
+      const getPayload = this.#initialEventPayloadGetters.get(eventType);
+      if (getPayload) {
+        const initialValue = selector(...getPayload());
+        this.#eventPayloadCache.set(handler, initialValue);
+      }
+    }
+  }
+
+  /**
+   * Unsubscribe from an event.
+   *
+   * Unregisters the given function as an event handler for the given event.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param handler - The event handler to unregister.
+   * @throws Will throw when the given event handler is not registered for this event.
+   * @template EventType - A type union of Event type strings.
+   */
+  unsubscribe<EventType extends Event['type']>(
+    eventType: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
+  ) {
+    const subscribers = this.#events.get(eventType);
+
+    if (!subscribers || !subscribers.has(handler)) {
+      throw new Error(`Subscription not found for event: ${eventType}`);
+    }
+
+    const selector = subscribers.get(handler);
+    if (selector) {
+      this.#eventPayloadCache.delete(handler);
+    }
+
+    subscribers.delete(handler);
+  }
+
+  /**
+   * Clear subscriptions for a specific event.
+   *
+   * This will remove all subscribed handlers for this event.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @template EventType - A type union of Event type strings.
+   */
+  clearEventSubscriptions<EventType extends Event['type']>(
+    eventType: EventType,
+  ) {
+    this.#events.delete(eventType);
+  }
+
+  /**
+   * Clear all subscriptions.
+   *
+   * This will remove all subscribed handlers for all events.
+   */
+  clearSubscriptions() {
+    this.#events.clear();
+  }
+
+  /**
+   * Get a restricted messenger
+   *
+   * Returns a wrapper around the messenger instance that restricts access to actions and events.
+   * The provided allowlists grant the ability to call the listed actions and subscribe to the
+   * listed events. The "name" provided grants ownership of any actions and events under that
+   * namespace. Ownership allows registering actions and publishing events, as well as
+   * unregistering actions and clearing event subscriptions.
+   *
+   * @param options - Messenger options.
+   * @param options.name - The name of the thing this messenger will be handed to (e.g. the
+   * controller name). This grants "ownership" of actions and events under this namespace to the
+   * restricted messenger returned.
+   * @param options.allowedActions - The list of actions that this restricted messenger should be
+   * allowed to call.
+   * @param options.allowedEvents - The list of events that this restricted messenger should be
+   * allowed to subscribe to.
+   * @template Namespace - The namespace for this messenger. Typically this is the name of the
+   * module that this messenger has been created for. The authority to publish events and register
+   * actions under this namespace is granted to this restricted messenger instance.
+   * @template AllowedAction - A type union of the 'type' string for any allowed actions.
+   * This must not include internal actions that are in the messenger's namespace.
+   * @template AllowedEvent - A type union of the 'type' string for any allowed events.
+   * This must not include internal events that are in the messenger's namespace.
+   * @returns The restricted messenger.
+   */
+  getRestricted<
+    Namespace extends string,
+    AllowedAction extends NotNamespacedBy<Namespace, Action['type']> = never,
+    AllowedEvent extends NotNamespacedBy<Namespace, Event['type']> = never,
+  >({
+    name,
+    allowedActions,
+    allowedEvents,
+  }: {
+    name: Namespace;
+    allowedActions: NotNamespacedBy<
+      Namespace,
+      Extract<Action['type'], AllowedAction>
+    >[];
+    allowedEvents: NotNamespacedBy<
+      Namespace,
+      Extract<Event['type'], AllowedEvent>
+    >[];
+  }): RestrictedMessenger<
+    Namespace,
+    | NarrowToNamespace<Action, Namespace>
+    | NarrowToAllowed<Action, AllowedAction>,
+    NarrowToNamespace<Event, Namespace> | NarrowToAllowed<Event, AllowedEvent>,
+    AllowedAction,
+    AllowedEvent
+  > {
+    return new RestrictedMessenger({
+      messenger: this,
+      name,
+      allowedActions,
+      allowedEvents,
+    });
+  }
+}

--- a/packages/messenger/src/RestrictedMessenger.test.ts
+++ b/packages/messenger/src/RestrictedMessenger.test.ts
@@ -1,0 +1,1330 @@
+import sinon from 'sinon';
+
+import { Messenger } from './Messenger';
+import { RestrictedMessenger } from './RestrictedMessenger';
+
+describe('RestrictedMessenger', () => {
+  describe('constructor', () => {
+    it('should throw if no messenger is provided', () => {
+      expect(
+        () =>
+          new RestrictedMessenger({
+            name: 'Test',
+            allowedActions: [],
+            allowedEvents: [],
+          }),
+      ).toThrow('Messenger not provided');
+    });
+
+    it('should accept messenger parameter', () => {
+      type CountAction = {
+        type: 'CountController:count';
+        handler: (increment: number) => void;
+      };
+      const messenger = new Messenger<CountAction, never>();
+      const restrictedMessenger = new RestrictedMessenger<
+        'CountController',
+        CountAction,
+        never,
+        never,
+        never
+      >({
+        messenger,
+        name: 'CountController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+
+      let count = 0;
+      restrictedMessenger.registerActionHandler(
+        'CountController:count',
+        (increment: number) => {
+          count += increment;
+        },
+      );
+      restrictedMessenger.call('CountController:count', 1);
+
+      expect(count).toBe(1);
+    });
+  });
+
+  it('should allow registering and calling an action handler', () => {
+    type CountAction = {
+      type: 'CountController:count';
+      handler: (increment: number) => void;
+    };
+    const messenger = new Messenger<CountAction, never>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    let count = 0;
+    restrictedMessenger.registerActionHandler(
+      'CountController:count',
+      (increment: number) => {
+        count += increment;
+      },
+    );
+    restrictedMessenger.call('CountController:count', 1);
+
+    expect(count).toBe(1);
+  });
+
+  it('should allow registering and calling multiple different action handlers', () => {
+    type MessageAction =
+      | { type: 'MessageController:concat'; handler: (message: string) => void }
+      | {
+          type: 'MessageController:reset';
+          handler: (initialMessage: string) => void;
+        };
+    const messenger = new Messenger<MessageAction, never>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    let message = '';
+    restrictedMessenger.registerActionHandler(
+      'MessageController:reset',
+      (initialMessage: string) => {
+        message = initialMessage;
+      },
+    );
+
+    restrictedMessenger.registerActionHandler(
+      'MessageController:concat',
+      (s: string) => {
+        message += s;
+      },
+    );
+
+    restrictedMessenger.call('MessageController:reset', 'hello');
+    restrictedMessenger.call('MessageController:concat', ', world');
+
+    expect(message).toBe('hello, world');
+  });
+
+  it('should allow registering and calling an action handler with no parameters', () => {
+    type IncrementAction = {
+      type: 'CountController:increment';
+      handler: () => void;
+    };
+    const messenger = new Messenger<IncrementAction, never>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    let count = 0;
+    restrictedMessenger.registerActionHandler(
+      'CountController:increment',
+      () => {
+        count += 1;
+      },
+    );
+    restrictedMessenger.call('CountController:increment');
+
+    expect(count).toBe(1);
+  });
+
+  it('should allow registering and calling an action handler with multiple parameters', () => {
+    type MessageAction = {
+      type: 'MessageController:message';
+      handler: (to: string, message: string) => void;
+    };
+    const messenger = new Messenger<MessageAction, never>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const messages: Record<string, string> = {};
+    restrictedMessenger.registerActionHandler(
+      'MessageController:message',
+      (to, message) => {
+        messages[to] = message;
+      },
+    );
+
+    restrictedMessenger.call('MessageController:message', '0x123', 'hello');
+
+    expect(messages['0x123']).toBe('hello');
+  });
+
+  it('should allow registering and calling an action handler with a return value', () => {
+    type AddAction = {
+      type: 'MathController:add';
+      handler: (a: number, b: number) => number;
+    };
+    const messenger = new Messenger<AddAction, never>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MathController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    restrictedMessenger.registerActionHandler('MathController:add', (a, b) => {
+      return a + b;
+    });
+    const result = restrictedMessenger.call('MathController:add', 5, 10);
+
+    expect(result).toBe(15);
+  });
+
+  it('should not allow registering multiple action handlers under the same name', () => {
+    type CountAction = { type: 'PingController:ping'; handler: () => void };
+    const messenger = new Messenger<CountAction, never>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'PingController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    restrictedMessenger.registerActionHandler(
+      'PingController:ping',
+      () => undefined,
+    );
+
+    expect(() => {
+      restrictedMessenger.registerActionHandler(
+        'PingController:ping',
+        () => undefined,
+      );
+    }).toThrow('A handler for PingController:ping has already been registered');
+  });
+
+  it('should throw when registering an external action as an action handler', () => {
+    type CountAction = {
+      type: 'CountController:count';
+      handler: (increment: number) => void;
+    };
+    const messenger = new Messenger<CountAction, never>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    expect(() => {
+      restrictedMessenger.registerActionHandler(
+        // @ts-expect-error: suppressing to test runtime error handling
+        'OtherController:other',
+        () => undefined,
+      );
+    }).toThrow(
+      `Only allowed registering action handlers prefixed by 'CountController:'`,
+    );
+  });
+
+  it('should throw when publishing an event that is not in the current namespace', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    expect(() => {
+      restrictedMessenger.subscribe(
+        // @ts-expect-error: suppressing to test runtime error handling
+        'OtherController:other',
+        () => undefined,
+      );
+    }).toThrow(`Event missing from allow list: OtherController:other`);
+  });
+
+  it('should throw when publishing an external event', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    type OtherEvent = {
+      type: 'OtherController:other';
+      payload: [unknown];
+    };
+    const messenger = new Messenger<never, MessageEvent | OtherEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['OtherController:other'],
+    });
+
+    expect(() => {
+      restrictedMessenger.publish(
+        // @ts-expect-error: suppressing to test runtime error handling
+        'OtherController:other',
+        () => undefined,
+      );
+    }).toThrow(
+      `Only allowed publishing events prefixed by 'MessageController:'`,
+    );
+  });
+
+  it('should throw when unsubscribing to an event that is not an allowed event', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    expect(() => {
+      restrictedMessenger.unsubscribe(
+        // @ts-expect-error: suppressing to test runtime error handling
+        'OtherController:other',
+        () => undefined,
+      );
+    }).toThrow(`Event missing from allow list: OtherController:other`);
+  });
+
+  it('should throw when clearing the subscription for an external event', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    type OtherEvent = {
+      type: 'OtherController:other';
+      payload: [unknown];
+    };
+    const messenger = new Messenger<never, MessageEvent | OtherEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['OtherController:other'],
+    });
+
+    expect(() => {
+      restrictedMessenger.clearEventSubscriptions(
+        // @ts-expect-error: suppressing to test runtime error handling
+        'OtherController:other',
+      );
+    }).toThrow(`Only allowed clearing events prefixed by 'MessageController:'`);
+  });
+
+  it('should throw when calling an external action that is not an allowed action', () => {
+    type CountAction = {
+      type: 'CountController:count';
+      handler: (increment: number) => void;
+    };
+    const messenger = new Messenger<CountAction, never>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'PingController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    expect(() => {
+      // @ts-expect-error suppressing to test runtime error handling
+      restrictedMessenger.call('CountController:count');
+    }).toThrow('Action missing from allow list: CountController:count');
+  });
+
+  it('should throw when registering an external action handler', () => {
+    type CountAction = {
+      type: 'CountController:count';
+      handler: (increment: number) => void;
+    };
+    const messenger = new Messenger<CountAction, never>();
+    const restrictedMessenger = messenger.getRestricted<
+      'PingController',
+      CountAction['type']
+    >({
+      name: 'PingController',
+      allowedActions: ['CountController:count'],
+      allowedEvents: [],
+    });
+
+    expect(() => {
+      restrictedMessenger.registerActionHandler(
+        // @ts-expect-error suppressing to test runtime error handling
+        'CountController:count',
+        () => undefined,
+      );
+    }).toThrow(
+      `Only allowed registering action handlers prefixed by 'PingController:'`,
+    );
+  });
+
+  it('should throw when unregistering an external action handler', () => {
+    type CountAction = {
+      type: 'CountController:count';
+      handler: (increment: number) => void;
+    };
+    const messenger = new Messenger<CountAction, never>();
+    const restrictedMessenger = messenger.getRestricted<
+      'PingController',
+      CountAction['type']
+    >({
+      name: 'PingController',
+      allowedActions: ['CountController:count'],
+      allowedEvents: [],
+    });
+    expect(() => {
+      restrictedMessenger.unregisterActionHandler(
+        // @ts-expect-error suppressing to test runtime error handling
+        'CountController:count',
+      );
+    }).toThrow(
+      `Only allowed unregistering action handlers prefixed by 'PingController:'`,
+    );
+  });
+
+  it('should throw when calling unregistered action', () => {
+    type PingAction = { type: 'PingController:ping'; handler: () => void };
+    const messenger = new Messenger<PingAction, never>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'PingController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    expect(() => {
+      restrictedMessenger.call('PingController:ping');
+    }).toThrow('A handler for PingController:ping has not been registered');
+  });
+
+  it('should throw when calling an action that has been unregistered', () => {
+    type PingAction = { type: 'PingController:ping'; handler: () => void };
+    const messenger = new Messenger<PingAction, never>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'PingController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    expect(() => {
+      restrictedMessenger.call('PingController:ping');
+    }).toThrow('A handler for PingController:ping has not been registered');
+
+    let pingCount = 0;
+    restrictedMessenger.registerActionHandler('PingController:ping', () => {
+      pingCount += 1;
+    });
+
+    restrictedMessenger.unregisterActionHandler('PingController:ping');
+
+    expect(() => {
+      restrictedMessenger.call('PingController:ping');
+    }).toThrow('A handler for PingController:ping has not been registered');
+    expect(pingCount).toBe(0);
+  });
+
+  it('should throw when registering an initial event payload outside of the namespace', () => {
+    type MessageEvent = {
+      type: 'OtherController:complexMessage';
+      payload: [Record<string, unknown>];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    expect(() =>
+      restrictedMessenger.registerInitialEventPayload({
+        // @ts-expect-error suppressing to test runtime error handling
+        eventType: 'OtherController:complexMessage',
+        // @ts-expect-error suppressing to test runtime error handling
+        getPayload: () => [{}],
+      }),
+    ).toThrow(
+      `Only allowed publishing events prefixed by 'MessageController:'`,
+    );
+  });
+
+  it('should publish event to subscriber', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const handler = sinon.stub();
+    restrictedMessenger.subscribe('MessageController:message', handler);
+    restrictedMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBe(true);
+    expect(handler.callCount).toBe(1);
+  });
+
+  describe('on first state change with an initial payload function registered', () => {
+    it('should publish event if selected payload differs', () => {
+      const state = {
+        propA: 1,
+        propB: 1,
+      };
+      type MessageEvent = {
+        type: 'MessageController:complexMessage';
+        payload: [typeof state];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+      restrictedMessenger.registerInitialEventPayload({
+        eventType: 'MessageController:complexMessage',
+        getPayload: () => [state],
+      });
+      const handler = sinon.stub();
+      const selector = sinon.fake((obj: Record<string, unknown>) => obj.propA);
+      restrictedMessenger.subscribe(
+        'MessageController:complexMessage',
+        handler,
+        selector,
+      );
+
+      state.propA += 1;
+      restrictedMessenger.publish('MessageController:complexMessage', state);
+
+      expect(handler.getCall(0)?.args).toStrictEqual([2, 1]);
+      expect(handler.callCount).toBe(1);
+    });
+
+    it('should not publish event if selected payload is the same', () => {
+      const state = {
+        propA: 1,
+        propB: 1,
+      };
+      type MessageEvent = {
+        type: 'MessageController:complexMessage';
+        payload: [typeof state];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+      restrictedMessenger.registerInitialEventPayload({
+        eventType: 'MessageController:complexMessage',
+        getPayload: () => [state],
+      });
+      const handler = sinon.stub();
+      const selector = sinon.fake((obj: Record<string, unknown>) => obj.propA);
+      restrictedMessenger.subscribe(
+        'MessageController:complexMessage',
+        handler,
+        selector,
+      );
+
+      restrictedMessenger.publish('MessageController:complexMessage', state);
+
+      expect(handler.callCount).toBe(0);
+    });
+  });
+
+  describe('on first state change without an initial payload function registered', () => {
+    it('should publish event if selected payload differs', () => {
+      const state = {
+        propA: 1,
+        propB: 1,
+      };
+      type MessageEvent = {
+        type: 'MessageController:complexMessage';
+        payload: [typeof state];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+      const handler = sinon.stub();
+      const selector = sinon.fake((obj: Record<string, unknown>) => obj.propA);
+      restrictedMessenger.subscribe(
+        'MessageController:complexMessage',
+        handler,
+        selector,
+      );
+
+      state.propA += 1;
+      restrictedMessenger.publish('MessageController:complexMessage', state);
+
+      expect(handler.getCall(0)?.args).toStrictEqual([2, undefined]);
+      expect(handler.callCount).toBe(1);
+    });
+
+    it('should publish event even when selected payload does not change', () => {
+      const state = {
+        propA: 1,
+        propB: 1,
+      };
+      type MessageEvent = {
+        type: 'MessageController:complexMessage';
+        payload: [typeof state];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+      const handler = sinon.stub();
+      const selector = sinon.fake((obj: Record<string, unknown>) => obj.propA);
+      restrictedMessenger.subscribe(
+        'MessageController:complexMessage',
+        handler,
+        selector,
+      );
+
+      restrictedMessenger.publish('MessageController:complexMessage', state);
+
+      expect(handler.getCall(0)?.args).toStrictEqual([1, undefined]);
+      expect(handler.callCount).toBe(1);
+    });
+
+    it('should not publish if selector returns undefined', () => {
+      const state = {
+        propA: undefined,
+        propB: 1,
+      };
+      type MessageEvent = {
+        type: 'MessageController:complexMessage';
+        payload: [typeof state];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+      const handler = sinon.stub();
+      const selector = sinon.fake((obj: Record<string, unknown>) => obj.propA);
+      restrictedMessenger.subscribe(
+        'MessageController:complexMessage',
+        handler,
+        selector,
+      );
+
+      restrictedMessenger.publish('MessageController:complexMessage', state);
+
+      expect(handler.callCount).toBe(0);
+    });
+  });
+
+  describe('on later state change', () => {
+    it('should call selector event handler with previous selector return value', () => {
+      type MessageEvent = {
+        type: 'MessageController:complexMessage';
+        payload: [Record<string, unknown>];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+
+      const handler = sinon.stub();
+      const selector = sinon.fake((obj: Record<string, unknown>) => obj.prop1);
+      messenger.subscribe(
+        'MessageController:complexMessage',
+        handler,
+        selector,
+      );
+      restrictedMessenger.publish('MessageController:complexMessage', {
+        prop1: 'a',
+        prop2: 'b',
+      });
+      restrictedMessenger.publish('MessageController:complexMessage', {
+        prop1: 'z',
+        prop2: 'b',
+      });
+
+      expect(handler.getCall(0).calledWithExactly('a', undefined)).toBe(true);
+      expect(handler.getCall(1).calledWithExactly('z', 'a')).toBe(true);
+      expect(handler.callCount).toBe(2);
+    });
+
+    it('should publish event with selector to subscriber', () => {
+      type MessageEvent = {
+        type: 'MessageController:complexMessage';
+        payload: [Record<string, unknown>];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+
+      const handler = sinon.stub();
+      const selector = sinon.fake((obj: Record<string, unknown>) => obj.prop1);
+      restrictedMessenger.subscribe(
+        'MessageController:complexMessage',
+        handler,
+        selector,
+      );
+      restrictedMessenger.publish('MessageController:complexMessage', {
+        prop1: 'a',
+        prop2: 'b',
+      });
+
+      expect(handler.calledWithExactly('a', undefined)).toBe(true);
+      expect(handler.callCount).toBe(1);
+    });
+
+    it('should not publish event with selector if selector return value is unchanged', () => {
+      type MessageEvent = {
+        type: 'MessageController:complexMessage';
+        payload: [Record<string, unknown>];
+      };
+      const messenger = new Messenger<never, MessageEvent>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'MessageController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+
+      const handler = sinon.stub();
+      const selector = sinon.fake((obj: Record<string, unknown>) => obj.prop1);
+      restrictedMessenger.subscribe(
+        'MessageController:complexMessage',
+        handler,
+        selector,
+      );
+      restrictedMessenger.publish('MessageController:complexMessage', {
+        prop1: 'a',
+        prop2: 'b',
+      });
+      restrictedMessenger.publish('MessageController:complexMessage', {
+        prop1: 'a',
+        prop3: 'c',
+      });
+
+      expect(handler.calledWithExactly('a', undefined)).toBe(true);
+      expect(handler.callCount).toBe(1);
+    });
+  });
+
+  it('should allow publishing multiple different events to subscriber', () => {
+    type MessageEvent =
+      | { type: 'MessageController:message'; payload: [string] }
+      | { type: 'MessageController:ping'; payload: [] };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const messageHandler = sinon.stub();
+    const pingHandler = sinon.stub();
+    restrictedMessenger.subscribe('MessageController:message', messageHandler);
+
+    restrictedMessenger.subscribe('MessageController:ping', pingHandler);
+
+    restrictedMessenger.publish('MessageController:message', 'hello');
+    restrictedMessenger.publish('MessageController:ping');
+
+    expect(messageHandler.calledWithExactly('hello')).toBe(true);
+    expect(messageHandler.callCount).toBe(1);
+    expect(pingHandler.calledWithExactly()).toBe(true);
+    expect(pingHandler.callCount).toBe(1);
+  });
+
+  it('should publish event with no payload to subscriber', () => {
+    type PingEvent = { type: 'PingController:ping'; payload: [] };
+    const messenger = new Messenger<never, PingEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'PingController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const handler = sinon.stub();
+    restrictedMessenger.subscribe('PingController:ping', handler);
+    restrictedMessenger.publish('PingController:ping');
+
+    expect(handler.calledWithExactly()).toBe(true);
+    expect(handler.callCount).toBe(1);
+  });
+
+  it('should publish event with multiple payload parameters to subscriber', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string, string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const handler = sinon.stub();
+    restrictedMessenger.subscribe('MessageController:message', handler);
+
+    restrictedMessenger.publish('MessageController:message', 'hello', 'there');
+
+    expect(handler.calledWithExactly('hello', 'there')).toBe(true);
+    expect(handler.callCount).toBe(1);
+  });
+
+  it('should publish event once to subscriber even if subscribed multiple times', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const handler = sinon.stub();
+    restrictedMessenger.subscribe('MessageController:message', handler);
+
+    restrictedMessenger.subscribe('MessageController:message', handler);
+    restrictedMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBe(true);
+    expect(handler.callCount).toBe(1);
+  });
+
+  it('should publish event to many subscribers', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const handler1 = sinon.stub();
+    const handler2 = sinon.stub();
+    restrictedMessenger.subscribe('MessageController:message', handler1);
+
+    restrictedMessenger.subscribe('MessageController:message', handler2);
+    restrictedMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler1.calledWithExactly('hello')).toBe(true);
+    expect(handler1.callCount).toBe(1);
+    expect(handler2.calledWithExactly('hello')).toBe(true);
+    expect(handler2.callCount).toBe(1);
+  });
+
+  it('should not call subscriber after unsubscribing', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const handler = sinon.stub();
+    restrictedMessenger.subscribe('MessageController:message', handler);
+
+    restrictedMessenger.unsubscribe('MessageController:message', handler);
+    restrictedMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler.callCount).toBe(0);
+  });
+
+  it('should throw when unsubscribing when there are no subscriptions', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const handler = sinon.stub();
+    expect(() =>
+      restrictedMessenger.unsubscribe('MessageController:message', handler),
+    ).toThrow(`Subscription not found for event: MessageController:message`);
+  });
+
+  it('should throw when unsubscribing a handler that is not subscribed', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const handler1 = sinon.stub();
+    const handler2 = sinon.stub();
+    restrictedMessenger.subscribe('MessageController:message', handler1);
+
+    expect(() =>
+      restrictedMessenger.unsubscribe('MessageController:message', handler2),
+    ).toThrow(`Subscription not found for event: MessageController:message`);
+  });
+
+  it('should not call subscriber after clearing event subscriptions', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const handler = sinon.stub();
+    restrictedMessenger.subscribe('MessageController:message', handler);
+
+    restrictedMessenger.clearEventSubscriptions('MessageController:message');
+    restrictedMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler.callCount).toBe(0);
+  });
+
+  it('should not throw when clearing event that has no subscriptions', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    expect(() =>
+      restrictedMessenger.clearEventSubscriptions('MessageController:message'),
+    ).not.toThrow();
+  });
+
+  it('should allow calling an internal action', () => {
+    type CountAction = {
+      type: 'CountController:count';
+      handler: (increment: number) => void;
+    };
+    const messenger = new Messenger<CountAction, never>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    let count = 0;
+    restrictedMessenger.registerActionHandler(
+      'CountController:count',
+      (increment: number) => {
+        count += increment;
+      },
+    );
+    restrictedMessenger.call('CountController:count', 1);
+
+    expect(count).toBe(1);
+  });
+
+  it('should allow calling an external action', () => {
+    type CountAction = {
+      type: 'CountController:count';
+      handler: (increment: number) => void;
+    };
+    const messenger = new Messenger<CountAction, never>();
+    const externalRestrictedMessenger = messenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+    const restrictedMessenger = messenger.getRestricted<
+      'OtherController',
+      CountAction['type']
+    >({
+      name: 'OtherController',
+      allowedActions: ['CountController:count'],
+      allowedEvents: [],
+    });
+
+    let count = 0;
+    externalRestrictedMessenger.registerActionHandler(
+      'CountController:count',
+      (increment: number) => {
+        count += increment;
+      },
+    );
+    restrictedMessenger.call('CountController:count', 1);
+
+    expect(count).toBe(1);
+  });
+
+  it('should allow subscribing to an internal event', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const restrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    const handler = sinon.stub();
+    restrictedMessenger.subscribe('MessageController:message', handler);
+
+    restrictedMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBe(true);
+    expect(handler.callCount).toBe(1);
+  });
+
+  it('should allow subscribing to an external event', () => {
+    type MessageEvent = {
+      type: 'MessageController:message';
+      payload: [string];
+    };
+    const messenger = new Messenger<never, MessageEvent>();
+    const externalRestrictedMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+    const restrictedMessenger = messenger.getRestricted<
+      'OtherController',
+      never,
+      MessageEvent['type']
+    >({
+      name: 'OtherController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message'],
+    });
+
+    const handler = sinon.stub();
+    restrictedMessenger.subscribe('MessageController:message', handler);
+
+    externalRestrictedMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBe(true);
+    expect(handler.callCount).toBe(1);
+  });
+
+  it('should allow interacting with internal and external actions', () => {
+    type MessageAction =
+      | { type: 'MessageController:concat'; handler: (message: string) => void }
+      | {
+          type: 'MessageController:reset';
+          handler: (initialMessage: string) => void;
+        };
+    type CountAction = {
+      type: 'CountController:count';
+      handler: (increment: number) => void;
+    };
+    const messenger = new Messenger<MessageAction | CountAction, never>();
+
+    const messageMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: ['CountController:count'],
+      allowedEvents: [],
+    });
+    const countMessenger = messenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    let count = 0;
+    countMessenger.registerActionHandler(
+      'CountController:count',
+      (increment: number) => {
+        count += increment;
+      },
+    );
+
+    let fullMessage = '';
+    messageMessenger.registerActionHandler(
+      'MessageController:concat',
+      (message: string) => {
+        fullMessage += message;
+      },
+    );
+
+    messageMessenger.registerActionHandler(
+      'MessageController:reset',
+      (message: string) => {
+        fullMessage = message;
+      },
+    );
+
+    messageMessenger.call('MessageController:reset', 'hello');
+    messageMessenger.call('CountController:count', 1);
+
+    expect(fullMessage).toBe('hello');
+    expect(count).toBe(1);
+  });
+
+  it('should allow interacting with internal and external events', () => {
+    type MessageEvent =
+      | { type: 'MessageController:message'; payload: [string] }
+      | { type: 'MessageController:ping'; payload: [] };
+    type CountEvent = { type: 'CountController:update'; payload: [number] };
+    const messenger = new Messenger<never, MessageEvent | CountEvent>();
+
+    const messageMessenger = messenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['CountController:update'],
+    });
+    const countMessenger = messenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+
+    let pings = 0;
+    messageMessenger.subscribe('MessageController:ping', () => {
+      pings += 1;
+    });
+    let currentCount;
+    messageMessenger.subscribe('CountController:update', (newCount: number) => {
+      currentCount = newCount;
+    });
+    messageMessenger.publish('MessageController:ping');
+    countMessenger.publish('CountController:update', 10);
+
+    expect(pings).toBe(1);
+    expect(currentCount).toBe(10);
+  });
+
+  describe('registerMethodActionHandlers', () => {
+    it('should register action handlers for specified methods on the given messenger client', () => {
+      type TestActions =
+        | { type: 'TestService:getType'; handler: () => string }
+        | {
+            type: 'TestService:getCount';
+            handler: () => number;
+          };
+
+      const messenger = new Messenger<TestActions, never>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'TestService',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+
+      class TestService {
+        name = 'TestService';
+
+        getType() {
+          return 'api';
+        }
+
+        getCount() {
+          return 42;
+        }
+      }
+
+      const service = new TestService();
+      const methodNames = ['getType', 'getCount'] as const;
+
+      restrictedMessenger.registerMethodActionHandlers(service, methodNames);
+
+      const state = restrictedMessenger.call('TestService:getType');
+      expect(state).toBe('api');
+
+      const count = restrictedMessenger.call('TestService:getCount');
+      expect(count).toBe(42);
+    });
+
+    it('should bind action handlers to the given messenger client', () => {
+      type TestAction = {
+        type: 'TestService:getPrivateValue';
+        handler: () => string;
+      };
+      const messenger = new Messenger<TestAction, never>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'TestService',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+
+      class TestService {
+        name = 'TestService';
+
+        privateValue = 'secret';
+
+        getPrivateValue() {
+          return this.privateValue;
+        }
+      }
+
+      const service = new TestService();
+      restrictedMessenger.registerMethodActionHandlers(service, [
+        'getPrivateValue',
+      ]);
+
+      const result = restrictedMessenger.call('TestService:getPrivateValue');
+      expect(result).toBe('secret');
+    });
+
+    it('should handle async methods', async () => {
+      type TestAction = {
+        type: 'TestService:fetchData';
+        handler: (id: string) => Promise<string>;
+      };
+      const messenger = new Messenger<TestAction, never>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'TestService',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+
+      class TestService {
+        name = 'TestService';
+
+        async fetchData(id: string) {
+          return `data-${id}`;
+        }
+      }
+
+      const service = new TestService();
+      restrictedMessenger.registerMethodActionHandlers(service, ['fetchData']);
+
+      const result = await restrictedMessenger.call(
+        'TestService:fetchData',
+        '123',
+      );
+      expect(result).toBe('data-123');
+    });
+
+    it('should not throw when given an empty methodNames array', () => {
+      type TestAction = { type: 'TestController:test'; handler: () => void };
+      const messenger = new Messenger<TestAction, never>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'TestController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+
+      class TestController {
+        name = 'TestController';
+      }
+
+      const controller = new TestController();
+      const methodNames: readonly string[] = [];
+
+      expect(() => {
+        restrictedMessenger.registerMethodActionHandlers(
+          controller,
+          methodNames as never[],
+        );
+      }).not.toThrow();
+    });
+
+    it('should skip non-function properties', () => {
+      type TestAction = {
+        type: 'TestController:getValue';
+        handler: () => string;
+      };
+      const messenger = new Messenger<TestAction, never>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'TestController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+
+      class TestController {
+        name = 'TestController';
+
+        readonly nonFunction = 'not a function';
+
+        getValue() {
+          return 'test';
+        }
+      }
+
+      const controller = new TestController();
+      restrictedMessenger.registerMethodActionHandlers(controller, [
+        'getValue',
+      ]);
+
+      // getValue should be registered
+      expect(restrictedMessenger.call('TestController:getValue')).toBe('test');
+
+      // nonFunction should not be registered
+      expect(() => {
+        // @ts-expect-error - This is a test
+        restrictedMessenger.call('TestController:nonFunction');
+      }).toThrow(
+        'A handler for TestController:nonFunction has not been registered',
+      );
+    });
+
+    it('should work with class inheritance', () => {
+      type TestActions =
+        | { type: 'ChildController:baseMethod'; handler: () => string }
+        | { type: 'ChildController:childMethod'; handler: () => string };
+
+      const messenger = new Messenger<TestActions, never>();
+      const restrictedMessenger = messenger.getRestricted({
+        name: 'ChildController',
+        allowedActions: [],
+        allowedEvents: [],
+      });
+
+      class BaseController {
+        name = 'BaseController';
+
+        baseMethod() {
+          return 'base method';
+        }
+      }
+
+      class ChildController extends BaseController {
+        name = 'ChildController';
+
+        childMethod() {
+          return 'child method';
+        }
+      }
+
+      const controller = new ChildController();
+      restrictedMessenger.registerMethodActionHandlers(controller, [
+        'baseMethod',
+        'childMethod',
+      ]);
+
+      expect(restrictedMessenger.call('ChildController:baseMethod')).toBe(
+        'base method',
+      );
+      expect(restrictedMessenger.call('ChildController:childMethod')).toBe(
+        'child method',
+      );
+    });
+  });
+});

--- a/packages/messenger/src/RestrictedMessenger.ts
+++ b/packages/messenger/src/RestrictedMessenger.ts
@@ -1,0 +1,425 @@
+import type {
+  ActionConstraint,
+  ActionHandler,
+  Messenger,
+  EventConstraint,
+  ExtractActionParameters,
+  ExtractActionResponse,
+  ExtractEventHandler,
+  ExtractEventPayload,
+  NamespacedName,
+  NotNamespacedBy,
+  SelectorEventHandler,
+  SelectorFunction,
+} from './Messenger';
+
+/**
+ * A universal supertype of all `RestrictedMessenger` instances. This type can be assigned to any
+ * `RestrictedMessenger` type.
+ *
+ * @template Namespace - Name of the module this messenger is for. Optionally can be used to
+ * narrow this type to a constraint for the messenger of a specific module.
+ */
+export type RestrictedMessengerConstraint<Namespace extends string = string> =
+  RestrictedMessenger<
+    Namespace,
+    ActionConstraint,
+    EventConstraint,
+    string,
+    string
+  >;
+
+/**
+ * A restricted messenger.
+ *
+ * This acts as a wrapper around the messenger instance that restricts access to actions
+ * and events.
+ *
+ * @template Namespace - The namespace for this messenger. Typically this is the name of the controller or
+ * module that this messenger has been created for. The authority to publish events and register
+ * actions under this namespace is granted to this restricted messenger instance.
+ * @template Action - A type union of all Action types.
+ * @template Event - A type union of all Event types.
+ * @template AllowedAction - A type union of the 'type' string for any allowed actions.
+ * This must not include internal actions that are in the messenger's namespace.
+ * @template AllowedEvent - A type union of the 'type' string for any allowed events.
+ * This must not include internal events that are in the messenger's namespace.
+ */
+export class RestrictedMessenger<
+  Namespace extends string,
+  Action extends ActionConstraint,
+  Event extends EventConstraint,
+  AllowedAction extends string,
+  AllowedEvent extends string,
+> {
+  readonly #messenger: Messenger<ActionConstraint, EventConstraint>;
+
+  readonly #namespace: Namespace;
+
+  readonly #allowedActions: NotNamespacedBy<Namespace, AllowedAction>[];
+
+  readonly #allowedEvents: NotNamespacedBy<Namespace, AllowedEvent>[];
+
+  /**
+   * Constructs a restricted messenger
+   *
+   * The provided allowlists grant the ability to call the listed actions and subscribe to the
+   * listed events. The "name" provided grants ownership of any actions and events under that
+   * namespace. Ownership allows registering actions and publishing events, as well as
+   * unregistering actions and clearing event subscriptions.
+   *
+   * @param options - Options.
+   * @param options.messenger - The messenger instance that is being wrapped.
+   * @param options.name - The name of the thing this messenger will be handed to (e.g. the
+   * controller name). This grants "ownership" of actions and events under this namespace to the
+   * restricted messenger returned.
+   * @param options.allowedActions - The list of actions that this restricted messenger should be
+   * allowed to call.
+   * @param options.allowedEvents - The list of events that this restricted messenger should be
+   * allowed to subscribe to.
+   */
+  constructor({
+    messenger,
+    name,
+    allowedActions,
+    allowedEvents,
+  }: {
+    messenger?: Messenger<ActionConstraint, EventConstraint>;
+    name: Namespace;
+    allowedActions: NotNamespacedBy<Namespace, AllowedAction>[];
+    allowedEvents: NotNamespacedBy<Namespace, AllowedEvent>[];
+  }) {
+    if (!messenger) {
+      throw new Error('Messenger not provided');
+    }
+    // The above condition guarantees that one of these options is defined.
+    this.#messenger = messenger;
+    this.#namespace = name;
+    this.#allowedActions = allowedActions;
+    this.#allowedEvents = allowedEvents;
+  }
+
+  /**
+   * Register an action handler.
+   *
+   * This will make the registered function available to call via the `call` method.
+   *
+   * The action type this handler is registered under *must* be in the current namespace.
+   *
+   * @param action - The action type. This is a unique identifier for this action.
+   * @param handler - The action handler. This function gets called when the `call` method is
+   * invoked with the given action type.
+   * @throws Will throw if an action handler that is not in the current namespace is being registered.
+   * @template ActionType - A type union of Action type strings that are namespaced by Namespace.
+   */
+  registerActionHandler<
+    ActionType extends Action['type'] & NamespacedName<Namespace>,
+  >(action: ActionType, handler: ActionHandler<Action, ActionType>) {
+    /* istanbul ignore if */ // Branch unreachable with valid types
+    if (!this.#isInCurrentNamespace(action)) {
+      throw new Error(
+        `Only allowed registering action handlers prefixed by '${
+          this.#namespace
+        }:'`,
+      );
+    }
+    this.#messenger.registerActionHandler(action, handler);
+  }
+
+  /**
+   * Registers action handlers for a list of methods on a messenger client
+   *
+   * @param messengerClient - The object that is expected to make use of the messenger.
+   * @param methodNames - The names of the methods on the messenger client to register as action
+   * handlers
+   */
+  registerMethodActionHandlers<
+    MessengerClient extends { name: string },
+    MethodNames extends keyof MessengerClient & string,
+  >(messengerClient: MessengerClient, methodNames: readonly MethodNames[]) {
+    this.#messenger.registerMethodActionHandlers(messengerClient, methodNames);
+  }
+
+  /**
+   * Unregister an action handler.
+   *
+   * This will prevent this action from being called.
+   *
+   * The action type being unregistered *must* be in the current namespace.
+   *
+   * @param action - The action type. This is a unique identifier for this action.
+   * @throws Will throw if an action handler that is not in the current namespace is being unregistered.
+   * @template ActionType - A type union of Action type strings that are namespaced by Namespace.
+   */
+  unregisterActionHandler<
+    ActionType extends Action['type'] & NamespacedName<Namespace>,
+  >(action: ActionType) {
+    /* istanbul ignore if */ // Branch unreachable with valid types
+    if (!this.#isInCurrentNamespace(action)) {
+      throw new Error(
+        `Only allowed unregistering action handlers prefixed by '${
+          this.#namespace
+        }:'`,
+      );
+    }
+    this.#messenger.unregisterActionHandler(action);
+  }
+
+  /**
+   * Call an action.
+   *
+   * This function will call the action handler corresponding to the given action type, passing
+   * along any parameters given.
+   *
+   * The action type being called must be on the action allowlist.
+   *
+   * @param actionType - The action type. This is a unique identifier for this action.
+   * @param params - The action parameters. These must match the type of the parameters of the
+   * registered action handler.
+   * @throws Will throw when no handler has been registered for the given type.
+   * @template ActionType - A type union of allowed Action type strings.
+   * @returns The action return value.
+   */
+  call<
+    ActionType extends
+      | AllowedAction
+      | (Action['type'] & NamespacedName<Namespace>),
+  >(
+    actionType: ActionType,
+    ...params: ExtractActionParameters<Action, ActionType>
+  ): ExtractActionResponse<Action, ActionType> {
+    if (!this.#isAllowedAction(actionType)) {
+      throw new Error(`Action missing from allow list: ${actionType}`);
+    }
+    const response = this.#messenger.call<ActionType>(actionType, ...params);
+
+    return response;
+  }
+
+  /**
+   * Register a function for getting the initial payload for an event.
+   *
+   * This is used for events that represent a state change, where the payload is the state.
+   * Registering a function for getting the payload allows event selectors to have a point of
+   * comparison the first time state changes.
+   *
+   * The event type *must* be in the current namespace
+   *
+   * @param args - The arguments to this function
+   * @param args.eventType - The event type to register a payload for.
+   * @param args.getPayload - A function for retrieving the event payload.
+   */
+  registerInitialEventPayload<
+    EventType extends Event['type'] & NamespacedName<Namespace>,
+  >({
+    eventType,
+    getPayload,
+  }: {
+    eventType: EventType;
+    getPayload: () => ExtractEventPayload<Event, EventType>;
+  }) {
+    /* istanbul ignore if */ // Branch unreachable with valid types
+    if (!this.#isInCurrentNamespace(eventType)) {
+      throw new Error(
+        `Only allowed publishing events prefixed by '${this.#namespace}:'`,
+      );
+    }
+    this.#messenger.registerInitialEventPayload({
+      eventType,
+      getPayload,
+    });
+  }
+
+  /**
+   * Publish an event.
+   *
+   * Publishes the given payload to all subscribers of the given event type.
+   *
+   * The event type being published *must* be in the current namespace.
+   *
+   * @param event - The event type. This is a unique identifier for this event.
+   * @param payload - The event payload. The type of the parameters for each event handler must
+   * match the type of this payload.
+   * @throws Will throw if an event that is not in the current namespace is being published.
+   * @template EventType - A type union of Event type strings that are namespaced by Namespace.
+   */
+  publish<EventType extends Event['type'] & NamespacedName<Namespace>>(
+    event: EventType,
+    ...payload: ExtractEventPayload<Event, EventType>
+  ) {
+    /* istanbul ignore if */ // Branch unreachable with valid types
+    if (!this.#isInCurrentNamespace(event)) {
+      throw new Error(
+        `Only allowed publishing events prefixed by '${this.#namespace}:'`,
+      );
+    }
+    this.#messenger.publish(event, ...payload);
+  }
+
+  /**
+   * Subscribe to an event.
+   *
+   * Registers the given function as an event handler for the given event type.
+   *
+   * The event type being subscribed to must be on the event allowlist.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param handler - The event handler. The type of the parameters for this event handler must
+   * match the type of the payload for this event type.
+   * @throws Will throw if the given event is not an allowed event for this messenger.
+   * @template EventType - A type union of Event type strings.
+   */
+  subscribe<
+    EventType extends
+      | AllowedEvent
+      | (Event['type'] & NamespacedName<Namespace>),
+  >(eventType: EventType, handler: ExtractEventHandler<Event, EventType>): void;
+
+  /**
+   * Subscribe to an event, with a selector.
+   *
+   * Registers the given handler function as an event handler for the given
+   * event type. When an event is published, its payload is first passed to the
+   * selector. The event handler is only called if the selector's return value
+   * differs from its last known return value.
+   *
+   * The event type being subscribed to must be on the event allowlist.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param handler - The event handler. The type of the parameters for this event
+   * handler must match the return type of the selector.
+   * @param selector - The selector function used to select relevant data from
+   * the event payload. The type of the parameters for this selector must match
+   * the type of the payload for this event type.
+   * @throws Will throw if the given event is not an allowed event for this messenger.
+   * @template EventType - A type union of Event type strings.
+   * @template SelectorReturnValue - The selector return value.
+   */
+  subscribe<
+    EventType extends
+      | AllowedEvent
+      | (Event['type'] & NamespacedName<Namespace>),
+    SelectorReturnValue,
+  >(
+    eventType: EventType,
+    handler: SelectorEventHandler<SelectorReturnValue>,
+    selector: SelectorFunction<Event, EventType, SelectorReturnValue>,
+  ): void;
+
+  subscribe<
+    EventType extends
+      | AllowedEvent
+      | (Event['type'] & NamespacedName<Namespace>),
+    SelectorReturnValue,
+  >(
+    event: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
+    selector?: SelectorFunction<Event, EventType, SelectorReturnValue>,
+  ) {
+    if (!this.#isAllowedEvent(event)) {
+      throw new Error(`Event missing from allow list: ${event}`);
+    }
+
+    if (selector) {
+      return this.#messenger.subscribe(event, handler, selector);
+    }
+    return this.#messenger.subscribe(event, handler);
+  }
+
+  /**
+   * Unsubscribe from an event.
+   *
+   * Unregisters the given function as an event handler for the given event.
+   *
+   * The event type being unsubscribed to must be on the event allowlist.
+   *
+   * @param event - The event type. This is a unique identifier for this event.
+   * @param handler - The event handler to unregister.
+   * @throws Will throw if the given event is not an allowed event for this messenger.
+   * @template EventType - A type union of allowed Event type strings.
+   */
+  unsubscribe<
+    EventType extends
+      | AllowedEvent
+      | (Event['type'] & NamespacedName<Namespace>),
+  >(event: EventType, handler: ExtractEventHandler<Event, EventType>) {
+    if (!this.#isAllowedEvent(event)) {
+      throw new Error(`Event missing from allow list: ${event}`);
+    }
+    this.#messenger.unsubscribe(event, handler);
+  }
+
+  /**
+   * Clear subscriptions for a specific event.
+   *
+   * This will remove all subscribed handlers for this event.
+   *
+   * The event type being cleared *must* be in the current namespace.
+   *
+   * @param event - The event type. This is a unique identifier for this event.
+   * @throws Will throw if a subscription for an event that is not in the current namespace is being cleared.
+   * @template EventType - A type union of Event type strings that are namespaced by Namespace.
+   */
+  clearEventSubscriptions<
+    EventType extends Event['type'] & NamespacedName<Namespace>,
+  >(event: EventType) {
+    if (!this.#isInCurrentNamespace(event)) {
+      throw new Error(
+        `Only allowed clearing events prefixed by '${this.#namespace}:'`,
+      );
+    }
+    this.#messenger.clearEventSubscriptions(event);
+  }
+
+  /**
+   * Determine whether the given event type is allowed. Event types are
+   * allowed if they are in the current namespace or on the list of
+   * allowed events.
+   *
+   * @param eventType - The event type to check.
+   * @returns Whether the event type is allowed.
+   */
+  #isAllowedEvent(
+    eventType: Event['type'],
+  ): eventType is
+    | NamespacedName<Namespace>
+    | NotNamespacedBy<Namespace, AllowedEvent> {
+    // Safely upcast to allow runtime check
+    const allowedEvents: string[] | null = this.#allowedEvents;
+    return (
+      this.#isInCurrentNamespace(eventType) ||
+      (allowedEvents !== null && allowedEvents.includes(eventType))
+    );
+  }
+
+  /**
+   * Determine whether the given action type is allowed. Action types
+   * are allowed if they are in the current namespace or on the list of
+   * allowed actions.
+   *
+   * @param actionType - The action type to check.
+   * @returns Whether the action type is allowed.
+   */
+  #isAllowedAction(
+    actionType: Action['type'],
+  ): actionType is
+    | NamespacedName<Namespace>
+    | NotNamespacedBy<Namespace, AllowedAction> {
+    // Safely upcast to allow runtime check
+    const allowedActions: string[] | null = this.#allowedActions;
+    return (
+      this.#isInCurrentNamespace(actionType) ||
+      (allowedActions !== null && allowedActions.includes(actionType))
+    );
+  }
+
+  /**
+   * Determine whether the given name is within the current namespace.
+   *
+   * @param name - The name to check
+   * @returns Whether the name is within the current namespace
+   */
+  #isInCurrentNamespace(name: string): name is NamespacedName<Namespace> {
+    return name.startsWith(`${this.#namespace}:`);
+  }
+}

--- a/packages/messenger/src/index.test.ts
+++ b/packages/messenger/src/index.test.ts
@@ -1,0 +1,12 @@
+import * as allExports from '.';
+
+describe('@metamask/messenger', () => {
+  it('has expected JavaScript exports', () => {
+    expect(Object.keys(allExports)).toMatchInlineSnapshot(`
+      Array [
+        "Messenger",
+        "RestrictedMessenger",
+      ]
+    `);
+  });
+});

--- a/packages/messenger/src/index.ts
+++ b/packages/messenger/src/index.ts
@@ -1,0 +1,17 @@
+export type {
+  ActionHandler,
+  ExtractActionParameters,
+  ExtractActionResponse,
+  ExtractEventHandler,
+  ExtractEventPayload,
+  GenericEventHandler,
+  SelectorFunction,
+  ActionConstraint,
+  EventConstraint,
+  NamespacedBy,
+  NotNamespacedBy,
+  NamespacedName,
+} from './Messenger';
+export { Messenger } from './Messenger';
+export type { RestrictedMessengerConstraint } from './RestrictedMessenger';
+export { RestrictedMessenger } from './RestrictedMessenger';

--- a/packages/messenger/tsconfig.build.json
+++ b/packages/messenger/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.packages.build.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [],
+  "include": ["../../types", "./src"]
+}

--- a/packages/messenger/tsconfig.json
+++ b/packages/messenger/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  },
+  "references": [],
+  "include": ["../../types", "./src"]
+}

--- a/packages/messenger/typedoc.json
+++ b/packages/messenger/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "out": "docs",
+  "tsconfig": "./tsconfig.build.json"
+}

--- a/teams.json
+++ b/teams.json
@@ -23,6 +23,7 @@
   "metamask/keyring-controller": "team-accounts",
   "metamask/logging-controller": "team-confirmations",
   "metamask/message-manager": "team-confirmations",
+  "metamask/messenger": "team-wallet-framework",
   "metamask/multichain-api-middleware": "team-wallet-api-platform",
   "metamask/multichain-network-controller": "team-wallet-api-platform",
   "metamask/name-controller": "team-confirmations",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -27,6 +27,7 @@
     { "path": "./packages/keyring-controller/tsconfig.build.json" },
     { "path": "./packages/logging-controller/tsconfig.build.json" },
     { "path": "./packages/message-manager/tsconfig.build.json" },
+    { "path": "./packages/messenger/tsconfig.build.json" },
     { "path": "./packages/multichain-api-middleware/tsconfig.build.json" },
     { "path": "./packages/multichain-network-controller/tsconfig.build.json" },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     { "path": "./packages/json-rpc-middleware-stream" },
     { "path": "./packages/keyring-controller" },
     { "path": "./packages/message-manager" },
+    { "path": "./packages/messenger" },
     { "path": "./packages/multichain-api-middleware" },
     { "path": "./packages/multichain-network-controller" },
     { "path": "./packages/multichain-transactions-controller" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3783,6 +3783,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/messenger@workspace:packages/messenger":
+  version: 0.0.0-use.local
+  resolution: "@metamask/messenger@workspace:packages/messenger"
+  dependencies:
+    "@metamask/auto-changelog": "npm:^3.4.4"
+    "@types/jest": "npm:^27.4.1"
+    deepmerge: "npm:^4.2.2"
+    immer: "npm:^9.0.6"
+    jest: "npm:^27.5.1"
+    sinon: "npm:^9.2.4"
+    ts-jest: "npm:^27.1.4"
+    typedoc: "npm:^0.24.8"
+    typedoc-plugin-missing-exports: "npm:^2.0.0"
+    typescript: "npm:~5.2.2"
+  languageName: unknown
+  linkType: soft
+
 "@metamask/metamask-eth-abis@npm:^3.1.1":
   version: 3.1.1
   resolution: "@metamask/metamask-eth-abis@npm:3.1.1"


### PR DESCRIPTION
## Explanation

The `Messenger` class and related code has been copied from the `@metamask/base-controller` package to a new `@metamask/messenger` package. Separating the messenger from the base controller reduces the impact of base controller breaking changes, and aligns well with our plans to use the `Messenger` class more often for non-controllers.

This move will also simplify the effort to implement some new breaking changes to the `Messenger` class (the new `delegation` method, see issue #5626). This new package will not be released until the breaking changes have been applied here. Those changes will come in later PRs; for now, the code was copied over with zero changes.

## References

Related to #5626

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
