### PR TITLE
fix: prevent wrong transaction type assignment  when read contract fails

### DIFF
--- a/packages/transaction-controller/src/utils/transaction-type.test.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.test.ts
@@ -179,7 +179,7 @@ describe('determineTransactionType', () => {
     });
   });
 
-  it('returns a simple send type with a null getCodeResponse when "to" is truthy and there is data, but getCode returns an error', async () => {
+  it('returns a contract interaction type when getCode returns an error and data is unknown', async () => {
     const result = await determineTransactionType(
       {
         ...txParams,
@@ -188,7 +188,7 @@ describe('determineTransactionType', () => {
       createMockEthQuery(null, true),
     );
     expect(result).toMatchObject({
-      type: TransactionType.simpleSend,
+      type: TransactionType.contractInteraction,
       getCodeResponse: null,
     });
   });
@@ -246,6 +246,18 @@ describe('determineTransactionType', () => {
     expect(result).toMatchObject({
       type: TransactionType.contractInteraction,
       getCodeResponse: undefined,
+    });
+  });
+
+  it('returns transfer type when readAddressAsContract throws an error', async () => {
+    const result = await determineTransactionType(
+      txParams,
+      createMockEthQuery(null, true),
+    );
+
+    expect(result).toMatchObject({
+      type: TransactionType.tokenMethodTransfer,
+      getCodeResponse: null,
     });
   });
 });


### PR DESCRIPTION
## Explanation

The issue happens when users tries to send a token but provider returns an error when trying to identify if the address is a contract or not. It's an edge case identified on BNB.

This PR improves transaction type detection logic when interacting with an address that may or may not be a contract. Previously, if an error occurred while trying to determine whether an address was a contract (via eth_getCode), the logic would default to returning `simpleSend`, which could lead to incorrect transaction classification.

**Key Changes**
- Improved error handling in `readAddressAsContract`:
  This helper now returns an error field alongside `contractCode` and `isContractAddress`, enabling downstream logic to make better-informed decisions.

- Enhanced `determineTransactionType` logic:
  If `eth_getCode` fails, we no longer assume a `simpleSend`. Instead, we:
  Fallback to checking the presence of transaction data and attempt decoding via the 4-byte method selector.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes https://github.com/MetaMask/metamask-mobile/issues/16574

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
