### PR TITLE
feat: Stop persisting `permissionActivityLog` state

### DIFF
--- a/packages/permission-log-controller/CHANGELOG.md
+++ b/packages/permission-log-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Stop persisting `permissionActivityLog` state ([#6156](https://github.com/MetaMask/core/pull/6156))
+  - This will require a migration to delete existing persisted state.
 - Bump `@metamask/utils` from `^11.2.0` to `^11.4.2` ([#6054](https://github.com/MetaMask/core/pull/6054))
 - Bump `@metamask/base-controller` from ^8.0.0 to ^8.0.1 ([#5722](https://github.com/MetaMask/core/pull/5722))
 

--- a/packages/permission-log-controller/src/PermissionLogController.ts
+++ b/packages/permission-log-controller/src/PermissionLogController.ts
@@ -110,7 +110,7 @@ export class PermissionLogController extends BaseController<
           anonymous: false,
         },
         permissionActivityLog: {
-          persist: true,
+          persist: false,
           anonymous: false,
         },
       },


### PR DESCRIPTION
## Explanation

The `permissionActivityLog` property of the `PermissionLogController` state tracks all calls to restricted methods. This was intended as a diagnostic aid, but in practice it is rarely used. This log is causing performance issues related to disk writes because it can be triggered while the wallet is idle (by snaps calling restricted methods).

To reduce the performance burden of this property, it is no longer persisted. This list will still be available in-memory for diagnosing problems, but will not be preserved across restarts.

## References

Relates to https://github.com/MetaMask/metamask-extension/issues/33879

Here is the draft PR of this update for `metamask-extension` that addresses the breaking changes: https://github.com/MetaMask/metamask-extension/pull/34465
This controller is not used by mobile, so there is no draft PR for mobile.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
