### PR TITLE
Release 656.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "655.0.0",
+  "version": "656.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2]
+
 ### Fixed
 
 - Prevent infinite loading after quotes are refreshed ([#7020](https://github.com/MetaMask/core/pull/7020))
@@ -34,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#6820](https://github.com/MetaMask/core/pull/6820))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@2.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@2.0.2...HEAD
+[2.0.2]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@2.0.1...@metamask/transaction-pay-controller@2.0.2
 [2.0.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@2.0.0...@metamask/transaction-pay-controller@2.0.1
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@1.0.0...@metamask/transaction-pay-controller@2.0.0
 [1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/transaction-pay-controller@1.0.0

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-pay-controller",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Manages alternate payment strategies to provide required funds for transactions in MetaMask",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
Patch release of `@metamask/transaction-pay-controller`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps monorepo to 656.0.0 and publishes @metamask/transaction-pay-controller 2.0.2 with a fix preventing infinite loading after quote refresh.
> 
> - **Release**
>   - Bump root `package.json` to `656.0.0`.
> - **@metamask/transaction-pay-controller**
>   - Version bump: `2.0.1` → `2.0.2` in `packages/transaction-pay-controller/package.json`.
>   - Changelog: add `2.0.2` entry noting fix to prevent infinite loading after quote refresh; update comparison links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0205e4591d92af8101f13dccbbe624c2362aaba7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->