### PR TITLE
refactor: migrate `PermissionLogController` to `@metamask/messenger`

### DIFF
--- a/packages/permission-log-controller/CHANGELOG.md
+++ b/packages/permission-log-controller/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export `PermissionLogControllerGetStateAction` messenger action and `PermissionLogControllerStateChangeEvent` messenger event ([#6536](https://github.com/MetaMask/core/pull/6536))
+
 ### Changed
 
+- **BREAKING:** Use new `Messenger` from `@metamask/messenger` ([#6536](https://github.com/MetaMask/core/pull/6536))
+  - Previously, `PermissionLogController` accepted a `RestrictedMessenger` instance from `@metamask/base-controller`.
 - Bump `@metamask/base-controller` from `^8.0.1` to `^8.3.0` ([#6284](https://github.com/MetaMask/core/pull/6284), [#6355](https://github.com/MetaMask/core/pull/6355), [#6465](https://github.com/MetaMask/core/pull/6465))
 
 ## [4.0.0]

--- a/packages/permission-log-controller/package.json
+++ b/packages/permission-log-controller/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@metamask/base-controller": "^8.3.0",
     "@metamask/json-rpc-engine": "^10.0.3",
+    "@metamask/messenger": "^0.2.0",
     "@metamask/utils": "^11.4.2"
   },
   "devDependencies": {

--- a/packages/permission-log-controller/src/PermissionLogController.ts
+++ b/packages/permission-log-controller/src/PermissionLogController.ts
@@ -1,8 +1,10 @@
 import {
   BaseController,
-  type RestrictedMessenger,
-} from '@metamask/base-controller';
+  type ControllerGetStateAction,
+  type ControllerStateChangeEvent,
+} from '@metamask/base-controller/next';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
+import type { Messenger } from '@metamask/messenger';
 import {
   type Json,
   type JsonRpcRequest,
@@ -70,12 +72,24 @@ export type PermissionLogControllerOptions = {
   messenger: PermissionLogControllerMessenger;
 };
 
-export type PermissionLogControllerMessenger = RestrictedMessenger<
+export type PermissionLogControllerGetStateAction = ControllerGetStateAction<
   typeof name,
-  never,
-  never,
-  never,
-  never
+  PermissionLogControllerState
+>;
+
+export type PermissionLogControllerActions =
+  PermissionLogControllerGetStateAction;
+
+export type PermissionLogControllerStateChangeEvent =
+  ControllerStateChangeEvent<typeof name, PermissionLogControllerState>;
+
+export type PermissionLogControllerEvents =
+  PermissionLogControllerStateChangeEvent;
+
+export type PermissionLogControllerMessenger = Messenger<
+  typeof name,
+  PermissionLogControllerActions,
+  PermissionLogControllerEvents
 >;
 
 const defaultState: PermissionLogControllerState = {

--- a/packages/permission-log-controller/src/index.ts
+++ b/packages/permission-log-controller/src/index.ts
@@ -1,1 +1,17 @@
-export * from './PermissionLogController';
+export { PermissionLogController } from './PermissionLogController';
+export type {
+  JsonRpcRequestWithOrigin,
+  Caveat,
+  Permission,
+  PermissionActivityLog,
+  PermissionLog,
+  PermissionEntry,
+  PermissionHistory,
+  PermissionLogControllerActions,
+  PermissionLogControllerGetStateAction,
+  PermissionLogControllerStateChangeEvent,
+  PermissionLogControllerEvents,
+  PermissionLogControllerMessenger,
+  PermissionLogControllerState,
+  PermissionLogControllerOptions,
+} from './PermissionLogController';

--- a/packages/permission-log-controller/tests/PermissionLogController.test.ts
+++ b/packages/permission-log-controller/tests/PermissionLogController.test.ts
@@ -1,8 +1,14 @@
-import { Messenger } from '@metamask/base-controller';
 import type {
   JsonRpcEngineReturnHandler,
   JsonRpcEngineNextCallback,
 } from '@metamask/json-rpc-engine';
+import {
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  type MessengerActions,
+  type MessengerEvents,
+  type MockAnyNamespace,
+} from '@metamask/messenger';
 import {
   type PendingJsonRpcResponse,
   type JsonRpcRequest,
@@ -13,9 +19,10 @@ import { nanoid } from 'nanoid';
 import { constants, getters, noop } from './helpers';
 import { LOG_LIMIT, LOG_METHOD_TYPES } from '../src/enums';
 import {
+  PermissionLogController,
   type Permission,
   type PermissionLogControllerState,
-  PermissionLogController,
+  type PermissionLogControllerMessenger,
 } from '../src/PermissionLogController';
 
 const { PERMS, RPC_REQUESTS } = getters;
@@ -33,6 +40,29 @@ class CustomError extends Error {
 
 const name = 'PermissionLogController';
 
+type AllPermissionLogControllerActions =
+  MessengerActions<PermissionLogControllerMessenger>;
+
+type AllPermissionLogControllerEvents =
+  MessengerEvents<PermissionLogControllerMessenger>;
+
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  AllPermissionLogControllerActions,
+  AllPermissionLogControllerEvents
+>;
+
+/**
+ * Creates and returns a root messenger for testing
+ *
+ * @returns A messenger instance
+ */
+function getRootMessenger(): RootMessenger {
+  return new Messenger({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+}
+
 const initController = ({
   restrictedMethods,
   state,
@@ -40,10 +70,15 @@ const initController = ({
   restrictedMethods: Set<string>;
   state?: Partial<PermissionLogControllerState>;
 }): PermissionLogController => {
-  const messenger = new Messenger().getRestricted({
-    name,
-    allowedActions: [],
-    allowedEvents: [],
+  const rootMessenger = getRootMessenger();
+  const messenger = new Messenger<
+    typeof name,
+    AllPermissionLogControllerActions,
+    AllPermissionLogControllerEvents,
+    RootMessenger
+  >({
+    namespace: name,
+    parent: rootMessenger,
   });
   return new PermissionLogController({
     messenger,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4138,6 +4138,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^8.3.0"
     "@metamask/json-rpc-engine": "npm:^10.0.3"
+    "@metamask/messenger": "npm:^0.2.0"
     "@metamask/utils": "npm:^11.4.2"
     "@types/deep-freeze-strict": "npm:^1.1.0"
     "@types/jest": "npm:^27.4.1"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This PR migrates `PermissionLogController` to the new `@metamask/messenger` message bus, as opposed to the one exported from `@metamask/base-controller`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Related to #5626

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes