### PR TITLE
chore: update old identity code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 /packages/multichain-transactions-controller @MetaMask/accounts-engineers
 /packages/multichain-account-service         @MetaMask/accounts-engineers
 /packages/account-tree-controller            @MetaMask/accounts-engineers
+/packages/profile-sync-controller            @MetaMask/accounts-engineers
 
 ## Assets Team
 /packages/assets-controllers         @MetaMask/metamask-assets
@@ -89,7 +90,6 @@
 /packages/network-controller           @MetaMask/core-platform @MetaMask/metamask-assets
 /packages/permission-controller        @MetaMask/wallet-api-platform-engineers @MetaMask/core-platform
 /packages/permission-log-controller    @MetaMask/wallet-api-platform-engineers @MetaMask/core-platform
-/packages/profile-sync-controller      @MetaMask/identity
 /packages/remote-feature-flag-controller @MetaMask/extension-platform @MetaMask/mobile-platform
 /packages/foundryup                    @MetaMask/mobile-platform @MetaMask/extension-platform
 
@@ -138,8 +138,8 @@
 /packages/notification-services-controller/CHANGELOG.md @MetaMask/notifications @MetaMask/core-platform
 /packages/phishing-controller/package.json    @MetaMask/product-safety @MetaMask/core-platform
 /packages/phishing-controller/CHANGELOG.md    @MetaMask/product-safety @MetaMask/core-platform
-/packages/profile-sync-controller/package.json    @MetaMask/identity @MetaMask/core-platform
-/packages/profile-sync-controller/CHANGELOG.md    @MetaMask/identity @MetaMask/core-platform
+/packages/profile-sync-controller/package.json    @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/profile-sync-controller/CHANGELOG.md    @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/selected-network-controller/package.json @MetaMask/wallet-api-platform-engineers @MetaMask/core-platform
 /packages/selected-network-controller/CHANGELOG.md @MetaMask/wallet-api-platform-engineers @MetaMask/core-platform
 /packages/signature-controller/package.json       @MetaMask/confirmations @MetaMask/core-platform


### PR DESCRIPTION
## Explanation

This PR transfers code owned by Identity to @MetaMask/accounts-engineers .

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reassigns CODEOWNERS for `packages/profile-sync-controller` from Identity to Accounts Engineers, including package release entries.
> 
> - **CODEOWNERS**:
>   - Transfer ownership of `packages/profile-sync-controller` to `@MetaMask/accounts-engineers`.
>   - Update package release entries for `packages/profile-sync-controller` (`package.json`, `CHANGELOG.md`) to `@MetaMask/accounts-engineers`.
>   - Remove `@MetaMask/identity` joint ownership entry and add Accounts Team entry for `packages/profile-sync-controller`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b27278d4e382643dd433c2eb076cc55bef87adf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->