### PR TITLE
ci: Temporarily disable `analyse-code` job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
     name: All jobs complete
     runs-on: ubuntu-latest
     needs:
-      - analyse-code
+      # - analyse-code
       - lint-build-test
     outputs:
       passed: ${{ steps.set-output.outputs.passed }}


### PR DESCRIPTION
## Explanation

This hopefully fixes some rate limit issues.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Comments out the `analyse-code` job and removes it from the `all-jobs-complete` dependencies in the main CI workflow.
> 
> - **CI Workflow (`.github/workflows/main.yml`)**:
>   - Comment out `analyse-code` (Code scanner) job.
>   - Remove `analyse-code` from `all-jobs-complete.needs` (left as commented reference).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f517d94a038f921a48100e1df15eaf47916e49e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->