### PR TITLE
chore: Update `eth-json-rpc-middleware` README

### DIFF
--- a/merged-packages/eth-json-rpc-middleware/README.md
+++ b/merged-packages/eth-json-rpc-middleware/README.md
@@ -12,6 +12,12 @@ or
 
 `npm install @metamask/eth-json-rpc-middleware`
 
+## See also
+
+- [`@metamask/eth-json-rpc-filters`](https://github.com/MetaMask/eth-json-rpc-filters).
+- [`@metamask/eth-json-rpc-infura`](https://github.com/MetaMask/eth-json-rpc-infura).
+- [`@metamask/json-rpc-engine`](https://github.com/MetaMask/core/tree/main/packages/json-rpc-engine).
+
 ## Contributing
 
 This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).


### PR DESCRIPTION
## Explanation

This updates the README of `eth-json-rpc-middleware` to remove contributing and publishing instructions, and replaces them with a link to the monorepo contributing instructions instead, aligning it with other non-root packages.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the README: scoped package name, removes migration/test sections, refreshes See also links, and adds monorepo contributing link.
> 
> - **Docs** (`merged-packages/eth-json-rpc-middleware/README.md`):
>   - Rename heading to `@metamask/eth-json-rpc-middleware`.
>   - Remove migration warning banner and `Running Tests` section.
>   - Update `See also` links to `@metamask/eth-json-rpc-filters`, `@metamask/eth-json-rpc-infura`, and monorepo `json-rpc-engine`.
>   - Add `Contributing` section linking to monorepo README.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07b267ab50fdfe75b766d67f98e13c12be678bb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->