### PR TITLE
fix: add init function for network-enablement controllers

### DIFF
--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change transaction listener from `TransactionController:transactionConfirmed` to `TransactionController:transactionSubmitted` for earlier network enablement ([#6329](https://github.com/MetaMask/core/pull/6329))
+- Update transaction event handler to properly access chainId from nested transactionMeta structure ([#6329](https://github.com/MetaMask/core/pull/6329))
 - Bump `@metamask/controller-utils` from `^11.11.0` to `^11.12.0` ([#6303](https://github.com/MetaMask/core/pull/6303))
 
 ## [0.1.1]

--- a/packages/network-enablement-controller/package.json
+++ b/packages/network-enablement-controller/package.json
@@ -50,6 +50,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/multichain-network-controller": "^0.11.1",
     "@metamask/network-controller": "^24.1.0",
+    "@metamask/transaction-controller": "^59.2.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
@@ -67,7 +68,8 @@
   },
   "peerDependencies": {
     "@metamask/multichain-network-controller": "^0.11.0",
-    "@metamask/network-controller": "^24.0.0"
+    "@metamask/network-controller": "^24.0.0",
+    "@metamask/transaction-controller": "^59.0.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/network-enablement-controller/tsconfig.build.json
+++ b/packages/network-enablement-controller/tsconfig.build.json
@@ -9,7 +9,8 @@
     { "path": "../base-controller/tsconfig.build.json" },
     { "path": "../network-controller/tsconfig.build.json" },
     { "path": "../multichain-network-controller/tsconfig.build.json" },
-    { "path": "../controller-utils/tsconfig.build.json" }
+    { "path": "../controller-utils/tsconfig.build.json" },
+    { "path": "../transaction-controller/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/network-enablement-controller/tsconfig.json
+++ b/packages/network-enablement-controller/tsconfig.json
@@ -8,7 +8,8 @@
     { "path": "../base-controller" },
     { "path": "../network-controller" },
     { "path": "../multichain-network-controller" },
-    { "path": "../controller-utils" }
+    { "path": "../controller-utils" },
+    { "path": "../transaction-controller" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4023,6 +4023,7 @@ __metadata:
     "@metamask/controller-utils": "npm:^11.12.0"
     "@metamask/multichain-network-controller": "npm:^0.11.1"
     "@metamask/network-controller": "npm:^24.1.0"
+    "@metamask/transaction-controller": "npm:^59.2.0"
     "@metamask/utils": "npm:^11.4.2"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"
@@ -4036,6 +4037,7 @@ __metadata:
   peerDependencies:
     "@metamask/multichain-network-controller": ^0.11.0
     "@metamask/network-controller": ^24.0.0
+    "@metamask/transaction-controller": ^59.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Explanation

This PR adds an init function to the network-enablement controllers, initializing them from the network configuration. It also listens for the transaction:submitted event and enables the relevant network so users can immediately see the submitted transaction and their assets.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
