### PR TITLE
chore: Use stricter TypeScript configuration for linting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,10 @@
 
 yarn.lock linguist-generated=false
 
+# `tsconfig.json` is already recognized as JSONC. This ensures our other `tsconfig` files are as
+# well. They all use this naming convention.
+tsconfig.**.json linguist-language=jsonc
+
 # yarn v3
 # See: https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 /.yarn/releases/** binary

--- a/jest.config.packages.js
+++ b/jest.config.packages.js
@@ -78,7 +78,7 @@ module.exports = {
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   // Here we ensure that Jest resolves `@metamask/*` imports to the uncompiled source code for packages that live in this repo.
-  // NOTE: This must be synchronized with the `paths` option in `tsconfig.packages.json`.
+  // NOTE: This must be synchronized with the `paths` option in `tsconfig.base.json`.
   moduleNameMapper: {
     '^@metamask/json-rpc-engine/v2$': [
       '<rootDir>/../json-rpc-engine/src/v2/index.ts',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  /**
+   * This configuration is extended by all other TypeScript configurations.
+   */
+  "compilerOptions": {
+    "composite": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "target": "ES2020"
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
+  /**
+   * This configuration is used by the `build` script in `package.json`.
+   *
+   * This is just used as a way to request builds for all packages. `tsconfig.base.json` is not
+   * extended here because the `tsconfig.build.json` file referenced for each package already
+   * (indirectly) extends it.
+   */
   "references": [
     { "path": "./packages/account-tree-controller/tsconfig.build.json" },
     { "path": "./packages/accounts-controller/tsconfig.build.json" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
+  /**
+   * This configuration is used by the `lint` script in `package.json`, and by editors such as
+   * VSCode for TypeScript-related features.
+   */
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "esModuleInterop": true,
-    "module": "Node16",
-    "moduleResolution": "Node16",
     "noEmit": true
   },
   "references": [

--- a/tsconfig.packages.build.json
+++ b/tsconfig.packages.build.json
@@ -1,4 +1,7 @@
 {
+  /**
+   * This configuration is extended by the `tsconfig.build.json` configuration in each package.
+   */
   "extends": "./tsconfig.packages.json",
   "compilerOptions": {
     "declaration": true,

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -1,10 +1,9 @@
 {
+  /**
+   * This configuration is extended by the `tsconfig.json` configuration in each package.
+   */
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "esModuleInterop": true,
-    "lib": ["ES2020", "DOM"],
-    "module": "Node16",
-    "moduleResolution": "Node16",
     /**
      * Here we ensure that TypeScript resolves `@metamask/*` imports to the
      * uncompiled source code for packages that live in this repo.
@@ -15,8 +14,6 @@
     "paths": {
       "@metamask/json-rpc-engine/v2": ["../json-rpc-engine/src/v2/index.ts"],
       "@metamask/*": ["../*/src"]
-    },
-    "strict": true,
-    "target": "ES2020"
+    }
   }
 }

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,17 +1,22 @@
 {
+  /**
+   * This configuration is intended for the `scripts/` directory, both for linting and for editor
+   * TypeScript-related features.
+   *
+   * It's currently not actually used for that purpose, but it will be in a future PR.
+   *
+   * This is also extended by the `tsconfig.json` file in `scripts/create-package/`, which _is_
+   * actively used to support TypeScript-related editor features in that directory.
+   */
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "esModuleInterop": true,
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["ES2020"],
-    "module": "Node16",
-    "moduleResolution": "Node16",
     "noEmit": true,
     "noErrorTruncation": true,
-    "noUncheckedIndexedAccess": true,
-    "strict": true,
-    "target": "es2020"
+    "noUncheckedIndexedAccess": true
   },
   "include": ["./scripts/**/*.ts"],
   "exclude": ["**/node_modules"]


### PR DESCRIPTION
## Explanation

The `tsconfig.json` file has been updated to use stricter compiler options, matching what is used in other TSConfig files already. This was a blocker for using the rule
`@typescript-eslint/no-unnecessary-boolean-literal-compare` with newer versions of `typescript-eslint` (it requires `strictNullChecks` to work correctly).

To avoid duplicating this configuration, it was moved to a new file (`tsconfig.base.json`), and extended elsewhere. I've added a comment block to each root-level `tsconfig` file explaining its purpose as well, since it was getting difficult to keep track of them all.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce shared `tsconfig.base.json` and update repo configs and Jest mapping to extend/use it, consolidating strict TS settings.
> 
> - **TypeScript configuration**
>   - Add shared `tsconfig.base.json` with strict compiler options.
>   - Update root `tsconfig.json` to extend base and serve lint/editor use; remove duplicated options.
>   - Update `tsconfig.packages.json` to extend base; keep `paths` for `@metamask/*`.
>   - Update `tsconfig.packages.build.json` to extend packages config; no functional changes beyond inheritance.
>   - Add `tsconfig.build.json` to reference all package build configs (documentation clarified).
>   - Update `tsconfig.scripts.json` to extend base and drop redundant options.
> - **Tooling**
>   - Adjust Jest `moduleNameMapper` comment to reference `tsconfig.base.json`.
>   - Update `.gitattributes` to mark `tsconfig.**.json` as `jsonc` for linguist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22e5a48c54219138e13d7e8b7364fc269c22009b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->