### PR TITLE
refactor: migrate `ShieldController` to @metamask/messenger

### DIFF
--- a/packages/shield-controller/CHANGELOG.md
+++ b/packages/shield-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Use new `Messenger` from `@metamask/messenger` ([#6497](https://github.com/MetaMask/core/pull/6497))
+  - Previously, `ShieldController` accepted a `RestrictedMessenger` instance from `@metamask/base-controller`.
 - Bump `@metamask/base-controller` from `^8.2.0` to `^8.3.0` ([#6465](https://github.com/MetaMask/core/pull/6465))
 
 ## [0.1.2]

--- a/packages/shield-controller/package.json
+++ b/packages/shield-controller/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^8.3.0",
+    "@metamask/messenger": "^0.2.0",
     "@metamask/utils": "^11.4.2"
   },
   "devDependencies": {

--- a/packages/shield-controller/src/ShieldController.test.ts
+++ b/packages/shield-controller/src/ShieldController.test.ts
@@ -21,7 +21,7 @@ function setup({
   transactionHistoryLimit?: number;
 } = {}) {
   const backend = createMockBackend();
-  const { messenger, baseMessenger } = createMockMessenger();
+  const { messenger, rootMessenger } = createMockMessenger();
 
   const controller = new ShieldController({
     backend,
@@ -33,7 +33,7 @@ function setup({
   return {
     controller,
     messenger,
-    baseMessenger,
+    rootMessenger,
     backend,
   };
 }
@@ -41,15 +41,15 @@ function setup({
 describe('ShieldController', () => {
   describe('checkCoverage', () => {
     it('should trigger checkCoverage when a new transaction is added', async () => {
-      const { baseMessenger, backend } = setup();
+      const { rootMessenger, backend } = setup();
       const txMeta = generateMockTxMeta();
       const coverageResultReceived = new Promise<void>((resolve) => {
-        baseMessenger.subscribe(
+        rootMessenger.subscribe(
           'ShieldController:coverageResultReceived',
           (_coverageResult) => resolve(),
         );
       });
-      baseMessenger.publish(
+      rootMessenger.publish(
         'TransactionController:stateChange',
         { transactions: [txMeta] } as TransactionControllerState,
         undefined as never,
@@ -59,11 +59,11 @@ describe('ShieldController', () => {
     });
 
     it('should no longer trigger checkCoverage when controller is stopped', async () => {
-      const { controller, baseMessenger, backend } = setup();
+      const { controller, rootMessenger, backend } = setup();
       controller.stop();
       const txMeta = generateMockTxMeta();
       const coverageResultReceived = new Promise<void>((resolve, reject) => {
-        baseMessenger.subscribe(
+        rootMessenger.subscribe(
           'ShieldController:coverageResultReceived',
           (_coverageResult) => resolve(),
         );
@@ -72,7 +72,7 @@ describe('ShieldController', () => {
           100,
         );
       });
-      baseMessenger.publish(
+      rootMessenger.publish(
         'TransactionController:stateChange',
         { transactions: [txMeta] } as TransactionControllerState,
         undefined as never,
@@ -111,17 +111,17 @@ describe('ShieldController', () => {
     });
 
     it('should check coverage when a transaction is simulated', async () => {
-      const { baseMessenger, backend } = setup();
+      const { rootMessenger, backend } = setup();
       const txMeta = generateMockTxMeta();
       const coverageResultReceived = new Promise<void>((resolve) => {
-        baseMessenger.subscribe(
+        rootMessenger.subscribe(
           'ShieldController:coverageResultReceived',
           (_coverageResult) => resolve(),
         );
       });
 
       // Add transaction.
-      baseMessenger.publish(
+      rootMessenger.publish(
         'TransactionController:stateChange',
         { transactions: [txMeta] } as TransactionControllerState,
         undefined as never,
@@ -133,7 +133,7 @@ describe('ShieldController', () => {
       txMeta.simulationData = {
         tokenBalanceChanges: [],
       };
-      baseMessenger.publish(
+      rootMessenger.publish(
         'TransactionController:stateChange',
         { transactions: [txMeta] } as TransactionControllerState,
         undefined as never,

--- a/packages/shield-controller/src/ShieldController.ts
+++ b/packages/shield-controller/src/ShieldController.ts
@@ -1,8 +1,9 @@
-import { BaseController } from '@metamask/base-controller';
-import type {
-  ControllerStateChangeEvent,
-  RestrictedMessenger,
-} from '@metamask/base-controller';
+import {
+  BaseController,
+  type ControllerGetStateAction,
+  type ControllerStateChangeEvent,
+} from '@metamask/base-controller/next';
+import type { Messenger } from '@metamask/messenger';
 import type {
   TransactionControllerStateChangeEvent,
   TransactionMeta,
@@ -47,6 +48,11 @@ export function getDefaultShieldControllerState(): ShieldControllerState {
   };
 }
 
+export type ShieldControllerGetStateAction = ControllerGetStateAction<
+  typeof controllerName,
+  ShieldControllerState
+>;
+
 export type ShieldControllerCheckCoverageAction = {
   type: `${typeof controllerName}:checkCoverage`;
   handler: ShieldController['checkCoverage'];
@@ -55,7 +61,9 @@ export type ShieldControllerCheckCoverageAction = {
 /**
  * The internal actions available to the ShieldController.
  */
-export type ShieldControllerActions = ShieldControllerCheckCoverageAction;
+export type ShieldControllerActions =
+  | ShieldControllerGetStateAction
+  | ShieldControllerCheckCoverageAction;
 
 export type ShieldControllerCoverageResultReceivedEvent = {
   type: `${typeof controllerName}:coverageResultReceived`;
@@ -75,11 +83,6 @@ export type ShieldControllerEvents =
   | ShieldControllerStateChangeEvent;
 
 /**
- * The external actions available to the ShieldController.
- */
-type AllowedActions = never;
-
-/**
  * The external events available to the ShieldController.
  */
 type AllowedEvents = TransactionControllerStateChangeEvent;
@@ -87,12 +90,10 @@ type AllowedEvents = TransactionControllerStateChangeEvent;
 /**
  * The messenger of the {@link ShieldController}.
  */
-export type ShieldControllerMessenger = RestrictedMessenger<
+export type ShieldControllerMessenger = Messenger<
   typeof controllerName,
-  ShieldControllerActions | AllowedActions,
-  ShieldControllerEvents | AllowedEvents,
-  AllowedActions['type'],
-  AllowedEvents['type']
+  ShieldControllerActions,
+  ShieldControllerEvents | AllowedEvents
 >;
 
 /**
@@ -160,7 +161,7 @@ export class ShieldController extends BaseController<
   }
 
   start() {
-    this.messagingSystem.subscribe(
+    this.messenger.subscribe(
       'TransactionController:stateChange',
       this.#transactionControllerStateChangeHandler,
       (state) => state.transactions,
@@ -168,7 +169,7 @@ export class ShieldController extends BaseController<
   }
 
   stop() {
-    this.messagingSystem.unsubscribe(
+    this.messenger.unsubscribe(
       'TransactionController:stateChange',
       this.#transactionControllerStateChangeHandler,
     );
@@ -211,7 +212,7 @@ export class ShieldController extends BaseController<
     const coverageResult = await this.#fetchCoverageResult(txMeta);
 
     // Publish coverage result
-    this.messagingSystem.publish(
+    this.messenger.publish(
       `${controllerName}:coverageResultReceived`,
       coverageResult,
     );

--- a/packages/shield-controller/tests/mocks/messenger.ts
+++ b/packages/shield-controller/tests/mocks/messenger.ts
@@ -1,34 +1,61 @@
-import { Messenger } from '@metamask/base-controller';
-
-import type {
-  ExtractAvailableAction,
-  ExtractAvailableEvent,
-} from '../../../base-controller/tests/helpers';
-import type { ShieldControllerActions } from '../../src';
 import {
-  type ShieldControllerEvents,
-  type ShieldControllerMessenger,
-} from '../../src';
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  type MessengerActions,
+  type MessengerEvents,
+  type MockAnyNamespace,
+} from '@metamask/messenger';
+
+import { type ShieldControllerMessenger } from '../../src';
 import { controllerName } from '../../src/constants';
+
+type AllShieldControllerActions = MessengerActions<ShieldControllerMessenger>;
+
+type AllShieldControllerEvents = MessengerEvents<ShieldControllerMessenger>;
+
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  AllShieldControllerActions,
+  AllShieldControllerEvents
+>;
+
+/**
+ * Constructs the root messenger.
+ *
+ * @returns A root messenger.
+ */
+function getRootMessenger(): RootMessenger {
+  return new Messenger({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+}
 
 /**
  * Create a mock messenger.
  *
  * @returns A mock messenger.
  */
-export function createMockMessenger() {
-  const baseMessenger = new Messenger<
-    ShieldControllerActions | ExtractAvailableAction<ShieldControllerMessenger>,
-    ShieldControllerEvents | ExtractAvailableEvent<ShieldControllerMessenger>
-  >();
-  const messenger = baseMessenger.getRestricted({
-    name: controllerName,
-    allowedActions: [],
-    allowedEvents: ['TransactionController:stateChange'],
+export function createMockMessenger(): {
+  rootMessenger: RootMessenger;
+  messenger: ShieldControllerMessenger;
+} {
+  const rootMessenger = getRootMessenger();
+  const messenger = new Messenger<
+    typeof controllerName,
+    AllShieldControllerActions,
+    AllShieldControllerEvents,
+    RootMessenger
+  >({
+    namespace: controllerName,
+    parent: rootMessenger,
+  });
+  rootMessenger.delegate({
+    messenger,
+    events: ['TransactionController:stateChange'],
   });
 
   return {
-    baseMessenger,
+    rootMessenger,
     messenger,
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4469,6 +4469,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^8.3.0"
+    "@metamask/messenger": "npm:^0.2.0"
     "@metamask/transaction-controller": "npm:^60.2.0"
     "@metamask/utils": "npm:^11.4.2"
     "@ts-bridge/cli": "npm:^0.6.1"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This PR migrates `SignatureController` to the new `@metamask/messenger` message bus, as opposed to the one exported from `@metamask/base-controller`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Related to #5626

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes