### PR TITLE
chore: Disable ESLint warnings for removed rules

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -2,12 +2,6 @@
   "packages/accounts-controller/src/AccountsController.test.ts": {
     "import-x/namespace": 1
   },
-  "packages/accounts-controller/src/utils.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 8
-  },
-  "packages/approval-controller/src/ApprovalController.test.ts": {
-    "jest/no-conditional-in-test": 16
-  },
   "packages/assets-controllers/jest.environment.js": {
     "n/prefer-global/text-encoder": 1,
     "n/prefer-global/text-decoder": 1,
@@ -16,17 +10,11 @@
   "packages/assets-controllers/src/AccountTrackerController.ts": {
     "@typescript-eslint/no-misused-promises": 4
   },
-  "packages/assets-controllers/src/CurrencyRateController.test.ts": {
-    "jest/no-conditional-in-test": 1
-  },
   "packages/assets-controllers/src/DeFiPositionsController/DeFiPositionsController.ts": {
     "@typescript-eslint/no-misused-promises": 2
   },
   "packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.ts": {
     "@typescript-eslint/no-misused-promises": 3
-  },
-  "packages/assets-controllers/src/MultichainAssetsController/utils.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 1
   },
   "packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts": {
     "@typescript-eslint/no-misused-promises": 2
@@ -35,8 +23,7 @@
     "@typescript-eslint/no-misused-promises": 2
   },
   "packages/assets-controllers/src/NftController.test.ts": {
-    "import-x/namespace": 9,
-    "jest/no-conditional-in-test": 6
+    "import-x/namespace": 9
   },
   "packages/assets-controllers/src/NftController.ts": {
     "@typescript-eslint/no-misused-promises": 2
@@ -60,34 +47,23 @@
     "@typescript-eslint/no-misused-promises": 5
   },
   "packages/assets-controllers/src/TokenListController.test.ts": {
-    "import-x/namespace": 7,
-    "jest/no-conditional-in-test": 2
+    "import-x/namespace": 7
   },
   "packages/assets-controllers/src/TokenRatesController.ts": {
     "jsdoc/check-tag-names": 11
   },
   "packages/assets-controllers/src/TokensController.test.ts": {
-    "import-x/namespace": 1,
-    "jest/no-conditional-in-test": 2
+    "import-x/namespace": 1
   },
   "packages/assets-controllers/src/TokensController.ts": {
     "@typescript-eslint/no-unused-vars": 1,
     "jsdoc/check-tag-names": 10
-  },
-  "packages/assets-controllers/src/assetsUtil.test.ts": {
-    "jest/no-conditional-in-test": 2
   },
   "packages/assets-controllers/src/multicall.test.ts": {
     "@typescript-eslint/prefer-promise-reject-errors": 2
   },
   "packages/base-controller/src/BaseController.test.ts": {
     "import-x/namespace": 13
-  },
-  "packages/bridge-status-controller/src/utils/transaction.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 2
-  },
-  "packages/build-utils/src/transforms/remove-fenced-code.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 1
   },
   "packages/composable-controller/src/ComposableController.test.ts": {
     "import-x/namespace": 3
@@ -103,7 +79,6 @@
   },
   "packages/controller-utils/src/util.test.ts": {
     "import-x/no-named-as-default": 1,
-    "jest/no-conditional-in-test": 1,
     "promise/param-names": 2
   },
   "packages/controller-utils/src/util.ts": {
@@ -232,11 +207,9 @@
     "n/no-unsupported-features/node-builtins": 1
   },
   "packages/keyring-controller/src/KeyringController.test.ts": {
-    "@typescript-eslint/no-misused-promises": 1,
-    "jest/no-conditional-in-test": 2
+    "@typescript-eslint/no-misused-promises": 1
   },
   "packages/keyring-controller/src/KeyringController.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 2,
     "@typescript-eslint/no-unused-vars": 1
   },
   "packages/logging-controller/src/LoggingController.test.ts": {
@@ -245,20 +218,11 @@
   "packages/logging-controller/src/LoggingController.ts": {
     "jsdoc/check-tag-names": 1
   },
-  "packages/message-manager/src/AbstractMessageManager.test.ts": {
-    "jest/no-conditional-in-test": 7
-  },
   "packages/message-manager/src/AbstractMessageManager.ts": {
     "jsdoc/check-tag-names": 25
   },
-  "packages/message-manager/src/DecryptMessageManager.test.ts": {
-    "jest/no-conditional-in-test": 3
-  },
   "packages/message-manager/src/DecryptMessageManager.ts": {
     "jsdoc/check-tag-names": 11
-  },
-  "packages/message-manager/src/EncryptionPublicKeyManager.test.ts": {
-    "jest/no-conditional-in-test": 5
   },
   "packages/message-manager/src/EncryptionPublicKeyManager.ts": {
     "jsdoc/check-tag-names": 13
@@ -266,14 +230,8 @@
   "packages/message-manager/src/utils.ts": {
     "@typescript-eslint/no-unused-vars": 1
   },
-  "packages/multichain-api-middleware/src/handlers/wallet-invokeMethod.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 1
-  },
   "packages/multichain-transactions-controller/src/MultichainTransactionsController.ts": {
     "@typescript-eslint/no-misused-promises": 2
-  },
-  "packages/name-controller/src/NameController.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 1
   },
   "packages/name-controller/src/util.ts": {
     "jsdoc/require-returns": 1
@@ -284,9 +242,6 @@
   "packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts": {
     "@typescript-eslint/no-misused-promises": 1
   },
-  "packages/permission-controller/src/PermissionController.test.ts": {
-    "jest/no-conditional-in-test": 4
-  },
   "packages/permission-log-controller/src/PermissionLogController.ts": {
     "jsdoc/check-tag-names": 2
   },
@@ -295,9 +250,6 @@
   },
   "packages/phishing-controller/src/utils.test.ts": {
     "import-x/namespace": 5
-  },
-  "packages/phishing-controller/src/utils.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 1
   },
   "packages/rate-limit-controller/src/RateLimitController.ts": {
     "jsdoc/check-tag-names": 4
@@ -314,21 +266,6 @@
   "packages/seedless-onboarding-controller/jest.environment.js": {
     "n/no-unsupported-features/node-builtins": 1
   },
-  "packages/seedless-onboarding-controller/src/errors.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 1
-  },
-  "packages/selected-network-controller/tests/SelectedNetworkController.test.ts": {
-    "jest/no-conditional-in-test": 1
-  },
-  "packages/shield-controller/src/ShieldController.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 1
-  },
-  "packages/shield-controller/src/backend.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 3
-  },
-  "packages/signature-controller/src/SignatureController.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 4
-  },
   "packages/signature-controller/src/utils/normalize.ts": {
     "@typescript-eslint/no-unused-vars": 1
   },
