### PR TITLE
ci: Set `skip-checkout` to remove two unnecessary checkouts

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -35,14 +35,7 @@ runs:
         commit-starts-with: 'Release [version],Release v[version],Release/[version],Release/v[version],Release `[version]`'
         commit-message: ${{ github.event.pull_request.title }}
         before: ${{ steps.merge-base.outputs.MERGE_BASE }}
-
-    # `action-is-release` checks out the repository with `fetch-depth: 2`, so we
-    # need to check it out again with full history.
-    - name: Checkout repository
-      uses: actions/checkout@v5
-      if: steps.is-release.outputs.IS_RELEASE == 'true'
-      with:
-        fetch-depth: 0
+        skip-checkout: true
 
     - name: Get pull request number
       id: pr-number


### PR DESCRIPTION
## Explanation

Previously, the repository would be checked out three times in the check release action:

1. Once at the start, so we can get the merge base to use to check for a release.
2. Once by `action-is-release`.
3. Once after `action-is-release`, so we have the full Git history available again.

We can now use the `skip-checkout` option of `action-is-release` to avoid step 2, and since `action-is-release` isn't removing the Git history anymore, we can avoid step 3 as well.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids redundant repository checkouts in the check-release action by enabling skip-checkout and removing the follow-up checkout step.
> 
> - **CI/GitHub Actions**:
>   - **`check-release` composite action**:
>     - Enable `skip-checkout: true` for `MetaMask/action-is-release@v2` to prevent its internal checkout.
>     - Remove the conditional post-step repository checkout (previously to restore full history).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3f30cbd7dc6ed8819bf9211704cfee3fc9dda16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->