### PR TITLE
chore: replace `ts-node` with `tsx` in publish-preview workflow

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.PUBLISH_PREVIEW_NPM_TOKEN }}
       - name: Generate preview build message
-        run: yarn ts-node scripts/generate-preview-build-message.ts
+        run: yarn tsx scripts/generate-preview-build-message.ts
       - name: Post build preview in comment
         run: gh pr comment "${PR_NUMBER}" --body-file preview-build-message.txt
         env:


### PR DESCRIPTION
## Explanation

### What is the current state of things and why does it need to change?

The `publish-preview.yml` GitHub Actions workflow is still using `ts-node` to execute the `generate-preview-build-message.ts` script. However, the project has recently migrated from `ts-node` to `tsx` [PR](https://github.com/MetaMask/core/pull/6481)

## References

- N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
  - No test changes needed for this workflow update
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
  - No documentation changes needed
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
  - No changelog needed as this is an internal workflow change
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
  - No breaking changes - internal workflow update only


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the preview build message step in `.github/workflows/publish-preview.yml` from `yarn ts-node` to `yarn tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f0fd2911b62cb1d65be2a20ee7f0bd7ac2a2f9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->