### PR TITLE
feat: Add new metadata properties to `AppMetadataController`

### DIFF
--- a/packages/app-metadata-controller/CHANGELOG.md
+++ b/packages/app-metadata-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add two new controller state metadata properties: `includeInStateLogs` and `usedInUi` ([#6576](https://github.com/MetaMask/core/pull/6576))
+
 ### Changed
 
 - Bump `@metamask/base-controller` from `^8.0.0` to `^8.4.0` ([#5722](https://github.com/MetaMask/core/pull/5722), [#6284](https://github.com/MetaMask/core/pull/6284), [#6355](https://github.com/MetaMask/core/pull/6355), [#6465](https://github.com/MetaMask/core/pull/6465), [#6632](https://github.com/MetaMask/core/pull/6632))

--- a/packages/app-metadata-controller/src/AppMetadataController.test.ts
+++ b/packages/app-metadata-controller/src/AppMetadataController.test.ts
@@ -1,4 +1,4 @@
-import { Messenger } from '@metamask/base-controller';
+import { Messenger, deriveStateFromMetadata } from '@metamask/base-controller';
 
 import {
   AppMetadataController,
@@ -118,6 +118,77 @@ describe('AppMetadataController', () => {
           });
         },
       );
+    });
+  });
+
+  describe('metadata', () => {
+    it('includes expected state in debug snapshots', () => {
+      withController(({ controller }) => {
+        expect(
+          deriveStateFromMetadata(
+            controller.state,
+            controller.metadata,
+            'anonymous',
+          ),
+        ).toMatchInlineSnapshot(`
+          Object {
+            "currentAppVersion": "",
+            "currentMigrationVersion": 0,
+            "previousAppVersion": "",
+            "previousMigrationVersion": 0,
+          }
+        `);
+      });
+    });
+
+    it('includes expected state in state logs', () => {
+      withController(({ controller }) => {
+        expect(
+          deriveStateFromMetadata(
+            controller.state,
+            controller.metadata,
+            'includeInStateLogs',
+          ),
+        ).toMatchInlineSnapshot(`
+          Object {
+            "currentAppVersion": "",
+            "currentMigrationVersion": 0,
+            "previousAppVersion": "",
+            "previousMigrationVersion": 0,
+          }
+        `);
+      });
+    });
+
+    it('persists expected state', () => {
+      withController(({ controller }) => {
+        expect(
+          deriveStateFromMetadata(
+            controller.state,
+            controller.metadata,
+            'persist',
+          ),
+        ).toMatchInlineSnapshot(`
+          Object {
+            "currentAppVersion": "",
+            "currentMigrationVersion": 0,
+            "previousAppVersion": "",
+            "previousMigrationVersion": 0,
+          }
+        `);
+      });
+    });
+
+    it('exposes expected state to UI', () => {
+      withController(({ controller }) => {
+        expect(
+          deriveStateFromMetadata(
+            controller.state,
+            controller.metadata,
+            'usedInUi',
+          ),
+        ).toMatchInlineSnapshot(`Object {}`);
+      });
     });
   });
 });

--- a/packages/app-metadata-controller/src/AppMetadataController.ts
+++ b/packages/app-metadata-controller/src/AppMetadataController.ts
@@ -103,20 +103,28 @@ export type AppMetadataControllerMessenger = RestrictedMessenger<
  */
 const controllerMetadata = {
   currentAppVersion: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: true,
+    usedInUi: false,
   },
   previousAppVersion: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: true,
+    usedInUi: false,
   },
   previousMigrationVersion: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: true,
+    usedInUi: false,
   },
   currentMigrationVersion: {
+    includeInStateLogs: true,
     persist: true,
     anonymous: true,
+    usedInUi: false,
   },
 } satisfies StateMetadata<AppMetadataControllerState>;
 


### PR DESCRIPTION
## Explanation

The new metadata properties includeInStateLogs and usedInUi have been added to the `AppMetadataController`.

## References

Fixes https://github.com/MetaMask/core/issues/6515

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
