### PR TITLE
fix: Removed access token validation on wallet locked

### DIFF
--- a/packages/seedless-onboarding-controller/CHANGELOG.md
+++ b/packages/seedless-onboarding-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- remove `access_token` validation when the wallet is locked. ([#6133](https://github.com/MetaMask/core/pull/6133))
+
 ## [2.1.0]
 
 ### Added

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
@@ -211,7 +211,6 @@ async function withController<ReturnValue>(
   jest
     .spyOn(controller, 'checkMetadataAccessTokenExpired')
     .mockReturnValue(false);
-  jest.spyOn(controller, 'checkAccessTokenExpired').mockReturnValue(false);
 
   const { toprfClient } = controller;
   return await fn({
@@ -4799,103 +4798,6 @@ describe('SeedlessOnboardingController', () => {
             .mockRestore();
 
           const result = controller.checkMetadataAccessTokenExpired();
-          expect(result).toBe(true);
-        },
-      );
-    });
-  });
-
-  describe('checkAccessTokenExpired', () => {
-    const createMockJWTToken = (exp: number) => {
-      const payload = { exp };
-      const encodedPayload = btoa(JSON.stringify(payload));
-      return `header.${encodedPayload}.signature`;
-    };
-
-    it('should return false if access token is not expired', async () => {
-      const futureExp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
-      const validToken = createMockJWTToken(futureExp);
-
-      await withController(
-        {
-          state: getMockInitialControllerState({
-            withMockAuthenticatedUser: true,
-            accessToken: validToken,
-          }),
-        },
-        async ({ controller }) => {
-          // Restore the original implementation to test the real logic
-          jest.spyOn(controller, 'checkAccessTokenExpired').mockRestore();
-
-          const result = controller.checkAccessTokenExpired();
-          expect(result).toBe(false);
-        },
-      );
-    });
-
-    it('should return true if access token is expired', async () => {
-      const pastExp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
-      const expiredToken = createMockJWTToken(pastExp);
-
-      await withController(
-        {
-          state: getMockInitialControllerState({
-            withMockAuthenticatedUser: true,
-            accessToken: expiredToken,
-          }),
-        },
-        async ({ controller }) => {
-          // Restore the original implementation to test the real logic
-          jest.spyOn(controller, 'checkAccessTokenExpired').mockRestore();
-
-          const result = controller.checkAccessTokenExpired();
-          expect(result).toBe(true);
-        },
-      );
-    });
-
-    it('should return true if access token is missing', async () => {
-      const state = getMockInitialControllerState({
-        withMockAuthenticatedUser: true,
-      });
-      delete state.accessToken;
-      await withController(
-        {
-          state,
-        },
-        async ({ controller }) => {
-          // Restore the original implementation to test the real logic
-          jest.spyOn(controller, 'checkAccessTokenExpired').mockRestore();
-
-          const result = controller.checkAccessTokenExpired();
-          expect(result).toBe(true);
-        },
-      );
-    });
-
-    it('should return true if user is not authenticated', async () => {
-      await withController(async ({ controller }) => {
-        // Restore the original implementation to test the real logic
-        jest.spyOn(controller, 'checkAccessTokenExpired').mockRestore();
-
-        const result = controller.checkAccessTokenExpired();
-        expect(result).toBe(true);
-      });
-    });
-
-    it('should return true if token has invalid format', async () => {
-      await withController(
-        {
-          state: getMockInitialControllerState({
-            withMockAuthenticatedUser: true,
-            metadataAccessToken: 'invalid.token.format',
-          }),
-        },
-        async ({ controller }) => {
-          // Restore the original implementation to test the real logic
-          jest.spyOn(controller, 'checkAccessTokenExpired').mockRestore();
-
-          const result = controller.checkAccessTokenExpired();
           expect(result).toBe(true);
         },
       );

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -1801,7 +1801,13 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
       const isNodeAuthTokenExpired = this.checkNodeAuthTokenExpired();
       const isMetadataAccessTokenExpired =
         this.checkMetadataAccessTokenExpired();
-      const isAccessTokenExpired = this.checkAccessTokenExpired();
+
+      // access token is only accessible when the vault is unlocked
+      // so skip the check if the vault is locked
+      let isAccessTokenExpired = false;
+      if (this.#isUnlocked) {
+        isAccessTokenExpired = this.checkAccessTokenExpired();
+      }
 
       if (
         isNodeAuthTokenExpired ||
@@ -1882,12 +1888,8 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
   public checkAccessTokenExpired(): boolean {
     try {
       this.#assertIsAuthenticatedUser(this.state);
-      // access token is only accessible when the vault is unlocked
-      // so skip the check if the vault is locked
-      if (!this.#isUnlocked) {
-        return false;
-      }
       const { accessToken } = this.state;
+      console.log('checkAccessTokenExpired::accessToken', accessToken);
       if (!accessToken) {
         return true; // Consider missing token as expired
       }

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -275,7 +275,6 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
     revokeToken?: string;
     skipLock?: boolean;
   }) {
-    console.log('authenticate::params', params);
     const doAuthenticateWithNodes = async () => {
       try {
         const {
@@ -1889,7 +1888,6 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
     try {
       this.#assertIsAuthenticatedUser(this.state);
       const { accessToken } = this.state;
-      console.log('checkAccessTokenExpired::accessToken', accessToken);
       if (!accessToken) {
         return true; // Consider missing token as expired
       }

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -275,6 +275,7 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
     revokeToken?: string;
     skipLock?: boolean;
   }) {
+    console.log('authenticate::params', params);
     const doAuthenticateWithNodes = async () => {
       try {
         const {
@@ -1800,13 +1801,8 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
       const isNodeAuthTokenExpired = this.checkNodeAuthTokenExpired();
       const isMetadataAccessTokenExpired =
         this.checkMetadataAccessTokenExpired();
-      const isAccessTokenExpired = this.checkAccessTokenExpired();
 
-      if (
-        isNodeAuthTokenExpired ||
-        isMetadataAccessTokenExpired ||
-        isAccessTokenExpired
-      ) {
+      if (isNodeAuthTokenExpired || isMetadataAccessTokenExpired) {
         log(
           `JWT token expired during ${operationName}, attempting to refresh tokens`,
           'node auth token exp check',
@@ -1861,20 +1857,6 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
       const { metadataAccessToken } = this.state;
       // assertIsAuthenticatedUser will throw if metadataAccessToken is missing
       const decodedToken = decodeJWTToken(metadataAccessToken as string);
-      return decodedToken.exp < Math.floor(Date.now() / 1000);
-    } catch {
-      return true; // Consider unauthenticated user as having expired tokens
-    }
-  }
-
-  public checkAccessTokenExpired(): boolean {
-    try {
-      this.#assertIsAuthenticatedUser(this.state);
-      const { accessToken } = this.state;
-      if (!accessToken) {
-        return true; // Consider missing token as expired
-      }
-      const decodedToken = decodeJWTToken(accessToken);
       return decodedToken.exp < Math.floor(Date.now() / 1000);
     } catch {
       return true; // Consider unauthenticated user as having expired tokens

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -1801,13 +1801,7 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
       const isNodeAuthTokenExpired = this.checkNodeAuthTokenExpired();
       const isMetadataAccessTokenExpired =
         this.checkMetadataAccessTokenExpired();
-
-      // access token is only accessible when the vault is unlocked
-      // so skip the check if the vault is locked
-      let isAccessTokenExpired = false;
-      if (this.#isUnlocked) {
-        isAccessTokenExpired = this.checkAccessTokenExpired();
-      }
+      const isAccessTokenExpired = this.checkAccessTokenExpired();
 
       if (
         isNodeAuthTokenExpired ||
@@ -1862,6 +1856,11 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
     return decodedToken.exp < Date.now() / 1000;
   }
 
+  /**
+   * Check if the current metadata access token is expired.
+   *
+   * @returns True if the metadata access token is expired, false otherwise.
+   */
   public checkMetadataAccessTokenExpired(): boolean {
     try {
       this.#assertIsAuthenticatedUser(this.state);
@@ -1874,9 +1873,20 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
     }
   }
 
+  /**
+   * Check if the current access token is expired.
+   * When the vault is locked, the access token is not accessible, so we return false.
+   *
+   * @returns True if the access token is expired, false otherwise.
+   */
   public checkAccessTokenExpired(): boolean {
     try {
       this.#assertIsAuthenticatedUser(this.state);
+      // access token is only accessible when the vault is unlocked
+      // so skip the check if the vault is locked
+      if (!this.#isUnlocked) {
+        return false;
+      }
       const { accessToken } = this.state;
       if (!accessToken) {
         return true; // Consider missing token as expired


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR removes the `access_token` validation from the `checkIsPasswordOutdated` and `#executeWithTokenRefresh` when the wallet locked and the following issue.
The `checkIsPasswordOutdated` method can be called even when the wallet (vault) is locked but during the locked period, `access_token` is not accessible. This triggers the `refreshAuthToken` method whenever wallet is unlocked.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
