### PR TITLE
fix stale selectedNetworkClientId by converting to function pattern

### DIFF
--- a/packages/earn-controller/CHANGELOG.md
+++ b/packages/earn-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.11.0` to `^11.12.0` ([#6303](https://github.com/MetaMask/core/pull/6303))
 
+### Fixed
+
+- **BREAKING:** Convert `selectedNetworkClientId` parameter from string to function to prevent stale values after reinitialization ([#6312](https://github.com/MetaMask/core/pull/6312))
+
 ## [5.0.0]
 
 ### Added

--- a/packages/earn-controller/src/EarnController.test.ts
+++ b/packages/earn-controller/src/EarnController.test.ts
@@ -666,14 +666,14 @@ const setupController = async ({
   })),
 
   addTransactionFn = jest.fn(),
-  selectedNetworkClientId = '1',
+  selectedNetworkClientId = () => '1',
 }: {
   options?: Partial<ConstructorParameters<typeof EarnController>[0]>;
   mockGetNetworkClientById?: jest.Mock;
   mockGetNetworkControllerState?: jest.Mock;
   mockGetSelectedAccount?: jest.Mock;
   addTransactionFn?: jest.Mock;
-  selectedNetworkClientId?: string;
+  selectedNetworkClientId?: () => string;
 } = {}) => {
   const messenger = buildMessenger();
 
@@ -1967,7 +1967,7 @@ describe('EarnController', () => {
         }));
 
         const { controller } = await setupController({
-          selectedNetworkClientId: '',
+          selectedNetworkClientId: () => '',
         });
 
         await expect(
@@ -2140,7 +2140,7 @@ describe('EarnController', () => {
         }));
 
         const { controller } = await setupController({
-          selectedNetworkClientId: '',
+          selectedNetworkClientId: () => '',
         });
 
         await expect(
@@ -2313,7 +2313,7 @@ describe('EarnController', () => {
         }));
 
         const { controller } = await setupController({
-          selectedNetworkClientId: '',
+          selectedNetworkClientId: () => '',
         });
 
         await expect(

--- a/packages/earn-controller/src/EarnController.ts
+++ b/packages/earn-controller/src/EarnController.ts
@@ -283,7 +283,7 @@ export class EarnController extends BaseController<
 > {
   #earnSDK: EarnSdk | null = null;
 
-  #selectedNetworkClientId: string;
+  #selectedNetworkClientId: () => string;
 
   readonly #earnApiService: EarnApiService;
 
@@ -303,7 +303,7 @@ export class EarnController extends BaseController<
     messenger: EarnControllerMessenger;
     state?: Partial<EarnControllerState>;
     addTransactionFn: typeof TransactionController.prototype.addTransaction;
-    selectedNetworkClientId: string;
+    selectedNetworkClientId: () => string;
     env?: EarnEnvironments;
   }) {
     super({
@@ -329,7 +329,7 @@ export class EarnController extends BaseController<
 
     this.#selectedNetworkClientId = selectedNetworkClientId;
 
-    this.#initializeSDK(selectedNetworkClientId).catch(console.error);
+    this.#initializeSDK(selectedNetworkClientId()).catch(console.error);
     this.refreshPooledStakingData().catch(console.error);
     this.refreshLendingData().catch(console.error);
 
@@ -338,9 +338,9 @@ export class EarnController extends BaseController<
       'NetworkController:networkDidChange',
       (networkControllerState) => {
         this.#selectedNetworkClientId =
-          networkControllerState.selectedNetworkClientId;
+          () => networkControllerState.selectedNetworkClientId;
 
-        this.#initializeSDK(this.#selectedNetworkClientId).catch(console.error);
+        this.#initializeSDK(this.#selectedNetworkClientId()).catch(console.error);
 
         // refresh pooled staking data
         this.refreshPooledStakingVaultMetadata().catch(console.error);
@@ -917,7 +917,7 @@ export class EarnController extends BaseController<
     if (!transactionData) {
       throw new Error('Transaction data not found');
     }
-    if (!this.#selectedNetworkClientId) {
+    if (!this.#selectedNetworkClientId()) {
       throw new Error('Selected network client id not found');
     }
 
@@ -934,7 +934,7 @@ export class EarnController extends BaseController<
       },
       {
         ...txOptions,
-        networkClientId: this.#selectedNetworkClientId,
+        networkClientId: this.#selectedNetworkClientId(),
       },
     );
 
@@ -989,7 +989,7 @@ export class EarnController extends BaseController<
       throw new Error('Transaction data not found');
     }
 
-    if (!this.#selectedNetworkClientId) {
+    if (!this.#selectedNetworkClientId()) {
       throw new Error('Selected network client id not found');
     }
 
@@ -1006,7 +1006,7 @@ export class EarnController extends BaseController<
       },
       {
         ...txOptions,
-        networkClientId: this.#selectedNetworkClientId,
+        networkClientId: this.#selectedNetworkClientId(),
       },
     );
 
@@ -1061,7 +1061,7 @@ export class EarnController extends BaseController<
       throw new Error('Transaction data not found');
     }
 
-    if (!this.#selectedNetworkClientId) {
+    if (!this.#selectedNetworkClientId()) {
       throw new Error('Selected network client id not found');
     }
 
@@ -1078,7 +1078,7 @@ export class EarnController extends BaseController<
       },
       {
         ...txOptions,
-        networkClientId: this.#selectedNetworkClientId,
+        networkClientId: this.#selectedNetworkClientId(),
       },
     );
 


### PR DESCRIPTION
## Explanation

**Problem**

The selectedNetworkClientId parameter was being passed as a static string value, which could become stale and frozen after controller reinitialization. This led to the controller potentially using outdated network client IDs, especially during network switches or controller restarts.

**Solution**

**Controller Changes:**

- Modified selectedNetworkClientId parameter from string to () => string function
- This ensures the network client ID is dynamically evaluated each time it's accessed
- Prevents stale values from being cached during controller lifecycle

**Test Updates:**

- Updated test setup function to expect function type instead of string
- Fixed 4 test cases that were incorrectly passing string literals
- Maintained 100% test coverage with all tests passing


<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
