### PR TITLE
ci: Test scripts separately from packages

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -92,6 +92,28 @@ jobs:
             exit 1
           fi
 
+  test-scripts:
+    name: Test Scripts
+    runs-on: ubuntu-latest
+    needs: prepare
+    strategy:
+      matrix:
+        node-version: [22.x]
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v2
+        with:
+          is-high-risk-environment: false
+          node-version: ${{ matrix.node-version }}
+      - run: yarn test:scripts
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -106,7 +128,6 @@ jobs:
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
-      - run: yarn test:scripts
       - run: yarn workspace ${{ matrix.package-name }} run test
       - name: Require clean working directory
         shell: bash


### PR DESCRIPTION
## Explanation

Currently we test top-level monorepo scripts every time we run tests for a specific package. Instead they've now been moved to a separate job that runs just once.

This should reduce the time it takes to run tests by a few seconds, and it reduces noise when the script tests actually fail.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
