### PR TITLE
fix(accounts-controller): allow extra-properties in options BIP-44 Snap accounts

### DIFF
--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow extra `options` properties when detecting BIP-44 Snap account ([#6189](https://github.com/MetaMask/core/pull/6189))
+
 ## [32.0.0]
 
 ### Added

--- a/packages/accounts-controller/src/utils.ts
+++ b/packages/accounts-controller/src/utils.ts
@@ -2,7 +2,7 @@ import type { KeyringObject } from '@metamask/keyring-controller';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { Infer } from '@metamask/superstruct';
-import { is, number, object, string } from '@metamask/superstruct';
+import { is, number, string, type } from '@metamask/superstruct';
 import { hexToBytes } from '@metamask/utils';
 import { sha256 } from 'ethereum-cryptography/sha256';
 import type { V4Options } from 'uuid';
@@ -175,8 +175,11 @@ export function getEvmGroupIndexFromAddressIndex(
 /**
  * HD keyring account for Snap accounts that handles non-EVM HD accounts. (e.g the
  * Solana Snap).
+ *
+ * NOTE: We use `superstruct.type` here `superstruct.object` since it allows
+ * extra-properties than a Snap might add in its `options`.
  */
-export const HdSnapKeyringAccountOptionsStruct = object({
+export const HdSnapKeyringAccountOptionsStruct = type({
   entropySource: string(),
   index: number(),
   derivationPath: string(),


### PR DESCRIPTION
## Explanation

This is required since Snaps that supports BIP-44 accounts might have more options than the one we use to detect "legacy BIP-44 options".

`superstruct.object` is strict and does not allow extra-properties, while `superstruct.type` acts as normal structural typing (like in TypeScript).

## References

N/A

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
