### PR TITLE
feat: add feature announcement max version filtering

### DIFF
--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add max bound version segmentation for feature announcements ([#6773](https://github.com/MetaMask/core/pull/6773))
+  - Add `extensionMaximumVersionNumber` and `mobileMaximumVersionNumber` properties to feature announcements
 - Add optional `platformVersion` property to `NotificationServicesController` `FeatureAnnouncementEnv` type ([#6568](https://github.com/MetaMask/core/pull/6568))
 - Filtering logic to filter feature annonucements by version number ([#6568](https://github.com/MetaMask/core/pull/6568))
 - Add package `semver@^7.7.2` to handle semver version comparisons for announcement notification filtering ([#6568](https://github.com/MetaMask/core/pull/6568))

--- a/packages/notification-services-controller/src/NotificationServicesController/services/feature-announcements.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/services/feature-announcements.test.ts
@@ -101,98 +101,259 @@ describe('Feature Announcement Notifications', () => {
   const testPlatforms = [
     {
       platform: 'extension' as const,
-      versionField: 'extensionMinimumVersionNumber' as const,
+      minVersionField: 'extensionMinimumVersionNumber' as const,
+      maxVersionField: 'extensionMaximumVersionNumber' as const,
     },
     {
       platform: 'mobile' as const,
-      versionField: 'mobileMinimumVersionNumber' as const,
+      minVersionField: 'mobileMinimumVersionNumber' as const,
+      maxVersionField: 'mobileMaximumVersionNumber' as const,
     },
   ];
 
   describe.each(testPlatforms)(
     'Feature Announcement $platform filtering',
-    ({ platform, versionField }) => {
+    ({ platform, minVersionField, maxVersionField }) => {
+      // current platform version is 7.57.0 for all tests
+      const currentPlatformVersion = '7.57.0';
+
       const arrangeAct = async (
         minimumVersion: string | undefined,
+        maximumVersion: string | undefined,
         platformVersion: string | undefined,
       ) => {
         const apiResponse = createMockFeatureAnnouncementAPIResult();
         if (apiResponse.items && apiResponse.items[0]) {
           apiResponse.items[0].fields.extensionMinimumVersionNumber = undefined;
           apiResponse.items[0].fields.mobileMinimumVersionNumber = undefined;
+          apiResponse.items[0].fields.extensionMaximumVersionNumber = undefined;
+          apiResponse.items[0].fields.mobileMaximumVersionNumber = undefined;
+
           if (minimumVersion !== undefined) {
-            apiResponse.items[0].fields[versionField] = minimumVersion;
+            apiResponse.items[0].fields[minVersionField] = minimumVersion;
+          }
+          if (maximumVersion !== undefined) {
+            apiResponse.items[0].fields[maxVersionField] = maximumVersion;
           }
         }
-
         const mockEndpoint = mockFetchFeatureAnnouncementNotifications({
           status: 200,
           body: apiResponse,
         });
-
         const notifications = await getFeatureAnnouncementNotifications({
           ...featureAnnouncementsEnv,
           platform,
           platformVersion,
         });
-
         mockEndpoint.done();
         return notifications;
       };
 
-      const testCases = [
+      const minimumVersionSchema = [
         {
-          name: 'should show notifications when platform version meets minimum requirement',
-          minimumVersion: '1.0.0',
-          platformVersion: '2.0.0',
-          expectedLength: 1,
+          testName: 'shows notification when platform version is above minimum',
+          minimumVersion: '7.56.0',
+          platformVersion: currentPlatformVersion,
+          length: 1,
         },
         {
-          name: 'should show notifications when platform version equals minimum requirement',
-          minimumVersion: '1.0.0',
-          platformVersion: '1.0.0',
-          expectedLength: 1,
+          testName: 'hides notification when platform version equals minimum',
+          minimumVersion: '7.57.0',
+          platformVersion: currentPlatformVersion,
+          length: 0,
         },
         {
-          name: 'should hide notifications when platform version is below minimum requirement',
-          minimumVersion: '3.0.0',
-          platformVersion: '2.0.0',
-          expectedLength: 0,
+          testName: 'hides notification when platform version is below minimum',
+          minimumVersion: '7.58.0',
+          platformVersion: currentPlatformVersion,
+          length: 0,
         },
         {
-          name: 'should show notifications when no platform version is provided',
-          minimumVersion: '2.0.0',
-          platformVersion: undefined,
-          expectedLength: 1,
-        },
-        {
-          name: 'should show notifications when no minimum version is specified for the platform',
+          testName: 'shows notification when no minimum version is specified',
           minimumVersion: undefined,
-          platformVersion: '1.0.0',
-          expectedLength: 1,
+          platformVersion: currentPlatformVersion,
+          length: 1,
         },
         {
-          name: 'should handle invalid version strings gracefully',
+          testName: 'shows notification when no platform version is provided',
+          minimumVersion: '7.56.0',
+          platformVersion: undefined,
+          length: 1,
+        },
+        {
+          testName: 'hides notification when minimum version is malformed',
           minimumVersion: 'invalid-version',
-          platformVersion: '2.0.0',
-          expectedLength: 0,
-        },
-        {
-          name: 'should handle invalid platform version gracefully',
-          minimumVersion: '2.0.0',
-          platformVersion: 'invalid-version',
-          expectedLength: 0,
+          platformVersion: currentPlatformVersion,
+          length: 0,
         },
       ];
 
-      it.each(testCases)(
-        '$name',
-        async ({ minimumVersion, platformVersion, expectedLength }) => {
+      it.each(minimumVersionSchema)(
+        'minimum version test - $testName',
+        async ({ minimumVersion, platformVersion, length }) => {
           const notifications = await arrangeAct(
             minimumVersion,
+            undefined,
             platformVersion,
           );
-          expect(notifications).toHaveLength(expectedLength);
+          expect(notifications).toHaveLength(length);
+        },
+      );
+
+      const maximumVersionSchema = [
+        {
+          testName: 'shows notification when platform version is below maximum',
+          maximumVersion: '7.58.0',
+          platformVersion: currentPlatformVersion,
+          length: 1,
+        },
+        {
+          testName: 'hides notification when platform version equals maximum',
+          maximumVersion: '7.57.0',
+          platformVersion: currentPlatformVersion,
+          length: 0,
+        },
+        {
+          testName: 'hides notification when platform version is above maximum',
+          maximumVersion: '7.56.0',
+          platformVersion: currentPlatformVersion,
+          length: 0,
+        },
+        {
+          testName: 'shows notification when no maximum version is specified',
+          maximumVersion: undefined,
+          platformVersion: currentPlatformVersion,
+          length: 1,
+        },
+        {
+          testName: 'shows notification when no platform version is provided',
+          maximumVersion: '7.58.0',
+          platformVersion: undefined,
+          length: 1,
+        },
+        {
+          testName: 'hides notification when maximum version is malformed',
+          maximumVersion: 'invalid-version',
+          platformVersion: currentPlatformVersion,
+          length: 0,
+        },
+      ];
+
+      it.each(maximumVersionSchema)(
+        'maximum version test - $testName',
+        async ({ maximumVersion, platformVersion, length }) => {
+          const notifications = await arrangeAct(
+            undefined,
+            maximumVersion,
+            platformVersion,
+          );
+          expect(notifications).toHaveLength(length);
+        },
+      );
+
+      const minMaxVersionSchema = [
+        {
+          testName:
+            'shows notification when version is within both bounds (min < current < max)',
+          minimumVersion: '7.56.0',
+          maximumVersion: '7.58.0',
+          platformVersion: currentPlatformVersion,
+          length: 1,
+        },
+        {
+          testName:
+            'shows notification when version is above minimum and below maximum',
+          minimumVersion: '7.56.5',
+          maximumVersion: '7.57.5',
+          platformVersion: currentPlatformVersion,
+          length: 1,
+        },
+        {
+          testName: 'hides notification when version equals minimum bound',
+          minimumVersion: '7.57.0',
+          maximumVersion: '7.58.0',
+          platformVersion: currentPlatformVersion,
+          length: 0,
+        },
+        {
+          testName: 'hides notification when version equals maximum bound',
+          minimumVersion: '7.56.0',
+          maximumVersion: '7.57.0',
+          platformVersion: currentPlatformVersion,
+          length: 0,
+        },
+        {
+          testName: 'hides notification when version is below minimum bound',
+          minimumVersion: '7.58.0',
+          maximumVersion: '7.59.0',
+          platformVersion: currentPlatformVersion,
+          length: 0,
+        },
+        {
+          testName: 'hides notification when version is above maximum bound',
+          minimumVersion: '7.55.0',
+          maximumVersion: '7.56.0',
+          platformVersion: currentPlatformVersion,
+          length: 0,
+        },
+        {
+          testName: 'shows notification when both bounds are undefined',
+          minimumVersion: undefined,
+          maximumVersion: undefined,
+          platformVersion: currentPlatformVersion,
+          length: 1,
+        },
+        {
+          testName:
+            'shows notification when only minimum is defined and version is above it',
+          minimumVersion: '7.56.0',
+          maximumVersion: undefined,
+          platformVersion: currentPlatformVersion,
+          length: 1,
+        },
+        {
+          testName:
+            'shows notification when only maximum is defined and version is below it',
+          minimumVersion: undefined,
+          maximumVersion: '7.58.0',
+          platformVersion: currentPlatformVersion,
+          length: 1,
+        },
+        {
+          testName:
+            'shows notification when no platform version is provided regardless of bounds',
+          minimumVersion: '7.56.0',
+          maximumVersion: '7.58.0',
+          platformVersion: undefined,
+          length: 1,
+        },
+        {
+          testName:
+            'hides notification when minimum is malformed but maximum excludes current version',
+          minimumVersion: 'malformed',
+          maximumVersion: '7.56.0',
+          platformVersion: currentPlatformVersion,
+          length: 0,
+        },
+        {
+          testName:
+            'hides notification when maximum is malformed but minimum excludes current version',
+          minimumVersion: '7.58.0',
+          maximumVersion: 'malformed',
+          platformVersion: currentPlatformVersion,
+          length: 0,
+        },
+      ];
+
+      it.each(minMaxVersionSchema)(
+        'min & max version bounds test - $testName',
+        async ({ minimumVersion, maximumVersion, platformVersion, length }) => {
+          const notifications = await arrangeAct(
+            minimumVersion,
+            maximumVersion,
+            platformVersion,
+          );
+          expect(notifications).toHaveLength(length);
         },
       );
     },

--- a/packages/notification-services-controller/src/NotificationServicesController/types/feature-announcement/type-feature-announcement.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/types/feature-announcement/type-feature-announcement.ts
@@ -50,6 +50,9 @@ export type TypeFeatureAnnouncementFields = {
     // Min Versions
     extensionMinimumVersionNumber?: EntryFieldTypes.Text;
     mobileMinimumVersionNumber?: EntryFieldTypes.Text;
+    // Max Versions
+    extensionMaximumVersionNumber?: EntryFieldTypes.Text;
+    mobileMaximumVersionNumber?: EntryFieldTypes.Text;
   };
   contentTypeId: 'productAnnouncement';
 };


### PR DESCRIPTION
## Explanation

Adds max version filtering for feature announcements. This will allow us to show specific content below a version (e.g. prompt to update), and new content for the newer versions.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce maximum version fields and switch announcement filtering to bounded (min/max) semver checks with comprehensive tests.
> 
> - **Feature announcements filtering**:
>   - Switch from minimum-only `gte` check to bounded checks using `gt` (min) and `lt` (max) in `services/feature-announcements.ts`.
>   - Always show when no `platformVersion`; hide on semver parse errors; equality to bounds excluded.
> - **Data model**:
>   - Add `extensionMaximumVersionNumber` and `mobileMaximumVersionNumber` to `TypeFeatureAnnouncementFields` and include them in returned notification `data`.
> - **Tests** (`services/feature-announcements.test.ts`):
>   - Refactor to test both `minVersionField` and `maxVersionField` per platform.
>   - Add schemas covering min-only, max-only, combined bounds, undefined versions, malformed versions, and no `platformVersion`.
> - **Changelog**:
>   - Document addition of max bound version segmentation and new max version fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f581cc7d947202975d9eee2eeb217cb8ac0271c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->