### PR TITLE
ci: update github-tools changelog-check workflow to c0ec1c3

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   check_changelog:
-    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
+    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@c0ec1c3ac914eed3db9e840a1e363e9099e81b95
     with:
-      action-sha: fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
+      action-sha: c0ec1c3ac914eed3db9e840a1e363e9099e81b95
       base-branch: ${{ github.event.pull_request.base.ref }}
       head-ref: ${{ github.head_ref }}
       labels: ${{ toJSON(github.event.pull_request.labels) }}


### PR DESCRIPTION
## Explanation

Updates the `github-tools` changelog-check workflow to fix detection of `devDependencies`-only changes in `package.json`.

### What's Fixed

The previous version failed to properly detect when `package.json` changes were only in `devDependencies` because the git diff logic required both the start and end of the `devDependencies` section to be visible. With limited diff context (`-U20`), the closing brace was often not included in the diff output.

The new version increases git diff context from `-U20` to `-U9999` to ensure section headers are always visible, allowing proper detection of devDependencies-only changes.

### Changes

- Updated `MetaMask/github-tools/.github/workflows/changelog-check.yml` from `fc6fe1a` to `c0ec1c3` ([PR containing the fix](https://github.com/MetaMask/github-tools/pull/101)￼)

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the changelog-check GitHub Actions workflow to use MetaMask/github-tools commit c0ec1c3.
> 
> - **CI**:
>   - Update `changelog-check` reusable workflow reference and `action-sha` to `c0ec1c3` in `.github/workflows/changelog-check.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44a036eeef3451baa6d61f6218ec4de7d0457e0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->