### PR TITLE
feat(token-search-discovery-controller): export additional controller types from package index

### DIFF
--- a/packages/token-search-discovery-controller/CHANGELOG.md
+++ b/packages/token-search-discovery-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export additional controller types from package index ([#6837](https://github.com/MetaMask/core/pull/6837))
+  - Export `TokenSearchDiscoveryControllerActions` - union type of all controller actions
+  - Export `TokenSearchDiscoveryControllerGetStateAction` - action type for getting controller state
+  - Export `TokenSearchDiscoveryControllerEvents` - union type of all controller events
+  - Export `TokenSearchDiscoveryControllerStateChangeEvent` - state change event type
+
 ## [3.4.0]
 
 ### Added

--- a/packages/token-search-discovery-controller/src/index.ts
+++ b/packages/token-search-discovery-controller/src/index.ts
@@ -2,6 +2,10 @@ export { TokenSearchDiscoveryController } from './token-search-discovery-control
 export type {
   TokenSearchDiscoveryControllerMessenger,
   TokenSearchDiscoveryControllerState,
+  TokenSearchDiscoveryControllerActions,
+  TokenSearchDiscoveryControllerGetStateAction,
+  TokenSearchDiscoveryControllerEvents,
+  TokenSearchDiscoveryControllerStateChangeEvent,
 } from './token-search-discovery-controller';
 export type {
   TokenSearchResponseItem,


### PR DESCRIPTION
## Explanation

### What is the current state of things and why does it need to change?

Currently, the `@metamask/token-search-discovery-controller` package defines several important TypeScript types for controller actions and events internally, but these types are not exported from the package index. This makes it difficult for external consumers to properly type their messenger integrations when using the TokenSearchDiscoveryController.

Consumers who need to work with the controller's messenger system cannot access types like:
- `TokenSearchDiscoveryControllerActions` - the union type of all controller actions
- `TokenSearchDiscoveryControllerGetStateAction` - the action type for getting controller state
- `TokenSearchDiscoveryControllerEvents` - the union type of all controller events
- `TokenSearchDiscoveryControllerStateChangeEvent` - the state change event type

### What is the solution your changes offer and how does it work?

This PR exports the missing controller types from the package index, making them available to external consumers. This allows proper TypeScript typing when:
- Setting up messenger instances that interact with the TokenSearchDiscoveryController
- Handling controller actions and events
- Building integrations that need to reference these types

The changes are purely additive - no existing exports are modified or removed, ensuring backward compatibility.

### Are there any changes whose purpose might not obvious to those unfamiliar with the domain?

All changes are straightforward type exports. The types were already defined within the controller but were not accessible to external packages.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
  - No test changes needed as this only adds type exports
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
  - The exported types already have appropriate JSDoc comments
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
  - Changelog updated with the new exports
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
  - No breaking changes - this is purely additive

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Export controller action/event types from the package index and note the change in the changelog.
> 
> - **Exports** (in `src/index.ts`):
>   - Add type exports from `token-search-discovery-controller`:
>     - `TokenSearchDiscoveryControllerActions`
>     - `TokenSearchDiscoveryControllerGetStateAction`
>     - `TokenSearchDiscoveryControllerEvents`
>     - `TokenSearchDiscoveryControllerStateChangeEvent`
> - **Changelog**:
>   - Document added exports under `Unreleased`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48f83c3223b435a8be9663ee68c31c7b833cd748. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->