### PR TITLE
chore: Update `eth-json-rpc-middleware`

### DIFF
--- a/packages/eip-5792-middleware/CHANGELOG.md
+++ b/packages/eip-5792-middleware/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/utils` from `^11.8.0` to `^11.8.1` ([#6708](https://github.com/MetaMask/core/pull/6708))
 - Bump `@metamask/transaction-controller` from `^60.4.0` to `^60.6.0` ([#6708](https://github.com/MetaMask/core/pull/6733), [#6771](https://github.com/MetaMask/core/pull/6771))
+- Remove dependency `@metamask/eth-json-rpc-middleware` ([#6714](https://github.com/MetaMask/core/pull/6714))
 
 ## [1.2.0]
 

--- a/packages/eip-5792-middleware/package.json
+++ b/packages/eip-5792-middleware/package.json
@@ -47,7 +47,6 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/eth-json-rpc-middleware": "^17.0.1",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/transaction-controller": "^60.6.0",
     "@metamask/utils": "^11.8.1",

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/utils` from `^11.8.0` to `^11.8.1` ([#6708](https://github.com/MetaMask/core/pull/6708))
+- Update `@metamask/eth-json-rpc-middleware` from `^17.0.1` to `^18.0.0` ([#6714](https://github.com/MetaMask/core/pull/6714))
 
 ## [24.2.0]
 

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -51,7 +51,7 @@
     "@metamask/controller-utils": "^11.14.0",
     "@metamask/eth-block-tracker": "^12.0.1",
     "@metamask/eth-json-rpc-infura": "^10.2.0",
-    "@metamask/eth-json-rpc-middleware": "^17.0.1",
+    "@metamask/eth-json-rpc-middleware": "^18.0.0",
     "@metamask/eth-json-rpc-provider": "^5.0.0",
     "@metamask/eth-query": "^4.0.0",
     "@metamask/json-rpc-engine": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3077,7 +3077,6 @@ __metadata:
   resolution: "@metamask/eip-5792-middleware@workspace:packages/eip-5792-middleware"
   dependencies:
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/eth-json-rpc-middleware": "npm:^17.0.1"
     "@metamask/keyring-controller": "npm:^23.1.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/superstruct": "npm:^3.1.0"
@@ -3274,9 +3273,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:^17.0.1":
-  version: 17.0.1
-  resolution: "@metamask/eth-json-rpc-middleware@npm:17.0.1"
+"@metamask/eth-json-rpc-middleware@npm:^18.0.0":
+  version: 18.0.0
+  resolution: "@metamask/eth-json-rpc-middleware@npm:18.0.0"
   dependencies:
     "@metamask/eth-block-tracker": "npm:^12.0.0"
     "@metamask/eth-json-rpc-provider": "npm:^4.1.7"
@@ -3284,13 +3283,13 @@ __metadata:
     "@metamask/json-rpc-engine": "npm:^10.0.2"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.1.0"
+    "@metamask/utils": "npm:^11.7.0"
     "@types/bn.js": "npm:^5.1.5"
     bn.js: "npm:^5.2.1"
     klona: "npm:^2.0.6"
     pify: "npm:^5.0.0"
     safe-stable-stringify: "npm:^2.4.3"
-  checksum: 10/6a0709479f7187183f99bd76b2724cb72b4155ded506d939b7625ae17f63bff68bee9828e0d76af06e4d4009eecc87b63059e8796947442e96844a42af161e2f
+  checksum: 10/e25f7e4575d08a23070a46e1653e94b295f8b63816d7cd82f7f2bc8ed9777d4d16d6241016e9f8afe3c5b5e17b400de48e9751d64b3cc0478982f787ec2e586c
   languageName: node
   linkType: hard
 
@@ -4013,7 +4012,7 @@ __metadata:
     "@metamask/error-reporting-service": "npm:^2.1.0"
     "@metamask/eth-block-tracker": "npm:^12.0.1"
     "@metamask/eth-json-rpc-infura": "npm:^10.2.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^17.0.1"
+    "@metamask/eth-json-rpc-middleware": "npm:^18.0.0"
     "@metamask/eth-json-rpc-provider": "npm:^5.0.0"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/json-rpc-engine": "npm:^10.1.0"
@@ -4860,7 +4859,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.8.1":
+"@metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.7.0, @metamask/utils@npm:^11.8.1":
   version: 11.8.1
   resolution: "@metamask/utils@npm:11.8.1"
   dependencies:


### PR DESCRIPTION
## Explanation

Update `@metamask/eth-json-rpc-middleware` from v17 to v18. The breaking changes relate to dropping support for the legacy middleware function that pre-dates the creation of the RPC service, and some minor type changes regarding that RPC service parameter.

Changelog: https://github.com/MetaMask/eth-json-rpc-middleware/blob/main/CHANGELOG.md#1800

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade `@metamask/eth-json-rpc-middleware` to v18 in `network-controller` and remove it from `eip-5792-middleware`.
> 
> - **Dependencies**:
>   - `packages/network-controller`: Bump `@metamask/eth-json-rpc-middleware` from `^17.0.1` to `^18.0.0`; update changelog accordingly.
>   - `packages/eip-5792-middleware`: Remove dependency on `@metamask/eth-json-rpc-middleware`; update changelog accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 605577153a2a5ea8cc626edd8fceceb0f831d703. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->