### PR TITLE
fix: Add return type annotation to `getCaip25PermissionFromLegacyPermissions`

### DIFF
--- a/packages/chain-agnostic-permission/src/caip25Permission.ts
+++ b/packages/chain-agnostic-permission/src/caip25Permission.ts
@@ -591,7 +591,14 @@ export const getCaip25PermissionFromLegacyPermissions =
         value: Hex[];
       }[];
     };
-  }) => {
+  }): {
+    [Caip25EndowmentPermissionName]: {
+      caveats: NonEmptyArray<{
+        type: typeof Caip25CaveatType;
+        value: typeof caveatValueWithAccountsAndChains;
+      }>;
+    };
+  } => {
     const permissions = pick(requestedPermissions, [
       PermissionKeys.eth_accounts,
       PermissionKeys.permittedChains,


### PR DESCRIPTION


## Explanation

This enables the return type of `getCaip25PermissionFromLegacyPermissions` to be assignable to `RequestedPermissions`.

Because `RequestedPermissions` is defined using `NonEmptyArray`, assigning `ReturnType<typeof getCaip25PermissionFromLegacyPermissions>` to `RequestedPermissions` currently results in the following error:

```ts
Type '{ "endowment:caip25": { caveats: { type: string; value: Caip25CaveatValue; }[]; }; }' is not assignable to type 'RequestedPermissions'.
  Property '"endowment:caip25"' is incompatible with index signature.
    Type '{ caveats: { type: string; value: Caip25CaveatValue; }[]; }' is not assignable to type 'Partial<PermissionConstraint>'.
      Types of property 'caveats' are incompatible.
        Type '{ type: string; value: Caip25CaveatValue; }[]' is not assignable to type '[CaveatConstraint, ...CaveatConstraint[]]'.
          Source provides no match for required element at position 0 in target.ts(2322)
```

This commit fixes this issue.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
