### PR TITLE
chore(dependabot): Include GitHub Actions in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
@@ -10,3 +10,14 @@ updates:
     allow:
       - dependency-name: '@metamask/*'
     versioning-strategy: 'increase'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '06:00'
+    allow:
+      - dependency-name: 'MetaMask/*'
+      - dependency-name: 'actions/*'
+    target-branch: 'main'
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Explanation

This adds `actions/*` and `MetaMask/*` to the Dependabot config, ensuring we keep these actions up to date as well. I've limited it to these two, since we do use some other actions which are usually pinned to a specific hash, and require explicit approval to be used first.

## References

https://github.com/MetaMask/metamask-module-template/pull/274

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Dependabot config for GitHub Actions with daily 06:00 runs on main, allowing MetaMask/* and actions/*, and capping open PRs at 10.
> 
> - **Dependabot configuration**:
>   - **GitHub Actions updates**: Add `package-ecosystem: github-actions` with daily schedule at `06:00`, targeting `main`.
>     - Allow only `MetaMask/*` and `actions/*`.
>     - Set `open-pull-requests-limit` to `10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92188fd7f171601b4dbb12bb39c400bcc85012d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->