### PR TITLE
chore(profile-sync-controller): bring test grouping in line with other controllers

### DIFF
--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
@@ -44,472 +44,497 @@ const mockSignedInState = (): AuthenticationControllerState => {
   };
 };
 
-describe('authentication/authentication-controller - constructor() tests', () => {
-  it('should initialize with default state', () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const controller = new AuthenticationController({
-      messenger: createMockAuthenticationMessenger().messenger,
-      metametrics,
-    });
-
-    expect(controller.state.isSignedIn).toBe(false);
-    expect(controller.state.srpSessionData).toBeUndefined();
-  });
-
-  it('should initialize with override state', () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const controller = new AuthenticationController({
-      messenger: createMockAuthenticationMessenger().messenger,
-      state: mockSignedInState(),
-      metametrics,
-    });
-
-    expect(controller.state.isSignedIn).toBe(true);
-    expect(controller.state.srpSessionData).toBeDefined();
-  });
-
-  it('should throw an error if metametrics is not provided', () => {
-    expect(() => {
-      // @ts-expect-error - testing invalid params
-      new AuthenticationController({
+describe('AuthenticationController', () => {
+  describe('constructor', () => {
+    it('should initialize with default state', () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const controller = new AuthenticationController({
         messenger: createMockAuthenticationMessenger().messenger,
+        metametrics,
       });
-    }).toThrow('`metametrics` field is required');
-  });
-});
 
-describe('authentication/authentication-controller - performSignIn() tests', () => {
-  it('should create access token(s) and update state', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const mockEndpoints = arrangeAuthAPIs();
-    const {
-      messenger,
-      mockSnapGetPublicKey,
-      mockSnapGetAllPublicKeys,
-      mockSnapSignMessage,
-    } = createMockAuthenticationMessenger();
-
-    const controller = new AuthenticationController({ messenger, metametrics });
-
-    const result = await controller.performSignIn();
-    expect(mockSnapGetAllPublicKeys).toHaveBeenCalledTimes(1);
-    expect(mockSnapGetPublicKey).toHaveBeenCalledTimes(2);
-    expect(mockSnapSignMessage).toHaveBeenCalledTimes(1);
-    mockEndpoints.mockNonceUrl.done();
-    mockEndpoints.mockSrpLoginUrl.done();
-    mockEndpoints.mockOAuth2TokenUrl.done();
-    expect(result).toStrictEqual([
-      MOCK_OATH_TOKEN_RESPONSE.access_token,
-      MOCK_OATH_TOKEN_RESPONSE.access_token,
-    ]);
-
-    // Assert - state shows user is logged in
-    expect(controller.state.isSignedIn).toBe(true);
-    for (const id of MOCK_ENTROPY_SOURCE_IDS) {
-      expect(controller.state.srpSessionData?.[id]).toBeDefined();
-    }
-  });
-
-  it('leverages the _snapSignMessageCache', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const mockEndpoints = arrangeAuthAPIs();
-    const { messenger, mockSnapSignMessage } =
-      createMockAuthenticationMessenger();
-
-    const controller = new AuthenticationController({ messenger, metametrics });
-
-    await controller.performSignIn();
-    controller.performSignOut();
-    await controller.performSignIn();
-    expect(mockSnapSignMessage).toHaveBeenCalledTimes(1);
-    mockEndpoints.mockNonceUrl.done();
-    mockEndpoints.mockSrpLoginUrl.done();
-    mockEndpoints.mockOAuth2TokenUrl.done();
-    expect(controller.state.isSignedIn).toBe(true);
-    for (const id of MOCK_ENTROPY_SOURCE_IDS) {
-      expect(controller.state.srpSessionData?.[id]).toBeDefined();
-    }
-  });
-
-  it('should error when nonce endpoint fails', async () => {
-    expect(true).toBe(true);
-    await testAndAssertFailingEndpoints('nonce');
-  });
-
-  it('should error when login endpoint fails', async () => {
-    expect(true).toBe(true);
-    await testAndAssertFailingEndpoints('login');
-  });
-
-  it('should error when tokens endpoint fails', async () => {
-    expect(true).toBe(true);
-    await testAndAssertFailingEndpoints('token');
-  });
-
-  // When the wallet is locked, we are unable to call the snap
-  it('should error when wallet is locked', async () => {
-    const { messenger, baseMessenger, mockKeyringControllerGetState } =
-      createMockAuthenticationMessenger();
-    arrangeAuthAPIs();
-    const metametrics = createMockAuthMetaMetrics();
-
-    mockKeyringControllerGetState.mockReturnValue({ isUnlocked: true });
-
-    const controller = new AuthenticationController({ messenger, metametrics });
-
-    baseMessenger.publish('KeyringController:lock');
-    await expect(controller.performSignIn()).rejects.toThrow(expect.any(Error));
-
-    baseMessenger.publish('KeyringController:unlock');
-    expect(await controller.performSignIn()).toStrictEqual([
-      MOCK_OATH_TOKEN_RESPONSE.access_token,
-      MOCK_OATH_TOKEN_RESPONSE.access_token,
-    ]);
-  });
-
-  /**
-   * Jest Test & Assert Utility - for testing and asserting endpoint failures
-   *
-   * @param endpointFail - example endpoints to fail
-   */
-  async function testAndAssertFailingEndpoints(
-    endpointFail: 'nonce' | 'login' | 'token',
-  ) {
-    const mockEndpoints = mockAuthenticationFlowEndpoints({
-      endpointFail,
-    });
-    const { messenger } = createMockAuthenticationMessenger();
-    const metametrics = createMockAuthMetaMetrics();
-    const controller = new AuthenticationController({ messenger, metametrics });
-
-    await expect(controller.performSignIn()).rejects.toThrow(expect.any(Error));
-    expect(controller.state.isSignedIn).toBe(false);
-
-    const endpointsCalled = [
-      mockEndpoints.mockNonceUrl.isDone(),
-      mockEndpoints.mockSrpLoginUrl.isDone(),
-      mockEndpoints.mockOAuth2TokenUrl.isDone(),
-    ];
-    if (endpointFail === 'nonce') {
-      expect(endpointsCalled).toStrictEqual([true, false, false]);
-    }
-
-    if (endpointFail === 'login') {
-      expect(endpointsCalled).toStrictEqual([true, true, false]);
-    }
-
-    if (endpointFail === 'token') {
-      expect(endpointsCalled).toStrictEqual([true, true, true]);
-    }
-  }
-});
-
-describe('authentication/authentication-controller - performSignOut() tests', () => {
-  it('should remove signed in user and any access tokens', () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger } = createMockAuthenticationMessenger();
-    const controller = new AuthenticationController({
-      messenger,
-      state: mockSignedInState(),
-      metametrics,
+      expect(controller.state.isSignedIn).toBe(false);
+      expect(controller.state.srpSessionData).toBeUndefined();
     });
 
-    controller.performSignOut();
-    expect(controller.state.isSignedIn).toBe(false);
-    expect(controller.state.srpSessionData).toBeUndefined();
-  });
-});
+    it('should initialize with override state', () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const controller = new AuthenticationController({
+        messenger: createMockAuthenticationMessenger().messenger,
+        state: mockSignedInState(),
+        metametrics,
+      });
 
-describe('authentication/authentication-controller - getBearerToken() tests', () => {
-  it('should throw error if not logged in', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger } = createMockAuthenticationMessenger();
-    const controller = new AuthenticationController({
-      messenger,
-      state: { isSignedIn: false },
-      metametrics,
+      expect(controller.state.isSignedIn).toBe(true);
+      expect(controller.state.srpSessionData).toBeDefined();
     });
 
-    await expect(controller.getBearerToken()).rejects.toThrow(
-      expect.any(Error),
-    );
+    it('should throw an error if metametrics is not provided', () => {
+      expect(() => {
+        // @ts-expect-error - testing invalid params
+        new AuthenticationController({
+          messenger: createMockAuthenticationMessenger().messenger,
+        });
+      }).toThrow('`metametrics` field is required');
+    });
   });
 
-  it('should return original access token(s) in state', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger } = createMockAuthenticationMessenger();
-    const originalState = mockSignedInState();
-    const controller = new AuthenticationController({
-      messenger,
-      state: originalState,
-      metametrics,
+  describe('performSignIn', () => {
+    it('should create access token(s) and update state', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const mockEndpoints = arrangeAuthAPIs();
+      const {
+        messenger,
+        mockSnapGetPublicKey,
+        mockSnapGetAllPublicKeys,
+        mockSnapSignMessage,
+      } = createMockAuthenticationMessenger();
+
+      const controller = new AuthenticationController({
+        messenger,
+        metametrics,
+      });
+
+      const result = await controller.performSignIn();
+      expect(mockSnapGetAllPublicKeys).toHaveBeenCalledTimes(1);
+      expect(mockSnapGetPublicKey).toHaveBeenCalledTimes(2);
+      expect(mockSnapSignMessage).toHaveBeenCalledTimes(1);
+      mockEndpoints.mockNonceUrl.done();
+      mockEndpoints.mockSrpLoginUrl.done();
+      mockEndpoints.mockOAuth2TokenUrl.done();
+      expect(result).toStrictEqual([
+        MOCK_OATH_TOKEN_RESPONSE.access_token,
+        MOCK_OATH_TOKEN_RESPONSE.access_token,
+      ]);
+
+      // Assert - state shows user is logged in
+      expect(controller.state.isSignedIn).toBe(true);
+      for (const id of MOCK_ENTROPY_SOURCE_IDS) {
+        expect(controller.state.srpSessionData?.[id]).toBeDefined();
+      }
     });
 
-    const resultWithoutEntropySourceId = await controller.getBearerToken();
-    expect(resultWithoutEntropySourceId).toBeDefined();
-    expect(resultWithoutEntropySourceId).toBe(
-      originalState.srpSessionData?.[MOCK_ENTROPY_SOURCE_IDS[0]]?.token
-        .accessToken,
-    );
+    it('leverages the _snapSignMessageCache', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const mockEndpoints = arrangeAuthAPIs();
+      const { messenger, mockSnapSignMessage } =
+        createMockAuthenticationMessenger();
 
-    for (const id of MOCK_ENTROPY_SOURCE_IDS) {
-      const resultWithEntropySourceId = await controller.getBearerToken(id);
-      expect(resultWithEntropySourceId).toBeDefined();
-      expect(resultWithEntropySourceId).toBe(
-        originalState.srpSessionData?.[id]?.token.accessToken,
+      const controller = new AuthenticationController({
+        messenger,
+        metametrics,
+      });
+
+      await controller.performSignIn();
+      controller.performSignOut();
+      await controller.performSignIn();
+      expect(mockSnapSignMessage).toHaveBeenCalledTimes(1);
+      mockEndpoints.mockNonceUrl.done();
+      mockEndpoints.mockSrpLoginUrl.done();
+      mockEndpoints.mockOAuth2TokenUrl.done();
+      expect(controller.state.isSignedIn).toBe(true);
+      for (const id of MOCK_ENTROPY_SOURCE_IDS) {
+        expect(controller.state.srpSessionData?.[id]).toBeDefined();
+      }
+    });
+
+    it('should error when nonce endpoint fails', async () => {
+      expect(true).toBe(true);
+      await testAndAssertFailingEndpoints('nonce');
+    });
+
+    it('should error when login endpoint fails', async () => {
+      expect(true).toBe(true);
+      await testAndAssertFailingEndpoints('login');
+    });
+
+    it('should error when tokens endpoint fails', async () => {
+      expect(true).toBe(true);
+      await testAndAssertFailingEndpoints('token');
+    });
+
+    // When the wallet is locked, we are unable to call the snap
+    it('should error when wallet is locked', async () => {
+      const { messenger, baseMessenger, mockKeyringControllerGetState } =
+        createMockAuthenticationMessenger();
+      arrangeAuthAPIs();
+      const metametrics = createMockAuthMetaMetrics();
+
+      mockKeyringControllerGetState.mockReturnValue({ isUnlocked: true });
+
+      const controller = new AuthenticationController({
+        messenger,
+        metametrics,
+      });
+
+      baseMessenger.publish('KeyringController:lock');
+      await expect(controller.performSignIn()).rejects.toThrow(
+        expect.any(Error),
       );
-    }
-  });
 
-  it('should return new access token if state is invalid', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger } = createMockAuthenticationMessenger();
-    mockAuthenticationFlowEndpoints();
-    const originalState = mockSignedInState();
-    // eslint-disable-next-line jest/no-conditional-in-test
-    if (originalState.srpSessionData) {
-      originalState.srpSessionData[
-        MOCK_ENTROPY_SOURCE_IDS[0]
-      ].token.accessToken = MOCK_OATH_TOKEN_RESPONSE.access_token;
-
-      const d = new Date();
-      d.setMinutes(d.getMinutes() - 31); // expires at 30 mins
-      originalState.srpSessionData[MOCK_ENTROPY_SOURCE_IDS[0]].token.expiresIn =
-        d.getTime();
-    }
-
-    const controller = new AuthenticationController({
-      messenger,
-      state: originalState,
-      metametrics,
+      baseMessenger.publish('KeyringController:unlock');
+      expect(await controller.performSignIn()).toStrictEqual([
+        MOCK_OATH_TOKEN_RESPONSE.access_token,
+        MOCK_OATH_TOKEN_RESPONSE.access_token,
+      ]);
     });
 
-    const result = await controller.getBearerToken();
-    expect(result).toBeDefined();
-    expect(result).toBe(MOCK_OATH_TOKEN_RESPONSE.access_token);
-  });
+    /**
+     * Jest Test & Assert Utility - for testing and asserting endpoint failures
+     *
+     * @param endpointFail - example endpoints to fail
+     */
+    async function testAndAssertFailingEndpoints(
+      endpointFail: 'nonce' | 'login' | 'token',
+    ) {
+      const mockEndpoints = mockAuthenticationFlowEndpoints({
+        endpointFail,
+      });
+      const { messenger } = createMockAuthenticationMessenger();
+      const metametrics = createMockAuthMetaMetrics();
+      const controller = new AuthenticationController({
+        messenger,
+        metametrics,
+      });
 
-  // If the state is invalid, we need to re-login.
-  // But as wallet is locked, we will not be able to call the snap
-  it('should throw error if wallet is locked', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger, mockKeyringControllerGetState } =
-      createMockAuthenticationMessenger();
-    mockAuthenticationFlowEndpoints();
-
-    // Invalid/old state
-    const originalState = mockSignedInState();
-    // eslint-disable-next-line jest/no-conditional-in-test
-    if (originalState.srpSessionData) {
-      originalState.srpSessionData[
-        MOCK_ENTROPY_SOURCE_IDS[0]
-      ].token.accessToken = 'ACCESS_TOKEN_1';
-
-      const d = new Date();
-      d.setMinutes(d.getMinutes() - 31); // expires at 30 mins
-      originalState.srpSessionData[MOCK_ENTROPY_SOURCE_IDS[0]].token.expiresIn =
-        d.getTime();
-    }
-
-    // Mock wallet is locked
-    mockKeyringControllerGetState.mockReturnValue({ isUnlocked: false });
-
-    const controller = new AuthenticationController({
-      messenger,
-      state: originalState,
-      metametrics,
-    });
-
-    await expect(controller.getBearerToken()).rejects.toThrow(
-      expect.any(Error),
-    );
-  });
-});
-
-describe('authentication/authentication-controller - getSessionProfile() tests', () => {
-  it('should throw error if not logged in', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger } = createMockAuthenticationMessenger();
-    const controller = new AuthenticationController({
-      messenger,
-      state: { isSignedIn: false },
-      metametrics,
-    });
-
-    await expect(controller.getSessionProfile()).rejects.toThrow(
-      expect.any(Error),
-    );
-  });
-
-  it('should return original user profile(s) in state', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger } = createMockAuthenticationMessenger();
-    const originalState = mockSignedInState();
-    const controller = new AuthenticationController({
-      messenger,
-      state: originalState,
-      metametrics,
-    });
-
-    const resultWithoutEntropySourceId = await controller.getSessionProfile();
-    expect(resultWithoutEntropySourceId).toBeDefined();
-    expect(resultWithoutEntropySourceId).toStrictEqual(
-      originalState.srpSessionData?.[MOCK_ENTROPY_SOURCE_IDS[0]]?.profile,
-    );
-
-    for (const id of MOCK_ENTROPY_SOURCE_IDS) {
-      const resultWithEntropySourceId = await controller.getSessionProfile(id);
-      expect(resultWithEntropySourceId).toBeDefined();
-      expect(resultWithEntropySourceId).toStrictEqual(
-        originalState.srpSessionData?.[id]?.profile,
+      await expect(controller.performSignIn()).rejects.toThrow(
+        expect.any(Error),
       );
+      expect(controller.state.isSignedIn).toBe(false);
+
+      const endpointsCalled = [
+        mockEndpoints.mockNonceUrl.isDone(),
+        mockEndpoints.mockSrpLoginUrl.isDone(),
+        mockEndpoints.mockOAuth2TokenUrl.isDone(),
+      ];
+      if (endpointFail === 'nonce') {
+        expect(endpointsCalled).toStrictEqual([true, false, false]);
+      }
+
+      if (endpointFail === 'login') {
+        expect(endpointsCalled).toStrictEqual([true, true, false]);
+      }
+
+      if (endpointFail === 'token') {
+        expect(endpointsCalled).toStrictEqual([true, true, true]);
+      }
     }
   });
 
