### PR TITLE
chore: Re-enable the ESLint rule `jsdoc/match-description`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,10 +46,6 @@ const config = createConfig([
       'no-restricted-syntax': 'off',
       radix: 'off',
       'require-atomic-updates': 'off',
-      'jsdoc/match-description': [
-        'off',
-        { matchDescription: '^[A-Z`\\d_][\\s\\S]*[.?!`>)}]$' },
-      ],
     },
     settings: {
       jsdoc: {

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -834,8 +834,8 @@ function expectDependenciesForControllersAndServices(
 /**
  * Filter out dependency ranges which are not to be considered in `expectConsistentDependenciesAndDevDependencies`.
  *
- * @param {string} dependencyIdent - The dependency being filtered for
- * @param {Map<string, Dependency>} dependenciesByRange - Dependencies by range
+ * @param {string} dependencyIdent - The dependency being filtered for.
+ * @param {Map<string, Dependency>} dependenciesByRange - Dependencies by range.
  * @returns {Map<string, Dependency>} The resulting map.
  */
 function getInconsistentDependenciesAndDevDependencies(


### PR DESCRIPTION
## Explanation

The rule `jsdoc/match-description` has been re-enabled, and all violations fixed.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables the `jsdoc/match-description` ESLint rule and tidies JSDoc comment punctuation in `yarn.config.cjs`.
> 
> - **ESLint configuration**:
>   - Remove override that disabled `jsdoc/match-description` in `eslint.config.mjs`.
> - **Tooling**:
>   - Update JSDoc param/returns descriptions (punctuation) in `yarn.config.cjs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 030ecb8638fef521e46ecec38bb62a68725da28c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->