### PR TITLE
refactor(multichain-account-service)!: move `MultichainAccount{Wallet,Group}` implementations

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "resolutions": {
     "elliptic@6.5.4": "^6.5.7",
     "fast-xml-parser@^4.3.4": "^4.4.1",
-    "ws@7.4.6": "^7.5.10"
+    "ws@7.4.6": "^7.5.10",
+    "@metamask/account-api@^0.5.0": "npm:@metamask-previews/account-api@0.5.0-0e28ac0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.5",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
   "resolutions": {
     "elliptic@6.5.4": "^6.5.7",
     "fast-xml-parser@^4.3.4": "^4.4.1",
-    "ws@7.4.6": "^7.5.10",
-    "@metamask/account-api@^0.5.0": "npm:@metamask-previews/account-api@0.5.0-0e28ac0"
+    "ws@7.4.6": "^7.5.10"
   },
   "devDependencies": {
     "@babel/core": "^7.23.5",

--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump peer dependency `@metamask/account-api` from `^0.3.0` to `^0.5.0` ([#6214](https://github.com/MetaMask/core/pull/6214))
+- **BREAKING:** Bump peer dependency `@metamask/account-api` from `^0.3.0` to `^0.6.0` ([#6214](https://github.com/MetaMask/core/pull/6214)), ([#6216](https://github.com/MetaMask/core/pull/6216))
 - **BREAKING:** Move `wallet.metadata.type` tag to `wallet` node ([#6214](https://github.com/MetaMask/core/pull/6214))
   - This `type` can be used as a tag to strongly-type (tagged-union) the `AccountWalletObject`.
 - Defaults to the EVM account from a group when using `setSelectedAccountGroup` ([#6208](https://github.com/MetaMask/core/pull/6208))

--- a/packages/account-tree-controller/package.json
+++ b/packages/account-tree-controller/package.json
@@ -53,7 +53,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@metamask/account-api": "^0.5.0",
+    "@metamask/account-api": "^0.6.0",
     "@metamask/accounts-controller": "^32.0.1",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-api": "^19.0.0",
@@ -70,7 +70,7 @@
     "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
-    "@metamask/account-api": "^0.5.0",
+    "@metamask/account-api": "^0.6.0",
     "@metamask/accounts-controller": "^32.0.0",
     "@metamask/keyring-controller": "^22.0.0",
     "@metamask/providers": "^22.0.0",

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -8,7 +8,7 @@ import {
   AccountWalletType,
   toAccountGroupId,
   toAccountWalletId,
-  toMultichainAccountId,
+  toMultichainAccountGroupId,
   toMultichainAccountWalletId,
   type AccountGroupId,
 } from '@metamask/account-api';
@@ -383,18 +383,18 @@ describe('AccountTreeController', () => {
       const expectedWalletId1 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_1.metadata.id,
       );
-      const expectedWalletId1Group = toMultichainAccountId(
+      const expectedWalletId1Group = toMultichainAccountGroupId(
         expectedWalletId1,
         MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
       );
       const expectedWalletId2 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_2.metadata.id,
       );
-      const expectedWalletId2Group1 = toMultichainAccountId(
+      const expectedWalletId2Group1 = toMultichainAccountGroupId(
         expectedWalletId2,
         MOCK_HD_ACCOUNT_2.options.entropy.groupIndex,
       );
-      const expectedWalletId2Group2 = toMultichainAccountId(
+      const expectedWalletId2Group2 = toMultichainAccountGroupId(
         expectedWalletId2,
         MOCK_SNAP_ACCOUNT_1.options.entropy.groupIndex,
       );
@@ -563,7 +563,7 @@ describe('AccountTreeController', () => {
       const expectedWalletId = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_2.metadata.id,
       );
-      const expectedGroupId = toMultichainAccountId(
+      const expectedGroupId = toMultichainAccountGroupId(
         expectedWalletId,
         mockSnapAccountWithEntropy.options.entropy.groupIndex,
       );
@@ -675,7 +675,7 @@ describe('AccountTreeController', () => {
       const walletId1 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_1.metadata.id,
       );
-      const walletId1Group = toMultichainAccountId(
+      const walletId1Group = toMultichainAccountGroupId(
         walletId1,
         mockHdAccount1.options.entropy.groupIndex,
       );
@@ -752,7 +752,7 @@ describe('AccountTreeController', () => {
       const walletId1 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_1.metadata.id,
       );
-      const walletId1Group = toMultichainAccountId(
+      const walletId1Group = toMultichainAccountGroupId(
         walletId1,
         mockHdAccount1.options.entropy.groupIndex,
       );
@@ -829,14 +829,14 @@ describe('AccountTreeController', () => {
       const walletId1 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_1.metadata.id,
       );
-      const walletId1Group = toMultichainAccountId(
+      const walletId1Group = toMultichainAccountGroupId(
         walletId1,
         mockHdAccount1.options.entropy.groupIndex,
       );
       const walletId2 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_2.metadata.id,
       );
-      const walletId2Group = toMultichainAccountId(
+      const walletId2Group = toMultichainAccountGroupId(
         walletId2,
         mockHdAccount2.options.entropy.groupIndex,
       );
@@ -961,7 +961,7 @@ describe('AccountTreeController', () => {
       const groups = wallet.getAccountGroups();
       expect(groups).toHaveLength(1);
       expect(groups[0].id).toStrictEqual(
-        toMultichainAccountId(
+        toMultichainAccountGroupId(
           wallet.id as MultichainAccountWalletId,
           MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
         ),
@@ -979,7 +979,7 @@ describe('AccountTreeController', () => {
       expect(wallets).toHaveLength(1);
 
       const wallet = wallets[0];
-      const groupId = toMultichainAccountId(
+      const groupId = toMultichainAccountGroupId(
         wallet.id as MultichainAccountWalletId,
         MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
       );
@@ -1178,7 +1178,7 @@ describe('AccountTreeController', () => {
       const expectedWalletId2 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_2.metadata.id,
       );
-      const expectedGroupId2 = toMultichainAccountId(
+      const expectedGroupId2 = toMultichainAccountGroupId(
         expectedWalletId2,
         MOCK_HD_ACCOUNT_2.options.entropy.groupIndex,
       );
@@ -1218,7 +1218,7 @@ describe('AccountTreeController', () => {
       const expectedWalletId2 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_2.metadata.id,
       );
-      const expectedGroupId2 = toMultichainAccountId(
+      const expectedGroupId2 = toMultichainAccountGroupId(
         expectedWalletId2,
         nonEvmAccount2.options.entropy.groupIndex,
       );
@@ -1244,7 +1244,7 @@ describe('AccountTreeController', () => {
       const expectedWalletId = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_1.metadata.id,
       );
-      const expectedGroupId = toMultichainAccountId(
+      const expectedGroupId = toMultichainAccountGroupId(
         expectedWalletId,
         MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
       );
@@ -1277,7 +1277,7 @@ describe('AccountTreeController', () => {
       const expectedWalletId1 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_1.metadata.id,
       );
-      const expectedGroupId1 = toMultichainAccountId(
+      const expectedGroupId1 = toMultichainAccountGroupId(
         expectedWalletId1,
         MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
       );
@@ -1353,7 +1353,7 @@ describe('AccountTreeController', () => {
       const expectedWalletId1 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_1.metadata.id,
       );
-      const expectedGroupId1 = toMultichainAccountId(
+      const expectedGroupId1 = toMultichainAccountGroupId(
         expectedWalletId1,
         MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
       );
@@ -1387,7 +1387,7 @@ describe('AccountTreeController', () => {
       const expectedWalletId1 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_1.metadata.id,
       );
-      const expectedGroupId1 = toMultichainAccountId(
+      const expectedGroupId1 = toMultichainAccountGroupId(
         expectedWalletId1,
         MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
       );
@@ -1430,7 +1430,7 @@ describe('AccountTreeController', () => {
       const expectedWalletId1 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_1.metadata.id,
       );
-      const expectedGroupId1 = toMultichainAccountId(
+      const expectedGroupId1 = toMultichainAccountGroupId(
         expectedWalletId1,
         MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
       );
@@ -1467,7 +1467,7 @@ describe('AccountTreeController', () => {
       const expectedWalletId1 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_1.metadata.id,
       );
-      const expectedGroupId1 = toMultichainAccountId(
+      const expectedGroupId1 = toMultichainAccountGroupId(
         expectedWalletId1,
         MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
       );
@@ -1476,7 +1476,7 @@ describe('AccountTreeController', () => {
       const expectedWalletId2 = toMultichainAccountWalletId(
         MOCK_HD_KEYRING_2.metadata.id,
       );
-      const expectedGroupId2 = toMultichainAccountId(
+      const expectedGroupId2 = toMultichainAccountGroupId(
         expectedWalletId2,
         MOCK_HD_ACCOUNT_2.options.entropy.groupIndex,
       );
@@ -1557,7 +1557,7 @@ describe('AccountTreeController', () => {
       );
 
       const group: AccountGroupObject = {
-        id: toMultichainAccountId(
+        id: toMultichainAccountGroupId(
           toMultichainAccountWalletId('test'),
           MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
         ),

--- a/packages/account-tree-controller/src/group.ts
+++ b/packages/account-tree-controller/src/group.ts
@@ -1,6 +1,6 @@
 import type {
   AccountGroupType,
-  MultichainAccountId,
+  MultichainAccountGroupId,
 } from '@metamask/account-api';
 import type { AccountGroup, AccountGroupId } from '@metamask/account-api';
 import type { AccountId } from '@metamask/accounts-controller';
@@ -32,7 +32,7 @@ type IsAccountGroupObject<
  */
 export type AccountGroupMultichainAccountObject = {
   type: AccountGroupType.MultichainAccount;
-  id: MultichainAccountId;
+  id: MultichainAccountGroupId;
   // Blockchain Accounts (at least 1 account per multichain-accounts):
   accounts: [AccountId, ...AccountId[]];
   metadata: {

--- a/packages/account-tree-controller/src/rules/entropy.ts
+++ b/packages/account-tree-controller/src/rules/entropy.ts
@@ -2,7 +2,7 @@ import {
   AccountGroupType,
   AccountWalletType,
   isBip44Account,
-  toMultichainAccountId,
+  toMultichainAccountGroupId,
   toMultichainAccountWalletId,
 } from '@metamask/account-api';
 import { isEvmAccountType } from '@metamask/keyring-api';
@@ -48,7 +48,7 @@ export class EntropyRule
     }
 
     const walletId = toMultichainAccountWalletId(entropySource);
-    const groupId = toMultichainAccountId(
+    const groupId = toMultichainAccountGroupId(
       walletId,
       account.options.entropy.groupIndex,
     );

--- a/packages/account-tree-controller/src/wallet.ts
+++ b/packages/account-tree-controller/src/wallet.ts
@@ -42,9 +42,9 @@ export type AccountWalletEntropyObject = {
   type: AccountWalletType.Entropy;
   id: MultichainAccountWalletId;
   groups: {
-    // NOTE: Using `MultichainAccountId` instead of `AccountGroupId` would introduce
+    // NOTE: Using `MultichainAccountGroupId` instead of `AccountGroupId` would introduce
     // some type problems when using a group ID as an `AccountGroupId` directly. This
-    // would require some up-cast to a `MultichainAccountId` which could be considered
+    // would require some up-cast to a `MultichainAccountGroupId` which could be considered
     // unsafe... So we keep it as a `AccountGroupId` for now.
     [groupId: AccountGroupId]: AccountGroupMultichainAccountObject;
   };

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Bump peer dependency `@metamask/account-api` from `^0.3.0` to `^0.5.0` ([#6214](https://github.com/MetaMask/core/pull/6214))
+- **BREAKING:** Bump peer dependency `@metamask/account-api` from `^0.3.0` to `^0.6.0` ([#6214](https://github.com/MetaMask/core/pull/6214)), ([#6216](https://github.com/MetaMask/core/pull/6216))
+- **BREAKING:** Rename `MultichainAccount` to `MultichainAccountGroup` ([#6216](https://github.com/MetaMask/core/pull/6216))
+  - The naming was confusing and since a `MultichainAccount` is also an `AccountGroup` it makes sense to have the suffix there too.
+- **BREAKING:** Rename `getMultichainAccount*` to `getMultichainAccountGroup*` ([#6216](https://github.com/MetaMask/core/pull/6216))
+  - The naming was confusing and since a `MultichainAccount` is also an `AccountGroup` it makes sense to have the suffix there too.
 
 ## [0.3.0]
 

--- a/packages/multichain-account-service/package.json
+++ b/packages/multichain-account-service/package.json
@@ -51,6 +51,7 @@
     "@metamask/keyring-api": "^19.0.0",
     "@metamask/keyring-internal-api": "^7.0.0",
     "@metamask/keyring-snap-client": "^6.0.0",
+    "@metamask/keyring-utils": "^3.1.0",
     "@metamask/snaps-sdk": "^9.0.0",
     "@metamask/snaps-utils": "^11.0.0",
     "@metamask/superstruct": "^3.1.0"

--- a/packages/multichain-account-service/package.json
+++ b/packages/multichain-account-service/package.json
@@ -57,7 +57,7 @@
     "@metamask/superstruct": "^3.1.0"
   },
   "devDependencies": {
-    "@metamask/account-api": "^0.5.0",
+    "@metamask/account-api": "^0.6.0",
     "@metamask/accounts-controller": "^32.0.1",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/eth-snap-keyring": "^14.0.0",
@@ -74,7 +74,7 @@
     "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
-    "@metamask/account-api": "^0.5.0",
+    "@metamask/account-api": "^0.6.0",
     "@metamask/accounts-controller": "^32.0.0",
     "@metamask/keyring-controller": "^22.0.0",
     "@metamask/providers": "^22.0.0",

--- a/packages/multichain-account-service/src/MultichainAccountGroup.test.ts
+++ b/packages/multichain-account-service/src/MultichainAccountGroup.test.ts
@@ -1,0 +1,390 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import type { AccountSelector, Bip44Account } from '@metamask/account-api';
+import {
+  AccountGroupType,
+  isBip44Account,
+  toMultichainAccountGroupId,
+  toMultichainAccountWalletId,
+} from '@metamask/account-api';
+import {
+  BtcAccountType,
+  BtcMethod,
+  BtcScope,
+  EthAccountType,
+  EthMethod,
+  EthScope,
+  SolScope,
+} from '@metamask/keyring-api';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+
+import { MultichainAccountGroup } from './MultichainAccountGroup';
+import { MultichainAccountWallet } from './MultichainAccountWallet';
+import type { MockAccountProvider } from './tests';
+import {
+  MOCK_ENTROPY_SOURCE_1,
+  MOCK_HD_ACCOUNT_1,
+  MOCK_SOL_ACCOUNT_1,
+  MOCK_SNAP_ACCOUNT_2,
+  MOCK_BTC_P2WPKH_ACCOUNT_1,
+  MOCK_BTC_P2TR_ACCOUNT_1,
+  MockAccountBuilder,
+} from './tests';
+
+const MOCK_WALLET_1_ENTROPY_SOURCE = MOCK_ENTROPY_SOURCE_1;
+
+const MOCK_WALLET_1_EVM_ACCOUNT = MockAccountBuilder.from(MOCK_HD_ACCOUNT_1)
+  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
+  .withGroupIndex(0)
+  .get();
+const MOCK_WALLET_1_SOL_ACCOUNT = MockAccountBuilder.from(MOCK_SOL_ACCOUNT_1)
+  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
+  .withGroupIndex(0)
+  .get();
+const MOCK_WALLET_1_BTC_P2WPKH_ACCOUNT = MockAccountBuilder.from(
+  MOCK_BTC_P2WPKH_ACCOUNT_1,
+)
+  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
+  .withGroupIndex(0)
+  .get();
+const MOCK_WALLET_1_BTC_P2TR_ACCOUNT = MockAccountBuilder.from(
+  MOCK_BTC_P2TR_ACCOUNT_1,
+)
+  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
+  .withGroupIndex(0)
+  .get();
+
+function setupAccountProvider(
+  accounts: InternalAccount[],
+): MockAccountProvider {
+  const mocks: MockAccountProvider = {
+    accounts: [],
+    getAccount: jest.fn(),
+    getAccounts: jest.fn(),
+    createAccounts: jest.fn(),
+    discoverAndCreateAccounts: jest.fn(),
+  };
+
+  // You can mock this and all other mocks will re-use that list
+  // of accounts.
+  mocks.accounts = accounts;
+
+  const getAccounts = () =>
+    mocks.accounts.filter((account) => isBip44Account(account));
+
+  mocks.getAccounts.mockImplementation(getAccounts);
+  mocks.getAccount.mockImplementation(
+    (id: Bip44Account<InternalAccount>['id']) =>
+      // Assuming this never fails.
+      getAccounts().find((account) => account.id === id),
+  );
+
+  return mocks;
+}
+
+function setup({
+  groupIndex = 0,
+  accounts = [
+    [MOCK_WALLET_1_EVM_ACCOUNT],
+    [
+      MOCK_WALLET_1_SOL_ACCOUNT,
+      MOCK_WALLET_1_BTC_P2WPKH_ACCOUNT,
+      MOCK_WALLET_1_BTC_P2TR_ACCOUNT,
+      MOCK_SNAP_ACCOUNT_2, // Non-BIP-44 account.
+    ],
+  ],
+}: { groupIndex?: number; accounts?: InternalAccount[][] } = {}): {
+  wallet: MultichainAccountWallet<Bip44Account<InternalAccount>>;
+  group: MultichainAccountGroup<Bip44Account<InternalAccount>>;
+  providers: MockAccountProvider[];
+} {
+  const providers = accounts.map(setupAccountProvider);
+
+  const wallet = new MultichainAccountWallet<Bip44Account<InternalAccount>>({
+    providers,
+    entropySource: MOCK_WALLET_1_ENTROPY_SOURCE,
+  });
+
+  const group = new MultichainAccountGroup({
+    wallet,
+    groupIndex,
+    providers,
+  });
+
+  return { wallet, group, providers };
+}
+
+describe('MultichainAccount', () => {
+  describe('constructor', () => {
+    it('constructs a multichain account group', async () => {
+      const accounts = [
+        [MOCK_WALLET_1_EVM_ACCOUNT],
+        [MOCK_WALLET_1_SOL_ACCOUNT],
+      ];
+      const groupIndex = 0;
+      const { wallet, group } = setup({ groupIndex, accounts });
+
+      const expectedWalletId = toMultichainAccountWalletId(
+        wallet.entropySource,
+      );
+      const expectedAccounts = accounts.flat();
+
+      expect(group.id).toStrictEqual(
+        toMultichainAccountGroupId(expectedWalletId, groupIndex),
+      );
+      expect(group.type).toBe(AccountGroupType.MultichainAccount);
+      expect(group.index).toBe(groupIndex);
+      expect(group.wallet).toStrictEqual(wallet);
+      expect(group.getAccounts()).toHaveLength(expectedAccounts.length);
+      expect(group.getAccounts()).toStrictEqual(expectedAccounts);
+    });
+
+    it('constructs a multichain account group for a specific index', async () => {
+      const groupIndex = 2;
+      const { group } = setup({ groupIndex });
+
+      expect(group.index).toBe(groupIndex);
+    });
+  });
+
+  describe('getAccount', () => {
+    it('gets internal account from its id', async () => {
+      const evmAccount = MOCK_WALLET_1_EVM_ACCOUNT;
+      const solAccount = MOCK_WALLET_1_SOL_ACCOUNT;
+      const { group } = setup({ accounts: [[evmAccount], [solAccount]] });
+
+      expect(group.getAccount(evmAccount.id)).toBe(evmAccount);
+      expect(group.getAccount(solAccount.id)).toBe(solAccount);
+    });
+
+    it('returns undefined if the account ID does not belong to the multichain account group', async () => {
+      const { group } = setup();
+
+      expect(group.getAccount('unknown-id')).toBeUndefined();
+    });
+  });
+
+  describe('get', () => {
+    it.each([
+      {
+        tc: 'using id',
+        selector: { id: MOCK_WALLET_1_EVM_ACCOUNT.id },
+        expected: MOCK_WALLET_1_EVM_ACCOUNT,
+      },
+      {
+        tc: 'using address',
+        selector: { address: MOCK_WALLET_1_SOL_ACCOUNT.address },
+        expected: MOCK_WALLET_1_SOL_ACCOUNT,
+      },
+      {
+        tc: 'using type',
+        selector: { type: MOCK_WALLET_1_EVM_ACCOUNT.type },
+        expected: MOCK_WALLET_1_EVM_ACCOUNT,
+      },
+      {
+        tc: 'using scope',
+        selector: { scopes: [SolScope.Mainnet] },
+        expected: MOCK_WALLET_1_SOL_ACCOUNT,
+      },
+      {
+        tc: 'using another scope (but still included in the list of account.scopes)',
+        selector: { scopes: [SolScope.Testnet] },
+        expected: MOCK_WALLET_1_SOL_ACCOUNT,
+      },
+      {
+        tc: 'using specific EVM chain still matches with EVM EOA scopes',
+        selector: { scopes: [EthScope.Testnet] },
+        expected: MOCK_WALLET_1_EVM_ACCOUNT,
+      },
+      {
+        tc: 'using multiple scopes',
+        selector: { scopes: [SolScope.Mainnet, SolScope.Testnet] },
+        expected: MOCK_WALLET_1_SOL_ACCOUNT,
+      },
+      {
+        tc: 'using method',
+        selector: { methods: [EthMethod.SignTransaction] },
+        expected: MOCK_WALLET_1_EVM_ACCOUNT,
+      },
+      {
+        tc: 'using another method',
+        selector: { methods: [EthMethod.PersonalSign] },
+        expected: MOCK_WALLET_1_EVM_ACCOUNT,
+      },
+      {
+        tc: 'using multiple methods',
+        selector: {
+          methods: [EthMethod.SignTransaction, EthMethod.PersonalSign],
+        },
+        expected: MOCK_WALLET_1_EVM_ACCOUNT,
+      },
+    ] as {
+      tc: string;
+      selector: AccountSelector<Bip44Account<InternalAccount>>;
+      expected: Bip44Account<InternalAccount>;
+    }[])(
+      'gets internal account from selector: $tc',
+      async ({ selector, expected }) => {
+        const { group } = setup();
+
+        expect(group.get(selector)).toStrictEqual(expected);
+      },
+    );
+
+    it.each([
+      {
+        tc: 'using non-matching id',
+        selector: { id: '66da96d7-8f24-4895-82d6-183d740c2da1' },
+      },
+      {
+        tc: 'using non-matching address',
+        selector: { address: 'unknown-address' },
+      },
+      {
+        tc: 'using non-matching type',
+        selector: { type: 'unknown-type' },
+      },
+      {
+        tc: 'using non-matching scope',
+        selector: {
+          scopes: ['bip122:12a765e31ffd4059bada1e25190f6e98' /* Litecoin */],
+        },
+      },
+      {
+        tc: 'using non-matching method',
+        selector: { methods: ['eth_unknownMethod'] },
+      },
+    ] as {
+      tc: string;
+      selector: AccountSelector<Bip44Account<InternalAccount>>;
+    }[])(
+      'gets undefined if not matching selector: $tc',
+      async ({ selector }) => {
+        const { group } = setup();
+
+        expect(group.get(selector)).toBeUndefined();
+      },
+    );
+
+    it('throws if multiple candidates are found', async () => {
+      const { group } = setup();
+
+      const selector = {
+        scopes: [EthScope.Mainnet, SolScope.Mainnet],
+      };
+
+      expect(() => group.get(selector)).toThrow(
+        'Too many account candidates, expected 1, got: 2',
+      );
+    });
+  });
+
+  it.each([
+    {
+      tc: 'using id',
+      selector: { id: MOCK_WALLET_1_EVM_ACCOUNT.id },
+      expected: [MOCK_WALLET_1_EVM_ACCOUNT],
+    },
+    {
+      tc: 'using non-matching id',
+      selector: { id: '66da96d7-8f24-4895-82d6-183d740c2da1' },
+      expected: [],
+    },
+    {
+      tc: 'using address',
+      selector: { address: MOCK_WALLET_1_SOL_ACCOUNT.address },
+      expected: [MOCK_WALLET_1_SOL_ACCOUNT],
+    },
+    {
+      tc: 'using non-matching address',
+      selector: { address: 'unknown-address' },
+      expected: [],
+    },
+    {
+      tc: 'using type',
+      selector: { type: MOCK_WALLET_1_EVM_ACCOUNT.type },
+      expected: [MOCK_WALLET_1_EVM_ACCOUNT],
+    },
+    {
+      tc: 'using non-matching type',
+      selector: { type: 'unknown-type' },
+      expected: [],
+    },
+    {
+      tc: 'using scope',
+      selector: { scopes: [SolScope.Mainnet] },
+      expected: [MOCK_WALLET_1_SOL_ACCOUNT],
+    },
+    {
+      tc: 'using another scope (but still included in the list of account.scopes)',
+      selector: { scopes: [SolScope.Testnet] },
+      expected: [MOCK_WALLET_1_SOL_ACCOUNT],
+    },
+    {
+      tc: 'using specific EVM chain still matches with EVM EOA scopes',
+      selector: { scopes: [EthScope.Testnet] },
+      expected: [MOCK_WALLET_1_EVM_ACCOUNT],
+    },
+    {
+      tc: 'using multiple scopes',
+      selector: { scopes: [BtcScope.Mainnet, BtcScope.Testnet] },
+      expected: [
+        MOCK_WALLET_1_BTC_P2WPKH_ACCOUNT,
+        MOCK_WALLET_1_BTC_P2TR_ACCOUNT,
+      ],
+    },
+    {
+      tc: 'using non-matching scopes',
+      selector: {
+        scopes: ['bip122:12a765e31ffd4059bada1e25190f6e98' /* Litecoin */],
+      },
+      expected: [],
+    },
+    {
+      tc: 'using method',
+      selector: { methods: [BtcMethod.SendBitcoin] },
+      expected: [
+        MOCK_WALLET_1_BTC_P2WPKH_ACCOUNT,
+        MOCK_WALLET_1_BTC_P2TR_ACCOUNT,
+      ],
+    },
+    {
+      tc: 'using multiple methods',
+      selector: {
+        methods: [EthMethod.SignTransaction, EthMethod.PersonalSign],
+      },
+      expected: [MOCK_WALLET_1_EVM_ACCOUNT],
+    },
+    {
+      tc: 'using non-matching method',
+      selector: { methods: ['eth_unknownMethod'] },
+      expected: [],
+    },
+    {
+      tc: 'using multiple selectors',
+      selector: {
+        type: EthAccountType.Eoa,
+        methods: [EthMethod.SignTransaction, EthMethod.PersonalSign],
+      },
+      expected: [MOCK_WALLET_1_EVM_ACCOUNT],
+    },
+    {
+      tc: 'using non-matching selectors',
+      selector: {
+        type: BtcAccountType.P2wpkh,
+        methods: [EthMethod.SignTransaction, EthMethod.PersonalSign],
+      },
+      expected: [],
+    },
+  ] as {
+    tc: string;
+    selector: AccountSelector<Bip44Account<InternalAccount>>;
+    expected: Bip44Account<InternalAccount>[];
+  }[])(
+    'selects internal accounts from selector: $tc',
+    async ({ selector, expected }) => {
+      const { group } = setup();
+
+      expect(group.select(selector)).toStrictEqual(expected);
+    },
+  );
+});

--- a/packages/multichain-account-service/src/MultichainAccountGroup.test.ts
+++ b/packages/multichain-account-service/src/MultichainAccountGroup.test.ts
@@ -2,7 +2,6 @@
 import type { AccountSelector, Bip44Account } from '@metamask/account-api';
 import {
   AccountGroupType,
-  isBip44Account,
   toMultichainAccountGroupId,
   toMultichainAccountWalletId,
 } from '@metamask/account-api';
@@ -21,65 +20,14 @@ import { MultichainAccountGroup } from './MultichainAccountGroup';
 import { MultichainAccountWallet } from './MultichainAccountWallet';
 import type { MockAccountProvider } from './tests';
 import {
-  MOCK_ENTROPY_SOURCE_1,
-  MOCK_HD_ACCOUNT_1,
-  MOCK_SOL_ACCOUNT_1,
   MOCK_SNAP_ACCOUNT_2,
-  MOCK_BTC_P2WPKH_ACCOUNT_1,
-  MOCK_BTC_P2TR_ACCOUNT_1,
-  MockAccountBuilder,
+  MOCK_WALLET_1_BTC_P2TR_ACCOUNT,
+  MOCK_WALLET_1_BTC_P2WPKH_ACCOUNT,
+  MOCK_WALLET_1_ENTROPY_SOURCE,
+  MOCK_WALLET_1_EVM_ACCOUNT,
+  MOCK_WALLET_1_SOL_ACCOUNT,
+  setupAccountProvider,
 } from './tests';
-
-const MOCK_WALLET_1_ENTROPY_SOURCE = MOCK_ENTROPY_SOURCE_1;
-
-const MOCK_WALLET_1_EVM_ACCOUNT = MockAccountBuilder.from(MOCK_HD_ACCOUNT_1)
-  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
-  .withGroupIndex(0)
-  .get();
-const MOCK_WALLET_1_SOL_ACCOUNT = MockAccountBuilder.from(MOCK_SOL_ACCOUNT_1)
-  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
-  .withGroupIndex(0)
-  .get();
-const MOCK_WALLET_1_BTC_P2WPKH_ACCOUNT = MockAccountBuilder.from(
-  MOCK_BTC_P2WPKH_ACCOUNT_1,
-)
-  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
-  .withGroupIndex(0)
-  .get();
-const MOCK_WALLET_1_BTC_P2TR_ACCOUNT = MockAccountBuilder.from(
-  MOCK_BTC_P2TR_ACCOUNT_1,
-)
-  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
-  .withGroupIndex(0)
-  .get();
-
-function setupAccountProvider(
-  accounts: InternalAccount[],
-): MockAccountProvider {
-  const mocks: MockAccountProvider = {
-    accounts: [],
-    getAccount: jest.fn(),
-    getAccounts: jest.fn(),
-    createAccounts: jest.fn(),
-    discoverAndCreateAccounts: jest.fn(),
-  };
-
-  // You can mock this and all other mocks will re-use that list
-  // of accounts.
-  mocks.accounts = accounts;
-
-  const getAccounts = () =>
-    mocks.accounts.filter((account) => isBip44Account(account));
-
-  mocks.getAccounts.mockImplementation(getAccounts);
-  mocks.getAccount.mockImplementation(
-    (id: Bip44Account<InternalAccount>['id']) =>
-      // Assuming this never fails.
-      getAccounts().find((account) => account.id === id),
-  );
-
-  return mocks;
-}
 
 function setup({
   groupIndex = 0,
@@ -97,7 +45,9 @@ function setup({
   group: MultichainAccountGroup<Bip44Account<InternalAccount>>;
   providers: MockAccountProvider[];
 } {
-  const providers = accounts.map(setupAccountProvider);
+  const providers = accounts.map((providerAccounts) => {
+    return setupAccountProvider({ accounts: providerAccounts });
+  });
 
   const wallet = new MultichainAccountWallet<Bip44Account<InternalAccount>>({
     providers,

--- a/packages/multichain-account-service/src/MultichainAccountGroup.ts
+++ b/packages/multichain-account-service/src/MultichainAccountGroup.ts
@@ -83,16 +83,16 @@ export class MultichainAccountGroup<
   }
 
   /**
-   * Gets the multichain account ID.
+   * Gets the multichain account group ID.
    *
-   * @returns The multichain account ID.
+   * @returns The multichain account group ID.
    */
   get id(): MultichainAccountGroupId {
     return this.#id;
   }
 
   /**
-   * Gets the multichain account type.
+   * Gets the multichain account group type.
    *
    * @returns The multichain account type.
    */

--- a/packages/multichain-account-service/src/MultichainAccountGroup.ts
+++ b/packages/multichain-account-service/src/MultichainAccountGroup.ts
@@ -1,0 +1,231 @@
+import type { Bip44Account } from '@metamask/account-api';
+import type { AccountProvider } from '@metamask/account-api';
+import type { AccountSelector } from '@metamask/account-api';
+import { AccountGroupType } from '@metamask/account-api';
+import {
+  toMultichainAccountGroupId,
+  type MultichainAccountGroupId,
+  type MultichainAccountGroup as MultichainAccountGroupDefinition,
+} from '@metamask/account-api';
+import { type KeyringAccount } from '@metamask/keyring-api';
+import { isScopeEqualToAny } from '@metamask/keyring-utils';
+
+import type { MultichainAccountWallet } from './MultichainAccountWallet';
+
+/**
+ * A multichain account group that holds multiple accounts.
+ */
+export class MultichainAccountGroup<
+  Account extends Bip44Account<KeyringAccount>,
+> implements MultichainAccountGroupDefinition<Account>
+{
+  readonly #id: MultichainAccountGroupId;
+
+  readonly #wallet: MultichainAccountWallet<Account>;
+
+  readonly #index: number;
+
+  readonly #providers: AccountProvider<Account>[];
+
+  readonly #providerToAccounts: Map<AccountProvider<Account>, Account['id'][]>;
+
+  readonly #accountToProvider: Map<Account['id'], AccountProvider<Account>>;
+
+  constructor({
+    groupIndex,
+    wallet,
+    providers,
+  }: {
+    groupIndex: number;
+    wallet: MultichainAccountWallet<Account>;
+    providers: AccountProvider<Account>[];
+  }) {
+    this.#id = toMultichainAccountGroupId(wallet.id, groupIndex);
+    this.#index = groupIndex;
+    this.#wallet = wallet;
+    this.#providers = providers;
+    this.#providerToAccounts = new Map();
+    this.#accountToProvider = new Map();
+
+    this.sync();
+  }
+
+  /**
+   * Force multichain account synchronization.
+   *
+   * This can be used if account providers got new accounts that the multichain
+   * account doesn't know about.
+   */
+  sync(): void {
+    // Clear reverse mapping and re-construct it entirely based on the refreshed
+    // list of accounts from each providers.
+    this.#accountToProvider.clear();
+
+    for (const provider of this.#providers) {
+      // Filter account only for that index.
+      const accounts = [];
+      for (const account of provider.getAccounts()) {
+        if (
+          account.options.entropy.id === this.wallet.entropySource &&
+          account.options.entropy.groupIndex === this.index
+        ) {
+          // We only use IDs to always fetch the latest version of accounts.
+          accounts.push(account.id);
+        }
+      }
+      this.#providerToAccounts.set(provider, accounts);
+
+      // Reverse-mapping for fast indexing.
+      for (const id of accounts) {
+        this.#accountToProvider.set(id, provider);
+      }
+    }
+  }
+
+  /**
+   * Gets the multichain account ID.
+   *
+   * @returns The multichain account ID.
+   */
+  get id(): MultichainAccountGroupId {
+    return this.#id;
+  }
+
+  /**
+   * Gets the multichain account type.
+   *
+   * @returns The multichain account type.
+   */
+  get type(): AccountGroupType.MultichainAccount {
+    return AccountGroupType.MultichainAccount;
+  }
+
+  /**
+   * Gets the multichain account's wallet reference (parent).
+   *
+   * @returns The multichain account's wallet.
+   */
+  get wallet(): MultichainAccountWallet<Account> {
+    return this.#wallet;
+  }
+
+  /**
+   * Gets the multichain account group index.
+   *
+   * @returns The multichain account group index.
+   */
+  get index(): number {
+    return this.#index;
+  }
+
+  /**
+   * Checks if there's any underlying accounts for this multichain accounts.
+   *
+   * @returns True if there's any underlying accounts, false otherwise.
+   */
+  hasAccounts(): boolean {
+    // If there's anything in the reverse-map, it means we have some accounts.
+    return this.#accountToProvider.size > 0;
+  }
+
+  /**
+   * Gets the accounts for this multichain account.
+   *
+   * @returns The accounts.
+   */
+  getAccounts(): Account[] {
+    const allAccounts: Account[] = [];
+
+    for (const [provider, accounts] of this.#providerToAccounts.entries()) {
+      for (const id of accounts) {
+        const account = provider.getAccount(id);
+
+        if (account) {
+          // If for some reason we cannot get this account from the provider, it
+          // might means it has been deleted or something, so we just filter it
+          // out.
+          allAccounts.push(account);
+        }
+      }
+    }
+
+    return allAccounts;
+  }
+
+  /**
+   * Gets the account for a given account ID.
+   *
+   * @param id - Account ID.
+   * @returns The account or undefined if not found.
+   */
+  getAccount(id: Account['id']): Account | undefined {
+    const provider = this.#accountToProvider.get(id);
+
+    // If there's nothing in the map, it means we tried to get an account
+    // that does not belong to this multichain account.
+    if (!provider) {
+      return undefined;
+    }
+    return provider.getAccount(id);
+  }
+
+  /**
+   * Query an account matching the selector.
+   *
+   * @param selector - Query selector.
+   * @returns The account matching the selector or undefined if not matching.
+   * @throws If multiple accounts match the selector.
+   */
+  get(selector: AccountSelector<Account>): Account | undefined {
+    const accounts = this.select(selector);
+
+    if (accounts.length > 1) {
+      throw new Error(
+        `Too many account candidates, expected 1, got: ${accounts.length}`,
+      );
+    }
+
+    if (accounts.length === 0) {
+      return undefined;
+    }
+
+    return accounts[0]; // This is safe, see checks above.
+  }
+
+  /**
+   * Query accounts matching the selector.
+   *
+   * @param selector - Query selector.
+   * @returns The accounts matching the selector.
+   */
+  select(selector: AccountSelector<Account>): Account[] {
+    return this.getAccounts().filter((account) => {
+      let selected = true;
+
+      if (selector.id) {
+        selected &&= account.id === selector.id;
+      }
+      if (selector.address) {
+        selected &&= account.address === selector.address;
+      }
+      if (selector.type) {
+        selected &&= account.type === selector.type;
+      }
+      if (selector.methods !== undefined) {
+        selected &&= selector.methods.some((method) =>
+          account.methods.includes(method),
+        );
+      }
+      if (selector.scopes !== undefined) {
+        selected &&= selector.scopes.some((scope) => {
+          return (
+            // This will cover specific EVM EOA scopes as well.
+            isScopeEqualToAny(scope, account.scopes)
+          );
+        });
+      }
+
+      return selected;
+    });
+  }
+}

--- a/packages/multichain-account-service/src/MultichainAccountService.test.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.test.ts
@@ -358,8 +358,8 @@ describe('MultichainAccountService', () => {
       });
 
       const [multichainAccount1, multichainAccount2] =
-        wallet1.getMultichainAccounts();
-      const [multichainAccount3] = wallet2.getMultichainAccounts();
+        wallet1.getMultichainAccountGroups();
+      const [multichainAccount3] = wallet2.getMultichainAccountGroups();
 
       const walletAndMultichainAccount1 = service.getMultichainAccountAndWallet(
         account1.id,
@@ -396,15 +396,15 @@ describe('MultichainAccountService', () => {
       const wallet1 = service.getMultichainAccountWallet({
         entropySource: entropy1,
       });
-      expect(wallet1.getMultichainAccounts()).toHaveLength(1);
+      expect(wallet1.getMultichainAccountGroups()).toHaveLength(1);
 
       // Now we're adding `account2`.
       mocks.EvmAccountProvider.accounts = [account1, account2];
       messenger.publish('AccountsController:accountAdded', account2);
-      expect(wallet1.getMultichainAccounts()).toHaveLength(2);
+      expect(wallet1.getMultichainAccountGroups()).toHaveLength(2);
 
       const [multichainAccount1, multichainAccount2] =
-        wallet1.getMultichainAccounts();
+        wallet1.getMultichainAccountGroups();
 
       const walletAndMultichainAccount1 = service.getMultichainAccountAndWallet(
         account1.id,
@@ -437,16 +437,16 @@ describe('MultichainAccountService', () => {
       const wallet1 = service.getMultichainAccountWallet({
         entropySource: entropy1,
       });
-      expect(wallet1.getMultichainAccounts()).toHaveLength(1);
+      expect(wallet1.getMultichainAccountGroups()).toHaveLength(1);
 
       // Now we're adding `account2`.
       mocks.EvmAccountProvider.accounts = [account1, otherAccount1];
       messenger.publish('AccountsController:accountAdded', otherAccount1);
       // Still 1, that's the same multichain account, but a new "blockchain
       // account" got added.
-      expect(wallet1.getMultichainAccounts()).toHaveLength(1);
+      expect(wallet1.getMultichainAccountGroups()).toHaveLength(1);
 
-      const [multichainAccount1] = wallet1.getMultichainAccounts();
+      const [multichainAccount1] = wallet1.getMultichainAccountGroups();
 
       const walletAndMultichainAccount1 = service.getMultichainAccountAndWallet(
         account1.id,
@@ -477,7 +477,7 @@ describe('MultichainAccountService', () => {
       const wallet1 = service.getMultichainAccountWallet({
         entropySource: entropy1,
       });
-      expect(wallet1.getMultichainAccounts()).toHaveLength(2);
+      expect(wallet1.getMultichainAccountGroups()).toHaveLength(2);
 
       // No wallet 2 yet.
       expect(() =>
@@ -492,9 +492,9 @@ describe('MultichainAccountService', () => {
         entropySource: entropy2,
       });
       expect(wallet2).toBeDefined();
-      expect(wallet2.getMultichainAccounts()).toHaveLength(1);
+      expect(wallet2.getMultichainAccountGroups()).toHaveLength(1);
 
-      const [multichainAccount3] = wallet2.getMultichainAccounts();
+      const [multichainAccount3] = wallet2.getMultichainAccountGroups();
 
       const walletAndMultichainAccount3 = service.getMultichainAccountAndWallet(
         account3.id,
@@ -515,14 +515,14 @@ describe('MultichainAccountService', () => {
       const wallet1 = service.getMultichainAccountWallet({
         entropySource: entropy1,
       });
-      const oldMultichainAccounts = wallet1.getMultichainAccounts();
+      const oldMultichainAccounts = wallet1.getMultichainAccountGroups();
       expect(oldMultichainAccounts).toHaveLength(1);
       expect(oldMultichainAccounts[0].getAccounts()).toHaveLength(1);
 
       // Now we're publishing a new account that is not BIP-44 compatible.
       messenger.publish('AccountsController:accountAdded', MOCK_SNAP_ACCOUNT_2);
 
-      const newMultichainAccounts = wallet1.getMultichainAccounts();
+      const newMultichainAccounts = wallet1.getMultichainAccountGroups();
       expect(newMultichainAccounts).toHaveLength(1);
       expect(newMultichainAccounts[0].getAccounts()).toHaveLength(1);
     });
@@ -534,12 +534,12 @@ describe('MultichainAccountService', () => {
       const wallet1 = service.getMultichainAccountWallet({
         entropySource: entropy1,
       });
-      expect(wallet1.getMultichainAccounts()).toHaveLength(2);
+      expect(wallet1.getMultichainAccountGroups()).toHaveLength(2);
 
       // Now we're removing `account2`.
       mocks.EvmAccountProvider.accounts = [account1];
       messenger.publish('AccountsController:accountRemoved', account2.id);
-      expect(wallet1.getMultichainAccounts()).toHaveLength(1);
+      expect(wallet1.getMultichainAccountGroups()).toHaveLength(1);
 
       const walletAndMultichainAccount2 = service.getMultichainAccountAndWallet(
         account2.id,

--- a/packages/multichain-account-service/src/MultichainAccountService.test.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.test.ts
@@ -176,7 +176,7 @@ function setup({
 }
 
 describe('MultichainAccountService', () => {
-  describe('getMultichainAccounts', () => {
+  describe('getMultichainAccountGroups', () => {
     it('gets multichain accounts', () => {
       const { service } = setup({
         accounts: [
@@ -201,12 +201,12 @@ describe('MultichainAccountService', () => {
       });
 
       expect(
-        service.getMultichainAccounts({
+        service.getMultichainAccountGroups({
           entropySource: MOCK_HD_KEYRING_1.metadata.id,
         }),
       ).toHaveLength(1);
       expect(
-        service.getMultichainAccounts({
+        service.getMultichainAccountGroups({
           entropySource: MOCK_HD_KEYRING_2.metadata.id,
         }),
       ).toHaveLength(1);
@@ -227,16 +227,16 @@ describe('MultichainAccountService', () => {
         ],
       });
 
-      const multichainAccounts = service.getMultichainAccounts({
+      const groups = service.getMultichainAccountGroups({
         entropySource: MOCK_HD_KEYRING_1.metadata.id,
       });
-      expect(multichainAccounts).toHaveLength(2); // Group index 0 + 1.
+      expect(groups).toHaveLength(2); // Group index 0 + 1.
 
-      const internalAccounts0 = multichainAccounts[0].getAccounts();
+      const internalAccounts0 = groups[0].getAccounts();
       expect(internalAccounts0).toHaveLength(1); // Just EVM.
       expect(internalAccounts0[0].type).toBe(EthAccountType.Eoa);
 
-      const internalAccounts1 = multichainAccounts[1].getAccounts();
+      const internalAccounts1 = groups[1].getAccounts();
       expect(internalAccounts1).toHaveLength(1); // Just SOL.
       expect(internalAccounts1[0].type).toBe(SolAccountType.DataAccount);
     });
@@ -255,15 +255,15 @@ describe('MultichainAccountService', () => {
 
       // Wallet 2 should not exist, thus, this should throw.
       expect(() =>
-        // NOTE: We use `getMultichainAccounts` which uses `#getWallet` under the hood.
-        service.getMultichainAccounts({
+        // NOTE: We use `getMultichainAccountGroups` which uses `#getWallet` under the hood.
+        service.getMultichainAccountGroups({
           entropySource: MOCK_HD_KEYRING_2.metadata.id,
         }),
       ).toThrow('Unknown wallet, no wallet matching this entropy source');
     });
   });
 
-  describe('getMultichainAccount', () => {
+  describe('getMultichainAccountGroup', () => {
     it('gets a specific multichain account', () => {
       const accounts = [
         // Wallet 1:
@@ -281,13 +281,13 @@ describe('MultichainAccountService', () => {
       });
 
       const groupIndex = 1;
-      const multichainAccount = service.getMultichainAccount({
+      const group = service.getMultichainAccountGroup({
         entropySource: MOCK_HD_KEYRING_1.metadata.id,
         groupIndex,
       });
-      expect(multichainAccount.index).toBe(groupIndex);
+      expect(group.index).toBe(groupIndex);
 
-      const internalAccounts = multichainAccount.getAccounts();
+      const internalAccounts = group.getAccounts();
       expect(internalAccounts).toHaveLength(1);
       expect(internalAccounts[0]).toStrictEqual(accounts[1]);
     });
@@ -305,7 +305,7 @@ describe('MultichainAccountService', () => {
 
       const groupIndex = 1;
       expect(() =>
-        service.getMultichainAccount({
+        service.getMultichainAccountGroup({
           entropySource: MOCK_HD_KEYRING_1.metadata.id,
           groupIndex,
         }),
@@ -313,7 +313,7 @@ describe('MultichainAccountService', () => {
     });
   });
 
-  describe('getMultichainAccountAndWallet', () => {
+  describe('getAccountContext', () => {
     const entropy1 = 'entropy-1';
     const entropy2 = 'entropy-2';
 
@@ -361,32 +361,26 @@ describe('MultichainAccountService', () => {
         wallet1.getMultichainAccountGroups();
       const [multichainAccount3] = wallet2.getMultichainAccountGroups();
 
-      const walletAndMultichainAccount1 = service.getMultichainAccountAndWallet(
+      const walletAndMultichainAccount1 = service.getAccountContext(
         account1.id,
       );
-      const walletAndMultichainAccount2 = service.getMultichainAccountAndWallet(
+      const walletAndMultichainAccount2 = service.getAccountContext(
         account2.id,
       );
-      const walletAndMultichainAccount3 = service.getMultichainAccountAndWallet(
+      const walletAndMultichainAccount3 = service.getAccountContext(
         account3.id,
       );
 
       // NOTE: We use `toBe` here, cause we want to make sure we use the same
       // references with `get*` service's methods.
       expect(walletAndMultichainAccount1?.wallet).toBe(wallet1);
-      expect(walletAndMultichainAccount1?.multichainAccount).toBe(
-        multichainAccount1,
-      );
+      expect(walletAndMultichainAccount1?.group).toBe(multichainAccount1);
 
       expect(walletAndMultichainAccount2?.wallet).toBe(wallet1);
-      expect(walletAndMultichainAccount2?.multichainAccount).toBe(
-        multichainAccount2,
-      );
+      expect(walletAndMultichainAccount2?.group).toBe(multichainAccount2);
 
       expect(walletAndMultichainAccount3?.wallet).toBe(wallet2);
-      expect(walletAndMultichainAccount3?.multichainAccount).toBe(
-        multichainAccount3,
-      );
+      expect(walletAndMultichainAccount3?.group).toBe(multichainAccount3);
     });
 
     it('syncs the appropriate wallet and update reverse mapping on AccountsController:accountAdded', () => {
@@ -406,24 +400,20 @@ describe('MultichainAccountService', () => {
       const [multichainAccount1, multichainAccount2] =
         wallet1.getMultichainAccountGroups();
 
-      const walletAndMultichainAccount1 = service.getMultichainAccountAndWallet(
+      const walletAndMultichainAccount1 = service.getAccountContext(
         account1.id,
       );
-      const walletAndMultichainAccount2 = service.getMultichainAccountAndWallet(
+      const walletAndMultichainAccount2 = service.getAccountContext(
         account2.id,
       );
 
       // NOTE: We use `toBe` here, cause we want to make sure we use the same
       // references with `get*` service's methods.
       expect(walletAndMultichainAccount1?.wallet).toBe(wallet1);
-      expect(walletAndMultichainAccount1?.multichainAccount).toBe(
-        multichainAccount1,
-      );
+      expect(walletAndMultichainAccount1?.group).toBe(multichainAccount1);
 
       expect(walletAndMultichainAccount2?.wallet).toBe(wallet1);
-      expect(walletAndMultichainAccount2?.multichainAccount).toBe(
-        multichainAccount2,
-      );
+      expect(walletAndMultichainAccount2?.group).toBe(multichainAccount2);
     });
 
     it('syncs the appropriate multichain account and update reverse mapping on AccountsController:accountAdded', () => {
@@ -448,23 +438,19 @@ describe('MultichainAccountService', () => {
 
       const [multichainAccount1] = wallet1.getMultichainAccountGroups();
 
-      const walletAndMultichainAccount1 = service.getMultichainAccountAndWallet(
+      const walletAndMultichainAccount1 = service.getAccountContext(
         account1.id,
       );
       const walletAndMultichainOtherAccount1 =
-        service.getMultichainAccountAndWallet(otherAccount1.id);
+        service.getAccountContext(otherAccount1.id);
 
       // NOTE: We use `toBe` here, cause we want to make sure we use the same
       // references with `get*` service's methods.
       expect(walletAndMultichainAccount1?.wallet).toBe(wallet1);
-      expect(walletAndMultichainAccount1?.multichainAccount).toBe(
-        multichainAccount1,
-      );
+      expect(walletAndMultichainAccount1?.group).toBe(multichainAccount1);
 
       expect(walletAndMultichainOtherAccount1?.wallet).toBe(wallet1);
-      expect(walletAndMultichainOtherAccount1?.multichainAccount).toBe(
-        multichainAccount1,
-      );
+      expect(walletAndMultichainOtherAccount1?.group).toBe(multichainAccount1);
     });
 
     it('creates new detected wallets and update reverse mapping on AccountsController:accountAdded', () => {
@@ -496,16 +482,14 @@ describe('MultichainAccountService', () => {
 
       const [multichainAccount3] = wallet2.getMultichainAccountGroups();
 
-      const walletAndMultichainAccount3 = service.getMultichainAccountAndWallet(
+      const walletAndMultichainAccount3 = service.getAccountContext(
         account3.id,
       );
 
       // NOTE: We use `toBe` here, cause we want to make sure we use the same
       // references with `get*` service's methods.
       expect(walletAndMultichainAccount3?.wallet).toBe(wallet2);
-      expect(walletAndMultichainAccount3?.multichainAccount).toBe(
-        multichainAccount3,
-      );
+      expect(walletAndMultichainAccount3?.group).toBe(multichainAccount3);
     });
 
     it('ignores non-BIP-44 accounts on AccountsController:accountAdded', () => {
@@ -541,7 +525,7 @@ describe('MultichainAccountService', () => {
       messenger.publish('AccountsController:accountRemoved', account2.id);
       expect(wallet1.getMultichainAccountGroups()).toHaveLength(1);
 
-      const walletAndMultichainAccount2 = service.getMultichainAccountAndWallet(
+      const walletAndMultichainAccount2 = service.getAccountContext(
         account2.id,
       );
 
@@ -554,22 +538,22 @@ describe('MultichainAccountService', () => {
       const accounts = [MOCK_HD_ACCOUNT_1];
       const { messenger } = setup({ accounts });
 
-      const multichainAccount = messenger.call(
-        'MultichainAccountService:getMultichainAccount',
+      const group = messenger.call(
+        'MultichainAccountService:getMultichainAccountGroup',
         { entropySource: MOCK_HD_KEYRING_1.metadata.id, groupIndex: 0 },
       );
-      expect(multichainAccount).toBeDefined();
+      expect(group).toBeDefined();
     });
 
     it('gets multichain accounts with MultichainAccountService:getMultichainAccounts', () => {
       const accounts = [MOCK_HD_ACCOUNT_1];
       const { messenger } = setup({ accounts });
 
-      const multichainAccounts = messenger.call(
-        'MultichainAccountService:getMultichainAccounts',
+      const groups = messenger.call(
+        'MultichainAccountService:getMultichainAccountGroups',
         { entropySource: MOCK_HD_KEYRING_1.metadata.id },
       );
-      expect(multichainAccounts.length).toBeGreaterThan(0);
+      expect(groups.length).toBeGreaterThan(0);
     });
 
     it('gets multichain account wallet with MultichainAccountService:getMultichainAccountWallet', () => {

--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -73,12 +73,12 @@ export class MultichainAccountService {
     ];
 
     this.#messenger.registerActionHandler(
-      'MultichainAccountService:getMultichainAccount',
-      (...args) => this.getMultichainAccount(...args),
+      'MultichainAccountService:getMultichainAccountGroup',
+      (...args) => this.getMultichainAccountGroup(...args),
     );
     this.#messenger.registerActionHandler(
-      'MultichainAccountService:getMultichainAccounts',
-      (...args) => this.getMultichainAccounts(...args),
+      'MultichainAccountService:getMultichainAccountGroups',
+      (...args) => this.getMultichainAccountGroups(...args),
     );
     this.#messenger.registerActionHandler(
       'MultichainAccountService:getMultichainAccountWallet',
@@ -215,13 +215,13 @@ export class MultichainAccountService {
   }
 
   /**
-   * Gets a reference to the wallet and multichain account for a given account ID.
+   * Gets the account's context which contains its multichain wallet and
+   * multichain account group references.
    *
    * @param id - Account ID.
-   * @returns An object with references to the wallet and multichain account associated for
-   * that account ID, or undefined if this account ID is not part of any.
+   * @returns The account context if any, undefined otherwise.
    */
-  getMultichainAccountAndWallet(
+  getAccountContext(
     id: InternalAccount['id'],
   ): AccountContext<Bip44Account<InternalAccount>> | undefined {
     return this.#accountIdToContext.get(id);
@@ -255,7 +255,8 @@ export class MultichainAccountService {
   }
 
   /**
-   * Gets a reference to the multichain account matching this entropy source and group index.
+   * Gets a reference to the multichain account group matching this entropy source
+   * and a group index.
    *
    * @param options - Options.
    * @param options.entropySource - The entropy source of the multichain account.
@@ -263,7 +264,7 @@ export class MultichainAccountService {
    * @throws If none multichain account match this entropy source and group index.
    * @returns A reference to the multichain account.
    */
-  getMultichainAccount({
+  getMultichainAccountGroup({
     entropySource,
     groupIndex,
   }: {
@@ -281,14 +282,14 @@ export class MultichainAccountService {
   }
 
   /**
-   * Gets all multichain accounts for a given entropy source.
+   * Gets all multichain account groups for a given entropy source.
    *
    * @param options - Options.
    * @param options.entropySource - The entropy source to query.
    * @throws If no multichain accounts match this entropy source.
    * @returns A list of all multichain accounts.
    */
-  getMultichainAccounts({
+  getMultichainAccountGroups({
     entropySource,
   }: {
     entropySource: EntropySourceId;

--- a/packages/multichain-account-service/src/MultichainAccountWallet.test.ts
+++ b/packages/multichain-account-service/src/MultichainAccountWallet.test.ts
@@ -1,0 +1,204 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import type { Bip44Account } from '@metamask/account-api';
+import {
+  AccountWalletType,
+  toAccountGroupId,
+  toDefaultAccountGroupId,
+  toMultichainAccountGroupId,
+  toMultichainAccountWalletId,
+} from '@metamask/account-api';
+import type { EntropySourceId } from '@metamask/keyring-api';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+
+import { MultichainAccountWallet } from './MultichainAccountWallet';
+import type { MockAccountProvider } from './tests';
+import {
+  MOCK_SNAP_ACCOUNT_2,
+  MOCK_WALLET_1_BTC_P2TR_ACCOUNT,
+  MOCK_WALLET_1_BTC_P2WPKH_ACCOUNT,
+  MOCK_WALLET_1_ENTROPY_SOURCE,
+  MOCK_WALLET_1_EVM_ACCOUNT,
+  MOCK_WALLET_1_SOL_ACCOUNT,
+  setupAccountProvider,
+} from './tests';
+
+function setup({
+  entropySource = MOCK_WALLET_1_ENTROPY_SOURCE,
+  providers,
+  accounts = [
+    [MOCK_WALLET_1_EVM_ACCOUNT],
+    [
+      MOCK_WALLET_1_SOL_ACCOUNT,
+      MOCK_WALLET_1_BTC_P2WPKH_ACCOUNT,
+      MOCK_WALLET_1_BTC_P2TR_ACCOUNT,
+      MOCK_SNAP_ACCOUNT_2, // Non-BIP-44 account.
+    ],
+  ],
+}: {
+  entropySource?: EntropySourceId;
+  providers?: MockAccountProvider[];
+  accounts?: InternalAccount[][];
+} = {}): {
+  wallet: MultichainAccountWallet<Bip44Account<InternalAccount>>;
+  providers: MockAccountProvider[];
+} {
+  providers ??= accounts.map((providerAccounts) => {
+    return setupAccountProvider({ accounts: providerAccounts });
+  });
+
+  const wallet = new MultichainAccountWallet<Bip44Account<InternalAccount>>({
+    providers,
+    entropySource,
+  });
+
+  return { wallet, providers };
+}
+
+describe('MultichainAccountWallet', () => {
+  describe('constructor', () => {
+    it('constructs a multichain account wallet', () => {
+      const entropySource = MOCK_WALLET_1_ENTROPY_SOURCE;
+      const { wallet } = setup({
+        entropySource,
+      });
+
+      const expectedWalletId = toMultichainAccountWalletId(entropySource);
+      expect(wallet.id).toStrictEqual(expectedWalletId);
+      expect(wallet.type).toBe(AccountWalletType.Entropy);
+      expect(wallet.entropySource).toStrictEqual(entropySource);
+      expect(wallet.getMultichainAccountGroups()).toHaveLength(1); // All internal accounts are using index 0, so it means only 1 multichain account.
+    });
+  });
+
+  describe('getMultichainAccountGroup', () => {
+    it('gets a multichain account group from its index', () => {
+      const { wallet } = setup();
+
+      const groupIndex = 0;
+      const multichainAccountGroup =
+        wallet.getMultichainAccountGroup(groupIndex);
+      expect(multichainAccountGroup).toBeDefined();
+      expect(multichainAccountGroup?.index).toBe(groupIndex);
+
+      // We can still get a multichain account group as a "basic" account group too.
+      const group = wallet.getAccountGroup(
+        toMultichainAccountGroupId(wallet.id, groupIndex),
+      );
+      expect(group).toBeDefined();
+      expect(group?.id).toBe(multichainAccountGroup?.id);
+    });
+  });
+
+  describe('getAccountGroup', () => {
+    it('gets the default multichain account group', () => {
+      const { wallet } = setup();
+
+      const group = wallet.getAccountGroup(toDefaultAccountGroupId(wallet.id));
+      expect(group).toBeDefined();
+      expect(group?.id).toBe(toMultichainAccountGroupId(wallet.id, 0));
+    });
+
+    it('gets a multichain account group when using a multichain account group id', () => {
+      const { wallet } = setup();
+
+      const group = wallet.getAccountGroup(toDefaultAccountGroupId(wallet.id));
+      expect(group).toBeDefined();
+      expect(group?.id).toBe(toMultichainAccountGroupId(wallet.id, 0));
+    });
+
+    it('returns undefined when using a bad multichain account group id', () => {
+      const { wallet } = setup();
+
+      const group = wallet.getAccountGroup(toAccountGroupId(wallet.id, 'bad'));
+      expect(group).toBeUndefined();
+    });
+  });
+
+  describe('sync', () => {
+    it('force sync wallet after account provider got new account', () => {
+      const mockEvmAccount = MOCK_WALLET_1_EVM_ACCOUNT;
+      const provider = setupAccountProvider({
+        accounts: [mockEvmAccount],
+      });
+      const { wallet } = setup({
+        providers: [provider],
+      });
+
+      expect(wallet.getMultichainAccountGroups()).toHaveLength(1);
+      expect(wallet.getAccountGroups()).toHaveLength(1); // We can still get "basic" groups too.
+
+      // Add a new account for the next index.
+      provider.getAccounts.mockReturnValue([
+        mockEvmAccount,
+        {
+          ...mockEvmAccount,
+          options: {
+            ...mockEvmAccount.options,
+            entropy: {
+              ...mockEvmAccount.options.entropy,
+              groupIndex: 1,
+            },
+          },
+        },
+      ]);
+
+      // Force sync, so the wallet will "find" a new multichain account.
+      wallet.sync();
+      expect(wallet.getAccountGroups()).toHaveLength(2);
+      expect(wallet.getMultichainAccountGroups()).toHaveLength(2);
+    });
+
+    it('skips non-matching wallet during sync', () => {
+      const mockEvmAccount = MOCK_WALLET_1_EVM_ACCOUNT;
+      const provider = setupAccountProvider({
+        accounts: [mockEvmAccount],
+      });
+      const { wallet } = setup({
+        providers: [provider],
+      });
+
+      expect(wallet.getMultichainAccountGroups()).toHaveLength(1);
+
+      // Add a new account for another index but not for this wallet.
+      provider.getAccounts.mockReturnValue([
+        mockEvmAccount,
+        {
+          ...mockEvmAccount,
+          options: {
+            ...mockEvmAccount.options,
+            entropy: {
+              ...mockEvmAccount.options.entropy,
+              id: 'mock-unknown-entropy-id',
+              groupIndex: 1,
+            },
+          },
+        },
+      ]);
+
+      // Even if we have a new account, it's not for this wallet, so it should
+      // not create a new multichain account!
+      wallet.sync();
+      expect(wallet.getMultichainAccountGroups()).toHaveLength(1);
+    });
+
+    it('cleans up old multichain account group during sync', () => {
+      const mockEvmAccount = MOCK_WALLET_1_EVM_ACCOUNT;
+      const provider = setupAccountProvider({
+        accounts: [mockEvmAccount],
+      });
+      const { wallet } = setup({
+        providers: [provider],
+      });
+
+      expect(wallet.getMultichainAccountGroups()).toHaveLength(1);
+
+      // Account for index 0 got removed, thus, the multichain account for index 0
+      // will also be removed.
+      provider.getAccounts.mockReturnValue([]);
+
+      // We should not have any multichain account anymore.
+      wallet.sync();
+      expect(wallet.getMultichainAccountGroups()).toHaveLength(0);
+    });
+  });
+});

--- a/packages/multichain-account-service/src/MultichainAccountWallet.ts
+++ b/packages/multichain-account-service/src/MultichainAccountWallet.ts
@@ -1,0 +1,187 @@
+import type {
+  Bip44Account,
+  MultichainAccountWalletId,
+  MultichainAccountWallet as MultichainAccountWalletDefinition,
+} from '@metamask/account-api';
+import type { AccountGroupId } from '@metamask/account-api';
+import type { AccountProvider } from '@metamask/account-api';
+import {
+  getGroupIndexFromMultichainAccountId,
+  isMultichainAccountGroupId,
+} from '@metamask/account-api';
+import { toDefaultAccountGroupId } from '@metamask/account-api';
+import { AccountWalletType } from '@metamask/account-api';
+import {
+  type EntropySourceId,
+  type KeyringAccount,
+} from '@metamask/keyring-api';
+
+import { MultichainAccountGroup } from './MultichainAccountGroup';
+
+/**
+ * A multichain account wallet that holds multiple multichain accounts (one multichain account per
+ * group index).
+ */
+export class MultichainAccountWallet<
+  Account extends Bip44Account<KeyringAccount>,
+> implements MultichainAccountWalletDefinition<Account>
+{
+  readonly #id: MultichainAccountWalletId;
+
+  readonly #providers: AccountProvider<Account>[];
+
+  readonly #entropySource: EntropySourceId;
+
+  readonly #accounts: Map<number, MultichainAccountGroup<Account>>;
+
+  constructor({
+    providers,
+    entropySource,
+  }: {
+    providers: AccountProvider<Account>[];
+    entropySource: EntropySourceId;
+  }) {
+    this.#id = toMultichainAccountWalletId(entropySource);
+    this.#providers = providers;
+    this.#entropySource = entropySource;
+    this.#accounts = new Map();
+
+    // Initial synchronization.
+    this.sync();
+  }
+
+  /**
+   * Force wallet synchronization.
+   *
+   * This can be used if account providers got new accounts that the wallet
+   * doesn't know about.
+   */
+  sync(): void {
+    for (const provider of this.#providers) {
+      for (const account of provider.getAccounts()) {
+        const { entropy } = account.options;
+
+        // Filter for this wallet only.
+        if (entropy.id !== this.entropySource) {
+          continue;
+        }
+
+        // This multichain account might exists already.
+        let multichainAccount = this.#accounts.get(entropy.groupIndex);
+        if (!multichainAccount) {
+          multichainAccount = new MultichainAccountGroup<Account>({
+            groupIndex: entropy.groupIndex,
+            wallet: this,
+            providers: this.#providers,
+          });
+
+          this.#accounts.set(entropy.groupIndex, multichainAccount);
+        }
+      }
+    }
+
+    // Now force-sync all remaining multichain accounts.
+    for (const [groupIndex, multichainAccount] of this.#accounts.entries()) {
+      multichainAccount.sync();
+
+      // Clean up old multichain accounts.
+      if (!multichainAccount.hasAccounts()) {
+        this.#accounts.delete(groupIndex);
+      }
+    }
+  }
+
+  /**
+   * Gets the multichain account wallet ID.
+   *
+   * @returns The multichain account wallet ID.
+   */
+  get id(): MultichainAccountWalletId {
+    return this.#id;
+  }
+
+  /**
+   * Gets the multichain account wallet type, which is always {@link AccountWalletType.Entropy}.
+   *
+   * @returns The multichain account wallet type.
+   */
+  get type(): AccountWalletType.Entropy {
+    return AccountWalletType.Entropy;
+  }
+
+  /**
+   * Gets the multichain account wallet entropy source.
+   *
+   * @returns The multichain account wallet entropy source.
+   */
+  get entropySource(): EntropySourceId {
+    return this.#entropySource;
+  }
+
+  /**
+   * Gets multichain account for a given ID.
+   * The default group ID will default to the multichain account with index 0.
+   *
+   * @param id - Account group ID.
+   * @returns Account group.
+   */
+  getAccountGroup(
+    id: AccountGroupId,
+  ): MultichainAccountGroup<Account> | undefined {
+    // We consider the "default case" to be mapped to index 0.
+    if (id === toDefaultAccountGroupId(this.id)) {
+      return this.#accounts.get(0);
+    }
+
+    // If it is not a valid ID, we cannot extract the group index
+    // from it, so we fail fast.
+    if (!isMultichainAccountGroupId(id)) {
+      return undefined;
+    }
+
+    const groupIndex = getGroupIndexFromMultichainAccountId(id);
+    return this.#accounts.get(groupIndex);
+  }
+
+  /**
+   * Gets all multichain accounts. Similar to {@link MultichainAccountWallet.getMultichainAccountGroups}.
+   *
+   * @returns The multichain accounts.
+   */
+  getAccountGroups(): MultichainAccountGroup<Account>[] {
+    return this.getMultichainAccountGroups();
+  }
+
+  /**
+   * Gets multichain account group for a given index.
+   *
+   * @param groupIndex - Multichain account index.
+   * @returns The multichain account associated with the given index.
+   */
+  getMultichainAccountGroup(
+    groupIndex: number,
+  ): MultichainAccountGroup<Account> | undefined {
+    return this.#accounts.get(groupIndex);
+  }
+
+  /**
+   * Gets all multichain account groups.
+   *
+   * @returns The multichain accounts.
+   */
+  getMultichainAccountGroups(): MultichainAccountGroup<Account>[] {
+    return Array.from(this.#accounts.values()); // TODO: Prevent copy here.
+  }
+}
+
+/**
+ * Gets the multichain account wallet ID from its entropy source.
+ *
+ * @param entropySource - Entropy source ID of that wallet.
+ * @returns The multichain account wallet ID.
+ */
+export function toMultichainAccountWalletId(
+  entropySource: EntropySourceId,
+): MultichainAccountWalletId {
+  return `${AccountWalletType.Entropy}:${entropySource}`;
+}

--- a/packages/multichain-account-service/src/MultichainAccountWallet.ts
+++ b/packages/multichain-account-service/src/MultichainAccountWallet.ts
@@ -6,7 +6,7 @@ import type {
 import type { AccountGroupId } from '@metamask/account-api';
 import type { AccountProvider } from '@metamask/account-api';
 import {
-  getGroupIndexFromMultichainAccountId,
+  getGroupIndexFromMultichainAccountId as getGroupIndexFromMultichainAccountGroupId,
   isMultichainAccountGroupId,
 } from '@metamask/account-api';
 import { toDefaultAccountGroupId } from '@metamask/account-api';
@@ -139,7 +139,7 @@ export class MultichainAccountWallet<
       return undefined;
     }
 
-    const groupIndex = getGroupIndexFromMultichainAccountId(id);
+    const groupIndex = getGroupIndexFromMultichainAccountGroupId(id);
     return this.#accounts.get(groupIndex);
   }
 

--- a/packages/multichain-account-service/src/index.ts
+++ b/packages/multichain-account-service/src/index.ts
@@ -2,9 +2,9 @@ export type {
   MultichainAccountServiceActions,
   MultichainAccountServiceEvents,
   MultichainAccountServiceMessenger,
-  MultichainAccountServiceGetMultichainAccountAction,
+  MultichainAccountServiceGetMultichainAccountGroupAction,
   MultichainAccountServiceGetMultichainAccountWalletAction,
   MultichainAccountServiceGetMultichainAccountWalletsAction,
-  MultichainAccountServiceGetMultichainAccountsAction,
+  MultichainAccountServiceGetMultichainAccountGroupsAction,
 } from './types';
 export { MultichainAccountService } from './MultichainAccountService';

--- a/packages/multichain-account-service/src/tests/accounts.ts
+++ b/packages/multichain-account-service/src/tests/accounts.ts
@@ -258,3 +258,30 @@ export class MockAccountBuilder {
     return this.#account;
   }
 }
+
+export const MOCK_WALLET_1_ENTROPY_SOURCE = MOCK_ENTROPY_SOURCE_1;
+
+export const MOCK_WALLET_1_EVM_ACCOUNT = MockAccountBuilder.from(
+  MOCK_HD_ACCOUNT_1,
+)
+  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
+  .withGroupIndex(0)
+  .get();
+export const MOCK_WALLET_1_SOL_ACCOUNT = MockAccountBuilder.from(
+  MOCK_SOL_ACCOUNT_1,
+)
+  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
+  .withGroupIndex(0)
+  .get();
+export const MOCK_WALLET_1_BTC_P2WPKH_ACCOUNT = MockAccountBuilder.from(
+  MOCK_BTC_P2WPKH_ACCOUNT_1,
+)
+  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
+  .withGroupIndex(0)
+  .get();
+export const MOCK_WALLET_1_BTC_P2TR_ACCOUNT = MockAccountBuilder.from(
+  MOCK_BTC_P2TR_ACCOUNT_1,
+)
+  .withEntropySource(MOCK_WALLET_1_ENTROPY_SOURCE)
+  .withGroupIndex(0)
+  .get();

--- a/packages/multichain-account-service/src/tests/accounts.ts
+++ b/packages/multichain-account-service/src/tests/accounts.ts
@@ -1,6 +1,9 @@
 import { isBip44Account } from '@metamask/account-api';
 import type { EntropySourceId } from '@metamask/keyring-api';
 import {
+  BtcAccountType,
+  BtcMethod,
+  BtcScope,
   EthAccountType,
   EthMethod,
   EthScope,
@@ -102,7 +105,7 @@ export const MOCK_HD_ACCOUNT_2: InternalAccount = {
   },
 };
 
-export const MOCK_SNAP_ACCOUNT_1: InternalAccount = {
+export const MOCK_SOL_ACCOUNT_1: InternalAccount = {
   id: 'mock-snap-id-1',
   address: 'aabbccdd',
   options: {
@@ -116,15 +119,75 @@ export const MOCK_SNAP_ACCOUNT_1: InternalAccount = {
   },
   methods: SOL_METHODS,
   type: SolAccountType.DataAccount,
-  scopes: [SolScope.Mainnet],
+  scopes: [SolScope.Mainnet, SolScope.Testnet, SolScope.Devnet],
   metadata: {
-    name: 'Snap Account 1',
+    name: 'Solana Account 1',
     keyring: { type: KeyringTypes.snap },
     snap: MOCK_SNAP_1,
     importTime: 0,
     lastSelected: 0,
   },
 };
+
+export const MOCK_BTC_P2WPKH_ACCOUNT_1: InternalAccount = {
+  id: 'b0f030d8-e101-4b5a-a3dd-13f8ca8ec1db',
+  type: BtcAccountType.P2wpkh,
+  methods: [BtcMethod.SendBitcoin],
+  address: 'bc1qx8ls07cy8j8nrluy2u0xwn7gh8fxg0rg4s8zze',
+  options: {
+    entropy: {
+      type: KeyringAccountEntropyTypeOption.Mnemonic,
+      // NOTE: shares entropy with MOCK_HD_ACCOUNT_2
+      id: MOCK_HD_KEYRING_2.metadata.id,
+      groupIndex: 0,
+      derivationPath: '',
+    },
+  },
+  scopes: [BtcScope.Mainnet],
+  metadata: {
+    name: 'Bitcoin Native Segwit Account 1',
+    importTime: 0,
+    keyring: {
+      type: 'Snap keyring',
+    },
+    snap: {
+      id: 'mock-btc-snap-id',
+      enabled: true,
+      name: 'Mock Bitcoin Snap',
+    },
+  },
+};
+
+export const MOCK_BTC_P2TR_ACCOUNT_1: InternalAccount = {
+  id: 'a20c2e1a-6ff6-40ba-b8e0-ccdb6f9933bb',
+  type: BtcAccountType.P2tr,
+  methods: [BtcMethod.SendBitcoin],
+  address: 'tb1p5cyxnuxmeuwuvkwfem96lxx9wex9kkf4mt9ll6q60jfsnrzqg4sszkqjnh',
+  options: {
+    entropy: {
+      type: KeyringAccountEntropyTypeOption.Mnemonic,
+      // NOTE: shares entropy with MOCK_HD_ACCOUNT_2
+      id: MOCK_HD_KEYRING_2.metadata.id,
+      groupIndex: 0,
+      derivationPath: '',
+    },
+  },
+  scopes: [BtcScope.Testnet],
+  metadata: {
+    name: 'Bitcoin Taproot Account 1',
+    importTime: 0,
+    keyring: {
+      type: 'Snap keyring',
+    },
+    snap: {
+      id: 'mock-btc-snap-id',
+      enabled: true,
+      name: 'Mock Bitcoin Snap',
+    },
+  },
+};
+
+export const MOCK_SNAP_ACCOUNT_1 = MOCK_SOL_ACCOUNT_1;
 
 export const MOCK_SNAP_ACCOUNT_2: InternalAccount = {
   id: 'mock-snap-id-2',
@@ -141,6 +204,9 @@ export const MOCK_SNAP_ACCOUNT_2: InternalAccount = {
     lastSelected: 0,
   },
 };
+
+export const MOCK_SNAP_ACCOUNT_3 = MOCK_BTC_P2WPKH_ACCOUNT_1;
+export const MOCK_SNAP_ACCOUNT_4 = MOCK_BTC_P2TR_ACCOUNT_1;
 
 export const MOCK_HARDWARE_ACCOUNT_1: InternalAccount = {
   id: 'mock-hardware-id-1',

--- a/packages/multichain-account-service/src/tests/index.ts
+++ b/packages/multichain-account-service/src/tests/index.ts
@@ -1,2 +1,3 @@
 export * from './accounts';
 export * from './messenger';
+export * from './providers';

--- a/packages/multichain-account-service/src/tests/providers.ts
+++ b/packages/multichain-account-service/src/tests/providers.ts
@@ -1,0 +1,43 @@
+/* eslint-disable jsdoc/require-jsdoc */
+
+import type { Bip44Account } from '@metamask/account-api';
+import { isBip44Account } from '@metamask/account-api';
+import type { KeyringAccount } from '@metamask/keyring-api';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+
+import type { MultichainAccountServiceMessenger } from '../types';
+
+export type MockAccountProvider = {
+  accounts: InternalAccount[];
+  getAccount: jest.Mock;
+  getAccounts: jest.Mock;
+  createAccounts: jest.Mock;
+  discoverAndCreateAccounts: jest.Mock;
+};
+
+export function mockAccountProvider<Provider>(
+  providerClass: new (messenger: MultichainAccountServiceMessenger) => Provider,
+  mocks: MockAccountProvider,
+  accounts: InternalAccount[],
+  type?: KeyringAccount['type'],
+) {
+  jest
+    .mocked(providerClass)
+    .mockImplementation(() => mocks as unknown as Provider);
+
+  // You can mock this and all other mocks will re-use that list
+  // of accounts.
+  mocks.accounts = accounts;
+
+  const getAccounts = () =>
+    mocks.accounts.filter(
+      (account) => isBip44Account(account) && type && account.type === type,
+    );
+
+  mocks.getAccounts.mockImplementation(getAccounts);
+  mocks.getAccount.mockImplementation(
+    (id: Bip44Account<InternalAccount>['id']) =>
+      // Assuming this never fails.
+      getAccounts().find((account) => account.id === id),
+  );
+}

--- a/packages/multichain-account-service/src/types.ts
+++ b/packages/multichain-account-service/src/types.ts
@@ -18,14 +18,14 @@ import type {
   serviceName,
 } from './MultichainAccountService';
 
-export type MultichainAccountServiceGetMultichainAccountAction = {
-  type: `${typeof serviceName}:getMultichainAccount`;
-  handler: MultichainAccountService['getMultichainAccount'];
+export type MultichainAccountServiceGetMultichainAccountGroupAction = {
+  type: `${typeof serviceName}:getMultichainAccountGroup`;
+  handler: MultichainAccountService['getMultichainAccountGroup'];
 };
 
-export type MultichainAccountServiceGetMultichainAccountsAction = {
-  type: `${typeof serviceName}:getMultichainAccounts`;
-  handler: MultichainAccountService['getMultichainAccounts'];
+export type MultichainAccountServiceGetMultichainAccountGroupsAction = {
+  type: `${typeof serviceName}:getMultichainAccountGroups`;
+  handler: MultichainAccountService['getMultichainAccountGroups'];
 };
 
 export type MultichainAccountServiceGetMultichainAccountWalletAction = {
@@ -43,8 +43,8 @@ export type MultichainAccountServiceGetMultichainAccountWalletsAction = {
  * modules can call them.
  */
 export type MultichainAccountServiceActions =
-  | MultichainAccountServiceGetMultichainAccountAction
-  | MultichainAccountServiceGetMultichainAccountsAction
+  | MultichainAccountServiceGetMultichainAccountGroupAction
+  | MultichainAccountServiceGetMultichainAccountGroupsAction
   | MultichainAccountServiceGetMultichainAccountWalletAction
   | MultichainAccountServiceGetMultichainAccountWalletsAction;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,14 +2443,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-api@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@metamask/account-api@npm:0.5.0"
+"@metamask/account-api@npm:@metamask-previews/account-api@0.5.0-0e28ac0":
+  version: 0.5.0-0e28ac0
+  resolution: "@metamask-previews/account-api@npm:0.5.0-0e28ac0"
   dependencies:
-    "@metamask/keyring-api": "npm:^19.1.0"
-    "@metamask/keyring-utils": "npm:^3.1.0"
+    "@metamask/keyring-api": "npm:19.1.0"
+    "@metamask/keyring-utils": "npm:3.1.0"
     "@metamask/superstruct": "npm:^3.1.0"
-  checksum: 10/22f8a472ca9e1b3b6f0fb574e48d4dd54c837bafb9095cbd96c84fe277d7af8125074297a37f21e38e40a8e28fa020f637c61b84255af7e4a5bc086d0ab13ce9
+  checksum: 10/4cc0bf710d1483054290ddada118ffc2da0e442eb99f09470ddc93e77495c5a395499d4b19f9efe9c73192640b7ddceb4f919b6800d4ff7f9590d25f4d19547c
   languageName: node
   linkType: hard
 
@@ -3643,7 +3643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^19.0.0, @metamask/keyring-api@npm:^19.1.0":
+"@metamask/keyring-api@npm:19.1.0, @metamask/keyring-api@npm:^19.0.0":
   version: 19.1.0
   resolution: "@metamask/keyring-api@npm:19.1.0"
   dependencies:
@@ -3735,7 +3735,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-utils@npm:^3.1.0":
+"@metamask/keyring-utils@npm:3.1.0, @metamask/keyring-utils@npm:^3.1.0":
   version: 3.1.0
   resolution: "@metamask/keyring-utils@npm:3.1.0"
   dependencies:
@@ -3824,6 +3824,7 @@ __metadata:
     "@metamask/keyring-controller": "npm:^22.1.0"
     "@metamask/keyring-internal-api": "npm:^7.0.0"
     "@metamask/keyring-snap-client": "npm:^6.0.0"
+    "@metamask/keyring-utils": "npm:^3.1.0"
     "@metamask/providers": "npm:^22.1.0"
     "@metamask/snaps-controllers": "npm:^14.0.1"
     "@metamask/snaps-sdk": "npm:^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,17 +2443,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-api@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@metamask/account-api@npm:0.5.0"
-  dependencies:
-    "@metamask/keyring-api": "npm:^19.1.0"
-    "@metamask/keyring-utils": "npm:^3.1.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-  checksum: 10/22f8a472ca9e1b3b6f0fb574e48d4dd54c837bafb9095cbd96c84fe277d7af8125074297a37f21e38e40a8e28fa020f637c61b84255af7e4a5bc086d0ab13ce9
-  languageName: node
-  linkType: hard
-
 "@metamask/account-api@npm:^0.6.0":
   version: 0.6.0
   resolution: "@metamask/account-api@npm:0.6.0"
@@ -2468,7 +2457,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/account-tree-controller@workspace:packages/account-tree-controller"
   dependencies:
-    "@metamask/account-api": "npm:^0.5.0"
+    "@metamask/account-api": "npm:^0.6.0"
     "@metamask/accounts-controller": "npm:^32.0.1"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^8.0.1"
@@ -2488,7 +2477,7 @@ __metadata:
     typescript: "npm:~5.2.2"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/account-api": ^0.5.0
+    "@metamask/account-api": ^0.6.0
     "@metamask/accounts-controller": ^32.0.0
     "@metamask/keyring-controller": ^22.0.0
     "@metamask/providers": ^22.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,14 +2443,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-api@npm:@metamask-previews/account-api@0.5.0-0e28ac0":
-  version: 0.5.0-0e28ac0
-  resolution: "@metamask-previews/account-api@npm:0.5.0-0e28ac0"
+"@metamask/account-api@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@metamask/account-api@npm:0.5.0"
   dependencies:
-    "@metamask/keyring-api": "npm:19.1.0"
-    "@metamask/keyring-utils": "npm:3.1.0"
+    "@metamask/keyring-api": "npm:^19.1.0"
+    "@metamask/keyring-utils": "npm:^3.1.0"
     "@metamask/superstruct": "npm:^3.1.0"
-  checksum: 10/4cc0bf710d1483054290ddada118ffc2da0e442eb99f09470ddc93e77495c5a395499d4b19f9efe9c73192640b7ddceb4f919b6800d4ff7f9590d25f4d19547c
+  checksum: 10/22f8a472ca9e1b3b6f0fb574e48d4dd54c837bafb9095cbd96c84fe277d7af8125074297a37f21e38e40a8e28fa020f637c61b84255af7e4a5bc086d0ab13ce9
+  languageName: node
+  linkType: hard
+
+"@metamask/account-api@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@metamask/account-api@npm:0.6.0"
+  dependencies:
+    "@metamask/keyring-api": "npm:^19.1.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+  checksum: 10/b0cf1ee04d7099c1085c2fc82073e42116646f8c1f50eb9b5b1792aeeb7c44ccb19a7dd802d242c0fe2b6bf70d55f2cfc183f9f015ea2fc3e1d4608e5f3a2b24
   languageName: node
   linkType: hard
 
@@ -3643,7 +3653,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:19.1.0, @metamask/keyring-api@npm:^19.0.0":
+"@metamask/keyring-api@npm:^19.0.0, @metamask/keyring-api@npm:^19.1.0":
   version: 19.1.0
   resolution: "@metamask/keyring-api@npm:19.1.0"
   dependencies:
@@ -3735,7 +3745,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-utils@npm:3.1.0, @metamask/keyring-utils@npm:^3.1.0":
+"@metamask/keyring-utils@npm:^3.1.0":
   version: 3.1.0
   resolution: "@metamask/keyring-utils@npm:3.1.0"
   dependencies:
@@ -3815,7 +3825,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/multichain-account-service@workspace:packages/multichain-account-service"
   dependencies:
-    "@metamask/account-api": "npm:^0.5.0"
+    "@metamask/account-api": "npm:^0.6.0"
     "@metamask/accounts-controller": "npm:^32.0.1"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^8.0.1"
@@ -3839,7 +3849,7 @@ __metadata:
     typescript: "npm:~5.2.2"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/account-api": ^0.5.0
+    "@metamask/account-api": ^0.6.0
     "@metamask/accounts-controller": ^32.0.0
     "@metamask/keyring-controller": ^22.0.0
     "@metamask/providers": ^22.0.0


### PR DESCRIPTION
## Explanation

Moving the implementations out of `@metamask/account-api` to have them closer to the service (which makes more sense too).

Beware, `MultichainAccount` has been renamed to `MultichainAccountGroup` to emphasis more on the the "group" aspect of multichain accounts.

## References

- https://github.com/MetaMask/accounts/pull/333

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
