### PR TITLE
Release 682.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "681.0.0",
+  "version": "682.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0]
+
 ### Added
 
 - **BREAKING:** Add `sourceAmount` to `TransactionPayQuote` ([#7159](https://github.com/MetaMask/core/pull/7159))
@@ -98,7 +100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#6820](https://github.com/MetaMask/core/pull/6820))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@6.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@7.0.0...HEAD
+[7.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@6.0.0...@metamask/transaction-pay-controller@7.0.0
 [6.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@5.0.0...@metamask/transaction-pay-controller@6.0.0
 [5.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@4.0.0...@metamask/transaction-pay-controller@5.0.0
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@3.1.0...@metamask/transaction-pay-controller@4.0.0

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-pay-controller",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Manages alternate payment strategies to provide required funds for transactions in MetaMask",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
Major release of `@metamask/transaction-pay-controller`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publish @metamask/transaction-pay-controller v7.0.0 with breaking API additions to quotes/totals; bump monorepo to 682.0.0.
> 
> - **Packages**:
>   - `@metamask/transaction-pay-controller@7.0.0` (breaking):
>     - Add `sourceAmount` to `TransactionPayQuote`.
>     - Add `estimate` and `max` to `fee.sourceNetwork` in `TransactionPayQuote`.
>     - Add `isTargetGasFeeToken` to `fee` in `TransactionPayQuote`.
>     - Add matching fields to `TransactionPayTotals`.
>     - Use fixed fiat rate for Polygon USDCe and Arbitrum USDC.
>   - Update `CHANGELOG.md` links for `7.0.0`.
> - **Monorepo**:
>   - Bump root `package.json` `version` to `682.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 899111c05777ff351800dbcc7fbd5e5ca20df17d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->