### PR TITLE
feat: Add additional controller metadata

### DIFF
--- a/packages/base-controller/src/next/BaseController.test.ts
+++ b/packages/base-controller/src/next/BaseController.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable jest/no-export */
 import { Messenger } from '@metamask/messenger';
+import type { Json } from '@metamask/utils';
 import type { Draft, Patch } from 'immer';
 import * as sinon from 'sinon';
 
@@ -8,12 +9,15 @@ import type {
   ControllerEvents,
   ControllerGetStateAction,
   ControllerStateChangeEvent,
+  StatePropertyMetadata,
 } from './BaseController';
 import {
   BaseController,
   getAnonymizedState,
   getPersistentState,
+  deriveStateFromMetadata,
 } from './BaseController';
+
 
 export const countControllerName = 'CountController';
 
@@ -33,8 +37,10 @@ export type CountControllerEvent = ControllerStateChangeEvent<
 
 export const countControllerStateMetadata = {
   count: {
+    includeInDebugSnapshot: true,
+    includeInStateLogs: true,
     persist: true,
-    anonymous: true,
+    usedInUi: true,
   },
 };
 
@@ -104,8 +110,10 @@ type MessagesControllerEvent = ControllerStateChangeEvent<
 
 const messagesControllerStateMetadata = {
   messages: {
+    includeInDebugSnapshot: true,
+    includeInStateLogs: true,
     persist: true,
-    anonymous: true,
+    usedInUi: true,
   },
 };
 
@@ -573,362 +581,6 @@ describe('BaseController', () => {
     expect(listener1.callCount).toBe(0);
     expect(listener2.callCount).toBe(0);
   });
