### PR TITLE
feat: Rename `ListenerV2` export to `StateChangeListener`

### DIFF
--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Note that this should generally not be used, and further breaking changes may be made under this export without a corresponding major version bump for this package.
   - Changes:
     - Update `BaseController` type and constructor to require new `Messenger` from `@metamask/messenger` rather than `RestrictedMessenger` ([#6318](https://github.com/MetaMask/core/pull/6318))
+    - Rename `ListenerV2` type export to `StateChangeListener` ([#6339](https://github.com/MetaMask/core/pull/6339))
 
 ### Changed
 

--- a/packages/base-controller/src/next/BaseController.ts
+++ b/packages/base-controller/src/next/BaseController.ts
@@ -50,9 +50,7 @@ export type StateConstraint = Record<string, Json>;
  * @param patches - A list of patches describing any changes (see here for more
  * information: https://immerjs.github.io/immer/docs/patches)
  */
-// TODO: Either fix this lint violation or explain why it's necessary to ignore.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export type Listener<T> = (state: T, patches: Patch[]) => void;
+export type StateChangeListener<T> = (state: T, patches: Patch[]) => void;
 
 /**
  * An function to derive state.

--- a/packages/base-controller/src/next/index.ts
+++ b/packages/base-controller/src/next/index.ts
@@ -1,6 +1,6 @@
 export type {
   BaseControllerInstance,
-  Listener as ListenerV2,
+  StateChangeListener,
   StateConstraint,
   StateDeriver,
   StateDeriverConstraint,


### PR DESCRIPTION
## Explanation

The `ListenerV2` export of the `next` version of `BaseController` has been renamed to `StateChangeListener`.

## References

Fixes #6338

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