-  it('should return new user profile if state is invalid', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger } = createMockAuthenticationMessenger();
-    mockAuthenticationFlowEndpoints();
-    const originalState = mockSignedInState();
-    // eslint-disable-next-line jest/no-conditional-in-test
-    if (originalState.srpSessionData) {
-      originalState.srpSessionData[
-        MOCK_ENTROPY_SOURCE_IDS[0]
-      ].profile.identifierId = MOCK_LOGIN_RESPONSE.profile.identifier_id;
+  describe('performSignOut', () => {
+    it('should remove signed in user and any access tokens', () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState(),
+        metametrics,
+      });
 
-      const d = new Date();
-      d.setMinutes(d.getMinutes() - 31); // expires at 30 mins
-      originalState.srpSessionData[MOCK_ENTROPY_SOURCE_IDS[0]].token.expiresIn =
-        d.getTime();
-    }
-
-    const controller = new AuthenticationController({
-      messenger,
-      state: originalState,
-      metametrics,
+      controller.performSignOut();
+      expect(controller.state.isSignedIn).toBe(false);
+      expect(controller.state.srpSessionData).toBeUndefined();
     });
-
-    const result = await controller.getSessionProfile();
-    expect(result).toBeDefined();
-    expect(result.identifierId).toBe(MOCK_LOGIN_RESPONSE.profile.identifier_id);
-    expect(result.profileId).toBe(MOCK_LOGIN_RESPONSE.profile.profile_id);
   });
 
