### PR TITLE
chore: Remove unused ESLint directives about enum comparisons

### DIFF
--- a/packages/chain-agnostic-permission/src/operators/caip-permission-operator-accounts.ts
+++ b/packages/chain-agnostic-permission/src/operators/caip-permission-operator-accounts.ts
@@ -37,8 +37,6 @@ const isEip155ScopeString = (scopeString: InternalScopeString) => {
 
   return (
     namespace === KnownCaipNamespace.Eip155 ||
-    // We are trying to discern the type of `scopeString`.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
     scopeString === KnownWalletScopeString.Eip155
   );
 };
@@ -321,7 +319,6 @@ function isAddressWithParsedScopesInPermittedAccountIds(
     return parsedAccountScopes.some(({ namespace, reference }) => {
       if (
         namespace !== parsedPermittedAccount.chain.namespace &&
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
         parsedPermittedAccount.chain.namespace !== KnownCaipNamespace.Wallet
       ) {
         return false;
@@ -330,7 +327,6 @@ function isAddressWithParsedScopesInPermittedAccountIds(
       // handle wallet:<namespace>:<address> case where namespaces are mismatched but addresses match
       // i.e. wallet:notSolana:12389812309123 and solana:0:12389812309123
       if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
         parsedPermittedAccount.chain.namespace === KnownCaipNamespace.Wallet &&
         namespace !== parsedPermittedAccount.chain.reference
       ) {
@@ -348,7 +344,6 @@ function isAddressWithParsedScopesInPermittedAccountIds(
 
       // handle wallet:<namespace>:<address> case
       if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
         parsedPermittedAccount.chain.namespace === KnownCaipNamespace.Wallet
       ) {
         return address === parsedPermittedAccount.address;

--- a/packages/chain-agnostic-permission/src/scope/assert.ts
+++ b/packages/chain-agnostic-permission/src/scope/assert.ts
@@ -253,7 +253,6 @@ export function assertIsInternalScopeString(
     typeof scopeString !== 'string' ||
     // `InternalScopeString` is defined as either `KnownCaipNamespace.Wallet` or
     // `CaipChainId`, so our conditions intentionally match the type.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
     (scopeString !== KnownCaipNamespace.Wallet && !isCaipChainId(scopeString))
   ) {
     throw new Error('scopeString is not a valid InternalScopeString');

--- a/packages/chain-agnostic-permission/src/scope/supported.ts
+++ b/packages/chain-agnostic-permission/src/scope/supported.ts
@@ -95,8 +95,6 @@ export const isSupportedAccount = (
   const isSupportedNonEvmAccount = () =>
     getNonEvmAccountAddresses(chainId).includes(account);
 
-  // We are trying to discern the type of `namespace`.
-  /* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
   switch (namespace) {
     case KnownCaipNamespace.Wallet:
       if (reference === KnownCaipNamespace.Eip155) {
@@ -108,7 +106,6 @@ export const isSupportedAccount = (
     default:
       return isSupportedNonEvmAccount();
   }
-  /* eslint-enable @typescript-eslint/no-unsafe-enum-comparison */
 };
 
 /**
@@ -139,8 +136,6 @@ export const isSupportedMethod = (
     isCaipChainId(scopeString) &&
     getNonEvmSupportedMethods(scopeString).includes(method);
 
-  // We are trying to discern the type of `namespace`.
-  /* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
   if (namespace === KnownCaipNamespace.Wallet) {
     if (!reference) {
       return KnownWalletRpcMethods.includes(method);
@@ -156,7 +151,6 @@ export const isSupportedMethod = (
   if (namespace === KnownCaipNamespace.Eip155) {
     return KnownRpcMethods[namespace].includes(method);
   }
-  /* eslint-enable @typescript-eslint/no-unsafe-enum-comparison */
 
   return isSupportedNonEvmMethod();
 };

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1896,7 +1896,6 @@ export class KeyringController<
       throw new Error(KeyringControllerError.KeyringNotFound);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
     if (keyring.type !== KeyringTypes.hd) {
       throw new Error(KeyringControllerError.UnsupportedVerifySeedPhrase);
     }

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -1983,9 +1983,7 @@ export class SeedlessOnboardingController<
   #isAuthTokenError(error: unknown): boolean {
     if (error instanceof TOPRFError) {
       return (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
         error.code === TOPRFErrorCode.AuthTokenExpired ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
         error.code === TOPRFErrorCode.InvalidAuthToken
       );
     }


### PR DESCRIPTION
## Explanation

ESLint ignore directives about the rule `no-unusafe-enum-comparison` have been removed. This rule was disabled in the most recent ESLint config update.

## References

This change helps to unblock #7148

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes now-unnecessary ESLint disable directives for enum comparisons across permission, keyring, and seedless onboarding modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df5da81daaa488c21f439968485c0c0606b75636. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->