### PR TITLE
fix: account activity only displays accounts derived from the first SRP

### DIFF
--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -373,11 +373,19 @@ export default class NotificationServicesController extends BaseController<
       const { keyrings } = this.messagingSystem.call(
         'KeyringController:getState',
       );
-      const firstHDKeyring = keyrings.find(
+      const hdKeyrings = keyrings.filter(
         (k) => k.type === KeyringTypes.hd.toString(),
       );
-      const keyringAccounts = firstHDKeyring?.accounts ?? null;
-      return keyringAccounts;
+      const allKeyringAccounts = hdKeyrings.reduce<string[]>(
+        (accounts, keyring) => {
+          if (keyring.accounts && keyring.accounts.length > 0) {
+            return [...accounts, ...keyring.accounts];
+          }
+          return accounts;
+        },
+        [],
+      );
+      return allKeyringAccounts;
     },
 
     /**


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Account Activity only displays Accounts derived from the first SRP but not from a secondary SRP
## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

-->
Fixes https://github.com/MetaMask/core/issues/6323
Related to https://github.com/MetaMask/metamask-extension/issues/34995

After change:

https://github.com/user-attachments/assets/d35c7ce8-3e5c-4264-8bae-cbba1d4fbf53


## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
