### PR TITLE
chore: Fix invalid PR number in `eth-block-tracker` changelog

### DIFF
--- a/packages/eth-block-tracker/CHANGELOG.md
+++ b/packages/eth-block-tracker/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Update minimum Node.js version from `^18.16.0` to `^18.18.0` ([#7930](https://github.com/MetaMask/core/pull/7930))
+- **BREAKING:** Update minimum Node.js version from `^18.16.0` to `^18.18.0` ([#6865](https://github.com/MetaMask/core/pull/6865))
 - This package was migrated from `MetaMask/eth-block-tracker` to the
-  `MetaMask/core` monorepo ([#7930](https://github.com/MetaMask/core/pull/7930))
+  `MetaMask/core` monorepo ([#6865](https://github.com/MetaMask/core/pull/6865))
   - See [`MetaMask/eth-block-tracker`](https://github.com/MetaMask/eth-block-tracker/blob/main/CHANGELOG.md)
     for the original changelog.
 


### PR DESCRIPTION
## Explanation

The `eth-block-tracker` changelog accidentally contained an invalid PR number, which has been fixed in this PR.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects PR numbers in `packages/eth-block-tracker/CHANGELOG.md` from #7930 to #6865 for the Node.js minimum version change and monorepo migration notes.
> 
> - **Changelog (`packages/eth-block-tracker/CHANGELOG.md`)**:
>   - Correct PR references from `#7930` to `#6865` for:
>     - The breaking change updating minimum Node.js version
>     - The migration to the `MetaMask/core` monorepo
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caf93c0bc765dc656381bda19e9ee6fc506017b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->