### PR TITLE
feat: Add new metadata properties to Web3Auth controllers

### DIFF
--- a/packages/seedless-onboarding-controller/CHANGELOG.md
+++ b/packages/seedless-onboarding-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add two new controller state metadata properties: `includeInStateLogs` and `usedInUi` ([#6504](https://github.com/MetaMask/core/pull/6504))
+
 ## [4.0.0]
 
 ### Added

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
@@ -5525,20 +5525,15 @@ describe('SeedlessOnboardingController', () => {
             ),
           ).toMatchInlineSnapshot(`
             Object {
-              "accessToken": true,
               "authConnection": "google",
               "authConnectionId": "authConnectionId",
               "authPubKey": "authPubKey",
               "groupedAuthConnectionId": "groupedAuthConnectionId",
               "isSeedlessOnboardingUserAuthenticated": false,
-              "metadataAccessToken": true,
-              "nodeAuthTokens": true,
               "passwordOutdatedCache": Object {
                 "isExpiredPwd": false,
                 "timestamp": 1234567890,
               },
-              "refreshToken": true,
-              "revokeToken": true,
               "userId": "userId",
             }
           `);

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
@@ -5455,6 +5455,9 @@ describe('SeedlessOnboardingController', () => {
               isExpiredPwd: false,
               timestamp: 1234567890,
             },
+            pendingToBeRevokedTokens: [
+              { refreshToken: 'refreshToken', revokeToken: 'revokeToken' },
+            ],
             refreshToken: 'refreshToken',
             revokeToken: 'revokeToken',
             socialBackupsMetadata: [],
@@ -5603,10 +5606,10 @@ describe('SeedlessOnboardingController', () => {
                 "isExpiredPwd": false,
                 "timestamp": 1234567890,
               },
-              pendingToBeRevokedTokens: Array [
+              "pendingToBeRevokedTokens": Array [
                 Object {
                   "refreshToken": "refreshToken",
-                  "revokeToken": "revokeToken"
+                  "revokeToken": "revokeToken",
                 },
               ],
               "refreshToken": "refreshToken",

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
@@ -5506,6 +5506,9 @@ describe('SeedlessOnboardingController', () => {
               isExpiredPwd: false,
               timestamp: 1234567890,
             },
+            pendingToBeRevokedTokens: [
+              { refreshToken: 'refreshToken', revokeToken: 'revokeToken' },
+            ],
             refreshToken: 'refreshToken',
             revokeToken: 'revokeToken',
             socialBackupsMetadata: [],
@@ -5537,6 +5540,7 @@ describe('SeedlessOnboardingController', () => {
                 "isExpiredPwd": false,
                 "timestamp": 1234567890,
               },
+              "pendingToBeRevokedTokens": true,
               "refreshToken": true,
               "revokeToken": true,
               "userId": "userId",
@@ -5564,6 +5568,9 @@ describe('SeedlessOnboardingController', () => {
               isExpiredPwd: false,
               timestamp: 1234567890,
             },
+            pendingToBeRevokedTokens: [
+              { refreshToken: 'refreshToken', revokeToken: 'revokeToken' },
+            ],
             refreshToken: 'refreshToken',
             revokeToken: 'revokeToken',
             socialBackupsMetadata: [],
@@ -5596,6 +5603,12 @@ describe('SeedlessOnboardingController', () => {
                 "isExpiredPwd": false,
                 "timestamp": 1234567890,
               },
+              pendingToBeRevokedTokens: Array [
+                Object {
+                  "refreshToken": "refreshToken",
+                  "revokeToken": "revokeToken"
+                },
+              ],
               "refreshToken": "refreshToken",
               "socialBackupsMetadata": Array [],
               "socialLoginEmail": "socialLoginEmail",
@@ -5625,6 +5638,9 @@ describe('SeedlessOnboardingController', () => {
               isExpiredPwd: false,
               timestamp: 1234567890,
             },
+            pendingToBeRevokedTokens: [
+              { refreshToken: 'refreshToken', revokeToken: 'revokeToken' },
+            ],
             refreshToken: 'refreshToken',
             revokeToken: 'revokeToken',
             socialBackupsMetadata: [],

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
@@ -5525,15 +5525,20 @@ describe('SeedlessOnboardingController', () => {
             ),
           ).toMatchInlineSnapshot(`
             Object {
+              "accessToken": true,
               "authConnection": "google",
               "authConnectionId": "authConnectionId",
               "authPubKey": "authPubKey",
               "groupedAuthConnectionId": "groupedAuthConnectionId",
               "isSeedlessOnboardingUserAuthenticated": false,
+              "metadataAccessToken": true,
+              "nodeAuthTokens": true,
               "passwordOutdatedCache": Object {
                 "isExpiredPwd": false,
                 "timestamp": 1234567890,
               },
+              "refreshToken": true,
+              "revokeToken": true,
               "userId": "userId",
             }
           `);

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
@@ -1,5 +1,8 @@
 import { keccak256AndHexify } from '@metamask/auth-network-utils';
-import type { Messenger } from '@metamask/base-controller';
+import {
+  deriveStateFromMetadata,
+  type Messenger,
+} from '@metamask/base-controller';
 import type { EncryptionKey } from '@metamask/browser-passworder';
 import {
   encrypt,
@@ -5428,6 +5431,223 @@ describe('SeedlessOnboardingController', () => {
           // The first one was removed in the catch block (line 1911)
           // The second one was removed after successful revocation
           expect(controller.state.pendingToBeRevokedTokens?.length).toBe(1);
+        },
+      );
+    });
+  });
+
+  describe('metadata', () => {
+    it('includes expected state in debug snapshots', async () => {
+      await withController(
+        {
+          state: {
+            accessToken: 'accessToken',
+            authPubKey: 'authPubKey',
+            authConnection: AuthConnection.Google,
+            authConnectionId: 'authConnectionId',
+            encryptedKeyringEncryptionKey: 'encryptedKeyringEncryptionKey',
+            encryptedSeedlessEncryptionKey: 'encryptedSeedlessEncryptionKey',
+            groupedAuthConnectionId: 'groupedAuthConnectionId',
+            isSeedlessOnboardingUserAuthenticated: true,
+            metadataAccessToken: 'metadataAccessToken',
+            nodeAuthTokens: [],
+            passwordOutdatedCache: {
+              isExpiredPwd: false,
+              timestamp: 1234567890,
+            },
+            refreshToken: 'refreshToken',
+            revokeToken: 'revokeToken',
+            socialBackupsMetadata: [],
+            socialLoginEmail: 'socialLoginEmail',
+            userId: 'userId',
+            vault: 'vault',
+            vaultEncryptionKey: 'vaultEncryptionKey',
+            vaultEncryptionSalt: 'vaultEncryptionSalt',
+          },
+        },
+        ({ controller }) => {
+          expect(
+            deriveStateFromMetadata(
+              controller.state,
+              controller.metadata,
+              'anonymous',
+            ),
+          ).toMatchInlineSnapshot(`
+            Object {
+              "authConnection": "google",
+              "authConnectionId": "authConnectionId",
+              "groupedAuthConnectionId": "groupedAuthConnectionId",
+              "isSeedlessOnboardingUserAuthenticated": false,
+              "passwordOutdatedCache": Object {
+                "isExpiredPwd": false,
+                "timestamp": 1234567890,
+              },
+            }
+          `);
+        },
+      );
+    });
+
+    it('includes expected state in state logs', async () => {
+      await withController(
+        {
+          state: {
+            accessToken: 'accessToken',
+            authPubKey: 'authPubKey',
+            authConnection: AuthConnection.Google,
+            authConnectionId: 'authConnectionId',
+            encryptedKeyringEncryptionKey: 'encryptedKeyringEncryptionKey',
+            encryptedSeedlessEncryptionKey: 'encryptedSeedlessEncryptionKey',
+            groupedAuthConnectionId: 'groupedAuthConnectionId',
+            isSeedlessOnboardingUserAuthenticated: true,
+            metadataAccessToken: 'metadataAccessToken',
+            nodeAuthTokens: [],
+            passwordOutdatedCache: {
+              isExpiredPwd: false,
+              timestamp: 1234567890,
+            },
+            refreshToken: 'refreshToken',
+            revokeToken: 'revokeToken',
+            socialBackupsMetadata: [],
+            socialLoginEmail: 'socialLoginEmail',
+            userId: 'userId',
+            vault: 'vault',
+            vaultEncryptionKey: 'vaultEncryptionKey',
+            vaultEncryptionSalt: 'vaultEncryptionSalt',
+          },
+        },
+        ({ controller }) => {
+          expect(
+            deriveStateFromMetadata(
+              controller.state,
+              controller.metadata,
+              'includeInStateLogs',
+            ),
+          ).toMatchInlineSnapshot(`
+            Object {
+              "accessToken": true,
+              "authConnection": "google",
+              "authConnectionId": "authConnectionId",
+              "authPubKey": "authPubKey",
+              "groupedAuthConnectionId": "groupedAuthConnectionId",
+              "isSeedlessOnboardingUserAuthenticated": false,
+              "metadataAccessToken": true,
+              "nodeAuthTokens": true,
+              "passwordOutdatedCache": Object {
+                "isExpiredPwd": false,
+                "timestamp": 1234567890,
+              },
+              "refreshToken": true,
+              "revokeToken": true,
+              "userId": "userId",
+            }
+          `);
+        },
+      );
+    });
+
+    it('persists expected state', async () => {
+      await withController(
+        {
+          state: {
+            accessToken: 'accessToken',
+            authPubKey: 'authPubKey',
+            authConnection: AuthConnection.Google,
+            authConnectionId: 'authConnectionId',
+            encryptedKeyringEncryptionKey: 'encryptedKeyringEncryptionKey',
+            encryptedSeedlessEncryptionKey: 'encryptedSeedlessEncryptionKey',
+            groupedAuthConnectionId: 'groupedAuthConnectionId',
+            isSeedlessOnboardingUserAuthenticated: true,
+            metadataAccessToken: 'metadataAccessToken',
+            nodeAuthTokens: [],
+            passwordOutdatedCache: {
+              isExpiredPwd: false,
+              timestamp: 1234567890,
+            },
+            refreshToken: 'refreshToken',
+            revokeToken: 'revokeToken',
+            socialBackupsMetadata: [],
+            socialLoginEmail: 'socialLoginEmail',
+            userId: 'userId',
+            vault: 'vault',
+            vaultEncryptionKey: 'vaultEncryptionKey',
+            vaultEncryptionSalt: 'vaultEncryptionSalt',
+          },
+        },
+        ({ controller }) => {
+          expect(
+            deriveStateFromMetadata(
+              controller.state,
+              controller.metadata,
+              'persist',
+            ),
+          ).toMatchInlineSnapshot(`
+            Object {
+              "authConnection": "google",
+              "authConnectionId": "authConnectionId",
+              "authPubKey": "authPubKey",
+              "encryptedKeyringEncryptionKey": "encryptedKeyringEncryptionKey",
+              "encryptedSeedlessEncryptionKey": "encryptedSeedlessEncryptionKey",
+              "groupedAuthConnectionId": "groupedAuthConnectionId",
+              "isSeedlessOnboardingUserAuthenticated": false,
+              "metadataAccessToken": "metadataAccessToken",
+              "nodeAuthTokens": Array [],
+              "passwordOutdatedCache": Object {
+                "isExpiredPwd": false,
+                "timestamp": 1234567890,
+              },
+              "refreshToken": "refreshToken",
+              "socialBackupsMetadata": Array [],
+              "socialLoginEmail": "socialLoginEmail",
+              "userId": "userId",
+              "vault": "vault",
+            }
+          `);
+        },
+      );
+    });
+
+    it('exposes expected state to UI', async () => {
+      await withController(
+        {
+          state: {
+            accessToken: 'accessToken',
+            authPubKey: 'authPubKey',
+            authConnection: AuthConnection.Google,
+            authConnectionId: 'authConnectionId',
+            encryptedKeyringEncryptionKey: 'encryptedKeyringEncryptionKey',
+            encryptedSeedlessEncryptionKey: 'encryptedSeedlessEncryptionKey',
+            groupedAuthConnectionId: 'groupedAuthConnectionId',
+            isSeedlessOnboardingUserAuthenticated: true,
+            metadataAccessToken: 'metadataAccessToken',
+            nodeAuthTokens: [],
+            passwordOutdatedCache: {
+              isExpiredPwd: false,
+              timestamp: 1234567890,
+            },
+            refreshToken: 'refreshToken',
+            revokeToken: 'revokeToken',
+            socialBackupsMetadata: [],
+            socialLoginEmail: 'socialLoginEmail',
+            userId: 'userId',
+            vault: 'vault',
+            vaultEncryptionKey: 'vaultEncryptionKey',
+            vaultEncryptionSalt: 'vaultEncryptionSalt',
+          },
+        },
+        ({ controller }) => {
+          expect(
+            deriveStateFromMetadata(
+              controller.state,
+              controller.metadata,
+              'usedInUi',
+            ),
+          ).toMatchInlineSnapshot(`
+          Object {
+            "authConnection": "google",
+            "socialLoginEmail": "socialLoginEmail",
+          }
+        `);
         },
       );
     });

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -11,7 +11,11 @@ import {
   TOPRFErrorCode,
   TOPRFError,
 } from '@metamask/toprf-secure-backup';
-import { base64ToBytes, bytesToBase64 } from '@metamask/utils';
+import {
+  base64ToBytes,
+  bytesToBase64,
+  isNullOrUndefined,
+} from '@metamask/utils';
 import { gcm } from '@noble/ciphers/aes';
 import { bytesToUtf8, utf8ToBytes } from '@noble/ciphers/utils';
 import { managedNonce } from '@noble/ciphers/webcrypto';
@@ -178,8 +182,12 @@ const seedlessOnboardingMetadata: StateMetadata<SeedlessOnboardingControllerStat
       usedInUi: false,
     },
     pendingToBeRevokedTokens: {
+      includeInStateLogs: (pendingToBeRevokedTokens) =>
+        !isNullOrUndefined(pendingToBeRevokedTokens) &&
+        pendingToBeRevokedTokens.length > 0,
       persist: true,
       anonymous: false,
+      usedInUi: false,
     },
     // stays in vault
     accessToken: {

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -11,7 +11,11 @@ import {
   TOPRFErrorCode,
   TOPRFError,
 } from '@metamask/toprf-secure-backup';
-import { base64ToBytes, bytesToBase64 } from '@metamask/utils';
+import {
+  base64ToBytes,
+  bytesToBase64,
+  isNullOrUndefined,
+} from '@metamask/utils';
 import { gcm } from '@noble/ciphers/aes';
 import { bytesToUtf8, utf8ToBytes } from '@noble/ciphers/utils';
 import { managedNonce } from '@noble/ciphers/webcrypto';
@@ -93,60 +97,89 @@ export function getInitialSeedlessOnboardingControllerStateWithDefaults(
 const seedlessOnboardingMetadata: StateMetadata<SeedlessOnboardingControllerState> =
   {
     vault: {
+      includeInStateLogs: false,
       persist: true,
       anonymous: false,
+      usedInUi: false,
     },
     socialBackupsMetadata: {
+      includeInStateLogs: false,
       persist: true,
       anonymous: false,
+      usedInUi: false,
     },
     nodeAuthTokens: {
+      includeInStateLogs: (nodeAuthTokens) =>
+        !isNullOrUndefined(nodeAuthTokens),
       persist: true,
       anonymous: false,
+      usedInUi: false,
     },
     authConnection: {
+      includeInStateLogs: true,
       persist: true,
       anonymous: true,
+      usedInUi: true,
     },
     authConnectionId: {
+      includeInStateLogs: true,
       persist: true,
       anonymous: true,
+      usedInUi: false,
     },
     groupedAuthConnectionId: {
+      includeInStateLogs: true,
       persist: true,
       anonymous: true,
+      usedInUi: false,
     },
     userId: {
+      includeInStateLogs: true,
       persist: true,
       anonymous: false,
+      usedInUi: false,
     },
     socialLoginEmail: {
+      includeInStateLogs: false,
       persist: true,
       anonymous: false,
+      usedInUi: true,
     },
     vaultEncryptionKey: {
+      includeInStateLogs: false,
       persist: false,
       anonymous: false,
+      usedInUi: false,
     },
     vaultEncryptionSalt: {
+      includeInStateLogs: false,
       persist: false,
       anonymous: false,
+      usedInUi: false,
     },
     authPubKey: {
+      includeInStateLogs: true,
       persist: true,
       anonymous: false,
+      usedInUi: false,
     },
     passwordOutdatedCache: {
+      includeInStateLogs: true,
       persist: true,
       anonymous: true,
+      usedInUi: false,
     },
     refreshToken: {
+      includeInStateLogs: (refreshToken) => !isNullOrUndefined(refreshToken),
       persist: true,
       anonymous: false,
+      usedInUi: false,
     },
     revokeToken: {
+      includeInStateLogs: (revokeToken) => !isNullOrUndefined(revokeToken),
       persist: false,
       anonymous: false,
+      usedInUi: false,
     },
     pendingToBeRevokedTokens: {
       persist: true,
@@ -154,26 +187,37 @@ const seedlessOnboardingMetadata: StateMetadata<SeedlessOnboardingControllerStat
     },
     // stays in vault
     accessToken: {
+      includeInStateLogs: (accessToken) => !isNullOrUndefined(accessToken),
       persist: false,
       anonymous: false,
+      usedInUi: false,
     },
     // stays outside of vault as this token is accessed by the metadata service
     // before the vault is created or unlocked.
     metadataAccessToken: {
+      includeInStateLogs: (metadataAccessToken) =>
+        !isNullOrUndefined(metadataAccessToken),
       persist: true,
       anonymous: false,
+      usedInUi: false,
     },
     encryptedSeedlessEncryptionKey: {
+      includeInStateLogs: false,
       persist: true,
       anonymous: false,
+      usedInUi: false,
     },
     encryptedKeyringEncryptionKey: {
+      includeInStateLogs: false,
       persist: true,
       anonymous: false,
+      usedInUi: false,
     },
     isSeedlessOnboardingUserAuthenticated: {
+      includeInStateLogs: true,
       persist: true,
       anonymous: true,
+      usedInUi: false,
     },
   };
 

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -105,7 +105,8 @@ const seedlessOnboardingMetadata: StateMetadata<SeedlessOnboardingControllerStat
       usedInUi: false,
     },
     nodeAuthTokens: {
-      includeInStateLogs: false,
+      includeInStateLogs: (nodeAuthTokens) =>
+        !isNullOrUndefined(nodeAuthTokens),
       persist: true,
       anonymous: false,
       usedInUi: false,
@@ -165,26 +166,24 @@ const seedlessOnboardingMetadata: StateMetadata<SeedlessOnboardingControllerStat
       usedInUi: false,
     },
     refreshToken: {
-      includeInStateLogs: false,
+      includeInStateLogs: (refreshToken) => !isNullOrUndefined(refreshToken),
       persist: true,
       anonymous: false,
       usedInUi: false,
     },
     revokeToken: {
-      includeInStateLogs: false,
+      includeInStateLogs: (revokeToken) => !isNullOrUndefined(revokeToken),
       persist: false,
       anonymous: false,
       usedInUi: false,
     },
     pendingToBeRevokedTokens: {
-      includeInStateLogs: false,
       persist: true,
       anonymous: false,
-      usedInUi: false,
     },
     // stays in vault
     accessToken: {
-      includeInStateLogs: false,
+      includeInStateLogs: (accessToken) => !isNullOrUndefined(accessToken),
       persist: false,
       anonymous: false,
       usedInUi: false,
@@ -192,7 +191,8 @@ const seedlessOnboardingMetadata: StateMetadata<SeedlessOnboardingControllerStat
     // stays outside of vault as this token is accessed by the metadata service
     // before the vault is created or unlocked.
     metadataAccessToken: {
-      includeInStateLogs: false,
+      includeInStateLogs: (metadataAccessToken) =>
+        !isNullOrUndefined(metadataAccessToken),
       persist: true,
       anonymous: false,
       usedInUi: false,

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -11,11 +11,7 @@ import {
   TOPRFErrorCode,
   TOPRFError,
 } from '@metamask/toprf-secure-backup';
-import {
-  base64ToBytes,
-  bytesToBase64,
-  isNullOrUndefined,
-} from '@metamask/utils';
+import { base64ToBytes, bytesToBase64 } from '@metamask/utils';
 import { gcm } from '@noble/ciphers/aes';
 import { bytesToUtf8, utf8ToBytes } from '@noble/ciphers/utils';
 import { managedNonce } from '@noble/ciphers/webcrypto';

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -109,8 +109,7 @@ const seedlessOnboardingMetadata: StateMetadata<SeedlessOnboardingControllerStat
       usedInUi: false,
     },
     nodeAuthTokens: {
-      includeInStateLogs: (nodeAuthTokens) =>
-        !isNullOrUndefined(nodeAuthTokens),
+      includeInStateLogs: false,
       persist: true,
       anonymous: false,
       usedInUi: false,
@@ -170,24 +169,26 @@ const seedlessOnboardingMetadata: StateMetadata<SeedlessOnboardingControllerStat
       usedInUi: false,
     },
     refreshToken: {
-      includeInStateLogs: (refreshToken) => !isNullOrUndefined(refreshToken),
+      includeInStateLogs: false,
       persist: true,
       anonymous: false,
       usedInUi: false,
     },
     revokeToken: {
-      includeInStateLogs: (revokeToken) => !isNullOrUndefined(revokeToken),
+      includeInStateLogs: false,
       persist: false,
       anonymous: false,
       usedInUi: false,
     },
     pendingToBeRevokedTokens: {
+      includeInStateLogs: false,
       persist: true,
       anonymous: false,
+      usedInUi: false,
     },
     // stays in vault
     accessToken: {
-      includeInStateLogs: (accessToken) => !isNullOrUndefined(accessToken),
+      includeInStateLogs: false,
       persist: false,
       anonymous: false,
       usedInUi: false,
@@ -195,8 +196,7 @@ const seedlessOnboardingMetadata: StateMetadata<SeedlessOnboardingControllerStat
     // stays outside of vault as this token is accessed by the metadata service
     // before the vault is created or unlocked.
     metadataAccessToken: {
-      includeInStateLogs: (metadataAccessToken) =>
-        !isNullOrUndefined(metadataAccessToken),
+      includeInStateLogs: false,
       persist: true,
       anonymous: false,
       usedInUi: false,

--- a/packages/shield-controller/CHANGELOG.md
+++ b/packages/shield-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add two new controller state metadata properties: `includeInStateLogs` and `usedInUi` ([#6504](https://github.com/MetaMask/core/pull/6504))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^8.2.0` to `^8.3.0` ([#6465](https://github.com/MetaMask/core/pull/6465))

--- a/packages/shield-controller/src/ShieldController.test.ts
+++ b/packages/shield-controller/src/ShieldController.test.ts
@@ -1,3 +1,4 @@
+import { deriveStateFromMetadata } from '@metamask/base-controller';
 import type { TransactionControllerState } from '@metamask/transaction-controller';
 
 import { ShieldController } from './ShieldController';
@@ -140,6 +141,70 @@ describe('ShieldController', () => {
       );
       expect(await coverageResultReceived).toBeUndefined();
       expect(backend.checkCoverage).toHaveBeenCalledWith(txMeta);
+    });
+  });
+
+  describe('metadata', () => {
+    it('includes expected state in debug snapshots', () => {
+      const { controller } = setup();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'anonymous',
+        ),
+      ).toMatchInlineSnapshot(`Object {}`);
+    });
+
+    it('includes expected state in state logs', async () => {
+      const { controller } = setup();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'includeInStateLogs',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "coverageResults": Object {},
+          "orderedTransactionHistory": Array [],
+        }
+        `);
+    });
+
+    it('persists expected state', async () => {
+      const { controller } = setup();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'persist',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "coverageResults": Object {},
+          "orderedTransactionHistory": Array [],
+        }
+        `);
+    });
+
+    it('exposes expected state to UI', async () => {
+      const { controller } = setup();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'usedInUi',
+        ),
+      ).toMatchInlineSnapshot(`
+          Object {
+            "coverageResults": Object {},
+          }
+        `);
     });
   });
 });

--- a/packages/shield-controller/src/ShieldController.ts
+++ b/packages/shield-controller/src/ShieldController.ts
@@ -101,12 +101,16 @@ export type ShieldControllerMessenger = RestrictedMessenger<
  */
 const metadata = {
   coverageResults: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: false,
+    usedInUi: true,
   },
   orderedTransactionHistory: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: false,
+    usedInUi: false,
   },
 };
 

--- a/packages/subscription-controller/CHANGELOG.md
+++ b/packages/subscription-controller/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `cancelSubscription`: Cancel user active subscription.
 - `startShieldSubscriptionWithCard`: start shield subscription via card (with trial option) ([#6300](https://github.com/MetaMask/core/pull/6300))
 - Add `getPricing` method ([#6356](https://github.com/MetaMask/core/pull/6356))
-- Added `triggerAccessTokenRefresh` to trigger an access token refresh ([#6374](https://github.com/MetaMask/core/pull/6374))
 - Add methods `startSubscriptionWithCrypto` and `getCryptoApproveTransactionParams` method ([#6456](https://github.com/MetaMask/core/pull/6456))
+- Added `triggerAccessTokenRefresh` to trigger an access token refresh ([#6374](https://github.com/MetaMask/core/pull/6374))
 - Add two new controller state metadata properties: `includeInStateLogs` and `usedInUi` ([#6504](https://github.com/MetaMask/core/pull/6504))
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/subscription-controller/CHANGELOG.md
+++ b/packages/subscription-controller/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `cancelSubscription`: Cancel user active subscription.
 - `startShieldSubscriptionWithCard`: start shield subscription via card (with trial option) ([#6300](https://github.com/MetaMask/core/pull/6300))
 - Add `getPricing` method ([#6356](https://github.com/MetaMask/core/pull/6356))
-- Add methods `startSubscriptionWithCrypto` and `getCryptoApproveTransactionParams` method ([#6456](https://github.com/MetaMask/core/pull/6456))
 - Added `triggerAccessTokenRefresh` to trigger an access token refresh ([#6374](https://github.com/MetaMask/core/pull/6374))
+- Add methods `startSubscriptionWithCrypto` and `getCryptoApproveTransactionParams` method ([#6456](https://github.com/MetaMask/core/pull/6456))
+- Add two new controller state metadata properties: `includeInStateLogs` and `usedInUi` ([#6504](https://github.com/MetaMask/core/pull/6504))
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/subscription-controller/src/SubscriptionController.test.ts
+++ b/packages/subscription-controller/src/SubscriptionController.test.ts
@@ -1,4 +1,4 @@
-import { Messenger } from '@metamask/base-controller';
+import { deriveStateFromMetadata, Messenger } from '@metamask/base-controller';
 
 import {
   controllerName,
@@ -816,6 +816,68 @@ describe('SubscriptionController', () => {
         controller.triggerAccessTokenRefresh();
 
         expect(mockPerformSignOut).toHaveBeenCalledWith();
+      });
+    });
+  });
+
+  describe('metadata', () => {
+    it('includes expected state in debug snapshots', async () => {
+      await withController(({ controller }) => {
+        expect(
+          deriveStateFromMetadata(
+            controller.state,
+            controller.metadata,
+            'anonymous',
+          ),
+        ).toMatchInlineSnapshot(`Object {}`);
+      });
+    });
+
+    it('includes expected state in state logs', async () => {
+      await withController(({ controller }) => {
+        expect(
+          deriveStateFromMetadata(
+            controller.state,
+            controller.metadata,
+            'includeInStateLogs',
+          ),
+        ).toMatchInlineSnapshot(`
+        Object {
+          "subscriptions": Array [],
+        }
+      `);
+      });
+    });
+
+    it('persists expected state', async () => {
+      await withController(({ controller }) => {
+        expect(
+          deriveStateFromMetadata(
+            controller.state,
+            controller.metadata,
+            'persist',
+          ),
+        ).toMatchInlineSnapshot(`
+        Object {
+          "subscriptions": Array [],
+        }
+      `);
+      });
+    });
+
+    it('exposes expected state to UI', async () => {
+      await withController(({ controller }) => {
+        expect(
+          deriveStateFromMetadata(
+            controller.state,
+            controller.metadata,
+            'usedInUi',
+          ),
+        ).toMatchInlineSnapshot(`
+        Object {
+          "subscriptions": Array [],
+        }
+      `);
       });
     });
   });

--- a/packages/subscription-controller/src/SubscriptionController.ts
+++ b/packages/subscription-controller/src/SubscriptionController.ts
@@ -133,8 +133,10 @@ export function getDefaultSubscriptionControllerState(): SubscriptionControllerS
 const subscriptionControllerMetadata: StateMetadata<SubscriptionControllerState> =
   {
     subscriptions: {
+      includeInStateLogs: true,
       persist: true,
       anonymous: false,
+      usedInUi: true,
     },
   };
 


### PR DESCRIPTION
## Explanation

The new metadata properties `includeInStateLogs` and `usedInUi` have been added to all controllers maintained by the Web3Auth team.

## References

* Fixes #6521
* Related to #6443

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
