### PR TITLE
chore: add MegaETH multicall3 address

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add multicall address for Chains: `MegaETH Testnet V2`, `MegaETH Mainnet` ([#7287](https://github.com/MetaMask/core/pull/7287))
+
 ## [93.0.0]
 
 ### Added

--- a/packages/assets-controllers/src/multicall.ts
+++ b/packages/assets-controllers/src/multicall.ts
@@ -297,6 +297,10 @@ const MULTICALL_CONTRACT_BY_CHAINID = {
   '0x8f': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // XDC, contract found but not in multicall3 repo
   '0x32': '0x0B1795ccA8E4eC4df02346a082df54D437F8D9aF',
+  // MegaETH TESTNET v2 (timothy chain ID 6343)
+  '0x18c7': '0xcA11bde05977b3631167028862bE2a173976CA11',
+  // MegaETH mainnet, contract found matching multicall3 bytecode
+  '0x10e6': '0xcA11bde05977b3631167028862bE2a173976CA11',
 } as Record<Hex, Hex>;
 
 const multicallAbi = [


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Adding existing Multicall3 implementation of MegaETH to the multicall address book.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Multicall3 addresses for MegaETH Testnet v2 (0x18c7) and MegaETH Mainnet (0x10e6) and record the change in the changelog.
> 
> - **Assets Controllers**
>   - **Multicall support**: Add MegaETH networks to `MULTICALL_CONTRACT_BY_CHAINID` in `packages/assets-controllers/src/multicall.ts`
>     - `0x18c7` (MegaETH Testnet v2) → `0xcA11bde05977b3631167028862bE2a173976CA11`
>     - `0x10e6` (MegaETH Mainnet) → `0xcA11bde05977b3631167028862bE2a173976CA11`
>   - **Changelog**: Note addition of MegaETH Multicall addresses in `packages/assets-controllers/CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55439e2ccc7c74d6363ad29b1454292f70072d8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->