### PR TITLE
fix: update team-accounts label to team-accounts-framework in teams.json

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -1,6 +1,6 @@
 {
   "metamask/accounts-controller": "team-accounts-framework",
-  "metamask/multichain-transactions-controller": "team-accounts-framework,team-confirmations",
+  "metamask/multichain-transactions-controller": "team-confirmations",
   "metamask/multichain-account-service": "team-accounts-framework",
   "metamask/account-tree-controller": "team-accounts-framework",
   "metamask/profile-sync-controller": "team-accounts-framework",


### PR DESCRIPTION
## Explanation

[This bot](https://github.com/MetaMask/metamask-mobile/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22team-accounts%22%20author%3Aapp%2Fmetamask-patroll) seems to be re creating the team-accounts label which is a deprecated label. The new ownership should be under `team-accounts-framework`. 

I also removed the accounts team as owners of the `metamask/multichain-transactions-controller` in favour of `team-confirmations` based on [this slack thread](https://consensys.slack.com/archives/C080KDTTF6Y/p1755629594831599).

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reassigns package team labels in teams.json, moving accounts-related packages to team-accounts-framework and adjusting confirmations/network mappings.
> 
> - **Ownership mappings (`teams.json`)**:
>   - Move accounts-related packages from `team-accounts` to `team-accounts-framework`:
>     - `metamask/accounts-controller`, `metamask/multichain-account-service`, `metamask/account-tree-controller`, `metamask/profile-sync-controller`.
>   - Reassign `metamask/multichain-transactions-controller` to `team-confirmations`.
>   - Update multi-team entries:
>     - `metamask/keyring-controller`: `team-accounts-framework,team-core-platform` (was `team-accounts,team-core-platform`).
>     - `metamask/multichain-network-controller`: `team-core-platform,team-accounts-framework,team-assets` (replaces `team-accounts` with `team-accounts-framework`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52a4817c33933c7268e2f1c282a140aed00a01af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->