### PR TITLE
chore: Align `eth-json-rpc-middleware` dependencies with monorepo

### DIFF
--- a/merged-packages/eth-json-rpc-middleware/package.json
+++ b/merged-packages/eth-json-rpc-middleware/package.json
@@ -66,6 +66,7 @@
     "@metamask/network-controller": "^24.2.2",
     "@types/jest": "^27.4.1",
     "@types/pify": "^5.0.2",
+    "deepmerge": "^4.2.2",
     "jest": "^27.5.1",
     "tsd": "^0.31.2",
     "typedoc": "^0.24.8",


### PR DESCRIPTION
## Explanation

This aligns `eth-json-rpc-middleware` dependencies with the monorepo, to match the versions used by other packages, and to remove unnecessary dependencies.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns `package.json` with monorepo by bumping key MetaMask dependencies, updating a few dev deps, removing unused tooling, and adding `deepmerge`.
> 
> - **Dependencies**:
>   - Bump `@metamask/eth-block-tracker` to `^13.0.0`, `@metamask/eth-json-rpc-provider` to `^5.0.1`, `@metamask/eth-sig-util` to `^8.2.0`, `@metamask/json-rpc-engine` to `^10.1.1`, `@metamask/utils` to `^11.8.1`.
> - **DevDependencies**:
>   - Update `@metamask/error-reporting-service` to `^2.2.1`, `@metamask/network-controller` to `^24.2.2`.
>   - Add `deepmerge@^4.2.2`.
>   - Remove numerous lint/build/tooling packages (e.g., ESLint/Prettier configs/plugins, type tooling, ts-node, ts-jest, depcheck, rimraf, etc.).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ee5ce1cadcb3372b7bb92ef8fe779be0ccfcea4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->