-  // If the state is invalid, we need to re-login.
-  // But as wallet is locked, we will not be able to call the snap
-  it('should throw error if wallet is locked', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger, mockKeyringControllerGetState } =
-      createMockAuthenticationMessenger();
-    mockAuthenticationFlowEndpoints();
+  describe('getBearerToken', () => {
+    it('should throw error if not logged in', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      const controller = new AuthenticationController({
+        messenger,
+        state: { isSignedIn: false },
+        metametrics,
+      });
 
-    // Invalid/old state
-    const originalState = mockSignedInState();
-    // eslint-disable-next-line jest/no-conditional-in-test
-    if (originalState.srpSessionData) {
-      originalState.srpSessionData[
-        MOCK_ENTROPY_SOURCE_IDS[0]
-      ].profile.identifierId = MOCK_LOGIN_RESPONSE.profile.identifier_id;
-
-      const d = new Date();
-      d.setMinutes(d.getMinutes() - 31); // expires at 30 mins
-      originalState.srpSessionData[MOCK_ENTROPY_SOURCE_IDS[0]].token.expiresIn =
-        d.getTime();
-    }
-
-    // Mock wallet is locked
-    mockKeyringControllerGetState.mockReturnValue({ isUnlocked: false });
-
-    const controller = new AuthenticationController({
-      messenger,
-      state: originalState,
-      metametrics,
+      await expect(controller.getBearerToken()).rejects.toThrow(
+        expect.any(Error),
+      );
     });
 
-    await expect(controller.getSessionProfile()).rejects.toThrow(
-      expect.any(Error),
-    );
+    it('should return original access token(s) in state', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      const originalState = mockSignedInState();
+      const controller = new AuthenticationController({
+        messenger,
+        state: originalState,
+        metametrics,
+      });
+
+      const resultWithoutEntropySourceId = await controller.getBearerToken();
+      expect(resultWithoutEntropySourceId).toBeDefined();
+      expect(resultWithoutEntropySourceId).toBe(
+        originalState.srpSessionData?.[MOCK_ENTROPY_SOURCE_IDS[0]]?.token
+          .accessToken,
+      );
+
+      for (const id of MOCK_ENTROPY_SOURCE_IDS) {
+        const resultWithEntropySourceId = await controller.getBearerToken(id);
+        expect(resultWithEntropySourceId).toBeDefined();
+        expect(resultWithEntropySourceId).toBe(
+          originalState.srpSessionData?.[id]?.token.accessToken,
+        );
+      }
+    });
+
+    it('should return new access token if state is invalid', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      mockAuthenticationFlowEndpoints();
+      const originalState = mockSignedInState();
+      // eslint-disable-next-line jest/no-conditional-in-test
+      if (originalState.srpSessionData) {
+        originalState.srpSessionData[
+          MOCK_ENTROPY_SOURCE_IDS[0]
+        ].token.accessToken = MOCK_OATH_TOKEN_RESPONSE.access_token;
+
+        const d = new Date();
+        d.setMinutes(d.getMinutes() - 31); // expires at 30 mins
+        originalState.srpSessionData[
+          MOCK_ENTROPY_SOURCE_IDS[0]
+        ].token.expiresIn = d.getTime();
+      }
+
+      const controller = new AuthenticationController({
+        messenger,
+        state: originalState,
+        metametrics,
+      });
+
+      const result = await controller.getBearerToken();
+      expect(result).toBeDefined();
+      expect(result).toBe(MOCK_OATH_TOKEN_RESPONSE.access_token);
+    });
+
+    // If the state is invalid, we need to re-login.
+    // But as wallet is locked, we will not be able to call the snap
+    it('should throw error if wallet is locked', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger, mockKeyringControllerGetState } =
+        createMockAuthenticationMessenger();
+      mockAuthenticationFlowEndpoints();
+
+      // Invalid/old state
+      const originalState = mockSignedInState();
+      // eslint-disable-next-line jest/no-conditional-in-test
+      if (originalState.srpSessionData) {
+        originalState.srpSessionData[
+          MOCK_ENTROPY_SOURCE_IDS[0]
+        ].token.accessToken = 'ACCESS_TOKEN_1';
+
+        const d = new Date();
+        d.setMinutes(d.getMinutes() - 31); // expires at 30 mins
+        originalState.srpSessionData[
+          MOCK_ENTROPY_SOURCE_IDS[0]
+        ].token.expiresIn = d.getTime();
+      }
+
+      // Mock wallet is locked
+      mockKeyringControllerGetState.mockReturnValue({ isUnlocked: false });
+
+      const controller = new AuthenticationController({
+        messenger,
+        state: originalState,
+        metametrics,
+      });
+
+      await expect(controller.getBearerToken()).rejects.toThrow(
+        expect.any(Error),
+      );
+    });
   });
-});
 
-describe('authentication/authentication-controller - getUserProfileMetaMetrics() tests', () => {
-  it('should throw error if not logged in', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger } = createMockAuthenticationMessenger();
-    const controller = new AuthenticationController({
-      messenger,
-      state: { isSignedIn: false },
-      metametrics,
+  describe('getSessionProfile', () => {
+    it('should throw error if not logged in', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      const controller = new AuthenticationController({
+        messenger,
+        state: { isSignedIn: false },
+        metametrics,
+      });
+
+      await expect(controller.getSessionProfile()).rejects.toThrow(
+        expect.any(Error),
+      );
     });
 
-    await expect(controller.getUserProfileLineage()).rejects.toThrow(
-      expect.any(Error),
-    );
+    it('should return original user profile(s) in state', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      const originalState = mockSignedInState();
+      const controller = new AuthenticationController({
+        messenger,
+        state: originalState,
+        metametrics,
+      });
+
+      const resultWithoutEntropySourceId = await controller.getSessionProfile();
+      expect(resultWithoutEntropySourceId).toBeDefined();
+      expect(resultWithoutEntropySourceId).toStrictEqual(
+        originalState.srpSessionData?.[MOCK_ENTROPY_SOURCE_IDS[0]]?.profile,
+      );
+
+      for (const id of MOCK_ENTROPY_SOURCE_IDS) {
+        const resultWithEntropySourceId =
+          await controller.getSessionProfile(id);
+        expect(resultWithEntropySourceId).toBeDefined();
+        expect(resultWithEntropySourceId).toStrictEqual(
+          originalState.srpSessionData?.[id]?.profile,
+        );
+      }
+    });
+
+    it('should return new user profile if state is invalid', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      mockAuthenticationFlowEndpoints();
+      const originalState = mockSignedInState();
+      // eslint-disable-next-line jest/no-conditional-in-test
+      if (originalState.srpSessionData) {
+        originalState.srpSessionData[
+          MOCK_ENTROPY_SOURCE_IDS[0]
+        ].profile.identifierId = MOCK_LOGIN_RESPONSE.profile.identifier_id;
+
+        const d = new Date();
+        d.setMinutes(d.getMinutes() - 31); // expires at 30 mins
+        originalState.srpSessionData[
+          MOCK_ENTROPY_SOURCE_IDS[0]
+        ].token.expiresIn = d.getTime();
+      }
+
+      const controller = new AuthenticationController({
+        messenger,
+        state: originalState,
+        metametrics,
+      });
+
+      const result = await controller.getSessionProfile();
+      expect(result).toBeDefined();
+      expect(result.identifierId).toBe(
+        MOCK_LOGIN_RESPONSE.profile.identifier_id,
+      );
+      expect(result.profileId).toBe(MOCK_LOGIN_RESPONSE.profile.profile_id);
+    });
+
+    // If the state is invalid, we need to re-login.
+    // But as wallet is locked, we will not be able to call the snap
+    it('should throw error if wallet is locked', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger, mockKeyringControllerGetState } =
+        createMockAuthenticationMessenger();
+      mockAuthenticationFlowEndpoints();
+
+      // Invalid/old state
+      const originalState = mockSignedInState();
+      // eslint-disable-next-line jest/no-conditional-in-test
+      if (originalState.srpSessionData) {
+        originalState.srpSessionData[
+          MOCK_ENTROPY_SOURCE_IDS[0]
+        ].profile.identifierId = MOCK_LOGIN_RESPONSE.profile.identifier_id;
+
+        const d = new Date();
+        d.setMinutes(d.getMinutes() - 31); // expires at 30 mins
+        originalState.srpSessionData[
+          MOCK_ENTROPY_SOURCE_IDS[0]
+        ].token.expiresIn = d.getTime();
+      }
+
+      // Mock wallet is locked
+      mockKeyringControllerGetState.mockReturnValue({ isUnlocked: false });
+
+      const controller = new AuthenticationController({
+        messenger,
+        state: originalState,
+        metametrics,
+      });
+
+      await expect(controller.getSessionProfile()).rejects.toThrow(
+        expect.any(Error),
+      );
+    });
   });
 
