### PR TITLE
feat: Add new metadata properties to `RemoteFeatureFlagController`

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -334,8 +334,7 @@
   },
   "packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts": {
     "@typescript-eslint/prefer-readonly": 1,
-    "jsdoc/check-tag-names": 2,
-    "prettier/prettier": 1
+    "jsdoc/check-tag-names": 2
   },
   "packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts": {
     "jsdoc/tag-lines": 2

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add two new controller state metadata properties: `includeInStateLogs` and `usedInUi` ([#6574](https://github.com/MetaMask/core/pull/6574))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^8.0.1` to `^8.4.0` ([#6284](https://github.com/MetaMask/core/pull/6284), [#6355](https://github.com/MetaMask/core/pull/6355), [#6465](https://github.com/MetaMask/core/pull/6465), [#6632](https://github.com/MetaMask/core/pull/6632))

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -1,4 +1,4 @@
-import { Messenger } from '@metamask/base-controller';
+import { Messenger, deriveStateFromMetadata } from '@metamask/base-controller';
 
 import type { AbstractClientConfigApiService } from './client-config-api-service/abstract-client-config-api-service';
 import {
@@ -339,6 +339,75 @@ describe('RemoteFeatureFlagController', () => {
         remoteFeatureFlags: {},
         cacheTimestamp: 0,
       });
+    });
+  });
+
+  describe('metadata', () => {
+    it('includes expected state in debug snapshots', () => {
+      const controller = createController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'anonymous',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "cacheTimestamp": 0,
+          "remoteFeatureFlags": Object {},
+        }
+      `);
+    });
+
+    it('includes expected state in state logs', () => {
+      const controller = createController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'includeInStateLogs',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "cacheTimestamp": 0,
+          "remoteFeatureFlags": Object {},
+        }
+      `);
+    });
+
+    it('persists expected state', () => {
+      const controller = createController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'persist',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "cacheTimestamp": 0,
+          "remoteFeatureFlags": Object {},
+        }
+      `);
+    });
+
+    it('exposes expected state to UI', () => {
+      const controller = createController();
+
+      expect(
+        deriveStateFromMetadata(
+          controller.state,
+          controller.metadata,
+          'usedInUi',
+        ),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "remoteFeatureFlags": Object {},
+        }
+      `);
     });
   });
 });

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -29,8 +29,18 @@ export type RemoteFeatureFlagControllerState = {
 };
 
 const remoteFeatureFlagControllerMetadata = {
-  remoteFeatureFlags: { persist: true, anonymous: true },
-  cacheTimestamp: { persist: true, anonymous: true },
+  remoteFeatureFlags: {
+    includeInStateLogs: true,
+    persist: true,
+    anonymous: true,
+    usedInUi: true,
+  },
+  cacheTimestamp: {
+    includeInStateLogs: true,
+    persist: true,
+    anonymous: true,
+    usedInUi: false,
+  },
 };
 
 // === MESSENGER ===
@@ -192,7 +202,8 @@ export class RemoteFeatureFlagController extends BaseController<
    * @private
    */
   async #updateCache(remoteFeatureFlags: FeatureFlags) {
-    const processedRemoteFeatureFlags = await this.#processRemoteFeatureFlags(remoteFeatureFlags);
+    const processedRemoteFeatureFlags =
+      await this.#processRemoteFeatureFlags(remoteFeatureFlags);
     this.update(() => {
       return {
         remoteFeatureFlags: processedRemoteFeatureFlags,


### PR DESCRIPTION
## Explanation

The new metadata properties `includeInStateLogs` and `usedInUi` have been added to the `RemoteFeatureFlagController`.

## References

Relates to https://github.com/MetaMask/core/issues/6516

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
