### PR TITLE
feat(account-tree-controller): force-init before any account insertion/removal

### DIFF
--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Implicitly call `init` before mutating the tree ([#6709](https://github.com/MetaMask/core/pull/6709))
+  - This ensure the tree to always use existing accounts before inserting/removing any new accounts if `init` has not been called yet.
+
 ### Fixed
 
 - Added logic that prevents an account within a group from being out of order ([#6683](https://github.com/MetaMask/core/pull/6683))

--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `reinit` method ([#6709](https://github.com/MetaMask/core/pull/6709))
+  - This method can be used if we change the entire list of accounts of the `AccountsController` and want to re-initilize the tree with it.
 
 ### Changed
 

--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Implicitly call `init` before mutating the tree ([#6709](https://github.com/MetaMask/core/pull/6709))
-  - This ensure the tree to always use existing accounts before inserting/removing any new accounts if `init` has not been called yet.
+  - This ensure the tree is always using existing accounts before inserting/removing any new accounts if `init` has not been called yet.
 
 ### Fixed
 

--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `reinit` method ([#6709](https://github.com/MetaMask/core/pull/6709))
+
 ### Changed
 
 - Implicitly call `init` before mutating the tree ([#6709](https://github.com/MetaMask/core/pull/6709))

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -838,7 +838,7 @@ describe('AccountTreeController', () => {
         () => MOCK_HD_ACCOUNT_2,
       );
 
-      controller.init();
+      controller.reinit();
 
       const newDefaultAccountGroupId = toMultichainAccountGroupId(
         toMultichainAccountWalletId(MOCK_HD_ACCOUNT_2.options.entropy.id),
@@ -848,6 +848,70 @@ describe('AccountTreeController', () => {
       expect(controller.state.accountTree.selectedAccountGroup).toStrictEqual(
         newDefaultAccountGroupId,
       );
+    });
+
+    it('is a no-op if init is called twice', () => {
+      const { controller, mocks } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      controller.init();
+      expect(
+        mocks.AccountsController.listMultichainAccounts,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mocks.AccountsController.getSelectedMultichainAccount,
+      ).toHaveBeenCalledTimes(1);
+
+      // Calling init again is a no-op, so we're not fetching the list of accounts
+      // a second time.
+      controller.init();
+      expect(
+        mocks.AccountsController.listMultichainAccounts,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mocks.AccountsController.getSelectedMultichainAccount,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('is re-fetching the list of accounts during re-init', () => {
+      const { controller, mocks } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      controller.init();
+      expect(
+        mocks.AccountsController.listMultichainAccounts,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mocks.AccountsController.getSelectedMultichainAccount,
+      ).toHaveBeenCalledTimes(1);
+
+      // Deep copy initial tree.
+      const initialTree = JSON.parse(
+        JSON.stringify(controller.state.accountTree),
+      );
+
+      // We now change the list of accounts entirely and call re-init to re-fetch
+      // the new account list.
+      mocks.AccountsController.accounts = [MOCK_HD_ACCOUNT_2];
+
+      controller.reinit();
+      expect(
+        mocks.AccountsController.listMultichainAccounts,
+      ).toHaveBeenCalledTimes(2);
+      expect(
+        mocks.AccountsController.getSelectedMultichainAccount,
+      ).toHaveBeenCalledTimes(2);
+
+      // Deep copy new tree.
+      const updatedTree = JSON.parse(
+        JSON.stringify(controller.state.accountTree),
+      );
+
+      expect(initialTree).not.toStrictEqual(updatedTree);
     });
   });
 
@@ -1935,7 +1999,7 @@ describe('AccountTreeController', () => {
       controller.setAccountGroupName(expectedGroupId1, customName);
 
       // Re-init to test persistence
-      controller.init();
+      controller.reinit();
 
       const wallet = controller.state.accountTree.wallets[expectedWalletId1];
       const group = wallet?.groups[expectedGroupId1];
@@ -1966,7 +2030,7 @@ describe('AccountTreeController', () => {
       const customName = 'My Primary Wallet';
       controller.setAccountWalletName(expectedWalletId1, customName);
 
-      controller.init();
+      controller.reinit();
 
       const wallet = controller.state.accountTree.wallets[expectedWalletId1];
       expect(wallet?.metadata.name).toBe(customName);
@@ -2083,7 +2147,7 @@ describe('AccountTreeController', () => {
       controller.setAccountGroupPinned(expectedGroupId, true);
 
       // Re-init to test persistence
-      controller.init();
+      controller.reinit();
 
       // Verify pinned state persists
       expect(
@@ -2120,7 +2184,7 @@ describe('AccountTreeController', () => {
       controller.setAccountGroupHidden(expectedGroupId, true);
 
       // Re-init to test persistence
-      controller.init();
+      controller.reinit();
 
       // Verify hidden state persists
       expect(
@@ -2881,7 +2945,7 @@ describe('AccountTreeController', () => {
       expect(wallet1.groups[group2Id].metadata.name).toBe('Account 2'); // groupIndex 1 → Account 2
 
       // Simulate app restart by re-initializing
-      controller.init();
+      controller.reinit();
 
       // Names should remain the same (consistent entropy.groupIndex)
       const state2 = controller.state;
@@ -3060,7 +3124,7 @@ describe('AccountTreeController', () => {
       controller.setAccountGroupName(group1Id, 'Custom Name');
 
       // Step 3: Re-initialize (simulate app restart)
-      controller.init();
+      controller.reinit();
 
       // Step 4: Verify the second group gets its proper name without conflict
       const state2 = controller.state;
@@ -3476,7 +3540,7 @@ describe('AccountTreeController', () => {
         () => MOCK_HD_ACCOUNT_2,
       );
 
-      controller.init();
+      controller.reinit();
 
       const oldDefaultAccountGroupId = defaultAccountGroupId;
       const newDefaultAccountGroupId = toMultichainAccountGroupId(

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -4245,7 +4245,7 @@ describe('AccountTreeController', () => {
       mocks.AccountsController.accounts = [mockHdAccount2, mockHdAccount1];
 
       // Re-init the controller should still give proper naming.
-      controller.init();
+      controller.reinit();
 
       [mockHdAccount1, mockHdAccount2].forEach((mockAccount, index) => {
         const walletId = toMultichainAccountWalletId(

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -339,7 +339,7 @@ export class AccountTreeController extends BaseController<
    * Re-initialize the controller's state.
    *
    * This is done in one single (atomic) `update` block to avoid having a temporary
-   * cleared state.
+   * cleared state. Use this when you need to force a full re-init even if already initialized.
    */
   reinit() {
     this.#initialized = false;

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -662,24 +662,29 @@ export class AccountTreeController extends BaseController<
     // incoming account change.
     this.#initAtLeastOnce();
 
-    this.update((state) => {
-      this.#insert(state.accountTree.wallets, account);
+    // Check if this account got already added by `#initAtLeastOnce`, if not, then we
+    // can proceed
+    if (!this.#accountIdToContext.has(account.id)) {
+      this.update((state) => {
+        this.#insert(state.accountTree.wallets, account);
 
-      const context = this.#accountIdToContext.get(account.id);
-      if (context) {
-        const { walletId, groupId } = context;
+        const context = this.#accountIdToContext.get(account.id);
+        if (context) {
+          const { walletId, groupId } = context;
 
-        const wallet = state.accountTree.wallets[walletId];
-        if (wallet) {
-          this.#applyAccountWalletMetadata(state, walletId);
-          this.#applyAccountGroupMetadata(state, walletId, groupId);
+          const wallet = state.accountTree.wallets[walletId];
+          if (wallet) {
+            this.#applyAccountWalletMetadata(state, walletId);
+            this.#applyAccountGroupMetadata(state, walletId, groupId);
+          }
         }
-      }
-    });
-    this.messagingSystem.publish(
-      `${controllerName}:accountTreeChange`,
-      this.state.accountTree,
-    );
+      });
+
+      this.messagingSystem.publish(
+        `${controllerName}:accountTreeChange`,
+        this.state.accountTree,
+      );
+    }
   }
 
   /**

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -663,7 +663,7 @@ export class AccountTreeController extends BaseController<
     this.#initAtLeastOnce();
 
     // Check if this account got already added by `#initAtLeastOnce`, if not, then we
-    // can proceed
+    // can proceed.
     if (!this.#accountIdToContext.has(account.id)) {
       this.update((state) => {
         this.#insert(state.accountTree.wallets, account);

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -252,7 +252,7 @@ export class AccountTreeController extends BaseController<
   init() {
     if (this.#initialized) {
       // We prevent re-initilializing the state multiple times. Though, we can use
-      // `clearState` + `init` to re-init everything from scratch.
+      // `reinit` to re-init everything from scratch.
       return;
     }
 
@@ -333,6 +333,26 @@ export class AccountTreeController extends BaseController<
     }
 
     this.#initialized = true;
+  }
+
+  /**
+   * Re-initialize the controller's state.
+   *
+   * This is done in one single (atomic) `update` block to avoid having a temporary
+   * cleared state.
+   */
+  reinit() {
+    this.#initialized = false;
+    this.init();
+  }
+
+  /**
+   * Force-init if the controller's state has not been initilized yet.
+   */
+  #initAtLeastOnce() {
+    if (!this.#initialized) {
+      this.init();
+    }
   }
 
   /**
@@ -640,9 +660,7 @@ export class AccountTreeController extends BaseController<
   #handleAccountAdded(account: InternalAccount) {
     // We force-init to make sure we have the proper account groups for the
     // incoming account change.
-    if (!this.#initialized) {
-      this.init();
-    }
+    this.#initAtLeastOnce();
 
     this.update((state) => {
       this.#insert(state.accountTree.wallets, account);
@@ -673,9 +691,7 @@ export class AccountTreeController extends BaseController<
   #handleAccountRemoved(accountId: AccountId) {
     // We force-init to make sure we have the proper account groups for the
     // incoming account change.
-    if (!this.#initialized) {
-      this.init();
-    }
+    this.#initAtLeastOnce();
 
     const context = this.#accountIdToContext.get(accountId);
 


### PR DESCRIPTION
## Explanation

We now enforce that `init` got called before making any change to the tree to avoid having out-of-order account groups.

I stumbled upon this bug when running E2E on mobile. Basically, the way the fixture are setup on mobile were triggering `:accountAdded` before calling `AccountTreeController.init`, which resulted in having "Account 2" inserted before "Account 1".

But, since "Account 1" was already part of the initial `internalAccounts` it should have been inserted before any new accounts.

Thus, forcing `init` to be called implicitly fixes this order/sequence.

## References

E2E were failing on this PR, because of this bug:
- https://github.com/MetaMask/metamask-mobile/pull/20255

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
