### PR TITLE
chore: Synchronously initialise network controller provider if `lookupNetwork` is `false`

### DIFF
--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add two new controller state metadata properties: `includeInStateLogs` and `usedInUi` ([#6525](https://github.com/MetaMask/core/pull/6525))
-- Add `lookupNetwork` option to `initializeProvider`, to allow for skipping the request used to populate metadata for the globally selected network ([#6575](https://github.com/MetaMask/core/pull/6575))
+- Add `lookupNetwork` option to `initializeProvider`, to allow for skipping the request used to populate metadata for the globally selected network ([#6575](https://github.com/MetaMask/core/pull/6575), [#6607](https://github.com/MetaMask/core/pull/6607))
+  - If `lookupNetwork` is set to `false`, the function is fully synchronous, and does not return a promise.
 
 ### Changed
 

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1571,7 +1571,50 @@ export class NetworkController extends BaseController<
    * You can pass `false` if you'd like to disable this request and call
    * `lookupNetwork` yourself.
    */
-  async initializeProvider({
+  initializeProvider(options: { lookupNetwork: false }): void;
+
+  /**
+   * Creates proxies for accessing the global network client and its block
+   * tracker. You must call this method in order to use
+   * `getProviderAndBlockTracker` (or its replacement,
+   * `getSelectedNetworkClient`).
+   *
+   * @param options - Optional arguments.
+   * @param options.lookupNetwork - Usually, metadata for the global network
+   * will be populated via a call to `lookupNetwork` after creating the provider
+   * and block tracker proxies. This allows for responding to the status of the
+   * global network after initializing this controller; however, it requires
+   * making a request to the network to do so. In the clients, where controllers
+   * are initialized before the UI is shown, this may be undesirable, as it
+   * means that if the user has just installed MetaMask, their IP address may be
+   * shared with a third party before they have a chance to finish onboarding.
+   * You can pass `false` if you'd like to disable this request and call
+   * `lookupNetwork` yourself.
+   * @returns A promise that resolves when the network lookup completes.
+   */
+  initializeProvider(options: { lookupNetwork?: true }): Promise<void>;
+
+  /**
+   * Creates proxies for accessing the global network client and its block
+   * tracker. You must call this method in order to use
+   * `getProviderAndBlockTracker` (or its replacement,
+   * `getSelectedNetworkClient`).
+   *
+   * @param options - Optional arguments.
+   * @param options.lookupNetwork - Usually, metadata for the global network
+   * will be populated via a call to `lookupNetwork` after creating the provider
+   * and block tracker proxies. This allows for responding to the status of the
+   * global network after initializing this controller; however, it requires
+   * making a request to the network to do so. In the clients, where controllers
+   * are initialized before the UI is shown, this may be undesirable, as it
+   * means that if the user has just installed MetaMask, their IP address may be
+   * shared with a third party before they have a chance to finish onboarding.
+   * You can pass `false` if you'd like to disable this request and call
+   * `lookupNetwork` yourself.
+   * @returns A promise if `lookupNetwork` is true or undefined, otherwise
+   * returns nothing.
+   */
+  initializeProvider({
     lookupNetwork = true,
   }: {
     lookupNetwork?: boolean;
@@ -1579,8 +1622,10 @@ export class NetworkController extends BaseController<
     this.#applyNetworkSelection(this.state.selectedNetworkClientId);
 
     if (lookupNetwork) {
-      await this.lookupNetwork();
+      return this.lookupNetwork();
     }
+
+    return undefined;
   }
 
   /**

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1592,7 +1592,7 @@ export class NetworkController extends BaseController<
    * `lookupNetwork` yourself.
    * @returns A promise that resolves when the network lookup completes.
    */
-  initializeProvider(options: { lookupNetwork?: true }): Promise<void>;
+  initializeProvider(options?: { lookupNetwork?: boolean }): Promise<void>;
 
   /**
    * Creates proxies for accessing the global network client and its block

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1594,26 +1594,6 @@ export class NetworkController extends BaseController<
    */
   initializeProvider(options?: { lookupNetwork?: boolean }): Promise<void>;
 
-  /**
-   * Creates proxies for accessing the global network client and its block
-   * tracker. You must call this method in order to use
-   * `getProviderAndBlockTracker` (or its replacement,
-   * `getSelectedNetworkClient`).
-   *
-   * @param options - Optional arguments.
-   * @param options.lookupNetwork - Usually, metadata for the global network
-   * will be populated via a call to `lookupNetwork` after creating the provider
-   * and block tracker proxies. This allows for responding to the status of the
-   * global network after initializing this controller; however, it requires
-   * making a request to the network to do so. In the clients, where controllers
-   * are initialized before the UI is shown, this may be undesirable, as it
-   * means that if the user has just installed MetaMask, their IP address may be
-   * shared with a third party before they have a chance to finish onboarding.
-   * You can pass `false` if you'd like to disable this request and call
-   * `lookupNetwork` yourself.
-   * @returns A promise if `lookupNetwork` is true or undefined, otherwise
-   * returns nothing.
-   */
   initializeProvider({
     lookupNetwork = true,
   }: {

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -1294,6 +1294,48 @@ describe('NetworkController', () => {
         }
       });
     });
+
+    it('initializes the provider synchronously if lookupNetwork is false', async () => {
+      await withController(
+        {
+          state: {
+            selectedNetworkClientId: 'AAAA-AAAA-AAAA-AAAA',
+            networkConfigurationsByChainId: {
+              '0x1337': buildCustomNetworkConfiguration({
+                chainId: '0x1337',
+                rpcEndpoints: [
+                  buildCustomRpcEndpoint({
+                    networkClientId: 'AAAA-AAAA-AAAA-AAAA',
+                  }),
+                ],
+              }),
+            },
+          },
+        },
+        async ({ controller }) => {
+          const fakeProvider = buildFakeProvider([
+            {
+              request: {
+                method: 'test_method',
+                params: [],
+              },
+              response: {
+                result: 'test response',
+              },
+            },
+          ]);
+
+          const fakeNetworkClient = buildFakeClient(fakeProvider);
+          createNetworkClientMock.mockReturnValue(fakeNetworkClient);
+
+          const result = controller.initializeProvider({
+            lookupNetwork: false,
+          });
+
+          expect(result).toBeUndefined();
+        },
+      );
+    });
   });
 
   describe('getProviderAndBlockTracker', () => {


### PR DESCRIPTION
## Explanation

This updates the `initializeProvider` function of the network controller to be synchronous if `lookupNetwork` is `false`, i.e., when no async operations need to be performed. Previously the function was `async` meaning it would always return a promise, regardless of whether any async operations are performed. With some function overloads and by removing async (returning a promise instead when necessary), we can make it fully synchronous when `lookupNetwork` is `false`.

Doing this will allow for safe initialisation of the network controller state in places where awaiting may be difficult, like in the client's modular controller initialisation.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
