### PR TITLE
fix: hardcode xchain swaps action_type to swapbridge_v1

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** Remove `getActionType` export and hardcode `action_type` to `swapbridge-v1`. Deprecate `crosschain-v1` MetricsActionType because it shouldn't be used after swaps and bridge are unified ([#6270](https://github.com/MetaMask/core/pull/6270))
+
 ## [38.0.0]
 
 ### Fixed

--- a/packages/bridge-controller/src/__snapshots__/bridge-controller.test.ts.snap
+++ b/packages/bridge-controller/src/__snapshots__/bridge-controller.test.ts.snap
@@ -55,7 +55,6 @@ Array [
   Array [
     "Unified SwapBridge Completed",
     Object {
-      "action_type": "crosschain-v1",
       "actual_time_minutes": 10,
       "approval_transaction": "PENDING",
       "chain_id_destination": "eip155:10",
@@ -92,7 +91,7 @@ Array [
   Array [
     "Unified SwapBridge Failed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "actual_time_minutes": 10,
       "allowance_reset_transaction": "PENDING",
       "approval_transaction": "PENDING",
@@ -131,7 +130,7 @@ Array [
   Array [
     "Unified SwapBridge Failed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": "eip155:1",
       "chain_id_source": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       "custom_slippage": true,
@@ -167,7 +166,7 @@ Array [
   Array [
     "Unified SwapBridge Snap Confirmation Page Viewed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": null,
       "chain_id_source": "eip155:1",
       "custom_slippage": false,
@@ -192,7 +191,7 @@ Array [
   Array [
     "Unified SwapBridge Submitted",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": "eip155:10",
       "chain_id_source": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       "custom_slippage": true,
@@ -227,7 +226,7 @@ Array [
   Array [
     "Unified SwapBridge All Quotes Opened",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "can_submit": true,
       "chain_id_destination": null,
       "chain_id_source": "eip155:1",
@@ -255,7 +254,7 @@ Array [
   Array [
     "Unified SwapBridge All Quotes Sorted",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "best_quote_provider": "provider_bridge2",
       "can_submit": true,
       "chain_id_destination": null,
@@ -285,7 +284,7 @@ Array [
   Array [
     "Unified SwapBridge Button Clicked",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": null,
       "chain_id_source": "eip155:1",
       "location": "Main View",
@@ -303,7 +302,7 @@ Array [
   Array [
     "Unified SwapBridge Source Destination Flipped",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": "eip155:10",
       "chain_id_source": "eip155:1",
       "security_warnings": Array [
@@ -324,7 +323,7 @@ Array [
     "Unified SwapBridge Page Viewed",
     Object {
       "abc": 1,
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": null,
       "chain_id_source": "eip155:1",
       "token_address_destination": null,
@@ -339,7 +338,7 @@ Array [
   Array [
     "Unified SwapBridge Quote Selected",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "best_quote_provider": "provider_bridge2",
       "can_submit": false,
       "chain_id_destination": null,
@@ -370,7 +369,7 @@ Array [
   Array [
     "Unified SwapBridge Quotes Received",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "best_quote_provider": "provider_bridge2",
       "can_submit": true,
       "chain_id_destination": null,
@@ -404,7 +403,7 @@ Array [
   Array [
     "Unified SwapBridge Input Changed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "input": "chain_source",
       "input_value": "eip155:1",
     },
@@ -412,7 +411,7 @@ Array [
   Array [
     "Unified SwapBridge Input Changed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "input": "chain_destination",
       "input_value": "eip155:10",
     },
@@ -420,7 +419,7 @@ Array [
   Array [
     "Unified SwapBridge Input Changed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "input": "token_destination",
       "input_value": "eip155:10/erc20:0x123",
     },
@@ -428,7 +427,7 @@ Array [
   Array [
     "Unified SwapBridge Input Changed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "input": "slippage",
       "input_value": 0.5,
     },
@@ -436,7 +435,7 @@ Array [
   Array [
     "Unified SwapBridge Quotes Requested",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": "eip155:10",
       "chain_id_source": "eip155:1",
       "custom_slippage": true,
@@ -457,7 +456,7 @@ Array [
   Array [
     "Unified SwapBridge Quotes Received",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "best_quote_provider": "provider_bridge2",
       "can_submit": true,
       "chain_id_destination": "eip155:10",
@@ -788,7 +787,7 @@ Array [
   Array [
     "Unified SwapBridge Input Changed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "input": "chain_source",
       "input_value": "eip155:1",
     },
@@ -796,7 +795,7 @@ Array [
   Array [
     "Unified SwapBridge Input Changed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "input": "chain_destination",
       "input_value": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
     },
@@ -804,7 +803,7 @@ Array [
   Array [
     "Unified SwapBridge Input Changed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "input": "token_destination",
       "input_value": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:123d1",
     },
@@ -812,7 +811,7 @@ Array [
   Array [
     "Unified SwapBridge Input Changed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "input": "slippage",
       "input_value": 0.5,
     },
@@ -820,7 +819,7 @@ Array [
   Array [
     "Unified SwapBridge Quotes Requested",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       "chain_id_source": "eip155:1",
       "custom_slippage": true,
@@ -841,7 +840,7 @@ Array [
   Array [
     "Unified SwapBridge Quotes Requested",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       "chain_id_source": "eip155:1",
       "custom_slippage": true,
@@ -862,7 +861,7 @@ Array [
   Array [
     "Unified SwapBridge Quotes Requested",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       "chain_id_source": "eip155:1",
       "custom_slippage": true,
@@ -883,7 +882,7 @@ Array [
   Array [
     "Unified SwapBridge Quote Error",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       "chain_id_source": "eip155:1",
       "custom_slippage": true,
@@ -905,7 +904,7 @@ Array [
   Array [
     "Unified SwapBridge Quotes Requested",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "chain_id_destination": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       "chain_id_source": "eip155:1",
       "custom_slippage": true,
@@ -929,7 +928,7 @@ Array [
   Array [
     "Unified SwapBridge Input Changed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "input": "chain_source",
       "input_value": "eip155:1",
     },
@@ -945,7 +944,7 @@ Array [
   Array [
     "Unified SwapBridge Input Changed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "input": "slippage",
       "input_value": 0.5,
     },

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -32,7 +32,6 @@ import * as featureFlagUtils from './utils/feature-flags';
 import * as fetchUtils from './utils/fetch';
 import {
   MetaMetricsSwapsEventSource,
-  MetricsActionType,
   MetricsSwapType,
   UnifiedSwapBridgeEventName,
 } from './utils/metrics/constants';
@@ -1811,7 +1810,6 @@ describe('BridgeController', function () {
       bridgeController.trackUnifiedSwapBridgeEvent(
         UnifiedSwapBridgeEventName.SnapConfirmationViewed,
         {
-          action_type: MetricsActionType.CROSSCHAIN_V1,
           price_impact: 0,
           usd_quoted_gas: 0,
           gas_included: false,
@@ -1869,7 +1867,6 @@ describe('BridgeController', function () {
       bridgeController.trackUnifiedSwapBridgeEvent(
         UnifiedSwapBridgeEventName.Completed,
         {
-          action_type: MetricsActionType.CROSSCHAIN_V1,
           approval_transaction: StatusTypes.PENDING,
           source_transaction: StatusTypes.PENDING,
           destination_transaction: StatusTypes.PENDING,
@@ -1907,7 +1904,6 @@ describe('BridgeController', function () {
       bridgeController.trackUnifiedSwapBridgeEvent(
         UnifiedSwapBridgeEventName.Failed,
         {
-          action_type: MetricsActionType.CROSSCHAIN_V1,
           allowance_reset_transaction: StatusTypes.PENDING,
           approval_transaction: StatusTypes.PENDING,
           source_transaction: StatusTypes.PENDING,

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -48,10 +48,12 @@ import {
 } from './utils/caip-formatters';
 import { getBridgeFeatureFlags } from './utils/feature-flags';
 import { fetchAssetPrices, fetchBridgeQuotes } from './utils/fetch';
-import { UnifiedSwapBridgeEventName } from './utils/metrics/constants';
+import {
+  MetricsActionType,
+  UnifiedSwapBridgeEventName,
+} from './utils/metrics/constants';
 import {
   formatProviderLabel,
-  getActionTypeFromQuoteRequest,
   getRequestParams,
   getSwapTypeFromQuote,
   isCustomSlippage,
@@ -819,8 +821,8 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     propertiesFromClient: Pick<RequiredEventContextFromClient, T>[T],
   ): CrossChainSwapsEventProperties<T> => {
     const baseProperties = {
-      action_type: getActionTypeFromQuoteRequest(this.state.quoteRequest),
       ...propertiesFromClient,
+      action_type: MetricsActionType.SWAPBRIDGE_V1,
     };
     switch (eventName) {
       case UnifiedSwapBridgeEventName.ButtonClicked:

--- a/packages/bridge-controller/src/index.ts
+++ b/packages/bridge-controller/src/index.ts
@@ -17,7 +17,6 @@ export type {
 export {
   formatProviderLabel,
   getRequestParams,
-  getActionType,
   getSwapType,
   isHardwareWallet,
   isCustomSlippage,

--- a/packages/bridge-controller/src/utils/metrics/constants.ts
+++ b/packages/bridge-controller/src/utils/metrics/constants.ts
@@ -29,6 +29,9 @@ export enum MetaMetricsSwapsEventSource {
 }
 
 export enum MetricsActionType {
+  /**
+   * @deprecated new events should use SWAPBRIDGE_V1 instead
+   */
   CROSSCHAIN_V1 = 'crosschain-v1',
   SWAPBRIDGE_V1 = 'swapbridge-v1',
 }

--- a/packages/bridge-controller/src/utils/metrics/properties.test.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.test.ts
@@ -1,11 +1,10 @@
 import { SolScope } from '@metamask/keyring-api';
 import type { CaipChainId } from '@metamask/utils';
 
-import { MetricsActionType, MetricsSwapType } from './constants';
+import { MetricsSwapType } from './constants';
 import {
   toInputChangedPropertyKey,
   toInputChangedPropertyValue,
-  getActionTypeFromQuoteRequest,
   getSwapTypeFromQuote,
   formatProviderLabel,
   getRequestParams,
@@ -134,26 +133,6 @@ describe('properties', () => {
       const result = slippageFormatter?.({});
 
       expect(result).toBeUndefined();
-    });
-  });
-
-  describe('getActionType', () => {
-    it('should return SWAPBRIDGE_V1 when srcChainId equals destChainId', () => {
-      const result = getActionTypeFromQuoteRequest({
-        srcChainId: '1',
-        destChainId: '1',
-      });
-
-      expect(result).toBe(MetricsActionType.SWAPBRIDGE_V1);
-    });
-
-    it('should return CROSSCHAIN_V1 when srcChainId does not equal destChainId', () => {
-      const result = getActionTypeFromQuoteRequest({
-        srcChainId: '1',
-        destChainId: '2',
-      });
-
-      expect(result).toBe(MetricsActionType.CROSSCHAIN_V1);
     });
   });
 

--- a/packages/bridge-controller/src/utils/metrics/properties.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.ts
@@ -1,6 +1,6 @@
 import type { CaipChainId } from '@metamask/utils';
 
-import { MetricsActionType, MetricsSwapType } from './constants';
+import { MetricsSwapType } from './constants';
 import type { InputKeys, InputValues } from './types';
 import type { AccountsControllerState } from '../../../../accounts-controller/src/AccountsController';
 import { DEFAULT_BRIDGE_CONTROLLER_STATE } from '../../constants/bridge';
@@ -43,22 +43,6 @@ export const toInputChangedPropertyValue: Partial<
   destChainId: ({ destChainId }) =>
     destChainId ? formatChainIdToCaip(destChainId) : undefined,
   slippage: ({ slippage }) => (slippage ? Number(slippage) : slippage),
-};
-
-export const getActionType = (
-  srcChainId?: GenericQuoteRequest['srcChainId'],
-  destChainId?: GenericQuoteRequest['destChainId'],
-) => {
-  if (srcChainId && !isCrossChain(srcChainId, destChainId ?? srcChainId)) {
-    return MetricsActionType.SWAPBRIDGE_V1;
-  }
-  return MetricsActionType.CROSSCHAIN_V1;
-};
-
-export const getActionTypeFromQuoteRequest = (
-  quoteRequest: Partial<GenericQuoteRequest>,
-) => {
-  return getActionType(quoteRequest.srcChainId, quoteRequest.destChainId);
 };
 
 export const getSwapType = (

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -120,9 +120,7 @@ export type RequiredEventContextFromClient = {
     QuoteFetchData,
     'price_impact'
   > &
-    TradeData & {
-      action_type: MetricsActionType;
-    };
+    TradeData;
   [UnifiedSwapBridgeEventName.Submitted]: TradeData &
     Pick<QuoteFetchData, 'price_impact'> &
     Pick<RequestMetadata, 'stx_enabled' | 'usd_amount_source'> &
@@ -137,7 +135,6 @@ export type RequiredEventContextFromClient = {
       usd_actual_gas: number;
       quote_vs_execution_ratio: number;
       quoted_vs_used_gas_ratio: number;
-      action_type: MetricsActionType;
     };
   [UnifiedSwapBridgeEventName.Failed]:
     | // Tx failed before confirmation
@@ -155,7 +152,6 @@ export type RequiredEventContextFromClient = {
         TradeData & {
           actual_time_minutes: number;
           error_message?: string;
-          action_type: MetricsActionType;
         });
   // Emitted by clients
   [UnifiedSwapBridgeEventName.AllQuotesOpened]: Pick<
@@ -219,9 +215,7 @@ export type EventPropertiesFromControllerState = {
   [UnifiedSwapBridgeEventName.Submitted]: RequestParams &
     RequestMetadata &
     TradeData &
-    Pick<QuoteFetchData, 'price_impact'> & {
-      action_type: MetricsActionType;
-    };
+    Pick<QuoteFetchData, 'price_impact'> & {};
   [UnifiedSwapBridgeEventName.Completed]: null;
   [UnifiedSwapBridgeEventName.Failed]: RequestParams &
     RequestMetadata &
@@ -229,7 +223,6 @@ export type EventPropertiesFromControllerState = {
     TradeData &
     Pick<QuoteFetchData, 'price_impact'> & {
       actual_time_minutes: number;
-      action_type: MetricsActionType;
     };
   [UnifiedSwapBridgeEventName.AllQuotesOpened]: RequestParams &
     RequestMetadata &

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Bump peer dependency `@metamask/bridge-controller` to `^38.0.0` ([#6268](https://github.com/MetaMask/core/pull/6268))
 - Hardcode `action_type` to `swapbridge-v1` after swaps and bridge unification ([#6270](https://github.com/MetaMask/core/pull/6270))
 
-
 ## [37.0.1]
 
 ### Changed

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Bump peer dependency `@metamask/bridge-controller` to `^38.0.0` ([#6268](https://github.com/MetaMask/core/pull/6268))
+- Hardcode `action_type` to `swapbridge-v1` after swaps and bridge unification ([#6270](https://github.com/MetaMask/core/pull/6270))
+
 
 ## [37.0.1]
 

--- a/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
+++ b/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
@@ -147,7 +147,7 @@ Array [
     "BridgeController:trackUnifiedSwapBridgeEvent",
     "Unified SwapBridge Failed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "actual_time_minutes": 105213.34261666666,
       "allowance_reset_transaction": undefined,
       "approval_transaction": undefined,
@@ -315,7 +315,7 @@ Array [
     "BridgeController:trackUnifiedSwapBridgeEvent",
     "Unified SwapBridge Completed",
     Object {
-      "action_type": "crosschain-v1",
+      "action_type": "swapbridge-v1",
       "actual_time_minutes": 105213.34261666666,
       "allowance_reset_transaction": undefined,
       "approval_transaction": undefined,

--- a/packages/bridge-status-controller/src/bridge-status-controller.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.ts
@@ -10,10 +10,10 @@ import {
   isSolanaChainId,
   StatusTypes,
   UnifiedSwapBridgeEventName,
-  getActionType,
   formatChainIdToCaip,
   isCrossChain,
   isHardwareWallet,
+  MetricsActionType,
 } from '@metamask/bridge-controller';
 import type { TraceCallback } from '@metamask/controller-utils';
 import { toHex } from '@metamask/controller-utils';
@@ -1173,10 +1173,7 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
     );
 
     const requiredEventProperties = {
-      action_type: getActionType(
-        historyItem.quote.srcChainId,
-        historyItem.quote.destChainId,
-      ),
+      action_type: MetricsActionType.SWAPBRIDGE_V1,
       ...(eventProperties ?? {}),
       ...getRequestParamFromHistory(historyItem),
       ...getRequestMetadataFromHistory(historyItem, selectedAccount),


### PR DESCRIPTION
## Explanation

The `action_type` property indicates whether an event is published before or after the Unified swaps+bridge launch. This change hardcodes `swapbridge_v1` for all future events

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References
Fixes https://consensyssoftware.atlassian.net/browse/SWAPS-2784
<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
