### PR TITLE
Revert "ci: Temporarily disable `analyse-code` job (#6953)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,17 +24,17 @@ jobs:
         run: ${{ steps.download-actionlint.outputs.executable }} -color
         shell: bash
 
-  # analyse-code:
-  #  name: Code scanner
-  #  needs: check-workflows
-  #  uses: ./.github/workflows/security-code-scanner.yml
-  #  permissions:
-  #    actions: read
-  #    contents: read
-  #    security-events: write
-  #  secrets:
-  #    SECURITY_SCAN_METRICS_TOKEN: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
-  #    APPSEC_BOT_SLACK_WEBHOOK: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
+  analyse-code:
+    name: Code scanner
+    needs: check-workflows
+    uses: ./.github/workflows/security-code-scanner.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    secrets:
+      SECURITY_SCAN_METRICS_TOKEN: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
+      APPSEC_BOT_SLACK_WEBHOOK: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
 
   lint-build-test:
     name: Lint, build, and test
@@ -77,7 +77,7 @@ jobs:
     name: All jobs complete
     runs-on: ubuntu-latest
     needs:
-      # - analyse-code
+      - analyse-code
       - lint-build-test
     outputs:
       passed: ${{ steps.set-output.outputs.passed }}


### PR DESCRIPTION
## Explanation

This reverts commit b8a3c587beea3b9f3515cda290fef4949961baa8. This commit was only meant to be temporary, as a workaround to rate limits during a period where we were merging a lot of PRs in quick succession. We've finished that now.

## References

Reverts #6953

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables the `analyse-code` security scan and makes it a required dependency for the completion gate in the main workflow.
> 
> - **CI/CD (GitHub Actions)**:
>   - Re-enable `analyse-code` job in `/.github/workflows/main.yml`, invoking `./.github/workflows/security-code-scanner.yml` with required permissions and secrets.
>   - Update `all-jobs-complete` to depend on `analyse-code` (alongside `lint-build-test`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f09f40a55e79b2c3b563523c778115cc0cf44e95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->