### PR TITLE
feat: SubscriptionController: get pricing

### DIFF
--- a/packages/subscription-controller/CHANGELOG.md
+++ b/packages/subscription-controller/CHANGELOG.md
@@ -13,5 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `getSubscription`: Retrieve current user subscription info if exist.
   - `cancelSubscription`: Cancel user active subscription.
 - `startShieldSubscriptionWithCard`: start shield subscription via card (with trial option) ([#6300](https://github.com/MetaMask/core/pull/6300))
+- Add `getPricing` method ([#6356](https://github.com/MetaMask/core/pull/6356))
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/subscription-controller/src/SubscriptionController.test.ts
+++ b/packages/subscription-controller/src/SubscriptionController.test.ts
@@ -14,7 +14,7 @@ import {
   type SubscriptionControllerOptions,
   type SubscriptionControllerState,
 } from './SubscriptionController';
-import type { Subscription } from './types';
+import type { Subscription, PricingResponse } from './types';
 import {
   PaymentType,
   ProductType,
@@ -114,11 +114,13 @@ function createMockSubscriptionService() {
   const mockGetSubscriptions = jest.fn().mockImplementation();
   const mockCancelSubscription = jest.fn();
   const mockStartSubscriptionWithCard = jest.fn();
+  const mockGetPricing = jest.fn();
 
   const mockService = {
     getSubscriptions: mockGetSubscriptions,
     cancelSubscription: mockCancelSubscription,
     startSubscriptionWithCard: mockStartSubscriptionWithCard,
+    getPricing: mockGetPricing,
   };
 
   return {
@@ -126,6 +128,7 @@ function createMockSubscriptionService() {
     mockGetSubscriptions,
     mockCancelSubscription,
     mockStartSubscriptionWithCard,
+    mockGetPricing,
   };
 }
 
@@ -523,6 +526,26 @@ describe('SubscriptionController', () => {
         expect(mockService.cancelSubscription).toHaveBeenCalledWith({
           subscriptionId: 'sub_123456789',
         });
+      });
+    });
+  });
+
+  describe('getPricing', () => {
+    const mockPricingResponse: PricingResponse = {
+      products: [],
+      paymentMethods: {
+        type: 'crypto',
+        chains: [],
+      },
+    };
+
+    it('should return pricing response', async () => {
+      await withController(async ({ controller, mockService }) => {
+        mockService.getPricing.mockResolvedValue(mockPricingResponse);
+
+        const result = await controller.getPricing();
+
+        expect(result).toStrictEqual(mockPricingResponse);
       });
     });
   });

--- a/packages/subscription-controller/src/SubscriptionController.test.ts
+++ b/packages/subscription-controller/src/SubscriptionController.test.ts
@@ -533,10 +533,7 @@ describe('SubscriptionController', () => {
   describe('getPricing', () => {
     const mockPricingResponse: PricingResponse = {
       products: [],
-      paymentMethods: {
-        type: 'crypto',
-        chains: [],
-      },
+      paymentMethods: [],
     };
 
     it('should return pricing response', async () => {

--- a/packages/subscription-controller/src/SubscriptionController.ts
+++ b/packages/subscription-controller/src/SubscriptionController.ts
@@ -14,6 +14,7 @@ import {
 import {
   SubscriptionStatus,
   type ISubscriptionService,
+  type PricingResponse,
   type ProductType,
   type StartSubscriptionRequest,
   type Subscription,
@@ -36,6 +37,10 @@ export type SubscriptionControllerStartShieldSubscriptionWithCardAction = {
   type: `${typeof controllerName}:startShieldSubscriptionWithCard`;
   handler: SubscriptionController['startShieldSubscriptionWithCard'];
 };
+export type SubscriptionControllerGetPricingAction = {
+  type: `${typeof controllerName}:getPricing`;
+  handler: SubscriptionController['getPricing'];
+};
 
 export type SubscriptionControllerGetStateAction = ControllerGetStateAction<
   typeof controllerName,
@@ -45,6 +50,7 @@ export type SubscriptionControllerActions =
   | SubscriptionControllerGetSubscriptionsAction
   | SubscriptionControllerCancelSubscriptionAction
   | SubscriptionControllerStartShieldSubscriptionWithCardAction
+  | SubscriptionControllerGetPricingAction
   | SubscriptionControllerGetStateAction;
 
 export type AllowedActions =
@@ -167,6 +173,20 @@ export class SubscriptionController extends BaseController<
       'SubscriptionController:startShieldSubscriptionWithCard',
       this.startShieldSubscriptionWithCard.bind(this),
     );
+
+    this.messagingSystem.registerActionHandler(
+      'SubscriptionController:getPricing',
+      this.getPricing.bind(this),
+    );
+  }
+
+  /**
+   * Gets the pricing information from the subscription service.
+   *
+   * @returns The pricing information.
+   */
+  async getPricing(): Promise<PricingResponse> {
+    return await this.#subscriptionService.getPricing();
   }
 
   async getSubscriptions() {

--- a/packages/subscription-controller/src/SubscriptionService.test.ts
+++ b/packages/subscription-controller/src/SubscriptionService.test.ts
@@ -296,10 +296,7 @@ describe('SubscriptionService', () => {
   describe('getPricing', () => {
     const mockPricingResponse: PricingResponse = {
       products: [],
-      paymentMethods: {
-        type: 'crypto',
-        chains: [],
-      },
+      paymentMethods: [],
     };
 
     it('should fetch pricing successfully', async () => {

--- a/packages/subscription-controller/src/SubscriptionService.test.ts
+++ b/packages/subscription-controller/src/SubscriptionService.test.ts
@@ -7,7 +7,11 @@ import {
 } from './constants';
 import { SubscriptionServiceError } from './errors';
 import { SubscriptionService } from './SubscriptionService';
-import type { StartSubscriptionRequest, Subscription } from './types';
+import type {
+  StartSubscriptionRequest,
+  Subscription,
+  PricingResponse,
+} from './types';
 import {
   PaymentType,
   ProductType,
@@ -286,6 +290,28 @@ describe('SubscriptionService', () => {
       await expect(service.startSubscriptionWithCard(request)).rejects.toThrow(
         SubscriptionControllerErrorMessage.SubscriptionProductsEmpty,
       );
+    });
+  });
+
+  describe('getPricing', () => {
+    const mockPricingResponse: PricingResponse = {
+      products: [],
+      paymentMethods: {
+        type: 'crypto',
+        chains: [],
+      },
+    };
+
+    it('should fetch pricing successfully', async () => {
+      const config = createMockConfig();
+      const service = new SubscriptionService(config);
+      const testUrl = getTestUrl(Env.DEV);
+
+      nock(testUrl).get('/api/v1/pricing').reply(200, mockPricingResponse);
+
+      const result = await service.getPricing();
+
+      expect(result).toStrictEqual(mockPricingResponse);
     });
   });
 });

--- a/packages/subscription-controller/src/SubscriptionService.ts
+++ b/packages/subscription-controller/src/SubscriptionService.ts
@@ -8,6 +8,7 @@ import type {
   AuthUtils,
   GetSubscriptionsResponse,
   ISubscriptionService,
+  PricingResponse,
   StartSubscriptionRequest,
   StartSubscriptionResponse,
 } from './types';
@@ -100,5 +101,10 @@ export class SubscriptionService implements ISubscriptionService {
   async #getAuthorizationHeader(): Promise<{ Authorization: string }> {
     const accessToken = await this.authUtils.getAccessToken();
     return { Authorization: `Bearer ${accessToken}` };
+  }
+
+  async getPricing(): Promise<PricingResponse> {
+    const path = 'pricing';
+    return await this.#makeRequest<PricingResponse>(path);
   }
 }

--- a/packages/subscription-controller/src/index.ts
+++ b/packages/subscription-controller/src/index.ts
@@ -25,7 +25,7 @@ export type {
   ProductType,
   ProductPrice,
   ProductPricing,
-  ChainPaymentDetails,
+  ChainPaymentInfo,
   PricingPaymentMethod,
   PricingResponse,
 } from './types';

--- a/packages/subscription-controller/src/index.ts
+++ b/packages/subscription-controller/src/index.ts
@@ -5,6 +5,7 @@ export type {
   SubscriptionControllerGetSubscriptionsAction,
   SubscriptionControllerCancelSubscriptionAction,
   SubscriptionControllerStartShieldSubscriptionWithCardAction,
+  SubscriptionControllerGetPricingAction,
   SubscriptionControllerGetStateAction,
   SubscriptionControllerMessenger,
   SubscriptionControllerOptions,

--- a/packages/subscription-controller/src/index.ts
+++ b/packages/subscription-controller/src/index.ts
@@ -25,6 +25,7 @@ export type {
   ProductType,
   ProductPrice,
   ProductPricing,
+  TokenPaymentInfo,
   ChainPaymentInfo,
   PricingPaymentMethod,
   PricingResponse,

--- a/packages/subscription-controller/src/index.ts
+++ b/packages/subscription-controller/src/index.ts
@@ -23,6 +23,11 @@ export type {
   PaymentType,
   Product,
   ProductType,
+  ProductPrice,
+  ProductPricing,
+  ChainPaymentDetails,
+  PricingPaymentMethod,
+  PricingResponse,
 } from './types';
 export { SubscriptionServiceError } from './errors';
 export { Env, SubscriptionControllerErrorMessage } from './constants';

--- a/packages/subscription-controller/src/types.ts
+++ b/packages/subscription-controller/src/types.ts
@@ -94,7 +94,7 @@ export type ProductPricing = {
   prices: ProductPrice[];
 };
 
-export type ChainPaymentDetails = {
+export type ChainPaymentInfo = {
   chainId: string;
   paymentAddress: string;
   tokens: {
@@ -109,7 +109,7 @@ export type ChainPaymentDetails = {
 
 export type PricingPaymentMethod = {
   type: PaymentType;
-  chains?: ChainPaymentDetails[];
+  chains?: ChainPaymentInfo[];
 };
 
 export type PricingResponse = {

--- a/packages/subscription-controller/src/types.ts
+++ b/packages/subscription-controller/src/types.ts
@@ -80,33 +80,41 @@ export type AuthUtils = {
   getAccessToken: () => Promise<string>;
 };
 
-export type PricingResponse = {
-  products: {
-    name: string;
-    prices: {
-      interval: string; // "month" | "year"
-      unitAmount: string; // amount in the smallest unit of the currency, e.g., cents
-      unitDecimals: number; // number of decimals for the smallest unit of the currency
-      currency: string; // "usd"
-      trialPeriodDays: number;
-      minBillingCycles: number;
-    }[];
+export type ProductPrice = {
+  interval: string; // "month" | "year"
+  unitAmount: string; // amount in the smallest unit of the currency, e.g., cents
+  unitDecimals: number; // number of decimals for the smallest unit of the currency
+  currency: string; // "usd"
+  trialPeriodDays: number;
+  minBillingCycles: number;
+};
+
+export type ProductPricing = {
+  name: string;
+  prices: ProductPrice[];
+};
+
+export type ChainPaymentDetails = {
+  chainId: string;
+  paymentAddress: string;
+  tokens: {
+    symbol: string;
+    address: string;
+    decimals: number;
+    conversionRate: {
+      usd: string;
+    };
   }[];
-  paymentMethods: {
-    type: string; // "crypto" | "card"
-    chains: {
-      chainId: string; // "0x1",
-      paymentAddress: string; // "0x...",
-      tokens: {
-        symbol: string; // "USDC" | "USDT"
-        address: string; // "0x..."
-        decimals: number; // 18
-        conversionRate: {
-          usd: string; // "1.0"
-        };
-      }[];
-    }[];
-  };
+};
+
+export type PricingPaymentMethod = {
+  type: PaymentType;
+  chains?: ChainPaymentDetails[];
+};
+
+export type PricingResponse = {
+  products: ProductPricing[];
+  paymentMethods: PricingPaymentMethod[];
 };
 
 export type ISubscriptionService = {

--- a/packages/subscription-controller/src/types.ts
+++ b/packages/subscription-controller/src/types.ts
@@ -94,17 +94,19 @@ export type ProductPricing = {
   prices: ProductPrice[];
 };
 
+export type TokenPaymentInfo = {
+  symbol: string;
+  address: string;
+  decimals: number;
+  conversionRate: {
+    usd: string;
+  };
+};
+
 export type ChainPaymentInfo = {
   chainId: string;
   paymentAddress: string;
-  tokens: {
-    symbol: string;
-    address: string;
-    decimals: number;
-    conversionRate: {
-      usd: string;
-    };
-  }[];
+  tokens: TokenPaymentInfo[];
 };
 
 export type PricingPaymentMethod = {

--- a/packages/subscription-controller/src/types.ts
+++ b/packages/subscription-controller/src/types.ts
@@ -80,10 +80,40 @@ export type AuthUtils = {
   getAccessToken: () => Promise<string>;
 };
 
+export type PricingResponse = {
+  products: {
+    name: string;
+    prices: {
+      interval: string; // "month" | "year"
+      unitAmount: string; // amount in the smallest unit of the currency, e.g., cents
+      unitDecimals: number; // number of decimals for the smallest unit of the currency
+      currency: string; // "usd"
+      trialPeriodDays: number;
+      minBillingCycles: number;
+    }[];
+  }[];
+  paymentMethods: {
+    type: string; // "crypto" | "card"
+    chains: {
+      chainId: string; // "0x1",
+      paymentAddress: string; // "0x...",
+      tokens: {
+        symbol: string; // "USDC" | "USDT"
+        address: string; // "0x..."
+        decimals: number; // 18
+        conversionRate: {
+          usd: string; // "1.0"
+        };
+      }[];
+    }[];
+  };
+};
+
 export type ISubscriptionService = {
   getSubscriptions(): Promise<GetSubscriptionsResponse>;
   cancelSubscription(request: { subscriptionId: string }): Promise<void>;
   startSubscriptionWithCard(
     request: StartSubscriptionRequest,
   ): Promise<StartSubscriptionResponse>;
+  getPricing(): Promise<PricingResponse>;
 };


### PR DESCRIPTION
## Explanation

Add a "getPricing" method to the SubscriptionController, which allows the frontend to query the available products and their pricing.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
