### PR TITLE
call revoke token in background

### DIFF
--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -654,16 +654,27 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
         revokeToken,
       } = await this.#unlockVaultAndGetVaultData(password);
       this.#setUnlocked();
-
+      await this.#createNewVaultWithAuthData({
+        password,
+        rawToprfEncryptionKey: toprfEncryptionKey,
+        rawToprfPwEncryptionKey: toprfPwEncryptionKey,
+        rawToprfAuthKeyPair: toprfAuthKeyPair,
+      });
       if (revokeToken) {
-        await this.#revokeRefreshTokenAndUpdateState(revokeToken);
-        // re-creating vault to persist the new revoke token
-        await this.#createNewVaultWithAuthData({
-          password,
-          rawToprfEncryptionKey: toprfEncryptionKey,
-          rawToprfPwEncryptionKey: toprfPwEncryptionKey,
-          rawToprfAuthKeyPair: toprfAuthKeyPair,
-        });
+        // this call is not critical for unlocking, so we can do it in the background without await.
+        this.#revokeRefreshTokenAndUpdateState(revokeToken)
+          .then(() => {
+            // re-creating vault to persist the new revoke token
+            return this.#createNewVaultWithAuthData({
+              password,
+              rawToprfEncryptionKey: toprfEncryptionKey,
+              rawToprfPwEncryptionKey: toprfPwEncryptionKey,
+              rawToprfAuthKeyPair: toprfAuthKeyPair,
+            });
+          })
+          .catch((error) => {
+            log('Error revoking refresh token', error);
+          });
       }
     });
   }
@@ -759,18 +770,30 @@ export class SeedlessOnboardingController<EncryptionKey> extends BaseController<
         vaultKey,
       );
       this.#setUnlocked();
-
-      if (revokeToken) {
-        // revoke and recyle refresh token after unlock to keep refresh token fresh, avoid malicious use of leaked refresh token
-        await this.#revokeRefreshTokenAndUpdateState(revokeToken);
-      }
-      // re-creating vault to persist the new revoke token
       await this.#createNewVaultWithAuthData({
         password: globalPassword,
         rawToprfEncryptionKey: latestEncKey,
         rawToprfPwEncryptionKey: latestPwEncKey,
         rawToprfAuthKeyPair: latestAuthKeyPair,
       });
+      if (revokeToken) {
+        // // revoke and recyle refresh token after unlock to keep refresh token fresh, avoid malicious use of leaked refresh token
+        // // this call is not critical for unlocking, so we can do it in the background without await.
+        this.#revokeRefreshTokenAndUpdateState(revokeToken)
+          .then(() => {
+            // re-creating vault to persist the new revoke token.
+            // TODO: Optimize this function such that updates to vault wont require re-creating the vault.
+            return this.#createNewVaultWithAuthData({
+              password: globalPassword,
+              rawToprfEncryptionKey: latestEncKey,
+              rawToprfPwEncryptionKey: latestPwEncKey,
+              rawToprfAuthKeyPair: latestAuthKeyPair,
+            });
+          })
+          .catch((error) => {
+            log('Error revoking refresh token', error);
+          });
+      }
 
       // restore the current keyring encryption key with the new global password
       await this.storeKeyringEncryptionKey(keyringEncryptionKey);


### PR DESCRIPTION
## Explanation

- This PR moves revoke token call in background. Revoking refresh token  is not a must after submit password so can be done in background and even when it fails it should affect user wallet unlock.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
