### PR TITLE
fix(multichain-account-service): fix account event subscription + clear state before re-init service

### DIFF
--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -113,6 +113,13 @@ export class MultichainAccountService {
       'MultichainAccountService:alignWallet',
       (...args) => this.alignWallet(...args),
     );
+
+    this.#messenger.subscribe('AccountsController:accountAdded', (account) =>
+      this.#handleOnAccountAdded(account),
+    );
+    this.#messenger.subscribe('AccountsController:accountRemoved', (id) =>
+      this.#handleOnAccountRemoved(id),
+    );
   }
 
   /**
@@ -120,6 +127,9 @@ export class MultichainAccountService {
    * multichain accounts and wallets.
    */
   init(): void {
+    this.#wallets.clear();
+    this.#accountIdToContext.clear();
+
     // Create initial wallets.
     const { keyrings } = this.#messenger.call('KeyringController:getState');
     for (const keyring of keyrings) {
@@ -146,13 +156,6 @@ export class MultichainAccountService {
         }
       }
     }
-
-    this.#messenger.subscribe('AccountsController:accountAdded', (account) =>
-      this.#handleOnAccountAdded(account),
-    );
-    this.#messenger.subscribe('AccountsController:accountRemoved', (id) =>
-      this.#handleOnAccountRemoved(id),
-    );
   }
 
   #handleOnAccountAdded(account: KeyringAccount): void {


### PR DESCRIPTION
## Explanation

The event subscription has to be moved in the constructor otherwise if we call `init` multiple times, we will subscribe to those same events multiple times.

Also, moving those subscriptions on the constructor ensure that the service will pick up newly added accounts after the service is being created even if `init` has not been called yet, which seems to be another bug on the extension given that the service is not initialized properly after the first on-boarding...

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
