### PR TITLE
feat(account-tree-controller): add assert for account name prefix

### DIFF
--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -438,6 +438,7 @@ export class AccountTreeController extends BaseController<
 
       // Get the prefix for groups of this wallet
       const namePrefix = rule.getDefaultAccountGroupPrefix(wallet);
+      assert(namePrefix.length > 0, 'Account name prefix cannot be empty');
 
       // Skip computed names for now - use default naming with per-wallet logic
       // TODO: Implement computed names in a future iteration


### PR DESCRIPTION
## Explanation

Add a small `assert` to avoid having non-conventional group naming if our prefix is empty (those prefixes are not dynamic, so this should never happen anyway).

## References

- https://github.com/MetaMask/core/pull/6679#discussion_r2372348953

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
