### PR TITLE
fix(account-tree-controller): swallow group creation errors

### DIFF
--- a/packages/account-tree-controller/src/backup-and-sync/syncing/legacy.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/syncing/legacy.ts
@@ -49,6 +49,8 @@ export const performLegacyAccountSyncing = async (
   );
 
   if (numberOfAccountGroupsToCreate > 0) {
+    // Creating multichain account group is idempotent, so we can safely
+    // re-create every groups starting from 0.
     for (let i = 0; i < numberOfAccountGroupsToCreate; i++) {
       backupAndSyncLogger(`Creating account group ${i} for legacy account`);
       await createMultichainAccountGroup(


### PR DESCRIPTION
## Explanation

This PR swallows all group creation errors during backup and sync. This was already the case for multichain syncs but we forgot to do it for legacy syncs. It's now swallowed in every flow.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
