### PR TITLE
Alert users about invalid or incomplete release PRs 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,37 +45,11 @@ jobs:
     needs: check-workflows
     uses: ./.github/workflows/lint-build-test.yml
 
-  is-release:
-    name: Determine whether this is a release merge commit
-    needs: lint-build-test
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    outputs:
-      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
-    steps:
-      - id: is-release
-        uses: MetaMask/action-is-release@dc4672b05e3b1d464cdaf783579b04a4e43f8b02
-        with:
-          commit-starts-with: 'Release [version],Release v[version],Release/[version],Release/v[version],Release `[version]`'
-
-  publish-release:
-    name: Publish release
-    needs: is-release
-    if: needs.is-release.outputs.IS_RELEASE == 'true'
+  validate-release:
+    name: Identify and validate release
+    uses: ./.github/workflows/validate-release.yml
     permissions:
-      contents: write
-    uses: ./.github/workflows/publish-release.yml
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  create-update-issues:
-    name: Create update issues
-    needs: [is-release, publish-release]
-    if: needs.is-release.outputs.IS_RELEASE == 'true'
-    uses: ./.github/workflows/create-update-issues.yaml
-    secrets:
-      CORE_CREATE_UPDATE_ISSUES_TOKEN: ${{ secrets.CORE_CREATE_UPDATE_ISSUES_TOKEN }}
+      pull-requests: write
 
   all-jobs-complete:
     name: All jobs complete
@@ -78,6 +57,7 @@ jobs:
     needs:
       - analyse-code
       - lint-build-test
+      - validate-release
     outputs:
       passed: ${{ steps.set-output.outputs.passed }}
     steps:
@@ -97,3 +77,23 @@ jobs:
           if [[ $passed != "true" ]]; then
             exit 1
           fi
