### PR TITLE
feat: Rename `messagingSystem` to `messenger`

### DIFF
--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Changes:
     - Update `BaseController` type and constructor to require new `Messenger` from `@metamask/messenger` rather than `RestrictedMessenger` ([#6318](https://github.com/MetaMask/core/pull/6318))
     - Rename `ListenerV2` type export to `StateChangeListener` ([#6339](https://github.com/MetaMask/core/pull/6339))
+    - Rename `messagingSystem` protected instance variable to `messenger` ([#6337](https://github.com/MetaMask/core/pull/6337))
 
 ### Changed
 

--- a/packages/base-controller/src/next/BaseController.test.ts
+++ b/packages/base-controller/src/next/BaseController.test.ts
@@ -1080,7 +1080,7 @@ describe('getPersistentState', () => {
 
       onVisit = ({ visitors }: VisitorControllerState) => {
         if (visitors.length > this.state.maxVisitors) {
-          this.messagingSystem.call('VisitorController:clear');
+          this.messenger.call('VisitorController:clear');
         }
       };
 

--- a/packages/base-controller/src/next/BaseController.ts
+++ b/packages/base-controller/src/next/BaseController.ts
@@ -187,7 +187,7 @@ export class BaseController<
   /**
    * The controller messenger. This is used to interact with other parts of the application.
    */
-  protected messagingSystem: ControllerMessenger;
+  protected messenger: ControllerMessenger;
 
   /**
    * The controller messenger.
@@ -248,7 +248,7 @@ export class BaseController<
       ControllerActions<ControllerName, ControllerState>,
       ControllerEvents<ControllerName, ControllerState>
     >;
-    this.messagingSystem = messenger;
+    this.messenger = messenger;
     this.name = name;
     // Here we use `freeze` from Immer to enforce that the state is deeply
     // immutable. Note that this is a runtime check, not a compile-time check.
@@ -348,7 +348,7 @@ export class BaseController<
    * listeners from being garbage collected.
    */
   protected destroy() {
-    this.messagingSystem.clearEventSubscriptions(`${this.name}:stateChange`);
+    this.messenger.clearEventSubscriptions(`${this.name}:stateChange`);
   }
 }
 


### PR DESCRIPTION
## Explanation

On the `next` version of the `BaseController`, the protected instance variable `messagingSystem` has been renamed to `messenger`.

## References

Fixes #6336

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
