### PR TITLE
chore: Remove obsolete changelog section from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,14 +23,6 @@ For example:
 * Related to #67890
 -->
 
-## Changelog
-
-<!--
-THIS SECTION IS NO LONGER NEEDED.
-
-The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
--->
-
 ## Checklist
 
 - [ ] I've updated the test suite for new or updated code as appropriate


### PR DESCRIPTION
## Explanation

This section has not been used for some time now. Leaving it here was helpful for the transition to the new changelog process, but it has been long enough now that I don't think it's needed anymore.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
