### PR TITLE
method 'decodePermissionFromPermissionContextForOrigin' is now synchronous

### DIFF
--- a/packages/gator-permissions-controller/CHANGELOG.md
+++ b/packages/gator-permissions-controller/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/utils` from `^11.4.2` to `^11.8.0` ([#6588](https://github.com/MetaMask/core/pull/6588))
 - Bump `@metamask/base-controller` from `^8.3.0` to `^8.4.0` ([#6632](https://github.com/MetaMask/core/pull/6632))
+- Function `decodePermissionFromPermissionContextForOrigin` is now synchronous ([#6656](https://github.com/MetaMask/core/pull/6656))
 
 ## [0.1.0]
 

--- a/packages/gator-permissions-controller/src/GatorPermissionsController.test.ts
+++ b/packages/gator-permissions-controller/src/GatorPermissionsController.test.ts
@@ -488,8 +488,8 @@ describe('GatorPermissionsController', () => {
       });
     });
 
-    it('throws if contracts are not found', async () => {
-      await expect(
+    it('throws if contracts are not found', () => {
+      expect(() =>
         controller.decodePermissionFromPermissionContextForOrigin({
           origin: controller.permissionsProviderSnapId,
           chainId: 999999,
@@ -501,10 +501,10 @@ describe('GatorPermissionsController', () => {
           },
           metadata: buildMetadata(''),
         }),
-      ).rejects.toThrow('Contracts not found for chainId: 999999');
+      ).toThrow('Contracts not found for chainId: 999999');
     });
 
-    it('decodes a native-token-stream permission successfully', async () => {
+    it('decodes a native-token-stream permission successfully', () => {
       const {
         TimestampEnforcer,
         NativeTokenStreamingEnforcer,
@@ -552,13 +552,12 @@ describe('GatorPermissionsController', () => {
         caveats,
       };
 
-      const result =
-        await controller.decodePermissionFromPermissionContextForOrigin({
-          origin: controller.permissionsProviderSnapId,
-          chainId,
-          delegation,
-          metadata: buildMetadata('Test justification'),
-        });
+      const result = controller.decodePermissionFromPermissionContextForOrigin({
+        origin: controller.permissionsProviderSnapId,
+        chainId,
+        delegation,
+        metadata: buildMetadata('Test justification'),
+      });
 
       expect(result.chainId).toBe(numberToHex(chainId));
       expect(result.address).toBe(delegator);
@@ -581,8 +580,8 @@ describe('GatorPermissionsController', () => {
       expect(result.permission.justification).toBe('Test justification');
     });
 
-    it('throws when origin does not match permissions provider', async () => {
-      await expect(
+    it('throws when origin does not match permissions provider', () => {
+      expect(() =>
         controller.decodePermissionFromPermissionContextForOrigin({
           origin: 'not-the-provider',
           chainId: 1,
@@ -594,10 +593,10 @@ describe('GatorPermissionsController', () => {
           },
           metadata: buildMetadata(''),
         }),
-      ).rejects.toThrow('Origin not-the-provider not allowed');
+      ).toThrow('Origin not-the-provider not allowed');
     });
 
-    it('throws when enforcers do not identify a supported permission', async () => {
+    it('throws when enforcers do not identify a supported permission', () => {
       const { TimestampEnforcer, ValueLteEnforcer } = contracts;
 
       const expiryTerms = createTimestampTerms(
@@ -615,7 +614,7 @@ describe('GatorPermissionsController', () => {
         { enforcer: ValueLteEnforcer, terms: '0x', args: '0x' } as const,
       ];
 
-      await expect(
+      expect(() =>
         controller.decodePermissionFromPermissionContextForOrigin({
           origin: controller.permissionsProviderSnapId,
           chainId,
@@ -627,10 +626,10 @@ describe('GatorPermissionsController', () => {
           },
           metadata: buildMetadata(''),
         }),
-      ).rejects.toThrow('Failed to decode permission');
+      ).toThrow('Failed to decode permission');
     });
 
-    it('throws when authority is not ROOT_AUTHORITY', async () => {
+    it('throws when authority is not ROOT_AUTHORITY', () => {
       const {
         TimestampEnforcer,
         NativeTokenStreamingEnforcer,
@@ -674,7 +673,7 @@ describe('GatorPermissionsController', () => {
       const invalidAuthority =
         '0x0000000000000000000000000000000000000000' as Hex;
 
-      await expect(
+      expect(() =>
         controller.decodePermissionFromPermissionContextForOrigin({
           origin: controller.permissionsProviderSnapId,
           chainId,
@@ -686,7 +685,7 @@ describe('GatorPermissionsController', () => {
           },
           metadata: buildMetadata(''),
         }),
-      ).rejects.toThrow('Failed to decode permission');
+      ).toThrow('Failed to decode permission');
     });
   });
 });

--- a/packages/gator-permissions-controller/src/GatorPermissionsController.ts
+++ b/packages/gator-permissions-controller/src/GatorPermissionsController.ts
@@ -541,7 +541,7 @@ export default class GatorPermissionsController extends BaseController<
    * @throws If the origin is not allowed, the context cannot be decoded into exactly one delegation,
    * or the enforcers/terms do not match a supported permission type.
    */
-  public async decodePermissionFromPermissionContextForOrigin({
+  public decodePermissionFromPermissionContextForOrigin({
     origin,
     chainId,
     delegation: { caveats, delegator, delegate, authority },
@@ -554,7 +554,7 @@ export default class GatorPermissionsController extends BaseController<
       origin: string;
     };
     delegation: DelegationDetails;
-  }): Promise<DecodedPermission> {
+  }): DecodedPermission {
     if (origin !== this.permissionsProviderSnapId) {
       throw new OriginNotAllowedError({ origin });
     }

--- a/packages/gator-permissions-controller/src/index.ts
+++ b/packages/gator-permissions-controller/src/index.ts
@@ -30,6 +30,7 @@ export type {
   SupportedGatorPermissionType,
   GatorPermissionsMapByPermissionType,
   GatorPermissionsListByPermissionTypeAndChainId,
+  DelegationDetails,
 } from './types';
 
 export type {


### PR DESCRIPTION
## Explanation

The method `decodePermissionFromPermissionContextForOrigin` was incorrectly implemented as a synchronous function. This change updates this function and related tests to be synchronous.

Because this function has not yet been released, this is not being considered a breaking change.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
