### PR TITLE
docs: Add missing step in "new package" docs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -380,7 +380,8 @@ problem, we have created a CLI that automates most of the job for us, creatively
    - By default, `create-package` gives your package an MIT license.
    - If your desired license is _not_ MIT, then you must update your `LICENSE` file and the
      `license` field of `package.json`.
-3. Add your dependencies.
+3. Update `.github/CODEOWNERS` and `teams.json` to assign a team as the owner of the new package.
+4. Add your dependencies.
    - Do this as normal using `yarn`.
    - Remember, if you are adding other monorepo packages as dependents, don't forget to add them
      to the `references` array in your package's `tsconfig.json` and `tsconfig.build.json`.


### PR DESCRIPTION
## Explanation

Add a missing step in the contributor documentation for creating a new package. The template covers most things, but the team ownership is at the root level and required by our Yarn constraints.

## References

N/A

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
