### PR TITLE
`@metamask/eip-5792-middleware` init version to 0.0.0

### DIFF
--- a/packages/eip-5792-middleware/package.json
+++ b/packages/eip-5792-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eip-5792-middleware",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Implements the JSON-RPC methods for sending multiple calls from the user's wallet, and checking their status, as referenced in EIP-5792",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
`@metamask/eip-5792-middleware` was incorrectly initialized with a version of `1.0.0`. We need to initialize packages with a version of 0.0.0 before publication.