### PR TITLE
fix(account-tree-controller): emit `:selectedAccountGroupChange` during tree init

### DIFF
--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Publish `AccountTreeController:selectedAccountGroupChange` during `init` ([#6431](https://github.com/MetaMask/core/pull/6431))
+
 ## [0.12.0]
 
 ### Added

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -2669,6 +2669,7 @@ describe('AccountTreeController', () => {
 
       controller.init();
 
+      const oldDefaultAccountGroupId = defaultAccountGroupId;
       const newDefaultAccountGroupId = toMultichainAccountGroupId(
         toMultichainAccountWalletId(MOCK_HD_ACCOUNT_2.options.entropy.id),
         MOCK_HD_ACCOUNT_2.options.entropy.groupIndex,
@@ -2679,7 +2680,7 @@ describe('AccountTreeController', () => {
       );
       expect(selectedAccountGroupChangeListener).toHaveBeenCalledWith(
         newDefaultAccountGroupId,
-        '',
+        oldDefaultAccountGroupId,
       );
     });
 

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -642,6 +642,45 @@ describe('AccountTreeController', () => {
         controller.state.accountTree.wallets[wallet2Id]?.metadata.name,
       ).toBe('HD Wallet');
     });
+
+    it('re-select a new group when tree is re-initialized and current selected group no longer exists', () => {
+      const { controller, mocks } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      mocks.AccountsController.getSelectedAccount.mockImplementation(
+        () => MOCK_HD_ACCOUNT_1,
+      );
+
+      controller.init();
+
+      const defaultAccountGroupId = toMultichainAccountGroupId(
+        toMultichainAccountWalletId(MOCK_HD_ACCOUNT_1.options.entropy.id),
+        MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
+      );
+
+      expect(controller.state.accountTree.selectedAccountGroup).toStrictEqual(
+        defaultAccountGroupId,
+      );
+
+      mocks.AccountsController.accounts = [MOCK_HD_ACCOUNT_2];
+      mocks.KeyringController.keyrings = [MOCK_HD_KEYRING_2];
+      mocks.AccountsController.getSelectedAccount.mockImplementation(
+        () => MOCK_HD_ACCOUNT_2,
+      );
+
+      controller.init();
+
+      const newDefaultAccountGroupId = toMultichainAccountGroupId(
+        toMultichainAccountWalletId(MOCK_HD_ACCOUNT_2.options.entropy.id),
+        MOCK_HD_ACCOUNT_2.options.entropy.groupIndex,
+      );
+
+      expect(controller.state.accountTree.selectedAccountGroup).toStrictEqual(
+        newDefaultAccountGroupId,
+      );
+    });
   });
 
   describe('getAccountGroupObject', () => {
@@ -2591,6 +2630,55 @@ describe('AccountTreeController', () => {
 
       expect(selectedAccountGroupChangeListener).toHaveBeenCalledWith(
         defaultAccountGroupId,
+        '',
+      );
+    });
+
+    it('emits selectedAccountGroupChange when tree is re-initialized and current selected group no longer exists', () => {
+      const { controller, messenger, mocks } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      mocks.AccountsController.getSelectedAccount.mockImplementation(
+        () => MOCK_HD_ACCOUNT_1,
+      );
+
+      controller.init();
+
+      const defaultAccountGroupId = toMultichainAccountGroupId(
+        toMultichainAccountWalletId(MOCK_HD_ACCOUNT_1.options.entropy.id),
+        MOCK_HD_ACCOUNT_1.options.entropy.groupIndex,
+      );
+
+      expect(controller.state.accountTree.selectedAccountGroup).toStrictEqual(
+        defaultAccountGroupId,
+      );
+
+      const selectedAccountGroupChangeListener = jest.fn();
+      messenger.subscribe(
+        'AccountTreeController:selectedAccountGroupChange',
+        selectedAccountGroupChangeListener,
+      );
+
+      mocks.AccountsController.accounts = [MOCK_HD_ACCOUNT_2];
+      mocks.KeyringController.keyrings = [MOCK_HD_KEYRING_2];
+      mocks.AccountsController.getSelectedAccount.mockImplementation(
+        () => MOCK_HD_ACCOUNT_2,
+      );
+
+      controller.init();
+
+      const newDefaultAccountGroupId = toMultichainAccountGroupId(
+        toMultichainAccountWalletId(MOCK_HD_ACCOUNT_2.options.entropy.id),
+        MOCK_HD_ACCOUNT_2.options.entropy.groupIndex,
+      );
+
+      expect(controller.state.accountTree.selectedAccountGroup).toStrictEqual(
+        newDefaultAccountGroupId,
+      );
+      expect(selectedAccountGroupChangeListener).toHaveBeenCalledWith(
+        newDefaultAccountGroupId,
         '',
       );
     });

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -201,22 +201,28 @@ export class AccountTreeController extends BaseController<
       }
     }
 
-    // No group is selected yet OR group no longer exists, re-sync with the
-    // AccountsController.
-    const syncSelectedAccountGroup =
-      !previousSelectedAccountGroupStillExists ||
-      previousSelectedAccountGroup === '';
-
     this.update((state) => {
       state.accountTree.wallets = wallets;
 
-      if (syncSelectedAccountGroup) {
+      if (
+        !previousSelectedAccountGroupStillExists ||
+        previousSelectedAccountGroup === ''
+      ) {
+        // No group is selected yet OR group no longer exists, re-sync with the
+        // AccountsController.
         state.accountTree.selectedAccountGroup =
           this.#getDefaultSelectedAccountGroup(wallets);
       }
     });
 
-    if (syncSelectedAccountGroup) {
+    // We still compare the previous and new value, the previous one could have been
+    // an empty string and `#getDefaultSelectedAccountGroup` could also return an
+    // empty string too, thus, we would re-use the same value here again. In that
+    // case, no need to fire any event.
+    if (
+      previousSelectedAccountGroup !==
+      this.state.accountTree.selectedAccountGroup
+    ) {
       this.messagingSystem.publish(
         `${controllerName}:selectedAccountGroupChange`,
         this.state.accountTree.selectedAccountGroup,

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -198,6 +198,13 @@ export class AccountTreeController extends BaseController<
         // No group is selected yet, re-sync with the AccountsController.
         state.accountTree.selectedAccountGroup =
           this.#getDefaultSelectedAccountGroup(wallets);
+
+        // Also publish initial group that has been selected.
+        this.messagingSystem.publish(
+          `${controllerName}:selectedAccountGroupChange`,
+          state.accountTree.selectedAccountGroup,
+          '', // No group was initially selected.
+        );
       }
     });
   }


### PR DESCRIPTION
## Explanation

The `init` function can be used in several scenarios:
- Initial controller initialization
  - Other controllers might want to know which group will be selected
- During re-onboarding, all accounts will be removed and the tree might be re-`init`
  - We want to fire the group that has been automatically selected after resetting the entire tree


## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
