### PR TITLE
feat: include 'AuthorizationList' params in tx init and log requests

### DIFF
--- a/packages/shield-controller/CHANGELOG.md
+++ b/packages/shield-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `AuthorizationList` in transaction init and log requests for 7702 transactions. ([#7246](https://github.com/MetaMask/core/pull/7246))
+
 ### Changed
 
 - Move peer dependencies for controller and service packages to direct dependencies ([#7209](https://github.com/MetaMask/core/pull/7209), [#7220](https://github.com/MetaMask/core/pull/7220), [#7236](https://github.com/MetaMask/core/pull/7236))

--- a/packages/shield-controller/src/backend.test.ts
+++ b/packages/shield-controller/src/backend.test.ts
@@ -3,7 +3,11 @@ import {
   SignatureRequestType,
 } from '@metamask/signature-controller';
 
-import { parseSignatureRequestMethod, ShieldRemoteBackend } from './backend';
+import {
+  makeInitCoverageCheckBody,
+  parseSignatureRequestMethod,
+  ShieldRemoteBackend,
+} from './backend';
 import { SignTypedDataVersion } from './constants';
 import {
   generateMockSignatureRequest,
@@ -421,6 +425,43 @@ describe('ShieldRemoteBackend', () => {
       expect(parseSignatureRequestMethod(signatureRequest)).toBe(
         EthMethod.SignTypedDataV4,
       );
+    });
+  });
+
+  describe('makeInitCoverageCheckBody', () => {
+    it('makes init coverage check body', () => {
+      const txMeta = generateMockTxMeta();
+      const body = makeInitCoverageCheckBody(txMeta);
+      expect(body).toMatchObject({
+        txParams: [txMeta.txParams],
+      });
+    });
+
+    it('makes init coverage check body with authorization list', () => {
+      const txMeta = generateMockTxMeta();
+      const body = makeInitCoverageCheckBody({
+        ...txMeta,
+        txParams: {
+          ...txMeta.txParams,
+          authorizationList: [
+            {
+              address: '0x0000000000000000000000000000000000000000',
+            },
+          ],
+        },
+      });
+      expect(body).toMatchObject({
+        txParams: [
+          {
+            ...txMeta.txParams,
+            authorizationList: [
+              {
+                address: '0x0000000000000000000000000000000000000000',
+              },
+            ],
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/shield-controller/src/backend.ts
+++ b/packages/shield-controller/src/backend.ts
@@ -286,7 +286,7 @@ export class ShieldRemoteBackend implements ShieldBackend {
  * @param txMeta - The transaction metadata.
  * @returns The body for the init coverage check request.
  */
-function makeInitCoverageCheckBody(
+export function makeInitCoverageCheckBody(
   txMeta: TransactionMeta,
 ): InitCoverageCheckRequest {
   return {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR adds 7702 tx params in shield init and log requests.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds AuthorizationList to transaction coverage init/log request bodies, exports makeInitCoverageCheckBody, and updates tests and changelog.
> 
> - **Backend**:
>   - Update `InitCoverageCheckRequest` to include optional `authorizationList` in `txParams` and propagate it in `makeInitCoverageCheckBody`.
>   - Export `makeInitCoverageCheckBody` from `backend.ts`.
> - **Tests**:
>   - Import and test `makeInitCoverageCheckBody` for cases with/without `authorizationList`.
> - **Docs**:
>   - Update `CHANGELOG.md` noting addition of `AuthorizationList` in transaction init and log requests for 7702 transactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66e016994598d3bccbe18197d5ba6a1bb41d7eb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->