### PR TITLE
chore: Update CODEOWNERS to migrate snaps to core platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,9 +39,6 @@
 ## Product Safety Team
 /packages/phishing-controller              @MetaMask/product-safety
 
-## Snaps Team
-/packages/rate-limit-controller            @MetaMask/snaps-devs
-
 ## Swaps-Bridge Team
 /packages/bridge-controller                @MetaMask/swaps-engineers
 /packages/bridge-status-controller        @MetaMask/swaps-engineers
@@ -73,6 +70,7 @@
 /packages/sample-controllers           @MetaMask/core-platform
 /packages/polling-controller           @MetaMask/core-platform
 /packages/preferences-controller       @MetaMask/core-platform
+/packages/rate-limit-controller        @MetaMask/core-platform
 
 ## Wallet UX Team
 /packages/announcement-controller      @MetaMask/wallet-ux
@@ -89,7 +87,7 @@
 /packages/keyring-controller           @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/multichain-network-controller  @MetaMask/core-platform @MetaMask/accounts-engineers @MetaMask/metamask-assets
 /packages/network-controller           @MetaMask/core-platform @MetaMask/metamask-assets
-/packages/permission-controller        @MetaMask/wallet-api-platform-engineers @MetaMask/core-platform @MetaMask/snaps-devs
+/packages/permission-controller        @MetaMask/wallet-api-platform-engineers @MetaMask/core-platform
 /packages/permission-log-controller    @MetaMask/wallet-api-platform-engineers @MetaMask/core-platform
 /packages/profile-sync-controller      @MetaMask/identity
 /packages/remote-feature-flag-controller @MetaMask/extension-platform @MetaMask/mobile-platform
@@ -146,8 +144,6 @@
 /packages/selected-network-controller/CHANGELOG.md @MetaMask/wallet-api-platform-engineers @MetaMask/core-platform
 /packages/signature-controller/package.json       @MetaMask/confirmations @MetaMask/core-platform
 /packages/signature-controller/CHANGELOG.md       @MetaMask/confirmations @MetaMask/core-platform
-/packages/rate-limit-controller/package.json      @MetaMask/snaps-devs @MetaMask/core-platform
-/packages/rate-limit-controller/CHANGELOG.md      @MetaMask/snaps-devs @MetaMask/core-platform
 /packages/transaction-controller/package.json     @MetaMask/confirmations @MetaMask/core-platform
 /packages/transaction-controller/CHANGELOG.md     @MetaMask/confirmations @MetaMask/core-platform
 /packages/user-operation-controller/package.json  @MetaMask/confirmations @MetaMask/core-platform


### PR DESCRIPTION
## Explanation

The snaps team and wallet framework teams have been combined into the core platform team. All `snaps-dev` entries in CODEOWNERS have been updated to be owned by `core-platform`.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
