### PR TITLE
Revert "Relase/676.0.0 (#7142)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "676.0.0",
+  "version": "675.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/shield-controller/CHANGELOG.md
+++ b/packages/shield-controller/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0]
-
 ### Added
 
 - Added metrics in the Shield coverage response to track the latency ( [#7133](https://github.com/MetaMask/core/pull/7133))
@@ -130,8 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the shield-controller package ([#6137](https://github.com/MetaMask/core/pull/6137)
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/shield-controller@2.1.0...HEAD
-[2.1.0]: https://github.com/MetaMask/core/compare/@metamask/shield-controller@2.0.0...@metamask/shield-controller@2.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/shield-controller@2.0.0...HEAD
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/shield-controller@1.2.0...@metamask/shield-controller@2.0.0
 [1.2.0]: https://github.com/MetaMask/core/compare/@metamask/shield-controller@1.1.0...@metamask/shield-controller@1.2.0
 [1.1.0]: https://github.com/MetaMask/core/compare/@metamask/shield-controller@1.0.0...@metamask/shield-controller@1.1.0

--- a/packages/shield-controller/package.json
+++ b/packages/shield-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/shield-controller",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "Controller handling shield transaction coverage logic",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
This reverts commit 9b84201fc17fa592dcfdb701762e987eecaa1269.

## Explanation

This release used an invalid commit name (Relase/676.0.0)  so the publish CI script did not run.
Reverting and will add this back as a fast follow.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rolls back release versions (core to 675.0.0, shield-controller to 2.0.0) and updates shield-controller changelog accordingly.
> 
> - **Versions**:
>   - Roll back root `package.json` from `676.0.0` to `675.0.0`.
>   - Roll back `packages/shield-controller/package.json` from `2.1.0` to `2.0.0`.
> - **Changelog (`packages/shield-controller/CHANGELOG.md`)**:
>   - Remove `2.1.0` section; keep its entry under `Unreleased`.
>   - Update compare links to reference `2.0.0` and drop `2.1.0` link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9b1b52fbcc95e63fa3a64ec359c4f0461364a87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->