### PR TITLE
fix(accounts-controller): workaround compiler error for recursive type

### DIFF
--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -906,12 +906,7 @@ export class AccountsController extends BaseController<
     const previouslySelectedAccount =
       this.state.internalAccounts.selectedAccount;
 
-    this.update((draft: WritableDraft<AccountsControllerState>) => {
-      // By-passing recursive-type issue. We have other type-assertion that checks that both
-      // types are compatible.
-      const state = draft as WritableDraft<AccountsControllerStrictState>;
-
-      // We're casting this type to avoid having this same error in every `#update` calls.
+    this.update((state: WritableDraft<AccountsControllerStrictState>) => {
       callback(state);
 
       // If the account no longer exists (or none is selected), we need to re-select another one.

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -480,14 +480,8 @@ export class AccountsController extends BaseController<
     };
 
     this.#update((state) => {
-      // FIXME: Using the state as-is cause the following error: "Type instantiation is excessively
-      // deep and possibly infinite.ts(2589)" (https://github.com/MetaMask/utils/issues/168)
-      // Using a type-cast workaround this error and is slightly better than using a @ts-expect-error
-      // which sometimes fail when compiling locally.
-      (state as AccountsControllerState).internalAccounts.accounts[account.id] =
-        internalAccount;
-      (state as AccountsControllerState).internalAccounts.selectedAccount =
-        account.id;
+      state.internalAccounts.accounts[account.id] = internalAccount;
+      state.internalAccounts.selectedAccount = account.id;
     });
 
     this.messagingSystem.publish(
@@ -530,12 +524,7 @@ export class AccountsController extends BaseController<
     };
 
     this.#update((state) => {
-      // FIXME: Using the state as-is cause the following error: "Type instantiation is excessively
-      // deep and possibly infinite.ts(2589)" (https://github.com/MetaMask/utils/issues/168)
-      // Using a type-cast workaround this error and is slightly better than using a @ts-expect-error
-      // which sometimes fail when compiling locally.
-      (state as AccountsControllerState).internalAccounts.accounts[accountId] =
-        internalAccount;
+      state.internalAccounts.accounts[accountId] = internalAccount;
     });
 
     if (metadata.name) {
@@ -605,8 +594,7 @@ export class AccountsController extends BaseController<
     }
 
     this.#update((state) => {
-      (state as AccountsControllerStrictState).internalAccounts.accounts =
-        internalAccounts;
+      state.internalAccounts.accounts = internalAccounts;
     });
   }
 

--- a/packages/accounts-controller/src/typing.ts
+++ b/packages/accounts-controller/src/typing.ts
@@ -19,6 +19,7 @@ export type StrictInternalAccount = Omit<InternalAccount, 'options'> & {
   // In anyway, we should rarely have to use those "untyped" options.
   options: {
     entropy?: KeyringAccountEntropyOptions;
+    exportable?: boolean;
   };
 };
 

--- a/packages/accounts-controller/src/typing.ts
+++ b/packages/accounts-controller/src/typing.ts
@@ -1,0 +1,34 @@
+import type { KeyringAccountEntropyOptions } from '@metamask/keyring-api';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+
+import type { AccountsControllerState } from './AccountsController';
+
+/**
+ * Type constraint to ensure a type is compatible with {@link AccountsControllerState}.
+ * If the constraint is not matching, this type will resolve to `never` and thus, fails
+ * to compile.
+ */
+type IsAccountControllerState<Type extends AccountsControllerState> = Type;
+
+/**
+ * A type compatible with {@link InternalAccount} which removes any use of recursive-type.
+ */
+export type StrictInternalAccount = Omit<InternalAccount, 'options'> & {
+  // Use stricter options, which are relying on `Json` (which sometimes
+  // cause compiler errors because of instanciation "too deep".
+  // In anyway, we should rarely have to use those "untyped" options.
+  options: {
+    entropy?: KeyringAccountEntropyOptions;
+  };
+};
+
+/**
+ * A type compatible with {@link AccountControllerState} which can be used to
+ * avoid recursive-type issue with `internalAccounts`.
+ */
+export type AccountsControllerStrictState = IsAccountControllerState<{
+  internalAccounts: {
+    accounts: Record<InternalAccount['id'], StrictInternalAccount>;
+    selectedAccount: InternalAccount['id'];
+  };
+}>;


### PR DESCRIPTION
## Explanation

Narrowing the `AccountControllerState` internally to avoid facing this issue:
- https://github.com/MetaMask/utils/issues/168

This has no impact on the controller behavior or interface, it's purely related to the type-system and compiler errors.

I had errors when I was running the test locally with the compiler, but the CI ran fine. Now, it runs fine on both environment with no error/warning.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
