### PR TITLE
Release 561.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "560.0.0",
+  "version": "561.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -95,7 +95,7 @@
     "@metamask/preferences-controller": "^19.0.0",
     "@metamask/providers": "^22.1.0",
     "@metamask/snaps-controllers": "^14.0.1",
-    "@metamask/transaction-controller": "^60.3.0",
+    "@metamask/transaction-controller": "^60.4.0",
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.191",
     "@types/node": "^16.18.54",

--- a/packages/bridge-controller/package.json
+++ b/packages/bridge-controller/package.json
@@ -73,7 +73,7 @@
     "@metamask/remote-feature-flag-controller": "^1.7.0",
     "@metamask/snaps-controllers": "^14.0.1",
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/transaction-controller": "^60.3.0",
+    "@metamask/transaction-controller": "^60.4.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/bridge-status-controller/package.json
+++ b/packages/bridge-status-controller/package.json
@@ -63,7 +63,7 @@
     "@metamask/gas-fee-controller": "^24.0.0",
     "@metamask/network-controller": "^24.1.0",
     "@metamask/snaps-controllers": "^14.0.1",
-    "@metamask/transaction-controller": "^60.3.0",
+    "@metamask/transaction-controller": "^60.4.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/earn-controller/package.json
+++ b/packages/earn-controller/package.json
@@ -59,7 +59,7 @@
     "@metamask/account-tree-controller": "^0.16.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/network-controller": "^24.1.0",
