### PR TITLE
refactor(account-tree-controller)!: remove `AccountTree{Wallet,Group}` in-memory instances

### DIFF
--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Bump peer dependency `@metamask/account-api` from `^0.3.0` to `^0.9.0` ([#6214](https://github.com/MetaMask/core/pull/6214)), ([#6216](https://github.com/MetaMask/core/pull/6216)), ([#6222](https://github.com/MetaMask/core/pull/6222)), ([#6248](https://github.com/MetaMask/core/pull/6248))
+- **BREAKING:** Remove use of in-memory wallets and groups (`AccountTree{Wallet,Object}`) ([#6265](https://github.com/MetaMask/core/pull/6265))
+  - Those types are not ready to be used and adds no value for now.
 - **BREAKING:** Move `wallet.metadata.type` tag to `wallet` node ([#6214](https://github.com/MetaMask/core/pull/6214))
   - This `type` can be used as a tag to strongly-type (tagged-union) the `AccountWalletObject`.
 - Defaults to the EVM account from a group when using `setSelectedAccountGroup` ([#6208](https://github.com/MetaMask/core/pull/6208))

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -1,8 +1,4 @@
-import type {
-  AccountWalletId,
-  Bip44Account,
-  MultichainAccountWalletId,
-} from '@metamask/account-api';
+import type { AccountWalletId, Bip44Account } from '@metamask/account-api';
 import {
   AccountGroupType,
   AccountWalletType,
@@ -29,7 +25,6 @@ import type { GetSnap as SnapControllerGetSnap } from '@metamask/snaps-controlle
 
 import { AccountTreeController } from './AccountTreeController';
 import type { AccountGroupObject } from './group';
-import { AccountTreeGroup } from './group';
 import { BaseRule } from './rule';
 import { getAccountWalletNameFromKeyringType } from './rules/keyring';
 import {
@@ -40,7 +35,6 @@ import {
   type AllowedActions,
   type AllowedEvents,
 } from './types';
-import { AccountTreeWallet } from './wallet';
 
 // Local mock of EMPTY_ACCOUNT to avoid circular dependency
 const EMPTY_ACCOUNT_MOCK: InternalAccount = {
@@ -1190,7 +1184,7 @@ describe('AccountTreeController', () => {
         AccountWalletType.Entropy,
         MOCK_HD_KEYRING_1.metadata.id,
       );
-      const wallet = controller.getAccountWallet(walletId);
+      const wallet = controller.getAccountWalletObject(walletId);
       expect(wallet).toBeDefined();
     });
 
@@ -1203,12 +1197,12 @@ describe('AccountTreeController', () => {
 
       const badGroupId: AccountWalletId = 'entropy:unknown';
 
-      const wallet = controller.getAccountWallet(badGroupId);
+      const wallet = controller.getAccountWalletObject(badGroupId);
       expect(wallet).toBeUndefined();
     });
   });
 
-  describe('getAccountWallets', () => {
+  describe('getAccountWalletObjects', () => {
     it('gets all wallets', () => {
       const { controller } = setup({
         accounts: [MOCK_HD_ACCOUNT_1, MOCK_HD_ACCOUNT_2],
@@ -1216,206 +1210,8 @@ describe('AccountTreeController', () => {
       });
       controller.init();
 
-      const wallets = controller.getAccountWallets();
+      const wallets = controller.getAccountWalletObjects();
       expect(wallets).toHaveLength(2);
-    });
-  });
-
-  describe('AccountTreeWallet', () => {
-    it('gets account groups from a wallet', () => {
-      const { controller } = setup({
-        accounts: [MOCK_HD_ACCOUNT_1],
-        keyrings: [MOCK_HD_KEYRING_1],
-      });
-      controller.init();
-
-      const wallets = controller.getAccountWallets();
-      expect(wallets).toHaveLength(1);
-
-      const wallet = wallets[0];
-      expect(wallet.id).toBeDefined();
-      expect(wallet.name).toBeDefined();
-      expect(wallet.type).toBeDefined();
-
-      const groups = wallet.getAccountGroups();
-      expect(groups).toHaveLength(1);
-      expect(groups[0].id).toStrictEqual(
-        toMultichainAccountGroupId(
-          wallet.id as MultichainAccountWalletId,
-          MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
-        ),
-      );
-    });
-
-    it('gets a specific account group using its ID', () => {
-      const { controller } = setup({
-        accounts: [MOCK_HD_ACCOUNT_1],
-        keyrings: [MOCK_HD_KEYRING_1],
-      });
-      controller.init();
-
-      const wallets = controller.getAccountWallets();
-      expect(wallets).toHaveLength(1);
-
-      const wallet = wallets[0];
-      const groupId = toMultichainAccountGroupId(
-        wallet.id as MultichainAccountWalletId,
-        MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
-      );
-
-      const group = wallet.getAccountGroup(groupId);
-      expect(group).toBeDefined();
-      expect(group?.id).toStrictEqual(groupId);
-
-      expect(() => wallet.getAccountGroupOrThrow(groupId)).not.toThrow();
-    });
-
-    it('throws if it cannot get an account group', () => {
-      const { controller } = setup({
-        accounts: [MOCK_HD_ACCOUNT_1],
-        keyrings: [MOCK_HD_KEYRING_1],
-      });
-      controller.init();
-
-      const wallets = controller.getAccountWallets();
-      expect(wallets).toHaveLength(1);
-
-      const wallet = wallets[0];
-      const groupId = toAccountGroupId(wallet.id, 'bad-id');
-      expect(() => wallet.getAccountGroupOrThrow(groupId)).toThrow(
-        'Unable to get account group',
-      );
-    });
-  });
-
-  describe('AccountTreeGroup', () => {
-    const setupGroup = ({
-      accounts = [MOCK_HD_ACCOUNT_1],
-    }: { accounts?: InternalAccount[] } = {}) => {
-      const { controller, mocks } = setup({
-        accounts,
-        keyrings: [MOCK_HD_KEYRING_1],
-      });
-      controller.init();
-
-      const wallets = controller.getAccountWallets();
-      expect(wallets).toHaveLength(1);
-
-      const wallet = wallets[0];
-      const groups = wallet.getAccountGroups();
-      expect(groups).toHaveLength(1);
-
-      const group = groups[0];
-
-      return { group, controller, mocks };
-    };
-
-    it('gets accounts from an account group', () => {
-      const { group } = setupGroup();
-
-      expect(group.id).toBeDefined();
-      expect(group.wallet).toBeDefined();
-      expect(group.name).toBeDefined();
-      expect(group.type).toBeDefined();
-
-      const accounts = group.getAccounts();
-      const accountIds = group.getAccountIds();
-      expect(accounts).toHaveLength(1);
-      expect(accounts.map((account) => account.id)).toStrictEqual(accountIds);
-    });
-
-    it('throws if an account cannot be resolved', () => {
-      const { group, mocks } = setupGroup();
-
-      const accountIds = group.getAccountIds();
-      expect(accountIds).toHaveLength(1);
-
-      mocks.AccountsController.getAccount.mockReturnValue(undefined);
-      expect(() => group.getAccounts()).toThrow(
-        `Unable to get account with ID: "${MOCK_HD_ACCOUNT_1.id}"`,
-      );
-    });
-
-    it('gets one account using a selector', () => {
-      const { group } = setupGroup();
-
-      expect(group.get({ scopes: [EthScope.Mainnet] })).toBe(MOCK_HD_ACCOUNT_1);
-    });
-
-    it('gets no account if selector did not match', () => {
-      const { group } = setupGroup();
-
-      expect(group.get({ scopes: [SolScope.Mainnet] })).toBeUndefined();
-    });
-
-    it('throws if too many accounts are matching selector', () => {
-      const { group } = setupGroup({
-        accounts: [MOCK_HD_ACCOUNT_2, MOCK_HD_ACCOUNT_2],
-      });
-
-      expect(() => group.get({ scopes: [EthScope.Mainnet] })).toThrow(
-        'Too many account candidates, expected 1, got: 2',
-      );
-    });
-
-    it('selects accounts using a selector', () => {
-      const { group } = setupGroup();
-
-      expect(group.select({ scopes: [EthScope.Mainnet] })).toStrictEqual([
-        MOCK_HD_ACCOUNT_1,
-      ]);
-    });
-
-    it('selects no account if selector did not match', () => {
-      const { group } = setupGroup();
-
-      expect(group.select({ scopes: [SolScope.Mainnet] })).toStrictEqual([]);
-    });
-
-    it('gets the only account from a group', () => {
-      const { group } = setupGroup({ accounts: [MOCK_HARDWARE_ACCOUNT_1] });
-
-      expect(group.getOnlyAccount()).toBe(MOCK_HARDWARE_ACCOUNT_1);
-    });
-
-    it('throws if the group has more than 1 account when calling getOnlyAccount', () => {
-      const messenger = getAccountTreeControllerMessenger();
-
-      const wallet = new AccountTreeWallet({
-        messenger,
-        wallet: {
-          id: toAccountWalletId(AccountWalletType.Keyring, KeyringTypes.simple),
-          type: AccountWalletType.Keyring,
-          groups: {},
-          metadata: {
-            name: '',
-            keyring: {
-              type: KeyringTypes.simple,
-            },
-          },
-        },
-      });
-      const group = new AccountTreeGroup({
-        messenger,
-        wallet,
-        group: {
-          id: toAccountGroupId(wallet.id, 'bad'),
-          type: AccountGroupType.SingleAccount,
-          // Testing an error case here, so we have to cast.
-          accounts: [MOCK_HD_ACCOUNT_1.id, MOCK_HD_ACCOUNT_2.id] as unknown as [
-            InternalAccount['id'],
-          ],
-          metadata: {
-            name: '',
-            pinned: false,
-            hidden: false,
-          },
-        },
-      });
-
-      expect(() => group.getOnlyAccount()).toThrow(
-        'Group contains more than 1 account',
-      );
     });
   });
 

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -15,7 +15,6 @@ import type {
   AccountTreeControllerState,
 } from './types';
 import type { AccountWalletObject } from './wallet';
-import { AccountTreeWallet } from './wallet';
 
 export const controllerName = 'AccountTreeController';
 
@@ -253,19 +252,19 @@ export class AccountTreeController extends BaseController<
     }
   }
 
-  getAccountWallet(walletId: AccountWalletId): AccountTreeWallet | undefined {
+  getAccountWalletObject(
+    walletId: AccountWalletId,
+  ): AccountWalletObject | undefined {
     const wallet = this.state.accountTree.wallets[walletId];
     if (!wallet) {
       return undefined;
     }
 
-    return new AccountTreeWallet({ messenger: this.messagingSystem, wallet });
+    return wallet;
   }
 
-  getAccountWallets(): AccountTreeWallet[] {
-    return Object.values(this.state.accountTree.wallets).map((wallet) => {
-      return new AccountTreeWallet({ messenger: this.messagingSystem, wallet });
-    });
+  getAccountWalletObjects(): AccountWalletObject[] {
+    return Object.values(this.state.accountTree.wallets);
   }
 
   #handleAccountAdded(account: InternalAccount) {

--- a/packages/account-tree-controller/src/group.ts
+++ b/packages/account-tree-controller/src/group.ts
@@ -1,20 +1,11 @@
 import {
-  select,
-  selectOne,
   type AccountGroupType,
   type MultichainAccountGroupId,
 } from '@metamask/account-api';
-import type {
-  AccountGroup,
-  AccountGroupId,
-  AccountSelector,
-} from '@metamask/account-api';
+import type { AccountGroupId } from '@metamask/account-api';
 import type { AccountId } from '@metamask/accounts-controller';
-import type { InternalAccount } from '@metamask/keyring-internal-api';
 
 import type { UpdatableField, ExtractFieldValues } from './type-utils.js';
-import type { AccountTreeControllerMessenger } from './types';
-import type { AccountTreeWallet } from './wallet';
 
 /**
  * Persisted metadata for account groups (stored in controller state for persistence/sync).
@@ -34,8 +25,6 @@ export type AccountTreeGroupPersistedMetadata = {
 export type AccountTreeGroupMetadata = Required<
   ExtractFieldValues<AccountTreeGroupPersistedMetadata>
 >;
-
-export const DEFAULT_ACCOUNT_GROUP_NAME: string = 'Default';
 
 /**
  * Type constraint for a {@link AccountGroupObject}. If one of its union-members
@@ -95,84 +84,3 @@ export type AccountGroupObjectOf<GroupType extends AccountGroupType> = Extract<
     },
   { type: GroupType }
 >['object'];
-
-/**
- * Account group coming from the {@link AccountTreeController}.
- */
-export class AccountTreeGroup implements AccountGroup<InternalAccount> {
-  readonly #messenger: AccountTreeControllerMessenger;
-
-  readonly #group: AccountGroupObject;
-
-  readonly #wallet: AccountTreeWallet;
-
-  constructor({
-    messenger,
-    wallet,
-    group,
-  }: {
-    messenger: AccountTreeControllerMessenger;
-    wallet: AccountTreeWallet;
-    group: AccountGroupObject;
-  }) {
-    this.#messenger = messenger;
-    this.#group = group;
-    this.#wallet = wallet;
-  }
-
-  get id(): AccountGroupId {
-    return this.#group.id;
-  }
-
-  get wallet(): AccountTreeWallet {
-    return this.#wallet;
-  }
-
-  get type(): AccountGroupType {
-    return this.#group.type;
-  }
-
-  get name(): string {
-    return this.#group.metadata.name;
-  }
-
-  getAccountIds(): [InternalAccount['id'], ...InternalAccount['id'][]] {
-    return this.#group.accounts;
-  }
-
-  getAccount(id: string): InternalAccount | undefined {
-    return this.#messenger.call('AccountsController:getAccount', id);
-  }
-
-  #getAccount(id: string): InternalAccount {
-    const account = this.getAccount(id);
-
-    if (!account) {
-      throw new Error(`Unable to get account with ID: "${id}"`);
-    }
-    return account;
-  }
-
-  getAccounts(): InternalAccount[] {
-    return this.#group.accounts.map((id) => this.#getAccount(id));
-  }
-
-  getOnlyAccount(): InternalAccount {
-    const accountIds = this.getAccountIds();
-
-    if (accountIds.length > 1) {
-      throw new Error('Group contains more than 1 account');
-    }
-
-    // A group always have at least one account.
-    return this.#getAccount(accountIds[0]);
-  }
-
-  get(selector: AccountSelector<InternalAccount>): InternalAccount | undefined {
-    return selectOne(this.getAccounts(), selector);
-  }
-
-  select(selector: AccountSelector<InternalAccount>): InternalAccount[] {
-    return select(this.getAccounts(), selector);
-  }
-}

--- a/packages/account-tree-controller/src/index.ts
+++ b/packages/account-tree-controller/src/index.ts
@@ -1,5 +1,5 @@
-export type { AccountTreeWallet, AccountWalletObject } from './wallet';
-export type { AccountTreeGroup, AccountGroupObject } from './group';
+export type { AccountWalletObject } from './wallet';
+export type { AccountGroupObject } from './group';
 
 export type {
   AccountTreeControllerState,

--- a/packages/account-tree-controller/src/wallet.ts
+++ b/packages/account-tree-controller/src/wallet.ts
@@ -3,10 +3,9 @@ import type {
   AccountWalletId,
   MultichainAccountWalletId,
 } from '@metamask/account-api';
-import { type AccountGroupId, type AccountWallet } from '@metamask/account-api';
+import { type AccountGroupId } from '@metamask/account-api';
 import type { EntropySourceId } from '@metamask/keyring-api';
 import type { KeyringTypes } from '@metamask/keyring-controller';
-import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { SnapId } from '@metamask/snaps-sdk';
 
 import type {
@@ -14,9 +13,7 @@ import type {
   AccountGroupObject,
   AccountGroupSingleAccountObject,
 } from './group';
-import { AccountTreeGroup } from './group';
 import type { UpdatableField, ExtractFieldValues } from './type-utils.js';
-import { type AccountTreeControllerMessenger } from './types';
 
 /**
  * Persisted metadata for account wallets (stored in controller state for persistence/sync).
@@ -117,84 +114,3 @@ export type AccountWalletObjectOf<WalletType extends AccountWalletType> =
     | { type: AccountWalletType.Snap; object: AccountWalletSnapObject },
     { type: WalletType }
   >['object'];
-
-/**
- * Account wallet coming from the {@link AccountTreeController}.
- */
-export class AccountTreeWallet implements AccountWallet<InternalAccount> {
-  readonly #wallet: AccountWalletObject;
-
-  protected messenger: AccountTreeControllerMessenger;
-
-  protected groups: Map<AccountGroupId, AccountTreeGroup>;
-
-  constructor({
-    messenger,
-    wallet,
-  }: {
-    messenger: AccountTreeControllerMessenger;
-    wallet: AccountWalletObject;
-  }) {
-    this.messenger = messenger;
-    this.#wallet = wallet;
-    this.groups = new Map();
-
-    for (const [groupId, group] of Object.entries(this.#wallet.groups)) {
-      this.groups.set(
-        groupId as AccountGroupId,
-        new AccountTreeGroup({
-          messenger: this.messenger,
-          wallet: this,
-          group,
-        }),
-      );
-    }
-  }
-
-  get id(): AccountWalletId {
-    return this.#wallet.id;
-  }
-
-  get type(): AccountWalletType {
-    return this.#wallet.type;
-  }
-
-  get name(): string {
-    return this.#wallet.metadata.name;
-  }
-
-  /**
-   * Gets account tree group for a given ID.
-   *
-   * @param groupId - Group ID.
-   * @returns Account tree group, or undefined if not found.
-   */
-  getAccountGroup(groupId: AccountGroupId): AccountTreeGroup | undefined {
-    return this.groups.get(groupId);
-  }
-
-  /**
-   * Gets account tree group for a given ID.
-   *
-   * @param groupId - Group ID.
-   * @throws If the account group is not found.
-   * @returns Account tree group.
-   */
-  getAccountGroupOrThrow(groupId: AccountGroupId): AccountTreeGroup {
-    const group = this.getAccountGroup(groupId);
-    if (!group) {
-      throw new Error('Unable to get account group');
-    }
-
-    return group;
-  }
-
-  /**
-   * Gets all account tree groups.
-   *
-   * @returns Account tree groups.
-   */
-  getAccountGroups(): AccountTreeGroup[] {
-    return Array.from(this.groups.values());
-  }
-}


### PR DESCRIPTION
## Explanation

This implementation is not good enough to start using it.

We will re-enable this once we have a better solution for those. For the moment, we will add actions to the controller to be able to fetch accounts from the selected account group and that should cover most use-cases for the moment.

They will be replaced by:
- https://github.com/MetaMask/core/pull/6266

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
