### PR TITLE
feat: add generic number format

### DIFF
--- a/packages/assets-controllers/src/utils/formatters.test.ts
+++ b/packages/assets-controllers/src/utils/formatters.test.ts
@@ -8,6 +8,27 @@ const invalidValues = [
   Number.NEGATIVE_INFINITY,
 ];
 
+describe('formatNumber', () => {
+  const { formatNumber } = createFormatters({ locale });
+
+  it('formats a basic integer', () => {
+    expect(formatNumber(1234)).toBe('1,234');
+  });
+
+  it('respects fraction digit options', () => {
+    expect(
+      formatNumber(1.2345, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }),
+    ).toBe('1.23');
+  });
+
+  it('returns empty string for invalid number', () => {
+    expect(formatNumber(NaN)).toBe('');
+  });
+});
+
 describe('formatCurrency', () => {
   const { formatCurrency } = createFormatters({ locale });
 

--- a/packages/assets-controllers/src/utils/formatters.ts
+++ b/packages/assets-controllers/src/utils/formatters.ts
@@ -52,6 +52,30 @@ function getCachedNumberFormat(
 }
 
 /**
+ * Format a number with optional Intl overrides.
+ *
+ * @param config - Configuration object with locale.
+ * @param config.locale - Locale string.
+ * @param value - Numeric value to format.
+ * @param options - Optional Intl.NumberFormat overrides.
+ * @returns Formatted number string.
+ */
+function formatNumber(
+  config: { locale: string },
+  value: number | bigint | `${number}`,
+  options: Intl.NumberFormatOptions = {},
+) {
+  if (!Number.isFinite(Number(value))) {
+    return '';
+  }
+
+  const numberFormat = getCachedNumberFormat(config.locale, options);
+
+  // @ts-expect-error Remove this comment once TypeScript is updated to 5.5+
+  return numberFormat.format(value);
+}
+
+/**
  * Format a value as a currency string.
  *
  * @param config - Configuration object with locale.
@@ -260,6 +284,13 @@ function formatTokenQuantity(
  */
 export function createFormatters({ locale = FALLBACK_LOCALE }) {
   return {
+    /**
+     * Format a number with optional Intl overrides.
+     *
+     * @param value - Numeric value to format.
+     * @param options - Optional Intl.NumberFormat overrides.
+     */
+    formatNumber: formatNumber.bind(null, { locale }),
     /**
      * Format a value as a currency string.
      *


### PR DESCRIPTION
## Explanation

Add a generic `formatNumber` option to allow clients flexibility while using the formatting cache.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
