### PR TITLE
chore: Selectively disable `jsodc/check-tag-names` ESLint rule

### DIFF
--- a/eslint-warning-thresholds.json
+++ b/eslint-warning-thresholds.json
@@ -31,9 +31,6 @@
   "packages/assets-controllers/src/NftDetectionController.test.ts": {
     "import-x/namespace": 6
   },
-  "packages/assets-controllers/src/NftDetectionController.ts": {
-    "jsdoc/check-tag-names": 34
-  },
   "packages/assets-controllers/src/Standards/ERC20Standard.test.ts": {
     "jest/no-commented-out-tests": 1
   },
@@ -49,15 +46,11 @@
   "packages/assets-controllers/src/TokenListController.test.ts": {
     "import-x/namespace": 7
   },
-  "packages/assets-controllers/src/TokenRatesController.ts": {
-    "jsdoc/check-tag-names": 11
-  },
   "packages/assets-controllers/src/TokensController.test.ts": {
     "import-x/namespace": 1
   },
   "packages/assets-controllers/src/TokensController.ts": {
-    "@typescript-eslint/no-unused-vars": 1,
-    "jsdoc/check-tag-names": 10
+    "@typescript-eslint/no-unused-vars": 1
   },
   "packages/assets-controllers/src/multicall.test.ts": {
     "@typescript-eslint/prefer-promise-reject-errors": 2
@@ -74,8 +67,7 @@
     "no-shadow": 2
   },
   "packages/controller-utils/src/siwe.ts": {
-    "@typescript-eslint/no-unused-vars": 1,
-    "jsdoc/check-tag-names": 5
+    "@typescript-eslint/no-unused-vars": 1
   },
   "packages/controller-utils/src/util.test.ts": {
     "import-x/no-named-as-default": 1,
@@ -89,9 +81,6 @@
   },
   "packages/eip-5792-middleware/src/hooks/processSendCalls.ts": {
     "@typescript-eslint/no-misused-promises": 1
-  },
-  "packages/ens-controller/src/EnsController.ts": {
-    "jsdoc/check-tag-names": 6
   },
   "packages/eth-block-tracker/src/PollingBlockTracker.test.ts": {
     "@typescript-eslint/unbound-method": 4
@@ -114,9 +103,6 @@
   "packages/gas-fee-controller/src/GasFeeController.test.ts": {
     "import-x/namespace": 2
   },
-  "packages/gas-fee-controller/src/GasFeeController.ts": {
-    "jsdoc/check-tag-names": 20
-  },
   "packages/json-rpc-middleware-stream/src/index.test.ts": {
     "@typescript-eslint/prefer-promise-reject-errors": 1,
     "no-empty-function": 1
@@ -133,18 +119,6 @@
   "packages/logging-controller/src/LoggingController.test.ts": {
     "import-x/namespace": 1
   },
-  "packages/logging-controller/src/LoggingController.ts": {
-    "jsdoc/check-tag-names": 1
-  },
-  "packages/message-manager/src/AbstractMessageManager.ts": {
-    "jsdoc/check-tag-names": 23
-  },
-  "packages/message-manager/src/DecryptMessageManager.ts": {
-    "jsdoc/check-tag-names": 11
-  },
-  "packages/message-manager/src/EncryptionPublicKeyManager.ts": {
-    "jsdoc/check-tag-names": 13
-  },
   "packages/message-manager/src/utils.ts": {
     "@typescript-eslint/no-unused-vars": 1
   },
@@ -157,17 +131,8 @@
   "packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts": {
     "@typescript-eslint/no-misused-promises": 1
   },
-  "packages/permission-log-controller/src/PermissionLogController.ts": {
-    "jsdoc/check-tag-names": 2
-  },
-  "packages/phishing-controller/src/PhishingController.ts": {
-    "jsdoc/check-tag-names": 32
-  },
   "packages/phishing-controller/src/utils.test.ts": {
     "import-x/namespace": 5
-  },
-  "packages/rate-limit-controller/src/RateLimitController.ts": {
-    "jsdoc/check-tag-names": 4
   },
   "packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts": {
     "promise/param-names": 1
@@ -202,11 +167,7 @@
     "no-empty-function": 1
   },
   "tests/fake-provider.ts": {
-    "@typescript-eslint/prefer-promise-reject-errors": 1,
-    "jsdoc/check-tag-names": 12
-  },
-  "tests/mock-network.ts": {
-    "jsdoc/check-tag-names": 10
+    "@typescript-eslint/prefer-promise-reject-errors": 1
   },
   "tests/setupAfterEnv/nock.ts": {
     "import-x/no-named-as-default-member": 3

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -169,7 +169,6 @@ const config = createConfig([
       'import-x/namespace': 'warn',
       'import-x/no-named-as-default': 'warn',
       'import-x/order': 'warn',
-      'jsdoc/check-tag-names': 'warn',
       'jsdoc/require-returns': 'warn',
       'jsdoc/tag-lines': 'warn',
       'no-unused-private-class-members': 'warn',
@@ -247,6 +246,32 @@ const config = createConfig([
       // These files use `self` because they're written for a service worker context.
       // TODO: Move these files to the extension repository, `core` is just for platform-agnostic code.
       'consistent-this': 'off',
+    },
+  },
+  {
+    files: [
+      'packages/assets-controllers/src/NftDetectionController.ts',
+      'packages/assets-controllers/src/TokenRatesController.ts',
+      'packages/assets-controllers/src/TokensController.ts',
+      'packages/controller-utils/src/siwe.ts',
+      'packages/ens-controller/src/EnsController.ts',
+      'packages/gas-fee-controller/src/GasFeeController.ts',
+      'packages/logging-controller/src/LoggingController.ts',
+      'packages/message-manager/src/AbstractMessageManager.ts',
+      'packages/message-manager/src/DecryptMessageManager.ts',
+      'packages/message-manager/src/EncryptionPublicKeyManager.ts',
+      'packages/permission-log-controller/src/PermissionLogController.ts',
+      'packages/phishing-controller/src/PhishingController.ts',
+      'packages/rate-limit-controller/src/RateLimitController.ts',
+      'tests/fake-provider.ts',
+      'tests/mock-network.ts',
+    ],
+    rules: {
+      // TODO: Re-enable this rule
+      // This has been temporarily disabled because the auto-fix mangles pre-existing JSDoc blocks
+      // for types that don't follow TSDoc properly.
+      // See https://github.com/gajus/eslint-plugin-jsdoc/issues/1054
+      'jsdoc/check-tag-names': 'off',
     },
   },
 ]);


### PR DESCRIPTION
## Explanation

The ESLint rule `jsdoc/check-tag-names` mangles a lot of comment blocks we have for types. The types are currently written in a way that doesn't comply with the TSDoc spec, and we should fix them, but leaving the rule enabled (even with error suppression!) prevents us from using `--fix`.

The rule has been selectively disabled in each file that has malformed doc blocks impacted by this problem. We can remove these files one-by-one as we fix the inline docs.

## References

Relates to #6790

These changes were extracted from the draft PR #7148

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `jsdoc/check-tag-names` for specific files via ESLint overrides and updates warning thresholds accordingly.
> 
> - **ESLint Configuration**:
>   - Remove global `jsdoc/check-tag-names` warning from TypeScript rules.
>   - Add targeted override disabling `jsdoc/check-tag-names` for specific files (e.g., various controllers, message-manager files, tests).
> - **Warning Thresholds**:
>   - Update `eslint-warning-thresholds.json` to drop `jsdoc/check-tag-names` entries for affected files.
>   - Minor cleanup to reflect current active rules (e.g., `TokensController.ts`, `siwe.ts`, `tests/fake-provider.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc830189575f19db4667234e8b795d0add53bb64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->