### PR TITLE
Revert "ci: update github-tools changelog-check workflow to c0ec1c3"

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   check_changelog:
-    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@c0ec1c3ac914eed3db9e840a1e363e9099e81b95
+    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
     with:
-      action-sha: c0ec1c3ac914eed3db9e840a1e363e9099e81b95
+      action-sha: fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
       base-branch: ${{ github.event.pull_request.base.ref }}
       head-ref: ${{ github.head_ref }}
       labels: ${{ toJSON(github.event.pull_request.labels) }}


### PR DESCRIPTION
Reverts MetaMask/core#7063

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps the changelog-check reusable workflow and action-sha in `.github/workflows/changelog-check.yml` to commit `fc6fe1a3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c2a8cfea9a8f2a8e3b6a1280fc14f0890e0d673. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->