-    "@metamask/transaction-controller": "^60.3.0",
+    "@metamask/transaction-controller": "^60.4.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/eip-5792-middleware/CHANGELOG.md
+++ b/packages/eip-5792-middleware/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `@metamask/transaction-controller` from `^60.2.0` to `^60.3.0` ([#6561](https://github.com/MetaMask/core/pull/6561))
+- Bump `@metamask/transaction-controller` from `^60.2.0` to `^60.4.0` ([#6561](https://github.com/MetaMask/core/pull/6561), [#6641](https://github.com/MetaMask/core/pull/6641))
 - Bump `@metamask/utils` from `^11.4.2` to `^11.8.0` ([#6588](https://github.com/MetaMask/core/pull/6588))
 
 ## [1.1.0]

--- a/packages/eip-5792-middleware/package.json
+++ b/packages/eip-5792-middleware/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@metamask/eth-json-rpc-middleware": "^17.0.1",
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/transaction-controller": "^60.3.0",
+    "@metamask/transaction-controller": "^60.4.0",
     "@metamask/utils": "^11.8.0",
     "uuid": "^8.3.2"
   },

--- a/packages/network-enablement-controller/package.json
+++ b/packages/network-enablement-controller/package.json
@@ -50,7 +50,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/multichain-network-controller": "^0.12.0",
     "@metamask/network-controller": "^24.1.0",
-    "@metamask/transaction-controller": "^60.3.0",
+    "@metamask/transaction-controller": "^60.4.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/shield-controller/package.json
+++ b/packages/shield-controller/package.json
@@ -56,7 +56,7 @@
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/signature-controller": "^33.0.0",
-    "@metamask/transaction-controller": "^60.3.0",
+    "@metamask/transaction-controller": "^60.4.0",
     "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [60.4.0]
+
 ### Added
 
 - Expose `confirmExternalTransaction`, `getNonceLock`, `getTransactions`, and `updateTransaction` actions through the messenger ([#6615](https://github.com/MetaMask/core/pull/6615))
@@ -1816,7 +1818,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@60.3.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@60.4.0...HEAD
+[60.4.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@60.3.0...@metamask/transaction-controller@60.4.0
 [60.3.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@60.2.0...@metamask/transaction-controller@60.3.0
 [60.2.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@60.1.0...@metamask/transaction-controller@60.2.0
 [60.1.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-controller@60.0.0...@metamask/transaction-controller@60.1.0

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-controller",
-  "version": "60.3.0",
+  "version": "60.4.0",
   "description": "Stores transactions alongside their periodically updated statuses and manages interactions such as approval and cancellation",
   "keywords": [
     "MetaMask",

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -67,7 +67,7 @@
     "@metamask/gas-fee-controller": "^24.0.0",
     "@metamask/keyring-controller": "^23.1.0",
     "@metamask/network-controller": "^24.1.0",
-    "@metamask/transaction-controller": "^60.3.0",
+    "@metamask/transaction-controller": "^60.4.0",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2612,7 +2612,7 @@ __metadata:
     "@metamask/snaps-controllers": "npm:^14.0.1"
     "@metamask/snaps-sdk": "npm:^9.0.0"
     "@metamask/snaps-utils": "npm:^11.0.0"
-    "@metamask/transaction-controller": "npm:^60.3.0"
+    "@metamask/transaction-controller": "npm:^60.4.0"
     "@metamask/utils": "npm:^11.8.0"
     "@types/bn.js": "npm:^5.1.5"
     "@types/jest": "npm:^27.4.1"
@@ -2747,7 +2747,7 @@ __metadata:
     "@metamask/remote-feature-flag-controller": "npm:^1.7.0"
     "@metamask/snaps-controllers": "npm:^14.0.1"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^60.3.0"
+    "@metamask/transaction-controller": "npm:^60.4.0"
     "@metamask/utils": "npm:^11.8.0"
     "@types/jest": "npm:^27.4.1"
     bignumber.js: "npm:^9.1.2"
@@ -2787,7 +2787,7 @@ __metadata:
     "@metamask/polling-controller": "npm:^14.0.0"
     "@metamask/snaps-controllers": "npm:^14.0.1"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^60.3.0"
+    "@metamask/transaction-controller": "npm:^60.4.0"
     "@metamask/utils": "npm:^11.8.0"
     "@types/jest": "npm:^27.4.1"
     bignumber.js: "npm:^9.1.2"
@@ -3058,7 +3058,7 @@ __metadata:
     "@metamask/keyring-api": "npm:^21.0.0"
     "@metamask/network-controller": "npm:^24.1.0"
     "@metamask/stake-sdk": "npm:^3.2.1"
-    "@metamask/transaction-controller": "npm:^60.3.0"
+    "@metamask/transaction-controller": "npm:^60.4.0"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"
     jest: "npm:^27.5.1"
@@ -3082,7 +3082,7 @@ __metadata:
     "@metamask/keyring-controller": "npm:^23.1.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^60.3.0"
+    "@metamask/transaction-controller": "npm:^60.4.0"
     "@metamask/utils": "npm:^11.8.0"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"
@@ -4042,7 +4042,7 @@ __metadata:
     "@metamask/controller-utils": "npm:^11.14.0"
     "@metamask/multichain-network-controller": "npm:^0.12.0"
     "@metamask/network-controller": "npm:^24.1.0"
-    "@metamask/transaction-controller": "npm:^60.3.0"
+    "@metamask/transaction-controller": "npm:^60.4.0"
     "@metamask/utils": "npm:^11.8.0"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"
@@ -4493,7 +4493,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/base-controller": "npm:^8.4.0"
     "@metamask/signature-controller": "npm:^33.0.0"
-    "@metamask/transaction-controller": "npm:^60.3.0"
+    "@metamask/transaction-controller": "npm:^60.4.0"
     "@metamask/utils": "npm:^11.8.0"
     "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^27.4.1"
@@ -4742,7 +4742,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^60.3.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
+"@metamask/transaction-controller@npm:^60.4.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/transaction-controller@workspace:packages/transaction-controller"
   dependencies:
@@ -4815,7 +4815,7 @@ __metadata:
     "@metamask/polling-controller": "npm:^14.0.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^60.3.0"
+    "@metamask/transaction-controller": "npm:^60.4.0"
     "@metamask/utils": "npm:^11.8.0"
     "@types/jest": "npm:^27.4.1"
     bn.js: "npm:^5.2.1"


### PR DESCRIPTION
This release publishes a new minor version of `@metamask/transaction-controller`, which primarily adds new messenger events that `SmartTransactionsController` can now use instead of receiving function references.

---

This release includes:

- `@metamask/transaction-controller` (60.3.0 -> 60.4.0)