### PR TITLE
feat: Add new metadata properties to accounts controllers

### DIFF
--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add two new controller state metadata properties: `includeInStateLog` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
+
 ### Changed
 
 - Account group name uniqueness validation now scoped to wallet level instead of global ([#6550](https://github.com/MetaMask/core/pull/6550))

--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add two new controller state metadata properties: `includeInStateLog` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
+- Add two new controller state metadata properties: `includeInStateLogs` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
 
 ### Changed
 

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -8,7 +8,7 @@ import {
   toMultichainAccountWalletId,
   type AccountGroupId,
 } from '@metamask/account-api';
-import { Messenger } from '@metamask/base-controller';
+import { Messenger, deriveStateFromMetadata } from '@metamask/base-controller';
 import {
   EthAccountType,
   EthMethod,
@@ -2851,6 +2851,79 @@ describe('AccountTreeController', () => {
       controller.setSelectedAccountGroup(groupId);
 
       expect(selectedAccountGroupChangeListener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('metadata', () => {
+    it('includes expected state in debug snapshots', () => {
+      const { controller } = setup();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'anonymous',
+        ),
+      ).toMatchInlineSnapshot(`Object {}`);
+    });
+
+    it('includes expected state in state logs', () => {
+      const { controller } = setup();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'includeInStateLogs',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "accountGroupsMetadata": Object {},
+          "accountTree": Object {
+            "selectedAccountGroup": "",
+            "wallets": Object {},
+          },
+          "accountWalletsMetadata": Object {},
+        }
+      `);
+    });
+
+    it('persists expected state', () => {
+      const { controller } = setup();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'persist',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "accountGroupsMetadata": Object {},
+          "accountWalletsMetadata": Object {},
+        }
+      `);
+    });
+
+    it('exposes expected state to UI', () => {
+      const { controller } = setup();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'usedInUi',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "accountGroupsMetadata": Object {},
+          "accountTree": Object {
+            "selectedAccountGroup": "",
+            "wallets": Object {},
+          },
+          "accountWalletsMetadata": Object {},
+        }
+      `);
     });
   });
 });

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -28,16 +28,22 @@ export const controllerName = 'AccountTreeController';
 const accountTreeControllerMetadata: StateMetadata<AccountTreeControllerState> =
   {
     accountTree: {
+      includeInStateLogs: true,
       persist: false, // We do re-recompute this state everytime.
       anonymous: false,
+      usedInUi: true,
     },
     accountGroupsMetadata: {
+      includeInStateLogs: true,
       persist: true,
       anonymous: false,
+      usedInUi: true,
     },
     accountWalletsMetadata: {
+      includeInStateLogs: true,
       persist: true,
       anonymous: false,
+      usedInUi: true,
     },
   };
 

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add two new controller state metadata properties: `includeInStateLog` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
+- Add two new controller state metadata properties: `includeInStateLogs` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
 
 ### Changed
 

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add two new controller state metadata properties: `includeInStateLog` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^8.1.0` to `^8.3.0` ([#6355](https://github.com/MetaMask/core/pull/6355), [#6465](https://github.com/MetaMask/core/pull/6465))

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -1,4 +1,4 @@
-import { Messenger } from '@metamask/base-controller';
+import { Messenger, deriveStateFromMetadata } from '@metamask/base-controller';
 import { InfuraNetworkType } from '@metamask/controller-utils';
 import type {
   AccountAssetListUpdatedEventPayload,
@@ -269,7 +269,7 @@ function setupAccountsController({
     AccountsControllerActions | AllowedActions,
     AccountsControllerEvents | AllowedEvents
   >;
-}): {
+} = {}): {
   accountsController: AccountsController;
   messenger: Messenger<
     AccountsControllerActions | AllowedActions,
@@ -3837,6 +3837,77 @@ describe('AccountsController', () => {
           expect(accountName).toBe('Account 4');
         });
       });
+    });
+  });
+
+  describe('metadata', () => {
+    it('includes expected state in debug snapshots', () => {
+      const { accountsController: controller } = setupAccountsController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'anonymous',
+        ),
+      ).toMatchInlineSnapshot(`Object {}`);
+    });
+
+    it('includes expected state in state logs', () => {
+      const { accountsController: controller } = setupAccountsController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'includeInStateLogs',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "internalAccounts": Object {
+            "accounts": Object {},
+            "selectedAccount": "",
+          },
+        }
+      `);
+    });
+
+    it('persists expected state', () => {
+      const { accountsController: controller } = setupAccountsController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'persist',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "internalAccounts": Object {
+            "accounts": Object {},
+            "selectedAccount": "",
+          },
+        }
+      `);
+    });
+
+    it('exposes expected state to UI', () => {
+      const { accountsController: controller } = setupAccountsController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'usedInUi',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "internalAccounts": Object {
+            "accounts": Object {},
+            "selectedAccount": "",
+          },
+        }
+      `);
     });
   });
 });

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -222,8 +222,10 @@ export type AccountsControllerMessenger = RestrictedMessenger<
 
 const accountsControllerMetadata = {
   internalAccounts: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: false,
+    usedInUi: true,
   },
 };
 

--- a/packages/multichain-transactions-controller/CHANGELOG.md
+++ b/packages/multichain-transactions-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add two new controller state metadata properties: `includeInStateLog` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
+- Add two new controller state metadata properties: `includeInStateLogs` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
 
 ### Changed
 

--- a/packages/multichain-transactions-controller/CHANGELOG.md
+++ b/packages/multichain-transactions-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add two new controller state metadata properties: `includeInStateLog` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^8.1.0` to `^8.3.0` ([#6355](https://github.com/MetaMask/core/pull/6355), [#6465](https://github.com/MetaMask/core/pull/6465))

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
@@ -1,4 +1,4 @@
-import { Messenger } from '@metamask/base-controller';
+import { deriveStateFromMetadata, Messenger } from '@metamask/base-controller';
 import type {
   AccountTransactionsUpdatedEventPayload,
   CaipAssetType,
@@ -950,5 +950,67 @@ describe('MultichainTransactionsController', () => {
       'MultichainTransactionsController:transactionSubmitted',
       transactions[1],
     );
+  });
+
+  describe('metadata', () => {
+    it('includes expected state in debug snapshots', () => {
+      const { controller } = setupController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'anonymous',
+        ),
+      ).toMatchInlineSnapshot(`Object {}`);
+    });
+
+    it('includes expected state in state logs', () => {
+      const { controller } = setupController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'includeInStateLogs',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "nonEvmTransactions": Object {},
+        }
+      `);
+    });
+
+    it('persists expected state', () => {
+      const { controller } = setupController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'persist',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "nonEvmTransactions": Object {},
+        }
+      `);
+    });
+
+    it('exposes expected state to UI', () => {
+      const { controller } = setupController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'usedInUi',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "nonEvmTransactions": Object {},
+        }
+      `);
+    });
   });
 });

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
@@ -149,8 +149,10 @@ export type AllowedEvents =
  */
 const multichainTransactionsControllerMetadata = {
   nonEvmTransactions: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: false,
+    usedInUi: true,
   },
 };
 

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add two new controller state metadata properties: `includeInStateLog` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
+
 ### Changed
 
 - Implement deferred login pattern in `SRPJwtBearerAuth` to prevent race conditions during concurrent authentication attempts ([#6353](https://github.com/MetaMask/core/pull/6353))

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add two new controller state metadata properties: `includeInStateLog` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
+- Add two new controller state metadata properties: `includeInStateLogs` and `usedInUi` ([#6470](https://github.com/MetaMask/core/pull/6470))
 
 ### Changed
 

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
@@ -1,4 +1,4 @@
-import { Messenger } from '@metamask/base-controller';
+import { Messenger, deriveStateFromMetadata } from '@metamask/base-controller';
 
 import AuthenticationController from './AuthenticationController';
 import type {
@@ -535,6 +535,80 @@ describe('AuthenticationController', () => {
 
       expect(controller.isSignedIn()).toBe(true);
     });
+  });
+});
+
+describe('metadata', () => {
+  it('includes expected state in debug snapshots', () => {
+    const controller = new AuthenticationController({
+      messenger: createMockAuthenticationMessenger().messenger,
+      metametrics: createMockAuthMetaMetrics(),
+    });
+
+    expect(
+      deriveStateFromMetadata(
+        controller.state,
+        controller.metadata,
+        'anonymous',
+      ),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "isSignedIn": false,
+      }
+    `);
+  });
+
+  it('includes expected state in state logs', () => {
+    const controller = new AuthenticationController({
+      messenger: createMockAuthenticationMessenger().messenger,
+      metametrics: createMockAuthMetaMetrics(),
+    });
+
+    expect(
+      deriveStateFromMetadata(
+        controller.state,
+        controller.metadata,
+        'includeInStateLogs',
+      ),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "isSignedIn": false,
+      }
+    `);
+  });
+
+  it('persists expected state', () => {
+    const controller = new AuthenticationController({
+      messenger: createMockAuthenticationMessenger().messenger,
+      metametrics: createMockAuthMetaMetrics(),
+    });
+
+    expect(
+      deriveStateFromMetadata(controller.state, controller.metadata, 'persist'),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "isSignedIn": false,
+      }
+    `);
+  });
+
+  it('exposes expected state to UI', () => {
+    const controller = new AuthenticationController({
+      messenger: createMockAuthenticationMessenger().messenger,
+      metametrics: createMockAuthMetaMetrics(),
+    });
+
+    expect(
+      deriveStateFromMetadata(
+        controller.state,
+        controller.metadata,
+        'usedInUi',
+      ),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "isSignedIn": false,
+      }
+    `);
   });
 });
 

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -43,12 +43,16 @@ export const defaultState: AuthenticationControllerState = {
 };
 const metadata: StateMetadata<AuthenticationControllerState> = {
   isSignedIn: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: true,
+    usedInUi: true,
   },
   srpSessionData: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: false,
+    usedInUi: true,
   },
 };
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -1,3 +1,4 @@
+import { deriveStateFromMetadata } from '@metamask/base-controller';
 import type nock from 'nock';
 
 import { mockUserStorageMessenger } from './__fixtures__/mockMessenger';
@@ -16,7 +17,6 @@ import { BACKUPANDSYNC_FEATURES } from './constants';
 import { MOCK_STORAGE_DATA, MOCK_STORAGE_KEY } from './mocks/mockStorage';
 import UserStorageController, { defaultState } from './UserStorageController';
 import { USER_STORAGE_FEATURE_NAMES } from '../../shared/storage-schema';
-import { deriveStateFromMetadata } from '@metamask/base-controller';
 
 describe('UserStorageController', () => {
   describe('constructor', () => {

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -16,6 +16,7 @@ import { BACKUPANDSYNC_FEATURES } from './constants';
 import { MOCK_STORAGE_DATA, MOCK_STORAGE_KEY } from './mocks/mockStorage';
 import UserStorageController, { defaultState } from './UserStorageController';
 import { USER_STORAGE_FEATURE_NAMES } from '../../shared/storage-schema';
+import { deriveStateFromMetadata } from '@metamask/base-controller';
 
 describe('UserStorageController', () => {
   describe('constructor', () => {
@@ -860,5 +861,91 @@ describe('UserStorageController', () => {
       messengerMocks.baseMessenger.publish('KeyringController:unlock');
       expect(await controller.getStorageKey()).toBe(MOCK_STORAGE_KEY);
     });
+  });
+});
+
+describe('metadata', () => {
+  it('includes expected state in debug snapshots', () => {
+    const controller = new UserStorageController({
+      messenger: mockUserStorageMessenger().messenger,
+    });
+
+    expect(
+      deriveStateFromMetadata(
+        controller.state,
+        controller.metadata,
+        'anonymous',
+      ),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "isAccountSyncingEnabled": true,
+        "isBackupAndSyncEnabled": true,
+        "isContactSyncingEnabled": true,
+      }
+    `);
+  });
+
+  it('includes expected state in state logs', () => {
+    const controller = new UserStorageController({
+      messenger: mockUserStorageMessenger().messenger,
+    });
+
+    expect(
+      deriveStateFromMetadata(
+        controller.state,
+        controller.metadata,
+        'includeInStateLogs',
+      ),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "hasAccountSyncingSyncedAtLeastOnce": false,
+        "isAccountSyncingEnabled": true,
+        "isAccountSyncingReadyToBeDispatched": false,
+        "isBackupAndSyncEnabled": true,
+        "isContactSyncingEnabled": true,
+      }
+    `);
+  });
+
+  it('persists expected state', () => {
+    const controller = new UserStorageController({
+      messenger: mockUserStorageMessenger().messenger,
+    });
+
+    expect(
+      deriveStateFromMetadata(controller.state, controller.metadata, 'persist'),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "hasAccountSyncingSyncedAtLeastOnce": false,
+        "isAccountSyncingEnabled": true,
+        "isAccountSyncingReadyToBeDispatched": false,
+        "isBackupAndSyncEnabled": true,
+        "isContactSyncingEnabled": true,
+      }
+    `);
+  });
+
+  it('exposes expected state to UI', () => {
+    const controller = new UserStorageController({
+      messenger: mockUserStorageMessenger().messenger,
+    });
+
+    expect(
+      deriveStateFromMetadata(
+        controller.state,
+        controller.metadata,
+        'usedInUi',
+      ),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "hasAccountSyncingSyncedAtLeastOnce": false,
+        "isAccountSyncingEnabled": true,
+        "isAccountSyncingReadyToBeDispatched": false,
+        "isBackupAndSyncEnabled": true,
+        "isBackupAndSyncUpdateLoading": false,
+        "isContactSyncingEnabled": true,
+        "isContactSyncingInProgress": false,
+      }
+    `);
   });
 });

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -108,36 +108,52 @@ export const defaultState: UserStorageControllerState = {
 
 const metadata: StateMetadata<UserStorageControllerState> = {
   isBackupAndSyncEnabled: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: true,
+    usedInUi: true,
   },
   isBackupAndSyncUpdateLoading: {
+    includeInStateLogs: false,
     persist: false,
     anonymous: false,
+    usedInUi: true,
   },
   isAccountSyncingEnabled: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: true,
+    usedInUi: true,
   },
   isContactSyncingEnabled: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: true,
+    usedInUi: true,
   },
   isContactSyncingInProgress: {
+    includeInStateLogs: false,
     persist: false,
     anonymous: false,
+    usedInUi: true,
   },
   hasAccountSyncingSyncedAtLeastOnce: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: false,
+    usedInUi: true,
   },
   isAccountSyncingReadyToBeDispatched: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: false,
+    usedInUi: true,
   },
   isAccountSyncingInProgress: {
+    includeInStateLogs: false,
     persist: false,
     anonymous: false,
+    usedInUi: false,
   },
 };
 


### PR DESCRIPTION
## Explanation

The new metadata properties `includeInStateLogs` and `usedInUi` have been added to all controllers maintained by the accounts team.

## References

Related to #6443

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