@@ -344,12 +281,7 @@
     "jsdoc/require-returns": 1
   },
   "scripts/create-package/utils.test.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 3,
-    "import-x/no-named-as-default-member": 2,
-    "jest/no-conditional-in-test": 1
-  },
-  "scripts/create-package/utils.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 5
+    "import-x/no-named-as-default-member": 2
   },
   "tests/fake-block-tracker.ts": {
     "no-empty-function": 1
@@ -359,7 +291,6 @@
     "jsdoc/check-tag-names": 12
   },
   "tests/mock-network.ts": {
-    "@typescript-eslint/no-unsafe-enum-comparison": 1,
     "jsdoc/check-tag-names": 10
   },
   "tests/setupAfterEnv/nock.ts": {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,7 +82,6 @@ const config = createConfig([
     rules: {
       // TODO: These rules created more errors after the upgrade to ESLint 9.
       // Re-enable these rules and address any lint violations.
-      'jest/no-conditional-in-test': 'warn',
       'jest/prefer-lowercase-title': 'warn',
       'jest/prefer-strict-equal': 'warn',
 
@@ -163,7 +162,6 @@ const config = createConfig([
       '@typescript-eslint/no-base-to-string': 'warn',
       '@typescript-eslint/no-duplicate-enum-values': 'warn',
       '@typescript-eslint/no-misused-promises': 'warn',
-      '@typescript-eslint/no-unsafe-enum-comparison': 'warn',
       '@typescript-eslint/no-unused-vars': 'warn',
       '@typescript-eslint/only-throw-error': 'warn',
       '@typescript-eslint/prefer-promise-reject-errors': 'warn',


### PR DESCRIPTION
## Explanation

These two rules were removed from our shared config. We can remove them completely rather than suppressing these warnings.

## References

This is a follow-up to https://github.com/MetaMask/core/pull/7103

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes warning thresholds and rule entries for `jest/no-conditional-in-test` and `@typescript-eslint/no-unsafe-enum-comparison` across config and thresholds.
> 
> - **ESLint config**:
>   - Remove `jest/no-conditional-in-test` from test rules in `eslint.config.mjs`.
>   - Remove `@typescript-eslint/no-unsafe-enum-comparison` from TypeScript rules in `eslint.config.mjs`.
> - **Warning thresholds**:
>   - Purge occurrences of `jest/no-conditional-in-test` and `@typescript-eslint/no-unsafe-enum-comparison` across `eslint-warning-thresholds.json`.
>   - Minor cleanup of related per-file entries (retaining other warnings).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebee223614c9b26c796c1c85221a2f670bda50b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->