### PR TITLE
fix(multichain-account-service): export providers + constant names

### DIFF
--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add missing exports for providers (`{EVM,SOL}_ACCOUNT_PROVIDER_NAME` + `${Evm,Sol}AccountProvider}`) ([#6660](https://github.com/MetaMask/core/pull/6660))
-  - This are required when setting the new account providers when constructing the service.
+  - These are required when setting the new account providers when constructing the service.
 
 ## [0.10.0]
 

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add missing exports for providers (`{EVM,SOL}_ACCOUNT_PROVIDER_NAME` + `${Evm,Sol}AccountProvider}`) ([#6660](https://github.com/MetaMask/core/pull/6660))
+  - This are required when setting the new account providers when constructing the service.
+
 ## [0.10.0]
 
 ### Added

--- a/packages/multichain-account-service/src/index.ts
+++ b/packages/multichain-account-service/src/index.ts
@@ -18,6 +18,10 @@ export {
   BaseBip44AccountProvider,
   SnapAccountProvider,
   TimeoutError,
+  EVM_ACCOUNT_PROVIDER_NAME,
+  EvmAccountProvider,
+  SOL_ACCOUNT_PROVIDER_NAME,
+  SolAccountProvider,
 } from './providers';
 export { MultichainAccountWallet } from './MultichainAccountWallet';
 export { MultichainAccountGroup } from './MultichainAccountGroup';


### PR DESCRIPTION
## Explanation

Add missing exports that needs to be used for the `providerConfigs`.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
