### PR TITLE
feat: add pay properties to transaction metadata

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `metamaskPay` and `requiredTransactionIds` properties to `TransactionMeta` ([#6361](https://github.com/MetaMask/core/pull/6361))
+  - Add `updateRequiredTransactionIds` method.
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^8.1.0` to `^8.2.0` ([#6355](https://github.com/MetaMask/core/pull/6355))

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -7740,6 +7740,70 @@ describe('TransactionController', () => {
     });
   });
 
+  describe('updateRequiredTransactionIds', () => {
+    it('updates required transaction IDs in state', () => {
+      const { controller } = setupController({
+        options: {
+          state: {
+            transactions: [TRANSACTION_META_MOCK],
+          },
+        },
+      });
+
+      controller.updateRequiredTransactionIds({
+        transactionId: TRANSACTION_META_MOCK.id,
+        requiredTransactionIds: ['123-456', '234-567'],
+      });
+
+      expect(
+        controller.state.transactions[0].requiredTransactionIds,
+      ).toStrictEqual(['123-456', '234-567']);
+    });
+
+    it('appends to existing values by default', () => {
+      const { controller } = setupController({
+        options: {
+          state: {
+            transactions: [
+              { ...TRANSACTION_META_MOCK, requiredTransactionIds: ['123-456'] },
+            ],
+          },
+        },
+      });
+
+      controller.updateRequiredTransactionIds({
+        transactionId: TRANSACTION_META_MOCK.id,
+        requiredTransactionIds: ['234-567'],
+      });
+
+      expect(
+        controller.state.transactions[0].requiredTransactionIds,
+      ).toStrictEqual(['123-456', '234-567']);
+    });
+
+    it('replaces existing values if append is false', () => {
+      const { controller } = setupController({
+        options: {
+          state: {
+            transactions: [
+              { ...TRANSACTION_META_MOCK, requiredTransactionIds: ['123-456'] },
+            ],
+          },
+        },
+      });
+
+      controller.updateRequiredTransactionIds({
+        transactionId: TRANSACTION_META_MOCK.id,
+        requiredTransactionIds: ['234-567'],
+        append: false,
+      });
+
+      expect(
+        controller.state.transactions[0].requiredTransactionIds,
+      ).toStrictEqual(['234-567']);
+    });
+  });
+
   describe('updateSelectedGasFeeToken', () => {
     it('updates selected gas fee token in state', () => {
       const { controller } = setupController({

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -2707,6 +2707,23 @@ export class TransactionController extends BaseController<
     });
   }
 
+  updateRequiredTransactionIds({
+    transactionId,
+    requiredTransactionIds,
+  }: {
+    transactionId: string;
+    requiredTransactionIds: string[];
+  }) {
+    this.#updateTransactionInternal({ transactionId }, (transactionMeta) => {
+      const { requiredTransactionIds: existing } = transactionMeta;
+
+      transactionMeta.requiredTransactionIds = [
+        ...(existing ?? []),
+        ...requiredTransactionIds,
+      ];
+    });
+  }
+
   #addMetadata(transactionMeta: TransactionMeta) {
     validateTxParams(transactionMeta.txParams);
     this.update((state) => {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -2707,18 +2707,28 @@ export class TransactionController extends BaseController<
     });
   }
 
+  /**
+   * Update the required transaction IDs for a transaction.
+   *
+   * @param request - The request object.
+   * @param request.transactionId - The ID of the transaction to update.
+   * @param request.requiredTransactionIds - The additional required transaction IDs.
+   * @param request.append - Whether to append the IDs to any existing values. Defaults to true.
+   */
   updateRequiredTransactionIds({
     transactionId,
     requiredTransactionIds,
+    append,
   }: {
     transactionId: string;
     requiredTransactionIds: string[];
+    append?: boolean;
   }) {
     this.#updateTransactionInternal({ transactionId }, (transactionMeta) => {
       const { requiredTransactionIds: existing } = transactionMeta;
 
       transactionMeta.requiredTransactionIds = [
-        ...(existing ?? []),
+        ...(existing && append !== false ? existing : []),
         ...requiredTransactionIds,
       ];
     });

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -53,6 +53,7 @@ export type {
   IsAtomicBatchSupportedResultEntry,
   LegacyGasFeeEstimates,
   Log,
+  MetamaskPayMetadata,
   NestedTransactionMetadata,
   PublishBatchHook,
   PublishBatchHookRequest,

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -292,6 +292,9 @@ export type TransactionMeta = {
    */
   originalType?: TransactionType;
 
+  /** Metadata specific to the MetaMask Pay feature. */
+  metamaskPay?: MetamaskPayMetadata;
+
   /**
    * Account transaction balance after swap.
    */
@@ -341,6 +344,12 @@ export type TransactionMeta = {
    * When the transaction is dropped, this is the replacement transaction ID.
    */
   replacedById?: string;
+
+  /**
+   * IDs of any transactions that must be confirmed before this one is submitted.
+   * Unlike a transaction batch, these transactions can be on alternate chains.
+   */
+  requiredTransactionIds?: string[];
 
   /**
    * The number of times that the transaction submit has been retried.
@@ -1909,4 +1918,22 @@ export type AssetsFiatValues = {
    * The fiat value of the sending assets.
    */
   sending?: string;
+};
+
+/** Metadata specific to the MetaMask Pay feature. */
+export type MetamaskPayMetadata = {
+  /** Total fee from any bridge transactions, in fiat currency. */
+  bridgeFeeFiat?: string;
+
+  /** Chain ID of the payment token. */
+  chainId?: Hex;
+
+  /** Total network fee in fiat currency, including the original and bridge transactions. */
+  networkFeeFiat?: string;
+
+  /** Address of the payment token that the transaction funds were sourced from. */
+  tokenAddress?: Hex;
+
+  /** Total cost of the transaction in fiat currency, including gas, fees, and the funds themselves. */
+  totalFiat?: string;
 };


### PR DESCRIPTION
## Explanation

Add optional `metamaskPay` and `requiredTransactionIds` properties to `TransactionMeta`.

Also add `updateRequiredTransactionIds` method to update new property.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
