### PR TITLE
chore(bridge-controller): faster utils

### DIFF
--- a/packages/bridge-controller/src/utils/bridge.ts
+++ b/packages/bridge-controller/src/utils/bridge.ts
@@ -168,6 +168,8 @@ export const isNativeAddress = (address?: string | null) =>
       (reference) => address.includes(reference) || reference.endsWith(address),
     ));
 
+const SOLANA_MAINNET_CHAIN_ID_STRING = SolScope.Mainnet.toString();
+const SOLANA_CHAIN_ID_STRING = ChainId.SOLANA.toString();
 /**
  * Checks whether the chainId matches Solana in CaipChainId or number format
  *
@@ -178,25 +180,31 @@ export const isSolanaChainId = (
   chainId: Hex | number | CaipChainId | string,
 ) => {
   if (isCaipChainId(chainId)) {
-    return chainId === SolScope.Mainnet.toString();
+    return chainId === SOLANA_MAINNET_CHAIN_ID_STRING;
   }
-  return chainId.toString() === ChainId.SOLANA.toString();
+  return chainId.toString() === SOLANA_CHAIN_ID_STRING;
 };
+
+const BITCOIN_MAINNET_CHAIN_ID_STRING = BtcScope.Mainnet.toString();
+const BITCOIN_CHAIN_ID_STRING = ChainId.BTC.toString();
 
 export const isBitcoinChainId = (
   chainId: Hex | number | CaipChainId | string,
 ) => {
   if (isCaipChainId(chainId)) {
-    return chainId === BtcScope.Mainnet.toString();
+    return chainId === BITCOIN_MAINNET_CHAIN_ID_STRING;
   }
-  return chainId.toString() === ChainId.BTC.toString();
+  return chainId.toString() === BITCOIN_CHAIN_ID_STRING;
 };
+
+const TRON_MAINNET_CHAIN_ID_STRING = TrxScope.Mainnet.toString();
+const TRON_CHAIN_ID_STRING = ChainId.TRON.toString();
 
 export const isTronChainId = (chainId: Hex | number | CaipChainId | string) => {
   if (isCaipChainId(chainId)) {
-    return chainId === TrxScope.Mainnet.toString();
+    return chainId === TRON_MAINNET_CHAIN_ID_STRING;
   }
-  return chainId.toString() === ChainId.TRON.toString();
+  return chainId.toString() === TRON_CHAIN_ID_STRING;
 };
 
 /**


### PR DESCRIPTION
## Explanation

While working on https://github.com/MetaMask/metamask-mobile/pull/22744 I noticed that if do this small change of pre-converting values I can save up to 25% of time when looping though big array of tokens where this functions were used multiple times per one loop.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Related to https://github.com/MetaMask/metamask-mobile/pull/22744 

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Precomputes chain ID string constants and uses them in `isSolanaChainId`, `isBitcoinChainId`, and `isTronChainId` within `utils/bridge.ts`.
> 
> - **utils/bridge.ts**:
>   - Add constants: `SOLANA_MAINNET_CHAIN_ID_STRING`, `SOLANA_CHAIN_ID_STRING`, `BITCOIN_MAINNET_CHAIN_ID_STRING`, `BITCOIN_CHAIN_ID_STRING`, `TRON_MAINNET_CHAIN_ID_STRING`, `TRON_CHAIN_ID_STRING`.
>   - Update `isSolanaChainId`, `isBitcoinChainId`, `isTronChainId` to compare against precomputed strings instead of inline `toString()` calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68f77e1f1848bae3e01d2fc3179fcaa782789a66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->