### PR TITLE
feat: export token scan types

### DIFF
--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `TokenScanCacheData` to allow consumers to have a type to reference if grabbing values directly from the controller's state ([#7208](https://github.com/MetaMask/core/pull/7208))
+- Export `TokenScanCacheData` and `TokenScanResultType` to allow consumers to have a type to reference if grabbing values directly from the controller's state ([#7208](https://github.com/MetaMask/core/pull/7208))
 
 ## [16.0.0]
 

--- a/packages/phishing-controller/src/index.ts
+++ b/packages/phishing-controller/src/index.ts
@@ -8,7 +8,7 @@ export type {
 } from './PhishingDetector';
 export { PhishingDetector } from './PhishingDetector';
 export type { PhishingDetectionScanResult, AddressScanResult } from './types';
-export type { TokenScanCacheData } from './types';
+export type { TokenScanCacheData, TokenScanResultType } from './types';
 export {
   PhishingDetectorResultType,
   RecommendedAction,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Exports `TokenScanCacheData` and `TokenScanResultType` so that users of the PhishingController do not need to create their own types when accessing cache entries within the token scan cache.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exports `TokenScanCacheData` and `TokenScanResultType` from `src/index.ts` and documents the change in the changelog.
> 
> - **phishing-controller**
>   - **Exports**: Add `TokenScanCacheData` and `TokenScanResultType` to public exports in `src/index.ts`.
>   - **Docs**: Update `CHANGELOG.md` under Unreleased to note these new exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7a587bf975c36a2a856b4f95eec6123fbda452b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->