### PR TITLE
feat: Introduce new Launch Darkly environment types

### DIFF
--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `EnvironmentType` `Beta`, `Test`, and `Exp` ([#6183](https://github.com/MetaMask/core/pull/6183))
+
 ### Changed
 
 - Bump `@metamask/utils` from `^11.2.0` to `^11.4.2` ([#6054](https://github.com/MetaMask/core/pull/6054))
 - Bump `@metamask/base-controller` from ^8.0.0 to ^8.0.1 ([#5722](https://github.com/MetaMask/core/pull/5722))
 - Bump `@metamask/controller-utils` to `^11.11.0` ([#5935](https://github.com/MetaMask/core/pull/5935), [#5583](https://github.com/MetaMask/core/pull/5583), [#5765](https://github.com/MetaMask/core/pull/5765), [#5812](https://github.com/MetaMask/core/pull/5812), [#6069](https://github.com/MetaMask/core/pull/6069))
+- Deprecate `DistributionType` option `Beta` in favor of using `DistributionType` `Main` with `EnvironmentType` `Beta` ([#6183](https://github.com/MetaMask/core/pull/6183))
 
 ## [1.6.0]
 

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-types.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-types.ts
@@ -10,6 +10,9 @@ export enum ClientType {
 export enum DistributionType {
   Main = 'main',
   Flask = 'flask',
+  /**
+   * @deprecated Use DistributionType Main with EnvironmentType Beta instead
+   */
   Beta = 'beta',
 }
 
@@ -17,6 +20,9 @@ export enum EnvironmentType {
   Production = 'prod',
   ReleaseCandidate = 'rc',
   Development = 'dev',
+  Beta = 'beta',
+  Test = 'test',
+  Exp = 'exp',
 }
 
 /** Type representing the feature flags collection */


### PR DESCRIPTION
## Explanation

Platform team is working on unifying build commands. To introduce new commands we need to introduce additional LaunchDarkly EnvironmentType variables for them. Here is the target state: https://docs.google.com/spreadsheets/d/1tj3Pi2RpOmGs0cnQfv219khs7JSyzW8Raz7eHXlGBqE/edit?gid=0#gid=0

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
