### PR TITLE
Revert "ci: update github-tools changelog-check workflow to bfb5e6f"

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   check_changelog:
-    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@bfb5e6fb233edeedd5ee9ed3f15ff7fa9171337f
+    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
     with:
-      action-sha: bfb5e6fb233edeedd5ee9ed3f15ff7fa9171337f
+      action-sha: fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
       base-branch: ${{ github.event.pull_request.base.ref }}
       head-ref: ${{ github.head_ref }}
       labels: ${{ toJSON(github.event.pull_request.labels) }}


### PR DESCRIPTION
Reverts MetaMask/core#7076

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `.github/workflows/changelog-check.yml` to use `MetaMask/github-tools` changelog-check workflow at commit `fc6fe1a` (including `action-sha`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7d9989251d2947b8df0af790e0e68a67bb18705. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->