### PR TITLE
fix: make anvil symlink relative

### DIFF
--- a/packages/foundryup/CHANGELOG.md
+++ b/packages/foundryup/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix: make anvil symlink relative (#6202)
+
 ## [1.0.0]
 
 ### Added


### PR DESCRIPTION
## Explanation

Makes the symlinks that foundryup installs relative instead of absolute, to fix MetaMask/MetaMask-planning#5448

## References

Fixes: MetaMask/MetaMask-planning#5448