### PR TITLE
chore: Add `clearSubscriptions` test and reorganize

### DIFF
--- a/packages/base-controller/src/Messenger.test.ts
+++ b/packages/base-controller/src/Messenger.test.ts
@@ -528,35 +528,46 @@ describe('Messenger', () => {
     );
   });
 
-  it('should not call subscriber after clearing event subscriptions', () => {
-    type MessageEvent = { type: 'message'; payload: [string] };
-    const messenger = new Messenger<never, MessageEvent>();
+  describe('clearEventSubscriptions', () => {
+    it('should not call subscriber after clearing event subscriptions', () => {
+      type MessageEvent = { type: 'message'; payload: [string] };
+      const messenger = new Messenger<never, MessageEvent>();
 
-    const handler = sinon.stub();
-    messenger.subscribe('message', handler);
-    messenger.clearEventSubscriptions('message');
-    messenger.publish('message', 'hello');
+      const handler = sinon.stub();
+      messenger.subscribe('message', handler);
+      messenger.clearEventSubscriptions('message');
+      messenger.publish('message', 'hello');
 
-    expect(handler.callCount).toBe(0);
+      expect(handler.callCount).toBe(0);
+    });
+
+    it('should not throw when clearing event that has no subscriptions', () => {
+      type MessageEvent = { type: 'message'; payload: [string] };
+      const messenger = new Messenger<never, MessageEvent>();
+
+      expect(() => messenger.clearEventSubscriptions('message')).not.toThrow();
+    });
   });
 
-  it('should not throw when clearing event that has no subscriptions', () => {
-    type MessageEvent = { type: 'message'; payload: [string] };
-    const messenger = new Messenger<never, MessageEvent>();
+  describe('clearSubscriptions', () => {
+    it('should not call subscriber after resetting subscriptions', () => {
+      type MessageEvent = { type: 'message'; payload: [string] };
+      const messenger = new Messenger<never, MessageEvent>();
 
-    expect(() => messenger.clearEventSubscriptions('message')).not.toThrow();
-  });
+      const handler = sinon.stub();
+      messenger.subscribe('message', handler);
+      messenger.clearSubscriptions();
+      messenger.publish('message', 'hello');
 
-  it('should not call subscriber after resetting subscriptions', () => {
-    type MessageEvent = { type: 'message'; payload: [string] };
-    const messenger = new Messenger<never, MessageEvent>();
+      expect(handler.callCount).toBe(0);
+    });
 
-    const handler = sinon.stub();
-    messenger.subscribe('message', handler);
-    messenger.clearSubscriptions();
-    messenger.publish('message', 'hello');
+    it('should not throw when clearing subscriptions on messenger that has no subscriptions', () => {
+      type MessageEvent = { type: 'message'; payload: [string] };
+      const messenger = new Messenger<never, MessageEvent>();
 
-    expect(handler.callCount).toBe(0);
+      expect(() => messenger.clearSubscriptions()).not.toThrow();
+    });
   });
 
   describe('registerMethodActionHandlers', () => {

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -528,35 +528,46 @@ describe('Messenger', () => {
     );
   });
 
-  it('should not call subscriber after clearing event subscriptions', () => {
-    type MessageEvent = { type: 'message'; payload: [string] };
-    const messenger = new Messenger<never, MessageEvent>();
+  describe('clearEventSubscriptions', () => {
+    it('should not call subscriber after clearing event subscriptions', () => {
+      type MessageEvent = { type: 'message'; payload: [string] };
+      const messenger = new Messenger<never, MessageEvent>();
 
-    const handler = sinon.stub();
-    messenger.subscribe('message', handler);
-    messenger.clearEventSubscriptions('message');
-    messenger.publish('message', 'hello');
+      const handler = sinon.stub();
+      messenger.subscribe('message', handler);
+      messenger.clearEventSubscriptions('message');
+      messenger.publish('message', 'hello');
 
-    expect(handler.callCount).toBe(0);
+      expect(handler.callCount).toBe(0);
+    });
+
+    it('should not throw when clearing event that has no subscriptions', () => {
+      type MessageEvent = { type: 'message'; payload: [string] };
+      const messenger = new Messenger<never, MessageEvent>();
+
+      expect(() => messenger.clearEventSubscriptions('message')).not.toThrow();
+    });
   });
 
-  it('should not throw when clearing event that has no subscriptions', () => {
-    type MessageEvent = { type: 'message'; payload: [string] };
-    const messenger = new Messenger<never, MessageEvent>();
+  describe('clearSubscriptions', () => {
+    it('should not call subscriber after resetting subscriptions', () => {
+      type MessageEvent = { type: 'message'; payload: [string] };
+      const messenger = new Messenger<never, MessageEvent>();
 
-    expect(() => messenger.clearEventSubscriptions('message')).not.toThrow();
-  });
+      const handler = sinon.stub();
+      messenger.subscribe('message', handler);
+      messenger.clearSubscriptions();
+      messenger.publish('message', 'hello');
 
-  it('should not call subscriber after resetting subscriptions', () => {
-    type MessageEvent = { type: 'message'; payload: [string] };
-    const messenger = new Messenger<never, MessageEvent>();
+      expect(handler.callCount).toBe(0);
+    });
 
-    const handler = sinon.stub();
-    messenger.subscribe('message', handler);
-    messenger.clearSubscriptions();
-    messenger.publish('message', 'hello');
+    it('should not throw when clearing subscriptions on messenger that has no subscriptions', () => {
+      type MessageEvent = { type: 'message'; payload: [string] };
+      const messenger = new Messenger<never, MessageEvent>();
 
-    expect(handler.callCount).toBe(0);
+      expect(() => messenger.clearSubscriptions()).not.toThrow();
+    });
   });
 
   describe('registerMethodActionHandlers', () => {


### PR DESCRIPTION
## Explanation

A new test case has been added for `clearSubscriptions` to improve functional test coverage. Additionally, the tests for `clearEventSubscriptions` and `clearSubscriptions` have been grouped in `describe` blocks to better match our test conventions.

## References

This was extracted from #6132

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
