### PR TITLE
Integrate erc7715 types from @metamask/7715-permission-types package

### DIFF
--- a/packages/gator-permissions-controller/CHANGELOG.md
+++ b/packages/gator-permissions-controller/CHANGELOG.md
@@ -10,5 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release ([#6033](https://github.com/MetaMask/core/pull/6033))
+- Integrate erc7715 types from @metamask/7715-permission-types package ([#6033](https://github.com/MetaMask/core/pull/6033))
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/gator-permissions-controller/package.json
+++ b/packages/gator-permissions-controller/package.json
@@ -47,6 +47,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
+    "@metamask/7715-permission-types": "^0.2.0",
     "@metamask/base-controller": "^8.2.0",
     "@metamask/snaps-sdk": "^9.0.0",
     "@metamask/snaps-utils": "^11.0.0",
@@ -75,5 +76,10 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
+  },
+  "lavamoat": {
+    "allowScripts": {
+      "@lavamoat/preinstall-always-fail": false
+    }
   }
 }

--- a/packages/gator-permissions-controller/src/GatorPermissionContoller.test.ts
+++ b/packages/gator-permissions-controller/src/GatorPermissionContoller.test.ts
@@ -1,3 +1,4 @@
+import type { AccountSigner } from '@metamask/7715-permission-types';
 import { Messenger } from '@metamask/base-controller';
 import type { HandleSnapRequest, HasSnap } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
@@ -14,10 +15,9 @@ import {
   mockNativeTokenStreamStorageEntry,
 } from './test/mocks';
 import type {
-  AccountSigner,
   GatorPermissionsMap,
   StoredGatorPermission,
-  PermissionTypes,
+  PermissionTypesWithCustom,
 } from './types';
 import type {
   ExtractAvailableAction,
@@ -30,7 +30,7 @@ const MOCK_GATOR_PERMISSIONS_PROVIDER_SNAP_ID =
   'local:http://localhost:8082' as SnapId;
 const MOCK_GATOR_PERMISSIONS_STORAGE_ENTRIES: StoredGatorPermission<
   AccountSigner,
-  PermissionTypes
+  PermissionTypesWithCustom
 >[] = mockGatorPermissionsStorageEntriesFactory({
   [MOCK_CHAIN_ID_1]: {
     nativeTokenStream: 5,
@@ -198,11 +198,9 @@ describe('GatorPermissionsController', () => {
           result[permissionType],
         ).flat();
         flattenedStoredGatorPermissions.forEach((permission) => {
-          expect(
-            permission.permissionResponse.isAdjustmentAllowed,
-          ).toBeUndefined();
-          expect(permission.permissionResponse.accountMeta).toBeUndefined();
           expect(permission.permissionResponse.signer).toBeUndefined();
+          expect(permission.permissionResponse.dependencyInfo).toBeUndefined();
+          expect(permission.permissionResponse.rules).toBeUndefined();
         });
       };
 

--- a/packages/gator-permissions-controller/src/GatorPermissionsController.ts
+++ b/packages/gator-permissions-controller/src/GatorPermissionsController.ts
@@ -1,3 +1,4 @@
+import type { Signer } from '@metamask/7715-permission-types';
 import type {
   RestrictedMessenger,
   ControllerGetStateAction,
@@ -19,8 +20,7 @@ import type { StoredGatorPermissionSanitized } from './types';
 import {
   GatorPermissionsSnapRpcMethod,
   type GatorPermissionsMap,
-  type PermissionTypes,
-  type SignerParam,
+  type PermissionTypesWithCustom,
   type StoredGatorPermission,
 } from './types';
 import {
@@ -284,7 +284,9 @@ export default class GatorPermissionsController extends BaseController<
     snapId,
   }: {
     snapId: SnapId;
-  }): Promise<StoredGatorPermission<SignerParam, PermissionTypes>[] | null> {
+  }): Promise<
+    StoredGatorPermission<Signer, PermissionTypesWithCustom>[] | null
+  > {
     try {
       const response = (await this.messagingSystem.call(
         'SnapController:handleRequest',
@@ -298,7 +300,7 @@ export default class GatorPermissionsController extends BaseController<
               GatorPermissionsSnapRpcMethod.PermissionProviderGetGrantedPermissions,
           },
         },
-      )) as StoredGatorPermission<SignerParam, PermissionTypes>[] | null;
+      )) as StoredGatorPermission<Signer, PermissionTypesWithCustom>[] | null;
 
       return response;
     } catch (error) {
@@ -321,14 +323,18 @@ export default class GatorPermissionsController extends BaseController<
    * @returns The sanitized stored gator permission.
    */
   #sanitizeStoredGatorPermission(
-    storedGatorPermission: StoredGatorPermission<SignerParam, PermissionTypes>,
-  ): StoredGatorPermissionSanitized<SignerParam, PermissionTypes> {
+    storedGatorPermission: StoredGatorPermission<
+      Signer,
+      PermissionTypesWithCustom
+    >,
+  ): StoredGatorPermissionSanitized<Signer, PermissionTypesWithCustom> {
     const { permissionResponse } = storedGatorPermission;
-    const { isAdjustmentAllowed, accountMeta, signer, ...rest } =
-      permissionResponse;
+    const { rules, dependencyInfo, signer, ...rest } = permissionResponse;
     return {
       ...storedGatorPermission,
-      permissionResponse: { ...rest },
+      permissionResponse: {
+        ...rest,
+      },
     };
   }
 
@@ -340,7 +346,7 @@ export default class GatorPermissionsController extends BaseController<
    */
   #categorizePermissionsDataByTypeAndChainId(
     storedGatorPermissions:
-      | StoredGatorPermission<SignerParam, PermissionTypes>[]
+      | StoredGatorPermission<Signer, PermissionTypesWithCustom>[]
       | null,
   ): GatorPermissionsMap {
     if (!storedGatorPermissions) {
@@ -369,8 +375,8 @@ export default class GatorPermissionsController extends BaseController<
               gatorPermissionsMap[permissionType][
                 chainId
               ] as StoredGatorPermissionSanitized<
-                SignerParam,
-                PermissionTypes
+                Signer,
+                PermissionTypesWithCustom
               >[]
             ).push(sanitizedStoredGatorPermission);
             break;
@@ -383,8 +389,8 @@ export default class GatorPermissionsController extends BaseController<
               gatorPermissionsMap.other[
                 chainId
               ] as StoredGatorPermissionSanitized<
-                SignerParam,
-                PermissionTypes
+                Signer,
+                PermissionTypesWithCustom
               >[]
             ).push(sanitizedStoredGatorPermission);
             break;

--- a/packages/gator-permissions-controller/src/index.ts
+++ b/packages/gator-permissions-controller/src/index.ts
@@ -18,15 +18,8 @@ export type {
   GatorPermissionsControllerErrorCode,
   GatorPermissionsSnapRpcMethod,
   MetaMaskBasePermissionData,
-  NativeTokenStreamPermission,
-  NativeTokenPeriodicPermission,
-  Erc20TokenStreamPermission,
-  Erc20TokenPeriodicPermission,
   CustomPermission,
-  PermissionTypes,
-  AccountSigner,
-  WalletSigner,
-  SignerParam,
+  PermissionTypesWithCustom,
   PermissionRequest,
   PermissionResponse,
   PermissionResponseSanitized,
@@ -37,3 +30,13 @@ export type {
   GatorPermissionsMapByPermissionType,
   GatorPermissionsListByPermissionTypeAndChainId,
 } from './types';
+
+export type {
+  NativeTokenStreamPermission,
+  NativeTokenPeriodicPermission,
+  Erc20TokenStreamPermission,
+  Erc20TokenPeriodicPermission,
+  AccountSigner,
+  WalletSigner,
+  Signer,
+} from '@metamask/7715-permission-types';

--- a/packages/gator-permissions-controller/src/test/mock.test.ts
+++ b/packages/gator-permissions-controller/src/test/mock.test.ts
@@ -35,11 +35,6 @@ describe('mockGatorPermissionsStorageEntriesFactory', () => {
 
     expect(result).toHaveLength(16);
 
-    // Check that entries have different expiry times
-    const expiryTimes = result.map((entry) => entry.permissionResponse.expiry);
-    const uniqueExpiryTimes = new Set(expiryTimes);
-    expect(uniqueExpiryTimes.size).toBe(16);
-
     // Check that all entries have the correct chainId
     const chainIds = result.map((entry) => entry.permissionResponse.chainId);
     expect(chainIds).toContain('0x1');
@@ -329,11 +324,6 @@ describe('mockGatorPermissionsStorageEntriesFactory', () => {
 
     // Total expected entries
     expect(result).toHaveLength(16);
-
-    // Verify all entries have unique expiry times
-    const expiryTimes = result.map((entry) => entry.permissionResponse.expiry);
-    const uniqueExpiryTimes = new Set(expiryTimes);
-    expect(uniqueExpiryTimes.size).toBe(16);
 
     // Verify chain IDs are correct
     const chainIds = result.map((entry) => entry.permissionResponse.chainId);

--- a/packages/gator-permissions-controller/src/test/mocks.ts
+++ b/packages/gator-permissions-controller/src/test/mocks.ts
@@ -1,13 +1,15 @@
-import type { Hex } from '@metamask/utils';
-
 import type {
   AccountSigner,
-  CustomPermission,
   Erc20TokenPeriodicPermission,
   Erc20TokenStreamPermission,
   NativeTokenPeriodicPermission,
   NativeTokenStreamPermission,
-  PermissionTypes,
+} from '@metamask/7715-permission-types';
+import type { Hex } from '@metamask/utils';
+
+import type {
+  CustomPermission,
+  PermissionTypesWithCustom,
   StoredGatorPermission,
 } from '../types';
 
@@ -17,14 +19,13 @@ export const mockNativeTokenStreamStorageEntry = (
   permissionResponse: {
     chainId: chainId as Hex,
     address: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
-    expiry: 1750291201,
-    isAdjustmentAllowed: true,
     signer: {
       type: 'account',
       data: { address: '0x4f71DA06987BfeDE90aF0b33E1e3e4ffDCEE7a63' },
     },
     permission: {
       type: 'native-token-stream',
+      isAdjustmentAllowed: true,
       data: {
         maxAmount: '0x22b1c8c1227a0000',
         initialAmount: '0x6f05b59d3b20000',
@@ -33,10 +34,9 @@ export const mockNativeTokenStreamStorageEntry = (
         justification:
           'This is a very important request for streaming allowance for some very important thing',
       },
-      rules: {},
     },
     context: '0x00000000',
-    accountMeta: [
+    dependencyInfo: [
       {
         factory: '0x69Aa2f9fe1572F1B640E1bbc512f5c3a734fc77c',
         factoryData: '0x0000000',
@@ -55,14 +55,13 @@ export const mockNativeTokenPeriodicStorageEntry = (
   permissionResponse: {
     chainId: chainId as Hex,
     address: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
-    expiry: 1850291200,
-    isAdjustmentAllowed: true,
     signer: {
       type: 'account',
       data: { address: '0x4f71DA06987BfeDE90aF0b33E1e3e4ffDCEE7a63' },
     },
     permission: {
       type: 'native-token-periodic',
+      isAdjustmentAllowed: true,
       data: {
         periodAmount: '0x22b1c8c1227a0000',
         periodDuration: 1747699200,
@@ -70,10 +69,9 @@ export const mockNativeTokenPeriodicStorageEntry = (
         justification:
           'This is a very important request for streaming allowance for some very important thing',
       },
-      rules: {},
     },
     context: '0x00000000',
-    accountMeta: [
+    dependencyInfo: [
       {
         factory: '0x69Aa2f9fe1572F1B640E1bbc512f5c3a734fc77c',
         factoryData: '0x0000000',
@@ -92,14 +90,13 @@ export const mockErc20TokenStreamStorageEntry = (
   permissionResponse: {
     chainId: chainId as Hex,
     address: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
-    expiry: 1750298200,
-    isAdjustmentAllowed: true,
     signer: {
       type: 'account',
       data: { address: '0x4f71DA06987BfeDE90aF0b33E1e3e4ffDCEE7a63' },
     },
     permission: {
       type: 'erc20-token-stream',
+      isAdjustmentAllowed: true,
       data: {
         initialAmount: '0x22b1c8c1227a0000',
         maxAmount: '0x6f05b59d3b20000',
@@ -109,10 +106,9 @@ export const mockErc20TokenStreamStorageEntry = (
         justification:
           'This is a very important request for streaming allowance for some very important thing',
       },
-      rules: {},
     },
     context: '0x00000000',
-    accountMeta: [
+    dependencyInfo: [
       {
         factory: '0x69Aa2f9fe1572F1B640E1bbc512f5c3a734fc77c',
         factoryData: '0x0000000',
@@ -131,14 +127,13 @@ export const mockErc20TokenPeriodicStorageEntry = (
   permissionResponse: {
     chainId: chainId as Hex,
     address: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
-    expiry: 1750291600,
-    isAdjustmentAllowed: true,
     signer: {
       type: 'account',
       data: { address: '0x4f71DA06987BfeDE90aF0b33E1e3e4ffDCEE7a63' },
     },
     permission: {
       type: 'erc20-token-periodic',
+      isAdjustmentAllowed: true,
       data: {
         periodAmount: '0x22b1c8c1227a0000',
         periodDuration: 1747699200,
@@ -147,10 +142,9 @@ export const mockErc20TokenPeriodicStorageEntry = (
         justification:
           'This is a very important request for streaming allowance for some very important thing',
       },
-      rules: {},
     },
     context: '0x00000000',
-    accountMeta: [
+    dependencyInfo: [
       {
         factory: '0x69Aa2f9fe1572F1B640E1bbc512f5c3a734fc77c',
         factoryData: '0x0000000',
@@ -170,23 +164,21 @@ export const mockCustomPermissionStorageEntry = (
   permissionResponse: {
     chainId: chainId as Hex,
     address: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
-    expiry: 1750291200,
-    isAdjustmentAllowed: true,
     signer: {
       type: 'account',
       data: { address: '0x4f71DA06987BfeDE90aF0b33E1e3e4ffDCEE7a63' },
     },
     permission: {
       type: 'custom',
+      isAdjustmentAllowed: true,
       data: {
         justification:
           'This is a very important request for streaming allowance for some very important thing',
         ...data,
       },
-      rules: {},
     },
     context: '0x00000000',
-    accountMeta: [
+    dependencyInfo: [
       {
         factory: '0x69Aa2f9fe1572F1B640E1bbc512f5c3a734fc77c',
         factoryData: '0x0000000',
@@ -226,9 +218,11 @@ export type MockGatorPermissionsStorageEntriesConfig = {
  */
 export function mockGatorPermissionsStorageEntriesFactory(
   config: MockGatorPermissionsStorageEntriesConfig,
-): StoredGatorPermission<AccountSigner, PermissionTypes>[] {
-  const result: StoredGatorPermission<AccountSigner, PermissionTypes>[] = [];
-  let globalIndex = 0;
+): StoredGatorPermission<AccountSigner, PermissionTypesWithCustom>[] {
+  const result: StoredGatorPermission<
+    AccountSigner,
+    PermissionTypesWithCustom
+  >[] = [];
 
   Object.entries(config).forEach(([chainId, counts]) => {
     if (counts.custom.count !== counts.custom.data.length) {
@@ -243,13 +237,14 @@ export function mockGatorPermissionsStorageEntriesFactory(
      */
     const createEntries = (
       count: number,
-      createEntry: () => StoredGatorPermission<AccountSigner, PermissionTypes>,
+      createEntry: () => StoredGatorPermission<
+        AccountSigner,
+        PermissionTypesWithCustom
+      >,
     ) => {
       for (let i = 0; i < count; i++) {
         const entry = createEntry();
-        entry.permissionResponse.expiry += globalIndex;
         result.push(entry);
-        globalIndex += 1;
       }
     };
 
@@ -275,9 +270,7 @@ export function mockGatorPermissionsStorageEntriesFactory(
         chainId as Hex,
         counts.custom.data[i],
       );
-      entry.permissionResponse.expiry += globalIndex;
       result.push(entry);
-      globalIndex += 1;
     }
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2365,6 +2365,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/7715-permission-types@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@metamask/7715-permission-types@npm:0.2.0"
+  checksum: 10/63ed53567f20d12b6b91e6fa7d346781e40a88ab10d68fa4fb5b76f7b07ba1fd360f0c1e81fc0f9700e34f7ded6b7ac79bc3ec70676544c21c8dbb3dc8252a28
+  languageName: node
+  linkType: hard
+
 "@metamask/abi-utils@npm:^2.0.3":
   version: 2.0.4
   resolution: "@metamask/abi-utils@npm:2.0.4"
@@ -3542,6 +3549,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
+    "@metamask/7715-permission-types": "npm:^0.2.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^8.2.0"
     "@metamask/snaps-controllers": "npm:^14.0.1"


### PR DESCRIPTION
## Explanation

Integrate [ERC-7715](https://eip.tools/eip/7715) types from [@metamask/7715-permission-types](https://github.com/MetaMask/delegation-toolkit/tree/main/packages/7715-permission-types) package to avoid type duplication across multiple repos. MM clients will use the  ERC-7715 types exposed via the `@metamask/gator-permissions-controller` to manage gator permissions.

## References

- Related to https://github.com/MetaMask/metamask-extension/pull/35219

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
