### PR TITLE
fix: `generate-method-action-types` works for services as well

### DIFF
--- a/scripts/generate-method-action-types.ts
+++ b/scripts/generate-method-action-types.ts
@@ -309,10 +309,10 @@ function createASTVisitor(context: VisitorContext) {
       }
     }
 
-    // Find the controller class
+    // Find the controller or service class
     if (ts.isClassDeclaration(node) && node.name) {
       const classText = node.name.text;
-      if (classText.includes('Controller')) {
+      if (classText.includes('Controller') || classText.includes('Service')) {
         context.className = classText;
 
         // Extract method info for exposed methods


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
The `generate-method-action-types.ts` script was only generating action types for files ending with `controller.ts`. This change updates the script to also consider files ending with `service.ts`, allowing it to generate action types for service files as well.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes