### PR TITLE
chore: add multicall addresses

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add multicall addresses in `MULTICALL_CONTRACT_BY_CHAINID` ([#6896](https://github.com/MetaMask/core/pull/6896))
-  - Add multicall adderess for Chains: `Injective`, `Hemi`, `Plasma`, `Nonmia`, `XRPL`, `Soneium`, `Genesys`, `EDU`, `Abstract`, `Berachain`, `MegaETH Testnet`, `Apechain`, `Matchain`, `Monad Testnet`, `Monad`, `Katana`, `Lens`, `Plume`, `XDC`
+  - Add multicall address for Chains: `Injective`, `Hemi`, `Plasma`, `Nonmia`, `XRPL`, `Soneium`, `Genesys`, `EDU`, `Abstract`, `Berachain`, `MegaETH Testnet`, `Apechain`, `Matchain`, `Monad Testnet`, `Monad`, `Katana`, `Lens`, `Plume`, `XDC`
 
 ## [81.0.1]
 

--- a/packages/assets-controllers/src/multicall.ts
+++ b/packages/assets-controllers/src/multicall.ts
@@ -270,31 +270,31 @@ const MULTICALL_CONTRACT_BY_CHAINID = {
   // XRPL, contract found but not in multicall3 repo
   '0x15f900': '0x6B5eFbC0C82eBb26CA13a4F11836f36Fc6fdBC5D',
   // Soneium, contract found but not in multicall3 repo
-  '0x74c' : '0xcA11bde05977b3631167028862bE2a173976CA11',
+  '0x74c': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Genesys, contract found but not in multicall3 repo
-  '0x407b' : '0x90a2377F233E3461BACa6080d4837837d8762927',
+  '0x407b': '0x90a2377F233E3461BACa6080d4837837d8762927',
   // EDU (Animoca)
-  '0xa3c3' : '0xcA11bde05977b3631167028862bE2a173976CA11',
+  '0xa3c3': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Abstract
-  '0xab5' : '0xF9cda624FBC7e059355ce98a31693d299FACd963',
+  '0xab5': '0xF9cda624FBC7e059355ce98a31693d299FACd963',
   // Berachain, contract found but not in multicall3 repo
-  '0x138de' : '0xcA11bde05977b3631167028862bE2a173976CA11',
+  '0x138de': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // MegaETH TESTNET
-  '0x18c6' : '0xcA11bde05977b3631167028862bE2a173976CA11',
+  '0x18c6': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Apechain
-  '0x8173' : '0xcA11bde05977b3631167028862bE2a173976CA11',
+  '0x8173': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Matchain, contract found but not in multicall3 repo
-  '0x2ba' : '0xcA11bde05977b3631167028862bE2a173976CA11',
+  '0x2ba': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Monad TESTNET
-  '0x279f' : '0xcA11bde05977b3631167028862bE2a173976CA11',
+  '0x279f': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Katana
-  '0xb67d2' : '0xcA11bde05977b3631167028862bE2a173976CA11',
+  '0xb67d2': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Lens, contract found but not in multicall3 repo
-  '0xe8' : '0xcA11bde05977b3631167028862bE2a173976CA11',
+  '0xe8': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Plume
-  '0x18232' : '0xcA11bde05977b3631167028862bE2a173976CA11',
+  '0x18232': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Monad Mainnet
-  '0x8f' : '0xcA11bde05977b3631167028862bE2a173976CA11',
+  '0x8f': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // XDC, contract found but not in multicall3 repo
   '0x32': '0x0B1795ccA8E4eC4df02346a082df54D437F8D9aF',
 } as Record<Hex, Hex>;


### PR DESCRIPTION
## Explanation
Adds new MULTICALL_CONTRACT_BY_CHAINID mappings for multiple chains and documents them in the changelog.

**assets-controllers:**

**Multicall support:** 

Extend MULTICALL_CONTRACT_BY_CHAINID in src/multicall.ts with new addresses for Injective (0x6f0), Hemi (0xa867), Plasma (0x2611), Nonmia (0xa6), XRPL (0x15f900), Soneium (0x74c), Genesys (0x407b), EDU (0xa3c3), Abstract (0xab5), Berachain (0x138de), MegaETH Testnet (0x18c6), Apechain (0x8173), Matchain (0x2ba), Monad Testnet (0x279f), Katana (0xb67d2), Lens (0xe8), Plume (0x18232), Monad (0x8f), XDC (0x32).
Docs: Update CHANGELOG.md under [Unreleased] to note added multicall addresses.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new `MULTICALL_CONTRACT_BY_CHAINID` mappings for multiple chains and documents them in the changelog.
> 
> - **assets-controllers**:
>   - **Multicall support**: Extend `MULTICALL_CONTRACT_BY_CHAINID` in `src/multicall.ts` with new addresses for `Injective (0x6f0)`, `Hemi (0xa867)`, `Plasma (0x2611)`, `Nonmia (0xa6)`, `XRPL (0x15f900)`, `Soneium (0x74c)`, `Genesys (0x407b)`, `EDU (0xa3c3)`, `Abstract (0xab5)`, `Berachain (0x138de)`, `MegaETH Testnet (0x18c6)`, `Apechain (0x8173)`, `Matchain (0x2ba)`, `Monad Testnet (0x279f)`, `Katana (0xb67d2)`, `Lens (0xe8)`, `Plume (0x18232)`, `Monad (0x8f)`, `XDC (0x32)`.
>   - **Docs**: Update `CHANGELOG.md` under `[Unreleased]` to note added multicall addresses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df26abf85995677d91cc6db829329695a18cb016. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->