### PR TITLE
chore: mm-foundryup --version stable

### DIFF
--- a/packages/foundryup/src/options.ts
+++ b/packages/foundryup/src/options.ts
@@ -141,8 +141,10 @@ function getOptions(
       default: 'nightly',
       coerce: (
         rawVersion: string,
-      ): { version: 'nightly' | `v${string}`; tag: string } => {
-        if (rawVersion.startsWith('nightly')) {
+      ): { version: 'stable' | 'nightly' | `v${string}`; tag: string } => {
+        if (rawVersion === 'stable') {
+          return { version: 'stable', tag: 'stable' };
+        } else if (rawVersion.startsWith('nightly')) {
           return { version: 'nightly', tag: rawVersion };
           // we don't validate the version much, we just trust the user
         } else if (isVersionString(rawVersion)) {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

When running `yarn mm-foundryup install --version=stable` this fails.

It checks if it is a valid version string starting with `'v'` or `'nightly'`. But both nightly and stable are valid tags. This logic should be changed to include `stable`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

To match the existing behavior of `foundryup --install stable`.

Fixes https://github.com/MetaMask/core/issues/6245

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
