### PR TITLE
chore: Align `eth-block-tracker` dependencies with monorepo

### DIFF
--- a/merged-packages/eth-block-tracker/package.json
+++ b/merged-packages/eth-block-tracker/package.json
@@ -58,6 +58,7 @@
     "@metamask/json-rpc-engine": "^10.1.1",
     "@types/jest": "^27.4.1",
     "@types/json-rpc-random-id": "^1.0.1",
+    "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.4",
     "typedoc": "^0.24.8",


### PR DESCRIPTION
## Explanation

This aligns `eth-block-tracker` dependencies with the monorepo, to match the versions used by other packages, and to remove unnecessary dependencies.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns `eth-block-tracker` dependencies/devDependencies with the monorepo, updating key MetaMask libs and pruning unused tooling.
> 
> - **Dependencies**:
>   - Update `@metamask/eth-json-rpc-provider` to `^5.0.1` and `@metamask/utils` to `^11.8.1`; adjust `@metamask/safe-event-emitter` to `^3.0.0`.
> - **DevDependencies**:
>   - Bump `@metamask/json-rpc-engine` to `^10.1.1`.
>   - Remove various lint/build tooling (multiple ESLint configs/plugins, Prettier, `depcheck`, `rimraf`, `ts-node`, etc.).
>   - Add `typedoc-plugin-missing-exports@^2.0.0` and keep `typescript@~5.2.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d79a3e3ca0070f149f530ef714993c8987cc2668. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->