### PR TITLE
ci: Skip (re-)checkout in check release action if not a release

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -40,6 +40,7 @@ runs:
     # need to check it out again with full history.
     - name: Checkout repository
       uses: actions/checkout@v5
+      if: steps.is-release.outputs.IS_RELEASE == 'true'
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
## Explanation

I forgot to add a check for `IS_RELEASE` in the re-checkout step in the check release action. This means we were unnecessarily checking out the repository again for commits or pull requests that are not releases.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add an `if: steps.is-release.outputs.IS_RELEASE == 'true'` guard to the re-checkout step in `.github/actions/check-release/action.yml` so full-history checkout runs only for release PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69cef3e31207b95bce5cf2d632c73223cba42e29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->