### PR TITLE
feat: register Bitcoin and Tron account provider wrappers

### DIFF
--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -15,17 +15,21 @@ import { areUint8ArraysEqual } from '@metamask/utils';
 import { projectLogger as log } from './logger';
 import type { MultichainAccountGroup } from './MultichainAccountGroup';
 import { MultichainAccountWallet } from './MultichainAccountWallet';
-import type {
-  EvmAccountProviderConfig,
-  NamedAccountProvider,
-  SolAccountProviderConfig,
+import {
+  BtcAccountProvider,
+  EvmAccountProvider,
+  SolAccountProvider,
+  TrxAccountProvider,
+  type BtcAccountProviderConfig,
+  type EvmAccountProviderConfig,
+  type NamedAccountProvider,
+  type SolAccountProviderConfig,
+  type TrxAccountProviderConfig,
 } from './providers';
 import {
   AccountProviderWrapper,
   isAccountProviderWrapper,
 } from './providers/AccountProviderWrapper';
-import { EvmAccountProvider } from './providers/EvmAccountProvider';
-import { SolAccountProvider } from './providers/SolAccountProvider';
 import type { MultichainAccountServiceMessenger } from './types';
 
 export const serviceName = 'MultichainAccountService';
@@ -39,6 +43,8 @@ export type MultichainAccountServiceOptions = {
   providerConfigs?: {
     [EvmAccountProvider.NAME]?: EvmAccountProviderConfig;
     [SolAccountProvider.NAME]?: SolAccountProviderConfig;
+    [BtcAccountProvider.NAME]?: BtcAccountProviderConfig;
+    [TrxAccountProvider.NAME]?: TrxAccountProviderConfig
   };
 };
 
@@ -101,6 +107,20 @@ export class MultichainAccountService {
         new SolAccountProvider(
           this.#messenger,
           providerConfigs?.[SolAccountProvider.NAME],
+        ),
+      ),
+      new AccountProviderWrapper(
+        this.#messenger,
+        new BtcAccountProvider(
+          this.#messenger,
+          providerConfigs?.[BtcAccountProvider.NAME],
+        ),
+      ),
+      new AccountProviderWrapper(
+        this.#messenger,
+        new TrxAccountProvider(
+          this.#messenger,
+          providerConfigs?.[TrxAccountProvider.NAME],
         ),
       ),
       // Custom account providers that can be provided by the MetaMask client.


### PR DESCRIPTION
## Explanation

As we move towards the new Account Provider model we must not forget to include Bitcoin and Tron support. These changes are essential to have their accounts automatically discovered on the MetaMask Extension for example.

## References

Tron Epic: https://consensyssoftware.atlassian.net/browse/NWNT-410?atlOrigin=eyJpIjoiY2Y5ZjYzYmU1MjBhNGZjNmI3NGE5MGZjMTI1ZDA0ZjciLCJwIjoiaiJ9

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Registers `BtcAccountProvider` and `TrxAccountProvider` in `MultichainAccountService`, wires their configs, and updates tests to mock and validate them.
> 
> - **MultichainAccountService**:
>   - Register `BtcAccountProvider` and `TrxAccountProvider` alongside existing `EvmAccountProvider` and `SolAccountProvider` using `AccountProviderWrapper`.
>   - Extend `providerConfigs` to accept `BtcAccountProvider` and `TrxAccountProvider` configs.
>   - Update imports to source providers and types from `./providers`.
> - **Tests (`MultichainAccountService.test.ts`)**:
>   - Mock `BtcAccountProvider` and `TrxAccountProvider`; extend `Mocks` to include them.
>   - Set static `NAME` constants for BTC/TRX providers in setup.
>   - Add `mockAccountProvider` calls for BTC (`BtcAccountType.P2wpkh`) and TRX (`TrxAccountType.Eoa`).
>   - Verify provider config forwarding for BTC/TRX and optional config behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0bad505f7d02b92b58d0d9e2763c18f59849574. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->