### PR TITLE
chore: update stablecoins LD config format

### DIFF
--- a/packages/bridge-controller/src/constants/bridge.ts
+++ b/packages/bridge-controller/src/constants/bridge.ts
@@ -53,6 +53,7 @@ export const DEFAULT_FEATURE_FLAG_CONFIG: FeatureFlagsPlatformConfig = {
   maxRefreshCount: DEFAULT_MAX_REFRESH_COUNT,
   support: false,
   chains: {},
+  stablecoins: [],
 };
 
 export const DEFAULT_BRIDGE_CONTROLLER_STATE: BridgeControllerState = {

--- a/packages/bridge-controller/src/index.ts
+++ b/packages/bridge-controller/src/index.ts
@@ -132,7 +132,6 @@ export {
 
 export {
   selectBridgeQuotes,
-  selectDefaultSlippagePercentage,
   type BridgeAppState,
   selectExchangeRateByChainIdAndAddress,
   selectIsQuoteExpired,
@@ -144,4 +143,7 @@ export { DEFAULT_FEATURE_FLAG_CONFIG } from './constants/bridge';
 
 export { getBridgeFeatureFlags } from './utils/feature-flags';
 
-export { BRIDGE_DEFAULT_SLIPPAGE } from './utils/slippage';
+export {
+  BRIDGE_DEFAULT_SLIPPAGE,
+  getDefaultSlippagePercentage,
+} from './utils/slippage';

--- a/packages/bridge-controller/src/selectors.ts
+++ b/packages/bridge-controller/src/selectors.ts
@@ -48,7 +48,6 @@ import {
   calcTotalEstimatedNetworkFee,
   calcTotalMaxNetworkFee,
 } from './utils/quote';
-import { getDefaultSlippagePercentage } from './utils/slippage';
 
 /**
  * The controller states that provide exchange rates
@@ -451,39 +450,3 @@ export const selectMinimumBalanceForRentExemptionInSOL = (
   new BigNumber(state.minimumBalanceForRentExemptionInLamports ?? 0)
     .div(10 ** 9)
     .toString();
-
-export const selectDefaultSlippagePercentage = createBridgeSelector(
-  [
-    (state) => selectBridgeFeatureFlags(state).chains,
-    (_, slippageParams: Parameters<typeof getDefaultSlippagePercentage>[0]) =>
-      slippageParams.srcTokenAddress,
-    (_, slippageParams: Parameters<typeof getDefaultSlippagePercentage>[0]) =>
-      slippageParams.destTokenAddress,
-    (_, slippageParams: Parameters<typeof getDefaultSlippagePercentage>[0]) =>
-      slippageParams.srcChainId
-        ? formatChainIdToCaip(slippageParams.srcChainId)
-        : undefined,
-    (_, slippageParams: Parameters<typeof getDefaultSlippagePercentage>[0]) =>
-      slippageParams.destChainId
-        ? formatChainIdToCaip(slippageParams.destChainId)
-        : undefined,
-  ],
-  (
-    featureFlagsByChain,
-    srcTokenAddress,
-    destTokenAddress,
-    srcChainId,
-    destChainId,
-  ) => {
-    return getDefaultSlippagePercentage(
-      {
-        srcTokenAddress,
-        destTokenAddress,
-        srcChainId,
-        destChainId,
-      },
-      srcChainId ? featureFlagsByChain[srcChainId]?.stablecoins : undefined,
-      destChainId ? featureFlagsByChain[destChainId]?.stablecoins : undefined,
-    );
-  },
-);

--- a/packages/bridge-controller/src/utils/validators.ts
+++ b/packages/bridge-controller/src/utils/validators.ts
@@ -106,7 +106,6 @@ export const ChainConfigurationSchema = type({
   isActiveDest: boolean(),
   refreshRate: optional(number()),
   topAssets: optional(array(string())),
-  stablecoins: optional(array(string())),
   isUnifiedUIEnabled: optional(boolean()),
   isSingleSwapBridgeButtonEnabled: optional(boolean()),
   isGaslessSwapEnabled: optional(boolean()),
@@ -154,6 +153,10 @@ export const PlatformConfigSchema = type({
       minimumVersion: VersionStringSchema,
     }),
   ),
+  /**
+   * The list of stablecoin assetIds in CAIP format. EVM assetIds are lowercased. Non-EVM assetIds are not lowercased.
+   */
+  stablecoins: array(CaipAssetTypeStruct),
 });
 
 export const validateFeatureFlagsResponse = (

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Use new `Messenger` from `@metamask/messenger` ([#6444](https://github.com/MetaMask/core/pull/6444))
   - Previously, `BridgeStatusController` accepted a `RestrictedMessenger` instance from `@metamask/base-controller`.
 - Bump `@metamask/polling-controller` from `^14.0.1` to `^14.0.2` ([#6940](https://github.com/MetaMask/core/pull/6940))
+- Use lowercased token addresses when publishing metrics ([#6966](https://github.com/MetaMask/core/pull/6966))
 
 ## [55.0.0]
 

--- a/packages/bridge-status-controller/src/utils/metrics.test.ts
+++ b/packages/bridge-status-controller/src/utils/metrics.test.ts
@@ -996,7 +996,7 @@ describe('metrics utils', () => {
         stx_enabled: false,
         token_address_source: 'eip155:1/slip44:60',
         token_address_destination:
-          'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'.toLowerCase(),
         custom_slippage: false,
         is_hardware_wallet: false,
         swap_type: MetricsSwapType.SINGLE,
@@ -1068,8 +1068,8 @@ describe('metrics utils', () => {
       const result = getEVMTxPropertiesFromTransactionMeta(
         noAddressesTransactionMeta,
       );
-      expect(result.token_address_source).toBe('');
-      expect(result.token_address_destination).toBe('');
+      expect(result.token_address_source).toBe('eip155:1/token:fsdxfs');
+      expect(result.token_address_destination).toBe('eip155:1/token:fsdxfs');
     });
 
     it('should handle crosschain swap type', () => {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References
Fixes https://github.com/MetaMask/core/pull/6616
<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves stablecoin config to a top-level CAIP asset list and updates slippage, selectors, validators, and CAIP formatting accordingly.
> 
> - **Feature flags/config**:
>   - Add `stablecoins: CaipAssetType[]` to platform config and default config; remove chain-level `stablecoins`.
>   - Update `PlatformConfigSchema` to validate top-level CAIP stablecoins list.
> - **Slippage**:
>   - Refactor `getDefaultSlippagePercentage` to take `srcAssetId`, `destAssetId`, and global `stablecoins` (CAIP); adjust logic for cross-chain, Solana, and EVM stablecoin pairs.
>   - Export `getDefaultSlippagePercentage` and `BRIDGE_DEFAULT_SLIPPAGE` from index.
> - **Selectors/exports**:
>   - Remove `selectDefaultSlippagePercentage` selector and its exports/usages.
> - **CAIP formatters**:
>   - `formatAddressToAssetId` now always returns a CAIP asset ID; lowercases EVM addresses and uses `erc20:` vs non‑EVM `token:`.
>   - Improve error messages and deprecate `formatAddressToCaipReference` in JSDoc; add explicit throws docs.
> - **Tests**:
>   - Update slippage tests to use CAIP asset IDs and new `getDefaultSlippagePercentage` API.
>   - Adjust expectations per updated schemas and utilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80f273579c7ac8352526af1a3232ae579dbbc076. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->