### PR TITLE
refactor: migrate `RateLimitController` to `@metamask/messenger`

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -323,9 +323,7 @@
     "@typescript-eslint/prefer-readonly": 1
   },
   "packages/rate-limit-controller/src/RateLimitController.ts": {
-    "jsdoc/check-tag-names": 4,
-    "jsdoc/require-returns": 1,
-    "jsdoc/tag-lines": 3
+    "jsdoc/check-tag-names": 4
   },
   "packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts": {
     "import-x/order": 1,

--- a/packages/rate-limit-controller/CHANGELOG.md
+++ b/packages/rate-limit-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Use new `Messenger` from `@metamask/messenger` ([#6503](https://github.com/MetaMask/core/pull/6503))
+  - Previously, `RateLimitController` accepted a `RestrictedMessenger` instance from `@metamask/base-controller`.
 - Bump `@metamask/utils` from `^11.2.0` to `^11.4.2` ([#6054](https://github.com/MetaMask/core/pull/6054))
 - Bump `@metamask/base-controller` from `^8.0.0` to `^8.3.0` ([#5722](https://github.com/MetaMask/core/pull/5722), [#6284](https://github.com/MetaMask/core/pull/6284), [#6355](https://github.com/MetaMask/core/pull/6355), [#6465](https://github.com/MetaMask/core/pull/6465))
 

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^8.3.0",
+    "@metamask/messenger": "^0.2.0",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/utils": "^11.4.2"
   },

--- a/packages/rate-limit-controller/src/RateLimitController.test.ts
+++ b/packages/rate-limit-controller/src/RateLimitController.test.ts
@@ -1,12 +1,15 @@
-import { Messenger } from '@metamask/base-controller';
+import {
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  type MessengerActions,
+  type MessengerEvents,
+  type MockAnyNamespace,
+} from '@metamask/messenger';
 
-import type {
-  RateLimitControllerActions,
-  RateLimitControllerEvents,
-} from './RateLimitController';
+import type { RateLimitMessenger } from './RateLimitController';
 import { RateLimitController } from './RateLimitController';
 
-const name = 'RateLimitController';
+const controllerName = 'RateLimitController';
 
 const implementations = {
   apiWithoutCustomLimit: {
@@ -21,29 +24,48 @@ const implementations = {
 
 type RateLimitedApis = typeof implementations;
 
+type AllRateLimitControllerActions = MessengerActions<
+  RateLimitMessenger<RateLimitedApis>
+>;
+
+type AllRateLimitControllerEvents = MessengerEvents<
+  RateLimitMessenger<RateLimitedApis>
+>;
+
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  AllRateLimitControllerActions,
+  AllRateLimitControllerEvents
+>;
+
 /**
- * Constructs an unrestricted messenger.
+ * Creates and returns a root messenger for testing
  *
- * @returns An unrestricted messenger.
+ * @returns A messenger instance
  */
-function getUnrestrictedMessenger() {
-  return new Messenger<
-    RateLimitControllerActions<RateLimitedApis>,
-    RateLimitControllerEvents<RateLimitedApis>
-  >();
+function getRootMessenger(): RootMessenger {
+  return new Messenger({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
 }
 
 /**
- * Constructs a restricted messenger.
+ * Constructs a messenger for the RateLimitController.
  *
- * @param messenger - An optional unrestricted messenger
- * @returns A restricted messenger.
+ * @param rootMessenger - An optional root messenger
+ * @returns A messenger for the RateLimitController.
  */
-function getRestrictedMessenger(messenger = getUnrestrictedMessenger()) {
-  return messenger.getRestricted({
-    name,
-    allowedActions: [],
-    allowedEvents: [],
+function getMessenger(
+  rootMessenger = getRootMessenger(),
+): RateLimitMessenger<RateLimitedApis> {
+  return new Messenger<
+    typeof controllerName,
+    AllRateLimitControllerActions,
+    AllRateLimitControllerEvents,
+    RootMessenger
+  >({
+    namespace: controllerName,
+    parent: rootMessenger,
   });
 }
 
@@ -62,8 +84,8 @@ describe('RateLimitController', () => {
   });
 
   it('action: RateLimitController:call', async () => {
-    const unrestricted = getUnrestrictedMessenger();
-    const messenger = getRestrictedMessenger(unrestricted);
+    const rootMessenger = getRootMessenger();
+    const messenger = getMessenger(rootMessenger);
 
     // Registers action handlers
     new RateLimitController({
@@ -72,7 +94,7 @@ describe('RateLimitController', () => {
     });
 
     expect(
-      await unrestricted.call(
+      await rootMessenger.call(
         'RateLimitController:call',
         origin,
         'apiWithoutCustomLimit',
@@ -88,7 +110,7 @@ describe('RateLimitController', () => {
   });
 
   it('uses apiWithoutCustomLimit method', async () => {
-    const messenger = getRestrictedMessenger();
+    const messenger = getMessenger();
 
     const controller = new RateLimitController({
       implementations,
@@ -105,7 +127,7 @@ describe('RateLimitController', () => {
   });
 
   it('returns false if rate-limited', async () => {
-    const messenger = getRestrictedMessenger();
+    const messenger = getMessenger();
     const controller = new RateLimitController({
       implementations,
       messenger,
@@ -154,7 +176,7 @@ describe('RateLimitController', () => {
   });
 
   it('rate limit is reset after timeout', async () => {
-    const messenger = getRestrictedMessenger();
+    const messenger = getMessenger();
     const controller = new RateLimitController({
       implementations,
       messenger,
@@ -198,7 +220,7 @@ describe('RateLimitController', () => {
   });
 
   it('timeout is only applied once per window', async () => {
-    const messenger = getRestrictedMessenger();
+    const messenger = getMessenger();
     const controller = new RateLimitController({
       implementations,
       messenger,

--- a/packages/rate-limit-controller/src/RateLimitController.ts
+++ b/packages/rate-limit-controller/src/RateLimitController.ts
@@ -1,15 +1,15 @@
-import type {
-  ActionConstraint,
-  RestrictedMessenger,
-  ControllerGetStateAction,
-  ControllerStateChangeEvent,
-} from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import {
+  BaseController,
+  type ControllerGetStateAction,
+  type ControllerStateChangeEvent,
+} from '@metamask/base-controller/next';
+import type { Messenger, ActionConstraint } from '@metamask/messenger';
 import { rpcErrors } from '@metamask/rpc-errors';
 import { getKnownPropertyNames } from '@metamask/utils';
 
 /**
  * A rate-limited API endpoint.
+ *
  * @property method - The method that is rate-limited.
  * @property rateLimitTimeout - The time window in which the rate limit is applied (in ms).
  * @property rateLimitCount - The amount of calls an origin can make in the rate limit time window.
@@ -27,6 +27,7 @@ export type RateLimitedApiMap = Record<string, RateLimitedApi>;
 
 /**
  * A map of rate-limited API types to the number of requests made in a given interval for each origin and api type combination.
+ *
  * @template RateLimitedApis - A {@link RateLimitedApiMap} containing the rate-limited API endpoints that is used by the {@link RateLimitController}.
  */
 export type RateLimitedRequests<RateLimitedApis extends RateLimitedApiMap> =
@@ -34,6 +35,7 @@ export type RateLimitedRequests<RateLimitedApis extends RateLimitedApiMap> =
 
 /**
  * The state of the {@link RateLimitController}.
+ *
  * @template RateLimitedApis - A {@link RateLimitedApiMap} containing the rate-limited API endpoints that is used by the {@link RateLimitController}.
  * @property requests - An object containing the number of requests made in a given interval for each origin and api type combination.
  */
@@ -41,20 +43,26 @@ export type RateLimitState<RateLimitedApis extends RateLimitedApiMap> = {
   requests: RateLimitedRequests<RateLimitedApis>;
 };
 
-const name = 'RateLimitController';
+const controllerName = 'RateLimitController';
 
 export type RateLimitControllerStateChangeEvent<
   RateLimitedApis extends RateLimitedApiMap,
-> = ControllerStateChangeEvent<typeof name, RateLimitState<RateLimitedApis>>;
+> = ControllerStateChangeEvent<
+  typeof controllerName,
+  RateLimitState<RateLimitedApis>
+>;
 
 export type RateLimitControllerGetStateAction<
   RateLimitedApis extends RateLimitedApiMap,
-> = ControllerGetStateAction<typeof name, RateLimitState<RateLimitedApis>>;
+> = ControllerGetStateAction<
+  typeof controllerName,
+  RateLimitState<RateLimitedApis>
+>;
 
 export type RateLimitControllerCallApiAction<
   RateLimitedApis extends RateLimitedApiMap,
 > = {
-  type: `${typeof name}:call`;
+  type: `${typeof controllerName}:call`;
   handler: RateLimitController<RateLimitedApis>['call'];
 };
 
@@ -69,12 +77,10 @@ export type RateLimitControllerEvents<
 > = RateLimitControllerStateChangeEvent<RateLimitedApis>;
 
 export type RateLimitMessenger<RateLimitedApis extends RateLimitedApiMap> =
-  RestrictedMessenger<
-    typeof name,
+  Messenger<
+    typeof controllerName,
     RateLimitControllerActions<RateLimitedApis>,
-    RateLimitControllerEvents<RateLimitedApis>,
-    never,
-    never
+    RateLimitControllerEvents<RateLimitedApis>
   >;
 
 const metadata = {
@@ -87,7 +93,7 @@ const metadata = {
 export class RateLimitController<
   RateLimitedApis extends RateLimitedApiMap,
 > extends BaseController<
-  typeof name,
+  typeof controllerName,
   RateLimitState<RateLimitedApis>,
   RateLimitMessenger<RateLimitedApis>
 > {
@@ -126,7 +132,7 @@ export class RateLimitController<
       >((acc, key) => ({ ...acc, [key]: {} }), {} as never),
     };
     super({
-      name,
+      name: controllerName,
       metadata,
       messenger,
       state: { ...defaultState, ...state },
@@ -135,8 +141,8 @@ export class RateLimitController<
     this.rateLimitTimeout = rateLimitTimeout;
     this.rateLimitCount = rateLimitCount;
 
-    this.messagingSystem.registerActionHandler(
-      `${name}:call`,
+    this.messenger.registerActionHandler(
+      `${controllerName}:call`,
       (
         origin: string,
         type: keyof RateLimitedApis,
@@ -151,6 +157,7 @@ export class RateLimitController<
    * @param origin - The requesting origin.
    * @param type - The type of API call to make.
    * @param args - Arguments for the API call.
+   * @returns The result of the API call.
    */
   async call<ApiType extends keyof RateLimitedApis>(
     origin: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4316,6 +4316,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^8.3.0"
+    "@metamask/messenger": "npm:^0.2.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/utils": "npm:^11.4.2"
     "@types/jest": "npm:^27.4.1"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This PR migrates `RateLimitController ` to the new `@metamask/messenger` message bus, as opposed to the one exported from `@metamask/base-controller`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Related to #5626

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes