### PR TITLE
Revert "chore: release 575.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "575.0.0",
+  "version": "574.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/subscription-controller/CHANGELOG.md
+++ b/packages/subscription-controller/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0]
-
 ### Changed
 
 - Added `displayBrand` in card payment type ([#6669](https://github.com/MetaMask/core/pull/6669))
@@ -36,6 +34,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/controller-utils` from `^11.12.0` to `^11.14.0` ([#6620](https://github.com/MetaMask/core/pull/6620), [#6629](https://github.com/MetaMask/core/pull/6629))
 - Bump `@metamask/utils` from `^11.4.2` to `^11.8.0` ([#6588](https://github.com/MetaMask/core/pull/6588))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/subscription-controller@0.2.0...HEAD
-[0.2.0]: https://github.com/MetaMask/core/compare/@metamask/subscription-controller@0.1.0...@metamask/subscription-controller@0.2.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/subscription-controller@0.1.0...HEAD
 [0.1.0]: https://github.com/MetaMask/core/releases/tag/@metamask/subscription-controller@0.1.0

--- a/packages/subscription-controller/package.json
+++ b/packages/subscription-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/subscription-controller",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Handle user subscription",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
Reverts MetaMask/core#6695 because it was using the wrong format for the PR title, so it didn't trigger a release