### PR TITLE
fix: Fix mistake in `StatePropertyMetadataConstraint` type

### DIFF
--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- In experimental `next` export, fix the `StatePropertyMetadataConstraint` type ([#6942](https://github.com/MetaMask/core/pull/6942))
+  - It incorrectly used the old metadata property `anonymous` instead of `includeInDebugSnapshot`
+
 ## [8.4.2]
 
 ### Fixed

--- a/packages/base-controller/src/next/BaseController.ts
+++ b/packages/base-controller/src/next/BaseController.ts
@@ -112,7 +112,7 @@ export type StateDeriverConstraint = (value: never) => Json;
  * This type can be assigned to any `StatePropertyMetadata` type.
  */
 export type StatePropertyMetadataConstraint = {
-  anonymous: boolean | StateDeriverConstraint;
+  includeInDebugSnapshot: boolean | StateDeriverConstraint;
   includeInStateLogs?: boolean | StateDeriverConstraint;
   persist: boolean | StateDeriverConstraint;
   usedInUi?: boolean;


### PR DESCRIPTION
## Explanation

In the `next` export of `base-controller`, the type `StatePropertyMetadataConstraint` mistakenly referenced the old metadata property name `anonymous` rather than `includeInDebugSnapshot`. The type has been updated to use the correct name.

## References

Fixes a mistake introduced in #6593

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects `StatePropertyMetadataConstraint` in the experimental `next` export to use `includeInDebugSnapshot` instead of `anonymous`, and updates the changelog.
> 
> - **Type fix (experimental `next`)**
>   - Update `StatePropertyMetadataConstraint` in `packages/base-controller/src/next/BaseController.ts` to use `includeInDebugSnapshot` (replacing `anonymous`).
> - **Changelog**
>   - Add Unreleased entry documenting the fix in `packages/base-controller/CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31f5c116c5a11da4ea127d0b1accb3fa37b2e59b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->