### PR TITLE
feat: Dynamic OP Stack L1 gas via gas API

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add optional `isIntentComplete` property to `TransactionMeta` to indicate transaction outcome was achieved via an alternate chain or mechanism ([#6950](https://github.com/MetaMask/core/pull/6950))
 
+### Changed
+
+- Identify OP stack chains using gas API ([#6899](https://github.com/MetaMask/core/pull/6899))
+
 ## [61.0.0]
 
 ### Changed

--- a/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.test.ts
@@ -1,38 +1,139 @@
+import * as ControllerUtils from '@metamask/controller-utils';
+import { hexToNumber, type Hex } from '@metamask/utils';
+
 import { OptimismLayer1GasFeeFlow } from './OptimismLayer1GasFeeFlow';
 import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { TransactionMeta } from '../types';
 import { TransactionStatus } from '../types';
 
-const TRANSACTION_META_MOCK: TransactionMeta = {
-  id: '1',
-  chainId: CHAIN_IDS.OPTIMISM,
-  networkClientId: 'testNetworkClientId',
-  status: TransactionStatus.unapproved,
-  time: 0,
-  txParams: {
-    from: '0x123',
-    gas: '0x1234',
-  },
+jest.mock('@metamask/controller-utils', () => {
+  const actual = jest.requireActual('@metamask/controller-utils');
+  return { ...actual, handleFetch: jest.fn() };
+});
+
+type SupportedNetworksResponseMock = {
+  fullSupport: number[];
+  partialSupport: { optimism: number[] };
 };
 
-describe('OptimismLayer1GasFeeFlow', () => {
-  describe('matchesTransaction', () => {
-    it.each([
-      ['Optimisim mainnet', CHAIN_IDS.OPTIMISM],
-      ['Optimisim testnet', CHAIN_IDS.OPTIMISM_TESTNET],
-    ])('returns true if chain ID is %s', (_title, chainId) => {
-      const flow = new OptimismLayer1GasFeeFlow();
+/**
+ * Creates a minimal `TransactionMeta` object for testing with the provided chain ID.
+ *
+ * @param chainId - The hex-encoded chain ID to set on the transaction.
+ * @returns A `TransactionMeta` stub suitable for tests.
+ */
+function createTransaction(chainId: string): TransactionMeta {
+  return {
+    id: '1',
+    chainId: chainId as Hex,
+    networkClientId: 'testNetworkClientId',
+    status: TransactionStatus.unapproved,
+    time: 0,
+    txParams: {
+      from: '0x123',
+      gas: '0x1234',
+    },
+  };
+}
 
-      const transaction = {
-        ...TRANSACTION_META_MOCK,
-        chainId,
-      };
+describe('OptimismLayer1GasFeeFlow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  const messenger = {} as TransactionControllerMessenger;
+
+  describe('matchesTransaction', () => {
+    let handleFetchMock: jest.MockedFunction<
+      (url: string, init?: unknown) => Promise<SupportedNetworksResponseMock>
+    >;
+
+    beforeEach(() => {
+      handleFetchMock = ControllerUtils.handleFetch as jest.MockedFunction<
+        (url: string, init?: unknown) => Promise<SupportedNetworksResponseMock>
+      >;
+      handleFetchMock.mockReset();
+    });
+
+    it.each([
+      ['Optimism mainnet', CHAIN_IDS.OPTIMISM],
+      ['Optimism testnet', CHAIN_IDS.OPTIMISM_TESTNET],
+    ])(
+      'uses the fallback list when remote fetch fails for %s',
+      async (_title: string, chainId: string) => {
+        handleFetchMock.mockRejectedValue(new Error('ignore'));
+        const flow = new OptimismLayer1GasFeeFlow();
+        const transactionMeta = createTransaction(chainId);
+
+        expect(
+          await flow.matchesTransaction({
+            transactionMeta,
+            messenger,
+          }),
+        ).toBe(true);
+      },
+    );
+
+    it('returns true when the remote list contains the chain', async () => {
+      handleFetchMock.mockResolvedValue({
+        fullSupport: [],
+        partialSupport: { optimism: [hexToNumber(CHAIN_IDS.OPTIMISM)] },
+      });
+      const flow = new OptimismLayer1GasFeeFlow();
+      const transactionMeta = createTransaction(CHAIN_IDS.OPTIMISM);
 
       expect(
-        flow.matchesTransaction({
-          transactionMeta: transaction,
-          messenger: {} as TransactionControllerMessenger,
+        await flow.matchesTransaction({
+          transactionMeta,
+          messenger,
+        }),
+      ).toBe(true);
+    });
+
+    it('falls back to static list when remote list omits the chain', async () => {
+      handleFetchMock.mockResolvedValue({
+        fullSupport: [],
+        partialSupport: { optimism: [] },
+      });
+      const flow = new OptimismLayer1GasFeeFlow();
+      const transactionMeta = createTransaction(CHAIN_IDS.BASE);
+
+      expect(
+        await flow.matchesTransaction({
+          transactionMeta,
+          messenger,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when neither remote nor fallback include the chain', async () => {
+      handleFetchMock.mockResolvedValue({
+        fullSupport: [],
+        partialSupport: { optimism: [] },
+      });
+      const flow = new OptimismLayer1GasFeeFlow();
+      const transactionMeta = createTransaction('0x9999');
+
+      expect(
+        await flow.matchesTransaction({
+          transactionMeta,
+          messenger,
+        }),
+      ).toBe(false);
+    });
+
+    it('uses the fallback list when the remote payload is missing', async () => {
+      handleFetchMock.mockResolvedValue(
+        undefined as unknown as SupportedNetworksResponseMock,
+      );
+
+      const flow = new OptimismLayer1GasFeeFlow();
+      const transactionMeta = createTransaction(CHAIN_IDS.ZORA);
+
+      expect(
+        await flow.matchesTransaction({
+          transactionMeta,
+          messenger,
         }),
       ).toBe(true);
     });

--- a/packages/transaction-controller/src/gas-flows/ScrollLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/ScrollLayer1GasFeeFlow.ts
@@ -9,22 +9,26 @@ const SCROLL_CHAIN_IDS: Hex[] = [CHAIN_IDS.SCROLL, CHAIN_IDS.SCROLL_SEPOLIA];
 
 // BlockExplorer link: https://scrollscan.com/address/0x5300000000000000000000000000000000000002#code
 const SCROLL_GAS_PRICE_ORACLE_ADDRESS =
-  '0x5300000000000000000000000000000000000002';
+  '0x5300000000000000000000000000000000000002' as Hex;
 
 /**
  * Scroll layer 1 gas fee flow that obtains gas fee estimate using an oracle contract.
  */
 export class ScrollLayer1GasFeeFlow extends OracleLayer1GasFeeFlow {
-  constructor() {
-    super(SCROLL_GAS_PRICE_ORACLE_ADDRESS, true);
+  protected override getOracleAddressForChain(_chainId: Hex): Hex {
+    return SCROLL_GAS_PRICE_ORACLE_ADDRESS;
   }
 
-  matchesTransaction({
+  protected override shouldSignTransaction(): boolean {
+    return true;
+  }
+
+  async matchesTransaction({
     transactionMeta,
   }: {
     transactionMeta: TransactionMeta;
     messenger: TransactionControllerMessenger;
-  }): boolean {
+  }): Promise<boolean> {
     return SCROLL_CHAIN_IDS.includes(transactionMeta.chainId);
   }
 }

--- a/packages/transaction-controller/src/helpers/GasFeePoller.test.ts
+++ b/packages/transaction-controller/src/helpers/GasFeePoller.test.ts
@@ -126,7 +126,7 @@ describe('GasFeePoller', () => {
   const layer1GasFeeFlowsMock: jest.Mocked<Layer1GasFeeFlow[]> = [];
   const getGasFeeControllerEstimatesMock = jest.fn();
   const findNetworkClientIdByChainIdMock = jest.fn();
-  const messengerMock = jest.fn() as unknown as TransactionControllerMessenger;
+  let messengerMock: TransactionControllerMessenger;
 
   beforeEach(() => {
     jest.clearAllTimers();
@@ -145,6 +145,15 @@ describe('GasFeePoller', () => {
     ]);
 
     getTransactionLayer1GasFeeMock.mockResolvedValue(LAYER1_GAS_FEE_MOCK);
+
+    messengerMock = {
+      publish: jest.fn(),
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+      call: jest.fn(),
+      registerActionHandler: jest.fn(),
+      unregisterActionHandler: jest.fn(),
+    } as unknown as TransactionControllerMessenger;
 
     constructorOptions = {
       findNetworkClientIdByChainId: findNetworkClientIdByChainIdMock,
@@ -193,7 +202,7 @@ describe('GasFeePoller', () => {
         expect(gasFeeFlowMock.getGasFees).toHaveBeenCalledWith({
           ethQuery: expect.any(Object),
           gasFeeControllerData: {},
-          messenger: expect.any(Function),
+          messenger: messengerMock,
           transactionMeta: TRANSACTION_META_MOCK,
         });
       });
@@ -208,7 +217,7 @@ describe('GasFeePoller', () => {
         expect(getTransactionLayer1GasFeeMock).toHaveBeenCalledWith({
           provider: expect.any(Object),
           layer1GasFeeFlows: layer1GasFeeFlowsMock,
-          messenger: expect.any(Function),
+          messenger: messengerMock,
           transactionMeta: TRANSACTION_META_MOCK,
         });
       });
@@ -344,7 +353,7 @@ describe('GasFeePoller', () => {
         expect(gasFeeFlowMock.getGasFees).toHaveBeenCalledWith({
           ethQuery: expect.any(EthQuery),
           gasFeeControllerData: expect.any(Object),
-          messenger: expect.any(Function),
+          messenger: messengerMock,
           transactionMeta: {
             id: '1',
             chainId: TRANSACTION_BATCH_META_MOCK.chainId,

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1437,7 +1437,7 @@ export type Layer1GasFeeFlow = {
    * @param args - The arguments for the matcher function.
    * @param args.transactionMeta - The transaction metadata.
    * @param args.messenger - The messenger instance.
-   * @returns Whether the gas fee flow supports the transaction.
+   * @returns A promise that resolves to whether the gas fee flow supports the transaction.
    */
   matchesTransaction({
     transactionMeta,
@@ -1445,7 +1445,7 @@ export type Layer1GasFeeFlow = {
   }: {
     transactionMeta: TransactionMeta;
     messenger: TransactionControllerMessenger;
-  }): boolean;
+  }): Promise<boolean>;
 
   /**
    * Get layer 1 gas fee estimates for a specific transaction.

--- a/packages/transaction-controller/src/utils/layer1-gas-fee-flow.test.ts
+++ b/packages/transaction-controller/src/utils/layer1-gas-fee-flow.test.ts
@@ -33,7 +33,7 @@ function createLayer1GasFeeFlowMock({
   layer1Fee: Hex;
 }): jest.Mocked<Layer1GasFeeFlow> {
   return {
-    matchesTransaction: jest.fn().mockReturnValue(match),
+    matchesTransaction: jest.fn().mockResolvedValue(match),
     getLayer1Fee: jest.fn().mockResolvedValue({ layer1Fee }),
   };
 }

--- a/packages/transaction-controller/src/utils/layer1-gas-fee-flow.ts
+++ b/packages/transaction-controller/src/utils/layer1-gas-fee-flow.ts
@@ -46,17 +46,23 @@ export async function updateTransactionLayer1GasFee(
  * @param messenger - The messenger instance.
  * @returns The layer 1 gas fee flow for the transaction, or undefined if none match.
  */
-function getLayer1GasFeeFlow(
+async function getLayer1GasFeeFlow(
   transactionMeta: TransactionMeta,
   layer1GasFeeFlows: Layer1GasFeeFlow[],
   messenger: TransactionControllerMessenger,
-): Layer1GasFeeFlow | undefined {
-  return layer1GasFeeFlows.find((layer1GasFeeFlow) =>
-    layer1GasFeeFlow.matchesTransaction({
+): Promise<Layer1GasFeeFlow | undefined> {
+  for (const layer1GasFeeFlow of layer1GasFeeFlows) {
+    const matches = await layer1GasFeeFlow.matchesTransaction({
       transactionMeta,
       messenger,
-    }),
-  );
+    });
+
+    if (matches) {
+      return layer1GasFeeFlow;
+    }
+  }
+
+  return undefined;
 }
 
 /**
@@ -75,7 +81,7 @@ export async function getTransactionLayer1GasFee({
   provider,
   transactionMeta,
 }: UpdateLayer1GasFeeRequest): Promise<Hex | undefined> {
-  const layer1GasFeeFlow = getLayer1GasFeeFlow(
+  const layer1GasFeeFlow = await getLayer1GasFeeFlow(
     transactionMeta,
     layer1GasFeeFlows,
     messenger,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

- fetch the OP Stack supported chain list from the gas API with a static fallback so OptimismLayer1GasFeeFlow can react to remote updates
- make OracleLayer1GasFeeFlow accept an optional default oracle and throw unless subclasses override getOracleAddressForChain, removing the now-unneeded constructor in the Optimism flow
- allow Layer1GasFeeFlow.matchesTransaction to be async
 
## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Dynamically detects OP Stack chains via gas API (with static fallback) and refactors the L1 oracle flow with default oracle/signing while making Layer1GasFeeFlow.matchesTransaction async.
> 
> - **Gas Flows**:
>   - **OptimismLayer1GasFeeFlow**: Fetches supported OP Stack chains from `gas.api` (`/v1/supportedNetworks`) with fallback to `FALLBACK_OPTIMISM_STACK_CHAIN_IDS`; uses base class default oracle; `matchesTransaction` is async.
>   - **OracleLayer1GasFeeFlow**: Adds default OP Stack oracle address and hooks `getOracleAddressForChain` and `shouldSignTransaction`; updates signing to use `Uint8Array`.
>   - **ScrollLayer1GasFeeFlow**: Overrides new hooks (oracle address, requires signing); `matchesTransaction` now async.
> - **Types/Utils**:
>   - `Layer1GasFeeFlow.matchesTransaction` returns `Promise<boolean>`; update `getTransactionLayer1GasFee` flow selection to async.
> - **Helpers**:
>   - `GasFeePoller` tests updated to pass `messenger` object and expect it in calls.
> - **Tests**:
>   - Add/adjust tests for OP Stack remote list handling, default oracle config, Scroll overrides, and async matching.
> - **Changelog**:
>   - Note change: Identify OP stack chains using gas API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc31d4ba780989523cffab22f502504a0fa83a04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->