### PR TITLE
feat: SubscriptionController: trigger token refresh

### DIFF
--- a/packages/subscription-controller/CHANGELOG.md
+++ b/packages/subscription-controller/CHANGELOG.md
@@ -14,5 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `cancelSubscription`: Cancel user active subscription.
 - `startShieldSubscriptionWithCard`: start shield subscription via card (with trial option) ([#6300](https://github.com/MetaMask/core/pull/6300))
 - Add `getPricing` method ([#6356](https://github.com/MetaMask/core/pull/6356))
+- Added `triggerAccessTokenRefresh` to trigger an access token refresh ([#6374](https://github.com/MetaMask/core/pull/6374))
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/subscription-controller/src/SubscriptionController.test.ts
+++ b/packages/subscription-controller/src/SubscriptionController.test.ts
@@ -83,7 +83,7 @@ function createCustomSubscriptionMessenger(props?: {
  * @param overrideMessengers.messenger - messenger to override
  * @returns series of mocks to actions that can be called
  */
-function mockSubscriptionMessenger(overrideMessengers?: {
+function createMockSubscriptionMessenger(overrideMessengers?: {
   baseMessenger: Messenger<AllowedActions, AllowedEvents>;
   messenger: SubscriptionControllerMessenger;
 }) {
@@ -101,15 +101,6 @@ function mockSubscriptionMessenger(overrideMessengers?: {
     messenger,
     mockPerformSignOut,
   };
-}
-
-/**
- * Creates a mock subscription messenger for testing.
- *
- * @returns The mock messenger and related mocks.
- */
-function createMockSubscriptionMessenger() {
-  return mockSubscriptionMessenger();
 }
 
 /**

--- a/packages/subscription-controller/src/SubscriptionController.ts
+++ b/packages/subscription-controller/src/SubscriptionController.ts
@@ -244,6 +244,9 @@ export class SubscriptionController extends BaseController<
    * Triggers an access token refresh.
    */
   triggerAccessTokenRefresh() {
+    // We perform a sign out to clear the access token from the authentication
+    // controller. Next time the access token is requested, a new access token
+    // will be fetched.
     this.messagingSystem.call('AuthenticationController:performSignOut');
   }
 

--- a/packages/subscription-controller/src/SubscriptionController.ts
+++ b/packages/subscription-controller/src/SubscriptionController.ts
@@ -54,7 +54,8 @@ export type SubscriptionControllerActions =
   | SubscriptionControllerGetStateAction;
 
 export type AllowedActions =
-  AuthenticationController.AuthenticationControllerGetBearerToken;
+  | AuthenticationController.AuthenticationControllerGetBearerToken
+  | AuthenticationController.AuthenticationControllerPerformSignOut;
 
 // Events
 export type SubscriptionControllerStateChangeEvent = ControllerStateChangeEvent<
@@ -230,6 +231,13 @@ export class SubscriptionController extends BaseController<
     ) {
       throw new Error(SubscriptionControllerErrorMessage.UserAlreadySubscribed);
     }
+  }
+
+  /**
+   * Triggers an access token refresh.
+   */
+  triggerAccessTokenRefresh() {
+    this.messagingSystem.call('AuthenticationController:performSignOut');
   }
 
   #assertIsUserSubscribed(request: { subscriptionId: string }) {

--- a/packages/subscription-controller/src/SubscriptionController.ts
+++ b/packages/subscription-controller/src/SubscriptionController.ts
@@ -215,12 +215,19 @@ export class SubscriptionController extends BaseController<
           : subscription,
       );
     });
+
+    this.triggerAccessTokenRefresh();
   }
 
   async startShieldSubscriptionWithCard(request: StartSubscriptionRequest) {
     this.#assertIsUserNotSubscribed({ products: request.products });
 
-    return await this.#subscriptionService.startSubscriptionWithCard(request);
+    const response =
+      await this.#subscriptionService.startSubscriptionWithCard(request);
+
+    this.triggerAccessTokenRefresh();
+
+    return response;
   }
 
   #assertIsUserNotSubscribed({ products }: { products: ProductType[] }) {


### PR DESCRIPTION
## Explanation

Add a "triggerAuthTokenRefresh" method to the SubscriptionController, which allows to trigger a refresh of the access token, for example, after the subscription status has changed.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
