### PR TITLE
fix(account-tree-controller): use getSelectedMultichainAccount

### DIFF
--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -229,7 +229,7 @@ function getAccountTreeControllerMessenger(
     allowedActions: [
       'AccountsController:listMultichainAccounts',
       'AccountsController:getAccount',
-      'AccountsController:getSelectedAccount',
+      'AccountsController:getSelectedMultichainAccount',
       'AccountsController:setSelectedAccount',
       'UserStorageController:getState',
       'UserStorageController:performGetStorage',
@@ -305,7 +305,7 @@ function setup({
     AccountsController: {
       accounts: InternalAccount[];
       listMultichainAccounts: jest.Mock;
-      getSelectedAccount: jest.Mock;
+      getSelectedMultichainAccount: jest.Mock;
       getAccount: jest.Mock;
     };
     UserStorageController: {
@@ -329,7 +329,7 @@ function setup({
       accounts,
       listMultichainAccounts: jest.fn(),
       getAccount: jest.fn(),
-      getSelectedAccount: jest.fn(),
+      getSelectedMultichainAccount: jest.fn(),
     },
     UserStorageController: {
       getState: jest.fn(),
@@ -366,13 +366,13 @@ function setup({
       mocks.AccountsController.getAccount,
     );
 
-    // Mock AccountsController:getSelectedAccount to return the first account
-    mocks.AccountsController.getSelectedAccount.mockImplementation(
+    // Mock AccountsController:getSelectedMultichainAccount to return the first account
+    mocks.AccountsController.getSelectedMultichainAccount.mockImplementation(
       () => accounts[0] || MOCK_HD_ACCOUNT_1,
     );
     messenger.registerActionHandler(
-      'AccountsController:getSelectedAccount',
-      mocks.AccountsController.getSelectedAccount,
+      'AccountsController:getSelectedMultichainAccount',
+      mocks.AccountsController.getSelectedMultichainAccount,
     );
 
     // Mock AccountsController:setSelectedAccount
@@ -750,7 +750,7 @@ describe('AccountTreeController', () => {
         keyrings: [MOCK_HD_KEYRING_1],
       });
 
-      mocks.AccountsController.getSelectedAccount.mockImplementation(
+      mocks.AccountsController.getSelectedMultichainAccount.mockImplementation(
         () => MOCK_HD_ACCOUNT_1,
       );
 
@@ -767,7 +767,7 @@ describe('AccountTreeController', () => {
 
       mocks.AccountsController.accounts = [MOCK_HD_ACCOUNT_2];
       mocks.KeyringController.keyrings = [MOCK_HD_KEYRING_2];
-      mocks.AccountsController.getSelectedAccount.mockImplementation(
+      mocks.AccountsController.getSelectedMultichainAccount.mockImplementation(
         () => MOCK_HD_ACCOUNT_2,
       );
 
@@ -1554,10 +1554,10 @@ describe('AccountTreeController', () => {
 
       // Unregister existing handler and register new one BEFORE init
       messenger.unregisterActionHandler(
-        'AccountsController:getSelectedAccount',
+        'AccountsController:getSelectedMultichainAccount',
       );
       messenger.registerActionHandler(
-        'AccountsController:getSelectedAccount',
+        'AccountsController:getSelectedMultichainAccount',
         () => EMPTY_ACCOUNT_MOCK,
       );
 
@@ -1581,17 +1581,17 @@ describe('AccountTreeController', () => {
         keyrings: [MOCK_HD_KEYRING_1, MOCK_HD_KEYRING_2],
       });
 
-      // Mock getSelectedAccount to return an account not in the tree BEFORE init
+      // Mock getSelectedMultichainAccount to return an account not in the tree BEFORE init
       const unknownAccount: InternalAccount = {
         ...MOCK_HD_ACCOUNT_1,
         id: 'unknown-account-id',
       };
 
       messenger.unregisterActionHandler(
-        'AccountsController:getSelectedAccount',
+        'AccountsController:getSelectedMultichainAccount',
       );
       messenger.registerActionHandler(
-        'AccountsController:getSelectedAccount',
+        'AccountsController:getSelectedMultichainAccount',
         () => unknownAccount,
       );
 
@@ -1609,18 +1609,18 @@ describe('AccountTreeController', () => {
       expect(controller.getSelectedAccountGroup()).toBe(expectedGroupId1);
     });
 
-    it('returns empty string when no wallets exist and getSelectedAccount returns EMPTY_ACCOUNT', () => {
+    it('returns empty string when no wallets exist and getSelectedMultichainAccount returns EMPTY_ACCOUNT', () => {
       const { controller, messenger } = setup({
         accounts: [],
         keyrings: [],
       });
 
-      // Mock getSelectedAccount to return EMPTY_ACCOUNT_MOCK (id is '') BEFORE init
+      // Mock getSelectedMultichainAccount to return EMPTY_ACCOUNT_MOCK (id is '') BEFORE init
       messenger.unregisterActionHandler(
-        'AccountsController:getSelectedAccount',
+        'AccountsController:getSelectedMultichainAccount',
       );
       messenger.registerActionHandler(
-        'AccountsController:getSelectedAccount',
+        'AccountsController:getSelectedMultichainAccount',
         () => EMPTY_ACCOUNT_MOCK,
       );
 
@@ -2813,7 +2813,7 @@ describe('AccountTreeController', () => {
         keyrings: [MOCK_HD_KEYRING_1],
       });
 
-      mocks.AccountsController.getSelectedAccount.mockImplementation(
+      mocks.AccountsController.getSelectedMultichainAccount.mockImplementation(
         () => MOCK_HD_ACCOUNT_1,
       );
 
@@ -2842,7 +2842,7 @@ describe('AccountTreeController', () => {
         keyrings: [MOCK_HD_KEYRING_1],
       });
 
-      mocks.AccountsController.getSelectedAccount.mockImplementation(
+      mocks.AccountsController.getSelectedMultichainAccount.mockImplementation(
         () => MOCK_HD_ACCOUNT_1,
       );
 
@@ -2865,7 +2865,7 @@ describe('AccountTreeController', () => {
 
       mocks.AccountsController.accounts = [MOCK_HD_ACCOUNT_2];
       mocks.KeyringController.keyrings = [MOCK_HD_KEYRING_2];
-      mocks.AccountsController.getSelectedAccount.mockImplementation(
+      mocks.AccountsController.getSelectedMultichainAccount.mockImplementation(
         () => MOCK_HD_ACCOUNT_2,
       );
 

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -828,7 +828,7 @@ export class AccountTreeController extends BaseController<
     [walletId: AccountWalletId]: AccountWalletObject;
   }): AccountGroupId | '' {
     const selectedAccount = this.messagingSystem.call(
-      'AccountsController:getSelectedAccount',
+      'AccountsController:getSelectedMultichainAccount',
     );
     if (selectedAccount && selectedAccount.id) {
       const accountMapping = this.#accountIdToContext.get(selectedAccount.id);

--- a/packages/account-tree-controller/src/types.ts
+++ b/packages/account-tree-controller/src/types.ts
@@ -3,7 +3,7 @@ import type {
   AccountsControllerAccountAddedEvent,
   AccountsControllerAccountRemovedEvent,
   AccountsControllerGetAccountAction,
-  AccountsControllerGetSelectedAccountAction,
+  AccountsControllerGetSelectedMultichainAccountAction,
   AccountsControllerListMultichainAccountsAction,
   AccountsControllerSelectedAccountChangeEvent,
   AccountsControllerSetSelectedAccountAction,
@@ -115,7 +115,7 @@ export type AccountTreeControllerSetAccountGroupPinnedAction = {
 
 export type AllowedActions =
   | AccountsControllerGetAccountAction
-  | AccountsControllerGetSelectedAccountAction
+  | AccountsControllerGetSelectedMultichainAccountAction
   | AccountsControllerListMultichainAccountsAction
   | AccountsControllerSetSelectedAccountAction
   | KeyringControllerGetStateAction


### PR DESCRIPTION
## Explanation

Back-porting fix from:
- https://github.com/MetaMask/metamask-mobile/pull/19692

Basically, coming from our old account model, the selected account could be a Solana account, thus, it might exactly match (speaking of group index here) the equivalent EVM `getSelectedAccount`.

To fix this, we use `getSelectedMultichainAccount` which can either select a EVM or non-EVM account, thus, allowing the controller to pick the right account group.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
