### PR TITLE
chore: Temporarily disable `@typescript-eslint/naming-convention`

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -101,15 +101,11 @@
     "@typescript-eslint/unbound-method": 5,
     "no-restricted-syntax": 28
   },
-  "packages/eth-block-tracker/tests/buildDeferred.ts": {
-    "@typescript-eslint/naming-convention": 1
-  },
   "packages/eth-block-tracker/tests/recordCallsToSetTimeout.ts": {
     "@typescript-eslint/no-explicit-any": 1
   },
   "packages/eth-block-tracker/tests/setupAfterEnv.ts": {
     "@typescript-eslint/consistent-type-definitions": 1,
-    "@typescript-eslint/naming-convention": 1,
     "@typescript-eslint/no-explicit-any": 3
   },
   "packages/eth-block-tracker/tests/withBlockTracker.ts": {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -188,7 +188,6 @@ const config = createConfig([
   {
     files: ['**/*.d.ts'],
     rules: {
-      '@typescript-eslint/naming-convention': 'warn',
       'import-x/unambiguous': 'off',
     },
   },
@@ -224,7 +223,6 @@ const config = createConfig([
       // TODO: Re-enable these rules or add inline ignores for warranted cases
       '@typescript-eslint/prefer-nullish-coalescing': 'warn',
       'no-restricted-syntax': 'warn',
-      '@typescript-eslint/naming-convention': 'warn',
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/unbound-method': 'warn',
       '@typescript-eslint/consistent-type-definitions': 'warn',

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -5,7 +5,7 @@ declare global {
     // We're using `interface` here so that we can extend and not override it.
     // In addition, we must use the generic parameter name `R` to match the
     // Jest types.
-    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions,@typescript-eslint/naming-convention
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
     interface Matchers<R> {
       toBeFulfilled(): Promise<R>;
       toNeverResolve(): Promise<R>;


### PR DESCRIPTION
## Explanation

The rule `@typescript-eslint/naming-convention` was already disabled for most files, but it was set to `warn` in a few places still. It's now completely disabled instead.

This was done to reduce the set of changes that are part of the upcoming switch to error suppression (#6790), and also for consistency. We still want to use this rule, but we can gradually begin enforcing it in a more controlled manner using error suppression, across the entire repository at once rather than selectively.

## References

Relates to #6790

These changes were extracted from the draft PR #7148

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fully disables `@typescript-eslint/naming-convention` across overrides and thresholds, and cleans up a related inline disable.
> 
> - **ESLint config**:
>   - Remove `@typescript-eslint/naming-convention` from overrides in `**/*.d.ts` and `packages/eth-block-tracker/**/*.ts` in `eslint.config.mjs`.
> - **Warning thresholds**:
>   - Drop `@typescript-eslint/naming-convention` entries from `eslint-warning-thresholds.json` for `packages/eth-block-tracker/tests/buildDeferred.ts` and `packages/eth-block-tracker/tests/setupAfterEnv.ts`.
> - **Types**:
>   - Remove inline disable for `@typescript-eslint/naming-convention` in `types/global.d.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8f5e9e764614ac6c7d77f2c663b633dc9f0aec3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->