### PR TITLE
refactor: migrate `SignatureController` to `@metamask/messenger`

### DIFF
--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Use new `Messenger` from `@metamask/messenger` ([#6496](https://github.com/MetaMask/core/pull/6496))
+  - Previously, `SignatureController` accepted a `RestrictedMessenger` instance from `@metamask/base-controller`.
 - Bump `@metamask/base-controller` from `^8.1.0` to `^8.3.0` ([#6355](https://github.com/MetaMask/core/pull/6355), [#6465](https://github.com/MetaMask/core/pull/6465))
 
 ## [33.0.0]

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -50,6 +50,7 @@
     "@metamask/base-controller": "^8.3.0",
     "@metamask/controller-utils": "^11.12.0",
     "@metamask/eth-sig-util": "^8.2.0",
+    "@metamask/messenger": "^0.2.0",
     "@metamask/utils": "^11.4.2",
     "jsonschema": "^1.4.1",
     "lodash": "^4.17.21",

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -4,12 +4,11 @@ import type {
   AcceptResultCallbacks,
   AddResult,
 } from '@metamask/approval-controller';
-import type {
-  ControllerGetStateAction,
-  ControllerStateChangeEvent,
-  RestrictedMessenger,
-} from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import {
+  BaseController,
+  type ControllerGetStateAction,
+  type ControllerStateChangeEvent,
+} from '@metamask/base-controller/next';
 import type { TraceCallback, TraceContext } from '@metamask/controller-utils';
 import {
   ApprovalType,
@@ -28,6 +27,7 @@ import {
   SigningStage,
   type AddLog,
 } from '@metamask/logging-controller';
+import type { Messenger } from '@metamask/messenger';
 import type { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
 import type { Hex, Json } from '@metamask/utils';
 // This package purposefully relies on Node's EventEmitter module.
@@ -140,12 +140,10 @@ export type SignatureControllerActions = GetSignatureState;
 
 export type SignatureControllerEvents = SignatureStateChange;
 
-export type SignatureControllerMessenger = RestrictedMessenger<
+export type SignatureControllerMessenger = Messenger<
   typeof controllerName,
   SignatureControllerActions | AllowedActions,
-  SignatureControllerEvents,
-  AllowedActions['type'],
-  never
+  SignatureControllerEvents
 >;
 
 export type SignatureControllerOptions = {
@@ -675,7 +673,7 @@ export class SignatureController extends BaseController<
 
       switch (type) {
         case SignatureRequestType.PersonalSign:
-          signature = await this.messagingSystem.call(
+          signature = await this.messenger.call(
             'KeyringController:signPersonalMessage',
             // Keyring controller temporarily using message manager types.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -688,7 +686,7 @@ export class SignatureController extends BaseController<
             ? this.#parseTypedData(messageParams, metadata.version)
             : messageParams;
 
-          signature = await this.messagingSystem.call(
+          signature = await this.messenger.call(
             'KeyringController:signTypedMessage',
             finalRequest,
             metadata.version as SignTypedDataVersion,
@@ -767,7 +765,7 @@ export class SignatureController extends BaseController<
       parentContext: traceContext,
     });
 
-    return (await this.messagingSystem.call(
+    return (await this.messenger.call(
       'ApprovalController:addRequest',
       {
         id,
@@ -870,7 +868,7 @@ export class SignatureController extends BaseController<
       version,
     );
 
-    this.messagingSystem.call('LoggingController:add', {
+    this.messenger.call('LoggingController:add', {
       type: LogType.EthSignLog,
       data: {
         signingMethod,
@@ -912,7 +910,7 @@ export class SignatureController extends BaseController<
       throw new Error('Network client ID not found in request');
     }
 
-    const networkClient = this.messagingSystem.call(
+    const networkClient = this.messenger.call(
       'NetworkController:getNetworkClientById',
       networkClientId,
     );
@@ -953,7 +951,7 @@ export class SignatureController extends BaseController<
   }
 
   #getInternalAccounts(): Hex[] {
-    const state = this.messagingSystem.call('AccountsController:getState');
+    const state = this.messenger.call('AccountsController:getState');
 
     /* istanbul ignore next */
     return Object.values(state.internalAccounts?.accounts ?? {})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4497,6 +4497,7 @@ __metadata:
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/keyring-controller": "npm:^23.0.0"
     "@metamask/logging-controller": "npm:^6.0.4"
+    "@metamask/messenger": "npm:^0.2.0"
     "@metamask/network-controller": "npm:^24.1.0"
     "@metamask/utils": "npm:^11.4.2"
     "@types/jest": "npm:^27.4.1"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This PR migrates `SignatureController` to the new `@metamask/messenger` message bus, as opposed to the one exported from `@metamask/base-controller`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Related to #5626

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes