### PR TITLE
ci: Fix `claims-controller` errors in `tsconfig.json`

### DIFF
--- a/packages/claims-controller/tsconfig.json
+++ b/packages/claims-controller/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.packages.build.json",
+  "extends": "../../tsconfig.packages.json",
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist",
@@ -7,14 +7,14 @@
   },
   "references": [
     {
-      "path": "../base-controller/tsconfig.build.json"
+      "path": "../base-controller/tsconfig.json"
     },
     {
-      "path": "../messenger/tsconfig.build.json"
+      "path": "../messenger/tsconfig.json"
     },
     {
-      "path": "../profile-sync-controller/tsconfig.build.json"
+      "path": "../profile-sync-controller/tsconfig.json"
     }
   ],
-  "include": ["../../types", "./src"]
+  "include": ["../../types", "./src", "./tests"]
 }


### PR DESCRIPTION
## Explanation

The `tsconfig.json` file for `claims-controller` was extending from the wrong file, and was referencing the wrong configurations in other packages. This caused lint errors locally in my editor, and in the PR #7078 where we are updating how type information is read by the linter.

The issue was that the `tsconfig.build.json` files were being referenced, which exclude test code and test files.

## References

The error was introduced in https://github.com/MetaMask/core/pull/7072

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `claims-controller` to the correct `tsconfig` base, updates package references to non-build configs, and includes tests in type checking.
> 
> - **TypeScript config (`packages/claims-controller/tsconfig.json`)**:
>   - Extend from `../../tsconfig.packages.json` instead of `../../tsconfig.packages.build.json`.
>   - Update project references to `../{base-controller,messenger,profile-sync-controller}/tsconfig.json` (replacing `tsconfig.build.json`).
>   - Expand `include` to add `./tests` alongside `../../types` and `./src`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26ad4a9517abfe68bb636784ed57e9f95ca9002b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->