### PR TITLE
chore: Update obsolete property name in error message

### DIFF
--- a/packages/composable-controller/src/ComposableController.ts
+++ b/packages/composable-controller/src/ComposableController.ts
@@ -12,7 +12,7 @@ import type { Messenger } from '@metamask/messenger';
 export const controllerName = 'ComposableController';
 
 export const INVALID_CONTROLLER_ERROR =
-  'Invalid controller: controller must have a `messagingSystem` and inherit from `BaseController`.';
+  'Invalid controller: controller must inherit from `BaseController`.';
 
 /**
  * The narrowest supertype for the composable controller state object.


### PR DESCRIPTION
## Explanation

The `INVALID_CONTROLLER_ERROR` error message incorrectly referenced the property name `messagingSystem`, which is no longer used in the next version of the `BaseController` class (which the `ComposableController` switched to in the PR #6710).

The error message was updated to no mention the messenger instance variable at all, since the check that triggered the error doesn't look for it anyway.

## References

Fixes minor error introduced by #6710

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `INVALID_CONTROLLER_ERROR` to remove obsolete `messagingSystem` reference, stating only that controllers must inherit from `BaseController`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05b6cb390808e22229be5c26a3605ba23a0a7def. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->