### PR TITLE
feat(account-tree-controller): automatically removes empty groups and wallets

### DIFF
--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This `type` can be used as a tag to strongly-type (tagged-union) the `AccountGroupObject`.
 - Add `group.metadata` metadata object ([#6214](https://github.com/MetaMask/core/pull/6214))
   - Given the `group.type` you will now have access to specific metadata information (e.g. `groupIndex` for multichain account groups)
-- Add `pruneEmptyGroupAndWallet` helper method ([#6234](https://github.com/MetaMask/core/pull/6234))
-  - This method ensures that there aren't any empty nodes in the `AccountTreeController` upon account removal.
+- Automatically prune empty groups and wallets upon account removal ([#6234](https://github.com/MetaMask/core/pull/6234))
+  - This ensures that there aren't any empty nodes in the `AccountTreeController` state.
 
 ### Changed
 

--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This `type` can be used as a tag to strongly-type (tagged-union) the `AccountGroupObject`.
 - Add `group.metadata` metadata object ([#6214](https://github.com/MetaMask/core/pull/6214))
   - Given the `group.type` you will now have access to specific metadata information (e.g. `groupIndex` for multichain account groups)
+- Add `pruneEmptyGroupAndWallet` helper method ([#6234](https://github.com/MetaMask/core/pull/6234))
+  - This method ensures that there aren't any empty nodes in the `AccountTreeController` upon account removal.
 
 ### Changed
 

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -713,7 +713,6 @@ describe('AccountTreeController', () => {
     });
 
     it('prunes an empty group if it holds no accounts', () => {
-      // 2 accounts that share the same entropy source (thus, same wallet).
       const mockHdAccount1: Bip44Account<InternalAccount> = MOCK_HD_ACCOUNT_1;
       const mockHdAccount2 = {
         ...MOCK_HD_ACCOUNT_2,
@@ -731,7 +730,6 @@ describe('AccountTreeController', () => {
         keyrings: [MOCK_HD_KEYRING_1],
       });
 
-      // Create entropy wallets that will both get "Wallet" as base name, then get numbered
       controller.init();
 
       messenger.publish('AccountsController:accountRemoved', mockHdAccount1.id);
@@ -780,7 +778,6 @@ describe('AccountTreeController', () => {
     });
 
     it('prunes an empty wallet if it holds no groups', () => {
-      // 2 accounts that share the same entropy source (thus, same wallet).
       const mockHdAccount1: Bip44Account<InternalAccount> = MOCK_HD_ACCOUNT_1;
 
       const { controller, messenger } = setup({
@@ -788,13 +785,13 @@ describe('AccountTreeController', () => {
         keyrings: [MOCK_HD_KEYRING_1],
       });
 
-      // Create entropy wallets that will both get "Wallet" as base name, then get numbered
       controller.init();
 
       messenger.publish('AccountsController:accountRemoved', mockHdAccount1.id);
 
       expect(controller.state).toStrictEqual({
         accountTree: {
+          // No wallets should be present.
           wallets: {},
           selectedAccountGroup: expect.any(String), // Will be set after init
         },

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -775,6 +775,8 @@ describe('AccountTreeController', () => {
                     entropy: {
                       groupIndex: mockHdAccount2.options.entropy.groupIndex,
                     },
+                    pinned: false,
+                    hidden: false,
                   },
                   accounts: [mockHdAccount2.id],
                 },
@@ -790,6 +792,8 @@ describe('AccountTreeController', () => {
           },
           selectedAccountGroup: expect.any(String), // Will be set after init
         },
+        accountGroupsMetadata: {},
+        accountWalletsMetadata: {},
       } as AccountTreeControllerState);
     });
 
@@ -806,6 +810,8 @@ describe('AccountTreeController', () => {
       messenger.publish('AccountsController:accountRemoved', mockHdAccount1.id);
 
       expect(controller.state).toStrictEqual({
+        accountGroupsMetadata: {},
+        accountWalletsMetadata: {},
         accountTree: {
           // No wallets should be present.
           wallets: {},

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -270,12 +270,39 @@ export class AccountTreeController extends BaseController<
                 this.#getDefaultAccountGroupId(state.accountTree.wallets);
             }
           }
+          if (accounts.length === 0) {
+            this.#pruneEmptyGroupAndWallet(state, walletId, groupId);
+          }
         }
       });
 
       // Clear reverse-mapping for that account.
       this.#accountIdToContext.delete(accountId);
     }
+  }
+
+  /**
+   * Helper method to prune a group if it holds no accounts and additionally
+   * prune the wallet if it holds no groups. This action should take place
+   * after a singular account removal.
+   *
+   * NOTE: This method should only be used for a group that we know to be empty.
+   *
+   * @param state - The AccountTreeController state to prune.
+   * @param walletId - The wallet ID to prune, the wallet should be the parent of the associated group that holds the removed account.
+   * @param groupId - The group ID to prune, the group should be the parent of the associated account that was removed.
+   * @returns The updated state.
+   */
+  #pruneEmptyGroupAndWallet(
+    state: AccountTreeControllerState,
+    walletId: AccountWalletId,
+    groupId: AccountGroupId,
+  ) {
+    delete state.accountTree.wallets[walletId].groups[groupId];
+    if (Object.keys(state.accountTree.wallets[walletId].groups).length === 0) {
+      delete state.accountTree.wallets[walletId];
+    }
+    return state;
   }
 
   #insert(

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -334,7 +334,10 @@ export class AccountTreeController extends BaseController<
     groupId: AccountGroupId,
   ) {
     const { wallets } = state.accountTree;
+
     delete wallets[walletId].groups[groupId];
+    this.#groupIdToWalletId.delete(groupId);
+
     if (Object.keys(wallets[walletId].groups).length === 0) {
       delete state.accountTree.wallets[walletId];
     }

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -339,7 +339,7 @@ export class AccountTreeController extends BaseController<
     this.#groupIdToWalletId.delete(groupId);
 
     if (Object.keys(wallets[walletId].groups).length === 0) {
-      delete state.accountTree.wallets[walletId];
+      delete wallets[walletId];
     }
     return state;
   }

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -298,8 +298,9 @@ export class AccountTreeController extends BaseController<
     walletId: AccountWalletId,
     groupId: AccountGroupId,
   ) {
-    delete state.accountTree.wallets[walletId].groups[groupId];
-    if (Object.keys(state.accountTree.wallets[walletId].groups).length === 0) {
+    const { wallets } = state.accountTree;
+    delete wallets[walletId].groups[groupId];
+    if (Object.keys(wallets[walletId].groups).length === 0) {
       delete state.accountTree.wallets[walletId];
     }
     return state;


### PR DESCRIPTION
## Explanation

* What is the current state of things and why does it need to change? Account removal can leave empty nodes in the Account tree controller.
* What is the solution your changes offer and how does it work? My solution prunes the tree when there is an empty group and/or wallet.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
