### PR TITLE
chore: Re-enable lint rules with no violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,20 +31,14 @@ const config = createConfig([
       'id-length': 'off',
 
       // TODO: re-enble most of these rules
-      'function-paren-newline': 'off',
       'id-denylist': 'off',
-      'implicit-arrow-linebreak': 'off',
-      'import-x/no-anonymous-default-export': 'off',
       'import-x/no-unassigned-import': 'off',
-      'lines-around-comment': 'off',
       'no-async-promise-executor': 'off',
       'no-case-declarations': 'off',
-      'no-invalid-this': 'off',
       'no-negated-condition': 'off',
       'no-new': 'off',
       'no-param-reassign': 'off',
       'no-restricted-syntax': 'off',
-      radix: 'off',
       'require-atomic-updates': 'off',
       'jsdoc/match-description': [
         'off',
@@ -119,14 +113,6 @@ const config = createConfig([
       },
     },
     rules: {
-      // These rules have been customized from their defaults.
-      '@typescript-eslint/switch-exhaustiveness-check': [
-        'error',
-        {
-          considerDefaultExhaustiveForUnions: true,
-        },
-      ],
-
       // TODO: Disable in `eslint-config-typescript`, tracked here: https://github.com/MetaMask/eslint-config/issues/413
       '@typescript-eslint/no-unnecessary-type-arguments': 'off',
 


### PR DESCRIPTION
## Explanation

These lint rules were temporarily disabled at some point in the past, but we still want to use them. There were no violations for any of these rules, so they have been re-enabled.

Whatever violations motivated disabling these must have been incidentally fixed since then.

Additionally, the modifications made for `@typescript-eslint/switch-exhaustiveness-check` are now in the shared config, so the override was no longer needed.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes several `off` overrides to re-enable ESLint rules and drops the custom `@typescript-eslint/switch-exhaustiveness-check` config.
> 
> - **ESLint config (`eslint.config.mjs`)**:
>   - Re-enable defaults by removing `off` overrides for: `function-paren-newline`, `implicit-arrow-linebreak`, `import-x/no-anonymous-default-export`, `lines-around-comment`, `no-invalid-this`, `radix`.
>   - Remove custom rule config for `@typescript-eslint/switch-exhaustiveness-check`.
>   - All other rules/settings remain as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25896e092656aae030bb6c78022fb422f696ebed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->