-  it('should return the profile MetaMetrics data', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    mockAuthenticationFlowEndpoints();
+  describe('getUserProfileMetaMetrics', () => {
+    it('should throw error if not logged in', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      const controller = new AuthenticationController({
+        messenger,
+        state: { isSignedIn: false },
+        metametrics,
+      });
 
-    const { messenger } = createMockAuthenticationMessenger();
-    const originalState = mockSignedInState();
-    const controller = new AuthenticationController({
-      messenger,
-      state: originalState,
-      metametrics,
+      await expect(controller.getUserProfileLineage()).rejects.toThrow(
+        expect.any(Error),
+      );
     });
 
-    const result = await controller.getUserProfileLineage();
-    expect(result).toBeDefined();
-    expect(result).toStrictEqual(MOCK_USER_PROFILE_LINEAGE_RESPONSE);
+    it('should return the profile MetaMetrics data', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      mockAuthenticationFlowEndpoints();
+
+      const { messenger } = createMockAuthenticationMessenger();
+      const originalState = mockSignedInState();
+      const controller = new AuthenticationController({
+        messenger,
+        state: originalState,
+        metametrics,
+      });
+
+      const result = await controller.getUserProfileLineage();
+      expect(result).toBeDefined();
+      expect(result).toStrictEqual(MOCK_USER_PROFILE_LINEAGE_RESPONSE);
+    });
+
+    it('should throw error if wallet is locked', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger, mockKeyringControllerGetState } =
+        createMockAuthenticationMessenger();
+
+      // Invalid/old state
+      const originalState = mockSignedInState();
+
+      // Mock wallet is locked
+      mockKeyringControllerGetState.mockReturnValue({ isUnlocked: false });
+
+      const controller = new AuthenticationController({
+        messenger,
+        state: originalState,
+        metametrics,
+      });
+
+      await expect(controller.getUserProfileLineage()).rejects.toThrow(
+        expect.any(Error),
+      );
+    });
   });
 
-  it('should throw error if wallet is locked', async () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger, mockKeyringControllerGetState } =
-      createMockAuthenticationMessenger();
+  describe('isSignedIn', () => {
+    it('should return false if not logged in', () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      const controller = new AuthenticationController({
+        messenger,
+        state: { isSignedIn: false },
+        metametrics,
+      });
 
-    // Invalid/old state
-    const originalState = mockSignedInState();
-
-    // Mock wallet is locked
-    mockKeyringControllerGetState.mockReturnValue({ isUnlocked: false });
-
-    const controller = new AuthenticationController({
-      messenger,
-      state: originalState,
-      metametrics,
+      expect(controller.isSignedIn()).toBe(false);
     });
 
-    await expect(controller.getUserProfileLineage()).rejects.toThrow(
-      expect.any(Error),
-    );
-  });
-});
+    it('should return true if logged in', () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState(),
+        metametrics,
+      });
 
-describe('authentication/authentication-controller - isSignedIn() tests', () => {
-  it('should return false if not logged in', () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger } = createMockAuthenticationMessenger();
-    const controller = new AuthenticationController({
-      messenger,
-      state: { isSignedIn: false },
-      metametrics,
+      expect(controller.isSignedIn()).toBe(true);
     });
-
-    expect(controller.isSignedIn()).toBe(false);
-  });
-
-  it('should return true if logged in', () => {
-    const metametrics = createMockAuthMetaMetrics();
-    const { messenger } = createMockAuthenticationMessenger();
-    const controller = new AuthenticationController({
-      messenger,
-      state: mockSignedInState(),
-      metametrics,
-    });
-
-    expect(controller.isSignedIn()).toBe(true);
   });
 });
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -17,267 +17,283 @@ import { MOCK_STORAGE_DATA, MOCK_STORAGE_KEY } from './mocks/mockStorage';
 import UserStorageController, { defaultState } from './UserStorageController';
 import { USER_STORAGE_FEATURE_NAMES } from '../../shared/storage-schema';
 
