### PR TITLE
feat: add `Monad Mainnet` support to `@metamask/assets-controllers`

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shared fiat currency and token formatters ([#6577](https://github.com/MetaMask/core/pull/6577))
 - Add `Monad Mainnet` support ([#6618](https://github.com/MetaMask/core/pull/6618))
 
+  - Add `Monad Mainnet` balance scan contract address in `SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID`
+  - Add `Monad Mainnet` in `SupportedTokenDetectionNetworks`
+  - Add `Monad Mainnet` in `SUPPORTED_CHAIN_IDS`
+
 ### Changed
 
 - Add `queryAllAccounts` parameter support to `AccountTrackerController.refresh()`, `AccountTrackerController._executePoll()`, and `TokenBalancesController.updateBalances()` for flexible account selection during balance updates ([#6600](https://github.com/MetaMask/core/pull/6600))

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Shared fiat currency and token formatters ([#6577](https://github.com/MetaMask/core/pull/6577))
+- Add `Monad Mainnet` support ([#6618](https://github.com/MetaMask/core/pull/6618))
 
 ### Changed
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,16 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [75.1.0]
-
 ### Added
 
-- Shared fiat currency and token formatters ([#6577](https://github.com/MetaMask/core/pull/6577))
 - Add `Monad Mainnet` support ([#6618](https://github.com/MetaMask/core/pull/6618))
 
   - Add `Monad Mainnet` balance scan contract address in `SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID`
   - Add `Monad Mainnet` in `SupportedTokenDetectionNetworks`
   - Add `Monad Mainnet` in `SUPPORTED_CHAIN_IDS`
+
+## [75.1.0]
+
+### Added
+
+- Shared fiat currency and token formatters ([#6577](https://github.com/MetaMask/core/pull/6577))
 
 ### Changed
 

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -74,6 +74,8 @@ export const SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID = {
     '0x6aa75276052d96696134252587894ef5ffa520af',
   [SupportedTokenDetectionNetworks.moonriver]:
     '0x6aa75276052d96696134252587894ef5ffa520af',
+  [SupportedTokenDetectionNetworks.monad_mainnet]:
+    '0xC856736BFe4DcB217F6678Ff2C4D7A7939B29A88',
 } as const satisfies Record<Hex, string>;
 
 export const STAKING_CONTRACT_ADDRESS_BY_CHAINID = {

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -194,6 +194,9 @@ export enum SupportedTokenDetectionNetworks {
   // TODO: Either fix this lint violation or explain why it's necessary to ignore.
   // eslint-disable-next-line @typescript-eslint/naming-convention
   sei = '0x531', // decimal: 1329
+  // TODO: Either fix this lint violation or explain why it's necessary to ignore.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  monad_mainnet = '0x8f', // decimal: 143
 }
 
 /**

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -259,6 +259,8 @@ export const SUPPORTED_CHAIN_IDS = [
   '0x531',
   // Sonic Mainnet
   '0x92',
+  // Monad Mainnet
+  '0x8f',
 ] as const;
 
 /**


### PR DESCRIPTION
## Explanation
This PR adds support for Monad Mainnet to the MetaMask assets controllers by integrating the new blockchain network (chain ID 0x8f) into the token detection and pricing systems.

### Notes
Monad Mainnet has not launch yet, there is no RPC but only infura to support this network 

Accounts API is not yet merged, so even we add the chain id, it wont discover the balance via API, but the RPC

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
