### PR TITLE
fix: Keep delegated handlers when unregistering actions

### DIFF
--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
 - Keep delegated handlers when unregistering actions ([#6395](https://github.com/MetaMask/core/pull/6395))
 

--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep delegated handlers when unregistering actions ([#6395](https://github.com/MetaMask/core/pull/6395))
+
 ## [0.1.0]
 
 ### Added

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -1268,31 +1268,6 @@ describe('Messenger', () => {
         `Cannot call 'Source:getLength', action not registered.`,
       );
     });
-
-    it('unregisters delegated action handlers when action is unregistered', () => {
-      type ExampleAction = {
-        type: 'Source:getLength';
-        handler: (input: string) => number;
-      };
-      const sourceMessenger = new Messenger<'Source', ExampleAction, never>({
-        namespace: 'Source',
-      });
-      const delegatedMessenger = new Messenger<
-        'Destination',
-        ExampleAction,
-        never
-      >({ namespace: 'Destination' });
-      sourceMessenger.delegate({
-        messenger: delegatedMessenger,
-        actions: ['Source:getLength'],
-      });
-
-      sourceMessenger.unregisterActionHandler('Source:getLength');
-
-      expect(() => delegatedMessenger.call('Source:getLength', 'test')).toThrow(
-        `A handler for Source:getLength has not been registered`,
-      );
-    });
   });
 
   describe('revoke', () => {

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -1265,7 +1265,7 @@ describe('Messenger', () => {
       });
 
       expect(() => delegatedMessenger.call('Source:getLength', 'test')).toThrow(
-        `Cannot call 'Source:getLength', action not registered.`,
+        `A handler for Source:getLength has not been registered`,
       );
     });
   });

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -356,14 +356,6 @@ export class Messenger<
     actionType: ActionType,
   ) {
     this.#actions.delete(actionType);
-    const delegationTargets = this.#actionDelegationTargets.get(actionType);
-    if (!delegationTargets) {
-      return;
-    }
-    for (const messenger of delegationTargets) {
-      messenger._internalUnregisterDelegatedActionHandler(actionType);
-    }
-    this.#actionDelegationTargets.delete(actionType);
   }
 
   /**

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -755,7 +755,7 @@ export class Messenger<
           | undefined;
         if (!actionHandler) {
           throw new Error(
-            `Cannot call '${actionType}', action not registered.`,
+            `A handler for ${actionType} has not been registered`,
           );
         }
         return actionHandler(...args);


### PR DESCRIPTION
## Explanation

Keep delegated handlers around even when unregistering actions. This helps with the resiliency of the messenger system in case actions are unregistered and registered elsewhere in the chain of delegations. This is also very useful for testing.

Additionally adjusts the error message thrown when a delegated action handler cannot be found to match an undelegated one.
