### PR TITLE
chore: Optimize "create-update-issues" script

### DIFF
--- a/scripts/create-update-issues.sh
+++ b/scripts/create-update-issues.sh
@@ -188,14 +188,14 @@ main() {
 
   local all_issues_extension
   if ! all_issues_extension=$(gh issue list --repo "$EXTENSION_REPO" --label "$DEFAULT_LABEL" --state open --json number,title,url 2>&1); then
-    echo "❌ Failed to fetch issues from ${repo}"
+    echo "❌ Failed to fetch issues from ${EXTENSION_REPO}"
     echo "$all_issues_extension"
     exit 1
   fi
 
   local all_issues_mobile
   if ! all_issues_mobile=$(gh issue list --repo "$MOBILE_REPO" --label "$DEFAULT_LABEL" --state open --json number,title,url 2>&1); then
-    echo "❌ Failed to fetch issues from ${repo}"
+    echo "❌ Failed to fetch issues from ${MOBILE_REPO}"
     echo "$all_issues_mobile"
     exit 1
   fi


### PR DESCRIPTION
## Explanation

The "fetch all issues" calls are now made once per repo rather than once per package per repo.

## References

This is a suggestion for #6090

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
