### PR TITLE
fix(network-enablement-controller): enable Bitcoin networks if enabled in MultichainNetworkController

### DIFF
--- a/packages/network-enablement-controller/src/NetworkEnablementController.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController.ts
@@ -17,7 +17,7 @@ import type { CaipChainId, CaipNamespace, Hex } from '@metamask/utils';
 import { KnownCaipNamespace } from '@metamask/utils';
 
 import { POPULAR_NETWORKS } from './constants';
-import { SolScope } from './types';
+import { BtcScope, SolScope } from './types';
 import {
   deriveKeys,
   isOnlyNetworkEnabledInNamespace,
@@ -117,6 +117,9 @@ const getDefaultNetworkEnablementControllerState =
       },
       [KnownCaipNamespace.Solana]: {
         [SolScope.Mainnet]: true,
+      },
+      [KnownCaipNamespace.Bip122]: {
+        [BtcScope.Mainnet]: true,
       },
     },
   });
@@ -270,6 +273,20 @@ export class NetworkEnablementController extends BaseController<
         // Enable Solana mainnet
         s.enabledNetworkMap[solanaKeys.namespace][solanaKeys.storageKey] = true;
       }
+
+      // Enable Bitcoin mainnet if it exists in MultichainNetworkController configurations
+      const bitcoinKeys = deriveKeys(BtcScope.Mainnet as CaipChainId);
+      if (
+        multichainState.multichainNetworkConfigurationsByChainId[
+          BtcScope.Mainnet
+        ]
+      ) {
+        // Ensure namespace bucket exists
+        this.#ensureNamespaceBucket(s, bitcoinKeys.namespace);
+        // Enable Bitcoin mainnet
+        s.enabledNetworkMap[bitcoinKeys.namespace][bitcoinKeys.storageKey] =
+          true;
+      }
     });
   }
 
@@ -334,6 +351,18 @@ export class NetworkEnablementController extends BaseController<
         ]
       ) {
         s.enabledNetworkMap[solanaKeys.namespace][solanaKeys.storageKey] = true;
+      }
+
+      // Enable Bitcoin mainnet if it exists in configurations
+      const bitcoinKeys = deriveKeys(BtcScope.Mainnet as CaipChainId);
+      if (
+        s.enabledNetworkMap[bitcoinKeys.namespace] &&
+        multichainState.multichainNetworkConfigurationsByChainId[
+          BtcScope.Mainnet
+        ]
+      ) {
+        s.enabledNetworkMap[bitcoinKeys.namespace][bitcoinKeys.storageKey] =
+          true;
       }
     });
   }

--- a/packages/network-enablement-controller/src/types.ts
+++ b/packages/network-enablement-controller/src/types.ts
@@ -6,3 +6,11 @@ export enum SolScope {
   Mainnet = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
   Testnet = 'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z',
 }
+
+/**
+ * Scopes for Bitcoin account type. See {@link KeyringAccount.scopes}.
+ */
+export enum BtcScope {
+  Mainnet = 'bip122:000000000019d6689c085ae165831e93',
+  Testnet = 'bip122:000000000933ea01ad0ee984209779ba',
+}


### PR DESCRIPTION
## Explanation

Bitcoin networks are not enabled by default in the Network Enablement Controller, causing the `enabledNetworks` object to show Bitcoin as an empty namespace (`"bip122": {}`) instead of showing Bitcoin mainnet as enabled. This is inconsistent with how Solana networks are handled.

This change makes Bitcoin networks follow the same enablement pattern as Solana networks:

1. Default state: Bitcoin mainnet is now enabled by default alongside Ethereum and Solana
2. Initialization: The `init()` method enables Bitcoin mainnet if it exists in MultichainNetworkController configurations
3. Popular networks: The enableAllPopularNetworks() method now includes Bitcoin mainnet enablement

## References

* Fixes [#12345](https://github.com/MetaMask/metamask-mobile/issues/19201)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