+
+  publish-release:
+    name: Publish release
+    needs:
+      - validate-release
+      - all-jobs-complete
+    if: "github.event_name == 'push' && needs.validate-release.outputs.RELEASE_VALIDATION_RESULT == 'valid-release'"
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-release.yml
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  create-update-issues:
+    name: Create update issues
+    needs: publish-release
+    uses: ./.github/workflows/create-update-issues.yaml
+    secrets:
+      CORE_CREATE_UPDATE_ISSUES_TOKEN: ${{ secrets.CORE_CREATE_UPDATE_ISSUES_TOKEN }}

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -1,0 +1,94 @@
+name: Validate Release
+
+on:
+  workflow_call:
+    outputs:
+      RELEASE_VALIDATION_RESULT:
+        description: The release validation result
+        value: ${{ jobs.validate-release.outputs.RELEASE_VALIDATION_RESULT }}
+
+jobs:
+  validate-release:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      RELEASE_VALIDATION_RESULT: ${{ steps.validate-release.outputs.RELEASE_VALIDATION_RESULT }}
+      RELEASE_VALIDATION_MESSAGE: ${{ steps.validate-release.outputs.RELEASE_VALIDATION_MESSAGE }}
+      EXISTING_COMMENT_ID: ${{ steps.check-bot-comments.outputs.EXISTING_COMMENT_ID }}
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
+        with:
+          is-high-risk-environment: false
+          # Fetch everything because if this is a pull request we need to
+          # compare with the base branch
+          fetch-depth: 0
+      - name: Check for existing bot comments
+        if: ${{ github.event_name == 'pull_request' }}
+        id: check-bot-comments
+        run: |
+          set -euo pipefail
+          EXISTING_COMMENT_ID=$(gh api "/repos/${GITHUB_REPOSITORY}/issues/${GITHUB_EVENT_PULL_REQUEST_NUMBER}/comments" --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- METAMASKBOT-RELEASE-VALIDATION -->"))] | sort_by(.created_at) | .[-1].id')
+          if [[ -n "$EXISTING_COMMENT_ID" && "$EXISTING_COMMENT_ID" != "null" ]]; then
+            echo "EXISTING_COMMENT_ID=$EXISTING_COMMENT_ID" >> "$GITHUB_OUTPUT"
+          else
+            echo "EXISTING_COMMENT_ID=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+      - name: Validate release
+        id: validate-release
+        run: |
+          set -euo pipefail
+          case "$GITHUB_EVENT_NAME" in
+            push)
+              exec yarn ts-node scripts/validate-release.ts "$GITHUB_EVENT_NAME" "$GITHUB_EVENT_BEFORE" "$GITHUB_SHA" "$GITHUB_EVENT_HEAD_COMMIT_MESSAGE"
+              ;;
+            pull_request)
+              exec yarn ts-node scripts/validate-release.ts "$GITHUB_EVENT_NAME" "$GITHUB_EVENT_PULL_REQUEST_BASE_SHA" "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" "$GITHUB_EVENT_PULL_REQUEST_TITLE" "$EXISTING_COMMENT_ID"
+              ;;
+            *)
+              echo "Unknown GitHub event name: $GITHUB_EVENT_NAME"
+              exit 1
+              ;;
+          esac
+        shell: bash
+        env:
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+          GITHUB_EVENT_HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          GITHUB_EVENT_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_EVENT_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+          EXISTING_COMMENT_ID: ${{ steps.check-bot-comments.outputs.EXISTING_COMMENT_ID }}
+      - name: Post or update PR comment
+        if: ${{ github.event_name == 'pull_request' && steps.validate-release.outputs.RELEASE_VALIDATION_MESSAGE != '' }}
+        run: |
+          set -euo pipefail
+
+          # Write the comment message to a file, skirting around issues with backticks
+          cat > comment-message.txt << 'EOF'
+          ${{ steps.validate-release.outputs.RELEASE_VALIDATION_MESSAGE }}
+          EOF
+
+          if [[ -n "$EXISTING_COMMENT_ID" ]]; then
+            gh api "/repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_COMMENT_ID}" --jq '.body' > existing-comment.txt
+            if cmp -s existing-comment.txt comment-message.txt; then
+              echo "Found existing comment, but content is unchanged. Not updating."
+            else
+              echo "Updating existing PR comment."
+              jq -n --rawfile body comment-message.txt '{body: $body}' > update-comment.json
+              gh api -X PATCH "/repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_COMMENT_ID}" --input update-comment.json
+              #gh api -X PATCH "/repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_COMMENT_ID}" --input comment-message.txt
+            fi
+          else
+            echo "Creating new PR comment."
+            gh pr comment "${GITHUB_EVENT_PULL_REQUEST_NUMBER}" --body-file comment-message.txt
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          EXISTING_COMMENT_ID: ${{ steps.check-bot-comments.outputs.EXISTING_COMMENT_ID }}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ws@7.4.6": "^7.5.10"
   },
   "devDependencies": {
+    "@actions/core": "^1.11.1",
     "@babel/core": "^7.23.5",
     "@babel/plugin-transform-modules-commonjs": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",

--- a/scripts/validate-release.ts
+++ b/scripts/validate-release.ts
@@ -1,0 +1,592 @@
+#!/usr/bin/env -S yarn ts-node
+
+import * as core from '@actions/core';
+import execa from 'execa';
+import { escapeRegExp } from 'lodash';
+
+const VALID_RELEASE_TITLE_PATTERNS = [
+  'Release [version]',
+  'Release v[version]',
+  'Release/[version]',
+  'Release/v[version]',
+  'Release `[version]`',
+];
+
+const VALID_GITHUB_EVENT_NAMES = ['push', 'pull_request'] as const;
+type GitHubEventName = (typeof VALID_GITHUB_EVENT_NAMES)[number];
+
+const ReleaseValidationStatus = {
+  NotARelease: 'not-a-release',
+  InvalidRelease: 'invalid-release',
+  ValidRelease: 'valid-release',
+  IncompleteRelease: 'incomplete-release',
+} as const;
+type ReleaseValidationStatus =
+  (typeof ReleaseValidationStatus)[keyof typeof ReleaseValidationStatus];
+
+type WorkspaceInfo = {
+  location: string;
+  name: string;
+};
+
+type BaseValidationResult = { message: string };
+type SuccessfulValidationResult = BaseValidationResult & { isSuccess: true };
+type FailedValidationResult = BaseValidationResult & {
+  isSuccess: false;
+  errorMessage: string;
+};
+type ValidationResult = SuccessfulValidationResult | FailedValidationResult;
+type RootVersionBumpedValidationResult = ValidationResult & {
+  currentVersion: string;
+};
+type ReleaseTitleValidationResult = ValidationResult;
+type AnyWorkspacePackageVersionBumpedValidationResult = ValidationResult;
+
+type ReleaseValidationResult = {
+  status: ReleaseValidationStatus;
+  errorMessages: string[];
+};
+
+// Run the script.
+main().catch((error) => {
+  core.setFailed(error.message);
+});
+
+/**
+ * The main function of the script.
+ */
+export async function main(): Promise<void> {
+  console.log('Parsing arguments');
+  console.log('-----------------\n');
+  const {
+    githubEventName,
+    baseRef,
+    headRef,
+    possibleReleaseTitle,
+    existingCommentId,
+  } = parseCommandLineArguments();
+  const botAlreadyCommented = existingCommentId !== '';
+  console.log(`- GitHub event name: ${githubEventName}`);
+  console.log(`- Base ref: ${baseRef}`);
+  console.log(`- Head ref: ${headRef}`);
+  console.log(`- Possible release title: ${possibleReleaseTitle}`);
+  console.log(`- Bot already commented: ${botAlreadyCommented}`);
+  console.log(`- Existing comment ID: ${existingCommentId || 'none'}`);
+  console.log('');
+
+  console.log('Running validations');
+  console.log('-------------------\n');
+  console.log('- Checking whether root version has been bumped...');
+  const rootVersionBumpedResult = await validateRootVersionBumped(
+    baseRef,
+    headRef,
+  );
+  console.log(`  - ${rootVersionBumpedResult.message}`);
+  console.log('- Checking format of release title...');
+  const releaseTitleResult = validateReleaseTitle({
+    githubEventName,
+    possibleReleaseTitle,
+    matchCurrentVersion: rootVersionBumpedResult.isSuccess
+      ? rootVersionBumpedResult.currentVersion
+      : null,
+  });
+  console.log(`  - ${releaseTitleResult.message}`);
+  console.log('- Checking whether any workspace packages have been bumped...');
+  const anyWorkspacePackageVersionBumpedResult =
+    await validateAnyPublicWorkspacePackageBumped(baseRef, headRef);
+  console.log(`  - ${anyWorkspacePackageVersionBumpedResult.message}`);
+
+  console.log('\nSummarizing results');
+  console.log('-------------------\n');
+  const releaseValidationResult = getReleaseValidationResult(
+    rootVersionBumpedResult,
+    releaseTitleResult,
+    anyWorkspacePackageVersionBumpedResult,
+  );
+  summarizeResults(releaseValidationResult, githubEventName);
+  core.setOutput('RELEASE_VALIDATION_RESULT', releaseValidationResult.status);
+
+  if (githubEventName === 'pull_request') {
+    const commentMessage = generateReleaseValidationMessage(
+      releaseValidationResult,
+      botAlreadyCommented,
+    );
+
+    if (commentMessage) {
+      core.setOutput('RELEASE_VALIDATION_MESSAGE', commentMessage);
+    }
+  }
+}
+
+/**
+ * Summarizes the release validation results by logging appropriate messages.
+ *
+ * @param releaseValidationResult - The result of the release validation.
+ * @param githubEventName - The GitHub event name (push or pull_request).
+ */
+function summarizeResults(
+  releaseValidationResult: ReleaseValidationResult,
+  githubEventName: GitHubEventName,
+): void {
+  switch (releaseValidationResult.status) {
+    case ReleaseValidationStatus.ValidRelease:
+      if (githubEventName === 'push') {
+        console.log(
+          'This appears to be a release commit. Release workflow will be run.',
+        );
+      } else {
+        console.log(
+          '✅ It appears that you have created a release PR, and it is valid. Good job!',
+        );
+      }
+      break;
+    case ReleaseValidationStatus.InvalidRelease:
+      if (githubEventName === 'push') {
+        console.log(
+          'This does not appear to be a release commit. Release workflow will be skipped.',
+        );
+      } else {
+        core.error('This release PR is invalid.');
+        console.log('❌ This release PR is invalid.\n');
+        console.log(
+          'It appears that you have created a release PR, but the following checks failed:\n',
+        );
+        for (const errorMessage of releaseValidationResult.errorMessages) {
+          console.log(`- ${errorMessage}`);
+        }
+        console.log(
+          '\nAll of the checks above need to pass before you can merge this PR.',
+        );
+      }
+      break;
+    case ReleaseValidationStatus.IncompleteRelease:
+      if (githubEventName === 'push') {
+        console.log(
+          'This does not appear to be a release commit. Release workflow will be skipped.',
+        );
+      } else {
+        console.log('⚠️ This may be an incomplete release PR.');
+        console.log(
+          'It appears that you have attempted to create a release PR, but the following checks failed:\n',
+        );
+        for (const errorMessage of releaseValidationResult.errorMessages) {
+          console.log(`- ${errorMessage}`);
+        }
+        console.log(
+          '\nYou may merge this PR, but if you meant for this to be a release PR, you should get all of the checks above passing.',
+        );
+      }
+      break;
+    default:
+      if (githubEventName === 'push') {
+        console.log(
+          'This does not appear to be a release commit. Release workflow will be skipped.',
+        );
+      } else {
+        console.log(
+          'This does not appear to be a release PR. You can merge this PR.',
+        );
+      }
+      break;
+  }
+}
+
+/**
+ * Generates the release validation message for PR comments.
+ *
+ * @param releaseValidationResult - The result of the release validation.
+ * @param botAlreadyCommented - Whether the bot has already commented on the PR.
+ * @returns The comment message, or empty string if no comment is needed.
+ */
+function generateReleaseValidationMessage(
+  releaseValidationResult: ReleaseValidationResult,
+  botAlreadyCommented: boolean,
+): string {
+  let commentMessage = '';
+
+  const isReleasePR =
+    releaseValidationResult.status !== ReleaseValidationStatus.NotARelease;
+
+  if (isReleasePR) {
+    const greeting = 'Hello 👋';
+    const marker = '<!-- METAMASKBOT-RELEASE-VALIDATION -->';
+
+    switch (releaseValidationResult.status) {
+      case ReleaseValidationStatus.InvalidRelease:
+        commentMessage = `${greeting} It looks like you're trying to make a release PR, but some things don't look right:
+
+${releaseValidationResult.errorMessages.map((msg) => `- ${msg}`).join('\n')}
+
+**You'll need to get all of these checks passing before you can merge this PR.**
+
+${marker}`;
+        break;
+      case ReleaseValidationStatus.IncompleteRelease:
+        commentMessage = `${greeting} Are you trying to make a release PR? If so, some things don't look right:
+
+${releaseValidationResult.errorMessages.map((msg) => `- ${msg}`).join('\n')}
+
+You may merge this PR, but if you meant for this to be a release PR, you'll need to get all of these checks passing first. (Otherwise, you can ignore this comment.)
+
+${marker}`;
+        break;
+      case ReleaseValidationStatus.ValidRelease:
+        // If we previously commented but now it's valid, show success message
+        if (botAlreadyCommented) {
+          commentMessage = `This release PR previously had issues, but it looks like they have been fixed. Good job! 🎉
+
+${marker}`;
+        }
+        // If it was always valid, no comment needed
+        break;
+      default:
+        break;
+    }
+  } else if (botAlreadyCommented) {
+    // If we previously thought it was a release PR but now it's not, update the comment
+    commentMessage = `_(This PR was previously recognized as a potential release candidate, and this comment reflected that. But now this is a regular PR, so there is nothing to see here.)_
+
+<!-- METAMASKBOT-RELEASE-VALIDATION -->`;
+  }
+
+  return commentMessage;
+}
+
+/**
+ * Gets the list of public workspace packages in the monorepo.
+ *
+ * @returns An array of public workspaces.
+ */
+async function getPublicWorkspaces(): Promise<WorkspaceInfo[]> {
+  const { stdout } = await execa('yarn', [
+    'workspaces',
+    'list',
+    '--json',
+    '--no-private',
+  ]);
+  return stdout
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line));
+}
+
+/**
+ * Fetches the `package.json` in the directory from the base and head commits
+ * and returns their version fields.
+ *
+ * @param baseRef - The ref of the first commit to fetch.
+ * @param headRef - The ref of the second commit to fetch.
+ * @param directory - The directory where `package.json` is located (must end
+ * with `/`).
+ * @returns The output.
+ */
+async function getPreviousAndCurrentPackageVersions(
+  baseRef: string,
+  headRef: string,
+  directory: string,
+): Promise<{ previousVersion: string; currentVersion: string }> {
+  const { stdout: rawPreviousManifest } = await execa('git', [
+    'show',
+    `${baseRef}:${directory}package.json`,
+  ]);
+  const { stdout: rawCurrentManifest } = await execa('git', [
+    'show',
+    `${headRef}:${directory}package.json`,
+  ]);
+
+  const previousManifest = JSON.parse(rawPreviousManifest) as {
+    version: string;
+  };
+  const currentManifest = JSON.parse(rawCurrentManifest) as { version: string };
+
+  return {
+    previousVersion: previousManifest.version,
+    currentVersion: currentManifest.version,
+  };
+}
+
+/**
+ * Prints the usage for this script.
+ */
+function printUsage() {
+  console.error(
+    `
+Identifies whether the given PR or commit is a release commit, and if so,
+validates it by ensuring that the title of the PR or commit is formatted
+correctly and the root package version is bumped alongside packages in the
+monorepo.
+
+USAGE: scripts/validate-release.ts <github-event-name> <base-ref> <head-ref> <possible-release-title> [existing-comment-id]
+
+ARGUMENTS:
+
+<github-event-name>
+  The name of the event that spawned this GitHub workflow. Either "push" or
+  "pull_request".
+<base-ref>
+  If GITHUB_EVENT_NAME is "pull_request", a ref to the base branch commit; if
+  "push" then a ref to the commit before the push.
+<head-ref>
+  If GITHUB_EVENT_NAME is "pull_request", a ref to the head branch commit; if
+  "push", then a ref to the head commit after the push.
+<possible-release-title>
+  If GITHUB_EVENT_NAME is "pull_request", the title of the pull request; if
+  "push", then the subject of the head commit pushed.
+[existing-comment-id]
+  Required if GITHUB_EVENT_NAME is "pull_request", ignored otherwise. The ID
+  of an existing comment from the MetaMask bot, or empty string if none exists.
+`.trimStart(),
+  );
+}
+
+/**
+ * Prints an error and the program usage, then exits.
+ *
+ * @param message - The message to print.
+ */
+function failWithInvalidUsage(message: string) {
+  console.error(`ERROR: ${message}\n`);
+  printUsage();
+  // This is okay, we want to exit early.
+  // eslint-disable-next-line n/no-process-exit
+  process.exit(1);
+}
+
+/**
+ * Parses the arguments given to the script.
+ *
+ * @returns The previous commit ID and release title prefix.
+ */
+function parseCommandLineArguments() {
+  const args = process.argv.slice(2);
+
+  if (args.length < 4) {
+    failWithInvalidUsage('Expected at least 4 arguments.');
+  }
+
+  const githubEventName = args[0];
+  const baseRef = args[1];
+  const headRef = args[2];
+  const possibleReleaseTitle = args[3];
+
+  if (githubEventName === 'pull_request' && args.length < 5) {
+    failWithInvalidUsage(
+      'Expected a 5th argument (existing-comment-id) when GitHub event name is "pull_request".',
+    );
+  }
+
+  const existingCommentId = args[4] || '';
+
+  if (
+    !(VALID_GITHUB_EVENT_NAMES as readonly string[]).includes(githubEventName)
+  ) {
+    failWithInvalidUsage(
+      'Expected GitHub event name to be one of "push" or "pull_request".',
+    );
+  }
+
+  return {
+    githubEventName: githubEventName as GitHubEventName,
+    baseRef,
+    headRef,
+    possibleReleaseTitle,
+    existingCommentId,
+  };
+}
+
+/**
+ * Checks if the subject of the commit or title of the pull request matches that
+ * which is expected of a release title.
+ *
+ * @param args - Arguments to this function.
+ * @param args.githubEventName - The name of the event that spawned this GitHub
+ * workflow.
+ * @param args.possibleReleaseTitle - The title of the commit or PR to check.
+ * @param args.matchCurrentVersion - If the possible title should include the
+ * current version, that version; otherwise null.
+ * @returns The result of the validation.
+ */
+function validateReleaseTitle({
+  githubEventName,
+  possibleReleaseTitle,
+  matchCurrentVersion,
+}: {
+  githubEventName: GitHubEventName;
+  possibleReleaseTitle: string;
+  matchCurrentVersion: string | null;
+}): ReleaseTitleValidationResult {
+  const niceValidReleaseTitlePatterns = matchCurrentVersion
+    ? VALID_RELEASE_TITLE_PATTERNS.map((pattern) =>
+        pattern.replace('[version]', matchCurrentVersion),
+      )
+    : VALID_RELEASE_TITLE_PATTERNS;
+  const validReleaseTitleRegexpSource = VALID_RELEASE_TITLE_PATTERNS.map(
+    (pattern) =>
+      escapeRegExp(pattern.replace('[version]', '__VERSION__')).replace(
+        '__VERSION__',
+        matchCurrentVersion ?? '\\d+\\.\\d+\\.\\d+',
+      ),
+  )
+    .map((pattern) => `(?:${pattern})`)
+    .join('|');
+  const validReleaseTitleRegexp = new RegExp(
+    `^(?:${validReleaseTitleRegexpSource})$`,
+    'u',
+  );
+  const match = possibleReleaseTitle.match(validReleaseTitleRegexp);
+  const source =
+    githubEventName === 'push' ? 'commit message' : 'pull request title';
+
+  if (match) {
+    return {
+      isSuccess: true,
+      message: `The ${source} "${possibleReleaseTitle}" matches a valid release title format`,
+    };
+  }
+  return {
+    isSuccess: false,
+    message: `The ${source} "${possibleReleaseTitle}" does not match a valid release title format`,
+    errorMessage: `Your ${source} must match one of the following formats: ${niceValidReleaseTitlePatterns
+      .map((pattern) => {
+        if (pattern.includes('`')) {
+          return `\`\` ${pattern} \`\``;
+        }
+        return `\`${pattern}\``;
+      })
+      .join(', ')}`,
+  };
+}
+
+/**
+ * Checks if the version in the the root package's `package.json` has been
+ * bumped.
+ *
+ * @param baseRef - The base commit ref.
+ * @param headRef - The head commit ref.
+ * @returns The result of the validation.
+ */
+async function validateRootVersionBumped(
+  baseRef: string,
+  headRef: string,
+): Promise<RootVersionBumpedValidationResult> {
+  const { previousVersion, currentVersion } =
+    await getPreviousAndCurrentPackageVersions(baseRef, headRef, './');
+
+  console.log(
+    'Previous version:',
+    previousVersion,
+    'Current version:',
+    currentVersion,
+  );
+
+  if (currentVersion !== previousVersion) {
+    return {
+      isSuccess: true,
+      message: `Root package version has been bumped from ${previousVersion} to ${currentVersion}`,
+      currentVersion,
+    };
+  }
+
+  return {
+    isSuccess: false,
+    message: 'Root package version has not been bumped',
+    errorMessage: 'Root package version must be bumped',
+    currentVersion,
+  };
+}
+
+/**
+ * Checks if any of the versions among workspace package have been bumped.
+ *
+ * @param baseRef - The base commit ref.
+ * @param headRef - The head commit ref.
+ * @returns The result of the validation.
+ */
+async function validateAnyPublicWorkspacePackageBumped(
+  baseRef: string,
+  headRef: string,
+): Promise<AnyWorkspacePackageVersionBumpedValidationResult> {
+  const publicWorkspaces = await getPublicWorkspaces();
+
+  const workspacesWithVersions = await Promise.all(
+    publicWorkspaces.map(async (publicWorkspace) => {
+      const { previousVersion, currentVersion } =
+        await getPreviousAndCurrentPackageVersions(
+          baseRef,
+          headRef,
+          `${publicWorkspace.location}/`,
+        );
+
+      return { name: publicWorkspace.name, previousVersion, currentVersion };
+    }),
+  );
+  const bumpedWorkspacesWithVersions = workspacesWithVersions.filter(
+    (workspace) => workspace.currentVersion !== workspace.previousVersion,
+  );
+
+  if (bumpedWorkspacesWithVersions.length > 0) {
+    return {
+      isSuccess: true,
+      message: `${bumpedWorkspacesWithVersions.length} workspace package(s) have been bumped`,
+    };
+  }
+
+  return {
+    isSuccess: false,
+    message: 'No workspace packages have been bumped',
+    errorMessage: 'You must bump one of the packages in this monorepo',
+  };
+}
+
+/**
+ * Determines the release validation status from how many validations succeeded.
+ *
+ * @param rootVersionBumpedResult - The "root version bumped" validation result.
+ * @param releaseTitleResult - The "release title" validation result.
+ * @param anyWorkspacePackageVersionBumpedResult - The "any workspace package
+ * version bumped" validation result.
+ * @returns The overall release validation status.
+ */
+function getReleaseValidationResult(
+  rootVersionBumpedResult: RootVersionBumpedValidationResult,
+  releaseTitleResult: ReleaseTitleValidationResult,
+  anyWorkspacePackageVersionBumpedResult: AnyWorkspacePackageVersionBumpedValidationResult,
+) {
+  const errorMessages = [
+    rootVersionBumpedResult,
+    releaseTitleResult,
+    anyWorkspacePackageVersionBumpedResult,
+  ]
+    .filter((result): result is FailedValidationResult => !result.isSuccess)
+    .map((result) => result.errorMessage);
+
+  if (rootVersionBumpedResult.isSuccess) {
+    if (
+      releaseTitleResult.isSuccess &&
+      anyWorkspacePackageVersionBumpedResult.isSuccess
+    ) {
+      return {
+        status: ReleaseValidationStatus.ValidRelease,
+        errorMessages,
+      };
+    }
+    return {
+      status: ReleaseValidationStatus.InvalidRelease,
+      errorMessages,
+    };
+  }
+
+  if (
+    !releaseTitleResult.isSuccess &&
+    !anyWorkspacePackageVersionBumpedResult.isSuccess
+  ) {
+    return {
+      status: ReleaseValidationStatus.NotARelease,
+      errorMessages,
+    };
+  }
+  return {
+    status: ReleaseValidationStatus.IncompleteRelease,
+    errorMessages,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,42 @@ __metadata:
   version: 8
   cacheKey: 10
 
+"@actions/core@npm:^1.11.1":
+  version: 1.11.1
+  resolution: "@actions/core@npm:1.11.1"
+  dependencies:
+    "@actions/exec": "npm:^1.1.1"
+    "@actions/http-client": "npm:^2.0.1"
+  checksum: 10/94f260e33607cc16567ce4c88014f069cd7da92baaa443b72cff80fdf4f1dcd18192e135df0d51ec29e8b82cfe214218715d482f2a7804efa5095737d1245f38
+  languageName: node
+  linkType: hard
+
+"@actions/exec@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@actions/exec@npm:1.1.1"
+  dependencies:
+    "@actions/io": "npm:^1.0.1"
+  checksum: 10/c04bd25191e522841c7e17862d70099de8db61278d2b4c744b69ac0197a48f85c75dba548e1c29c695c4cc5363d558846b4dcd3db9013463c18ba8cf36497c6d
+  languageName: node
+  linkType: hard
+
+"@actions/http-client@npm:^2.0.1":
+  version: 2.2.3
+  resolution: "@actions/http-client@npm:2.2.3"
+  dependencies:
+    tunnel: "npm:^0.0.6"
+    undici: "npm:^5.25.4"
+  checksum: 10/0c0a540c79e50f795d214f696710bb9c50bdf5bb1458be288140f2aae3686adec73fdb464c43da5ef94f985ac7736273efef21cb5ba5a3b09e85b403d852c04b
+  languageName: node
+  linkType: hard
+
+"@actions/io@npm:^1.0.1":
+  version: 1.1.3
+  resolution: "@actions/io@npm:1.1.3"
+  checksum: 10/4de44e8d428ba9f20049c844b37ecd486b589ed201f8cc8c5b550a9e4c72d1f594271ee2a7a6cfe8a42ebfb5dd527ef65016454656db391a353d41eab4f147e1
+  languageName: node
+  linkType: hard
+
 "@adraffy/ens-normalize@npm:1.10.1":
   version: 1.10.1
   resolution: "@adraffy/ens-normalize@npm:1.10.1"
@@ -1276,6 +1312,13 @@ __metadata:
     "@ethersproject/properties": "npm:^5.8.0"
     "@ethersproject/strings": "npm:^5.8.0"
   checksum: 10/b8e6aa7d2195bb568847f360f6525ddc3d145404fbd4553e2e05daf4a95f58167591feb69e16e3398a28114ea85e1895fc8f5bd1c0cbf8b578123d7c1d21c32d
+  languageName: node
+  linkType: hard
+
+"@fastify/busboy@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "@fastify/busboy@npm:2.1.1"
+  checksum: 10/2bb8a7eca8289ed14c9eb15239bc1019797454624e769b39a0b90ed204d032403adc0f8ed0d2aef8a18c772205fa7808cf5a1b91f21c7bfc7b6032150b1062c5
   languageName: node
   linkType: hard
 
@@ -2923,6 +2966,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/core-monorepo@workspace:."
   dependencies:
+    "@actions/core": "npm:^1.11.1"
     "@babel/core": "npm:^7.23.5"
     "@babel/plugin-transform-modules-commonjs": "npm:^7.23.3"
     "@babel/preset-typescript": "npm:^7.23.3"
@@ -14420,6 +14464,15 @@ __metadata:
   version: 6.19.8
   resolution: "undici-types@npm:6.19.8"
   checksum: 10/cf0b48ed4fc99baf56584afa91aaffa5010c268b8842f62e02f752df209e3dea138b372a60a963b3b2576ed932f32329ce7ddb9cb5f27a6c83040d8cd74b7a70
+  languageName: node
+  linkType: hard
+
+"undici@npm:^5.25.4":
+  version: 5.29.0
+  resolution: "undici@npm:5.29.0"
+  dependencies:
+    "@fastify/busboy": "npm:^2.0.0"
+  checksum: 10/0ceca8924a32acdcc0cfb8dd2d368c217840970aa3f5e314fc169608474be6341c5b8e50cad7bd257dbe3b4e432bc5d0a0d000f83644b54fa11a48735ec52b93
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Currently we use the `is-release` action to determine whether a commit merged to `main` is a release commit, and if so, we run the release workflow. A commit becomes a release commit when:

- the root package version is bumped
- the subject of the merged commit matches "Release X.Y.Z", "Release/X.Y.Z", or something similar

However, oftentimes engineers will create a PR and bump some packages' versions but forget to bump the root version, or they will mistitle the release PR. When this PR is merged, the release workflow won't run. But by then it is too late, and the engineer is forced to revert the PR and recreate it correctly. This is painful.

To prevent this, this commit replaces the `is-release` action with a custom workflow that looks at three things:

- whether the root package is bumped
- whether the title of the release is well-formed
- whether any of the packages in the monorepo have been bumped

As before, this workflow runs when a release commit is merged, and the result is used to determine whether to run the release workflow. But now, this workflow also runs on each pull request and acts as a gate:

- If the engineer bumps the root package but does not fulfill the other two requirements, then the workflow will fail and the PR will not be mergeable.
- If the engineer does not bump the root package but fulfills one or both of the other two requirements, then the workflow will not fail, but it will show a warning so that the engineer can double-check the PR.
- (Pull requests that do not fulfill any of the three requirements will be ignored.)

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes #6119.
Fixes #6480.

## Manual testing

You can see some evidence of manual testing on this branch. See this comment and its edits for what users will see in various scenarios: https://github.com/MetaMask/core/pull/6482#issuecomment-3313634655

### Testing the `pull_request` flow

(This will be called on each PR)

- Run `yarn ts-node ./scripts/validate-release.ts pull_request 43a68165e6c88823ae52358adb9399ec7e4cb1d2^ 43a68165e6c88823ae52358adb9399ec7e4cb1d2 "Release 1.2.3" ""` (`43a68165e6c88823ae52358adb9399ec7e4cb1d2` corresponds to release 535.0.0)
  - The `RELEASE_VALIDATION_STATUS` output should be "invalid-release" (because the root package was bumped, but the given commit message does not match a known release format)
  - The standard out should include "This release PR is invalid"  
  - The `RELEASE_VALIDATION_MESSAGE` output should be set and contain a similar message

- Run `yarn ts-node ./scripts/validate-release.ts pull_request 43a68165e6c88823ae52358adb9399ec7e4cb1d2^ 43a68165e6c88823ae52358adb9399ec7e4cb1d2 "Release 1.2.3" "1"`
  - Similar as above but the `RELEASE_VALIDATION_MESSAGE` output should change slightly (as `"1"` indicates that a bot comment already exists, and is the comment ID)

- Run `yarn ts-node ./scripts/validate-release.ts pull_request 43a68165e6c88823ae52358adb9399ec7e4cb1d2^ 43a68165e6c88823ae52358adb9399ec7e4cb1d2 "Release 535.0.0" ""`
  - The `RELEASE_VALIDATION_STATUS` output should be "valid-release" (because the given commit message _does_ match a known release format)
  - The standard out should include "It appears that you have created a release PR" should be printed 
  - No `RELEASE_VALIDATION_MESSAGE` should be set

- Run `yarn ts-node ./scripts/validate-release.ts pull_request 43a68165e6c88823ae52358adb9399ec7e4cb1d2^ 43a68165e6c88823ae52358adb9399ec7e4cb1d2 "Release/535.0.0" ""` (slight variation in PR title)
  - The standard out should include "It appears that you have created a release PR" should be printed
  - The `RELEASE_VALIDATION_STATUS` output should be "valid-release" (because the given commit message _does_ match a known release format)
  - No `RELEASE_VALIDATION_MESSAGE` should be set

- Run `yarn ts-node ./scripts/validate-release.ts pull_request b2d81c4e8ce6a68ce4af7844b34518416fd25f41^ b2d81c4e8ce6a68ce4af7844b34518416fd25f41 "Release 1.2.3" ""` (`b2d81c4e8ce6a68ce4af7844b34518416fd25f41` is not a release commit)
  - The standard out should include "This may be an incomplete release PR"
  - The `RELEASE_VALIDATION_MESSAGE` output should contain a similar message
  - The `RELEASE_VALIDATION_STATUS` output should be "incomplete-release" (because the root package was not bumped, but the given commit message matches a known release format)

- Run `yarn ts-node ./scripts/validate-release.ts pull_request b2d81c4e8ce6a68ce4af7844b34518416fd25f41^ b2d81c4e8ce6a68ce4af7844b34518416fd25f41 "Release 1.2.3" "1"`
  - Similar as above but the `RELEASE_VALIDATION_MESSAGE` output should change slightly (as `"1"` indicates that a bot comment already exists, and is the comment ID)

- Run `yarn ts-node ./scripts/validate-release.ts pull_request b2d81c4e8ce6a68ce4af7844b34518416fd25f41^ b2d81c4e8ce6a68ce4af7844b34518416fd25f41 "some commit message" ""`
  - The standard out should say "This does not appear to be a release commit"
  - The `RELEASE_VALIDATION_STATUS` output should be "not-a-release"
  - No `RELEASE_VALIDATION_MESSAGE` should be set

### Testing the `push` flow

(This will be called when a commit is merged to `main`)

- Run `yarn ts-node ./scripts/validate-release.ts push 43a68165e6c88823ae52358adb9399ec7e4cb1d2^ 43a68165e6c88823ae52358adb9399ec7e4cb1d2 "Release 1.2.3"` (`43a68165e6c88823ae52358adb9399ec7e4cb1d2` corresponds to release 535.0.0)
  - It should say "This does not appear to be a release commit", and the `RELEASE_VALIDATION_STATUS` output should be "invalid-release" (because the root package was bumped, but the given commit message does not match a known release format)

- Run `yarn ts-node ./scripts/validate-release.ts push 43a68165e6c88823ae52358adb9399ec7e4cb1d2^ 43a68165e6c88823ae52358adb9399ec7e4cb1d2 "Release 535.0.0"`
  - It should say "This appears to be a release commit", and the `RELEASE_VALIDATION_STATUS` output should be "valid-release" (because the given commit message _does_ match a known release format)

- Run `yarn ts-node ./scripts/validate-release.ts push 43a68165e6c88823ae52358adb9399ec7e4cb1d2^ 43a68165e6c88823ae52358adb9399ec7e4cb1d2 "Release/535.0.0"`
  - It should say "This appears to be a release commit", and the `RELEASE_VALIDATION_STATUS` output should be "valid-release"

- Run `yarn ts-node ./scripts/validate-release.ts push b2d81c4e8ce6a68ce4af7844b34518416fd25f41^ b2d81c4e8ce6a68ce4af7844b34518416fd25f41 "Release 1.2.3"` (`b2d81c4e8ce6a68ce4af7844b34518416fd25f41` is not a release commit)
  - It should say "This does not appear to be a release commit", but the `RELEASE_VALIDATION_STATUS` output should be "incomplete-release" (because the root package was not bumped, but the given commit message matches a known release format)

- Run `yarn ts-node ./scripts/validate-release.ts push b2d81c4e8ce6a68ce4af7844b34518416fd25f41^ b2d81c4e8ce6a68ce4af7844b34518416fd25f41 "some commit message"`
  - It should say "This does not appear to be a release commit", and the `RELEASE_VALIDATION_STATUS` output should be "not-a-release"

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when npm releases run and which PRs fail CI; mistakes in validation logic could block legitimate releases or miss bad release merges.
> 
> **Overview**
> Replaces the **`action-is-release`** gate with a **`validate-release`** reusable workflow and **`scripts/validate-release.ts`**, so release readiness is checked on **PRs and on `main` pushes** before publish runs.
> 
> On each change, the script compares base/head **`package.json`** versions (root + public workspaces), validates the PR title or merge commit subject against known **Release …** patterns, and classifies the result as **valid**, **invalid**, **incomplete**, or **not a release**. **`publish-release`** now runs only when a push yields **`valid-release`**; **`create-update-issues`** chains after publish instead of the old **`is-release`** job.
> 
> For **pull requests**, invalid release candidates **fail the check** (`core.error`), incomplete ones get **warnings** via a bot comment (create/update by marker), and PR workflows also react to **`edited`** titles. **`@actions/core`** is added for workflow outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eff0bbba04fa16b96c59c7d2db0dafe6bf2ba7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->