### PR TITLE
chore: Add `name` and `state` properties to `ErrorReportingService` to support modular initialisation

### DIFF
--- a/packages/error-reporting-service/CHANGELOG.md
+++ b/packages/error-reporting-service/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `name` and `state` properties to support modular initialization ([#6781](https://github.com/MetaMask/core/pull/6781))
+
 ## [2.1.0]
 
 ### Changed

--- a/packages/error-reporting-service/src/error-reporting-service.ts
+++ b/packages/error-reporting-service/src/error-reporting-service.ts
@@ -128,6 +128,10 @@ type ErrorReportingServiceOptions = {
  * ```
  */
 export class ErrorReportingService {
+  name: 'ErrorReportingService' = 'ErrorReportingService' as const;
+
+  state = null;
+
   readonly #captureException: ErrorReportingServiceOptions['captureException'];
 
   readonly #messenger: ErrorReportingServiceMessenger;


### PR DESCRIPTION
## Explanation

By adding a `name` and `state` (always `null`) property to a service, we can make it work with modular initialisation in the clients.

## References

https://github.com/MetaMask/metamask-extension/pull/36593/commits/194a4099da38f749dacd39db1d7538f2ea4fce77

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `name` and `state` (null) properties to `ErrorReportingService` and note the change in the changelog.
> 
> - **Error Reporting Service**:
>   - **Class update**: Add `name: 'ErrorReportingService'` and `state = null` to `src/error-reporting-service.ts`.
> - **Changelog**:
>   - Under `Unreleased` → Added: note new `name` and `state` properties to support modular initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71c9f4374b574cb6c8ae2708cc969dcddcd07836. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->