### PR TITLE
fix: Refresh EIP-1559 compatibility on network switch

### DIFF
--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1966,8 +1966,22 @@ export class NetworkController extends BaseController<
     }
     const { EIPS } = metadata;
 
-    // may want to include some 'freshness' value - something to make sure we refetch this from time to time
-    return EIPS[1559];
+    // If EIP-1559 compatibility is already cached, return it
+    if (EIPS[1559] !== undefined) {
+      return EIPS[1559];
+    }
+
+    // Otherwise, determine it now and cache the result
+    const isEIP1559Compatible = await this.#determineEIP1559Compatibility(
+      networkClientId,
+    );
+    this.update((state) => {
+      if (isEIP1559Compatible !== undefined) {
+        state.networksMetadata[networkClientId].EIPS[1559] =
+          isEIP1559Compatible;
+      }
+    });
+    return isEIP1559Compatible;
   }
 
   /**


### PR DESCRIPTION
## Explanation
The fix ensures that when a network switch happens and a transaction immediately follows, the EIP-1559 compatibility is correctly determined rather than returning undefined, which would cause transaction validation to fail.

Disclaimer: I'm not familiar with the network controller, this PR is just a draft for the team that owns the network controller.

## References
Fixes https://github.com/MetaMask/metamask-extension/issues/37570

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> When EIP-1559 compatibility is not cached in metadata, compute it on demand, cache the result, and add tests covering both compatible and incompatible cases.
> 
> - **Network Controller**
>   - `get1559CompatibilityWithNetworkClientId`: If `EIPS[1559]` is undefined, determine compatibility via `#determineEIP1559Compatibility`, cache it in `networksMetadata[networkClientId].EIPS[1559]`, and return the value; otherwise return the cached value.
> - **Tests**
>   - Add tests verifying on-demand determination and caching of EIP-1559 compatibility when `EIPS[1559]` is initially undefined for both compatible (`true`) and incompatible (`false`) scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 453379ff23e7946b6df2f87b4a2c36069399c185. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->