### PR TITLE
feat: introduce operator fee for OP stack networks

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Calculate operator fee for OP stack networks and include it in `layer1GasFee` ([#6979](https://github.com/MetaMask/core/pull/6979))
+
 ## [61.1.0]
 
 ### Added

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
@@ -2,13 +2,18 @@ import type { TypedTransaction } from '@ethereumjs/tx';
 import { TransactionFactory } from '@ethereumjs/tx';
 import { Contract } from '@ethersproject/contracts';
 import type { Provider } from '@metamask/network-controller';
-import type { Hex } from '@metamask/utils';
+import { add0x, type Hex } from '@metamask/utils';
+import BN from 'bn.js';
 
 import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
 import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
-import type { Layer1GasFeeFlowRequest, TransactionMeta } from '../types';
-import { TransactionStatus } from '../types';
+import {
+  type Layer1GasFeeFlowRequest,
+  type TransactionMeta,
+  TransactionStatus,
+} from '../types';
+import { bnFromHex, padHexToEvenLength } from '../utils/utils';
 
 jest.mock('@ethersproject/contracts', () => ({
   Contract: jest.fn(),
@@ -36,7 +41,8 @@ const TRANSACTION_META_MOCK: TransactionMeta = {
 
 const SERIALIZED_TRANSACTION_MOCK = '0x1234';
 const ORACLE_ADDRESS_MOCK = '0x5678' as Hex;
-const LAYER_1_FEE_MOCK = '0x9ABCD';
+const LAYER_1_FEE_MOCK = '0x09abcd';
+const OPERATOR_FEE_MOCK = '0x5';
 const DEFAULT_GAS_PRICE_ORACLE_ADDRESS =
   '0x420000000000000000000000000000000000000F';
 
@@ -98,9 +104,9 @@ class DefaultOracleLayer1GasFeeFlow extends OracleLayer1GasFeeFlow {
 
 describe('OracleLayer1GasFeeFlow', () => {
   const contractMock = jest.mocked(Contract);
-  const contractGetL1FeeMock: jest.MockedFn<
-    () => Promise<{ toHexString: () => string }>
-  > = jest.fn();
+  const contractGetL1FeeMock: jest.MockedFn<() => Promise<BN>> = jest.fn();
+  const contractGetOperatorFeeMock: jest.MockedFn<() => Promise<BN>> =
+    jest.fn();
 
   let request: Layer1GasFeeFlowRequest;
 
@@ -112,13 +118,14 @@ describe('OracleLayer1GasFeeFlow', () => {
 
     contractMock.mockClear();
     contractGetL1FeeMock.mockClear();
+    contractGetOperatorFeeMock.mockClear();
 
-    contractGetL1FeeMock.mockResolvedValue({
-      toHexString: () => LAYER_1_FEE_MOCK,
-    });
+    contractGetL1FeeMock.mockResolvedValue(bnFromHex(LAYER_1_FEE_MOCK));
+    contractGetOperatorFeeMock.mockResolvedValue(new BN(0));
 
     contractMock.mockReturnValue({
       getL1Fee: contractGetL1FeeMock,
+      getOperatorFee: contractGetOperatorFeeMock,
     } as unknown as Contract);
   });
 
@@ -156,6 +163,7 @@ describe('OracleLayer1GasFeeFlow', () => {
       expect(contractGetL1FeeMock).toHaveBeenCalledWith(
         serializedTransactionMock,
       );
+      expect(contractGetOperatorFeeMock).not.toHaveBeenCalled();
     });
 
     it('signs transaction with dummy key if supported by flow', async () => {
@@ -180,6 +188,7 @@ describe('OracleLayer1GasFeeFlow', () => {
       });
 
       expect(typedTransactionMock.sign).toHaveBeenCalledTimes(1);
+      expect(contractGetOperatorFeeMock).not.toHaveBeenCalled();
     });
 
     describe('throws', () => {
@@ -227,6 +236,80 @@ describe('OracleLayer1GasFeeFlow', () => {
       const [oracleAddress] = contractMock.mock.calls[0];
       expect(oracleAddress).toBe(DEFAULT_GAS_PRICE_ORACLE_ADDRESS);
       expect(typedTransactionMock.sign).not.toHaveBeenCalled();
+    });
+
+    it('adds operator fee when gas used is available', async () => {
+      const gasUsed = '0x5208';
+      request = {
+        ...request,
+        transactionMeta: {
+          ...request.transactionMeta,
+          gasUsed,
+        },
+      };
+
+      contractGetOperatorFeeMock.mockResolvedValueOnce(
+        bnFromHex(OPERATOR_FEE_MOCK),
+      );
+
+      const flow = new MockOracleLayer1GasFeeFlow(false);
+      const response = await flow.getLayer1Fee(request);
+
+      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(contractGetOperatorFeeMock).toHaveBeenCalledWith(gasUsed);
+      expect(response).toStrictEqual({
+        layer1Fee: add0x(
+          padHexToEvenLength(
+            bnFromHex(LAYER_1_FEE_MOCK)
+              .add(bnFromHex(OPERATOR_FEE_MOCK))
+              .toString(16),
+          ),
+        ) as Hex,
+      });
+    });
+
+    it('defaults operator fee to zero when call fails', async () => {
+      const gasUsed = '0x1';
+      request = {
+        ...request,
+        transactionMeta: {
+          ...request.transactionMeta,
+          gasUsed,
+        },
+      };
+
+      contractGetOperatorFeeMock.mockRejectedValueOnce(new Error('revert'));
+
+      const flow = new MockOracleLayer1GasFeeFlow(false);
+      const response = await flow.getLayer1Fee(request);
+
+      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(response).toStrictEqual({
+        layer1Fee: LAYER_1_FEE_MOCK,
+      });
+    });
+
+    it('defaults operator fee to zero when call returns undefined', async () => {
+      const gasUsed = '0x2';
+      request = {
+        ...request,
+        transactionMeta: {
+          ...request.transactionMeta,
+          gasUsed,
+        },
+      };
+
+      contractGetOperatorFeeMock.mockResolvedValueOnce(
+        undefined as unknown as BN,
+      );
+
+      const flow = new MockOracleLayer1GasFeeFlow(false);
+      const response = await flow.getLayer1Fee(request);
+
+      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(response).toStrictEqual({
+        layer1Fee: LAYER_1_FEE_MOCK,
+      });
     });
   });
 });

--- a/packages/transaction-controller/src/utils/utils.test.ts
+++ b/packages/transaction-controller/src/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { BN } from 'bn.js';
+import BN from 'bn.js';
 
 import * as util from './utils';
 import type {
@@ -272,6 +272,87 @@ describe('utils', () => {
 
     it('supports negative new value', () => {
       expect(util.getPercentageChange(new BN(2), new BN(-1))).toBe(150);
+    });
+  });
+
+  describe('bnFromHex', () => {
+    it('parses hex with 0x prefix', () => {
+      const result = util.bnFromHex('0x1a');
+      expect(result.eq(new BN(26))).toBe(true);
+    });
+
+    it('parses hex without prefix', () => {
+      const result = util.bnFromHex('1a');
+      expect(result.eq(new BN(26))).toBe(true);
+    });
+
+    it('parses uppercase 0X prefix', () => {
+      const result = util.bnFromHex('0XFF');
+      expect(result.eq(new BN(255))).toBe(true);
+    });
+
+    it('returns zero for empty data with 0x', () => {
+      const result = util.bnFromHex('0x');
+      expect(result.isZero()).toBe(true);
+    });
+
+    it('returns zero for empty string', () => {
+      const result = util.bnFromHex('');
+      expect(result.isZero()).toBe(true);
+    });
+
+    it('throws for invalid hex', () => {
+      expect(() => util.bnFromHex('0xzz')).toThrow(Error);
+    });
+  });
+
+  describe('toBN', () => {
+    it('returns the same BN instance', () => {
+      const input = new BN(123);
+      const result = util.toBN(input);
+      expect(result).toBe(input);
+    });
+
+    it('converts ethers-like BigNumber with toHexString', () => {
+      const bigNumberLike = { toHexString: () => '0x2a' };
+      const result = util.toBN(bigNumberLike);
+      expect(result.eq(new BN(42))).toBe(true);
+    });
+
+    it('converts object with _hex property', () => {
+      const hexLike = { _hex: '0x2a' };
+      const result = util.toBN(hexLike);
+      expect(result.eq(new BN(42))).toBe(true);
+    });
+
+    it('converts hex string values', () => {
+      expect(util.toBN('0x10').eq(new BN(16))).toBe(true);
+      expect(util.toBN('10').eq(new BN(16))).toBe(true);
+    });
+
+    it('converts bigint values', () => {
+      const result = util.toBN(123n);
+      expect(result.eq(new BN(123))).toBe(true);
+    });
+
+    it('converts number values', () => {
+      const result = util.toBN(456);
+      expect(result.eq(new BN(456))).toBe(true);
+    });
+
+    it('throws for unsupported types', () => {
+      expect(() => util.toBN(true as unknown)).toThrow(
+        'Unexpected value returned from oracle contract',
+      );
+      expect(() => util.toBN(null as unknown)).toThrow(
+        'Unexpected value returned from oracle contract',
+      );
+      expect(() => util.toBN(undefined as unknown)).toThrow(
+        'Unexpected value returned from oracle contract',
+      );
+      expect(() => util.toBN({} as unknown)).toThrow(
+        'Unexpected value returned from oracle contract',
+      );
     });
   });
 });


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds OP Stack operator fee to `layer1GasFee` by querying the oracle (`getOperatorFee`) and summing with `getL1Fee`, plus BN utilities and tests.
> 
> - **Layer 1 Gas Fee (oracle flow)**:
>   - Sum oracle `getL1Fee` with operator fee from `getOperatorFee(gasUsed)`; default operator fee to zero on failure/undefined; output normalized hex via `add0x` + `padHexToEvenLength`.
>   - Refactor to BN-based math and value coercion via new `toBN`; extract `#getGasPriceOracleContract`; keep default OP Stack oracle address and optional signing.
>   - Extend ABI with `getOperatorFee`.
> - **Utils**:
>   - Add `bnFromHex` and `toBN` helpers for parsing/converting to `BN`.
> - **Tests**:
>   - Update `OracleLayer1GasFeeFlow.test.ts` to mock BN returns and cover operator fee present/failure/undefined paths.
>   - Add tests for `bnFromHex` and `toBN`.
> - **Docs**:
>   - Update `CHANGELOG.md` to note inclusion of operator fee in `layer1GasFee`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e8d30444178eb9d4c2ae45dce84fef425b58c26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->