### PR TITLE
Follow up to eth-json-rpc-middleware rewrite PR

### DIFF
--- a/packages/eth-json-rpc-middleware/CHANGELOG.md
+++ b/packages/eth-json-rpc-middleware/CHANGELOG.md
@@ -7,21 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new function `providerAsMiddlewareV2` for converting an `InternalProvider` into a `JsonRpcEngine` v2-compatible middleware ([#7138](https://github.com/MetaMask/core/pull/7138))
+
 ### Changed
 
-- **BREAKING:** Migrate to `JsonRpcEngineV2` ([#7065](https://github.com/MetaMask/core/pull/7065))
-  - Migrates all middleware from `JsonRpcEngine` to `JsonRpcEngineV2`.
-  - Signatures of various middleware dependencies, e.g. `processTransaction` of `createWalletMiddleware`, have changed
-    and must be updated by consumers.
-    - Be advised that request objects are now deeply frozen, and cannot be mutated.
+- **BREAKING:** Migrate all middleware from `JsonRpcEngine` to `JsonRpcEngineV2` ([#7065](https://github.com/MetaMask/core/pull/7065))
   - To continue using this package with the legacy `JsonRpcEngine`, use the `asLegacyMiddleware` backwards compatibility function.
+- **BREAKING:** Change the signatures of hooks for `createWalletMiddleware` ([#7065](https://github.com/MetaMask/core/pull/7065))
+  - To wit:
+    - `getAccounts` takes an origin argument (`string`) instead of a `JsonRpcRequest`
+    - `processDecryptMessage` and `processEncryptionPublicKey` take a `MessageRequest` from `@metamask/message-manager` instead of `JsonRpcRequest`
+    - `processPersonalMessage`, `processTransaction`, `processSignTransaction`, `processTypedMessage`, `processTypedMessageV3` and `processTypedMessageV4` take a `context` as the third argument, before any other arguments
+  - Be advised that request objects are now deeply frozen, and cannot be mutated.
 - **BREAKING:** Use `InternalProvider` instead of `SafeEventEmitterProvider` ([#6796](https://github.com/MetaMask/core/pull/6796))
   - Wherever a `SafeEventEmitterProvider` was expected, an `InternalProvider` is now expected instead.
 - **BREAKING:** Stop retrying `undefined` results for methods that include a block tag parameter ([#7001](https://github.com/MetaMask/core/pull/7001))
   - The `retryOnEmpty` middleware will now throw an error if it encounters an `undefined` result when dispatching
     a request with a later block number than the originally requested block number.
   - In practice, this should happen rarely if ever.
-- Migrate all uses of `interface` to `type` ([#6885](https://github.com/MetaMask/core/pull/6885))
+- **BREAKING:** Migrate all uses of `interface` to `type` ([#6885](https://github.com/MetaMask/core/pull/6885))
 
 ## [21.0.0]
 

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rename `OriginalRequest` type to `MessageRequest` and permit string `id` values ([#7065](https://github.com/MetaMask/core/pull/7065))
   - Previously, only number values were permitted for the `id` property.
+  - `OriginalRequest` is kept for backward compatibility.
+
+### Deprecated
+
+- Deprecate `OriginalRequest`; use `MessageRequest` instead ([#7138](https://github.com/MetaMask/core/pull/7138))
 
 ## [14.0.0]
 

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -46,6 +46,13 @@ export type MessageRequest = {
 };
 
 /**
+ * Represents the request adding a message.
+ *
+ * @deprecated Please use `MessageRequest` instead.
+ */
+export type OriginalRequest = MessageRequest;
+
+/**
  * @type AbstractMessage
  *
  * Represents and contains data about a signing type signature request.

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - In practice, this should happen rarely if ever.
 - **BREAKING:** Migrate `NetworkClient` to `JsonRpcEngineV2` ([#7065](https://github.com/MetaMask/core/pull/7065))
   - This ought to be unobservable, but we mark it as breaking out of an abundance of caution.
+- **BREAKING:** Update signature of `request` in `AbstractRpcService` and `RpcServiceRequestable` so that the JSON-RPC request must be frozen ([#7138](https://github.com/MetaMask/core/pull/7138))
 - Bump `@metamask/controller-utils` from `^11.14.1` to `^11.15.0` ([#7003](https://github.com/MetaMask/core/pull/7003))
 
 ### Fixed

--- a/packages/network-controller/src/rpc-service/rpc-service-chain.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service-chain.ts
@@ -106,7 +106,9 @@ export class RpcServiceChain implements RpcServiceRequestable {
    * @throws A "parse" error if the response is not valid JSON.
    */
   async request<Params extends JsonRpcParams, Result extends Json>(
-    jsonRpcRequest: JsonRpcRequest<Params> & { method: 'eth_getBlockByNumber' },
+    jsonRpcRequest: Readonly<JsonRpcRequest<Params>> & {
+      method: 'eth_getBlockByNumber';
+    },
     fetchOptions?: FetchOptions,
   ): Promise<JsonRpcResponse<Result> | JsonRpcResponse<null>>;
 
@@ -129,12 +131,12 @@ export class RpcServiceChain implements RpcServiceRequestable {
    * @throws A "parse" error if the response is not valid JSON.
    */
   async request<Params extends JsonRpcParams, Result extends Json>(
-    jsonRpcRequest: JsonRpcRequest<Params>,
+    jsonRpcRequest: Readonly<JsonRpcRequest<Params>>,
     fetchOptions?: FetchOptions,
   ): Promise<JsonRpcResponse<Result>>;
 
   async request<Params extends JsonRpcParams, Result extends Json>(
-    jsonRpcRequest: JsonRpcRequest<Params>,
+    jsonRpcRequest: Readonly<JsonRpcRequest<Params>>,
     fetchOptions: FetchOptions = {},
   ): Promise<JsonRpcResponse<Result | null>> {
     return this.#services[0].request(jsonRpcRequest, fetchOptions);

--- a/packages/network-controller/src/rpc-service/rpc-service-requestable.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service-requestable.ts
@@ -62,7 +62,7 @@ export type RpcServiceRequestable = {
    * Makes a request to the target.
    */
   request<Params extends JsonRpcParams, Result extends Json>(
-    jsonRpcRequest: JsonRpcRequest<Params>,
+    jsonRpcRequest: Readonly<JsonRpcRequest<Params>>,
     fetchOptions?: FetchOptions,
   ): Promise<JsonRpcResponse<Result | null>>;
 };


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

The following changes extend c26899a49c1dc738e92800235fcd0ca470baa39d:

- `eth-json-rpc-middleware`
  - There were some unnecessary type assertions in `inflight-cache.ts` that have been removed.
- `message-manager`
  - The rename of `OriginalRequest` introduced a breaking change. We don't strictly need to do this now, so we keep the old type around for backward compatibility.
- `network-controller`
  - The changelog has been updated to mention that a new export was added, and to detail more changes to `createWalletMiddleware`.
  - The signatures of `request` in `RpcServiceRequestable` and `RpcServiceChain` were updated to match the same method in `RpcService` (and the change to `RpcServiceRequestable` was marked as breaking).

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Progresses https://github.com/MetaMask/core/issues/6327.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds providerAsMiddlewareV2, deprecates OriginalRequest, and updates RPC request types to require Readonly/frozen JSON-RPC requests; tightens inflight-cache typings.
> 
> - **eth-json-rpc-middleware**:
>   - **Added**: `providerAsMiddlewareV2` to convert an `InternalProvider` to v2 middleware.
>   - **Changed**: Changelog clarifies migration to `JsonRpcEngineV2` and updated `createWalletMiddleware` hook signatures.
>   - Tighten `inflight-cache` types: use `Readonly<Json>` for results, `unknown` for errors, and remove unnecessary casts.
> - **message-manager**:
>   - **Changed/Deprecated**: Keep `OriginalRequest` as a deprecated alias of `MessageRequest` in code and changelog.
> - **network-controller**:
>   - **BREAKING**: `request` signatures in `RpcServiceRequestable`/`RpcServiceChain` now accept `Readonly<JsonRpcRequest<...>>` (frozen requests); reflected in changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca59fe6373eed3eb9d0e281a16afec0582c1811a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->