### PR TITLE
feat: Introduce new Launch Darkly environment types

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump peer dependency `@metamask/remote-feature-flag-controller` from `^1.6.0` to `^1.7.0` ([#6183](https://github.com/MetaMask/core/pull/6183))
+
 ## [37.1.0]
 
 ### Added

--- a/packages/bridge-controller/package.json
+++ b/packages/bridge-controller/package.json
@@ -70,7 +70,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/eth-json-rpc-provider": "^4.1.8",
     "@metamask/network-controller": "^24.0.1",
-    "@metamask/remote-feature-flag-controller": "^1.6.0",
+    "@metamask/remote-feature-flag-controller": "^1.7.0",
     "@metamask/snaps-controllers": "^14.0.1",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/transaction-controller": "^59.0.0",
@@ -89,7 +89,7 @@
     "@metamask/accounts-controller": "^32.0.0",
     "@metamask/assets-controllers": "^73.0.0",
     "@metamask/network-controller": "^24.0.0",
-    "@metamask/remote-feature-flag-controller": "^1.6.0",
+    "@metamask/remote-feature-flag-controller": "^1.7.0",
     "@metamask/snaps-controllers": "^14.0.0",
     "@metamask/transaction-controller": "^59.0.0"
   },

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `EnvironmentType` `Beta` and `Test`
+- Add `EnvironmentType` `Beta`, `Test`, and `Exp`
 
 ### Changed
 

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -86,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release of the RemoteFeatureFlagController. ([#4931](https://github.com/MetaMask/core/pull/4931))
   - This controller manages the retrieval and caching of remote feature flags. It fetches feature flags from a remote API, caches them, and provides methods to access and manage these flags. The controller ensures that feature flags are refreshed based on a specified interval and handles cases where the controller is disabled or the network is unavailable.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.6.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.7.0...HEAD
 [1.7.0]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.6.0...@metamask/remote-feature-flag-controller@1.7.0
 [1.6.0]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.5.0...@metamask/remote-feature-flag-controller@1.6.0
 [1.5.0]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.4.0...@metamask/remote-feature-flag-controller@1.5.0

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -11,14 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `EnvironmentType` `Beta`, `Test`, and `Exp`
+- Add `EnvironmentType` `Beta`, `Test`, and `Exp` ([#6183](https://github.com/MetaMask/core/pull/6183))
 
 ### Changed
 
 - Bump `@metamask/utils` from `^11.2.0` to `^11.4.2` ([#6054](https://github.com/MetaMask/core/pull/6054))
 - Bump `@metamask/base-controller` from ^8.0.0 to ^8.0.1 ([#5722](https://github.com/MetaMask/core/pull/5722))
 - Bump `@metamask/controller-utils` to `^11.11.0` ([#5935](https://github.com/MetaMask/core/pull/5935), [#5583](https://github.com/MetaMask/core/pull/5583), [#5765](https://github.com/MetaMask/core/pull/5765), [#5812](https://github.com/MetaMask/core/pull/5812), [#6069](https://github.com/MetaMask/core/pull/6069))
-- Deprecate `DistributionType` option `Beta` in favor of using `DistributionType` `Main` with `EnvironmentType` `Beta`
+- Deprecate `DistributionType` option `Beta` in favor of using `DistributionType` `Main` with `EnvironmentType` `Beta` ([#6183](https://github.com/MetaMask/core/pull/6183))
 
 ## [1.6.0]
 

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0]
+
+### Added
+
+- Add `EnvironmentType` `Beta` and `Test`
+
 ### Changed
 
 - Bump `@metamask/utils` from `^11.2.0` to `^11.4.2` ([#6054](https://github.com/MetaMask/core/pull/6054))
 - Bump `@metamask/base-controller` from ^8.0.0 to ^8.0.1 ([#5722](https://github.com/MetaMask/core/pull/5722))
 - Bump `@metamask/controller-utils` to `^11.11.0` ([#5935](https://github.com/MetaMask/core/pull/5935), [#5583](https://github.com/MetaMask/core/pull/5583), [#5765](https://github.com/MetaMask/core/pull/5765), [#5812](https://github.com/MetaMask/core/pull/5812), [#6069](https://github.com/MetaMask/core/pull/6069))
+- Deprecate `DistributionType` option `Beta` in favor of using `DistributionType` `Main` with `EnvironmentType` `Beta`
 
 ## [1.6.0]
 
@@ -80,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This controller manages the retrieval and caching of remote feature flags. It fetches feature flags from a remote API, caches them, and provides methods to access and manage these flags. The controller ensures that feature flags are refreshed based on a specified interval and handles cases where the controller is disabled or the network is unavailable.
 
 [Unreleased]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.6.0...HEAD
+[1.7.0]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.6.0...@metamask/remote-feature-flag-controller@1.7.0
 [1.6.0]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.5.0...@metamask/remote-feature-flag-controller@1.6.0
 [1.5.0]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.4.0...@metamask/remote-feature-flag-controller@1.5.0
 [1.4.0]: https://github.com/MetaMask/core/compare/@metamask/remote-feature-flag-controller@1.3.0...@metamask/remote-feature-flag-controller@1.4.0

--- a/packages/remote-feature-flag-controller/package.json
+++ b/packages/remote-feature-flag-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/remote-feature-flag-controller",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "The RemoteFeatureFlagController manages the retrieval and caching of remote feature flags",
   "keywords": [
     "MetaMask",

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-types.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-types.ts
@@ -22,6 +22,7 @@ export enum EnvironmentType {
   Development = 'dev',
   Beta = 'beta',
   Test = 'test',
+  Exp = 'exp',
 }
 
 /** Type representing the feature flags collection */

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-types.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-types.ts
@@ -10,6 +10,9 @@ export enum ClientType {
 export enum DistributionType {
   Main = 'main',
   Flask = 'flask',
+  /**
+   * @deprecated Use DistributionType Main with EnvironmentType Beta instead
+   */
   Beta = 'beta',
 }
 
@@ -17,6 +20,8 @@ export enum EnvironmentType {
   Production = 'prod',
   ReleaseCandidate = 'rc',
   Development = 'dev',
+  Beta = 'beta',
+  Test = 'test',
 }
 
 /** Type representing the feature flags collection */

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump peer dependency `@metamask/remote-feature-flag-controller` from `^1.6.0` to `^1.7.0` ([#6183](https://github.com/MetaMask/core/pull/6183))
+
 ## [59.0.0]
 
 ### Added

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -78,7 +78,7 @@
     "@metamask/ethjs-provider-http": "^0.3.0",
     "@metamask/gas-fee-controller": "^24.0.0",
     "@metamask/network-controller": "^24.0.1",
-    "@metamask/remote-feature-flag-controller": "^1.6.0",
+    "@metamask/remote-feature-flag-controller": "^1.7.0",
     "@types/bn.js": "^5.1.5",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.18.54",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,7 +2791,7 @@ __metadata:
     "@metamask/multichain-network-controller": "npm:^0.11.0"
     "@metamask/network-controller": "npm:^24.0.1"
     "@metamask/polling-controller": "npm:^14.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^1.6.0"
+    "@metamask/remote-feature-flag-controller": "npm:^1.7.0"
     "@metamask/snaps-controllers": "npm:^14.0.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/transaction-controller": "npm:^59.0.0"
@@ -2813,7 +2813,7 @@ __metadata:
     "@metamask/accounts-controller": ^32.0.0
     "@metamask/assets-controllers": ^73.0.0
     "@metamask/network-controller": ^24.0.0
-    "@metamask/remote-feature-flag-controller": ^1.6.0
+    "@metamask/remote-feature-flag-controller": ^1.7.0
     "@metamask/snaps-controllers": ^14.0.0
     "@metamask/transaction-controller": ^59.0.0
   languageName: unknown
@@ -4305,7 +4305,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/remote-feature-flag-controller@npm:^1.6.0, @metamask/remote-feature-flag-controller@workspace:packages/remote-feature-flag-controller":
+"@metamask/remote-feature-flag-controller@npm:^1.6.0, @metamask/remote-feature-flag-controller@npm:^1.7.0, @metamask/remote-feature-flag-controller@workspace:packages/remote-feature-flag-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/remote-feature-flag-controller@workspace:packages/remote-feature-flag-controller"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4305,7 +4305,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/remote-feature-flag-controller@npm:^1.6.0, @metamask/remote-feature-flag-controller@npm:^1.7.0, @metamask/remote-feature-flag-controller@workspace:packages/remote-feature-flag-controller":
+"@metamask/remote-feature-flag-controller@npm:^1.7.0, @metamask/remote-feature-flag-controller@workspace:packages/remote-feature-flag-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/remote-feature-flag-controller@workspace:packages/remote-feature-flag-controller"
   dependencies:
@@ -4672,7 +4672,7 @@ __metadata:
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^24.0.1"
     "@metamask/nonce-tracker": "npm:^6.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^1.6.0"
+    "@metamask/remote-feature-flag-controller": "npm:^1.7.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/utils": "npm:^11.4.2"
     "@types/bn.js": "npm:^5.1.5"


### PR DESCRIPTION
## Explanation

Platform team is working on unifying build commands. To introduce new commands we need to introduce additional LaunchDarkly EnvironmentType variables for them. Here is the target state: https://docs.google.com/spreadsheets/d/1tj3Pi2RpOmGs0cnQfv219khs7JSyzW8Raz7eHXlGBqE/edit?gid=0#gid=0

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
