### PR TITLE
fix(multichain-account-service): add missing `name` class field

### DIFF
--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing `name` class field ([#6173](https://github.com/MetaMask/core/pull/6173))
+
 ## [0.2.0]
 
 ### Changed

--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -19,6 +19,8 @@ import { EvmAccountProvider } from './providers/EvmAccountProvider';
 import { SolAccountProvider } from './providers/SolAccountProvider';
 import type { MultichainAccountServiceMessenger } from './types';
 
+const serviceName = 'MultichainAccountService';
+
 /**
  * The options that {@link MultichainAccountService} takes.
  */
@@ -48,6 +50,11 @@ export class MultichainAccountService {
     MultichainAccountWalletId,
     MultichainAccountWallet<InternalAccount>
   >;
+
+  /**
+   * The name of the service.
+   */
+  name: typeof serviceName = serviceName;
 
   /**
    * Constructs a new MultichainAccountService.


### PR DESCRIPTION
## Explanation

This `.name` is required by the controller-init pattern on our clients, see:
- https://github.com/MetaMask/metamask-extension/blob/f1214299a2db41b310c31d14a7a15639c3f3c7b3/app/scripts/controller-init/types.ts#L23-L24

## References

N/A

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
