### PR TITLE
feat(remote-feature-flag-controller): export additional controller types from package index

### DIFF
--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export additional controller types from package index ([#6835](https://github.com/MetaMask/core/pull/6835))
+  - Export `RemoteFeatureFlagControllerActions` - union type of all controller actions
+  - Export `RemoteFeatureFlagControllerUpdateRemoteFeatureFlagsAction` - action type for updating feature flags
+  - Export `RemoteFeatureFlagControllerEvents` - union type of all controller events
+  - Export `RemoteFeatureFlagControllerStateChangeEvent` - state change event type
+
 ## [1.8.0]
 
 ### Added

--- a/packages/remote-feature-flag-controller/src/index.ts
+++ b/packages/remote-feature-flag-controller/src/index.ts
@@ -1,5 +1,12 @@
 export { RemoteFeatureFlagController } from './remote-feature-flag-controller';
-export type { RemoteFeatureFlagControllerMessenger } from './remote-feature-flag-controller';
+export type {
+  RemoteFeatureFlagControllerMessenger,
+  RemoteFeatureFlagControllerActions,
+  RemoteFeatureFlagControllerGetStateAction,
+  RemoteFeatureFlagControllerUpdateRemoteFeatureFlagsAction,
+  RemoteFeatureFlagControllerEvents,
+  RemoteFeatureFlagControllerStateChangeEvent,
+} from './remote-feature-flag-controller';
 export {
   ClientType,
   DistributionType,
@@ -8,7 +15,6 @@ export {
 
 export type {
   RemoteFeatureFlagControllerState,
-  RemoteFeatureFlagControllerGetStateAction,
   FeatureFlags,
 } from './remote-feature-flag-controller-types';
 export { ClientConfigApiService } from './client-config-api-service/client-config-api-service';

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-types.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-types.ts
@@ -1,4 +1,3 @@
-import type { ControllerGetStateAction } from '@metamask/base-controller';
 import type { Json } from '@metamask/utils';
 
 // Define accepted values for client, distribution, and environment
@@ -61,12 +60,3 @@ export type RemoteFeatureFlagControllerState = {
    */
   cacheTimestamp: number;
 };
-
-/**
- * The action to retrieve the state of the {@link RemoteFeatureFlagController}.
- */
-export type RemoteFeatureFlagControllerGetStateAction =
-  ControllerGetStateAction<
-    'RemoteFeatureFlagController',
-    RemoteFeatureFlagControllerState
-  >;

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -1,9 +1,9 @@
+import { BaseController } from '@metamask/base-controller';
 import type {
   ControllerGetStateAction,
   ControllerStateChangeEvent,
   RestrictedMessenger,
 } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
 
 import type { AbstractClientConfigApiService } from './client-config-api-service/abstract-client-config-api-service';
 import type {
@@ -45,19 +45,23 @@ const remoteFeatureFlagControllerMetadata = {
 
 // === MESSENGER ===
 
+/**
+ * The action to retrieve the state of the {@link RemoteFeatureFlagController}.
+ */
 export type RemoteFeatureFlagControllerGetStateAction =
   ControllerGetStateAction<
     typeof controllerName,
     RemoteFeatureFlagControllerState
   >;
 
-export type RemoteFeatureFlagControllerGetRemoteFeatureFlagAction = {
+export type RemoteFeatureFlagControllerUpdateRemoteFeatureFlagsAction = {
   type: `${typeof controllerName}:updateRemoteFeatureFlags`;
   handler: RemoteFeatureFlagController['updateRemoteFeatureFlags'];
 };
 
 export type RemoteFeatureFlagControllerActions =
-  RemoteFeatureFlagControllerGetStateAction;
+  | RemoteFeatureFlagControllerGetStateAction
+  | RemoteFeatureFlagControllerUpdateRemoteFeatureFlagsAction;
 
 export type AllowedActions = never;
 

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -23,6 +23,7 @@ import type {
   NetworkControllerEvents,
   NetworkClientId,
 } from '@metamask/network-controller';
+import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import assert from 'assert';
 import type { SinonFakeTimers } from 'sinon';
 import { useFakeTimers } from 'sinon';
@@ -43,7 +44,6 @@ import {
   buildCustomNetworkClientConfiguration,
   buildUpdateNetworkCustomRpcEndpointFields,
 } from '../../network-controller/tests/helpers';
-import type { RemoteFeatureFlagControllerGetStateAction } from '../../remote-feature-flag-controller/src';
 import {
   buildEthGasPriceRequestMock,
   buildEthBlockNumberRequestMock,


### PR DESCRIPTION
## Explanation

### What is the current state of things and why does it need to change?

Currently, the `@metamask/remote-feature-flag-controller` package defines several important TypeScript types for controller actions and events internally, but these types are not exported from the package index. This makes it difficult for external consumers to properly type their messenger integrations when using the RemoteFeatureFlagController.

Consumers who need to work with the controller's messenger system cannot access types like:
- `RemoteFeatureFlagControllerActions` - the union type of all controller actions
- `RemoteFeatureFlagControllerUpdateRemoteFeatureFlagsAction` - the specific action type for updating feature flags
- `RemoteFeatureFlagControllerEvents` - the union type of all controller events
- `RemoteFeatureFlagControllerStateChangeEvent` - the state change event type

### What is the solution your changes offer and how does it work?

This PR exports the missing controller types from the package index, making them available to external consumers. This allows proper TypeScript typing when:
- Setting up messenger instances that interact with the RemoteFeatureFlagController
- Handling controller actions and events
- Building integrations that need to reference these types

The changes are purely additive - no existing exports are modified or removed, ensuring backward compatibility.

### Are there any changes whose purpose might not obvious to those unfamiliar with the domain?

The PR also includes an internal refactoring where `RemoteFeatureFlagControllerGetStateAction` was moved from the types file to the main controller file. This is an internal organization change that doesn't affect the public API, as the type is still exported from the same package index location.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
  - No test changes needed as this only adds type exports
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
  - The exported types already have appropriate JSDoc comments
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
  - Changelog updated with the new exports
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
  - No breaking changes - this is purely additive

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exports RemoteFeatureFlagController action/event types from the package index and updates references, including adding the update action to the actions union.
> 
> - **Remote Feature Flag Controller**:
>   - **Exports**: Add `RemoteFeatureFlagControllerActions`, `RemoteFeatureFlagControllerUpdateRemoteFeatureFlagsAction`, `RemoteFeatureFlagControllerEvents`, `RemoteFeatureFlagControllerStateChangeEvent`, and re-export `RemoteFeatureFlagControllerGetStateAction` from `src/index.ts`.
>   - **Types/Refactor**: Move `RemoteFeatureFlagControllerGetStateAction` definition from `remote-feature-flag-controller-types.ts` to `remote-feature-flag-controller.ts`; rename/update the update action type and include it in `RemoteFeatureFlagControllerActions`.
>   - **Changelog**: Document new exports under Unreleased.
> - **Tests**:
>   - Update `TransactionControllerIntegration.test.ts` to import `RemoteFeatureFlagControllerGetStateAction` from `@metamask/remote-feature-flag-controller`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 674824f36fdab2a7ee2896fb0d7651c8e1482ad8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->