### PR TITLE
fix(account-tree-controller): do not save `lastUpdatedAt` for default names

### DIFF
--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set `lastUpdatedAt` to `0` when generating default account group names ([#6672](https://github.com/MetaMask/core/pull/6672))
+  - This created conflicts with backup and sync, where newly created local groups' names were taking precedence over user-defined backed up names.
+
 ## [0.18.0]
 
 ### Added

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -489,7 +489,10 @@ export class AccountTreeController extends BaseController<
       state.accountGroupsMetadata[group.id] ??= {};
       state.accountGroupsMetadata[group.id].name = {
         value: proposedName,
-        lastUpdatedAt: Date.now(),
+        // The `lastUpdatedAt` field is used for backup and sync, when comparing local names
+        // with backed up names. In this case, the generated name should never take precedence
+        // over a user-defined name, so we set `lastUpdatedAt` to 0.
+        lastUpdatedAt: 0,
       };
     }
 

--- a/packages/account-tree-controller/src/backup-and-sync/syncing/metadata.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/syncing/metadata.ts
@@ -52,8 +52,8 @@ export async function compareAndSyncMetadata<T>({
   }
 
   const isUserStorageMoreRecent =
-    localTimestamp &&
-    userStorageTimestamp &&
+    localTimestamp !== undefined &&
+    userStorageTimestamp !== undefined &&
     localTimestamp < userStorageTimestamp;
 
   // Validate user storage value using the provided validator


### PR DESCRIPTION
## Explanation

### Fixed

- Set `lastUpdatedAt` to `0` when generating default account group names.
  - This created conflicts with backup and sync, where newly created local groups' names were taking precedence over user-defined backed up names.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
