### PR TITLE
refactor(account-tree-controller): remove `wallet.metadata.entropy.index`

### DIFF
--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -15,10 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Custom names and metadata survive controller initialization and tree rebuilds.
   - Support for `lastUpdatedAt` timestamps for Account Syncing V2 compatibility.
 - Add setter methods for setting custom account group names, wallet names and their pinning state and visibility ([#6221](https://github.com/MetaMask/core/pull/6221))
-- Add `group.type` tag ([#6214](https://github.com/MetaMask/core/pull/6214))
+- Add `{wallet,group}.type` tag ([#6214](https://github.com/MetaMask/core/pull/6214))
   - This `type` can be used as a tag to strongly-type (tagged-union) the `AccountGroupObject`.
-- Add `group.metadata` metadata object ([#6214](https://github.com/MetaMask/core/pull/6214))
-  - Given the `group.type` you will now have access to specific metadata information (e.g. `groupIndex` for multichain account groups)
+  - The `type` from `wallet.metadata` has been moved to `wallet.type` instead and can be used to (tagged-union) the `AccountWalletObject`.
+- Add `{wallet,group}.metadata` metadata object ([#6214](https://github.com/MetaMask/core/pull/6214)), ([#6258](https://github.com/MetaMask/core/pull/6258))
+  - Given the `{wallet,group}.type` you will now have access to specific metadata information (e.g. `group.metadata.groupIndex` for multichain account groups or `wallet.metadata.entropy.id` for multichain account wallets)
 - Automatically prune empty groups and wallets upon account removal ([#6234](https://github.com/MetaMask/core/pull/6234))
   - This ensures that there aren't any empty nodes in the `AccountTreeController` state.
 

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -440,7 +440,6 @@ describe('AccountTreeController', () => {
                 name: 'Wallet 1',
                 entropy: {
                   id: MOCK_HD_KEYRING_1.metadata.id,
-                  index: 0,
                 },
               },
             },
@@ -480,7 +479,6 @@ describe('AccountTreeController', () => {
                 name: 'Wallet 2',
                 entropy: {
                   id: MOCK_HD_KEYRING_2.metadata.id,
-                  index: 1,
                 },
               },
             },
@@ -716,7 +714,6 @@ describe('AccountTreeController', () => {
                 name: 'Wallet 1',
                 entropy: {
                   id: MOCK_HD_KEYRING_1.metadata.id,
-                  index: 0,
                 },
               },
             },
@@ -785,7 +782,6 @@ describe('AccountTreeController', () => {
                 name: 'Wallet 1',
                 entropy: {
                   id: MOCK_HD_KEYRING_1.metadata.id,
-                  index: 0,
                 },
               },
             },
@@ -890,7 +886,6 @@ describe('AccountTreeController', () => {
                 name: 'Wallet 1',
                 entropy: {
                   id: MOCK_HD_KEYRING_1.metadata.id,
-                  index: 0,
                 },
               },
             },
@@ -977,7 +972,6 @@ describe('AccountTreeController', () => {
                 name: 'Wallet 1',
                 entropy: {
                   id: MOCK_HD_KEYRING_1.metadata.id,
-                  index: 0,
                 },
               },
             },
@@ -1004,7 +998,6 @@ describe('AccountTreeController', () => {
                 name: 'Wallet 2',
                 entropy: {
                   id: MOCK_HD_KEYRING_2.metadata.id,
-                  index: 1,
                 },
               },
             },

--- a/packages/account-tree-controller/src/rules/entropy.ts
+++ b/packages/account-tree-controller/src/rules/entropy.ts
@@ -60,8 +60,6 @@ export class EntropyRule
         metadata: {
           entropy: {
             id: entropySource,
-            // QUESTION: Should we re-compute the index everytime instead?
-            index: entropySourceIndex,
           },
         },
       },
@@ -83,7 +81,13 @@ export class EntropyRule
   getDefaultAccountWalletName(
     wallet: AccountWalletObjectOf<AccountWalletType.Entropy>,
   ): string {
-    return `Wallet ${wallet.metadata.entropy.index + 1}`; // Use human indexing (starts at 1).
+    // NOTE: We have checked during the rule matching, so we can safely assume it will
+    // well-defined here.
+    const entropySourceIndex = this.getEntropySourceIndex(
+      wallet.metadata.entropy.id,
+    );
+
+    return `Wallet ${entropySourceIndex + 1}`; // Use human indexing (starts at 1).
   }
 
   getDefaultAccountGroupName(

--- a/packages/account-tree-controller/src/wallet.ts
+++ b/packages/account-tree-controller/src/wallet.ts
@@ -65,7 +65,6 @@ export type AccountWalletEntropyObject = {
   metadata: AccountTreeWalletMetadata & {
     entropy: {
       id: EntropySourceId;
-      index: number;
     };
   };
 };


### PR DESCRIPTION
## Explanation

Removing the `wallet.metadata.entropy.index`. This is mainly used by us for the naming, and the "order" is the responsibility of the `KeyringController` mainly, not the `AccountTreeController`.

## References

N/A

## Changelog

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
