### PR TITLE
refactor: migrate `PreferencesController` to `@metamask/messenger`

### DIFF
--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Use new `Messenger` from `@metamask/messenger` ([#6534](https://github.com/MetaMask/core/pull/6534))
+  - Previously, `PreferencesController` accepted a `RestrictedMessenger` instance from `@metamask/base-controller`.
 - Bump `@metamask/base-controller` from `^8.1.0` to `^8.3.0` ([#6355](https://github.com/MetaMask/core/pull/6355), [#6465](https://github.com/MetaMask/core/pull/6465))
 
 ## [19.0.0]

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^8.3.0",
-    "@metamask/controller-utils": "^11.12.0"
+    "@metamask/controller-utils": "^11.12.0",
+    "@metamask/messenger": "^0.2.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -1,13 +1,17 @@
-import { Messenger } from '@metamask/base-controller';
 import { getDefaultKeyringState } from '@metamask/keyring-controller';
+import {
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  type MessengerActions,
+  type MessengerEvents,
+  type MockAnyNamespace,
+} from '@metamask/messenger';
 import { cloneDeep } from 'lodash';
 
 import { ETHERSCAN_SUPPORTED_CHAIN_IDS } from './constants';
 import type {
-  AllowedEvents,
   EtherscanSupportedHexChainId,
-  PreferencesControllerActions,
-  PreferencesControllerEvents,
+  PreferencesControllerMessenger,
 } from './PreferencesController';
 import { PreferencesController } from './PreferencesController';
 
@@ -54,7 +58,7 @@ describe('PreferencesController', () => {
 
   describe('KeyringController:stateChange', () => {
     it('should update identities state to reflect new keyring accounts', () => {
-      const messenger = getMessenger();
+      const messenger = getRootMessenger();
       const controller = setupPreferencesController({
         options: {
           state: {
@@ -102,7 +106,7 @@ describe('PreferencesController', () => {
     });
 
     it('should update identities state to reflect removed keyring accounts', () => {
-      const messenger = getMessenger();
+      const messenger = getRootMessenger();
       const controller = setupPreferencesController({
         options: {
           state: {
@@ -141,7 +145,7 @@ describe('PreferencesController', () => {
     });
 
     it('should update selected address to first identity if the selected address was removed', () => {
-      const messenger = getMessenger();
+      const messenger = getRootMessenger();
       const controller = setupPreferencesController({
         options: {
           state: {
@@ -183,7 +187,7 @@ describe('PreferencesController', () => {
         '0x01': { address: '0x01', importTime: 2, name: 'Account 2' },
         '0x02': { address: '0x02', importTime: 3, name: 'Account 3' },
       };
-      const messenger = getMessenger();
+      const messenger = getRootMessenger();
       const controller = setupPreferencesController({
         options: {
           state: {
@@ -221,7 +225,7 @@ describe('PreferencesController', () => {
         '0x01': { address: '0x01', importTime: 2, name: 'Account 2' },
         '0x02': { address: '0x02', importTime: 3, name: 'Account 3' },
       };
-      const messenger = getMessenger();
+      const messenger = getRootMessenger();
       const controller = setupPreferencesController({
         options: {
           state: {
@@ -259,7 +263,7 @@ describe('PreferencesController', () => {
         '0x01': { address: '0x01', importTime: 2, name: 'Account 2' },
         '0x02': { address: '0x02', importTime: 3, name: 'Account 3' },
       };
-      const messenger = getMessenger();
+      const messenger = getRootMessenger();
       const controller = setupPreferencesController({
         options: {
           state: {
@@ -305,7 +309,7 @@ describe('PreferencesController', () => {
         '0x01': { address: '0x01', importTime: 2, name: 'Account 2' },
         '0x02': { address: '0x02', importTime: 3, name: 'Account 3' },
       };
-      const messenger = getMessenger();
+      const messenger = getRootMessenger();
       const controller = setupPreferencesController({
         options: {
           state: {
@@ -574,22 +578,27 @@ describe('PreferencesController', () => {
   });
 });
 
+type AllPreferencesControllerActions =
+  MessengerActions<PreferencesControllerMessenger>;
+
+type AllPreferencesControllerEvents =
+  MessengerEvents<PreferencesControllerMessenger>;
+
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  AllPreferencesControllerActions,
+  AllPreferencesControllerEvents
+>;
+
 /**
- * Construct a messenger for use in PreferencesController tests.
+ * Creates and returns a root messenger for testing
  *
- * This is a utility function that saves us from manually entering the correct
- * type parameters for the Messenger each time we construct it.
- *
- * @returns A messenger
+ * @returns A messenger instance
  */
-function getMessenger(): Messenger<
-  PreferencesControllerActions,
-  PreferencesControllerEvents | AllowedEvents
-> {
-  return new Messenger<
-    PreferencesControllerActions,
-    PreferencesControllerEvents | AllowedEvents
-  >();
+function getRootMessenger(): RootMessenger {
+  return new Messenger({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
 }
 
 /**
@@ -602,22 +611,24 @@ function getMessenger(): Messenger<
  */
 function setupPreferencesController({
   options = {},
-  messenger = getMessenger(),
+  messenger = getRootMessenger(),
 }: {
   options?: Partial<ConstructorParameters<typeof PreferencesController>[0]>;
-  messenger?: Messenger<
-    PreferencesControllerActions,
-    PreferencesControllerEvents | AllowedEvents
-  >;
+  messenger?: RootMessenger;
 } = {}) {
-  const preferencesControllerMessenger = messenger.getRestricted<
+  const preferencesControllerMessenger = new Messenger<
     'PreferencesController',
-    never,
-    AllowedEvents['type']
+    AllPreferencesControllerActions,
+    AllPreferencesControllerEvents,
+    RootMessenger
   >({
-    name: 'PreferencesController',
-    allowedActions: [],
-    allowedEvents: ['KeyringController:stateChange'],
+    namespace: 'PreferencesController',
+    parent: messenger,
+  });
+  messenger.delegate({
+    messenger: preferencesControllerMessenger,
+    actions: [],
+    events: ['KeyringController:stateChange'],
   });
   return new PreferencesController({
     messenger: preferencesControllerMessenger,

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -2,13 +2,13 @@ import {
   BaseController,
   type ControllerStateChangeEvent,
   type ControllerGetStateAction,
-  type RestrictedMessenger,
-} from '@metamask/base-controller';
+} from '@metamask/base-controller/next';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import type {
   KeyringControllerState,
   KeyringControllerStateChangeEvent,
 } from '@metamask/keyring-controller';
+import type { Messenger } from '@metamask/messenger';
 import type { Hex } from '@metamask/utils';
 
 import { ETHERSCAN_SUPPORTED_CHAIN_IDS } from './constants';
@@ -190,14 +190,12 @@ export type PreferencesControllerActions = PreferencesControllerGetStateAction;
 
 export type PreferencesControllerEvents = PreferencesControllerStateChangeEvent;
 
-export type AllowedEvents = KeyringControllerStateChangeEvent;
+type AllowedEvents = KeyringControllerStateChangeEvent;
 
-export type PreferencesControllerMessenger = RestrictedMessenger<
+export type PreferencesControllerMessenger = Messenger<
   typeof name,
   PreferencesControllerActions,
-  PreferencesControllerEvents | AllowedEvents,
-  never,
-  AllowedEvents['type']
+  PreferencesControllerEvents | AllowedEvents
 >;
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4234,6 +4234,7 @@ __metadata:
     "@metamask/base-controller": "npm:^8.3.0"
     "@metamask/controller-utils": "npm:^11.12.0"
     "@metamask/keyring-controller": "npm:^23.0.0"
+    "@metamask/messenger": "npm:^0.2.0"
     "@metamask/utils": "npm:^11.4.2"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This PR migrates `PreferencesController` to the new `@metamask/messenger` message bus, as opposed to the one exported from `@metamask/base-controller`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Related to #5626

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes