### PR TITLE
feat: add useTestClock param when starting subscription

### DIFF
--- a/packages/subscription-controller/CHANGELOG.md
+++ b/packages/subscription-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- added `useTestClock` param to `StartSubscriptionRequest` and `StartCryptoSubscriptionRequest` ([#7129](https://github.com/MetaMask/core/pull/7129))
+- added `useTestClock` param to `StartSubscriptionRequest`, `StartCryptoSubscriptionRequest`, `CachedLastSelectedPaymentMethod` ([#7129](https://github.com/MetaMask/core/pull/7129))
 
 ### Changed
 

--- a/packages/subscription-controller/src/types.ts
+++ b/packages/subscription-controller/src/types.ts
@@ -418,4 +418,5 @@ export type CachedLastSelectedPaymentMethod = {
   paymentTokenAddress?: Hex;
   paymentTokenSymbol?: string;
   plan: RecurringInterval;
+  useTestClock?: boolean;
 };


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Subscription controller add `useTestClock` param to `StartSubscriptionRequest`, `StartCryptoSubscriptionRequest`, `CachedLastSelectedPaymentMethod`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional `useTestClock` to `StartSubscriptionRequest`, `StartCryptoSubscriptionRequest`, and `CachedLastSelectedPaymentMethod`.
> 
> - **Types**:
>   - Add optional `useTestClock` to `StartSubscriptionRequest` and `StartCryptoSubscriptionRequest` in `packages/subscription-controller/src/types.ts`.
>   - Add optional `useTestClock` to `CachedLastSelectedPaymentMethod`.
> - **Docs**:
>   - Update `packages/subscription-controller/CHANGELOG.md` under Unreleased Added section to note new `useTestClock` params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9ec0a8ffec59ccbbf353c3c8a9f9db965544800. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->