### PR TITLE
chore Prevent unused ESLint error directives

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,11 @@ const config = createConfig([
     ],
   },
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
+  {
     rules: {
       // Left disabled because various properties throughough this repo are snake_case because the
       // names come from external sources or must comply with standards

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -1139,7 +1139,6 @@ describe('CurrencyRateController', () => {
       jest
         .spyOn(tokenPricesService, 'fetchTokenPrices')
         .mockImplementation(async ({ assets }) => {
-          // eslint-disable-next-line jest/no-conditional-in-test
           if (assets.some((asset) => asset.chainId === '0x1')) {
             return [
               {
@@ -1168,7 +1167,7 @@ describe('CurrencyRateController', () => {
               },
             ];
           }
-          // eslint-disable-next-line jest/no-conditional-in-test
+
           if (assets.some((asset) => asset.chainId === '0x89')) {
             return [
               {
@@ -1262,11 +1261,9 @@ describe('CurrencyRateController', () => {
       const fetchTokenPricesSpy = jest
         .spyOn(tokenPricesService, 'fetchTokenPrices')
         .mockImplementation(async ({ assets }) => {
-          // eslint-disable-next-line jest/no-conditional-in-test
           if (
             assets.some(
               (asset) =>
-                // eslint-disable-next-line jest/no-conditional-in-test
                 asset.chainId === '0x1' || asset.chainId === '0xaa36a7',
             )
           ) {
@@ -1358,7 +1355,6 @@ describe('CurrencyRateController', () => {
       jest
         .spyOn(tokenPricesService, 'fetchTokenPrices')
         .mockImplementation(async ({ assets }) => {
-          // eslint-disable-next-line jest/no-conditional-in-test
           if (assets.some((asset) => asset.chainId === '0x1')) {
             // ETH succeeds
             return [
@@ -1498,7 +1494,6 @@ describe('CurrencyRateController', () => {
       const fetchTokenPricesSpy = jest
         .spyOn(tokenPricesService, 'fetchTokenPrices')
         .mockImplementation(async ({ assets }) => {
-          // eslint-disable-next-line jest/no-conditional-in-test
           if (assets.some((asset) => asset.chainId === '0x1')) {
             return [
               {


### PR DESCRIPTION
## Explanation

ESlint defaults to warning about unused directives. We are trying to keep this repository free of warnings (they are too easy to miss, and they build up over time and cause confusion about why lint is failing when it does fail).

The ESLint configuration has been updated to treat unused ESLint directives as errors. Existing violations have been fixed by running `yarn lint:eslint --fix`.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces unused ESLint disable directives as errors and removes obsolete disable comments in CurrencyRateController tests.
> 
> - **ESLint config**:
>   - Add `linterOptions.reportUnusedDisableDirectives: 'error'` in `eslint.config.mjs`.
> - **Tests**:
>   - Remove unused `// eslint-disable-next-line jest/no-conditional-in-test` directives in `packages/assets-controllers/src/CurrencyRateController.test.ts` (no test logic changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3c86f773d2682ef5a317df8de342118344a7c15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->