-describe('user-storage/user-storage-controller - constructor() tests', () => {
-  const arrangeMocks = () => {
-    return {
-      messengerMocks: mockUserStorageMessenger(),
+describe('UserStorageController', () => {
+  describe('constructor', () => {
+    const arrangeMocks = () => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+      };
     };
-  };
 
-  it('creates UserStorage with default state', () => {
-    const { messengerMocks } = arrangeMocks();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-    });
-
-    expect(controller.state.isBackupAndSyncEnabled).toBe(true);
-  });
-});
-
-describe('user-storage/user-storage-controller - performGetStorage() tests', () => {
-  const arrangeMocks = async () => {
-    return {
-      messengerMocks: mockUserStorageMessenger(),
-      mockAPI: await mockEndpointGetUserStorage(),
-    };
-  };
-
-  it('returns users notification storage', async () => {
-    const { messengerMocks, mockAPI } = await arrangeMocks();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-    });
-
-    const result = await controller.performGetStorage(
-      `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
-    );
-    mockAPI.done();
-    expect(result).toBe(MOCK_STORAGE_DATA);
-  });
-
-  it.each([
-    [
-      'fails when no bearer token is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-    [
-      'fails when no session identifier is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-  ])(
-    'rejects on auth failure - %s',
-    async (
-      _: string,
-      arrangeFailureCase: (
-        messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
-      ) => void,
-    ) => {
-      const { messengerMocks } = await arrangeMocks();
-      arrangeFailureCase(messengerMocks);
-      const controller = new UserStorageController({
-        messenger: messengerMocks.messenger,
-      });
-
-      await expect(
-        controller.performGetStorage(
-          `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
-        ),
-      ).rejects.toThrow(expect.any(Error));
-    },
-  );
-});
-
-describe('user-storage/user-storage-controller - performGetStorageAllFeatureEntries() tests', () => {
-  const arrangeMocks = async () => {
-    return {
-      messengerMocks: mockUserStorageMessenger(),
-      mockAPI: await mockEndpointGetUserStorageAllFeatureEntries(),
-    };
-  };
-
-  it('returns users notification storage', async () => {
-    const { messengerMocks, mockAPI } = await arrangeMocks();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-    });
-
-    const result =
-      await controller.performGetStorageAllFeatureEntries('notifications');
-    mockAPI.done();
-    expect(result).toStrictEqual([MOCK_STORAGE_DATA]);
-  });
-
-  it.each([
-    [
-      'fails when no bearer token is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-    [
-      'fails when no session identifier is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-  ])(
-    'rejects on auth failure - %s',
-    async (
-      _: string,
-      arrangeFailureCase: (
-        messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
-      ) => void,
-    ) => {
-      const { messengerMocks } = await arrangeMocks();
-      arrangeFailureCase(messengerMocks);
-      const controller = new UserStorageController({
-        messenger: messengerMocks.messenger,
-      });
-
-      await expect(
-        controller.performGetStorageAllFeatureEntries(
-          USER_STORAGE_FEATURE_NAMES.notifications,
-        ),
-      ).rejects.toThrow(expect.any(Error));
-    },
-  );
-});
-
-describe('user-storage/user-storage-controller - performSetStorage() tests', () => {
-  const arrangeMocks = (overrides?: { mockAPI?: nock.Scope }) => {
-    return {
-      messengerMocks: mockUserStorageMessenger(),
-      mockAPI: overrides?.mockAPI ?? mockEndpointUpsertUserStorage(),
-    };
-  };
-
-  it('saves users storage', async () => {
-    const { messengerMocks, mockAPI } = arrangeMocks();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-    });
-
-    await controller.performSetStorage(
-      `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
-      'new data',
-    );
-    expect(mockAPI.isDone()).toBe(true);
-  });
-
-  it.each([
-    [
-      'fails when no bearer token is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-    [
-      'fails when no session identifier is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-  ])(
-    'rejects on auth failure - %s',
-    async (
-      _: string,
-      arrangeFailureCase: (
-        messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
-      ) => void,
-    ) => {
+    it('creates UserStorage with default state', () => {
       const { messengerMocks } = arrangeMocks();
-      arrangeFailureCase(messengerMocks);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
       });
 
+      expect(controller.state.isBackupAndSyncEnabled).toBe(true);
+    });
+  });
+
+  describe('performGetStorage', () => {
+    const arrangeMocks = async () => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+        mockAPI: await mockEndpointGetUserStorage(),
+      };
+    };
+
+    it('returns users notification storage', async () => {
+      const { messengerMocks, mockAPI } = await arrangeMocks();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
+
+      const result = await controller.performGetStorage(
+        `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
+      );
+      mockAPI.done();
+      expect(result).toBe(MOCK_STORAGE_DATA);
+    });
+
+    it.each([
+      [
+        'fails when no bearer token is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+      [
+        'fails when no session identifier is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+    ])(
+      'rejects on auth failure - %s',
+      async (
+        _: string,
+        arrangeFailureCase: (
+          messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
+        ) => void,
+      ) => {
+        const { messengerMocks } = await arrangeMocks();
+        arrangeFailureCase(messengerMocks);
+        const controller = new UserStorageController({
+          messenger: messengerMocks.messenger,
+        });
+
+        await expect(
+          controller.performGetStorage(
+            `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
+          ),
+        ).rejects.toThrow(expect.any(Error));
+      },
+    );
+  });
+
+  describe('performGetStorageAllFeatureEntries', () => {
+    const arrangeMocks = async () => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+        mockAPI: await mockEndpointGetUserStorageAllFeatureEntries(),
+      };
+    };
+
+    it('returns users notification storage', async () => {
+      const { messengerMocks, mockAPI } = await arrangeMocks();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
+
+      const result =
+        await controller.performGetStorageAllFeatureEntries('notifications');
+      mockAPI.done();
+      expect(result).toStrictEqual([MOCK_STORAGE_DATA]);
+    });
+
+    it.each([
+      [
+        'fails when no bearer token is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+      [
+        'fails when no session identifier is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+    ])(
+      'rejects on auth failure - %s',
+      async (
+        _: string,
+        arrangeFailureCase: (
+          messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
+        ) => void,
+      ) => {
+        const { messengerMocks } = await arrangeMocks();
+        arrangeFailureCase(messengerMocks);
+        const controller = new UserStorageController({
+          messenger: messengerMocks.messenger,
+        });
+
+        await expect(
+          controller.performGetStorageAllFeatureEntries(
+            USER_STORAGE_FEATURE_NAMES.notifications,
+          ),
+        ).rejects.toThrow(expect.any(Error));
+      },
+    );
+  });
+
+  describe('performSetStorage', () => {
+    const arrangeMocks = (overrides?: { mockAPI?: nock.Scope }) => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+        mockAPI: overrides?.mockAPI ?? mockEndpointUpsertUserStorage(),
+      };
+    };
+
+    it('saves users storage', async () => {
+      const { messengerMocks, mockAPI } = arrangeMocks();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
+
+      await controller.performSetStorage(
+        `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
+        'new data',
+      );
+      expect(mockAPI.isDone()).toBe(true);
+    });
+
+    it.each([
+      [
+        'fails when no bearer token is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+      [
+        'fails when no session identifier is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+    ])(
+      'rejects on auth failure - %s',
+      async (
+        _: string,
+        arrangeFailureCase: (
+          messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
+        ) => void,
+      ) => {
+        const { messengerMocks } = arrangeMocks();
+        arrangeFailureCase(messengerMocks);
+        const controller = new UserStorageController({
+          messenger: messengerMocks.messenger,
+        });
+
+        await expect(
+          controller.performSetStorage(
+            `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
+            'new data',
+          ),
+        ).rejects.toThrow(expect.any(Error));
+      },
+    );
+
+    it('rejects if api call fails', async () => {
+      const { messengerMocks } = arrangeMocks({
+        mockAPI: mockEndpointUpsertUserStorage(
+          `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
+          { status: 500 },
+        ),
+      });
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
       await expect(
         controller.performSetStorage(
           `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
           'new data',
         ),
       ).rejects.toThrow(expect.any(Error));
-    },
-  );
-
-  it('rejects if api call fails', async () => {
-    const { messengerMocks } = arrangeMocks({
-      mockAPI: mockEndpointUpsertUserStorage(
-        `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
-        { status: 500 },
-      ),
     });
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-    });
-    await expect(
-      controller.performSetStorage(
-        `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
-        'new data',
-      ),
-    ).rejects.toThrow(expect.any(Error));
   });
-});
 
-describe('user-storage/user-storage-controller - performBatchSetStorage() tests', () => {
-  const arrangeMocks = (mockResponseStatus?: number) => {
-    return {
-      messengerMocks: mockUserStorageMessenger(),
-      mockAPI: mockEndpointBatchUpsertUserStorage(
-        USER_STORAGE_FEATURE_NAMES.notifications,
-        mockResponseStatus ? { status: mockResponseStatus } : undefined,
-      ),
+  describe('performBatchSetStorage', () => {
+    const arrangeMocks = (mockResponseStatus?: number) => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+        mockAPI: mockEndpointBatchUpsertUserStorage(
+          USER_STORAGE_FEATURE_NAMES.notifications,
+          mockResponseStatus ? { status: mockResponseStatus } : undefined,
+        ),
+      };
     };
-  };
 
-  it('batch saves to user storage', async () => {
-    const { messengerMocks, mockAPI } = arrangeMocks();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+    it('batch saves to user storage', async () => {
+      const { messengerMocks, mockAPI } = arrangeMocks();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
+
+      await controller.performBatchSetStorage(
+        USER_STORAGE_FEATURE_NAMES.notifications,
+        [['notification_settings', 'new data']],
+      );
+      expect(mockAPI.isDone()).toBe(true);
     });
 
-    await controller.performBatchSetStorage(
-      USER_STORAGE_FEATURE_NAMES.notifications,
-      [['notification_settings', 'new data']],
-    );
-    expect(mockAPI.isDone()).toBe(true);
-  });
+    it.each([
+      [
+        'fails when no bearer token is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+      [
+        'fails when no session identifier is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+    ])(
+      'rejects on auth failure - %s',
+      async (
+        _: string,
+        arrangeFailureCase: (
+          messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
+        ) => void,
+      ) => {
+        const { messengerMocks } = arrangeMocks();
+        arrangeFailureCase(messengerMocks);
+        const controller = new UserStorageController({
+          messenger: messengerMocks.messenger,
+        });
 
-  it.each([
-    [
-      'fails when no bearer token is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-    [
-      'fails when no session identifier is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-  ])(
-    'rejects on auth failure - %s',
-    async (
-      _: string,
-      arrangeFailureCase: (
-        messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
-      ) => void,
-    ) => {
-      const { messengerMocks } = arrangeMocks();
-      arrangeFailureCase(messengerMocks);
+        await expect(
+          controller.performBatchSetStorage(
+            USER_STORAGE_FEATURE_NAMES.notifications,
+            [['notification_settings', 'new data']],
+          ),
+        ).rejects.toThrow(expect.any(Error));
+      },
+    );
+
+    it('rejects if api call fails', async () => {
+      const { messengerMocks, mockAPI } = arrangeMocks(500);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
       });
@@ -288,74 +304,74 @@ describe('user-storage/user-storage-controller - performBatchSetStorage() tests'
           [['notification_settings', 'new data']],
         ),
       ).rejects.toThrow(expect.any(Error));
-    },
-  );
-
-  it('rejects if api call fails', async () => {
-    const { messengerMocks, mockAPI } = arrangeMocks(500);
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+      mockAPI.done();
     });
-
-    await expect(
-      controller.performBatchSetStorage(
-        USER_STORAGE_FEATURE_NAMES.notifications,
-        [['notification_settings', 'new data']],
-      ),
-    ).rejects.toThrow(expect.any(Error));
-    mockAPI.done();
   });
-});
 
-describe('user-storage/user-storage-controller - performBatchDeleteStorage() tests', () => {
-  const arrangeMocks = (mockResponseStatus?: number) => {
-    return {
-      messengerMocks: mockUserStorageMessenger(),
-      mockAPI: mockEndpointBatchDeleteUserStorage(
-        'notifications',
-        mockResponseStatus ? { status: mockResponseStatus } : undefined,
-      ),
+  describe('performBatchDeleteStorage', () => {
+    const arrangeMocks = (mockResponseStatus?: number) => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+        mockAPI: mockEndpointBatchDeleteUserStorage(
+          'notifications',
+          mockResponseStatus ? { status: mockResponseStatus } : undefined,
+        ),
+      };
     };
-  };
 
-  it('batch deletes entries in user storage', async () => {
-    const { messengerMocks, mockAPI } = arrangeMocks();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+    it('batch deletes entries in user storage', async () => {
+      const { messengerMocks, mockAPI } = arrangeMocks();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
+
+      await controller.performBatchDeleteStorage('notifications', [
+        'notification_settings',
+        'notification_settings',
+      ]);
+      expect(mockAPI.isDone()).toBe(true);
     });
 
-    await controller.performBatchDeleteStorage('notifications', [
-      'notification_settings',
-      'notification_settings',
-    ]);
-    expect(mockAPI.isDone()).toBe(true);
-  });
+    it.each([
+      [
+        'fails when no bearer token is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+      [
+        'fails when no session identifier is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+    ])(
+      'rejects on auth failure - %s',
+      async (
+        _: string,
+        arrangeFailureCase: (
+          messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
+        ) => void,
+      ) => {
+        const { messengerMocks } = arrangeMocks();
+        arrangeFailureCase(messengerMocks);
+        const controller = new UserStorageController({
+          messenger: messengerMocks.messenger,
+        });
 
-  it.each([
-    [
-      'fails when no bearer token is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-    [
-      'fails when no session identifier is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-  ])(
-    'rejects on auth failure - %s',
-    async (
-      _: string,
-      arrangeFailureCase: (
-        messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
-      ) => void,
-    ) => {
-      const { messengerMocks } = arrangeMocks();
-      arrangeFailureCase(messengerMocks);
+        await expect(
+          controller.performBatchDeleteStorage('notifications', [
+            'notification_settings',
+            'notification_settings',
+          ]),
+        ).rejects.toThrow(expect.any(Error));
+      },
+    );
+
+    it('rejects if api call fails', async () => {
+      const { messengerMocks, mockAPI } = arrangeMocks(500);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
       });
@@ -366,75 +382,74 @@ describe('user-storage/user-storage-controller - performBatchDeleteStorage() tes
           'notification_settings',
         ]),
       ).rejects.toThrow(expect.any(Error));
-    },
-  );
-
-  it('rejects if api call fails', async () => {
-    const { messengerMocks, mockAPI } = arrangeMocks(500);
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+      mockAPI.done();
     });
-
-    await expect(
-      controller.performBatchDeleteStorage('notifications', [
-        'notification_settings',
-        'notification_settings',
-      ]),
-    ).rejects.toThrow(expect.any(Error));
-    mockAPI.done();
   });
-});
 
-describe('user-storage/user-storage-controller - performDeleteStorage() tests', () => {
-  const arrangeMocks = async (mockResponseStatus?: number) => {
-    return {
-      messengerMocks: mockUserStorageMessenger(),
-      mockAPI: mockEndpointDeleteUserStorage(
-        `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
-        mockResponseStatus ? { status: mockResponseStatus } : undefined,
-      ),
+  describe('performDeleteStorage', () => {
+    const arrangeMocks = async (mockResponseStatus?: number) => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+        mockAPI: mockEndpointDeleteUserStorage(
+          `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
+          mockResponseStatus ? { status: mockResponseStatus } : undefined,
+        ),
+      };
     };
-  };
 
-  it('deletes a user storage entry', async () => {
-    const { messengerMocks, mockAPI } = await arrangeMocks();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+    it('deletes a user storage entry', async () => {
+      const { messengerMocks, mockAPI } = await arrangeMocks();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
+
+      await controller.performDeleteStorage(
+        `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
+      );
+      mockAPI.done();
+
+      expect(mockAPI.isDone()).toBe(true);
     });
 
-    await controller.performDeleteStorage(
-      `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
+    it.each([
+      [
+        'fails when no bearer token is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+      [
+        'fails when no session identifier is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+    ])(
+      'rejects on auth failure - %s',
+      async (
+        _: string,
+        arrangeFailureCase: (
+          messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
+        ) => void,
+      ) => {
+        const { messengerMocks } = await arrangeMocks();
+        arrangeFailureCase(messengerMocks);
+        const controller = new UserStorageController({
+          messenger: messengerMocks.messenger,
+        });
+
+        await expect(
+          controller.performDeleteStorage(
+            `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
+          ),
+        ).rejects.toThrow(expect.any(Error));
+      },
     );
-    mockAPI.done();
 
-    expect(mockAPI.isDone()).toBe(true);
-  });
-
-  it.each([
-    [
-      'fails when no bearer token is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-    [
-      'fails when no session identifier is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
-          new Error('MOCK FAILURE'),
-        ),
-    ],
-  ])(
-    'rejects on auth failure - %s',
-    async (
-      _: string,
-      arrangeFailureCase: (
-        messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
-      ) => void,
-    ) => {
-      const { messengerMocks } = await arrangeMocks();
-      arrangeFailureCase(messengerMocks);
+    it('rejects if api call fails', async () => {
+      const { messengerMocks, mockAPI } = await arrangeMocks(500);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
       });
@@ -444,74 +459,74 @@ describe('user-storage/user-storage-controller - performDeleteStorage() tests', 
           `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
         ),
       ).rejects.toThrow(expect.any(Error));
-    },
-  );
-
-  it('rejects if api call fails', async () => {
-    const { messengerMocks, mockAPI } = await arrangeMocks(500);
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+      mockAPI.done();
     });
-
-    await expect(
-      controller.performDeleteStorage(
-        `${USER_STORAGE_FEATURE_NAMES.notifications}.notification_settings`,
-      ),
-    ).rejects.toThrow(expect.any(Error));
-    mockAPI.done();
-  });
-});
-
-describe('user-storage/user-storage-controller - performDeleteStorageAllFeatureEntries() tests', () => {
-  const arrangeMocks = async (mockResponseStatus?: number) => {
-    return {
-      messengerMocks: mockUserStorageMessenger(),
-      mockAPI: mockEndpointDeleteUserStorageAllFeatureEntries(
-        USER_STORAGE_FEATURE_NAMES.notifications,
-        mockResponseStatus ? { status: mockResponseStatus } : undefined,
-      ),
-    };
-  };
-
-  it('deletes all user storage entries for a feature', async () => {
-    const { messengerMocks, mockAPI } = await arrangeMocks();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-    });
-
-    await controller.performDeleteStorageAllFeatureEntries(
-      USER_STORAGE_FEATURE_NAMES.notifications,
-    );
-    mockAPI.done();
-
-    expect(mockAPI.isDone()).toBe(true);
   });
 
-  it.each([
-    [
-      'fails when no bearer token is found (auth errors)',
-      (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-        messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
-          new Error('MOCK FAILURE'),
+  describe('performDeleteStorageAllFeatureEntries', () => {
+    const arrangeMocks = async (mockResponseStatus?: number) => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+        mockAPI: mockEndpointDeleteUserStorageAllFeatureEntries(
+          USER_STORAGE_FEATURE_NAMES.notifications,
+          mockResponseStatus ? { status: mockResponseStatus } : undefined,
         ),
-    ],
-    // [
-    //   'fails when no session identifier is found (auth errors)',
-    //   (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
-    //     messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
-    //       new Error('MOCK FAILURE'),
-    //     ),
-    // ],
-  ])(
-    'rejects on auth failure - %s',
-    async (
-      _: string,
-      arrangeFailureCase: (
-        messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
-      ) => void,
-    ) => {
-      const { messengerMocks } = await arrangeMocks();
-      arrangeFailureCase(messengerMocks);
+      };
+    };
+
+    it('deletes all user storage entries for a feature', async () => {
+      const { messengerMocks, mockAPI } = await arrangeMocks();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
+
+      await controller.performDeleteStorageAllFeatureEntries(
+        USER_STORAGE_FEATURE_NAMES.notifications,
+      );
+      mockAPI.done();
+
+      expect(mockAPI.isDone()).toBe(true);
+    });
+
+    it.each([
+      [
+        'fails when no bearer token is found (auth errors)',
+        (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+          messengerMocks.mockAuthGetBearerToken.mockRejectedValue(
+            new Error('MOCK FAILURE'),
+          ),
+      ],
+      // [
+      //   'fails when no session identifier is found (auth errors)',
+      //   (messengerMocks: ReturnType<typeof mockUserStorageMessenger>) =>
+      //     messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
+      //       new Error('MOCK FAILURE'),
+      //     ),
+      // ],
+    ])(
+      'rejects on auth failure - %s',
+      async (
+        _: string,
+        arrangeFailureCase: (
+          messengerMocks: ReturnType<typeof mockUserStorageMessenger>,
+        ) => void,
+      ) => {
+        const { messengerMocks } = await arrangeMocks();
+        arrangeFailureCase(messengerMocks);
+        const controller = new UserStorageController({
+          messenger: messengerMocks.messenger,
+        });
+
+        await expect(
+          controller.performDeleteStorageAllFeatureEntries(
+            USER_STORAGE_FEATURE_NAMES.notifications,
+          ),
+        ).rejects.toThrow(expect.any(Error));
+      },
+    );
+
+    it('rejects if api call fails', async () => {
+      const { messengerMocks, mockAPI } = await arrangeMocks(500);
       const controller = new UserStorageController({
         messenger: messengerMocks.messenger,
       });
@@ -521,338 +536,329 @@ describe('user-storage/user-storage-controller - performDeleteStorageAllFeatureE
           USER_STORAGE_FEATURE_NAMES.notifications,
         ),
       ).rejects.toThrow(expect.any(Error));
-    },
-  );
-
-  it('rejects if api call fails', async () => {
-    const { messengerMocks, mockAPI } = await arrangeMocks(500);
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+      mockAPI.done();
     });
-
-    await expect(
-      controller.performDeleteStorageAllFeatureEntries(
-        USER_STORAGE_FEATURE_NAMES.notifications,
-      ),
-    ).rejects.toThrow(expect.any(Error));
-    mockAPI.done();
   });
-});
 
-describe('user-storage/user-storage-controller - getStorageKey() tests', () => {
-  const arrangeMocks = async () => {
-    return {
-      messengerMocks: mockUserStorageMessenger(),
+  describe('getStorageKey', () => {
+    const arrangeMocks = async () => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+      };
     };
-  };
 
-  it('should return a storage key', async () => {
-    const { messengerMocks } = await arrangeMocks();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+    it('should return a storage key', async () => {
+      const { messengerMocks } = await arrangeMocks();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
+
+      const result = await controller.getStorageKey();
+      expect(result).toBe(MOCK_STORAGE_KEY);
     });
 
-    const result = await controller.getStorageKey();
-    expect(result).toBe(MOCK_STORAGE_KEY);
-  });
+    it('fails when no session identifier is found (auth error)', async () => {
+      const { messengerMocks } = await arrangeMocks();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
 
-  it('fails when no session identifier is found (auth error)', async () => {
-    const { messengerMocks } = await arrangeMocks();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+      messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
+        new Error('MOCK FAILURE'),
+      );
+
+      await expect(controller.getStorageKey()).rejects.toThrow(
+        expect.any(Error),
+      );
     });
-
-    messengerMocks.mockAuthGetSessionProfile.mockRejectedValue(
-      new Error('MOCK FAILURE'),
-    );
-
-    await expect(controller.getStorageKey()).rejects.toThrow(expect.any(Error));
   });
-});
 
-describe('user-storage/user-storage-controller - setIsBackupAndSyncFeatureEnabled tests', () => {
-  const arrangeMocks = async () => {
-    return {
-      messengerMocks: mockUserStorageMessenger(),
+  describe('setIsBackupAndSyncFeatureEnabled tests', () => {
+    const arrangeMocks = async () => {
+      return {
+        messengerMocks: mockUserStorageMessenger(),
+      };
     };
-  };
 
-  it('should enable user storage / backup and sync', async () => {
-    const { messengerMocks } = await arrangeMocks();
-    messengerMocks.mockAuthIsSignedIn.mockReturnValue(false); // mock that auth is not enabled
+    it('should enable user storage / backup and sync', async () => {
+      const { messengerMocks } = await arrangeMocks();
+      messengerMocks.mockAuthIsSignedIn.mockReturnValue(false); // mock that auth is not enabled
 
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-      state: {
-        isBackupAndSyncEnabled: false,
-        isBackupAndSyncUpdateLoading: false,
-        isAccountSyncingEnabled: false,
-        hasAccountSyncingSyncedAtLeastOnce: false,
-        isAccountSyncingReadyToBeDispatched: false,
-        isAccountSyncingInProgress: false,
-        isContactSyncingEnabled: false,
-        isContactSyncingInProgress: false,
-      },
-    });
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+        state: {
+          isBackupAndSyncEnabled: false,
+          isBackupAndSyncUpdateLoading: false,
+          isAccountSyncingEnabled: false,
+          hasAccountSyncingSyncedAtLeastOnce: false,
+          isAccountSyncingReadyToBeDispatched: false,
+          isAccountSyncingInProgress: false,
+          isContactSyncingEnabled: false,
+          isContactSyncingInProgress: false,
+        },
+      });
 
-    expect(controller.state.isBackupAndSyncEnabled).toBe(false);
-    await controller.setIsBackupAndSyncFeatureEnabled(
-      BACKUPANDSYNC_FEATURES.main,
-      true,
-    );
-    expect(controller.state.isBackupAndSyncEnabled).toBe(true);
-    expect(messengerMocks.mockAuthIsSignedIn).toHaveBeenCalled();
-    expect(messengerMocks.mockAuthPerformSignIn).toHaveBeenCalled();
-  });
-
-  it('should not update state if it throws', async () => {
-    const { messengerMocks } = await arrangeMocks();
-    messengerMocks.mockAuthIsSignedIn.mockReturnValue(false); // mock that auth is not enabled
-
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-      state: {
-        isBackupAndSyncEnabled: false,
-        isBackupAndSyncUpdateLoading: false,
-        isAccountSyncingEnabled: false,
-        hasAccountSyncingSyncedAtLeastOnce: false,
-        isAccountSyncingReadyToBeDispatched: false,
-        isAccountSyncingInProgress: false,
-        isContactSyncingEnabled: false,
-        isContactSyncingInProgress: false,
-      },
-    });
-
-    expect(controller.state.isBackupAndSyncEnabled).toBe(false);
-    messengerMocks.mockAuthPerformSignIn.mockRejectedValue(new Error('error'));
-
-    await expect(
-      controller.setIsBackupAndSyncFeatureEnabled(
+      expect(controller.state.isBackupAndSyncEnabled).toBe(false);
+      await controller.setIsBackupAndSyncFeatureEnabled(
         BACKUPANDSYNC_FEATURES.main,
         true,
-      ),
-    ).rejects.toThrow('error');
-    expect(controller.state.isBackupAndSyncEnabled).toBe(false);
-  });
-
-  it('should not disable backup and sync when disabling account syncing', async () => {
-    const { messengerMocks } = await arrangeMocks();
-    messengerMocks.mockAuthIsSignedIn.mockReturnValue(false); // mock that auth is not enabled
-
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-      state: {
-        isBackupAndSyncEnabled: true,
-        isBackupAndSyncUpdateLoading: false,
-        isAccountSyncingEnabled: true,
-        hasAccountSyncingSyncedAtLeastOnce: false,
-        isAccountSyncingReadyToBeDispatched: false,
-        isAccountSyncingInProgress: false,
-        isContactSyncingEnabled: true,
-        isContactSyncingInProgress: false,
-      },
+      );
+      expect(controller.state.isBackupAndSyncEnabled).toBe(true);
+      expect(messengerMocks.mockAuthIsSignedIn).toHaveBeenCalled();
+      expect(messengerMocks.mockAuthPerformSignIn).toHaveBeenCalled();
     });
 
-    expect(controller.state.isBackupAndSyncEnabled).toBe(true);
-    await controller.setIsBackupAndSyncFeatureEnabled(
-      BACKUPANDSYNC_FEATURES.accountSyncing,
-      false,
-    );
-    expect(controller.state.isAccountSyncingEnabled).toBe(false);
-    expect(controller.state.isBackupAndSyncEnabled).toBe(true);
-  });
-});
+    it('should not update state if it throws', async () => {
+      const { messengerMocks } = await arrangeMocks();
+      messengerMocks.mockAuthIsSignedIn.mockReturnValue(false); // mock that auth is not enabled
 
-describe('user-storage/user-storage-controller - syncInternalAccountsWithUserStorage() tests', () => {
-  const arrangeMocks = () => {
-    const messengerMocks = mockUserStorageMessengerForAccountSyncing();
-    const mockSyncInternalAccountsWithUserStorage = jest.spyOn(
-      AccountSyncControllerIntegrationModule,
-      'syncInternalAccountsWithUserStorage',
-    );
-    const mockSaveInternalAccountToUserStorage = jest.spyOn(
-      AccountSyncControllerIntegrationModule,
-      'saveInternalAccountToUserStorage',
-    );
-    return {
-      messenger: messengerMocks.messenger,
-      mockSyncInternalAccountsWithUserStorage,
-      mockSaveInternalAccountToUserStorage,
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+        state: {
+          isBackupAndSyncEnabled: false,
+          isBackupAndSyncUpdateLoading: false,
+          isAccountSyncingEnabled: false,
+          hasAccountSyncingSyncedAtLeastOnce: false,
+          isAccountSyncingReadyToBeDispatched: false,
+          isAccountSyncingInProgress: false,
+          isContactSyncingEnabled: false,
+          isContactSyncingInProgress: false,
+        },
+      });
+
+      expect(controller.state.isBackupAndSyncEnabled).toBe(false);
+      messengerMocks.mockAuthPerformSignIn.mockRejectedValue(
+        new Error('error'),
+      );
+
+      await expect(
+        controller.setIsBackupAndSyncFeatureEnabled(
+          BACKUPANDSYNC_FEATURES.main,
+          true,
+        ),
+      ).rejects.toThrow('error');
+      expect(controller.state.isBackupAndSyncEnabled).toBe(false);
+    });
+
+    it('should not disable backup and sync when disabling account syncing', async () => {
+      const { messengerMocks } = await arrangeMocks();
+      messengerMocks.mockAuthIsSignedIn.mockReturnValue(false); // mock that auth is not enabled
+
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+        state: {
+          isBackupAndSyncEnabled: true,
+          isBackupAndSyncUpdateLoading: false,
+          isAccountSyncingEnabled: true,
+          hasAccountSyncingSyncedAtLeastOnce: false,
+          isAccountSyncingReadyToBeDispatched: false,
+          isAccountSyncingInProgress: false,
+          isContactSyncingEnabled: true,
+          isContactSyncingInProgress: false,
+        },
+      });
+
+      expect(controller.state.isBackupAndSyncEnabled).toBe(true);
+      await controller.setIsBackupAndSyncFeatureEnabled(
+        BACKUPANDSYNC_FEATURES.accountSyncing,
+        false,
+      );
+      expect(controller.state.isAccountSyncingEnabled).toBe(false);
+      expect(controller.state.isBackupAndSyncEnabled).toBe(true);
+    });
+  });
+
+  describe('syncInternalAccountsWithUserStorage', () => {
+    const arrangeMocks = () => {
+      const messengerMocks = mockUserStorageMessengerForAccountSyncing();
+      const mockSyncInternalAccountsWithUserStorage = jest.spyOn(
+        AccountSyncControllerIntegrationModule,
+        'syncInternalAccountsWithUserStorage',
+      );
+      const mockSaveInternalAccountToUserStorage = jest.spyOn(
+        AccountSyncControllerIntegrationModule,
+        'saveInternalAccountToUserStorage',
+      );
+      return {
+        messenger: messengerMocks.messenger,
+        mockSyncInternalAccountsWithUserStorage,
+        mockSaveInternalAccountToUserStorage,
+      };
     };
-  };
 
-  // NOTE the actual testing of the implementation is done in `controller-integration.ts` file.
-  // See relevant unit tests to see how this feature works and is tested
-  it('should invoke syncing from the integration module', async () => {
-    const { messenger, mockSyncInternalAccountsWithUserStorage } =
-      arrangeMocks();
-    const controller = new UserStorageController({
-      messenger,
-      // We're only verifying that calling this controller method will call the integration module
-      // The actual implementation is tested in the integration tests
-      // This is done to prevent creating unnecessary nock instances in this test
-      config: {
-        accountSyncing: {
-          onAccountAdded: jest.fn(),
-          onAccountNameUpdated: jest.fn(),
-          onAccountSyncErroneousSituation: jest.fn(),
+    // NOTE the actual testing of the implementation is done in `controller-integration.ts` file.
+    // See relevant unit tests to see how this feature works and is tested
+    it('should invoke syncing from the integration module', async () => {
+      const { messenger, mockSyncInternalAccountsWithUserStorage } =
+        arrangeMocks();
+      const controller = new UserStorageController({
+        messenger,
+        // We're only verifying that calling this controller method will call the integration module
+        // The actual implementation is tested in the integration tests
+        // This is done to prevent creating unnecessary nock instances in this test
+        config: {
+          accountSyncing: {
+            onAccountAdded: jest.fn(),
+            onAccountNameUpdated: jest.fn(),
+            onAccountSyncErroneousSituation: jest.fn(),
+          },
         },
-      },
-    });
+      });
 
-    mockSyncInternalAccountsWithUserStorage.mockImplementation(
-      async (
-        {
-          onAccountAdded,
-          onAccountNameUpdated,
-          onAccountSyncErroneousSituation,
+      mockSyncInternalAccountsWithUserStorage.mockImplementation(
+        async (
+          {
+            onAccountAdded,
+            onAccountNameUpdated,
+            onAccountSyncErroneousSituation,
+          },
+          {
+            getMessenger = jest.fn(),
+            getUserStorageControllerInstance = jest.fn(),
+          },
+        ) => {
+          onAccountAdded?.();
+          onAccountNameUpdated?.();
+          onAccountSyncErroneousSituation?.('error message', {});
+          getMessenger();
+          getUserStorageControllerInstance();
+          return undefined;
         },
-        {
-          getMessenger = jest.fn(),
-          getUserStorageControllerInstance = jest.fn(),
+      );
+
+      await controller.syncInternalAccountsWithUserStorage();
+
+      expect(mockSyncInternalAccountsWithUserStorage).toHaveBeenCalled();
+      expect(controller.state.hasAccountSyncingSyncedAtLeastOnce).toBe(true);
+    });
+  });
+
+  describe('error handling edge cases', () => {
+    const arrangeMocks = () => {
+      const messengerMocks = mockUserStorageMessenger();
+      return { messengerMocks };
+    };
+
+    it('handles disabling backup & sync when already disabled', async () => {
+      const { messengerMocks } = arrangeMocks();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+        state: {
+          ...defaultState,
+          isBackupAndSyncEnabled: false,
         },
-      ) => {
-        onAccountAdded?.();
-        onAccountNameUpdated?.();
-        onAccountSyncErroneousSituation?.('error message', {});
-        getMessenger();
-        getUserStorageControllerInstance();
-        return undefined;
-      },
-    );
+      });
 
-    await controller.syncInternalAccountsWithUserStorage();
-
-    expect(mockSyncInternalAccountsWithUserStorage).toHaveBeenCalled();
-    expect(controller.state.hasAccountSyncingSyncedAtLeastOnce).toBe(true);
-  });
-});
-
-describe('user-storage/user-storage-controller - error handling edge cases', () => {
-  const arrangeMocks = () => {
-    const messengerMocks = mockUserStorageMessenger();
-    return { messengerMocks };
-  };
-
-  it('handles disabling backup & sync when already disabled', async () => {
-    const { messengerMocks } = arrangeMocks();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-      state: {
-        ...defaultState,
-        isBackupAndSyncEnabled: false,
-      },
+      await controller.setIsBackupAndSyncFeatureEnabled(
+        BACKUPANDSYNC_FEATURES.main,
+        false,
+      );
+      expect(controller.state.isBackupAndSyncEnabled).toBe(false);
     });
 
-    await controller.setIsBackupAndSyncFeatureEnabled(
-      BACKUPANDSYNC_FEATURES.main,
-      false,
-    );
-    expect(controller.state.isBackupAndSyncEnabled).toBe(false);
+    it('handles enabling backup & sync when already enabled and signed in', async () => {
+      const { messengerMocks } = arrangeMocks();
+      messengerMocks.mockAuthIsSignedIn.mockReturnValue(true);
+
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+        state: {
+          ...defaultState,
+          isBackupAndSyncEnabled: true,
+        },
+      });
+
+      await controller.setIsBackupAndSyncFeatureEnabled(
+        BACKUPANDSYNC_FEATURES.main,
+        true,
+      );
+      expect(controller.state.isBackupAndSyncEnabled).toBe(true);
+      expect(messengerMocks.mockAuthPerformSignIn).not.toHaveBeenCalled();
+    });
   });
 
-  it('handles enabling backup & sync when already enabled and signed in', async () => {
-    const { messengerMocks } = arrangeMocks();
-    messengerMocks.mockAuthIsSignedIn.mockReturnValue(true);
+  describe('account syncing edge cases', () => {
+    it('handles account syncing disabled case', async () => {
+      const messengerMocks = mockUserStorageMessenger();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
 
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-      state: {
-        ...defaultState,
-        isBackupAndSyncEnabled: true,
-      },
+      await controller.setIsBackupAndSyncFeatureEnabled(
+        BACKUPANDSYNC_FEATURES.accountSyncing,
+        false,
+      );
+      await controller.syncInternalAccountsWithUserStorage();
+
+      // Should not have called the account syncing module
+      expect(messengerMocks.mockAccountsListAccounts).not.toHaveBeenCalled();
     });
 
-    await controller.setIsBackupAndSyncFeatureEnabled(
-      BACKUPANDSYNC_FEATURES.main,
-      true,
-    );
-    expect(controller.state.isBackupAndSyncEnabled).toBe(true);
-    expect(messengerMocks.mockAuthPerformSignIn).not.toHaveBeenCalled();
-  });
-});
+    it('handles syncing when not signed in', async () => {
+      const messengerMocks = mockUserStorageMessenger();
+      messengerMocks.mockAuthIsSignedIn.mockReturnValue(false);
 
-describe('user-storage/user-storage-controller - account syncing edge cases', () => {
-  it('handles account syncing disabled case', async () => {
-    const messengerMocks = mockUserStorageMessenger();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
+
+      await controller.syncInternalAccountsWithUserStorage();
+
+      expect(messengerMocks.mockAuthIsSignedIn).toHaveBeenCalled();
+      expect(messengerMocks.mockAuthPerformSignIn).not.toHaveBeenCalled();
     });
-
-    await controller.setIsBackupAndSyncFeatureEnabled(
-      BACKUPANDSYNC_FEATURES.accountSyncing,
-      false,
-    );
-    await controller.syncInternalAccountsWithUserStorage();
-
-    // Should not have called the account syncing module
-    expect(messengerMocks.mockAccountsListAccounts).not.toHaveBeenCalled();
   });
 
-  it('handles syncing when not signed in', async () => {
-    const messengerMocks = mockUserStorageMessenger();
-    messengerMocks.mockAuthIsSignedIn.mockReturnValue(false);
+  describe('snap handling', () => {
+    it('leverages a cache', async () => {
+      const messengerMocks = mockUserStorageMessenger();
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
 
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+      expect(await controller.getStorageKey()).toBe(MOCK_STORAGE_KEY);
+      controller.flushStorageKeyCache();
+      expect(await controller.getStorageKey()).toBe(MOCK_STORAGE_KEY);
     });
 
-    await controller.syncInternalAccountsWithUserStorage();
+    it('throws if the wallet is locked', async () => {
+      const messengerMocks = mockUserStorageMessenger();
+      messengerMocks.mockKeyringGetState.mockReturnValue({
+        isUnlocked: false,
+        keyrings: [],
+      });
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
 
-    expect(messengerMocks.mockAuthIsSignedIn).toHaveBeenCalled();
-    expect(messengerMocks.mockAuthPerformSignIn).not.toHaveBeenCalled();
-  });
-});
-
-describe('user-storage/user-storage-controller - snap handling', () => {
-  it('leverages a cache', async () => {
-    const messengerMocks = mockUserStorageMessenger();
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
+      await expect(controller.getStorageKey()).rejects.toThrow(
+        '#snapSignMessage - unable to call snap, wallet is locked',
+      );
+      await expect(controller.listEntropySources()).rejects.toThrow(
+        'listEntropySources - unable to list entropy sources, wallet is locked',
+      );
     });
 
-    expect(await controller.getStorageKey()).toBe(MOCK_STORAGE_KEY);
-    controller.flushStorageKeyCache();
-    expect(await controller.getStorageKey()).toBe(MOCK_STORAGE_KEY);
-  });
+    it('handles wallet lock state changes', async () => {
+      const messengerMocks = mockUserStorageMessenger();
 
-  it('throws if the wallet is locked', async () => {
-    const messengerMocks = mockUserStorageMessenger();
-    messengerMocks.mockKeyringGetState.mockReturnValue({
-      isUnlocked: false,
-      keyrings: [],
+      messengerMocks.mockKeyringGetState.mockReturnValue({
+        isUnlocked: true,
+        keyrings: [],
+      });
+
+      const controller = new UserStorageController({
+        messenger: messengerMocks.messenger,
+      });
+
+      messengerMocks.baseMessenger.publish('KeyringController:lock');
+
+      await expect(controller.getStorageKey()).rejects.toThrow(
+        '#snapSignMessage - unable to call snap, wallet is locked',
+      );
+
+      messengerMocks.baseMessenger.publish('KeyringController:unlock');
+      expect(await controller.getStorageKey()).toBe(MOCK_STORAGE_KEY);
     });
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-    });
-
-    await expect(controller.getStorageKey()).rejects.toThrow(
-      '#snapSignMessage - unable to call snap, wallet is locked',
-    );
-    await expect(controller.listEntropySources()).rejects.toThrow(
-      'listEntropySources - unable to list entropy sources, wallet is locked',
-    );
-  });
-
-  it('handles wallet lock state changes', async () => {
-    const messengerMocks = mockUserStorageMessenger();
-
-    messengerMocks.mockKeyringGetState.mockReturnValue({
-      isUnlocked: true,
-      keyrings: [],
-    });
-
-    const controller = new UserStorageController({
-      messenger: messengerMocks.messenger,
-    });
-
-    messengerMocks.baseMessenger.publish('KeyringController:lock');
-
-    await expect(controller.getStorageKey()).rejects.toThrow(
-      '#snapSignMessage - unable to call snap, wallet is locked',
-    );
-
-    messengerMocks.baseMessenger.publish('KeyringController:unlock');
-    expect(await controller.getStorageKey()).toBe(MOCK_STORAGE_KEY);
   });
 });


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR updates the `AuthenticationController` and `UserStorageController` test suites to follow the same grouping and structure used in other controller tests, ensuring consistency across the codebase.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
