### PR TITLE
feat: Add `Messenger` error reporting

### DIFF
--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `captureException` constructor parameter ([#6605](https://github.com/MetaMask/core/pull/6605))
+  - This function will be used to capture any errors thrown from subscribers.
+  - If this is unset but a parent is provided, `captureException` is inherited from the parent.
+
+### Changed
+
+- Stop re-throwing subscriber errors in a `setTimeout` ([#6605](https://github.com/MetaMask/core/pull/6605))
+  - Instead errors are captured with `captureException`, or logged to the console.
+
 ## [0.2.0]
 
 ### Added


### PR DESCRIPTION
## Explanation

The `Messenger` class in `@metamask/messenger` has been updated to accept an optional `captureException` constructor parameter. This is now used to capture subscriber errors, instead of throwing them in a `setTimeout` (which would cause a crash on mobile).

## References

This is the implementation of the 2nd option in this ADR: https://github.com/MetaMask/decisions/blob/main/decisions/core/0016-core-classes-error-reporting.md#optional-captureexception-constructor-parameter-that-inherits-from-parent

Relates to #6613

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
