### PR TITLE
feat(multichain-account-service): add option to decide what to await for when creating group

### DIFF
--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add an optional `options` parameter to `MultichainAccountWallet.createMultichainAccountGroup()` ([#]())
+- Add an optional `options` parameter to `MultichainAccountWallet.createMultichainAccountGroup()` ([#6759](https://github.com/MetaMask/core/pull/6759))
   - Introduces `options.waitForAllProvidersToFinishCreatingAccounts`, that will make `createMultichainAccountGroup` await either only the EVM provider or all the providers to have created their accounts depending on the value. Defaults to `false` (only awaits for EVM accounts creation by default).
 - Only await for EVM account creation in `MultichainAccountWallet.createMultichainAccountGroup()` instead of all types of providers ([#6755](https://github.com/MetaMask/core/pull/6755))
   - Other type of providers will create accounts in the background and won't throw errors in case they fail to do so.

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.0]
-
 ### Changed
 
 - Add an optional `options` parameter to `MultichainAccountWallet.createMultichainAccountGroup()` ([#6759](https://github.com/MetaMask/core/pull/6759))
   - Introduces `options.waitForAllProvidersToFinishCreatingAccounts`, that will make `createMultichainAccountGroup` await either only the EVM provider or all the providers to have created their accounts depending on the value. Defaults to `false` (only awaits for EVM accounts creation by default).
+
+## [1.4.0]
+
+### Changed
+
 - Only await for EVM account creation in `MultichainAccountWallet.createMultichainAccountGroup()` instead of all types of providers ([#6755](https://github.com/MetaMask/core/pull/6755))
   - Other type of providers will create accounts in the background and won't throw errors in case they fail to do so.
   - Multichain account groups will now be "misaligned" for a short period of time, until each of the other providers finish creating their accounts.

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 - Add an optional `options` parameter to `MultichainAccountWallet.createMultichainAccountGroup()` ([#6759](https://github.com/MetaMask/core/pull/6759))
   - Introduces `options.waitForAllProvidersToFinishCreatingAccounts`, that will make `createMultichainAccountGroup` await either only the EVM provider or all the providers to have created their accounts depending on the value. Defaults to `false` (only awaits for EVM accounts creation by default).

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add an optional `options` parameter to `MultichainAccountWallet.createMultichainAccountGroup()` ([#]())
+  - Introduces `options.waitForAllProvidersToFinishCreatingAccounts`, that will make `createMultichainAccountGroup` await either only the EVM provider or all the providers to have created their accounts depending on the value. Defaults to `false` (only awaits for EVM accounts creation by default).
 - Only await for EVM account creation in `MultichainAccountWallet.createMultichainAccountGroup()` instead of all types of providers ([#6755](https://github.com/MetaMask/core/pull/6755))
   - Other type of providers will create accounts in the background and won't throw errors in case they fail to do so.
   - Multichain account groups will now be "misaligned" for a short period of time, until each of the other providers finish creating their accounts.

--- a/packages/multichain-account-service/src/MultichainAccountWallet.ts
+++ b/packages/multichain-account-service/src/MultichainAccountWallet.ts
@@ -296,11 +296,22 @@ export class MultichainAccountWallet<
    * NOTE: This operation WILL lock the wallet's mutex.
    *
    * @param groupIndex - The group index to use.
-   * @throws If any of the account providers fails to create their accounts.
+   * @param options - Options to configure the account creation.
+   * @param options.waitForAllProvidersToFinishCreatingAccounts - Whether to wait for all
+   * account providers to finish creating their accounts before returning. If `false`, only
+   * the EVM provider will be awaited, while all other providers will create their accounts
+   * in the background. Defaults to `false`.
+   * @throws If any of the account providers fails to create their accounts and
+   * the `waitForAllProvidersToFinishCreatingAccounts` option is set to `true`. If `false`,
+   * errors from non-EVM providers will be logged but ignored, and only errors from the
+   * EVM provider will be thrown.
    * @returns The multichain account group for this group index.
    */
   async createMultichainAccountGroup(
     groupIndex: number,
+    options: {
+      waitForAllProvidersToFinishCreatingAccounts?: boolean;
+    } = { waitForAllProvidersToFinishCreatingAccounts: false },
   ): Promise<MultichainAccountGroup<Account>> {
     return await this.#withLock('in-progress:create-accounts', async () => {
       const nextGroupIndex = this.getNextGroupIndex();
@@ -324,41 +335,72 @@ export class MultichainAccountWallet<
 
       this.#log(`Creating new group for index ${groupIndex}...`);
 
-      // Extract the EVM provider from the list of providers.
-      // We will only await the EVM provider to create its accounts, while
-      // all other providers will be started in the background.
-      const [evmProvider, ...otherProviders] = this.#providers;
-      assert(
-        evmProvider instanceof EvmAccountProvider,
-        'EVM account provider must be first',
-      );
+      if (options?.waitForAllProvidersToFinishCreatingAccounts) {
+        // Create account with all providers and await them.
+        const results = await Promise.allSettled(
+          this.#providers.map((provider) =>
+            provider.createAccounts({
+              entropySource: this.#entropySource,
+              groupIndex,
+            }),
+          ),
+        );
 
-      // Create account with the EVM provider first and await it.
-      // If it fails, we don't start creating accounts with other providers.
-      try {
-        await evmProvider.createAccounts({
-          entropySource: this.#entropySource,
-          groupIndex,
-        });
-      } catch (error) {
-        const errorMessage = `Unable to create multichain account group for index: ${groupIndex} with provider "${evmProvider.getName()}". Error: ${(error as Error).message}`;
-        this.#log(`${ERROR_PREFIX} ${errorMessage}:`, error);
-        throw new Error(errorMessage);
-      }
+        // If any of the provider failed to create their accounts, then we consider the
+        // multichain account group to have failed too.
+        if (results.some((result) => result.status === 'rejected')) {
+          // NOTE: Some accounts might still have been created on other account providers. We
+          // don't rollback them.
+          const error = `Unable to create multichain account group for index: ${groupIndex}`;
 
-      // Create account with other providers in the background
-      otherProviders.forEach((provider) => {
-        provider
-          .createAccounts({
+          let message = `${error}:`;
+          for (const result of results) {
+            if (result.status === 'rejected') {
+              message += `\n- ${result.reason}`;
+            }
+          }
+          this.#log(`${WARNING_PREFIX} ${message}`);
+          console.warn(message);
+
+          throw new Error(error);
+        }
+      } else {
+        // Extract the EVM provider from the list of providers.
+        // We will only await the EVM provider to create its accounts, while
+        // all other providers will be started in the background.
+        const [evmProvider, ...otherProviders] = this.#providers;
+        assert(
+          evmProvider instanceof EvmAccountProvider,
+          'EVM account provider must be first',
+        );
+
+        // Create account with the EVM provider first and await it.
+        // If it fails, we don't start creating accounts with other providers.
+        try {
+          await evmProvider.createAccounts({
             entropySource: this.#entropySource,
             groupIndex,
-          })
-          .catch((error) => {
-            // Log errors from background providers but don't fail the operation
-            const errorMessage = `Could not to create account with provider "${provider.getName()}" for multichain account group index: ${groupIndex}`;
-            this.#log(`${WARNING_PREFIX} ${errorMessage}:`, error);
           });
-      });
+        } catch (error) {
+          const errorMessage = `Unable to create multichain account group for index: ${groupIndex} with provider "${evmProvider.getName()}". Error: ${(error as Error).message}`;
+          this.#log(`${ERROR_PREFIX} ${errorMessage}:`, error);
+          throw new Error(errorMessage);
+        }
+
+        // Create account with other providers in the background
+        otherProviders.forEach((provider) => {
+          provider
+            .createAccounts({
+              entropySource: this.#entropySource,
+              groupIndex,
+            })
+            .catch((error) => {
+              // Log errors from background providers but don't fail the operation
+              const errorMessage = `Could not to create account with provider "${provider.getName()}" for multichain account group index: ${groupIndex}`;
+              this.#log(`${WARNING_PREFIX} ${errorMessage}:`, error);
+            });
+        });
+      }
 
       // --------------------------------------------------------------------------------
       // READ THIS CAREFULLY:
@@ -419,7 +461,9 @@ export class MultichainAccountWallet<
   async createNextMultichainAccountGroup(): Promise<
     MultichainAccountGroup<Account>
   > {
-    return this.createMultichainAccountGroup(this.getNextGroupIndex());
+    return this.createMultichainAccountGroup(this.getNextGroupIndex(), {
+      waitForAllProvidersToFinishCreatingAccounts: true,
+    });
   }
 
   /**


### PR DESCRIPTION
## Explanation

```md
- Add an optional `options` parameter to `MultichainAccountWallet.createMultichainAccountGroup()`
  - Introduces `options.waitForAllProvidersToFinishCreatingAccounts`, that will make `createMultichainAccountGroup` await either only the EVM provider or all the providers to have created their accounts depending on the value. Defaults to `false` (only awaits for EVM accounts creation by default).
```

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an `options.waitForAllProvidersToFinishCreatingAccounts` flag to `createMultichainAccountGroup`, defaulting to awaiting only EVM, and updates `createNextMultichainAccountGroup` to await all.
> 
> - **Multichain Account Service**:
>   - **`createMultichainAccountGroup`**:
>     - Add optional `options` with `waitForAllProvidersToFinishCreatingAccounts` (default `false`).
>     - If `true`: await all providers via `Promise.allSettled`; throw on any failure with aggregated warnings.
>     - If `false` (default): await EVM provider; start other providers in background, log but ignore their errors.
>     - Update JSDoc for parameters and error semantics.
>   - **`createNextMultichainAccountGroup`**: now calls `createMultichainAccountGroup` with `waitForAllProvidersToFinishCreatingAccounts: true`.
>   - **Tests**: add coverage for failure when waiting for all providers; adjust non-EVM background behavior test.
>   - **Changelog**: document new `options` parameter and behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 403d744d5c9890ea967898e50202dfb07dc7cca9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->