### PR TITLE
Revert "Release/502.0.0 (#6310)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "502.0.0",
+  "version": "501.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {


### PR DESCRIPTION
This reverts commit a30342dafecab2586e9174c8b369517c2bb533e0.

## Explanation

The problem is that in the assets-controllers package, both the devDependency and peerDependency for @metamask/account-tree-controller were bumped from ^0.7.0 to ^0.9.0.
Updating a peerDependency range like this is a breaking change that would require a major version bump of assets-controllers. However, since account-tree-controller was only released as 0.9.0 (minor version), the existing peer dependency range ^0.7.0 should already cover this version (^0.7.0 means >=0.7.0 <1.0.0).

## References

Reverts: https://github.com/MetaMask/core/pull/6310

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
