### PR TITLE
chore: include assetsFiatValues in swap and bridge addTransactionBatch params

### DIFF
--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Include `assetsFiatValue` for sending and receiving assets in batch transaction request parameters ([#6277](https://github.com/MetaMask/core/pull/6277))
+
 ### Changed
 
 - **BREAKING:** Bump peer dependency `@metamask/bridge-controller` to `^38.0.0` ([#6268](https://github.com/MetaMask/core/pull/6268))

--- a/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
+++ b/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
@@ -379,9 +379,9 @@ Object {
   "isStxEnabled": false,
   "pricingData": Object {
     "amountSent": "1.234",
-    "amountSentInUsd": undefined,
+    "amountSentInUsd": "1.01",
     "quotedGasInUsd": undefined,
-    "quotedReturnInUsd": undefined,
+    "quotedReturnInUsd": "0.134214",
   },
   "quote": Object {
     "bridgeId": "lifi",
@@ -503,7 +503,7 @@ Array [
       "stx_enabled": false,
       "token_symbol_destination": "ETH",
       "token_symbol_source": "ETH",
-      "usd_amount_source": 0,
+      "usd_amount_source": 1.01,
       "usd_quoted_gas": 0,
       "usd_quoted_return": 0,
     },
@@ -598,9 +598,9 @@ Object {
   "isStxEnabled": true,
   "pricingData": Object {
     "amountSent": "1.234",
-    "amountSentInUsd": undefined,
+    "amountSentInUsd": "1.01",
     "quotedGasInUsd": undefined,
-    "quotedReturnInUsd": undefined,
+    "quotedReturnInUsd": "0.134214",
   },
   "quote": Object {
     "bridgeId": "lifi",
@@ -735,6 +735,10 @@ Array [
       "requireApproval": false,
       "transactions": Array [
         Object {
+          "assetsFiatValues": Object {
+            "receiving": "2.9999",
+            "sending": "2.00",
+          },
           "params": Object {
             "data": "0xdata",
             "from": "0xaccount1",
@@ -768,7 +772,7 @@ Array [
       "stx_enabled": true,
       "token_symbol_destination": "ETH",
       "token_symbol_source": "ETH",
-      "usd_amount_source": 0,
+      "usd_amount_source": 1.01,
       "usd_quoted_gas": 0,
       "usd_quoted_return": 0,
     },
@@ -823,9 +827,9 @@ Object {
   "isStxEnabled": false,
   "pricingData": Object {
     "amountSent": "1.234",
-    "amountSentInUsd": undefined,
+    "amountSentInUsd": "1.01",
     "quotedGasInUsd": undefined,
-    "quotedReturnInUsd": undefined,
+    "quotedReturnInUsd": "0.134214",
   },
   "quote": Object {
     "bridgeId": "lifi",
@@ -1062,7 +1066,7 @@ Array [
       "stx_enabled": false,
       "token_symbol_destination": "ETH",
       "token_symbol_source": "ETH",
-      "usd_amount_source": 0,
+      "usd_amount_source": 1.01,
       "usd_quoted_gas": 0,
       "usd_quoted_return": 0,
     },
@@ -1150,9 +1154,9 @@ Object {
   "isStxEnabled": false,
   "pricingData": Object {
     "amountSent": "1.234",
-    "amountSentInUsd": undefined,
+    "amountSentInUsd": "1.01",
     "quotedGasInUsd": undefined,
-    "quotedReturnInUsd": undefined,
+    "quotedReturnInUsd": "0.134214",
   },
   "quote": Object {
     "bridgeId": "lifi",
@@ -1319,7 +1323,7 @@ Array [
       "stx_enabled": false,
       "token_symbol_destination": "ETH",
       "token_symbol_source": "ETH",
-      "usd_amount_source": 0,
+      "usd_amount_source": 1.01,
       "usd_quoted_gas": 0,
       "usd_quoted_return": 0,
     },
@@ -1388,9 +1392,9 @@ Object {
   "isStxEnabled": false,
   "pricingData": Object {
     "amountSent": "1.234",
-    "amountSentInUsd": undefined,
+    "amountSentInUsd": "1.01",
     "quotedGasInUsd": undefined,
-    "quotedReturnInUsd": undefined,
+    "quotedReturnInUsd": "0.134214",
   },
   "quote": Object {
     "bridgeId": "lifi",
@@ -1557,7 +1561,7 @@ Array [
       "stx_enabled": false,
       "token_symbol_destination": "WETH",
       "token_symbol_source": "ETH",
-      "usd_amount_source": 0,
+      "usd_amount_source": 1.01,
       "usd_quoted_gas": 0,
       "usd_quoted_return": 0,
     },
@@ -1623,7 +1627,7 @@ Array [
       "stx_enabled": false,
       "token_symbol_destination": "ETH",
       "token_symbol_source": "ETH",
-      "usd_amount_source": 0,
+      "usd_amount_source": 1.01,
       "usd_quoted_gas": 0,
       "usd_quoted_return": 0,
     },
@@ -1683,7 +1687,7 @@ Array [
       "stx_enabled": false,
       "token_symbol_destination": "ETH",
       "token_symbol_source": "ETH",
-      "usd_amount_source": 0,
+      "usd_amount_source": 1.01,
       "usd_quoted_gas": 0,
       "usd_quoted_return": 0,
     },
@@ -1736,9 +1740,9 @@ Object {
   "isStxEnabled": true,
   "pricingData": Object {
     "amountSent": "1.234",
-    "amountSentInUsd": undefined,
+    "amountSentInUsd": "1.01",
     "quotedGasInUsd": undefined,
-    "quotedReturnInUsd": undefined,
+    "quotedReturnInUsd": "0.134214",
   },
   "quote": Object {
     "bridgeId": "lifi",
@@ -1898,6 +1902,10 @@ Array [
           "type": "swapApproval",
         },
         Object {
+          "assetsFiatValues": Object {
+            "receiving": "2.9999",
+            "sending": "2.00",
+          },
           "params": Object {
             "data": "0xdata",
             "from": "0xaccount1",
@@ -1931,7 +1939,7 @@ Array [
       "stx_enabled": true,
       "token_symbol_destination": "ETH",
       "token_symbol_source": "ETH",
-      "usd_amount_source": 0,
+      "usd_amount_source": 1.01,
       "usd_quoted_gas": 0,
       "usd_quoted_return": 0,
     },
@@ -2008,9 +2016,9 @@ Object {
   "isStxEnabled": false,
   "pricingData": Object {
     "amountSent": "1.234",
-    "amountSentInUsd": undefined,
+    "amountSentInUsd": "1.01",
     "quotedGasInUsd": undefined,
-    "quotedReturnInUsd": undefined,
+    "quotedReturnInUsd": "0.134214",
   },
   "quote": Object {
     "bridgeId": "lifi",
@@ -2132,7 +2140,7 @@ Array [
       "stx_enabled": false,
       "token_symbol_destination": "WETH",
       "token_symbol_source": "ETH",
-      "usd_amount_source": 0,
+      "usd_amount_source": 1.01,
       "usd_quoted_gas": 0,
       "usd_quoted_return": 0,
     },

--- a/packages/bridge-status-controller/src/bridge-status-controller.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.test.ts
@@ -1838,8 +1838,12 @@ describe('BridgeStatusController', () => {
         destChainId: 10, // Optimism
       },
       estimatedProcessingTimeInSeconds: 15,
-      sentAmount: { amount: '1.234', valueInCurrency: null, usd: null },
-      toTokenAmount: { amount: '1.234', valueInCurrency: null, usd: null },
+      sentAmount: { amount: '1.234', valueInCurrency: '2.00', usd: '1.01' },
+      toTokenAmount: {
+        amount: '1.5',
+        valueInCurrency: '2.9999',
+        usd: '0.134214',
+      },
       totalNetworkFee: { amount: '1.234', valueInCurrency: null, usd: null },
       totalMaxNetworkFee: {
         amount: '1.234',
@@ -2231,8 +2235,12 @@ describe('BridgeStatusController', () => {
         destChainId: 42161,
       },
       estimatedProcessingTimeInSeconds: 0,
-      sentAmount: { amount: '1.234', valueInCurrency: null, usd: null },
-      toTokenAmount: { amount: '1.234', valueInCurrency: null, usd: null },
+      sentAmount: { amount: '1.234', valueInCurrency: '2.00', usd: '1.01' },
+      toTokenAmount: {
+        amount: '1.5',
+        valueInCurrency: '2.9999',
+        usd: '0.134214',
+      },
       totalNetworkFee: { amount: '1.234', valueInCurrency: null, usd: null },
       totalMaxNetworkFee: {
         amount: '1.234',

--- a/packages/bridge-status-controller/src/utils/transaction.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.ts
@@ -318,8 +318,8 @@ export const getAddTransactionBatchParams = async ({
     type: isBridgeTx ? TransactionType.bridge : TransactionType.swap,
     params: toBatchTxParams(disable7702, trade, gasFees),
     assetsFiatValues: {
-      sending: sentAmount?.usd?.toString(),
-      receiving: toTokenAmount?.usd?.toString(),
+      sending: sentAmount?.valueInCurrency?.toString(),
+      receiving: toTokenAmount?.valueInCurrency?.toString(),
     },
   });
   const transactionParams: Parameters<

--- a/packages/bridge-status-controller/src/utils/transaction.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.ts
@@ -238,6 +238,8 @@ export const getAddTransactionBatchParams = async ({
       feeData: { txFee },
       gasIncluded,
     },
+    sentAmount,
+    toTokenAmount,
   },
   requireApproval = false,
   estimateGasFeeFn,
@@ -315,6 +317,10 @@ export const getAddTransactionBatchParams = async ({
   transactions.push({
     type: isBridgeTx ? TransactionType.bridge : TransactionType.swap,
     params: toBatchTxParams(disable7702, trade, gasFees),
+    assetsFiatValues: {
+      sending: sentAmount?.usd?.toString(),
+      receiving: toTokenAmount?.usd?.toString(),
+    },
   });
   const transactionParams: Parameters<
     TransactionController['addTransactionBatch']


### PR DESCRIPTION
## Explanation

Adding the fiat values of the sent amount and the quoted received amount to the batch tx request, so that the confirmations team can consume the data in their metrics. More context in linked ticket

Example value
```
assetsFiatValues: {
  sending: "100.431243",
  receiving: "99.4",
},
```

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References
Fixes https://consensyssoftware.atlassian.net/browse/SWAPS-2759

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
