### PR TITLE
feat(multichain-account-service)!: add `KeyringAccount` instead of `InternalAccount`

### DIFF
--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Use `KeyringAccount` instead of `InternalAccount` ([#6227](https://github.com/MetaMask/core/pull/6227))
 - **BREAKING:** Bump peer dependency `@metamask/account-api` from `^0.3.0` to `^0.6.0` ([#6214](https://github.com/MetaMask/core/pull/6214)), ([#6216](https://github.com/MetaMask/core/pull/6216))
 - **BREAKING:** Rename `MultichainAccount` to `MultichainAccountGroup` ([#6216](https://github.com/MetaMask/core/pull/6216)), ([#6219](https://github.com/MetaMask/core/pull/6219))
   - The naming was confusing and since a `MultichainAccount` is also an `AccountGroup` it makes sense to have the suffix there too.

--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -9,7 +9,6 @@ import {
 } from '@metamask/account-api';
 import type { EntropySourceId, KeyringAccount } from '@metamask/keyring-api';
 import { KeyringTypes } from '@metamask/keyring-controller';
-import type { InternalAccount } from '@metamask/keyring-internal-api';
 
 import type { MultichainAccountGroup } from './MultichainAccountGroup';
 import { MultichainAccountWallet } from './MultichainAccountWallet';

--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -38,16 +38,16 @@ type AccountContext<Account extends Bip44Account<KeyringAccount>> = {
 export class MultichainAccountService {
   readonly #messenger: MultichainAccountServiceMessenger;
 
-  readonly #providers: AccountProvider<Bip44Account<InternalAccount>>[];
+  readonly #providers: AccountProvider<Bip44Account<KeyringAccount>>[];
 
   readonly #wallets: Map<
     MultichainAccountWalletId,
-    MultichainAccountWallet<Bip44Account<InternalAccount>>
+    MultichainAccountWallet<Bip44Account<KeyringAccount>>
   >;
 
   readonly #accountIdToContext: Map<
-    Bip44Account<InternalAccount>['id'],
-    AccountContext<Bip44Account<InternalAccount>>
+    Bip44Account<KeyringAccount>['id'],
+    AccountContext<Bip44Account<KeyringAccount>>
   >;
 
   /**
@@ -130,7 +130,7 @@ export class MultichainAccountService {
     );
   }
 
-  #handleOnAccountAdded(account: InternalAccount): void {
+  #handleOnAccountAdded(account: KeyringAccount): void {
     // We completely omit non-BIP-44 accounts!
     if (!isBip44Account(account)) {
       return;
@@ -187,7 +187,7 @@ export class MultichainAccountService {
     }
   }
 
-  #handleOnAccountRemoved(id: InternalAccount['id']): void {
+  #handleOnAccountRemoved(id: KeyringAccount['id']): void {
     // Force sync of the appropriate wallet if an account got removed.
     const found = this.#accountIdToContext.get(id);
     if (found) {
@@ -202,7 +202,7 @@ export class MultichainAccountService {
 
   #getWallet(
     entropySource: EntropySourceId,
-  ): MultichainAccountWallet<Bip44Account<InternalAccount>> {
+  ): MultichainAccountWallet<Bip44Account<KeyringAccount>> {
     const wallet = this.#wallets.get(
       toMultichainAccountWalletId(entropySource),
     );
@@ -222,8 +222,8 @@ export class MultichainAccountService {
    * @returns The account context if any, undefined otherwise.
    */
   getAccountContext(
-    id: InternalAccount['id'],
-  ): AccountContext<Bip44Account<InternalAccount>> | undefined {
+    id: KeyringAccount['id'],
+  ): AccountContext<Bip44Account<KeyringAccount>> | undefined {
     return this.#accountIdToContext.get(id);
   }
 
@@ -239,7 +239,7 @@ export class MultichainAccountService {
     entropySource,
   }: {
     entropySource: EntropySourceId;
-  }): MultichainAccountWallet<Bip44Account<InternalAccount>> {
+  }): MultichainAccountWallet<Bip44Account<KeyringAccount>> {
     return this.#getWallet(entropySource);
   }
 
@@ -249,7 +249,7 @@ export class MultichainAccountService {
    * @returns An array of all multichain account wallets.
    */
   getMultichainAccountWallets(): MultichainAccountWallet<
-    Bip44Account<InternalAccount>
+    Bip44Account<KeyringAccount>
   >[] {
     return Array.from(this.#wallets.values());
   }
@@ -270,7 +270,7 @@ export class MultichainAccountService {
   }: {
     entropySource: EntropySourceId;
     groupIndex: number;
-  }): MultichainAccountGroup<Bip44Account<InternalAccount>> {
+  }): MultichainAccountGroup<Bip44Account<KeyringAccount>> {
     const multichainAccount =
       this.#getWallet(entropySource).getMultichainAccountGroup(groupIndex);
 
@@ -293,7 +293,7 @@ export class MultichainAccountService {
     entropySource,
   }: {
     entropySource: EntropySourceId;
-  }): MultichainAccountGroup<Bip44Account<InternalAccount>>[] {
+  }): MultichainAccountGroup<Bip44Account<KeyringAccount>>[] {
     return this.#getWallet(entropySource).getMultichainAccountGroups();
   }
 }

--- a/packages/multichain-account-service/src/providers/BaseAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/BaseAccountProvider.ts
@@ -3,12 +3,12 @@ import {
   type AccountProvider,
   type Bip44Account,
 } from '@metamask/account-api';
-import type { InternalAccount } from '@metamask/keyring-internal-api';
+import type { KeyringAccount } from '@metamask/keyring-api';
 
 import type { MultichainAccountServiceMessenger } from '../types';
 
 export abstract class BaseAccountProvider
-  implements AccountProvider<Bip44Account<InternalAccount>>
+  implements AccountProvider<Bip44Account<KeyringAccount>>
 {
   protected readonly messenger: MultichainAccountServiceMessenger;
 
@@ -17,9 +17,9 @@ export abstract class BaseAccountProvider
   }
 
   #getAccounts(
-    filter: (account: InternalAccount) => boolean = () => true,
-  ): Bip44Account<InternalAccount>[] {
-    const accounts: Bip44Account<InternalAccount>[] = [];
+    filter: (account: KeyringAccount) => boolean = () => true,
+  ): Bip44Account<KeyringAccount>[] {
+    const accounts: Bip44Account<KeyringAccount>[] = [];
 
     for (const account of this.messenger.call(
       // NOTE: Even though the name is misleading, this only fetches all internal
@@ -39,11 +39,13 @@ export abstract class BaseAccountProvider
     return accounts;
   }
 
-  getAccounts(): Bip44Account<InternalAccount>[] {
+  getAccounts(): Bip44Account<KeyringAccount>[] {
     return this.#getAccounts();
   }
 
-  getAccount(id: InternalAccount['id']): Bip44Account<InternalAccount> {
+  getAccount(
+    id: Bip44Account<KeyringAccount>['id'],
+  ): Bip44Account<KeyringAccount> {
     // TODO: Maybe just use a proper find for faster lookup?
     const [found] = this.#getAccounts((account) => account.id === id);
 
@@ -54,5 +56,5 @@ export abstract class BaseAccountProvider
     return found;
   }
 
-  abstract isAccountCompatible(account: Bip44Account<InternalAccount>): boolean;
+  abstract isAccountCompatible(account: Bip44Account<KeyringAccount>): boolean;
 }


### PR DESCRIPTION
## Explanation

We now use `KeyringAccount` instead of `InternalAccount` since we don't really have any use of the `account.metadata` anymore since the introduction of groups/wallets `metadata`:
- https://github.com/MetaMask/core/pull/6214

We still rely on the `AccountsController` to get the `KeyringAccount`-compatible accounts for EVM accounts.

Once we have the unified keyring API, we could just use keyrings to get their accounts, though, for the moment we rely on `getAccount` and `getAccounts` to be sync methods, and we would have to change this to fit the current multichain account architecture. 

## References

- Discussion started here: https://github.com/MetaMask/core/pull/6222/files#r2247301489

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
