### PR TITLE
feat(multichain-account-service): expose `createMultichainAccountGroup` action

### DIFF
--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow custom account providers ([#6231](https://github.com/MetaMask/core/pull/6231))
   - You can now pass an extra option `providers` in the service's constructor.
-- Add multichain account group creation support ([#6222](https://github.com/MetaMask/core/pull/6222))
-  - This includes the new actions `MultichainAccountService:createNextMultichainAccountGroup` ([#6222](https://github.com/MetaMask/core/pull/6222)), and `MultichainAccountService:createMultichainAccountGroup` ([#6238](https://github.com/MetaMask/core/pull/6238))
+- Add multichain account group creation support ([#6222](https://github.com/MetaMask/core/pull/6222), [#6238](https://github.com/MetaMask/core/pull/6238))
+  - This includes the new actions `MultichainAccountService:createNextMultichainAccountGroup` and `MultichainAccountService:createMultichainAccountGroup`
 - Export `MultichainAccountWallet` and `MultichainAccountGroup` types ([#6220](https://github.com/MetaMask/core/pull/6220))
 
 ### Changed

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow custom account providers ([#6231](https://github.com/MetaMask/core/pull/6231))
   - You can now pass an extra option `providers` in the service's constructor.
 - Add multichain account group creation support ([#6222](https://github.com/MetaMask/core/pull/6222))
-  - This includes the new actions `MultichainAccountService:createNextMultichainAccountGroup` ([#6222](https://github.com/MetaMask/core/pull/6222)), and `MultichainAccountService:createMultichainAccountGroup` ([]())
+  - This includes the new actions `MultichainAccountService:createNextMultichainAccountGroup` ([#6222](https://github.com/MetaMask/core/pull/6222)), and `MultichainAccountService:createMultichainAccountGroup` ([#6238](https://github.com/MetaMask/core/pull/6238))
 - Export `MultichainAccountWallet` and `MultichainAccountGroup` types ([#6220](https://github.com/MetaMask/core/pull/6220))
 
 ### Changed

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow custom account providers ([#6231](https://github.com/MetaMask/core/pull/6231))
   - You can now pass an extra option `providers` in the service's constructor.
-- Add multichain account group creation support ([#6222](https://github.com/MetaMask/core/pull/6222), [#6238](https://github.com/MetaMask/core/pull/6238))
+- Add multichain account group creation support ([#6222](https://github.com/MetaMask/core/pull/6222)), ([#6238](https://github.com/MetaMask/core/pull/6238))
   - This includes the new actions `MultichainAccountService:createNextMultichainAccountGroup` and `MultichainAccountService:createMultichainAccountGroup`
 - Export `MultichainAccountWallet` and `MultichainAccountGroup` types ([#6220](https://github.com/MetaMask/core/pull/6220))
 

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow custom account providers ([#6231](https://github.com/MetaMask/core/pull/6231))
   - You can now pass an extra option `providers` in the service's constructor.
 - Add multichain account group creation support ([#6222](https://github.com/MetaMask/core/pull/6222))
-  - This also includes the new action `MultichainAccountService:createNextMultichainAccount`.
+  - This includes the new actions `MultichainAccountService:createNextMultichainAccountGroup` ([#6222](https://github.com/MetaMask/core/pull/6222)), and `MultichainAccountService:createMultichainAccountGroup` ([]())
 - Export `MultichainAccountWallet` and `MultichainAccountGroup` types ([#6220](https://github.com/MetaMask/core/pull/6220))
 
 ### Changed

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow custom account providers ([#6231](https://github.com/MetaMask/core/pull/6231))
   - You can now pass an extra option `providers` in the service's constructor.
 - Add multichain account group creation support ([#6222](https://github.com/MetaMask/core/pull/6222)), ([#6238](https://github.com/MetaMask/core/pull/6238))
-  - This includes the new actions `MultichainAccountService:createNextMultichainAccountGroup` and `MultichainAccountService:createMultichainAccountGroup`
+  - This includes the new actions `MultichainAccountService:createNextMultichainAccountGroup` and `MultichainAccountService:createMultichainAccountGroup`.
 - Export `MultichainAccountWallet` and `MultichainAccountGroup` types ([#6220](https://github.com/MetaMask/core/pull/6220))
 
 ### Changed

--- a/packages/multichain-account-service/src/MultichainAccountService.test.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.test.ts
@@ -525,6 +525,41 @@ describe('MultichainAccountService', () => {
     });
   });
 
+  describe('createMultichainAccountGroup', () => {
+    it('creates a multichain account group with the given group index', async () => {
+      const mockEvmAccount = MockAccountBuilder.from(MOCK_HD_ACCOUNT_1)
+        .withEntropySource(MOCK_HD_KEYRING_1.metadata.id)
+        .withGroupIndex(0)
+        .get();
+      const mockSolAccount = MockAccountBuilder.from(MOCK_HD_ACCOUNT_2)
+        .withEntropySource(MOCK_HD_KEYRING_1.metadata.id)
+        .withGroupIndex(1)
+        .get();
+
+      const { service } = setup({
+        accounts: [mockEvmAccount, mockSolAccount],
+      });
+
+      const firstGroup = await service.createMultichainAccountGroup({
+        entropySource: MOCK_HD_KEYRING_1.metadata.id,
+        groupIndex: 0,
+      });
+
+      const secondGroup = await service.createMultichainAccountGroup({
+        entropySource: MOCK_HD_KEYRING_1.metadata.id,
+        groupIndex: 1,
+      });
+
+      expect(firstGroup.index).toBe(0);
+      expect(firstGroup.getAccounts()).toHaveLength(1);
+      expect(firstGroup.getAccounts()[0]).toStrictEqual(mockEvmAccount);
+
+      expect(secondGroup.index).toBe(1);
+      expect(secondGroup.getAccounts()).toHaveLength(1);
+      expect(secondGroup.getAccounts()[0]).toStrictEqual(mockSolAccount);
+    });
+  });
+
   describe('actions', () => {
     it('gets a multichain account with MultichainAccountService:getMultichainAccount', () => {
       const accounts = [MOCK_HD_ACCOUNT_1];
@@ -580,6 +615,23 @@ describe('MultichainAccountService', () => {
       expect(nextGroup.index).toBe(1);
       // NOTE: There won't be any account for this group, since we're not
       // mocking the providers.
+    });
+
+    it('creates a multichain account group with MultichainAccountService:createMultichainAccountGroup', async () => {
+      const accounts = [MOCK_HD_ACCOUNT_1];
+      const { messenger } = setup({ accounts });
+
+      const firstGroup = await messenger.call(
+        'MultichainAccountService:createMultichainAccountGroup',
+        {
+          entropySource: MOCK_HD_KEYRING_1.metadata.id,
+          groupIndex: 0,
+        },
+      );
+
+      expect(firstGroup.index).toBe(0);
+      expect(firstGroup.getAccounts()).toHaveLength(1);
+      expect(firstGroup.getAccounts()[0]).toStrictEqual(MOCK_HD_ACCOUNT_1);
     });
   });
 });

--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -101,6 +101,10 @@ export class MultichainAccountService {
       'MultichainAccountService:createNextMultichainAccountGroup',
       (...args) => this.createNextMultichainAccountGroup(...args),
     );
+    this.#messenger.registerActionHandler(
+      'MultichainAccountService:createMultichainAccountGroup',
+      (...args) => this.createMultichainAccountGroup(...args),
+    );
   }
 
   /**
@@ -325,5 +329,25 @@ export class MultichainAccountService {
     return await this.#getWallet(
       entropySource,
     ).createNextMultichainAccountGroup();
+  }
+
+  /**
+   * Creates a multichain account group.
+   *
+   * @param options - Options.
+   * @param options.groupIndex - The group index to use.
+   * @param options.entropySource - The wallet's entropy source.
+   * @returns The multichain account group for this group index.
+   */
+  async createMultichainAccountGroup({
+    groupIndex,
+    entropySource,
+  }: {
+    groupIndex: number;
+    entropySource: EntropySourceId;
+  }): Promise<MultichainAccountGroup<Bip44Account<KeyringAccount>>> {
+    return await this.#getWallet(entropySource).createMultichainAccountGroup(
+      groupIndex,
+    );
   }
 }

--- a/packages/multichain-account-service/src/types.ts
+++ b/packages/multichain-account-service/src/types.ts
@@ -43,6 +43,11 @@ export type MultichainAccountServiceCreateNextMultichainAccountGroupAction = {
   handler: MultichainAccountService['createNextMultichainAccountGroup'];
 };
 
+export type MultichainAccountServiceCreateMultichainAccountGroupAction = {
+  type: `${typeof serviceName}:createMultichainAccountGroup`;
+  handler: MultichainAccountService['createMultichainAccountGroup'];
+};
+
 /**
  * All actions that {@link MultichainAccountService} registers so that other
  * modules can call them.
@@ -52,7 +57,8 @@ export type MultichainAccountServiceActions =
   | MultichainAccountServiceGetMultichainAccountGroupsAction
   | MultichainAccountServiceGetMultichainAccountWalletAction
   | MultichainAccountServiceGetMultichainAccountWalletsAction
-  | MultichainAccountServiceCreateNextMultichainAccountGroupAction;
+  | MultichainAccountServiceCreateNextMultichainAccountGroupAction
+  | MultichainAccountServiceCreateMultichainAccountGroupAction;
 
 /**
  * All events that {@link MultichainAccountService} publishes so that other modules


### PR DESCRIPTION
## Explanation

This PR adds the already existing `MultichainAccountWallet.createMultichainAccountGroup` method to `MultichainAccountService`, exposes it as a public method, and adds it as a messenger action.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
