### PR TITLE
feat: Create new experimental `next` export

### DIFF
--- a/packages/base-controller/next.js
+++ b/packages/base-controller/next.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/next/index.cjs');

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -26,12 +26,23 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./next": {
+      "import": {
+        "types": "./dist/next/index.d.mts",
+        "default": "./dist/next/index.mjs"
+      },
+      "require": {
+        "types": "./dist/next/index.d.cts",
+        "default": "./dist/next/index.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "next.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/base-controller/src/next/BaseController.test.ts
+++ b/packages/base-controller/src/next/BaseController.test.ts
@@ -1,0 +1,1148 @@
+/* eslint-disable jest/no-export */
+import type { Draft, Patch } from 'immer';
+import * as sinon from 'sinon';
+
+import type {
+  ControllerGetStateAction,
+  ControllerStateChangeEvent,
+} from './BaseController';
+import {
+  BaseController,
+  getAnonymizedState,
+  getPersistentState,
+  isBaseController,
+} from './BaseController';
+import { Messenger } from './Messenger';
+import type { RestrictedMessenger } from './RestrictedMessenger';
+import { JsonRpcEngine } from '../../json-rpc-engine/src';
+
+export const countControllerName = 'CountController';
+
+type CountControllerState = {
+  count: number;
+};
+
+export type CountControllerAction = ControllerGetStateAction<
+  typeof countControllerName,
+  CountControllerState
+>;
+
+export type CountControllerEvent = ControllerStateChangeEvent<
+  typeof countControllerName,
+  CountControllerState
+>;
+
+export const countControllerStateMetadata = {
+  count: {
+    persist: true,
+    anonymous: true,
+  },
+};
+
+type CountMessenger = RestrictedMessenger<
+  typeof countControllerName,
+  CountControllerAction,
+  CountControllerEvent,
+  never,
+  never
+>;
+
+/**
+ * Constructs a restricted messenger for the Count controller.
+ *
+ * @param messenger - The messenger.
+ * @returns A restricted messenger for the Count controller.
+ */
+export function getCountMessenger(
+  messenger?: Messenger<CountControllerAction, CountControllerEvent>,
+): CountMessenger {
+  if (!messenger) {
+    messenger = new Messenger<CountControllerAction, CountControllerEvent>();
+  }
+  return messenger.getRestricted({
+    name: countControllerName,
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}
+
+export class CountController extends BaseController<
+  typeof countControllerName,
+  CountControllerState,
+  CountMessenger
+> {
+  update(
+    callback: (
+      state: Draft<CountControllerState>,
+    ) => void | CountControllerState,
+  ) {
+    const res = super.update(callback);
+    return res;
+  }
+
+  applyPatches(patches: Patch[]) {
+    super.applyPatches(patches);
+  }
+
+  destroy() {
+    super.destroy();
+  }
+}
+
+const messagesControllerName = 'MessagesController';
+
+type Message = {
+  subject: string;
+  body: string;
+  headers: Record<string, string>;
+};
+
+type MessagesControllerState = {
+  messages: Message[];
+};
+
+type MessagesControllerAction = ControllerGetStateAction<
+  typeof messagesControllerName,
+  MessagesControllerState
+>;
+
+type MessagesControllerEvent = ControllerStateChangeEvent<
+  typeof messagesControllerName,
+  MessagesControllerState
+>;
+
+const messagesControllerStateMetadata = {
+  messages: {
+    persist: true,
+    anonymous: true,
+  },
+};
+
+type MessagesMessenger = RestrictedMessenger<
+  typeof messagesControllerName,
+  MessagesControllerAction,
+  MessagesControllerEvent,
+  never,
+  never
+>;
+
+/**
+ * Constructs a restricted messenger for the Messages controller.
+ *
+ * @param messenger - The messenger.
+ * @returns A restricted messenger for the Messages controller.
+ */
+function getMessagesMessenger(
+  messenger?: Messenger<MessagesControllerAction, MessagesControllerEvent>,
+): MessagesMessenger {
+  if (!messenger) {
+    messenger = new Messenger<
+      MessagesControllerAction,
+      MessagesControllerEvent
+    >();
+  }
+  return messenger.getRestricted({
+    name: messagesControllerName,
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}
+
+class MessagesController extends BaseController<
+  typeof messagesControllerName,
+  MessagesControllerState,
+  MessagesMessenger
+> {
+  update(
+    callback: (
+      state: Draft<MessagesControllerState>,
+    ) => void | MessagesControllerState,
+  ) {
+    const res = super.update(callback);
+    return res;
+  }
+
+  applyPatches(patches: Patch[]) {
+    super.applyPatches(patches);
+  }
+
+  destroy() {
+    super.destroy();
+  }
+}
+
+describe('isBaseController', () => {
+  it('should return true if passed a V2 controller', () => {
+    const messenger = new Messenger<
+      CountControllerAction,
+      CountControllerEvent
+    >();
+    const controller = new CountController({
+      messenger: getCountMessenger(messenger),
+      name: countControllerName,
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    expect(isBaseController(controller)).toBe(true);
+  });
+
+  it('should return false if passed a non-controller', () => {
+    const notController = new JsonRpcEngine();
+    expect(isBaseController(notController)).toBe(false);
+  });
+});
+
+describe('BaseController', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should set initial state', () => {
+    const controller = new CountController({
+      messenger: getCountMessenger(),
+      name: countControllerName,
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    expect(controller.state).toStrictEqual({ count: 0 });
+  });
+
+  it('should allow getting state via the getState action', () => {
+    const messenger = new Messenger<
+      CountControllerAction,
+      CountControllerEvent
+    >();
+    new CountController({
+      messenger: getCountMessenger(messenger),
+      name: countControllerName,
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    expect(messenger.call('CountController:getState')).toStrictEqual({
+      count: 0,
+    });
+  });
+
+  it('should set initial schema', () => {
+    const controller = new CountController({
+      messenger: getCountMessenger(),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    expect(controller.metadata).toStrictEqual(countControllerStateMetadata);
+  });
+
+  it('should not allow reassigning the `state` property', () => {
+    const controller = new CountController({
+      messenger: getCountMessenger(),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    expect(() => {
+      controller.state = { count: 1 };
+    }).toThrow(
+      "Controller state cannot be directly mutated; use 'update' method instead.",
+    );
+  });
+
+  it('should not allow reassigning an object property that exists in state', () => {
+    const controller = new MessagesController({
+      messenger: getMessagesMessenger(),
+      name: messagesControllerName,
+      state: {
+        messages: [
+          {
+            subject: 'Hi',
+            body: 'Hello, I hope you have a good day',
+            headers: {
+              'X-Foo': 'Bar',
+            },
+          },
+        ],
+      },
+      metadata: messagesControllerStateMetadata,
+    });
+
+    expect(() => {
+      controller.state.messages[0].headers['X-Baz'] = 'Qux';
+    }).toThrow('Cannot add property X-Baz, object is not extensible');
+  });
+
+  it('should not allow pushing a value onto an array property that exists in state', () => {
+    const controller = new MessagesController({
+      messenger: getMessagesMessenger(),
+      name: messagesControllerName,
+      state: {
+        messages: [
+          {
+            subject: 'Hi',
+            body: 'Hello, I hope you have a good day',
+            headers: {
+              'X-Foo': 'Bar',
+            },
+          },
+        ],
+      },
+      metadata: messagesControllerStateMetadata,
+    });
+
+    expect(() => {
+      controller.state.messages.push({
+        subject: 'Hello again',
+        body: 'Please join my network on LinkedIn',
+        headers: {},
+      });
+    }).toThrow('Cannot add property 1, object is not extensible');
+  });
+
+  it('should allow updating state by modifying draft', () => {
+    const controller = new CountController({
+      messenger: getCountMessenger(),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    controller.update((draft) => {
+      draft.count += 1;
+    });
+
+    expect(controller.state).toStrictEqual({ count: 1 });
+  });
+
+  it('should allow updating state by return a value', () => {
+    const controller = new CountController({
+      messenger: getCountMessenger(),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    controller.update(() => {
+      return { count: 1 };
+    });
+
+    expect(controller.state).toStrictEqual({ count: 1 });
+  });
+
+  it('should not call publish if the state has not been modified', () => {
+    const messenger = getCountMessenger();
+    const publishSpy = jest.spyOn(messenger, 'publish');
+
+    const controller = new CountController({
+      messenger,
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    controller.update((_draft) => {
+      // no-op
+    });
+
+    expect(controller.state).toStrictEqual({ count: 0 });
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return next state, patches and inverse patches after an update', () => {
+    const controller = new CountController({
+      messenger: getCountMessenger(),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    const returnObj = controller.update((draft) => {
+      draft.count += 1;
+    });
+
+    expect(returnObj).toBeDefined();
+    expect(returnObj.nextState).toStrictEqual({ count: 1 });
+    expect(returnObj.patches).toStrictEqual([
+      { op: 'replace', path: ['count'], value: 1 },
+    ]);
+
+    expect(returnObj.inversePatches).toStrictEqual([
+      { op: 'replace', path: ['count'], value: 0 },
+    ]);
+  });
+
+  it('should throw an error if update callback modifies draft and returns value', () => {
+    const controller = new CountController({
+      messenger: getCountMessenger(),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    expect(() => {
+      controller.update((draft) => {
+        draft.count += 1;
+        return { count: 10 };
+      });
+    }).toThrow(
+      '[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft.',
+    );
+  });
+
+  it('should allow for applying immer patches to state', () => {
+    const controller = new CountController({
+      messenger: getCountMessenger(),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    const returnObj = controller.update((draft) => {
+      draft.count += 1;
+    });
+
+    controller.applyPatches(returnObj.inversePatches);
+
+    expect(controller.state).toStrictEqual({ count: 0 });
+  });
+
+  it('should inform subscribers of state changes as a result of applying patches', () => {
+    const messenger = new Messenger<never, CountControllerEvent>();
+    const controller = new CountController({
+      messenger: getCountMessenger(messenger),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    const listener1 = sinon.stub();
+
+    messenger.subscribe('CountController:stateChange', listener1);
+    const { inversePatches } = controller.update(() => {
+      return { count: 1 };
+    });
+
+    controller.applyPatches(inversePatches);
+
+    expect(listener1.callCount).toBe(2);
+    expect(listener1.firstCall.args).toStrictEqual([
+      { count: 1 },
+      [{ op: 'replace', path: [], value: { count: 1 } }],
+    ]);
+
+    expect(listener1.secondCall.args).toStrictEqual([
+      { count: 0 },
+      [{ op: 'replace', path: [], value: { count: 0 } }],
+    ]);
+  });
+
+  it('should inform subscribers of state changes', () => {
+    const messenger = new Messenger<never, CountControllerEvent>();
+    const controller = new CountController({
+      messenger: getCountMessenger(messenger),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    const listener1 = sinon.stub();
+    const listener2 = sinon.stub();
+
+    messenger.subscribe('CountController:stateChange', listener1);
+    messenger.subscribe('CountController:stateChange', listener2);
+    controller.update(() => {
+      return { count: 1 };
+    });
+
+    expect(listener1.callCount).toBe(1);
+    expect(listener1.firstCall.args).toStrictEqual([
+      { count: 1 },
+      [{ op: 'replace', path: [], value: { count: 1 } }],
+    ]);
+    expect(listener2.callCount).toBe(1);
+    expect(listener2.firstCall.args).toStrictEqual([
+      { count: 1 },
+      [{ op: 'replace', path: [], value: { count: 1 } }],
+    ]);
+  });
+
+  it('should notify a subscriber with a selector of state changes', () => {
+    const messenger = new Messenger<never, CountControllerEvent>();
+    const controller = new CountController({
+      messenger: getCountMessenger(messenger),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    const listener = sinon.stub();
+    messenger.subscribe(
+      'CountController:stateChange',
+      listener,
+      ({ count }) => {
+        // Selector rounds down to nearest multiple of 10
+        return Math.floor(count / 10);
+      },
+    );
+
+    controller.update(() => {
+      return { count: 10 };
+    });
+
+    expect(listener.callCount).toBe(1);
+    expect(listener.firstCall.args).toStrictEqual([1, 0]);
+  });
+
+  it('should not inform a subscriber of state changes if the selected value is unchanged', () => {
+    const messenger = new Messenger<never, CountControllerEvent>();
+    const controller = new CountController({
+      messenger: getCountMessenger(messenger),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    const listener = sinon.stub();
+    messenger.subscribe(
+      'CountController:stateChange',
+      listener,
+      ({ count }) => {
+        // Selector rounds down to nearest multiple of 10
+        return Math.floor(count / 10);
+      },
+    );
+
+    controller.update(() => {
+      // Note that this rounds down to zero, so the selected value is still zero
+      return { count: 1 };
+    });
+
+    expect(listener.callCount).toBe(0);
+  });
+
+  it('should inform a subscriber of each state change once even after multiple subscriptions', () => {
+    const messenger = new Messenger<never, CountControllerEvent>();
+    const controller = new CountController({
+      messenger: getCountMessenger(messenger),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    const listener1 = sinon.stub();
+
+    messenger.subscribe('CountController:stateChange', listener1);
+    messenger.subscribe('CountController:stateChange', listener1);
+
+    controller.update(() => {
+      return { count: 1 };
+    });
+
+    expect(listener1.callCount).toBe(1);
+    expect(listener1.firstCall.args).toStrictEqual([
+      { count: 1 },
+      [{ op: 'replace', path: [], value: { count: 1 } }],
+    ]);
+  });
+
+  it('should no longer inform a subscriber about state changes after unsubscribing', () => {
+    const messenger = new Messenger<never, CountControllerEvent>();
+    const controller = new CountController({
+      messenger: getCountMessenger(messenger),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    const listener1 = sinon.stub();
+
+    messenger.subscribe('CountController:stateChange', listener1);
+    messenger.unsubscribe('CountController:stateChange', listener1);
+    controller.update(() => {
+      return { count: 1 };
+    });
+
+    expect(listener1.callCount).toBe(0);
+  });
+
+  it('should no longer inform a subscriber about state changes after unsubscribing once, even if they subscribed many times', () => {
+    const messenger = new Messenger<never, CountControllerEvent>();
+    const controller = new CountController({
+      messenger: getCountMessenger(messenger),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    const listener1 = sinon.stub();
+
+    messenger.subscribe('CountController:stateChange', listener1);
+    messenger.subscribe('CountController:stateChange', listener1);
+    messenger.unsubscribe('CountController:stateChange', listener1);
+    controller.update(() => {
+      return { count: 1 };
+    });
+
+    expect(listener1.callCount).toBe(0);
+  });
+
+  it('should throw when unsubscribing listener who was never subscribed', () => {
+    const messenger = new Messenger<never, CountControllerEvent>();
+    new CountController({
+      messenger: getCountMessenger(messenger),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    const listener1 = sinon.stub();
+
+    expect(() => {
+      messenger.unsubscribe('CountController:stateChange', listener1);
+    }).toThrow('Subscription not found for event: CountController:stateChange');
+  });
+
+  it('should no longer update subscribers after being destroyed', () => {
+    const messenger = new Messenger<never, CountControllerEvent>();
+    const controller = new CountController({
+      messenger: getCountMessenger(messenger),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+    const listener1 = sinon.stub();
+    const listener2 = sinon.stub();
+
+    messenger.subscribe('CountController:stateChange', listener1);
+    messenger.subscribe('CountController:stateChange', listener2);
+    controller.destroy();
+    controller.update(() => {
+      return { count: 1 };
+    });
+
+    expect(listener1.callCount).toBe(0);
+    expect(listener2.callCount).toBe(0);
+  });
+});
+
+describe('getAnonymizedState', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return empty state', () => {
+    expect(getAnonymizedState({}, {})).toStrictEqual({});
+  });
+
+  it('should return empty state when no properties are anonymized', () => {
+    const anonymizedState = getAnonymizedState(
+      { count: 1 },
+      { count: { anonymous: false, persist: false } },
+    );
+    expect(anonymizedState).toStrictEqual({});
+  });
+
+  it('should return state that is already anonymized', () => {
+    const anonymizedState = getAnonymizedState(
+      {
+        password: 'secret password',
+        privateKey: '123',
+        network: 'mainnet',
+        tokens: ['DAI', 'USDC'],
+      },
+      {
+        password: {
+          anonymous: false,
+          persist: false,
+        },
+        privateKey: {
+          anonymous: false,
+          persist: false,
+        },
+        network: {
+          anonymous: true,
+          persist: false,
+        },
+        tokens: {
+          anonymous: true,
+          persist: false,
+        },
+      },
+    );
+    expect(anonymizedState).toStrictEqual({
+      network: 'mainnet',
+      tokens: ['DAI', 'USDC'],
+    });
+  });
+
+  it('should use anonymizing function to anonymize state', () => {
+    const anonymizeTransactionHash = (hash: string) => {
+      return hash.split('').reverse().join('');
+    };
+
+    const anonymizedState = getAnonymizedState(
+      {
+        transactionHash: '0x1234',
+      },
+      {
+        transactionHash: {
+          anonymous: anonymizeTransactionHash,
+          persist: false,
+        },
+      },
+    );
+
+    expect(anonymizedState).toStrictEqual({ transactionHash: '4321x0' });
+  });
+
+  it('should allow returning a partial object from an anonymizing function', () => {
+    const anonymizeTxMeta = (txMeta: { hash: string; value: number }) => {
+      return { value: txMeta.value };
+    };
+
+    const anonymizedState = getAnonymizedState(
+      {
+        txMeta: {
+          hash: '0x123',
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          anonymous: anonymizeTxMeta,
+          persist: false,
+        },
+      },
+    );
+
+    expect(anonymizedState).toStrictEqual({ txMeta: { value: 10 } });
+  });
+
+  it('should allow returning a nested partial object from an anonymizing function', () => {
+    const anonymizeTxMeta = (txMeta: {
+      hash: string;
+      value: number;
+      history: { hash: string; value: number }[];
+    }) => {
+      return {
+        history: txMeta.history.map((entry) => {
+          return { value: entry.value };
+        }),
+        value: txMeta.value,
+      };
+    };
+
+    const anonymizedState = getAnonymizedState(
+      {
+        txMeta: {
+          hash: '0x123',
+          history: [
+            {
+              hash: '0x123',
+              value: 9,
+            },
+          ],
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          anonymous: anonymizeTxMeta,
+          persist: false,
+        },
+      },
+    );
+
+    expect(anonymizedState).toStrictEqual({
+      txMeta: { history: [{ value: 9 }], value: 10 },
+    });
+  });
+
+  it('should allow transforming types in an anonymizing function', () => {
+    const anonymizedState = getAnonymizedState(
+      {
+        count: '1',
+      },
+      {
+        count: {
+          anonymous: (count) => Number(count),
+          persist: false,
+        },
+      },
+    );
+
+    expect(anonymizedState).toStrictEqual({ count: 1 });
+  });
+
+  it('should suppress errors thrown when deriving state', () => {
+    const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
+    const persistentState = getAnonymizedState(
+      {
+        extraState: 'extraState',
+        privateKey: '123',
+        network: 'mainnet',
+      },
+      // @ts-expect-error Intentionally testing invalid state
+      {
+        privateKey: {
+          anonymous: true,
+          persist: true,
+        },
+        network: {
+          anonymous: false,
+          persist: false,
+        },
+      },
+    );
+    expect(persistentState).toStrictEqual({
+      privateKey: '123',
+    });
+    expect(setTimeoutStub.callCount).toBe(1);
+    const onTimeout = setTimeoutStub.firstCall.args[0];
+    expect(() => onTimeout()).toThrow(`No metadata found for 'extraState'`);
+  });
+});
+
+describe('getPersistentState', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return empty state', () => {
+    expect(getPersistentState({}, {})).toStrictEqual({});
+  });
+
+  it('should return empty state when no properties are persistent', () => {
+    const persistentState = getPersistentState(
+      { count: 1 },
+      { count: { anonymous: false, persist: false } },
+    );
+    expect(persistentState).toStrictEqual({});
+  });
+
+  it('should return persistent state', () => {
+    const persistentState = getPersistentState(
+      {
+        password: 'secret password',
+        privateKey: '123',
+        network: 'mainnet',
+        tokens: ['DAI', 'USDC'],
+      },
+      {
+        password: {
+          anonymous: false,
+          persist: true,
+        },
+        privateKey: {
+          anonymous: false,
+          persist: true,
+        },
+        network: {
+          anonymous: false,
+          persist: false,
+        },
+        tokens: {
+          anonymous: false,
+          persist: false,
+        },
+      },
+    );
+    expect(persistentState).toStrictEqual({
+      password: 'secret password',
+      privateKey: '123',
+    });
+  });
+
+  it('should use function to derive persistent state', () => {
+    const normalizeTransacitonHash = (hash: string) => {
+      return hash.toLowerCase();
+    };
+
+    const persistentState = getPersistentState(
+      {
+        transactionHash: '0X1234',
+      },
+      {
+        transactionHash: {
+          anonymous: false,
+          persist: normalizeTransacitonHash,
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({ transactionHash: '0x1234' });
+  });
+
+  it('should allow returning a partial object from a persist function', () => {
+    const getPersistentTxMeta = (txMeta: { hash: string; value: number }) => {
+      return { value: txMeta.value };
+    };
+
+    const persistentState = getPersistentState(
+      {
+        txMeta: {
+          hash: '0x123',
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          anonymous: false,
+          persist: getPersistentTxMeta,
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({ txMeta: { value: 10 } });
+  });
+
+  it('should allow returning a nested partial object from a persist function', () => {
+    const getPersistentTxMeta = (txMeta: {
+      hash: string;
+      value: number;
+      history: { hash: string; value: number }[];
+    }) => {
+      return {
+        history: txMeta.history.map((entry) => {
+          return { value: entry.value };
+        }),
+        value: txMeta.value,
+      };
+    };
+
+    const persistentState = getPersistentState(
+      {
+        txMeta: {
+          hash: '0x123',
+          history: [
+            {
+              hash: '0x123',
+              value: 9,
+            },
+          ],
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          anonymous: false,
+          persist: getPersistentTxMeta,
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({
+      txMeta: { history: [{ value: 9 }], value: 10 },
+    });
+  });
+
+  it('should allow transforming types in a persist function', () => {
+    const persistentState = getPersistentState(
+      {
+        count: '1',
+      },
+      {
+        count: {
+          anonymous: false,
+          persist: (count) => Number(count),
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({ count: 1 });
+  });
+
+  it('should suppress errors thrown when deriving state', () => {
+    const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
+    const persistentState = getPersistentState(
+      {
+        extraState: 'extraState',
+        privateKey: '123',
+        network: 'mainnet',
+      },
+      // @ts-expect-error Intentionally testing invalid state
+      {
+        privateKey: {
+          anonymous: false,
+          persist: true,
+        },
+        network: {
+          anonymous: false,
+          persist: false,
+        },
+      },
+    );
+    expect(persistentState).toStrictEqual({
+      privateKey: '123',
+    });
+    expect(setTimeoutStub.callCount).toBe(1);
+    const onTimeout = setTimeoutStub.firstCall.args[0];
+    expect(() => onTimeout()).toThrow(`No metadata found for 'extraState'`);
+  });
+
+  describe('inter-controller communication', () => {
+    // These two contrived mock controllers are setup to test with.
+    // The 'VisitorController' records strings that represent visitors.
+    // The 'VisitorOverflowController' monitors the 'VisitorController' to ensure the number of
+    // visitors doesn't exceed the maximum capacity. If it does, it will clear out all visitors.
+
+    const visitorName = 'VisitorController';
+
+    type VisitorControllerState = {
+      visitors: string[];
+    };
+    type VisitorControllerAction = {
+      type: `${typeof visitorName}:clear`;
+      handler: () => void;
+    };
+    type VisitorControllerEvent = {
+      type: `${typeof visitorName}:stateChange`;
+      payload: [VisitorControllerState, Patch[]];
+    };
+
+    const visitorControllerStateMetadata = {
+      visitors: {
+        persist: true,
+        anonymous: true,
+      },
+    };
+
+    type VisitorMessenger = RestrictedMessenger<
+      typeof visitorName,
+      VisitorControllerAction | VisitorOverflowControllerAction,
+      VisitorControllerEvent | VisitorOverflowControllerEvent,
+      never,
+      never
+    >;
+    class VisitorController extends BaseController<
+      typeof visitorName,
+      VisitorControllerState,
+      VisitorMessenger
+    > {
+      constructor(messagingSystem: VisitorMessenger) {
+        super({
+          messenger: messagingSystem,
+          metadata: visitorControllerStateMetadata,
+          name: visitorName,
+          state: { visitors: [] },
+        });
+
+        messagingSystem.registerActionHandler(
+          'VisitorController:clear',
+          this.clear,
+        );
+      }
+
+      clear = () => {
+        this.update(() => {
+          return { visitors: [] };
+        });
+      };
+
+      addVisitor(visitor: string) {
+        this.update(({ visitors }) => {
+          return { visitors: [...visitors, visitor] };
+        });
+      }
+
+      destroy() {
+        super.destroy();
+      }
+    }
+
+    const visitorOverflowName = 'VisitorOverflowController';
+
+    type VisitorOverflowControllerState = {
+      maxVisitors: number;
+    };
+    type VisitorOverflowControllerAction = {
+      type: `${typeof visitorOverflowName}:updateMax`;
+      handler: (max: number) => void;
+    };
+    type VisitorOverflowControllerEvent = {
+      type: `${typeof visitorOverflowName}:stateChange`;
+      payload: [VisitorOverflowControllerState, Patch[]];
+    };
+
+    const visitorOverflowControllerMetadata = {
+      maxVisitors: {
+        persist: false,
+        anonymous: true,
+      },
+    };
+
+    type VisitorOverflowMessenger = RestrictedMessenger<
+      typeof visitorOverflowName,
+      VisitorControllerAction | VisitorOverflowControllerAction,
+      VisitorControllerEvent | VisitorOverflowControllerEvent,
+      `${typeof visitorName}:clear`,
+      `${typeof visitorName}:stateChange`
+    >;
+
+    class VisitorOverflowController extends BaseController<
+      typeof visitorOverflowName,
+      VisitorOverflowControllerState,
+      VisitorOverflowMessenger
+    > {
+      constructor(messagingSystem: VisitorOverflowMessenger) {
+        super({
+          messenger: messagingSystem,
+          metadata: visitorOverflowControllerMetadata,
+          name: visitorOverflowName,
+          state: { maxVisitors: 5 },
+        });
+
+        messagingSystem.registerActionHandler(
+          'VisitorOverflowController:updateMax',
+          this.updateMax,
+        );
+
+        messagingSystem.subscribe(
+          'VisitorController:stateChange',
+          this.onVisit,
+        );
+      }
+
+      onVisit = ({ visitors }: VisitorControllerState) => {
+        if (visitors.length > this.state.maxVisitors) {
+          this.messagingSystem.call('VisitorController:clear');
+        }
+      };
+
+      updateMax = (max: number) => {
+        this.update(() => {
+          return { maxVisitors: max };
+        });
+      };
+
+      destroy() {
+        super.destroy();
+      }
+    }
+
+    it('should allow messaging between controllers', () => {
+      const messenger = new Messenger<
+        VisitorControllerAction | VisitorOverflowControllerAction,
+        VisitorControllerEvent | VisitorOverflowControllerEvent
+      >();
+      const visitorControllerMessenger = messenger.getRestricted({
+        name: visitorName,
+        allowedActions: [],
+        allowedEvents: [],
+      });
+      const visitorController = new VisitorController(
+        visitorControllerMessenger,
+      );
+      const visitorOverflowControllerMessenger = messenger.getRestricted({
+        name: visitorOverflowName,
+        allowedActions: ['VisitorController:clear'],
+        allowedEvents: ['VisitorController:stateChange'],
+      });
+      const visitorOverflowController = new VisitorOverflowController(
+        visitorOverflowControllerMessenger,
+      );
+
+      messenger.call('VisitorOverflowController:updateMax', 2);
+      visitorController.addVisitor('A');
+      visitorController.addVisitor('B');
+      visitorController.addVisitor('C'); // this should trigger an overflow
+
+      expect(visitorOverflowController.state.maxVisitors).toBe(2);
+      expect(visitorController.state.visitors).toHaveLength(0);
+    });
+  });
+});

--- a/packages/base-controller/src/next/BaseController.ts
+++ b/packages/base-controller/src/next/BaseController.ts
@@ -1,0 +1,388 @@
+import type { Json, PublicInterface } from '@metamask/utils';
+import { enablePatches, produceWithPatches, applyPatches, freeze } from 'immer';
+import type { Draft, Patch } from 'immer';
+
+import type { ActionConstraint, EventConstraint } from './Messenger';
+import type {
+  RestrictedMessenger,
+  RestrictedMessengerConstraint,
+} from './RestrictedMessenger';
+
+enablePatches();
+
+/**
+ * Determines if the given controller is an instance of `BaseController`
+ *
+ * @param controller - Controller instance to check
+ * @returns True if the controller is an instance of `BaseController`
+ */
+export function isBaseController(
+  controller: unknown,
+): controller is BaseControllerInstance {
+  return (
+    typeof controller === 'object' &&
+    controller !== null &&
+    'name' in controller &&
+    typeof controller.name === 'string' &&
+    'state' in controller &&
+    typeof controller.state === 'object' &&
+    'metadata' in controller &&
+    typeof controller.metadata === 'object'
+  );
+}
+
+/**
+ * A type that constrains the state of all controllers.
+ *
+ * In other words, the narrowest supertype encompassing all controller state.
+ */
+export type StateConstraint = Record<string, Json>;
+
+/**
+ * A state change listener.
+ *
+ * This function will get called for each state change, and is given a copy of
+ * the new state along with a set of patches describing the changes since the
+ * last update.
+ *
+ * @param state - The new controller state.
+ * @param patches - A list of patches describing any changes (see here for more
+ * information: https://immerjs.github.io/immer/docs/patches)
+ */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type Listener<T> = (state: T, patches: Patch[]) => void;
+
+/**
+ * An function to derive state.
+ *
+ * This function will accept one piece of the controller state (one property),
+ * and will return some derivation of that state.
+ *
+ * @param value - A piece of controller state.
+ * @returns Something derived from controller state.
+ */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type StateDeriver<T extends Json> = (value: T) => Json;
+
+/**
+ * State metadata.
+ *
+ * This metadata describes which parts of state should be persisted, and how to
+ * get an anonymized representation of the state.
+ */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type StateMetadata<T extends StateConstraint> = {
+  [P in keyof T]-?: StatePropertyMetadata<T[P]>;
+};
+
+/**
+ * Metadata for a single state property
+ *
+ * @property persist - Indicates whether this property should be persisted
+ * (`true` for persistent, `false` for transient), or is set to a function
+ * that derives the persistent state from the state.
+ * @property anonymous - Indicates whether this property is already anonymous,
+ * (`true` for anonymous, `false` if it has potential to be personally
+ * identifiable), or is set to a function that returns an anonymized
+ * representation of this state.
+ */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type StatePropertyMetadata<T extends Json> = {
+  persist: boolean | StateDeriver<T>;
+  anonymous: boolean | StateDeriver<T>;
+};
+
+/**
+ * A universal supertype of `StateDeriver` types.
+ * This type can be assigned to any `StateDeriver` type.
+ */
+export type StateDeriverConstraint = (value: never) => Json;
+
+/**
+ * A universal supertype of `StatePropertyMetadata` types.
+ * This type can be assigned to any `StatePropertyMetadata` type.
+ */
+export type StatePropertyMetadataConstraint = {
+  [P in 'anonymous' | 'persist']: boolean | StateDeriverConstraint;
+};
+
+/**
+ * A universal supertype of `StateMetadata` types.
+ * This type can be assigned to any `StateMetadata` type.
+ */
+export type StateMetadataConstraint = Record<
+  string,
+  StatePropertyMetadataConstraint
+>;
+
+/**
+ * The widest subtype of all controller instances that inherit from `BaseController` (formerly `BaseControllerV2`).
+ * Any `BaseController` subclass instance can be assigned to this type.
+ */
+export type BaseControllerInstance = Omit<
+  PublicInterface<
+    BaseController<string, StateConstraint, RestrictedMessengerConstraint>
+  >,
+  'metadata'
+> & {
+  metadata: StateMetadataConstraint;
+};
+
+export type ControllerGetStateAction<
+  ControllerName extends string,
+  ControllerState extends StateConstraint,
+> = {
+  type: `${ControllerName}:getState`;
+  handler: () => ControllerState;
+};
+
+export type ControllerStateChangeEvent<
+  ControllerName extends string,
+  ControllerState extends StateConstraint,
+> = {
+  type: `${ControllerName}:stateChange`;
+  payload: [ControllerState, Patch[]];
+};
+
+export type ControllerActions<
+  ControllerName extends string,
+  ControllerState extends StateConstraint,
+> = ControllerGetStateAction<ControllerName, ControllerState>;
+
+export type ControllerEvents<
+  ControllerName extends string,
+  ControllerState extends StateConstraint,
+> = ControllerStateChangeEvent<ControllerName, ControllerState>;
+
+/**
+ * Controller class that provides state management, subscriptions, and state metadata
+ */
+export class BaseController<
+  ControllerName extends string,
+  ControllerState extends StateConstraint,
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  messenger extends RestrictedMessenger<
+    ControllerName,
+    ActionConstraint | ControllerActions<ControllerName, ControllerState>,
+    EventConstraint | ControllerEvents<ControllerName, ControllerState>,
+    string,
+    string
+  >,
+> {
+  #internalState: ControllerState;
+
+  protected messagingSystem: messenger;
+
+  /**
+   * The name of the controller.
+   *
+   * This is used by the ComposableController to construct a composed application state.
+   */
+  public readonly name: ControllerName;
+
+  public readonly metadata: StateMetadata<ControllerState>;
+
+  /**
+   * Creates a BaseController instance.
+   *
+   * @param options - Controller options.
+   * @param options.messenger - Controller messaging system.
+   * @param options.metadata - ControllerState metadata, describing how to "anonymize" the state, and which
+   * parts should be persisted.
+   * @param options.name - The name of the controller, used as a namespace for events and actions.
+   * @param options.state - Initial controller state.
+   */
+  constructor({
+    messenger,
+    metadata,
+    name,
+    state,
+  }: {
+    messenger: messenger;
+    metadata: StateMetadata<ControllerState>;
+    name: ControllerName;
+    state: ControllerState;
+  }) {
+    this.messagingSystem = messenger;
+    this.name = name;
+    // Here we use `freeze` from Immer to enforce that the state is deeply
+    // immutable. Note that this is a runtime check, not a compile-time check.
+    // That is, unlike `Object.freeze`, this does not narrow the type
+    // recursively to `Readonly`. The equivalent in Immer is `Immutable`, but
+    // `Immutable` does not handle recursive types such as our `Json` type.
+    this.#internalState = freeze(state, true);
+    this.metadata = metadata;
+
+    this.messagingSystem.registerActionHandler(
+      `${name}:getState`,
+      () => this.state,
+    );
+
+    this.messagingSystem.registerInitialEventPayload({
+      eventType: `${name}:stateChange`,
+      getPayload: () => [this.state, []],
+    });
+  }
+
+  /**
+   * Retrieves current controller state.
+   *
+   * @returns The current state.
+   */
+  get state() {
+    return this.#internalState;
+  }
+
+  set state(_) {
+    throw new Error(
+      `Controller state cannot be directly mutated; use 'update' method instead.`,
+    );
+  }
+
+  /**
+   * Updates controller state. Accepts a callback that is passed a draft copy
+   * of the controller state. If a value is returned, it is set as the new
+   * state. Otherwise, any changes made within that callback to the draft are
+   * applied to the controller state.
+   *
+   * @param callback - Callback for updating state, passed a draft state
+   * object. Return a new state object or mutate the draft to update state.
+   * @returns An object that has the next state, patches applied in the update and inverse patches to
+   * rollback the update.
+   */
+  protected update(
+    callback: (state: Draft<ControllerState>) => void | ControllerState,
+  ): {
+    nextState: ControllerState;
+    patches: Patch[];
+    inversePatches: Patch[];
+  } {
+    // We run into ts2589, "infinite type depth", if we don't cast
+    // produceWithPatches here.
+    const [nextState, patches, inversePatches] = (
+      produceWithPatches as unknown as (
+        state: ControllerState,
+        cb: typeof callback,
+      ) => [ControllerState, Patch[], Patch[]]
+    )(this.#internalState, callback);
+
+    // Protect against unnecessary state updates when there is no state diff.
+    if (patches.length > 0) {
+      this.#internalState = nextState;
+      this.messagingSystem.publish(
+        `${this.name}:stateChange`,
+        nextState,
+        patches,
+      );
+    }
+
+    return { nextState, patches, inversePatches };
+  }
+
+  /**
+   * Applies immer patches to the current state. The patches come from the
+   * update function itself and can either be normal or inverse patches.
+   *
+   * @param patches - An array of immer patches that are to be applied to make
+   * or undo changes.
+   */
+  protected applyPatches(patches: Patch[]) {
+    const nextState = applyPatches(this.#internalState, patches);
+    this.#internalState = nextState;
+    this.messagingSystem.publish(
+      `${this.name}:stateChange`,
+      nextState,
+      patches,
+    );
+  }
+
+  /**
+   * Prepares the controller for garbage collection. This should be extended
+   * by any subclasses to clean up any additional connections or events.
+   *
+   * The only cleanup performed here is to remove listeners. While technically
+   * this is not required to ensure this instance is garbage collected, it at
+   * least ensures this instance won't be responsible for preventing the
+   * listeners from being garbage collected.
+   */
+  protected destroy() {
+    this.messagingSystem.clearEventSubscriptions(`${this.name}:stateChange`);
+  }
+}
+
+/**
+ * Returns an anonymized representation of the controller state.
+ *
+ * By "anonymized" we mean that it should not contain any information that could be personally
+ * identifiable.
+ *
+ * @param state - The controller state.
+ * @param metadata - The controller state metadata, which describes how to derive the
+ * anonymized state.
+ * @returns The anonymized controller state.
+ */
+export function getAnonymizedState<ControllerState extends StateConstraint>(
+  state: ControllerState,
+  metadata: StateMetadata<ControllerState>,
+): Record<keyof ControllerState, Json> {
+  return deriveStateFromMetadata(state, metadata, 'anonymous');
+}
+
+/**
+ * Returns the subset of state that should be persisted.
+ *
+ * @param state - The controller state.
+ * @param metadata - The controller state metadata, which describes which pieces of state should be persisted.
+ * @returns The subset of controller state that should be persisted.
+ */
+export function getPersistentState<ControllerState extends StateConstraint>(
+  state: ControllerState,
+  metadata: StateMetadata<ControllerState>,
+): Record<keyof ControllerState, Json> {
+  return deriveStateFromMetadata(state, metadata, 'persist');
+}
+
+/**
+ * Use the metadata to derive state according to the given metadata property.
+ *
+ * @param state - The full controller state.
+ * @param metadata - The controller metadata.
+ * @param metadataProperty - The metadata property to use to derive state.
+ * @returns The metadata-derived controller state.
+ */
+function deriveStateFromMetadata<ControllerState extends StateConstraint>(
+  state: ControllerState,
+  metadata: StateMetadata<ControllerState>,
+  metadataProperty: 'anonymous' | 'persist',
+): Record<keyof ControllerState, Json> {
+  return (Object.keys(state) as (keyof ControllerState)[]).reduce<
+    Record<keyof ControllerState, Json>
+  >((derivedState, key) => {
+    try {
+      const stateMetadata = metadata[key];
+      if (!stateMetadata) {
+        throw new Error(`No metadata found for '${String(key)}'`);
+      }
+      const propertyMetadata = stateMetadata[metadataProperty];
+      const stateProperty = state[key];
+      if (typeof propertyMetadata === 'function') {
+        derivedState[key] = propertyMetadata(stateProperty);
+      } else if (propertyMetadata) {
+        derivedState[key] = stateProperty;
+      }
+      return derivedState;
+    } catch (error) {
+      // Throw error after timeout so that it is captured as a console error
+      // (and by Sentry) without interrupting state-related operations
+      setTimeout(() => {
+        throw error;
+      });
+      return derivedState;
+    }
+  }, {} as never);
+}

--- a/packages/base-controller/src/next/index.ts
+++ b/packages/base-controller/src/next/index.ts
@@ -1,0 +1,19 @@
+export type {
+  BaseControllerInstance,
+  Listener as ListenerV2,
+  StateConstraint,
+  StateDeriver,
+  StateDeriverConstraint,
+  StateMetadata,
+  StateMetadataConstraint,
+  StatePropertyMetadata,
+  StatePropertyMetadataConstraint,
+  ControllerGetStateAction,
+  ControllerStateChangeEvent,
+} from './BaseController';
+export {
+  BaseController,
+  getAnonymizedState,
+  getPersistentState,
+  isBaseController,
+} from './BaseController';


### PR DESCRIPTION
## Explanation

This export will be used to test upcoming breaking changes for the `@metamask/base-controller` package related to #5626

## References

Relates to #5626

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
