### PR TITLE
chore: relax yarn constraints for peer dep <1.0.0

### DIFF
--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -663,7 +663,11 @@ function expectUpToDateWorkspacePeerDependencies(Yarn, workspace) {
           dependency.range,
         )
       ) {
-        dependency.update(`^${dependencyWorkspaceVersion.major}.0.0`);
+        // We allow "non-stable" peer dependency to be set to any range
+        // until they are being "stable" (^1.0.0).
+        if (dependencyWorkspaceVersion.major > 0) {
+          dependency.update(`^${dependencyWorkspaceVersion.major}.0.0`);
+        }
       }
     }
   }


### PR DESCRIPTION
## Explanation

Our `yarn constraints` is a bit too strict when developing new packages which can be considered "unstable" (version `<1.0.0`).

With the current contraints, it's not possible to depend on an specific minor/patch version of such package when developing new features (since the `peerDependencies` would automatically be fixed up to `^0.0.0` to match our current contraints).

This PR only forces `peerDependencies` to reference a major version only for peer dependencies with a version `>=1.0.0`.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
