### PR TITLE
chore(dev-deps): Bump `@ts-bridge/cli` from `^0.6.1` to `^0.6.4`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -26,3 +26,4 @@ npmPreapprovedPackages:
   - "@metamask/*"
   - "@metamask-previews/*"
   - "@lavamoat/*"
+  - "@ts-bridge/*"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@metamask/eth-json-rpc-provider": "^5.0.1",
     "@metamask/json-rpc-engine": "^10.1.1",
     "@metamask/utils": "^11.8.1",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.4",
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.191",
     "@types/node": "^16.18.54",

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -57,7 +57,7 @@
     "@metamask/accounts-controller": "^34.0.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-controller": "^24.0.0",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.4",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/delegation-controller/package.json
+++ b/packages/delegation-controller/package.json
@@ -55,7 +55,7 @@
     "@metamask/accounts-controller": "^34.0.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-controller": "^24.0.0",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.4",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/gator-permissions-controller/package.json
+++ b/packages/gator-permissions-controller/package.json
@@ -61,7 +61,7 @@
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/snaps-controllers": "^14.0.1",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.4",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/shield-controller/package.json
+++ b/packages/shield-controller/package.json
@@ -60,7 +60,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/signature-controller": "^35.0.0",
     "@metamask/transaction-controller": "^61.1.0",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.4",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -80,7 +80,7 @@
     "@metamask/gas-fee-controller": "^25.0.0",
     "@metamask/network-controller": "^25.0.0",
     "@metamask/remote-feature-flag-controller": "^2.0.0",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.4",
     "@types/bn.js": "^5.1.5",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.18.54",

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -69,7 +69,7 @@
     "@metamask/network-controller": "^25.0.0",
     "@metamask/remote-feature-flag-controller": "^2.0.0",
     "@metamask/transaction-controller": "^61.1.0",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.4",
     "@types/jest": "^27.4.1",
     "deepmerge": "^4.2.2",
     "jest": "^27.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3143,7 +3143,7 @@ __metadata:
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/profile-sync-controller": "npm:^26.0.0"
     "@metamask/utils": "npm:^11.8.1"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"
     jest: "npm:^27.5.1"
@@ -3177,7 +3177,7 @@ __metadata:
     "@metamask/eth-json-rpc-provider": "npm:^5.0.1"
     "@metamask/json-rpc-engine": "npm:^10.1.1"
     "@metamask/utils": "npm:^11.8.1"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^27.4.1"
     "@types/lodash": "npm:^4.14.191"
     "@types/node": "npm:^16.18.54"
@@ -3254,7 +3254,7 @@ __metadata:
     "@metamask/keyring-controller": "npm:^24.0.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/utils": "npm:^11.8.1"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"
     jest: "npm:^27.5.1"
@@ -3877,7 +3877,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:^9.0.0"
     "@metamask/snaps-utils": "npm:^11.0.0"
     "@metamask/utils": "npm:^11.8.1"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^27.4.1"
     deepmerge: "npm:^4.2.2"
     jest: "npm:^27.5.1"
@@ -4842,7 +4842,7 @@ __metadata:
     "@metamask/signature-controller": "npm:^35.0.0"
     "@metamask/transaction-controller": "npm:^61.1.0"
     "@metamask/utils": "npm:^11.8.1"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^27.4.1"
     cockatiel: "npm:^3.1.2"
     deepmerge: "npm:^4.2.2"
@@ -5128,7 +5128,7 @@ __metadata:
     "@metamask/remote-feature-flag-controller": "npm:^2.0.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/utils": "npm:^11.8.1"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.4"
     "@types/bn.js": "npm:^5.1.5"
     "@types/jest": "npm:^27.4.1"
     "@types/node": "npm:^16.18.54"
@@ -5177,7 +5177,7 @@ __metadata:
     "@metamask/remote-feature-flag-controller": "npm:^2.0.0"
     "@metamask/transaction-controller": "npm:^61.1.0"
     "@metamask/utils": "npm:^11.8.1"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^27.4.1"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
@@ -5896,9 +5896,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ts-bridge/cli@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "@ts-bridge/cli@npm:0.6.1"
+"@ts-bridge/cli@npm:^0.6.4":
+  version: 0.6.4
+  resolution: "@ts-bridge/cli@npm:0.6.4"
   dependencies:
     "@ts-bridge/resolver": "npm:^0.2.0"
     chalk: "npm:^5.3.0"
@@ -5909,7 +5909,7 @@ __metadata:
   bin:
     ts-bridge: ./dist/index.js
     tsbridge: ./dist/index.js
-  checksum: 10/1cbb8fbfc7f58b804553ab9bc06b689b409d4cdd0f1e960a0ea87971ec7885b5ee2a86cb192d955c7d3611afcadb960e7dfee66aeca60f798a70e7f97aa969c3
+  checksum: 10/257ee0cacec71c1b3cc018825088e06b4bd554ba5fe95bdb98c4c82edd6cd4bcff1054d351e6c7cdfdd3bd2145a055b5d14fa453a6ece761645e42b48b88e9a0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

This bumps `@ts-bridge/cli` from `^0.6.1` to `^0.6.4`. The main changes are:

- Better error messaging when building a package without dependencies being built.
- Better internal error handling around export detection.
- Small fixes for edge cases when using type imports and exports.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `@ts-bridge/cli` from `^0.6.1` to `^0.6.4` across the repo and adds `@ts-bridge/*` to Yarn’s preapproved packages list.
> 
> - **Tooling/Dev Dependencies**:
>   - Upgrade `@ts-bridge/cli` to `^0.6.4` in root `package.json` and multiple packages (`packages/*/package.json`).
>   - Update `yarn.lock` entries for `@ts-bridge/cli`.
> - **Yarn Config**:
>   - Add `@ts-bridge/*` to `npmPreapprovedPackages` in `.yarnrc.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aef8d02edec6e365f064ca1cd0fed53e4854018f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->