### PR TITLE
feat: Add Messenger `parent` parameter

### DIFF
--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - These allow delegating or revoking capabilities (actions or events) from one `Messenger` instance to another.
   - This allows passing capabilities through chains of messengers of arbitrary length
   - See this ADR for details: https://github.com/MetaMask/decisions/blob/main/decisions/core/0012-messenger-delegation.md
+- Add `parent` constructor parameter to `Messenger` ([#6142](https://github.com/MetaMask/core/pull/6142))
+  - All capabilities registered under this messenger's namespace are delegated to the parent automatically. This is similar to how the `RestrictedMessenger` would automatically delegate all capabilities to the messenger it was created from.
 
 ### Changed
 
@@ -25,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **BREAKING:** Remove `RestrictedMessenger` class ([#6132](https://github.com/MetaMask/core/pull/6132))
-  - Existing `RestrictedMessenger` instances should be replaced with a `Messenger`. We can now use the same class everywhere, passing capabilities using `delegate`.
+  - Existing `RestrictedMessenger` instances should be replaced with a `Messenger` with the `parent` constructor parameter set to the global messenger. We can now use the same class everywhere, passing capabilities using `delegate`.
   - See this ADR for details: https://github.com/MetaMask/decisions/blob/main/decisions/core/0012-messenger-delegation.md
 
 ### Fixed

--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - These allow delegating or revoking capabilities (actions or events) from one `Messenger` instance to another.
   - This allows passing capabilities through chains of messengers of arbitrary length
   - See this ADR for details: https://github.com/MetaMask/decisions/blob/main/decisions/core/0012-messenger-delegation.md
-- Add `parent` constructor parameter to `Messenger` ([#6142](https://github.com/MetaMask/core/pull/6142))
+- Add `parent` constructor parameter and type parameter to `Messenger` ([#6142](https://github.com/MetaMask/core/pull/6142))
   - All capabilities registered under this messenger's namespace are delegated to the parent automatically. This is similar to how the `RestrictedMessenger` would automatically delegate all capabilities to the messenger it was created from.
 
 ### Changed

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -34,7 +34,12 @@ describe('Messenger', () => {
     const parentMessenger = new Messenger<'Parent', CountAction, never>({
       namespace: 'Parent',
     });
-    const messenger = new Messenger<'Fixture', CountAction, never>({
+    const messenger = new Messenger<
+      'Fixture',
+      CountAction,
+      never,
+      typeof parentMessenger
+    >({
       namespace: 'Fixture',
       parent: parentMessenger,
     });
@@ -252,7 +257,12 @@ describe('Messenger', () => {
     const parentMessenger = new Messenger<'Parent', never, MessageEvent>({
       namespace: 'Parent',
     });
-    const messenger = new Messenger<'Fixture', never, MessageEvent>({
+    const messenger = new Messenger<
+      'Fixture',
+      never,
+      MessageEvent,
+      typeof parentMessenger
+    >({
       namespace: 'Fixture',
       parent: parentMessenger,
     });
@@ -565,7 +575,12 @@ describe('Messenger', () => {
     const parentMessenger = new Messenger<'Parent', never, MessageEvent>({
       namespace: 'Parent',
     });
-    const messenger = new Messenger<'Fixture', never, MessageEvent>({
+    const messenger = new Messenger<
+      'Fixture',
+      never,
+      MessageEvent,
+      typeof parentMessenger
+    >({
       namespace: 'Fixture',
       parent: parentMessenger,
     });
@@ -1289,7 +1304,12 @@ describe('Messenger', () => {
       const parentMessenger = new Messenger<'Parent', never, ExampleEvent>({
         namespace: 'Parent',
       });
-      const sourceMessenger = new Messenger<'Source', never, ExampleEvent>({
+      const sourceMessenger = new Messenger<
+        'Source',
+        never,
+        ExampleEvent,
+        typeof parentMessenger
+      >({
         namespace: 'Source',
         parent: parentMessenger,
       });

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -26,6 +26,28 @@ describe('Messenger', () => {
     expect(count).toBe(1);
   });
 
+  it('automatically delegates actions to parent upon registration', () => {
+    type CountAction = {
+      type: 'Fixture:count';
+      handler: (increment: number) => void;
+    };
+    const parentMessenger = new Messenger<'Parent', CountAction, never>({
+      namespace: 'Parent',
+    });
+    const messenger = new Messenger<'Fixture', CountAction, never>({
+      namespace: 'Fixture',
+      parent: parentMessenger,
+    });
+
+    let count = 0;
+    messenger.registerActionHandler('Fixture:count', (increment: number) => {
+      count += increment;
+    });
+    parentMessenger.call('Fixture:count', 1);
+
+    expect(count).toBe(1);
+  });
+
   it('should allow registering and calling multiple different action handlers', () => {
     // These 'Other' types are included to demonstrate that messenger generics can indeed be unions
     // of actions and events from different modules.
@@ -219,6 +241,24 @@ describe('Messenger', () => {
 
     const handler = sinon.stub();
     messenger.subscribe('Fixture:message', handler);
+    messenger.publish('Fixture:message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBe(true);
+    expect(handler.callCount).toBe(1);
+  });
+
+  it('automatically delegates events to parent upon first publish', () => {
+    type MessageEvent = { type: 'Fixture:message'; payload: [string] };
+    const parentMessenger = new Messenger<'Parent', never, MessageEvent>({
+      namespace: 'Parent',
+    });
+    const messenger = new Messenger<'Fixture', never, MessageEvent>({
+      namespace: 'Fixture',
+      parent: parentMessenger,
+    });
+
+    const handler = sinon.stub();
+    parentMessenger.subscribe('Fixture:message', handler);
     messenger.publish('Fixture:message', 'hello');
 
     expect(handler.calledWithExactly('hello')).toBe(true);
@@ -511,6 +551,42 @@ describe('Messenger', () => {
       expect(handler.calledWithExactly('a', undefined)).toBe(true);
       expect(handler.callCount).toBe(1);
     });
+  });
+
+  it('automatically delegates to parent when an initial payload is registered', () => {
+    const state = {
+      propA: 1,
+      propB: 1,
+    };
+    type MessageEvent = {
+      type: 'Fixture:complexMessage';
+      payload: [typeof state];
+    };
+    const parentMessenger = new Messenger<'Parent', never, MessageEvent>({
+      namespace: 'Parent',
+    });
+    const messenger = new Messenger<'Fixture', never, MessageEvent>({
+      namespace: 'Fixture',
+      parent: parentMessenger,
+    });
+    const handler = sinon.stub();
+
+    messenger.registerInitialEventPayload({
+      eventType: 'Fixture:complexMessage',
+      getPayload: () => [state],
+    });
+
+    parentMessenger.subscribe(
+      'Fixture:complexMessage',
+      handler,
+      (obj) => obj.propA,
+    );
+    messenger.publish('Fixture:complexMessage', state);
+    expect(handler.callCount).toBe(0);
+    state.propA += 1;
+    messenger.publish('Fixture:complexMessage', state);
+    expect(handler.getCall(0)?.args).toStrictEqual([2, 1]);
+    expect(handler.callCount).toBe(1);
   });
 
   it('should publish event to many subscribers with the same selector', () => {
@@ -1205,6 +1281,27 @@ describe('Messenger', () => {
   });
 
   describe('revoke', () => {
+    it('throws when attempting to revoke from parent', () => {
+      type ExampleEvent = {
+        type: 'Source:event';
+        payload: ['test'];
+      };
+      const parentMessenger = new Messenger<'Parent', never, ExampleEvent>({
+        namespace: 'Parent',
+      });
+      const sourceMessenger = new Messenger<'Source', never, ExampleEvent>({
+        namespace: 'Source',
+        parent: parentMessenger,
+      });
+
+      expect(() =>
+        sourceMessenger.revoke({
+          messenger: parentMessenger,
+          events: ['Source:event'],
+        }),
+      ).toThrow('Cannot revoke from parent');
+    });
+
     it('allows revoking a delegated event', () => {
       type ExampleEvent = {
         type: 'Source:event';

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -188,11 +188,7 @@ export class Messenger<
    * The parent messenger. All actions/events under this namespace are automatically delegated to
    * the parent messenger.
    */
-  readonly #parent?: Messenger<
-    string,
-    Action | ActionConstraint,
-    Event | EventConstraint
-  >;
+  readonly #parent?: DelegatedMessenger<Action, Event>;
 
   readonly #actions = new Map<Action['type'], Action['handler']>();
 
@@ -247,11 +243,7 @@ export class Messenger<
     parent,
   }: {
     namespace: Namespace;
-    parent?: Messenger<
-      string,
-      Action | ActionConstraint,
-      Event | EventConstraint
-    >;
+    parent?: DelegatedMessenger<Action, Event>;
   }) {
     this.#namespace = namespace;
     this.#parent = parent;


### PR DESCRIPTION
## Explanation

Add the `parent` constructor parameter to the `Messenger` class for automatic delegation of all capabilities under that messenger's namespace. This significantly reduces boilerplate, making the messenger easier to use in a similar manner to how the old `RestrictedMessenger` class wored.

See this ADR PR for details: MetaMask/decisions#53

## References

Depends upon #6132
Relates to #5626

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
