### PR TITLE
chore: Add missing TSDoc template directives

### DIFF
--- a/packages/base-controller/src/Messenger.ts
+++ b/packages/base-controller/src/Messenger.ts
@@ -177,7 +177,9 @@ export class Messenger<
    *
    * @param messengerClient - The object that is expected to make use of the messenger.
    * @param methodNames - The names of the methods on the messenger client to register as action
-   * handlers
+   * handlers.
+   * @template MessengerClient - The type expected to make use of the messenger.
+   * @template MethodNames - The type union of method names to register as action handlers.
    */
   registerMethodActionHandlers<
     MessengerClient extends { name: string },
@@ -252,6 +254,7 @@ export class Messenger<
    * @param args - The arguments to this function
    * @param args.eventType - The event type to register a payload for.
    * @param args.getPayload - A function for retrieving the event payload.
+   * @template EventType - A type union of Event type strings.
    */
   registerInitialEventPayload<EventType extends Event['type']>({
     eventType,

--- a/packages/base-controller/src/RestrictedMessenger.ts
+++ b/packages/base-controller/src/RestrictedMessenger.ts
@@ -131,7 +131,9 @@ export class RestrictedMessenger<
    *
    * @param messengerClient - The object that is expected to make use of the messenger.
    * @param methodNames - The names of the methods on the messenger client to register as action
-   * handlers
+   * handlers.
+   * @template MessengerClient - The type expected to make use of the messenger.
+   * @template MethodNames - The type union of method names to register as action handlers.
    */
   registerMethodActionHandlers<
     MessengerClient extends { name: string },
@@ -208,6 +210,7 @@ export class RestrictedMessenger<
    * @param args - The arguments to this function
    * @param args.eventType - The event type to register a payload for.
    * @param args.getPayload - A function for retrieving the event payload.
+   * @template EventType - A type union of Event type strings.
    */
   registerInitialEventPayload<
     EventType extends Event['type'] & NamespacedName<Namespace>,

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -177,7 +177,9 @@ export class Messenger<
    *
    * @param messengerClient - The object that is expected to make use of the messenger.
    * @param methodNames - The names of the methods on the messenger client to register as action
-   * handlers
+   * handlers.
+   * @template MessengerClient - The type expected to make use of the messenger.
+   * @template MethodNames - The type union of method names to register as action handlers.
    */
   registerMethodActionHandlers<
     MessengerClient extends { name: string },
@@ -252,6 +254,7 @@ export class Messenger<
    * @param args - The arguments to this function
    * @param args.eventType - The event type to register a payload for.
    * @param args.getPayload - A function for retrieving the event payload.
+   * @template EventType - A type union of Event type strings.
    */
   registerInitialEventPayload<EventType extends Event['type']>({
     eventType,


### PR DESCRIPTION
## Explanation

Two Messenger methods were missing template directives. They were added in all three Messenger classes (which are soon to be consolidated into one).


## References

Extracted from #6132

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
