### PR TITLE
fix: add platform to TokenBalancesController

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add `platform` property to `TokenBalancesController` to send better analytics for which platform is hitting out APIs ([#6768](https://github.com/MetaMask/core/pull/6768))
+
 ## [77.0.2]
 
 ### Changed

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -156,6 +156,7 @@ export type TokenBalancesControllerOptions = {
   allowExternalServices?: () => boolean;
   /** Custom logger. */
   log?: (...args: unknown[]) => void;
+  platform?: 'extension' | 'mobile';
 };
 // endregion
 
@@ -179,6 +180,8 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
   TokenBalancesControllerState,
   TokenBalancesControllerMessenger
 > {
+  readonly #platform: 'extension' | 'mobile';
+
   readonly #queryAllAccounts: boolean;
 
   readonly #accountsApiChainIds: ChainIdHex[];
@@ -212,6 +215,7 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     queryMultipleAccounts = true,
     accountsApiChainIds = [],
     allowExternalServices = () => true,
+    platform,
   }: TokenBalancesControllerOptions) {
     super({
       name: CONTROLLER,
@@ -220,6 +224,7 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
       state: { tokenBalances: {}, ...state },
     });
 
+    this.#platform = platform ?? 'extension';
     this.#queryAllAccounts = queryMultipleAccounts;
     this.#accountsApiChainIds = [...accountsApiChainIds];
     this.#defaultInterval = interval;
@@ -315,7 +320,7 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
    */
   readonly #createAccountsApiFetcher = (): BalanceFetcher => {
     const originalFetcher = new AccountsApiBalanceFetcher(
-      'extension',
+      this.#platform,
       this.#getProvider,
     );
 


### PR DESCRIPTION
## Explanation

This makes it easier to distinguish the platforms calling this API.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional `platform` ('extension' | 'mobile', default 'extension') to `TokenBalancesController` and uses it when creating `AccountsApiBalanceFetcher`; updates changelog.
> 
> - **Assets Controllers**:
>   - **`TokenBalancesController`**:
>     - Add optional `platform` constructor option (`'extension' | 'mobile'`, default `'extension'`).
>     - Store internally and pass to `AccountsApiBalanceFetcher` instead of hardcoding `'extension'`.
> - **Docs**:
>   - Update `packages/assets-controllers/CHANGELOG.md` under `Unreleased` to note new `platform` property.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd2fe71726d513b5d3009ee57f3bf0db1baaa751. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->