### PR TITLE
ci: Use `MetaMask/action-is-release@v2` for release check workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Check if the commit or pull request is a release
         id: is-release
         if: github.event_name != 'push'
-        uses: MetaMask/action-is-release@d063725cd15ee145d7e795a2e77db31a3e3f2c92
+        uses: MetaMask/action-is-release@v2
         with:
           commit-starts-with: 'Release [version],Release v[version],Release/[version],Release/v[version],Release `[version]`'
           commit-message: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## Explanation

The changes needed for the release check are now included in the stable version of `MetaMask/action-is-release`, so we can use that instead.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update workflow to use `MetaMask/action-is-release@v2` instead of a pinned commit for release detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7c4a07b225eee32fed571bfb32393ae624d0a92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->