### PR TITLE
chore: Migrate test fixture to messenger

### DIFF
--- a/packages/profile-sync-controller/src/controllers/user-storage/contact-syncing/__fixtures__/test-utils.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/contact-syncing/__fixtures__/test-utils.ts
@@ -5,8 +5,12 @@ import type {
 import type {
   ActionConstraint,
   EventConstraint,
-} from '@metamask/base-controller';
-import { Messenger as MessengerImpl } from '@metamask/base-controller';
+  MockAnyNamespace,
+} from '@metamask/messenger';
+import {
+  MOCK_ANY_NAMESPACE,
+  Messenger as MessengerImpl,
+} from '@metamask/messenger';
 
 import { MOCK_LOCAL_CONTACTS } from './mockContacts';
 
@@ -32,14 +36,18 @@ export function mockUserStorageMessengerForContactSyncing(options?: {
     clearEventSubscriptions: unknown;
     registerInitialEventPayload: jest.Mock;
   };
-  baseMessenger: MessengerImpl<ActionConstraint, EventConstraint>;
+  baseMessenger: MessengerImpl<
+    MockAnyNamespace,
+    ActionConstraint,
+    EventConstraint
+  >;
   mockAddressBookList: jest.Mock;
   mockAddressBookSet: jest.Mock;
   mockAddressBookDelete: jest.Mock;
   contactsUpdatedFromSync: AddressBookEntry[]; // Track contacts that were updated via sync
 } {
   // Start with a fresh messenger mock
-  const baseMessenger = new MessengerImpl();
+  const baseMessenger = new MessengerImpl({ namespace: MOCK_ANY_NAMESPACE });
 
   // Contacts that are synced/updated will be stored here for test inspection
   const contactsUpdatedFromSync: AddressBookEntry[] = [];


### PR DESCRIPTION
## Explanation

A test fixture used by the package `@metamask/profile-sync-controller` has been migrated to use the new `@metamask/messenger` package, in praration for the `Messenger` being removed from `@metamask/base-controller`.

## References

Relates to #5626

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the contact-syncing test fixture to use @metamask/messenger with namespaced Messenger and updated types.
> 
> - **Tests (contact syncing)**:
>   - Replace `@metamask/base-controller` `Messenger` with `@metamask/messenger` `Messenger` in `__fixtures__/test-utils.ts`.
>   - Add `MockAnyNamespace` typing and initialize `Messenger` with `MOCK_ANY_NAMESPACE`.
>   - Update generic types (`ActionConstraint`, `EventConstraint`) and imports to align with `@metamask/messenger` API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caf2a4700e002f2aeb259e8dc8e5c7dab238d87c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->