### PR TITLE
chore: Use consistent variable name for messenger

### DIFF
--- a/packages/bridge-status-controller/src/utils/gas.ts
+++ b/packages/bridge-status-controller/src/utils/gas.ts
@@ -62,7 +62,7 @@ export const getTxGasEstimates = ({
 
 export const calculateGasFees = async (
   disable7702: boolean,
-  messagingSystem: BridgeStatusControllerMessenger,
+  messenger: BridgeStatusControllerMessenger,
   estimateGasFeeFn: typeof TransactionController.prototype.estimateGasFee,
   { chainId: _, gasLimit, ...trade }: TxData,
   networkClientId: string,
@@ -82,7 +82,7 @@ export const calculateGasFees = async (
     to: trade.to as `0x${string}`,
     value: trade.value as `0x${string}`,
   };
-  const { gasFeeEstimates } = messagingSystem.call('GasFeeController:getState');
+  const { gasFeeEstimates } = messenger.call('GasFeeController:getState');
   const { estimates: txGasFeeEstimates } = await estimateGasFeeFn({
     transactionParams,
     chainId,

--- a/packages/bridge-status-controller/src/utils/transaction.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.ts
@@ -36,7 +36,7 @@ import type {
 export const generateActionId = () => (Date.now() + Math.random()).toString();
 
 export const getUSDTAllowanceResetTx = async (
-  messagingSystem: BridgeStatusControllerMessenger,
+  messenger: BridgeStatusControllerMessenger,
   quoteResponse: QuoteResponse & Partial<QuoteMetadata>,
 ) => {
   const hexChainId = formatChainIdToHex(quoteResponse.quote.srcChainId);
@@ -45,7 +45,7 @@ export const getUSDTAllowanceResetTx = async (
     isEthUsdt(hexChainId, quoteResponse.quote.srcAsset.address)
   ) {
     const allowance = new BigNumber(
-      await messagingSystem.call(
+      await messenger.call(
         'BridgeController:getBridgeERC20Allowance',
         quoteResponse.quote.srcAsset.address,
         hexChainId,

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -67,9 +67,9 @@ class FooController extends BaseController<
   FooControllerState,
   FooMessenger
 > {
-  constructor(messagingSystem: FooMessenger) {
+  constructor(messenger: FooMessenger) {
     super({
-      messenger: messagingSystem,
+      messenger,
       metadata: fooControllerStateMetadata,
       name: 'FooController',
       state: { foo: 'foo' },
@@ -116,9 +116,9 @@ class QuzController extends BaseController<
   QuzControllerState,
   QuzMessenger
 > {
-  constructor(messagingSystem: QuzMessenger) {
+  constructor(messenger: QuzMessenger) {
     super({
-      messenger: messagingSystem,
+      messenger,
       metadata: quzControllerStateMetadata,
       name: 'QuzController',
       state: { quz: 'quz' },


### PR DESCRIPTION
## Explanation

Various variables have been renamed from `messagingSystem` to `messenger` for consistency. These packages have all updated to the next version of the `BaseController`, which dropped the term `messagingSystem` in #6337.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames `messagingSystem` to `messenger` across controllers, utilities, and tests, updating all registrations, calls, and constructor params.
> 
> - **Controllers**:
>   - `packages/assets-controllers/src/AssetsContractController.ts`
>     - Rename protected field `messagingSystem` -> `messenger` and update all usages (`registerActionHandler`, `subscribe`, `call`).
>     - Adjust `methodsExcludedFromMessenger` to exclude `messenger`.
> - **Bridge Status Utils**:
>   - `packages/bridge-status-controller/src/utils/gas.ts`: Rename function param to `messenger` and update `GasFeeController:getState` call.
>   - `packages/bridge-status-controller/src/utils/transaction.ts`: Rename params to `messenger` and update `BridgeController:getBridgeERC20Allowance` and other controller calls.
> - **Tests**:
>   - `packages/composable-controller/src/ComposableController.test.ts`: Update test controllers’ constructors to accept `messenger` and pass through to `BaseController`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f56bc49691de9ba11317ce71818ad48b22880c71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->