### PR TITLE
perf: Prevent unnecessary state updates by using a selector in `MultichainAssetsRatesController`

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use a narrow selector when listening to `CurrencyRateController:stateChange` ([#6217](https://github.com/MetaMask/core/pull/6217))
+
 ## [73.0.1]
 
 ### Changed

--- a/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
+++ b/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
@@ -236,10 +236,11 @@ export class MultichainAssetsRatesController extends StaticIntervalPollingContro
 
     this.messagingSystem.subscribe(
       'CurrencyRateController:stateChange',
-      async (currencyRatesState: CurrencyRateState) => {
-        this.#currentCurrency = currencyRatesState.currentCurrency;
+      async (currentCurrency: string) => {
+        this.#currentCurrency = currentCurrency;
         await this.updateAssetsRates();
       },
+      (state) => state.currentCurrency,
     );
 
     this.messagingSystem.subscribe(

--- a/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
+++ b/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
@@ -240,7 +240,8 @@ export class MultichainAssetsRatesController extends StaticIntervalPollingContro
         this.#currentCurrency = currentCurrency;
         await this.updateAssetsRates();
       },
-      (state) => state.currentCurrency,
+      (currencyRateControllerState) =>
+        currencyRateControllerState.currentCurrency,
     );
 
     this.messagingSystem.subscribe(


### PR DESCRIPTION
## Explanation

Prevent unnecessary state updates by using a selector when listening to `CurrencyRateController:stateChange` in `MultichainAssetsRatesController`.

