### PR TITLE
test: Add additional tests for delegated action unregistration

### DIFF
--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -1226,6 +1226,68 @@ describe('Messenger', () => {
       expect(handler).toHaveBeenCalledWith('test');
     });
 
+    it('allows calling delegated action that was registered before delegation, unregistered, then registered again', () => {
+      type ExampleAction = {
+        type: 'Source:getLength';
+        handler: (input: string) => number;
+      };
+      const sourceMessenger = new Messenger<'Source', ExampleAction, never>({
+        namespace: 'Source',
+      });
+      const delegatedMessenger = new Messenger<
+        'Destination',
+        ExampleAction,
+        never
+      >({ namespace: 'Destination' });
+      const handler1 = jest.fn((input) => input.length);
+      const handler2 = jest.fn((input) => input.length);
+      // registration happens before delegation
+      sourceMessenger.registerActionHandler('Source:getLength', handler1);
+
+      sourceMessenger.delegate({
+        messenger: delegatedMessenger,
+        actions: ['Source:getLength'],
+      });
+      sourceMessenger.unregisterActionHandler('Source:getLength');
+      sourceMessenger.registerActionHandler('Source:getLength', handler2);
+
+      const result = delegatedMessenger.call('Source:getLength', 'test');
+      expect(result).toBe(4);
+      expect(handler1).not.toHaveBeenCalled();
+      expect(handler2).toHaveBeenCalledWith('test');
+    });
+
+    it('allows calling delegated action that was registered after delegation, unregistered, then registered again', () => {
+      type ExampleAction = {
+        type: 'Source:getLength';
+        handler: (input: string) => number;
+      };
+      const sourceMessenger = new Messenger<'Source', ExampleAction, never>({
+        namespace: 'Source',
+      });
+      const delegatedMessenger = new Messenger<
+        'Destination',
+        ExampleAction,
+        never
+      >({ namespace: 'Destination' });
+      const handler1 = jest.fn((input) => input.length);
+      const handler2 = jest.fn((input) => input.length);
+
+      sourceMessenger.delegate({
+        messenger: delegatedMessenger,
+        actions: ['Source:getLength'],
+      });
+      // registration happens after delegation
+      sourceMessenger.registerActionHandler('Source:getLength', handler1);
+      sourceMessenger.unregisterActionHandler('Source:getLength');
+      sourceMessenger.registerActionHandler('Source:getLength', handler2);
+
+      const result = delegatedMessenger.call('Source:getLength', 'test');
+      expect(result).toBe(4);
+      expect(handler1).not.toHaveBeenCalled();
+      expect(handler2).toHaveBeenCalledWith('test');
+    });
+
     it('throws an error when an action is delegated a second time', () => {
       type ExampleAction = {
         type: 'Source:getLength';
@@ -1274,6 +1336,33 @@ describe('Messenger', () => {
         messenger: delegatedMessenger,
         actions: ['Source:getLength'],
       });
+
+      expect(() => delegatedMessenger.call('Source:getLength', 'test')).toThrow(
+        `A handler for Source:getLength has not been registered`,
+      );
+    });
+
+    it('throws an error when delegated action is called after an action is undregistered', () => {
+      type ExampleAction = {
+        type: 'Source:getLength';
+        handler: (input: string) => number;
+      };
+      const sourceMessenger = new Messenger<'Source', ExampleAction, never>({
+        namespace: 'Source',
+      });
+      const delegatedMessenger = new Messenger<
+        'Destination',
+        ExampleAction,
+        never
+      >({ namespace: 'Destination' });
+      const handler = jest.fn((input) => input.length);
+      sourceMessenger.registerActionHandler('Source:getLength', handler);
+
+      sourceMessenger.delegate({
+        messenger: delegatedMessenger,
+        actions: ['Source:getLength'],
+      });
+      sourceMessenger.unregisterActionHandler('Source:getLength');
 
       expect(() => delegatedMessenger.call('Source:getLength', 'test')).toThrow(
         `A handler for Source:getLength has not been registered`,


### PR DESCRIPTION
## Explanation

Add additional tests for what happens when you unregister an action handler that has been delegated.

## References

This addresses a suggestion made on a previous PR: https://github.com/MetaMask/core/pull/6395/files#r2303969488

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
