### PR TITLE
docs: Update README to include `eth-block-tracker` in dependency graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Each package in this repository has its own README where you can find installati
 - [`@metamask/eip1193-permission-middleware`](packages/eip1193-permission-middleware)
 - [`@metamask/ens-controller`](packages/ens-controller)
 - [`@metamask/error-reporting-service`](packages/error-reporting-service)
+- [`@metamask/eth-block-tracker`](packages/eth-block-tracker)
 - [`@metamask/eth-json-rpc-provider`](packages/eth-json-rpc-provider)
 - [`@metamask/foundryup`](packages/foundryup)
 - [`@metamask/gas-fee-controller`](packages/gas-fee-controller)
@@ -106,6 +107,7 @@ linkStyle default opacity:0.5
   eip1193_permission_middleware(["@metamask/eip1193-permission-middleware"]);
   ens_controller(["@metamask/ens-controller"]);
   error_reporting_service(["@metamask/error-reporting-service"]);
+  eth_block_tracker(["@metamask/eth-block-tracker"]);
   eth_json_rpc_provider(["@metamask/eth-json-rpc-provider"]);
   foundryup(["@metamask/foundryup"]);
   gas_fee_controller(["@metamask/gas-fee-controller"]);
@@ -218,6 +220,8 @@ linkStyle default opacity:0.5
   ens_controller --> controller_utils;
   ens_controller --> network_controller;
   error_reporting_service --> base_controller;
+  eth_block_tracker --> eth_json_rpc_provider;
+  eth_block_tracker --> json_rpc_engine;
   eth_json_rpc_provider --> json_rpc_engine;
   gas_fee_controller --> base_controller;
   gas_fee_controller --> controller_utils;
@@ -252,6 +256,7 @@ linkStyle default opacity:0.5
   name_controller --> controller_utils;
   network_controller --> base_controller;
   network_controller --> controller_utils;
+  network_controller --> eth_block_tracker;
   network_controller --> eth_json_rpc_provider;
   network_controller --> json_rpc_engine;
   network_controller --> error_reporting_service;
@@ -301,17 +306,20 @@ linkStyle default opacity:0.5
   signature_controller --> controller_utils;
   signature_controller --> accounts_controller;
   signature_controller --> approval_controller;
+  signature_controller --> gator_permissions_controller;
   signature_controller --> keyring_controller;
   signature_controller --> logging_controller;
   signature_controller --> network_controller;
   subscription_controller --> base_controller;
   subscription_controller --> controller_utils;
+  subscription_controller --> polling_controller;
   subscription_controller --> profile_sync_controller;
   token_search_discovery_controller --> base_controller;
   transaction_controller --> base_controller;
   transaction_controller --> controller_utils;
   transaction_controller --> accounts_controller;
   transaction_controller --> approval_controller;
+  transaction_controller --> eth_block_tracker;
   transaction_controller --> eth_json_rpc_provider;
   transaction_controller --> gas_fee_controller;
   transaction_controller --> network_controller;
@@ -320,6 +328,7 @@ linkStyle default opacity:0.5
   user_operation_controller --> controller_utils;
   user_operation_controller --> polling_controller;
   user_operation_controller --> approval_controller;
+  user_operation_controller --> eth_block_tracker;
   user_operation_controller --> gas_fee_controller;
   user_operation_controller --> keyring_controller;
   user_operation_controller --> network_controller;


### PR DESCRIPTION
## Explanation

This adds `eth-block-tracker` to the root README dependency graph.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `@metamask/eth-block-tracker` to the README packages list and dependency graph with related edges, plus minor graph link updates.
> 
> - **README dependency graph**:
>   - **New package/node**: `@metamask/eth-block-tracker` added to packages list and graph.
>   - **Edges**:
>     - `eth_block_tracker` → `eth_json_rpc_provider`, `json_rpc_engine`.
>     - `network_controller`, `transaction_controller`, `user_operation_controller` → `eth_block_tracker`.
>     - Additional updates: `signature_controller` → `gator_permissions_controller`; `subscription_controller` → `polling_controller`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e6c77d92c813331d5bc349e544ace40b2cc8102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->