### PR TITLE
feat(account-tree-controller): add account group name uniqueness validation

### DIFF
--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add unique name validation for account groups to prevent duplicate group names ([#6492](https://github.com/MetaMask/core/pull/6492))
+  - `setAccountGroupName` now validates that group names are unique across all groups
+  - Added `isAccountGroupNameUnique` utility function in `group.ts` for checking name uniqueness
+  - Names are trimmed of leading/trailing whitespace before comparison to prevent accidental duplicates
+
 ### Changed
 
 - **BREAKING:** Remove support for `AccountsController:accountRenamed` event handling ([#6438](https://github.com/MetaMask/core/pull/6438))
 - Bump `@metamask/base-controller` from `^8.2.0` to `^8.3.0` ([#6465](https://github.com/MetaMask/core/pull/6465))
+- 
 
 ## [0.12.1]
 

--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -10,15 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add unique name validation for account groups to prevent duplicate group names ([#6492](https://github.com/MetaMask/core/pull/6492))
-  - `setAccountGroupName` now validates that group names are unique across all groups
-  - Added `isAccountGroupNameUnique` utility function in `group.ts` for checking name uniqueness
-  - Names are trimmed of leading/trailing whitespace before comparison to prevent accidental duplicates
+  - `setAccountGroupName` now validates that group names are unique across all groups.
+  - Added `isAccountGroupNameUnique` utility function to check name uniqueness.
+  - Names are trimmed of leading/trailing whitespace before comparison to prevent accidental duplicates.
 
 ### Changed
 
 - **BREAKING:** Remove support for `AccountsController:accountRenamed` event handling ([#6438](https://github.com/MetaMask/core/pull/6438))
 - Bump `@metamask/base-controller` from `^8.2.0` to `^8.3.0` ([#6465](https://github.com/MetaMask/core/pull/6465))
-- 
 
 ## [0.12.1]
 

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -1949,6 +1949,82 @@ describe('AccountTreeController', () => {
         controller.state.accountWalletsMetadata[nonExistentWalletId],
       ).toBeUndefined();
     });
+
+    it('should allow setting the same name for the same group', () => {
+      const { controller } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      controller.init();
+
+      const wallets = controller.getAccountWalletObjects();
+      const groups = Object.values(wallets[0].groups);
+      const groupId = groups[0].id;
+
+      const customName = 'My Custom Group';
+
+      // Set the name first time - should succeed
+      controller.setAccountGroupName(groupId, customName);
+
+      // Set the same name again for the same group - should succeed
+      expect(() => {
+        controller.setAccountGroupName(groupId, customName);
+      }).not.toThrow();
+    });
+
+    it('should prevent setting duplicate names across different groups', () => {
+      const { controller } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1, MOCK_HD_ACCOUNT_2],
+        keyrings: [MOCK_HD_KEYRING_1, MOCK_HD_KEYRING_2],
+      });
+
+      controller.init();
+
+      const wallets = controller.getAccountWalletObjects();
+
+      // We should have 2 wallets (one for each keyring)
+      expect(wallets).toHaveLength(2);
+
+      const wallet1 = wallets[0];
+      const wallet2 = wallets[1];
+      const groups1 = Object.values(wallet1.groups);
+      const groups2 = Object.values(wallet2.groups);
+
+      expect(groups1.length).toBeGreaterThanOrEqual(1);
+      expect(groups2.length).toBeGreaterThanOrEqual(1);
+
+      const groupId1 = groups1[0].id;
+      const groupId2 = groups2[0].id;
+      const duplicateName = 'Duplicate Group Name';
+
+      // Set name for first group - should succeed
+      controller.setAccountGroupName(groupId1, duplicateName);
+
+      // Try to set the same name for second group - should throw
+      expect(() => {
+        controller.setAccountGroupName(groupId2, duplicateName);
+      }).toThrow('Account group name already exists');
+    });
+
+    it('should ensure unique names when generating default names', () => {
+      const { controller } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1, MOCK_HD_ACCOUNT_2],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      controller.init();
+
+      const wallets = controller.getAccountWalletObjects();
+      const groups = Object.values(wallets[0].groups);
+
+      // All groups should have unique names by default
+      const names = groups.map((group) => group.metadata.name);
+      const uniqueNames = new Set(names);
+
+      expect(uniqueNames.size).toBe(names.length);
+      expect(names.every((name) => name.length > 0)).toBe(true);
+    });
   });
 
   describe('Fallback Naming', () => {

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -2025,6 +2025,39 @@ describe('AccountTreeController', () => {
       expect(uniqueNames.size).toBe(names.length);
       expect(names.every((name) => name.length > 0)).toBe(true);
     });
+
+    it('should prevent duplicate names when comparing trimmed names', () => {
+      const { controller } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1, MOCK_HD_ACCOUNT_2],
+        keyrings: [MOCK_HD_KEYRING_1, MOCK_HD_KEYRING_2],
+      });
+
+      controller.init();
+
+      const wallets = controller.getAccountWalletObjects();
+      expect(wallets).toHaveLength(2);
+
+      const wallet1 = wallets[0];
+      const wallet2 = wallets[1];
+      const groups1 = Object.values(wallet1.groups);
+      const groups2 = Object.values(wallet2.groups);
+
+      expect(groups1.length).toBeGreaterThanOrEqual(1);
+      expect(groups2.length).toBeGreaterThanOrEqual(1);
+
+      const groupId1 = groups1[0].id;
+      const groupId2 = groups2[0].id;
+
+      // Set name for first group with trailing spaces
+      const nameWithSpaces = '  My Group Name  ';
+      controller.setAccountGroupName(groupId1, nameWithSpaces);
+
+      // Try to set the same name for second group with different spacing - should throw
+      const nameWithDifferentSpacing = ' My Group Name ';
+      expect(() => {
+        controller.setAccountGroupName(groupId2, nameWithDifferentSpacing);
+      }).toThrow('Account group name already exists');
+    });
   });
 
   describe('Fallback Naming', () => {

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -1950,7 +1950,7 @@ describe('AccountTreeController', () => {
       ).toBeUndefined();
     });
 
-    it('should allow setting the same name for the same group', () => {
+    it('allows setting the same name for the same group', () => {
       const { controller } = setup({
         accounts: [MOCK_HD_ACCOUNT_1],
         keyrings: [MOCK_HD_KEYRING_1],
@@ -1973,7 +1973,7 @@ describe('AccountTreeController', () => {
       }).not.toThrow();
     });
 
-    it('should prevent setting duplicate names across different groups', () => {
+    it('prevents setting duplicate names across different groups', () => {
       const { controller } = setup({
         accounts: [MOCK_HD_ACCOUNT_1, MOCK_HD_ACCOUNT_2],
         keyrings: [MOCK_HD_KEYRING_1, MOCK_HD_KEYRING_2],
@@ -2007,7 +2007,7 @@ describe('AccountTreeController', () => {
       }).toThrow('Account group name already exists');
     });
 
-    it('should ensure unique names when generating default names', () => {
+    it('ensures unique names when generating default names', () => {
       const { controller } = setup({
         accounts: [MOCK_HD_ACCOUNT_1, MOCK_HD_ACCOUNT_2],
         keyrings: [MOCK_HD_KEYRING_1],
@@ -2026,7 +2026,7 @@ describe('AccountTreeController', () => {
       expect(names.every((name) => name.length > 0)).toBe(true);
     });
 
-    it('should prevent duplicate names when comparing trimmed names', () => {
+    it('prevents duplicate names when comparing trimmed names', () => {
       const { controller } = setup({
         accounts: [MOCK_HD_ACCOUNT_1, MOCK_HD_ACCOUNT_2],
         keyrings: [MOCK_HD_KEYRING_1, MOCK_HD_KEYRING_2],

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -694,6 +694,23 @@ export class AccountTreeController extends BaseController<
   }
 
   /**
+   * Asserts that an account group name is unique across all groups.
+   *
+   * @param groupId - The account group ID to exclude from the check.
+   * @param name - The name to validate for uniqueness.
+   * @throws Error if the name already exists in another group.
+   */
+  #assertAccountGroupNameIsUnique(groupId: AccountGroupId, name: string): void {
+    for (const wallet of Object.values(this.state.accountTree.wallets)) {
+      for (const [currentGroupId, group] of Object.entries(wallet.groups)) {
+        if (currentGroupId !== groupId && group.metadata.name === name) {
+          throw new Error('Account group name already exists');
+        }
+      }
+    }
+  }
+
+  /**
    * Gets the currently selected account group ID.
    *
    * @returns The selected account group ID or empty string if none selected.
@@ -891,10 +908,14 @@ export class AccountTreeController extends BaseController<
    * @param groupId - The account group ID.
    * @param name - The custom name to set.
    * @throws If the account group ID is not found in the current tree.
+   * @throws If the account group name already exists.
    */
   setAccountGroupName(groupId: AccountGroupId, name: string): void {
     // Validate that the group exists in the current tree
     this.#assertAccountGroupExists(groupId);
+
+    // Validate that the name is unique
+    this.#assertAccountGroupNameIsUnique(groupId, name);
 
     this.update((state) => {
       // Update persistent metadata

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -12,7 +12,7 @@ import { isEvmAccountType } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
 import type { AccountGroupObject } from './group';
-import { assertAccountGroupNameIsUnique } from './group';
+import { isAccountGroupNameUnique } from './group';
 import type { Rule } from './rule';
 import { EntropyRule } from './rules/entropy';
 import { KeyringRule } from './rules/keyring';
@@ -695,6 +695,19 @@ export class AccountTreeController extends BaseController<
   }
 
   /**
+   * Asserts that an account group name is unique across all groups.
+   *
+   * @param groupId - The account group ID to exclude from the check.
+   * @param name - The name to validate for uniqueness.
+   * @throws Error if the name already exists in another group.
+   */
+  #assertAccountGroupNameIsUnique(groupId: AccountGroupId, name: string): void {
+    if (!isAccountGroupNameUnique(this.state, groupId, name)) {
+      throw new Error('Account group name already exists');
+    }
+  }
+
+  /**
    * Gets the currently selected account group ID.
    *
    * @returns The selected account group ID or empty string if none selected.
@@ -899,7 +912,7 @@ export class AccountTreeController extends BaseController<
     this.#assertAccountGroupExists(groupId);
 
     // Validate that the name is unique
-    assertAccountGroupNameIsUnique(this.state, groupId, name);
+    this.#assertAccountGroupNameIsUnique(groupId, name);
 
     this.update((state) => {
       // Update persistent metadata

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -12,6 +12,7 @@ import { isEvmAccountType } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
 import type { AccountGroupObject } from './group';
+import { assertAccountGroupNameIsUnique } from './group';
 import type { Rule } from './rule';
 import { EntropyRule } from './rules/entropy';
 import { KeyringRule } from './rules/keyring';
@@ -694,23 +695,6 @@ export class AccountTreeController extends BaseController<
   }
 
   /**
-   * Asserts that an account group name is unique across all groups.
-   *
-   * @param groupId - The account group ID to exclude from the check.
-   * @param name - The name to validate for uniqueness.
-   * @throws Error if the name already exists in another group.
-   */
-  #assertAccountGroupNameIsUnique(groupId: AccountGroupId, name: string): void {
-    for (const wallet of Object.values(this.state.accountTree.wallets)) {
-      for (const [currentGroupId, group] of Object.entries(wallet.groups)) {
-        if (currentGroupId !== groupId && group.metadata.name === name) {
-          throw new Error('Account group name already exists');
-        }
-      }
-    }
-  }
-
-  /**
    * Gets the currently selected account group ID.
    *
    * @returns The selected account group ID or empty string if none selected.
@@ -915,7 +899,7 @@ export class AccountTreeController extends BaseController<
     this.#assertAccountGroupExists(groupId);
 
     // Validate that the name is unique
-    this.#assertAccountGroupNameIsUnique(groupId, name);
+    assertAccountGroupNameIsUnique(this.state, groupId, name);
 
     this.update((state) => {
       // Update persistent metadata

--- a/packages/account-tree-controller/src/group.ts
+++ b/packages/account-tree-controller/src/group.ts
@@ -5,7 +5,8 @@ import {
 import type { AccountGroupId } from '@metamask/account-api';
 import type { AccountId } from '@metamask/accounts-controller';
 
-import type { UpdatableField, ExtractFieldValues } from './type-utils.js';
+import type { UpdatableField, ExtractFieldValues } from './type-utils';
+import type { AccountTreeControllerState } from './types';
 
 /**
  * Persisted metadata for account groups (stored in controller state for persistence/sync).
@@ -84,3 +85,27 @@ export type AccountGroupObjectOf<GroupType extends AccountGroupType> = Extract<
     },
   { type: GroupType }
 >['object'];
+
+/**
+ * Asserts that an account group name is unique across all groups.
+ *
+ * @param state - The account tree controller state.
+ * @param groupId - The account group ID to exclude from the check.
+ * @param name - The name to validate for uniqueness.
+ * @throws Error if the name already exists in another group.
+ */
+export function assertAccountGroupNameIsUnique(
+  state: AccountTreeControllerState,
+  groupId: AccountGroupId,
+  name: string,
+): void {
+  const trimmedName = name.trim();
+
+  for (const wallet of Object.values(state.accountTree.wallets)) {
+    for (const group of Object.values(wallet.groups)) {
+      if (group.id !== groupId && group.metadata.name.trim() === trimmedName) {
+        throw new Error('Account group name already exists');
+      }
+    }
+  }
+}

--- a/packages/account-tree-controller/src/group.ts
+++ b/packages/account-tree-controller/src/group.ts
@@ -87,25 +87,27 @@ export type AccountGroupObjectOf<GroupType extends AccountGroupType> = Extract<
 >['object'];
 
 /**
- * Asserts that an account group name is unique across all groups.
+ * Checks if an account group name is unique across all groups.
  *
  * @param state - The account tree controller state.
  * @param groupId - The account group ID to exclude from the check.
  * @param name - The name to validate for uniqueness.
- * @throws Error if the name already exists in another group.
+ * @returns True if the name is unique, false otherwise.
  */
-export function assertAccountGroupNameIsUnique(
+export function isAccountGroupNameUnique(
   state: AccountTreeControllerState,
   groupId: AccountGroupId,
   name: string,
-): void {
+): boolean {
   const trimmedName = name.trim();
 
   for (const wallet of Object.values(state.accountTree.wallets)) {
     for (const group of Object.values(wallet.groups)) {
       if (group.id !== groupId && group.metadata.name.trim() === trimmedName) {
-        throw new Error('Account group name already exists');
+        return false;
       }
     }
   }
+
+  return true;
 }

--- a/packages/account-tree-controller/src/index.ts
+++ b/packages/account-tree-controller/src/index.ts
@@ -1,5 +1,6 @@
 export type { AccountWalletObject } from './wallet';
 export type { AccountGroupObject } from './group';
+export { isAccountGroupNameUnique } from './group';
 
 export type {
   AccountTreeControllerState,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Currently there is no method for ensuring account group uniqeuness. This PR adds function that does that.

- Implemented a new private method `#assertAccountGroupNameIsUnique` to ensure account group names are unique across different groups.
- Updated `setAccountGroupName` to validate uniqueness before setting a name.
- Added tests to verify that the same name can be set for the same group and that duplicate names across different groups are prevented.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
