### PR TITLE
chore: Fix incorrect property name referenced in comment

### DIFF
--- a/packages/base-controller/src/next/BaseController.ts
+++ b/packages/base-controller/src/next/BaseController.ts
@@ -201,7 +201,7 @@ export class BaseController<
   /**
    * The controller messenger.
    *
-   * This is the same as the `messagingSystem` property, but has a type that only lets us use
+   * This is the same as the `messenger` property, but has a type that only lets us use
    * actions and events that are part of the `BaseController` class.
    */
   readonly #messenger: Messenger<


### PR DESCRIPTION
## Explanation

This comment has had this mistake since #6337

## References

Fixes mistake in comment introduced in #6337

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a comment in `BaseController.ts` to reference `messenger` instead of `messagingSystem`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca4c894f95339cc197dcba943df45b662f2139a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->