### PR TITLE
chore: Add `@metamask-previews/*` to NPM age gate exceptions

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -24,4 +24,5 @@ npmMinimalAgeGate: 4320 # 3 days (in minutes)
 # regardless of their publish age.
 npmPreapprovedPackages:
   - "@metamask/*"
+  - "@metamask-previews/*"
   - "@lavamoat/*"


### PR DESCRIPTION
## Explanation

We sometimes use `@metamask-previews/*` to use preview builds for testing certain features. These will usually not be 3 days old, so can't be installed without an exception.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows installing `@metamask-previews/*` packages by adding them to `npmPreapprovedPackages` in `.yarnrc.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adac3b24afd2b6e6ecb32600b31121540a718df8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->