-});
-
-describe('getAnonymizedState', () => {
-  afterEach(() => {
-    sinon.restore();
-  });
-
-  it('should return empty state', () => {
-    expect(getAnonymizedState({}, {})).toStrictEqual({});
-  });
-
-  it('should return empty state when no properties are anonymized', () => {
-    const anonymizedState = getAnonymizedState(
-      { count: 1 },
-      { count: { anonymous: false, persist: false } },
-    );
-    expect(anonymizedState).toStrictEqual({});
-  });
-
-  it('should return state that is already anonymized', () => {
-    const anonymizedState = getAnonymizedState(
-      {
-        password: 'secret password',
-        privateKey: '123',
-        network: 'mainnet',
-        tokens: ['DAI', 'USDC'],
-      },
-      {
-        password: {
-          anonymous: false,
-          persist: false,
-        },
-        privateKey: {
-          anonymous: false,
-          persist: false,
-        },
-        network: {
-          anonymous: true,
-          persist: false,
-        },
-        tokens: {
-          anonymous: true,
-          persist: false,
-        },
-      },
-    );
-    expect(anonymizedState).toStrictEqual({
-      network: 'mainnet',
-      tokens: ['DAI', 'USDC'],
-    });
-  });
-
-  it('should use anonymizing function to anonymize state', () => {
-    const anonymizeTransactionHash = (hash: string) => {
-      return hash.split('').reverse().join('');
-    };
-
-    const anonymizedState = getAnonymizedState(
-      {
-        transactionHash: '0x1234',
-      },
-      {
-        transactionHash: {
-          anonymous: anonymizeTransactionHash,
-          persist: false,
-        },
-      },
-    );
-
-    expect(anonymizedState).toStrictEqual({ transactionHash: '4321x0' });
-  });
-
-  it('should allow returning a partial object from an anonymizing function', () => {
-    const anonymizeTxMeta = (txMeta: { hash: string; value: number }) => {
-      return { value: txMeta.value };
-    };
-
-    const anonymizedState = getAnonymizedState(
-      {
-        txMeta: {
-          hash: '0x123',
-          value: 10,
-        },
-      },
-      {
-        txMeta: {
-          anonymous: anonymizeTxMeta,
-          persist: false,
-        },
-      },
-    );
-
-    expect(anonymizedState).toStrictEqual({ txMeta: { value: 10 } });
-  });
-
-  it('should allow returning a nested partial object from an anonymizing function', () => {
-    const anonymizeTxMeta = (txMeta: {
-      hash: string;
-      value: number;
-      history: { hash: string; value: number }[];
-    }) => {
-      return {
-        history: txMeta.history.map((entry) => {
-          return { value: entry.value };
-        }),
-        value: txMeta.value,
-      };
-    };
-
-    const anonymizedState = getAnonymizedState(
-      {
-        txMeta: {
-          hash: '0x123',
-          history: [
-            {
-              hash: '0x123',
-              value: 9,
-            },
-          ],
-          value: 10,
-        },
-      },
-      {
-        txMeta: {
-          anonymous: anonymizeTxMeta,
-          persist: false,
-        },
-      },
-    );
-
-    expect(anonymizedState).toStrictEqual({
-      txMeta: { history: [{ value: 9 }], value: 10 },
-    });
-  });
-
-  it('should allow transforming types in an anonymizing function', () => {
-    const anonymizedState = getAnonymizedState(
-      {
-        count: '1',
-      },
-      {
-        count: {
-          anonymous: (count) => Number(count),
-          persist: false,
-        },
-      },
-    );
-
-    expect(anonymizedState).toStrictEqual({ count: 1 });
-  });
-
-  it('should suppress errors thrown when deriving state', () => {
-    const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
-    const persistentState = getAnonymizedState(
-      {
-        extraState: 'extraState',
-        privateKey: '123',
-        network: 'mainnet',
-      },
-      // @ts-expect-error Intentionally testing invalid state
-      {
-        privateKey: {
-          anonymous: true,
-          persist: true,
-        },
-        network: {
-          anonymous: false,
-          persist: false,
-        },
-      },
-    );
-    expect(persistentState).toStrictEqual({
-      privateKey: '123',
-    });
-    expect(setTimeoutStub.callCount).toBe(1);
-    const onTimeout = setTimeoutStub.firstCall.args[0];
-    expect(() => onTimeout()).toThrow(`No metadata found for 'extraState'`);
-  });
-});
-
-describe('getPersistentState', () => {
-  afterEach(() => {
-    sinon.restore();
-  });
-
-  it('should return empty state', () => {
-    expect(getPersistentState({}, {})).toStrictEqual({});
-  });
-
-  it('should return empty state when no properties are persistent', () => {
-    const persistentState = getPersistentState(
-      { count: 1 },
-      { count: { anonymous: false, persist: false } },
-    );
-    expect(persistentState).toStrictEqual({});
-  });
-
-  it('should return persistent state', () => {
-    const persistentState = getPersistentState(
-      {
-        password: 'secret password',
-        privateKey: '123',
-        network: 'mainnet',
-        tokens: ['DAI', 'USDC'],
-      },
-      {
-        password: {
-          anonymous: false,
-          persist: true,
-        },
-        privateKey: {
-          anonymous: false,
-          persist: true,
-        },
-        network: {
-          anonymous: false,
-          persist: false,
-        },
-        tokens: {
-          anonymous: false,
-          persist: false,
-        },
-      },
-    );
-    expect(persistentState).toStrictEqual({
-      password: 'secret password',
-      privateKey: '123',
-    });
-  });
-
-  it('should use function to derive persistent state', () => {
-    const normalizeTransacitonHash = (hash: string) => {
-      return hash.toLowerCase();
-    };
-
-    const persistentState = getPersistentState(
-      {
-        transactionHash: '0X1234',
-      },
-      {
-        transactionHash: {
-          anonymous: false,
-          persist: normalizeTransacitonHash,
-        },
-      },
-    );
-
-    expect(persistentState).toStrictEqual({ transactionHash: '0x1234' });
-  });
-
-  it('should allow returning a partial object from a persist function', () => {
-    const getPersistentTxMeta = (txMeta: { hash: string; value: number }) => {
-      return { value: txMeta.value };
-    };
-
-    const persistentState = getPersistentState(
-      {
-        txMeta: {
-          hash: '0x123',
-          value: 10,
-        },
-      },
-      {
-        txMeta: {
-          anonymous: false,
-          persist: getPersistentTxMeta,
-        },
-      },
-    );
-
-    expect(persistentState).toStrictEqual({ txMeta: { value: 10 } });
-  });
-
-  it('should allow returning a nested partial object from a persist function', () => {
-    const getPersistentTxMeta = (txMeta: {
-      hash: string;
-      value: number;
-      history: { hash: string; value: number }[];
-    }) => {
-      return {
-        history: txMeta.history.map((entry) => {
-          return { value: entry.value };
-        }),
-        value: txMeta.value,
-      };
-    };
-
-    const persistentState = getPersistentState(
-      {
-        txMeta: {
-          hash: '0x123',
-          history: [
-            {
-              hash: '0x123',
-              value: 9,
-            },
-          ],
-          value: 10,
-        },
-      },
-      {
-        txMeta: {
-          anonymous: false,
-          persist: getPersistentTxMeta,
-        },
-      },
-    );
-
-    expect(persistentState).toStrictEqual({
-      txMeta: { history: [{ value: 9 }], value: 10 },
-    });
-  });
-
-  it('should allow transforming types in a persist function', () => {
-    const persistentState = getPersistentState(
-      {
-        count: '1',
-      },
-      {
-        count: {
-          anonymous: false,
-          persist: (count) => Number(count),
-        },
-      },
-    );
-
-    expect(persistentState).toStrictEqual({ count: 1 });
-  });
-
-  it('should suppress errors thrown when deriving state', () => {
-    const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
-    const persistentState = getPersistentState(
-      {
-        extraState: 'extraState',
-        privateKey: '123',
-        network: 'mainnet',
-      },
-      // @ts-expect-error Intentionally testing invalid state
-      {
-        privateKey: {
-          anonymous: false,
-          persist: true,
-        },
-        network: {
-          anonymous: false,
-          persist: false,
-        },
-      },
-    );
-    expect(persistentState).toStrictEqual({
-      privateKey: '123',
-    });
-    expect(setTimeoutStub.callCount).toBe(1);
-    const onTimeout = setTimeoutStub.firstCall.args[0];
-    expect(() => onTimeout()).toThrow(`No metadata found for 'extraState'`);
-  });
 
   describe('inter-controller communication', () => {
     // These two contrived mock controllers are setup to test with.
@@ -958,8 +610,10 @@ describe('getPersistentState', () => {
 
     const visitorControllerStateMetadata = {
       visitors: {
+        includeInDebugSnapshot: true,
+        includeInStateLogs: true,
         persist: true,
-        anonymous: true,
+        usedInUi: true,
       },
     };
 
@@ -1026,8 +680,10 @@ describe('getPersistentState', () => {
 
     const visitorOverflowControllerMetadata = {
       maxVisitors: {
+        includeInDebugSnapshot: true,
+        includeInStateLogs: true,
         persist: false,
-        anonymous: true,
+        usedInUi: true,
       },
     };
 
@@ -1121,6 +777,652 @@ describe('getPersistentState', () => {
 
       expect(visitorOverflowController.state.maxVisitors).toBe(2);
       expect(visitorController.state.visitors).toHaveLength(0);
+    });
+  });
+});
+
+describe('getAnonymizedState', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return empty state', () => {
+    expect(getAnonymizedState({}, {})).toStrictEqual({});
+  });
+
+  it('should return empty state when no properties are anonymized', () => {
+    const anonymizedState = getAnonymizedState(
+      { count: 1 },
+      {
+        count: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+      },
+    );
+    expect(anonymizedState).toStrictEqual({});
+  });
+
+  it('should return state that is already anonymized', () => {
+    const anonymizedState = getAnonymizedState(
+      {
+        password: 'secret password',
+        privateKey: '123',
+        network: 'mainnet',
+        tokens: ['DAI', 'USDC'],
+      },
+      {
+        password: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+        privateKey: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+        network: {
+          includeInDebugSnapshot: true,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+        tokens: {
+          includeInDebugSnapshot: true,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+      },
+    );
+    expect(anonymizedState).toStrictEqual({
+      network: 'mainnet',
+      tokens: ['DAI', 'USDC'],
+    });
+  });
+
+  it('should use anonymizing function to anonymize state', () => {
+    const anonymizeTransactionHash = (hash: string) => {
+      return hash.split('').reverse().join('');
+    };
+
+    const anonymizedState = getAnonymizedState(
+      {
+        transactionHash: '0x1234',
+      },
+      {
+        transactionHash: {
+          includeInDebugSnapshot: anonymizeTransactionHash,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+      },
+    );
+
+    expect(anonymizedState).toStrictEqual({ transactionHash: '4321x0' });
+  });
+
+  it('should allow returning a partial object from an anonymizing function', () => {
+    const anonymizeTxMeta = (txMeta: { hash: string; value: number }) => {
+      return { value: txMeta.value };
+    };
+
+    const anonymizedState = getAnonymizedState(
+      {
+        txMeta: {
+          hash: '0x123',
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          includeInDebugSnapshot: anonymizeTxMeta,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+      },
+    );
+
+    expect(anonymizedState).toStrictEqual({ txMeta: { value: 10 } });
+  });
+
+  it('should allow returning a nested partial object from an anonymizing function', () => {
+    const anonymizeTxMeta = (txMeta: {
+      hash: string;
+      value: number;
+      history: { hash: string; value: number }[];
+    }) => {
+      return {
+        history: txMeta.history.map((entry) => {
+          return { value: entry.value };
+        }),
+        value: txMeta.value,
+      };
+    };
+
+    const anonymizedState = getAnonymizedState(
+      {
+        txMeta: {
+          hash: '0x123',
+          history: [
+            {
+              hash: '0x123',
+              value: 9,
+            },
+          ],
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          includeInDebugSnapshot: anonymizeTxMeta,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+      },
+    );
+
+    expect(anonymizedState).toStrictEqual({
+      txMeta: { history: [{ value: 9 }], value: 10 },
+    });
+  });
+
+  it('should allow transforming types in an anonymizing function', () => {
+    const anonymizedState = getAnonymizedState(
+      {
+        count: '1',
+      },
+      {
+        count: {
+          includeInDebugSnapshot: (count) => Number(count),
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+      },
+    );
+
+    expect(anonymizedState).toStrictEqual({ count: 1 });
+  });
+
+  it('should suppress errors thrown when deriving state', () => {
+    const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
+    const persistentState = getAnonymizedState(
+      {
+        extraState: 'extraState',
+        privateKey: '123',
+        network: 'mainnet',
+      },
+      // @ts-expect-error Intentionally testing invalid state
+      {
+        privateKey: {
+          includeInDebugSnapshot: true,
+          includeInStateLogs: true,
+          persist: true,
+          usedInUi: true,
+        },
+        network: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+      },
+    );
+    expect(persistentState).toStrictEqual({
+      privateKey: '123',
+    });
+    expect(setTimeoutStub.callCount).toBe(1);
+    const onTimeout = setTimeoutStub.firstCall.args[0];
+    expect(() => onTimeout()).toThrow(`No metadata found for 'extraState'`);
+  });
+});
+
+describe('getPersistentState', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return empty state', () => {
+    expect(getPersistentState({}, {})).toStrictEqual({});
+  });
+
+  it('should return empty state when no properties are persistent', () => {
+    const persistentState = getPersistentState(
+      { count: 1 },
+      {
+        count: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+      },
+    );
+    expect(persistentState).toStrictEqual({});
+  });
+
+  it('should return persistent state', () => {
+    const persistentState = getPersistentState(
+      {
+        password: 'secret password',
+        privateKey: '123',
+        network: 'mainnet',
+        tokens: ['DAI', 'USDC'],
+      },
+      {
+        password: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: true,
+          usedInUi: false,
+        },
+        privateKey: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: true,
+          usedInUi: false,
+        },
+        network: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+        tokens: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: false,
+        },
+      },
+    );
+    expect(persistentState).toStrictEqual({
+      password: 'secret password',
+      privateKey: '123',
+    });
+  });
+
+  it('should use function to derive persistent state', () => {
+    const normalizeTransacitonHash = (hash: string) => {
+      return hash.toLowerCase();
+    };
+
+    const persistentState = getPersistentState(
+      {
+        transactionHash: '0X1234',
+      },
+      {
+        transactionHash: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: normalizeTransacitonHash,
+          usedInUi: false,
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({ transactionHash: '0x1234' });
+  });
+
+  it('should allow returning a partial object from a persist function', () => {
+    const getPersistentTxMeta = (txMeta: { hash: string; value: number }) => {
+      return { value: txMeta.value };
+    };
+
+    const persistentState = getPersistentState(
+      {
+        txMeta: {
+          hash: '0x123',
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: getPersistentTxMeta,
+          usedInUi: false,
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({ txMeta: { value: 10 } });
+  });
+
+  it('should allow returning a nested partial object from a persist function', () => {
+    const getPersistentTxMeta = (txMeta: {
+      hash: string;
+      value: number;
+      history: { hash: string; value: number }[];
+    }) => {
+      return {
+        history: txMeta.history.map((entry) => {
+          return { value: entry.value };
+        }),
+        value: txMeta.value,
+      };
+    };
+
+    const persistentState = getPersistentState(
+      {
+        txMeta: {
+          hash: '0x123',
+          history: [
+            {
+              hash: '0x123',
+              value: 9,
+            },
+          ],
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: getPersistentTxMeta,
+          usedInUi: false,
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({
+      txMeta: { history: [{ value: 9 }], value: 10 },
+    });
+  });
+
+  it('should allow transforming types in a persist function', () => {
+    const persistentState = getPersistentState(
+      {
+        count: '1',
+      },
+      {
+        count: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: (count) => Number(count),
+          usedInUi: false,
+        },
+      },
+    );
+
+    expect(persistentState).toStrictEqual({ count: 1 });
+  });
+
+  it('should suppress errors thrown when deriving state', () => {
+    const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
+    const persistentState = getPersistentState(
+      {
+        extraState: 'extraState',
+        privateKey: '123',
+        network: 'mainnet',
+      },
+      // @ts-expect-error Intentionally testing invalid state
+      {
+        privateKey: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: true,
+          usedInUi: false,
+        },
+        network: {
+          includeInDebugSnapshot: false,
+          includeInStateLogs: false,
+          persist: false,
+          usedInUi: true,
+        },
+      },
+    );
+    expect(persistentState).toStrictEqual({
+      privateKey: '123',
+    });
+    expect(setTimeoutStub.callCount).toBe(1);
+    const onTimeout = setTimeoutStub.firstCall.args[0];
+    expect(() => onTimeout()).toThrow(`No metadata found for 'extraState'`);
+  });
+});
+
+describe('deriveStateFromMetadata', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe.each([
+    'includeInDebugSnapshot',
+    'includeInStateLogs',
+    'persist',
+    'usedInUi',
+  ] as const)('%s', (property: keyof StatePropertyMetadata<Json>) => {
+    it('should return empty state', () => {
+      expect(deriveStateFromMetadata({}, {}, property)).toStrictEqual({});
+    });
+
+    it('should return empty state when no properties are enabled', () => {
+      const derivedState = deriveStateFromMetadata(
+        { count: 1 },
+        {
+          count: {
+            includeInDebugSnapshot: false,
+            includeInStateLogs: false,
+            persist: false,
+            usedInUi: false,
+            [property]: false,
+          },
+        },
+        property,
+      );
+
+      expect(derivedState).toStrictEqual({});
+    });
+
+    it('should return derived state', () => {
+      const derivedState = deriveStateFromMetadata(
+        {
+          password: 'secret password',
+          privateKey: '123',
+          network: 'mainnet',
+          tokens: ['DAI', 'USDC'],
+        },
+        {
+          password: {
+            includeInDebugSnapshot: false,
+            includeInStateLogs: false,
+            persist: false,
+            usedInUi: false,
+            [property]: true,
+          },
+          privateKey: {
+            includeInDebugSnapshot: false,
+            includeInStateLogs: false,
+            persist: false,
+            usedInUi: false,
+            [property]: true,
+          },
+          network: {
+            includeInDebugSnapshot: false,
+            includeInStateLogs: false,
+            persist: false,
+            usedInUi: false,
+            [property]: false,
+          },
+          tokens: {
+            includeInDebugSnapshot: false,
+            includeInStateLogs: false,
+            persist: false,
+            usedInUi: false,
+            [property]: false,
+          },
+        },
+        property,
+      );
+
+      expect(derivedState).toStrictEqual({
+        password: 'secret password',
+        privateKey: '123',
+      });
+    });
+
+    if (property !== 'usedInUi') {
+      it('should use function to derive state', () => {
+        const normalizeTransactionHash = (hash: string) => {
+          return hash.toLowerCase();
+        };
+
+        const derivedState = deriveStateFromMetadata(
+          {
+            transactionHash: '0X1234',
+          },
+          {
+            transactionHash: {
+              includeInDebugSnapshot: false,
+              includeInStateLogs: false,
+              persist: false,
+              usedInUi: false,
+              [property]: normalizeTransactionHash,
+            },
+          },
+          property,
+        );
+
+        expect(derivedState).toStrictEqual({ transactionHash: '0x1234' });
+      });
+
+      it('should allow returning a partial object from a deriver', () => {
+        const getDerivedTxMeta = (txMeta: { hash: string; value: number }) => {
+          return { value: txMeta.value };
+        };
+
+        const derivedState = deriveStateFromMetadata(
+          {
+            txMeta: {
+              hash: '0x123',
+              value: 10,
+            },
+          },
+          {
+            txMeta: {
+              includeInDebugSnapshot: false,
+              includeInStateLogs: false,
+              persist: false,
+              usedInUi: false,
+              [property]: getDerivedTxMeta,
+            },
+          },
+          property,
+        );
+
+        expect(derivedState).toStrictEqual({ txMeta: { value: 10 } });
+      });
+
+      it('should allow returning a nested partial object from a deriver', () => {
+        const getDerivedTxMeta = (txMeta: {
+          hash: string;
+          value: number;
+          history: { hash: string; value: number }[];
+        }) => {
+          return {
+            history: txMeta.history.map((entry) => {
+              return { value: entry.value };
+            }),
+            value: txMeta.value,
+          };
+        };
+
+        const derivedState = deriveStateFromMetadata(
+          {
+            txMeta: {
+              hash: '0x123',
+              history: [
+                {
+                  hash: '0x123',
+                  value: 9,
+                },
+              ],
+              value: 10,
+            },
+          },
+          {
+            txMeta: {
+              includeInDebugSnapshot: false,
+              includeInStateLogs: false,
+              persist: false,
+              usedInUi: false,
+              [property]: getDerivedTxMeta,
+            },
+          },
+          property,
+        );
+
+        expect(derivedState).toStrictEqual({
+          txMeta: { history: [{ value: 9 }], value: 10 },
+        });
+      });
+
+      it('should allow transforming types in a deriver', () => {
+        const derivedState = deriveStateFromMetadata(
+          {
+            count: '1',
+          },
+          {
+            count: {
+              includeInDebugSnapshot: false,
+              includeInStateLogs: false,
+              persist: false,
+              usedInUi: false,
+              [property]: (count: string) => Number(count),
+            },
+          },
+          property,
+        );
+
+        expect(derivedState).toStrictEqual({ count: 1 });
+      });
+    }
+
+    it('should suppress errors thrown when deriving state', () => {
+      const setTimeoutStub = sinon.stub(globalThis, 'setTimeout');
+      const derivedState = deriveStateFromMetadata(
+        {
+          extraState: 'extraState',
+          privateKey: '123',
+          network: 'mainnet',
+        },
+        // @ts-expect-error Intentionally testing invalid state
+        {
+          privateKey: {
+            includeInDebugSnapshot: false,
+            includeInStateLogs: false,
+            persist: false,
+            usedInUi: false,
+            [property]: true,
+          },
+          network: {
+            includeInDebugSnapshot: false,
+            includeInStateLogs: false,
+            persist: false,
+            usedInUi: false,
+            [property]: false,
+          },
+        },
+        property,
+      );
+
+      expect(derivedState).toStrictEqual({
+        privateKey: '123',
+      });
+
+      expect(setTimeoutStub.callCount).toBe(1);
+      const onTimeout = setTimeoutStub.firstCall.args[0];
+      expect(() => onTimeout()).toThrow(`No metadata found for 'extraState'`);
     });
   });
 });

--- a/packages/base-controller/src/next/BaseController.ts
+++ b/packages/base-controller/src/next/BaseController.ts
@@ -58,20 +58,47 @@ export type StateMetadata<T extends StateConstraint> = {
 
 /**
  * Metadata for a single state property
- *
- * @property persist - Indicates whether this property should be persisted
- * (`true` for persistent, `false` for transient), or is set to a function
- * that derives the persistent state from the state.
- * @property anonymous - Indicates whether this property is already anonymous,
- * (`true` for anonymous, `false` if it has potential to be personally
- * identifiable), or is set to a function that returns an anonymized
- * representation of this state.
  */
-// TODO: Either fix this lint violation or explain why it's necessary to ignore.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export type StatePropertyMetadata<T extends Json> = {
-  persist: boolean | StateDeriver<T>;
-  anonymous: boolean | StateDeriver<T>;
+export type StatePropertyMetadata<ControllerState extends Json> = {
+  /**
+   * Indicates whether this property should be included in debug snapshots attached to Sentry
+   * errors.
+   *
+   * Set this to false if the state may contain personally identifiable information, or if it's
+   * too large to include in a debug snapshot.
+   */
+  includeInDebugSnapshot: boolean | StateDeriver<ControllerState>;
+  /**
+   * Indicates whether this property should be included in state logs.
+   *
+   * Set this to false if the data should be kept hidden from support agents (e.g. if it contains
+   * secret keys, or personally-identifiable information that is not useful for debugging).
+   *
+   * We do allow state logs to contain some personally identifiable information to assist with
+   * diagnosing errors (e.g. transaction hashes, addresses), but we still attempt to limit the
+   * data we expose to what is most useful for helping users.
+   */
+  includeInStateLogs: boolean | StateDeriver<ControllerState>;
+  /**
+   * Indicates whether this property should be persisted.
+   *
+   * If true, the property will be persisted and saved between sessions.
+   * If false, the property will not be saved between sessions, and it will always be missing from the `state` constructor parameter.
+   */
+  persist: boolean | StateDeriver<ControllerState>;
+  /**
+   * Indicates whether this property is used by the UI.
+   *
+   * If true, the property will be accessible from the UI.
+   * If false, it will be inaccessible from the UI.
+   *
+   * Making a property accessible to the UI has a performance overhead, so it's better to set this
+   * to `false` if it's not used in the UI, especially for properties that can be large in size.
+   *
+   * Note that we disallow the use of a state derivation function here to preserve type information
+   * for the UI (the state deriver type always returns `Json`).
+   */
+  usedInUi: boolean;
 };
 
 /**
@@ -337,6 +364,7 @@ export class BaseController<
  * By "anonymized" we mean that it should not contain any information that could be personally
  * identifiable.
  *
+ * @deprecated use `deriveStateFromMetadata` instead.
  * @param state - The controller state.
  * @param metadata - The controller state metadata, which describes how to derive the
  * anonymized state.
@@ -346,12 +374,13 @@ export function getAnonymizedState<ControllerState extends StateConstraint>(
   state: ControllerState,
   metadata: StateMetadata<ControllerState>,
 ): Record<keyof ControllerState, Json> {
-  return deriveStateFromMetadata(state, metadata, 'anonymous');
+  return deriveStateFromMetadata(state, metadata, 'includeInDebugSnapshot');
 }
 
 /**
  * Returns the subset of state that should be persisted.
  *
+ * @deprecated use `deriveStateFromMetadata` instead.
  * @param state - The controller state.
  * @param metadata - The controller state metadata, which describes which pieces of state should be persisted.
  * @returns The subset of controller state that should be persisted.
@@ -371,10 +400,12 @@ export function getPersistentState<ControllerState extends StateConstraint>(
  * @param metadataProperty - The metadata property to use to derive state.
  * @returns The metadata-derived controller state.
  */
-function deriveStateFromMetadata<ControllerState extends StateConstraint>(
+export function deriveStateFromMetadata<
+  ControllerState extends StateConstraint,
+>(
   state: ControllerState,
   metadata: StateMetadata<ControllerState>,
-  metadataProperty: 'anonymous' | 'persist',
+  metadataProperty: keyof StatePropertyMetadata<Json>,
 ): Record<keyof ControllerState, Json> {
   return (Object.keys(state) as (keyof ControllerState)[]).reduce<
     Record<keyof ControllerState, Json>


### PR DESCRIPTION
## Explanation

Add the `includeInStateLogs` and `usedInUi` state metadata properties, and rename `anonymous` to `includeInDebugSnapshot`. This is the implementation of the second option of this ADR: https://github.com/MetaMask/decisions/pull/101

## References

Related to https://github.com/MetaMask/decisions/pull/101

Fixes #643

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
