### PR TITLE
Feat/create minute exponential backoff

### DIFF
--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Bump `@metamask/base-controller` from `^8.4.1` to `^8.4.2` ([#6917](https://github.com/MetaMask/core/pull/6917))
 - Fix exponential backoff strategy in `ClientConfigApiService` to use proper Cockatiel `ExponentialBackoff` implementation
   - Replace custom `ExponentialMinuteBackoff` class with `createMinuteBasedExponentialBackoff()` function that configures Cockatiel's `ExponentialBackoff` with minute-based intervals
   - Ensures retry mechanism correctly implements the specified timing progression: 1st retry after 1 minute, 2nd retry after 2 minutes, 3rd retry after 4 minutes
+
+
+### Changed
+
+- Bump `@metamask/base-controller` from `^8.4.1` to `^8.4.2` ([#6917](https://github.com/MetaMask/core/pull/6917))
 
 ## [1.9.0]
 

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add exponential backoff strategy in `ClientConfigApiService` to use proper Cockatiel `ExponentialBackoff` implementation ([#6922](https://github.com/MetaMask/core/pull/6922))
-  - Replace custom `ExponentialMinuteBackoff` class with `createMinuteBasedExponentialBackoff()` function that configures Cockatiel's `ExponentialBackoff` with minute-based intervals
-  - Ensures retry mechanism correctly implements the specified timing progression: 1st retry after 1 minute, 2nd retry after 2 minutes, 3rd retry after 4 minutes
+- Add custom backoff interval support in `ClientConfigApiService` ([#6922](https://github.com/MetaMask/core/pull/6922))
+  - New `customBackoffInterval` parameter allows specifying exact retry intervals in seconds
+  - Example: `[100, 200, 300]` means 1st retry after 100s, 2nd after 200s, 3rd after 300s
+  - Falls back to default exponential backoff when no custom intervals provided
+  - Includes validation to ensure intervals array is compatible with retry configuration
 - Bump `@metamask/base-controller` from `^8.4.1` to `^8.4.2` ([#6917](https://github.com/MetaMask/core/pull/6917))
 
 ## [1.9.0]

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add exponential backoff strategy in `ClientConfigApiService` to use proper Cockatiel `ExponentialBackoff` implementation ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Add exponential backoff strategy in `ClientConfigApiService` to use proper Cockatiel `ExponentialBackoff` implementation ([#6922](https://github.com/MetaMask/core/pull/6922))
   - Replace custom `ExponentialMinuteBackoff` class with `createMinuteBasedExponentialBackoff()` function that configures Cockatiel's `ExponentialBackoff` with minute-based intervals
   - Ensures retry mechanism correctly implements the specified timing progression: 1st retry after 1 minute, 2nd retry after 2 minutes, 3rd retry after 4 minutes
 - Bump `@metamask/base-controller` from `^8.4.1` to `^8.4.2` ([#6917](https://github.com/MetaMask/core/pull/6917))

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Fix exponential backoff strategy in `ClientConfigApiService` to use proper Cockatiel `ExponentialBackoff` implementation
-  - Replace custom `ExponentialMinuteBackoff` class with `createMinuteBasedExponentialBackoff()` function that configures Cockatiel's `ExponentialBackoff` with minute-based intervals
-  - Ensures retry mechanism correctly implements the specified timing progression: 1st retry after 1 minute, 2nd retry after 2 minutes, 3rd retry after 4 minutes
-
 ### Changed
 
+- Add exponential backoff strategy in `ClientConfigApiService` to use proper Cockatiel `ExponentialBackoff` implementation ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+  - Replace custom `ExponentialMinuteBackoff` class with `createMinuteBasedExponentialBackoff()` function that configures Cockatiel's `ExponentialBackoff` with minute-based intervals
+  - Ensures retry mechanism correctly implements the specified timing progression: 1st retry after 1 minute, 2nd retry after 2 minutes, 3rd retry after 4 minutes
 - Bump `@metamask/base-controller` from `^8.4.1` to `^8.4.2` ([#6917](https://github.com/MetaMask/core/pull/6917))
 
 ## [1.9.0]

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Replace custom `ExponentialMinuteBackoff` class with `createMinuteBasedExponentialBackoff()` function that configures Cockatiel's `ExponentialBackoff` with minute-based intervals
   - Ensures retry mechanism correctly implements the specified timing progression: 1st retry after 1 minute, 2nd retry after 2 minutes, 3rd retry after 4 minutes
 
-
 ### Changed
 
 - Bump `@metamask/base-controller` from `^8.4.1` to `^8.4.2` ([#6917](https://github.com/MetaMask/core/pull/6917))

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/base-controller` from `^8.4.1` to `^8.4.2` ([#6917](https://github.com/MetaMask/core/pull/6917))
+- Fix exponential backoff strategy in `ClientConfigApiService` to use proper Cockatiel `ExponentialBackoff` implementation
+  - Replace custom `ExponentialMinuteBackoff` class with `createMinuteBasedExponentialBackoff()` function that configures Cockatiel's `ExponentialBackoff` with minute-based intervals
+  - Ensures retry mechanism correctly implements the specified timing progression: 1st retry after 1 minute, 2nd retry after 2 minutes, 3rd retry after 4 minutes
 
 ## [1.9.0]
 

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
@@ -245,6 +245,135 @@ describe('ClientConfigApiService', () => {
       expect(onDegraded).toHaveBeenCalled();
     }, 7000);
   });
+
+  describe('customBackoffInterval', () => {
+    it('should accept and use custom backoff intervals', async () => {
+      const mockFetch = createMockFetch({ error: networkError });
+      const customIntervals = [1, 2, 3]; // 1s, 2s, 3s
+      
+      const clientConfigApiService = new ClientConfigApiService({
+        fetch: mockFetch,
+        retries: 3,
+        customBackoffInterval: customIntervals,
+        config: {
+          client: ClientType.Extension,
+          distribution: DistributionType.Main,
+          environment: EnvironmentType.Production,
+        },
+      });
+      
+      await expect(
+        clientConfigApiService.fetchRemoteFeatureFlags(),
+      ).rejects.toThrow(networkError);
+      
+      // Verify that fetch was called the expected number of times
+      expect(mockFetch).toHaveBeenCalledTimes(4); // Initial + 3 retries
+    });
+
+    it('should validate custom backoff intervals array', () => {
+      const mockFetch = createMockFetch();
+      
+      // Test empty array
+      expect(() => {
+        new ClientConfigApiService({
+          fetch: mockFetch,
+          retries: 3,
+          customBackoffInterval: [],
+          config: {
+            client: ClientType.Extension,
+            distribution: DistributionType.Main,
+            environment: EnvironmentType.Production,
+          },
+        });
+      }).toThrow('customBackoffInterval array cannot be empty');
+      
+      // Test non-positive numbers
+      expect(() => {
+        new ClientConfigApiService({
+          fetch: mockFetch,
+          retries: 3,
+          customBackoffInterval: [1, -2, 3],
+          config: {
+            client: ClientType.Extension,
+            distribution: DistributionType.Main,
+            environment: EnvironmentType.Production,
+          },
+        });
+      }).toThrow('All customBackoffInterval values must be positive numbers');
+      
+      // Test array longer than retries
+      expect(() => {
+        new ClientConfigApiService({
+          fetch: mockFetch,
+          retries: 2,
+          customBackoffInterval: [1, 2, 3, 4],
+          config: {
+            client: ClientType.Extension,
+            distribution: DistributionType.Main,
+            environment: EnvironmentType.Production,
+          },
+        });
+      }).toThrow('customBackoffInterval array length (4) must be equal to maxRetries (2)');
+      
+      // Test array shorter than retries
+      expect(() => {
+        new ClientConfigApiService({
+          fetch: mockFetch,
+          retries: 3,
+          customBackoffInterval: [1, 2],
+          config: {
+            client: ClientType.Extension,
+            distribution: DistributionType.Main,
+            environment: EnvironmentType.Production,
+          },
+        });
+      }).toThrow('customBackoffInterval array length (2) must be equal to maxRetries (3)');
+    });
+
+    it('should fall back to exponential backoff when no custom intervals provided', async () => {
+      const mockFetch = createMockFetch({ error: networkError });
+      
+      const clientConfigApiService = new ClientConfigApiService({
+        fetch: mockFetch,
+        retries: 2,
+        config: {
+          client: ClientType.Extension,
+          distribution: DistributionType.Main,
+          environment: EnvironmentType.Production,
+        },
+      });
+
+      await expect(
+        clientConfigApiService.fetchRemoteFeatureFlags(),
+      ).rejects.toThrow(networkError);
+      
+      // Verify that fetch was called the expected number of times
+      expect(mockFetch).toHaveBeenCalledTimes(3); // Initial + 2 retries
+    });
+
+    it('should use custom backoff intervals that exactly match max retries', async () => {
+      const mockFetch = createMockFetch({ error: networkError });
+      const customIntervals = [1, 2, 3]; // Exactly 3 intervals for 3 retries
+      
+      const clientConfigApiService = new ClientConfigApiService({
+        fetch: mockFetch,
+        retries: 3,
+        customBackoffInterval: customIntervals,
+        config: {
+          client: ClientType.Extension,
+          distribution: DistributionType.Main,
+          environment: EnvironmentType.Production,
+        },
+      });
+
+      await expect(
+        clientConfigApiService.fetchRemoteFeatureFlags(),
+      ).rejects.toThrow(networkError);
+      
+      // Should retry the full number of times using the custom intervals
+      expect(mockFetch).toHaveBeenCalledTimes(4); // Initial + 3 retries
+    });
+  });
 });
 
 /**
@@ -257,14 +386,18 @@ describe('ClientConfigApiService', () => {
  * @returns A Jest mock function that resolves with a fetch-like Response object (or rejects with error if provided)
  */
 function createMockFetch({
-  response,
+  response = {
+    ok: true,
+    status: 200,
+    json: async () => mockServerFeatureFlagsResponse,
+  },
   error,
   delay = 0,
 }: {
   response?: Partial<Response>;
   error?: Error;
   delay?: number;
-}) {
+} = {}) {
   if (error) {
     return jest
       .fn()

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
@@ -408,7 +408,9 @@ function createMockFetch({
       .fn()
       .mockImplementation(
         () =>
-          new Promise((_, reject) => setTimeout(() => reject(error), delay)),
+          new Promise((_resolve, reject) =>
+            setTimeout(() => reject(error), delay),
+          ),
       );
   }
 

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
@@ -1,3 +1,4 @@
+import { ClientConfigApiService } from './client-config-api-service';
 import { BASE_URL } from '../constants';
 import type {
   ApiDataResponse,
@@ -8,7 +9,6 @@ import {
   DistributionType,
   EnvironmentType,
 } from '../remote-feature-flag-controller-types';
-import { ClientConfigApiService } from './client-config-api-service';
 
 const mockServerFeatureFlagsResponse: ApiDataResponse = [
   { feature1: false },
@@ -382,6 +382,7 @@ describe('ClientConfigApiService', () => {
 
 /**
  * Creates a mock fetch function with configurable response data and options
+ *
  * @template T - The type of data to be returned by the fetch response
  * @param params - Configuration parameters
  * @param params.response - Optional Response properties to override defaults

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
@@ -250,7 +250,7 @@ describe('ClientConfigApiService', () => {
     it('should accept and use custom backoff intervals', async () => {
       const mockFetch = createMockFetch({ error: networkError });
       const customIntervals = [1, 2, 3]; // 1s, 2s, 3s
-      
+
       const clientConfigApiService = new ClientConfigApiService({
         fetch: mockFetch,
         retries: 3,
@@ -261,18 +261,18 @@ describe('ClientConfigApiService', () => {
           environment: EnvironmentType.Production,
         },
       });
-      
+
       await expect(
         clientConfigApiService.fetchRemoteFeatureFlags(),
       ).rejects.toThrow(networkError);
-      
+
       // Verify that fetch was called the expected number of times
       expect(mockFetch).toHaveBeenCalledTimes(4); // Initial + 3 retries
     });
 
     it('should validate custom backoff intervals array', () => {
       const mockFetch = createMockFetch();
-      
+
       // Test empty array
       expect(() => {
         new ClientConfigApiService({
@@ -286,7 +286,7 @@ describe('ClientConfigApiService', () => {
           },
         });
       }).toThrow('customBackoffInterval array cannot be empty');
-      
+
       // Test non-positive numbers
       expect(() => {
         new ClientConfigApiService({
@@ -300,7 +300,7 @@ describe('ClientConfigApiService', () => {
           },
         });
       }).toThrow('All customBackoffInterval values must be positive numbers');
-      
+
       // Test array longer than retries
       expect(() => {
         new ClientConfigApiService({
@@ -313,8 +313,10 @@ describe('ClientConfigApiService', () => {
             environment: EnvironmentType.Production,
           },
         });
-      }).toThrow('customBackoffInterval array length (4) must be equal to maxRetries (2)');
-      
+      }).toThrow(
+        'customBackoffInterval array length (4) must be equal to maxRetries (2)',
+      );
+
       // Test array shorter than retries
       expect(() => {
         new ClientConfigApiService({
@@ -327,12 +329,14 @@ describe('ClientConfigApiService', () => {
             environment: EnvironmentType.Production,
           },
         });
-      }).toThrow('customBackoffInterval array length (2) must be equal to maxRetries (3)');
+      }).toThrow(
+        'customBackoffInterval array length (2) must be equal to maxRetries (3)',
+      );
     });
 
     it('should fall back to exponential backoff when no custom intervals provided', async () => {
       const mockFetch = createMockFetch({ error: networkError });
-      
+
       const clientConfigApiService = new ClientConfigApiService({
         fetch: mockFetch,
         retries: 2,
@@ -346,7 +350,7 @@ describe('ClientConfigApiService', () => {
       await expect(
         clientConfigApiService.fetchRemoteFeatureFlags(),
       ).rejects.toThrow(networkError);
-      
+
       // Verify that fetch was called the expected number of times
       expect(mockFetch).toHaveBeenCalledTimes(3); // Initial + 2 retries
     });
@@ -354,7 +358,7 @@ describe('ClientConfigApiService', () => {
     it('should use custom backoff intervals that exactly match max retries', async () => {
       const mockFetch = createMockFetch({ error: networkError });
       const customIntervals = [1, 2, 3]; // Exactly 3 intervals for 3 retries
-      
+
       const clientConfigApiService = new ClientConfigApiService({
         fetch: mockFetch,
         retries: 3,
@@ -369,7 +373,7 @@ describe('ClientConfigApiService', () => {
       await expect(
         clientConfigApiService.fetchRemoteFeatureFlags(),
       ).rejects.toThrow(networkError);
-      
+
       // Should retry the full number of times using the custom intervals
       expect(mockFetch).toHaveBeenCalledTimes(4); // Initial + 3 retries
     });

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
@@ -191,7 +191,7 @@ describe('ClientConfigApiService', () => {
       // Check that fetch was retried the correct number of times
       expect(mockFetch).toHaveBeenCalledTimes(maxRetries + 1); // Initial + retries
     });
-    
+
     it('should call the onBreak callback when the circuit opens', async () => {
       const onBreak = jest.fn();
       const mockFetch = createMockFetch({ error: networkError });

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
@@ -192,6 +192,64 @@ describe('ClientConfigApiService', () => {
       expect(mockFetch).toHaveBeenCalledTimes(maxRetries + 1); // Initial + retries
     });
 
+    it('should retry at correct time intervals (1min, 2min, 4min)', async () => {
+      jest.useFakeTimers();
+      
+      const networkError = new Error('Network error');
+      let callCount = 0;
+      
+      // Mock fetch to fail 3 times then succeed, and track call times with fake Date.now()
+      const mockFetch = jest.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount <= 3) {
+          return Promise.reject(networkError);
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ testFlag: true }]),
+        });
+      });
+
+      const clientConfigApiService = new ClientConfigApiService({
+        fetch: mockFetch,
+        retries: 3, // Allow 3 retries (4 total attempts)
+        maximumConsecutiveFailures: 10, // Prevent circuit breaker from interfering
+        config: {
+          client: ClientType.Extension,
+          distribution: DistributionType.Main,
+          environment: EnvironmentType.Production,
+        },
+      });
+
+      // Start the operation
+      const fetchPromise = clientConfigApiService.fetchRemoteFeatureFlags();
+      
+      // Initial call should happen immediately
+      await jest.advanceTimersByTimeAsync(0); // Process immediate promises
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // First retry should happen after 1 minute
+      await jest.advanceTimersByTimeAsync(60 * 1000);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      // Second retry should happen after 2 more minutes
+      await jest.advanceTimersByTimeAsync(2 * 60 * 1000);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+
+      // Third retry should happen after 4 more minutes
+      await jest.advanceTimersByTimeAsync(4 * 60 * 1000);
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+
+      // The final call should succeed
+      const result = await fetchPromise;
+      expect(result).toEqual({
+        remoteFeatureFlags: { testFlag: true },
+        cacheTimestamp: expect.any(Number),
+      });
+
+      jest.useRealTimers();
+    });
+
     it('should call the onBreak callback when the circuit opens', async () => {
       const onBreak = jest.fn();
       const mockFetch = createMockFetch({ error: networkError });

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
@@ -24,7 +24,8 @@ import type {
  * Each retry uses the corresponding interval from the array (in seconds).
  */
 class CustomIntervalBackoff implements IBackoffFactory<unknown> {
-  private intervals: number[];
+  private readonly intervals: number[];
+
   private currentIndex: number = 0;
 
   constructor(intervals: number[]) {
@@ -113,15 +114,15 @@ function createCustomBackoff(
  * This service is responsible for fetching feature flags from the ClientConfig API.
  */
 export class ClientConfigApiService implements AbstractClientConfigApiService {
-  #fetch: typeof fetch;
+  readonly #fetch: typeof fetch;
 
   readonly #policy: ServicePolicy;
 
-  #client: ClientType;
+  readonly #client: ClientType;
 
-  #distribution: DistributionType;
+  readonly #distribution: DistributionType;
 
-  #environment: EnvironmentType;
+  readonly #environment: EnvironmentType;
 
   /**
    * Constructs a new ClientConfigApiService object.
@@ -277,6 +278,7 @@ export class ClientConfigApiService implements AbstractClientConfigApiService {
   /**
    * Fetches feature flags from the API with specific client, distribution, and environment parameters.
    * Provides structured error handling, including fallback to cached data if available.
+   *
    * @returns An object of feature flags and their boolean values or a structured error object.
    */
   public async fetchRemoteFeatureFlags(): Promise<ServiceResponse> {
@@ -308,6 +310,7 @@ export class ClientConfigApiService implements AbstractClientConfigApiService {
 
   /**
    * Flattens an array of feature flag objects into a single feature flags object.
+   *
    * @param responseData - Array of objects containing feature flag key-value pairs
    * @returns A single object containing all feature flags merged together
    * @example

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
@@ -22,6 +22,8 @@ import type {
  * Custom backoff factory that implements exponential progression in minutes.
  * 1st retry: 1 minute, 2nd retry: 2 minutes, 3rd retry: 4 minutes, etc.
  * Uses Cockatiel's ExponentialBackoff with minute-based intervals.
+ * 
+ * @returns A Cockatiel ExponentialBackoff instance configured for minute-based intervals.
  */
 function createMinuteBasedExponentialBackoff() {
   return new ExponentialBackoff({

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
@@ -22,7 +22,7 @@ import type {
  * Custom backoff factory that implements exponential progression in minutes.
  * 1st retry: 1 minute, 2nd retry: 2 minutes, 3rd retry: 4 minutes, etc.
  * Uses Cockatiel's ExponentialBackoff with minute-based intervals.
- * 
+ *
  * @returns A Cockatiel ExponentialBackoff instance configured for minute-based intervals.
  */
 function createMinuteBasedExponentialBackoff() {

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -115,7 +115,7 @@ export class RemoteFeatureFlagController extends BaseController<
 
   #inProgressFlagUpdate?: Promise<ServiceResponse>;
 
-  #getMetaMetricsId: () => string;
+  readonly #getMetaMetricsId: () => string;
 
   /**
    * Constructs a new RemoteFeatureFlagController instance.
@@ -163,7 +163,6 @@ export class RemoteFeatureFlagController extends BaseController<
    * Checks if the cached feature flags are expired based on the fetch interval.
    *
    * @returns Whether the cache is expired (`true`) or still valid (`false`).
-   * @private
    */
   #isCacheExpired(): boolean {
     return Date.now() - this.state.cacheTimestamp > this.#fetchInterval;
@@ -203,7 +202,6 @@ export class RemoteFeatureFlagController extends BaseController<
    * Updates the controller's state with new feature flags and resets the cache timestamp.
    *
    * @param remoteFeatureFlags - The new feature flags to cache.
-   * @private
    */
   async #updateCache(remoteFeatureFlags: FeatureFlags) {
     const processedRemoteFeatureFlags =

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.ts
@@ -5,6 +5,7 @@ import type { FeatureFlagScopeValue } from '../remote-feature-flag-controller-ty
 
 /**
  * Converts a UUID string to a BigInt by removing dashes and converting to hexadecimal.
+ *
  * @param uuid - The UUID string to convert
  * @returns The UUID as a BigInt value
  */
@@ -22,6 +23,7 @@ const UUID_V4_VALUE_RANGE_BIGINT = MAX_UUID_V4_BIGINT - MIN_UUID_V4_BIGINT;
  * Generates a deterministic random number between 0 and 1 based on a metaMetricsId.
  * This is useful for A/B testing and feature flag rollouts where we want
  * consistent group assignment for the same user.
+ *
  * @param metaMetricsId - The unique identifier used to generate the deterministic random number. Must be either:
  * - A UUIDv4 string (e.g., '123e4567-e89b-12d3-a456-426614174000'
  * - A hex string with '0x' prefix (e.g., '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420')


### PR DESCRIPTION
## Explanation
This PR pushes for a retry to be called an exponential backoff by the minute. The remote feature flag controller will automatically:
Make an initial API request
If it fails, wait 1 minute and retry
If that fails, wait 2 minutes and retry
If that fails, wait 4 minutes and retry
After 3 failed retries (4 total attempts), the circuit breaker will prevent further attempts for a period.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [X] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional per-retry custom backoff intervals to `ClientConfigApiService` with validation and tests; defaults to exponential backoff when not provided.
> 
> - **ClientConfig API Service (`src/client-config-api-service/client-config-api-service.ts`)**
>   - Add optional `customBackoffInterval` (seconds) to constructor for precise per-retry delays.
>   - Implement `CustomIntervalBackoff` and integrate via `createServicePolicy({ backoff })`.
>   - Validate intervals (non-empty, positive numbers, length equals `retries`); throw descriptive errors.
>   - Default to `ExponentialBackoff` when no custom intervals are provided.
>   - Minor: make several private fields `readonly`; JSDoc improvements.
> - **Tests (`client-config-api-service.test.ts`)**
>   - Add coverage for custom intervals usage, validation errors, and fallback to exponential backoff.
>   - Utility `createMockFetch` defaults and behavior adjusted for tests.
> - **Controller (`src/remote-feature-flag-controller.ts`)**
>   - Minor: mark fields `readonly`; comment cleanups.
> - **Changelog**
>   - Document custom backoff interval support and defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d074edba60a59b82497a727c97375172d4e7dea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->