### PR TITLE
chore: Re-enable `@typescript-eslint/no-unnecessary-type-assertions`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -130,7 +130,6 @@ const config = createConfig([
 
       // TODO: re-enable most of these rules
       '@typescript-eslint/naming-convention': 'off',
-      '@typescript-eslint/no-unnecessary-type-assertion': 'off',
       '@typescript-eslint/unbound-method': 'off',
       '@typescript-eslint/prefer-enum-initializers': 'off',
       '@typescript-eslint/prefer-nullish-coalescing': 'off',

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -2386,7 +2386,7 @@ describe('AccountsController', () => {
           name: `${keyringTypeToName(keyringType)} 1`,
           id: 'mock-id',
           address: mockAddress1,
-          keyringType: keyringType as KeyringTypes,
+          keyringType,
           options: createMockInternalAccountOptions(0, keyringType, 0),
         }),
       ];

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -1052,7 +1052,7 @@ export class NftController extends BaseController<
         configuration: { chainId },
       } = this.messenger.call(
         'NetworkController:getNetworkClientById',
-        networkClientId as NetworkClientId,
+        networkClientId,
       );
 
       const nftContracts = allNftContracts[userAddress]?.[chainId] || [];
@@ -1676,7 +1676,7 @@ export class NftController extends BaseController<
       configuration: { chainId },
     } = this.messenger.call(
       'NetworkController:getNetworkClientById',
-      networkClientId as NetworkClientId,
+      networkClientId,
     );
 
     const checksumHexAddress = toChecksumHexAddress(address);
@@ -1718,7 +1718,7 @@ export class NftController extends BaseController<
       configuration: { chainId },
     } = this.messenger.call(
       'NetworkController:getNetworkClientById',
-      networkClientId as NetworkClientId,
+      networkClientId,
     );
     const checksumHexAddress = toChecksumHexAddress(address);
     this.#removeAndIgnoreIndividualNft(checksumHexAddress, tokenId, {
@@ -1769,7 +1769,7 @@ export class NftController extends BaseController<
       configuration: { chainId },
     } = this.messenger.call(
       'NetworkController:getNetworkClientById',
-      networkClientId as NetworkClientId,
+      networkClientId,
     );
     const { address, tokenId } = nft;
     let isOwned = nft.isCurrentlyOwned;
@@ -1845,7 +1845,7 @@ export class NftController extends BaseController<
       configuration: { chainId },
     } = this.messenger.call(
       'NetworkController:getNetworkClientById',
-      networkClientId as NetworkClientId,
+      networkClientId,
     );
     const { allNfts } = this.state;
     const nfts = allNfts[addressToSearch]?.[chainId] || [];
@@ -1896,7 +1896,7 @@ export class NftController extends BaseController<
       configuration: { chainId },
     } = this.messenger.call(
       'NetworkController:getNetworkClientById',
-      networkClientId as NetworkClientId,
+      networkClientId,
     );
     const { allNfts } = this.state;
     const nfts = [...(allNfts[addressToSearch]?.[chainId] || [])];

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -875,9 +875,7 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
 
         // Check if the chainId and token address match any staking contract
         const stakingContractAddress =
-          STAKING_CONTRACT_ADDRESS_BY_CHAINID[
-            r.chainId as keyof typeof STAKING_CONTRACT_ADDRESS_BY_CHAINID
-          ];
+          STAKING_CONTRACT_ADDRESS_BY_CHAINID[r.chainId];
         return (
           stakingContractAddress &&
           stakingContractAddress.toLowerCase() === r.token.toLowerCase()
@@ -1089,7 +1087,7 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
       return;
     }
     this.update((s) => {
-      delete s.tokenBalances[addr as ChecksumAddress];
+      delete s.tokenBalances[addr];
     });
   };
 
@@ -1258,7 +1256,7 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
           'TokenDetectionController:addDetectedTokensViaWs',
           {
             tokensSlice: newTokens,
-            chainId: chainId as Hex,
+            chainId,
           },
         );
       }

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -766,7 +766,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
         // Handle unprocessed networks by adding them to RPC detection
         const unprocessedChainIds = apiResult.unprocessedNetworks.map(
           (chainId: number) => toHex(chainId),
-        ) as Hex[];
+        );
         this.#addChainsToRpcDetection(
           chainsToDetectUsingRpc,
           unprocessedChainIds,

--- a/packages/assets-controllers/src/balances.ts
+++ b/packages/assets-controllers/src/balances.ts
@@ -142,9 +142,7 @@ function getEvmTokenBalances(
       const { chainId, tokenAddress, balance } = tokenBalance;
 
       const stakingContractAddress =
-        STAKING_CONTRACT_ADDRESS_BY_CHAINID[
-          chainId as keyof typeof STAKING_CONTRACT_ADDRESS_BY_CHAINID
-        ];
+        STAKING_CONTRACT_ADDRESS_BY_CHAINID[chainId];
       const isNative = tokenAddress === ZERO_ADDRESS;
       const isStakedNative = stakingContractAddress
         ? tokenAddress.toLowerCase() === stakingContractAddress.toLowerCase()
@@ -163,8 +161,8 @@ function getEvmTokenBalances(
       // Get market data
       const marketDataAddress =
         isNative || isStakedNative
-          ? getNativeTokenAddress(chainId as Hex)
-          : (tokenAddress as Hex);
+          ? getNativeTokenAddress(chainId)
+          : tokenAddress;
       const tokenMarketData =
         tokenRatesState?.marketData?.[chainId]?.[marketDataAddress];
       if (!tokenMarketData?.price) {
@@ -185,9 +183,7 @@ function getEvmTokenBalances(
         const accountTokens =
           tokensState?.allTokens?.[chainId]?.[account.address];
         const token = accountTokens?.find((t) => t.address === tokenAddress);
-        decimals = isNonNaNNumber(token?.decimals)
-          ? (token?.decimals as number)
-          : 18;
+        decimals = isNonNaNNumber(token?.decimals) ? token?.decimals : 18;
       }
       const decimalBalance = parseInt(balance, 16);
       if (!isNonNaNNumber(decimalBalance)) {

--- a/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
+++ b/packages/assets-controllers/src/crypto-compare-service/crypto-compare.ts
@@ -149,10 +149,9 @@ export async function fetchMultiExchangeRate(
   handleErrorResponse(response);
 
   const rates: Record<string, Record<string, number>> = {};
-  for (const [cryptocurrency, values] of Object.entries(response) as [
-    string,
-    Record<string, number>,
-  ][]) {
+  for (const [cryptocurrency, values] of Object.entries<Record<string, number>>(
+    response,
+  )) {
     const key = getKeyByValue(nativeSymbolOverrides, cryptocurrency);
     rates[key?.toLowerCase() ?? cryptocurrency.toLowerCase()] = {
       [fiatCurrency.toLowerCase()]: values[fiatCurrency.toUpperCase()],

--- a/packages/assets-controllers/src/multi-chain-accounts-service/api-balance-fetcher.test.ts
+++ b/packages/assets-controllers/src/multi-chain-accounts-service/api-balance-fetcher.test.ts
@@ -2043,8 +2043,7 @@ describe('AccountsApiBalanceFetcher', () => {
 
       // Create 60 accounts to force batching (50 per batch)
       for (let i = 0; i < 60; i++) {
-        const address =
-          `0x${i.toString(16).padStart(40, '0')}` as ChecksumAddress;
+        const address = `0x${i.toString(16).padStart(40, '0')}` as const;
         largeAccountList.push({
           id: i.toString(),
           address,
@@ -2157,8 +2156,7 @@ describe('AccountsApiBalanceFetcher', () => {
 
       // Create 55 accounts to force batching
       for (let i = 0; i < 55; i++) {
-        const address =
-          `0x${i.toString(16).padStart(40, '0')}` as ChecksumAddress;
+        const address = `0x${i.toString(16).padStart(40, '0')}` as const;
         largeAccountList.push({
           id: i.toString(),
           address,

--- a/packages/assets-controllers/src/multi-chain-accounts-service/api-balance-fetcher.ts
+++ b/packages/assets-controllers/src/multi-chain-accounts-service/api-balance-fetcher.ts
@@ -95,7 +95,7 @@ export class AccountsApiBalanceFetcher implements BalanceFetcher {
 
     for (const caipAddr of addrs) {
       const [, chainRef, address] = caipAddr.split(':');
-      const chainId = toHex(parseInt(chainRef, 10)) as ChainIdHex;
+      const chainId = toHex(parseInt(chainRef, 10));
       const checksumAddress = checksum(address);
 
       if (!addressesByChain[chainId]) {
@@ -123,10 +123,7 @@ export class AccountsApiBalanceFetcher implements BalanceFetcher {
         continue;
       }
 
-      const contractAddress =
-        STAKING_CONTRACT_ADDRESS_BY_CHAINID[
-          chainIdHex as keyof typeof STAKING_CONTRACT_ADDRESS_BY_CHAINID
-        ];
+      const contractAddress = STAKING_CONTRACT_ADDRESS_BY_CHAINID[chainIdHex];
       const provider = this.#getProvider(chainIdHex);
 
       const abi = [
@@ -173,7 +170,7 @@ export class AccountsApiBalanceFetcher implements BalanceFetcher {
                   success: true,
                   value: new BN((assets as BigNumber).toString()),
                   account: address,
-                  token: checksum(contractAddress) as ChecksumAddress,
+                  token: checksum(contractAddress),
                   chainId: chainIdHex,
                 });
               }
@@ -183,7 +180,7 @@ export class AccountsApiBalanceFetcher implements BalanceFetcher {
                 success: true,
                 value: new BN('0'),
                 account: address,
-                token: checksum(contractAddress) as ChecksumAddress,
+                token: checksum(contractAddress),
                 chainId: chainIdHex,
               });
             }
@@ -196,7 +193,7 @@ export class AccountsApiBalanceFetcher implements BalanceFetcher {
             results.push({
               success: false,
               account: address,
-              token: checksum(contractAddress) as ChecksumAddress,
+              token: checksum(contractAddress),
               chainId: chainIdHex,
             });
           }
@@ -298,9 +295,7 @@ export class AccountsApiBalanceFetcher implements BalanceFetcher {
     // Extract unprocessed networks and convert to hex chain IDs
     const unprocessedChainIds: ChainIdHex[] | undefined =
       apiResponse.unprocessedNetworks
-        ? apiResponse.unprocessedNetworks.map(
-            (chainId) => toHex(chainId) as ChainIdHex,
-          )
+        ? apiResponse.unprocessedNetworks.map((chainId) => toHex(chainId))
         : undefined;
 
     const stakedBalances = await this.#fetchStakedBalances(caipAddrs);
@@ -311,7 +306,7 @@ export class AccountsApiBalanceFetcher implements BalanceFetcher {
     const addressChainMap = new Map<string, Set<ChainIdHex>>();
     caipAddrs.forEach((caipAddr) => {
       const [, chainRef, address] = caipAddr.split(':');
-      const chainId = toHex(parseInt(chainRef, 10)) as ChainIdHex;
+      const chainId = toHex(parseInt(chainRef, 10));
       const checksumAddress = checksum(address);
 
       if (!addressChainMap.has(checksumAddress)) {
@@ -339,7 +334,7 @@ export class AccountsApiBalanceFetcher implements BalanceFetcher {
         // by mgrating tokenBalancesController to checksum addresses
         const finalAccount: ChecksumAddress | string =
           token === ZERO_ADDRESS ? account : addressPart;
-        const chainId = toHex(b.chainId) as ChainIdHex;
+        const chainId = toHex(b.chainId);
 
         let value: BN | undefined;
         try {

--- a/packages/assets-controllers/src/multicall.ts
+++ b/packages/assets-controllers/src/multicall.ts
@@ -801,10 +801,7 @@ const getStakedBalancesFallback = async (
 ): Promise<Record<string, BN>> => {
   const stakedBalanceMap: Record<string, BN> = {};
 
-  const stakingContractAddress =
-    STAKING_CONTRACT_ADDRESS_BY_CHAINID[
-      chainId as keyof typeof STAKING_CONTRACT_ADDRESS_BY_CHAINID
-    ];
+  const stakingContractAddress = STAKING_CONTRACT_ADDRESS_BY_CHAINID[chainId];
 
   if (!stakingContractAddress) {
     // No staking support for this chain
@@ -854,10 +851,7 @@ export const getStakedBalancesForAddresses = async (
   chainId: Hex,
   provider: Web3Provider,
 ): Promise<Record<string, BN>> => {
-  const stakingContractAddress =
-    STAKING_CONTRACT_ADDRESS_BY_CHAINID[
-      chainId as keyof typeof STAKING_CONTRACT_ADDRESS_BY_CHAINID
-    ];
+  const stakingContractAddress = STAKING_CONTRACT_ADDRESS_BY_CHAINID[chainId];
 
   if (!stakingContractAddress) {
     return {};
@@ -978,11 +972,7 @@ export const getTokenBalancesForMultipleAddresses = async (
   );
 
   // Check if Multicall3 is supported on this chain
-  if (
-    !MULTICALL_CONTRACT_BY_CHAINID[
-      chainId as keyof typeof MULTICALL_CONTRACT_BY_CHAINID
-    ]
-  ) {
+  if (!MULTICALL_CONTRACT_BY_CHAINID[chainId]) {
     // Fallback to individual balance calls when Multicall3 is not supported
     const tokenBalances = await getTokenBalancesFallback(
       uniqueTokenAddresses,

--- a/packages/assets-controllers/src/rpc-service/rpc-balance-fetcher.ts
+++ b/packages/assets-controllers/src/rpc-service/rpc-balance-fetcher.ts
@@ -74,9 +74,7 @@ export class RpcBalanceFetcher implements BalanceFetcher {
   }
 
   #getStakingContractAddress(chainId: ChainIdHex): string | undefined {
-    return STAKING_CONTRACT_ADDRESS_BY_CHAINID[
-      chainId as keyof typeof STAKING_CONTRACT_ADDRESS_BY_CHAINID
-    ];
+    return STAKING_CONTRACT_ADDRESS_BY_CHAINID[chainId];
   }
 
   async fetch({
@@ -136,7 +134,7 @@ export class RpcBalanceFetcher implements BalanceFetcher {
         const nativeBalance = tokenBalances[ZERO_ADDRESS]?.[address] || null;
         chainResults.push({
           success: true,
-          value: nativeBalance ? (nativeBalance as BN) : new BN('0'),
+          value: nativeBalance || new BN('0'),
           account: address as ChecksumAddress,
           token: ZERO_ADDRESS,
           chainId,
@@ -152,7 +150,7 @@ export class RpcBalanceFetcher implements BalanceFetcher {
         Object.entries(balances).forEach(([acct, bn]) => {
           chainResults.push({
             success: bn !== null,
-            value: bn as BN,
+            value: bn,
             account: acct as ChecksumAddress,
             token: checksum(tokenAddr),
             chainId,
@@ -175,7 +173,7 @@ export class RpcBalanceFetcher implements BalanceFetcher {
           const stakedBalance = stakedBalances?.[address] || null;
           chainResults.push({
             success: true,
-            value: stakedBalance ? (stakedBalance as BN) : new BN('0'),
+            value: stakedBalance || new BN('0'),
             account: address as ChecksumAddress,
             token: checksummedStakingAddress,
             chainId,
@@ -248,7 +246,7 @@ function buildAccountTokenGroupsStatic(
     if (!shouldInclude) {
       return;
     }
-    (tokens as unknown[]).forEach((t: unknown) =>
+    tokens.forEach((t: unknown) =>
       pairs.push({
         accountAddress: account as ChecksumAddress,
         tokenAddress: checksum((t as { address: string }).address),

--- a/packages/build-utils/src/transforms/remove-fenced-code.ts
+++ b/packages/build-utils/src/transforms/remove-fenced-code.ts
@@ -262,8 +262,7 @@ export function removeFencedCode(
       // Forbid empty fences
       const { line: previousLine, indices: previousIndices } =
         // We're only in this case if i > 0, so this will always be defined.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        parsedDirectives[i - 1]!;
+        parsedDirectives[i - 1];
       if (fileContent.substring(previousIndices[1], indices[0]).trim() === '') {
         throw new Error(
           `Empty fence found in file "${filePath}":\n${previousLine}\n${line}\n`,
@@ -320,7 +319,7 @@ export function multiSplice(
     throw new Error('Expected array of non-negative integers.');
   }
 
-  const retainedSubstrings = [];
+  const retainedSubstrings: string[] = [];
 
   // Get the first part to be included
   // The substring() call returns an empty string if splicingIndices[0] is 0,
@@ -340,8 +339,7 @@ export function multiSplice(
       retainedSubstrings.push(
         // splicingIndices[i] refers to an element between the first and last
         // elements of the array, and will always be defined.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        toSplice.substring(splicingIndices[i]!, splicingIndices[i + 1]),
+        toSplice.substring(splicingIndices[i], splicingIndices[i + 1]),
       );
     }
   }
@@ -349,8 +347,7 @@ export function multiSplice(
   // Get the last part to be included
   retainedSubstrings.push(
     // The last element of a non-empty array will always be defined.
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    toSplice.substring(splicingIndices[splicingIndices.length - 1]!),
+    toSplice.substring(splicingIndices[splicingIndices.length - 1]),
   );
   return retainedSubstrings.join('');
 }

--- a/packages/chain-agnostic-permission/src/operators/caip-permission-operator-accounts.ts
+++ b/packages/chain-agnostic-permission/src/operators/caip-permission-operator-accounts.ts
@@ -244,7 +244,7 @@ const setNonSCACaipAccountIdsInScopesObject = (
   const updatedScopesObject: InternalScopesObject = {};
 
   for (const [scopeString, scopeObject] of Object.entries(scopesObject)) {
-    const { namespace, reference } = parseScopeString(scopeString as string);
+    const { namespace, reference } = parseScopeString(scopeString);
 
     let caipAccounts: CaipAccountId[] = [];
 
@@ -252,7 +252,7 @@ const setNonSCACaipAccountIdsInScopesObject = (
       const addressSet = accountsByNamespace.get(namespace);
       if (addressSet) {
         caipAccounts = Array.from(addressSet).map(
-          (address) => `${namespace}:${reference}:${address}` as CaipAccountId,
+          (address) => `${namespace}:${reference}:${address}` as const,
         );
       }
     }

--- a/packages/core-backend/src/BackendWebSocketService.ts
+++ b/packages/core-backend/src/BackendWebSocketService.ts
@@ -530,8 +530,7 @@ export class BackendWebSocketService {
     log('Forcing WebSocket reconnection to clean up subscription state');
 
     // This ensures ws.onclose will schedule a reconnect (not treat it as manual disconnect)
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this.#ws!.close(FORCE_RECONNECT_CODE, FORCE_RECONNECT_REASON);
+    this.#ws.close(FORCE_RECONNECT_CODE, FORCE_RECONNECT_REASON);
   }
 
   /**
@@ -1130,7 +1129,7 @@ export class BackendWebSocketService {
 
     // Trigger channel callbacks for any message with a channel property
     if (this.#isChannelMessage(message)) {
-      const channelMsg = message as ServerNotificationMessage;
+      const channelMsg = message;
       this.#handleChannelMessage(channelMsg);
     }
   }

--- a/packages/delegation-controller/src/DelegationController.test.ts
+++ b/packages/delegation-controller/src/DelegationController.test.ts
@@ -413,12 +413,12 @@ describe(`${controllerName}`, () => {
       const { controller } = createController();
       const parentDelegation = {
         ...DELEGATION_MOCK,
-        authority: ROOT_AUTHORITY as Hex,
+        authority: ROOT_AUTHORITY,
       };
       const parentHash = hashDelegationMock(parentDelegation);
       const childDelegation = {
         ...DELEGATION_MOCK,
-        authority: parentHash as Hex,
+        authority: parentHash,
       };
       const childHash = hashDelegationMock(childDelegation);
       const parentEntry = {
@@ -473,7 +473,7 @@ describe(`${controllerName}`, () => {
       const { controller } = createController();
       const rootDelegation = {
         ...DELEGATION_MOCK,
-        authority: ROOT_AUTHORITY as Hex,
+        authority: ROOT_AUTHORITY,
       };
       const rootEntry = {
         ...DELEGATION_ENTRY_MOCK,
@@ -481,7 +481,7 @@ describe(`${controllerName}`, () => {
       };
       controller.store({ entry: rootEntry });
 
-      const result = controller.chain(ROOT_AUTHORITY as Hex);
+      const result = controller.chain(ROOT_AUTHORITY);
 
       expect(result).toBeNull();
     });
@@ -504,12 +504,12 @@ describe(`${controllerName}`, () => {
       const { controller } = createController();
       const parentDelegation = {
         ...DELEGATION_MOCK,
-        authority: ROOT_AUTHORITY as Hex,
+        authority: ROOT_AUTHORITY,
       };
       const parentHash = hashDelegationMock(parentDelegation);
       const childDelegation = {
         ...DELEGATION_MOCK,
-        authority: parentHash as Hex,
+        authority: parentHash,
       };
       const childHash = hashDelegationMock(childDelegation);
       const parentEntry = {
@@ -534,7 +534,7 @@ describe(`${controllerName}`, () => {
       const { controller } = createController();
       const parentDelegation = {
         ...DELEGATION_MOCK,
-        authority: ROOT_AUTHORITY as Hex,
+        authority: ROOT_AUTHORITY,
       };
       const parentHash = hashDelegationMock(parentDelegation);
       const child1Delegation = {
@@ -585,7 +585,7 @@ describe(`${controllerName}`, () => {
       //                           -> child2 -> grandchild2
       const rootDelegation = {
         ...DELEGATION_MOCK,
-        authority: ROOT_AUTHORITY as Hex,
+        authority: ROOT_AUTHORITY,
         salt: '0x0' as Hex,
       };
       const rootHash = hashDelegationMock(rootDelegation);

--- a/packages/eip-5792-middleware/src/hooks/getCapabilities.ts
+++ b/packages/eip-5792-middleware/src/hooks/getCapabilities.ts
@@ -109,7 +109,7 @@ export async function getCapabilities(
     }
 
     const status = isSupported ? 'supported' : 'ready';
-    const hexChainId = chainId as Hex;
+    const hexChainId = chainId;
 
     if (acc[hexChainId] === undefined) {
       acc[hexChainId] = {};
@@ -186,7 +186,7 @@ async function getAlternateGasFeesCapability(
         (isSupported && relaySupportedForChain));
 
     if (alternateGasFees) {
-      acc[chainId as Hex] = {
+      acc[chainId] = {
         alternateGasFees: {
           supported: true,
         },

--- a/packages/eip-7702-internal-rpc-middleware/src/wallet_getAccountUpgradeStatus.ts
+++ b/packages/eip-7702-internal-rpc-middleware/src/wallet_getAccountUpgradeStatus.ts
@@ -42,7 +42,7 @@ const isAccountUpgraded = async (
   }
 
   // Extract the 20-byte address (40 hex characters after the prefix)
-  const upgradedAddress = `0x${code.slice(8, 48)}` as Hex;
+  const upgradedAddress = `0x${code.slice(8, 48)}` as const;
 
   return { isUpgraded: true, upgradedAddress };
 };

--- a/packages/foundryup/src/options.ts
+++ b/packages/foundryup/src/options.ts
@@ -155,7 +155,7 @@ function getOptions(
       alias: 'a',
       description: 'Specify the architecture',
       // if `defaultArch` is not a supported Architecture yargs will throw an error
-      default: defaultArch as Architecture,
+      default: defaultArch,
       choices: Object.values(Architecture) as ArchitecturesTuple,
     },
     platform: {

--- a/packages/gator-permissions-controller/src/decodePermission/decodePermission.test.ts
+++ b/packages/gator-permissions-controller/src/decodePermission/decodePermission.test.ts
@@ -543,7 +543,7 @@ describe('decodePermission', () => {
         const caveats = [
           {
             enforcer: TimestampEnforcer,
-            terms: `0x${'0'.repeat(68)}` as Hex,
+            terms: `0x${'0'.repeat(68)}` as const,
             args: '0x',
           } as const,
           {

--- a/packages/gator-permissions-controller/src/decodePermission/utils.test.ts
+++ b/packages/gator-permissions-controller/src/decodePermission/utils.test.ts
@@ -31,23 +31,23 @@ describe('getChecksumEnforcersByChainId', () => {
 
     expect(result).toStrictEqual({
       erc20StreamingEnforcer: getChecksumAddress(
-        contracts.ERC20StreamingEnforcer as Hex,
+        contracts.ERC20StreamingEnforcer,
       ),
       erc20PeriodicEnforcer: getChecksumAddress(
-        contracts.ERC20PeriodTransferEnforcer as Hex,
+        contracts.ERC20PeriodTransferEnforcer,
       ),
       nativeTokenStreamingEnforcer: getChecksumAddress(
-        contracts.NativeTokenStreamingEnforcer as Hex,
+        contracts.NativeTokenStreamingEnforcer,
       ),
       nativeTokenPeriodicEnforcer: getChecksumAddress(
-        contracts.NativeTokenPeriodTransferEnforcer as Hex,
+        contracts.NativeTokenPeriodTransferEnforcer,
       ),
       exactCalldataEnforcer: getChecksumAddress(
-        contracts.ExactCalldataEnforcer as Hex,
+        contracts.ExactCalldataEnforcer,
       ),
-      valueLteEnforcer: getChecksumAddress(contracts.ValueLteEnforcer as Hex),
-      timestampEnforcer: getChecksumAddress(contracts.TimestampEnforcer as Hex),
-      nonceEnforcer: getChecksumAddress(contracts.NonceEnforcer as Hex),
+      valueLteEnforcer: getChecksumAddress(contracts.ValueLteEnforcer),
+      timestampEnforcer: getChecksumAddress(contracts.TimestampEnforcer),
+      nonceEnforcer: getChecksumAddress(contracts.NonceEnforcer),
     });
   });
 

--- a/packages/gator-permissions-controller/src/decodePermission/utils.ts
+++ b/packages/gator-permissions-controller/src/decodePermission/utils.ts
@@ -234,7 +234,7 @@ export function splitHex(value: Hex, lengths: number[]): Hex[] {
     const partCharLength = partLength * 2;
     const part = value.slice(start, start + partCharLength);
     start += partCharLength;
-    parts.push(`0x${part}` as Hex);
+    parts.push(`0x${part}` as const);
   }
   return parts;
 }

--- a/packages/gator-permissions-controller/src/test/mocks.ts
+++ b/packages/gator-permissions-controller/src/test/mocks.ts
@@ -17,7 +17,7 @@ export const mockNativeTokenStreamStorageEntry = (
   chainId: Hex,
 ): StoredGatorPermission<AccountSigner, NativeTokenStreamPermission> => ({
   permissionResponse: {
-    chainId: chainId as Hex,
+    chainId,
     address: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
     signer: {
       type: 'account',
@@ -53,7 +53,7 @@ export const mockNativeTokenPeriodicStorageEntry = (
   chainId: Hex,
 ): StoredGatorPermission<AccountSigner, NativeTokenPeriodicPermission> => ({
   permissionResponse: {
-    chainId: chainId as Hex,
+    chainId,
     address: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
     signer: {
       type: 'account',
@@ -88,7 +88,7 @@ export const mockErc20TokenStreamStorageEntry = (
   chainId: Hex,
 ): StoredGatorPermission<AccountSigner, Erc20TokenStreamPermission> => ({
   permissionResponse: {
-    chainId: chainId as Hex,
+    chainId,
     address: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
     signer: {
       type: 'account',
@@ -125,7 +125,7 @@ export const mockErc20TokenPeriodicStorageEntry = (
   chainId: Hex,
 ): StoredGatorPermission<AccountSigner, Erc20TokenPeriodicPermission> => ({
   permissionResponse: {
-    chainId: chainId as Hex,
+    chainId,
     address: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
     signer: {
       type: 'account',
@@ -162,7 +162,7 @@ export const mockCustomPermissionStorageEntry = (
   data: Record<string, unknown>,
 ): StoredGatorPermission<AccountSigner, CustomPermission> => ({
   permissionResponse: {
-    chainId: chainId as Hex,
+    chainId,
     address: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
     signer: {
       type: 'account',

--- a/packages/json-rpc-engine/src/v2/JsonRpcEngineV2.test.ts
+++ b/packages/json-rpc-engine/src/v2/JsonRpcEngineV2.test.ts
@@ -341,7 +341,7 @@ describe('JsonRpcEngineV2', () => {
           string | undefined,
           Context
         > = ({ context }) => {
-          return context.get('foo') as string | undefined;
+          return context.get('foo');
         };
         const engine = JsonRpcEngineV2.create({
           middleware: [middleware1, middleware2],

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1172,9 +1172,9 @@ export class KeyringController<
         default:
           throw new Error(`Unexpected import strategy: '${String(strategy)}'`);
       }
-      const newKeyring = (await this.#newKeyring(KeyringTypes.simple, [
+      const newKeyring = await this.#newKeyring(KeyringTypes.simple, [
         privateKey,
-      ])) as EthKeyring;
+      ]);
       const accounts = await newKeyring.getAccounts();
       return accounts[0];
     });
@@ -2317,7 +2317,7 @@ export class KeyringController<
   async #createKeyringWithFirstAccount(type: string, opts?: unknown) {
     this.#assertControllerMutexIsLocked();
 
-    const keyring = (await this.#newKeyring(type, opts)) as EthKeyring;
+    const keyring = await this.#newKeyring(type, opts);
 
     const [firstAccount] = await keyring.getAccounts();
     if (!firstAccount) {

--- a/packages/message-manager/src/AbstractMessageManager.ts
+++ b/packages/message-manager/src/AbstractMessageManager.ts
@@ -299,10 +299,7 @@ export abstract class AbstractMessageManager<
       status === 'errored' ||
       this.additionalFinishStatuses.includes(status)
     ) {
-      this.internalEvents.emit(
-        `${messageId as string}:finished`,
-        updatedMessage,
-      );
+      this.internalEvents.emit(`${messageId}:finished`, updatedMessage);
     }
   }
 

--- a/packages/multichain-account-service/src/providers/TrxAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/TrxAccountProvider.test.ts
@@ -143,7 +143,7 @@ function setup({
       handleRequest: mockHandleRequest,
       keyring: {
         createAccount: keyring.createAccount as jest.Mock,
-        discoverAccounts: keyring.discoverAccounts as jest.Mock,
+        discoverAccounts: keyring.discoverAccounts,
       },
     },
   };

--- a/packages/network-enablement-controller/src/selectors.ts
+++ b/packages/network-enablement-controller/src/selectors.ts
@@ -65,7 +65,7 @@ export const createSelectorForEnabledNetworksForNamespace = (
 export const selectAllEnabledNetworks = createSelector(
   selectEnabledNetworkMap,
   (enabledNetworkMap) => {
-    return (Object.keys(enabledNetworkMap) as CaipNamespace[]).reduce(
+    return Object.keys(enabledNetworkMap).reduce(
       (acc, ns) => {
         acc[ns] = Object.entries(enabledNetworkMap[ns])
           .filter(([, enabled]) => enabled)

--- a/packages/notification-services-controller/src/NotificationServicesController/processors/process-notifications.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/processors/process-notifications.ts
@@ -48,9 +48,7 @@ export function processNotification(
   };
 
   if (isFeatureAnnouncement(notification)) {
-    const n = processFeatureAnnouncement(
-      notification as FeatureAnnouncementRawNotification,
-    );
+    const n = processFeatureAnnouncement(notification);
     n.isRead = isFeatureAnnouncementRead(n, readNotifications);
     return n;
   }
@@ -63,7 +61,7 @@ export function processNotification(
     return processAPINotifications(notification);
   }
 
-  return exhaustedAllCases(notification as never);
+  return exhaustedAllCases(notification);
 }
 
 /**

--- a/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
+++ b/packages/remote-feature-flag-controller/src/utils/user-segmentation-utils.test.ts
@@ -11,8 +11,8 @@ const MOCK_METRICS_IDS = {
     '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
   MOBILE_MIN: '00000000-0000-4000-8000-000000000000',
   MOBILE_MAX: 'ffffffff-ffff-4fff-bfff-ffffffffffff',
-  EXTENSION_MIN: `0x${'0'.repeat(64) as string}`,
-  EXTENSION_MAX: `0x${'f'.repeat(64) as string}`,
+  EXTENSION_MIN: `0x${'0'.repeat(64)}`,
+  EXTENSION_MAX: `0x${'f'.repeat(64)}`,
   UUID_V3: '00000000-0000-3000-8000-000000000000',
   INVALID_HEX_NO_PREFIX:
     '86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -873,7 +873,7 @@ describe('SignatureController', () => {
             data: JSON.stringify({ test: 123 }),
           },
           REQUEST_MOCK,
-          version as SignTypedDataVersion,
+          version,
           { parseJsonData: true },
         );
 

--- a/packages/signature-controller/src/SignatureController.ts
+++ b/packages/signature-controller/src/SignatureController.ts
@@ -414,7 +414,7 @@ export class SignatureController extends BaseController<
 
     const normalizedMessageParams = normalizeTypedMessageParams(
       messageParams,
-      version as SignTypedDataVersion,
+      version,
     );
 
     return this.#processSignatureRequest({

--- a/packages/signature-controller/src/utils/decoding-api.ts
+++ b/packages/signature-controller/src/utils/decoding-api.ts
@@ -48,7 +48,7 @@ export async function decodeSignature(
   } catch (error: unknown) {
     return {
       error: {
-        message: (error as unknown as Error).message,
+        message: (error as Error).message,
         type: DECODING_API_ERRORS.DECODING_FAILED_WITH_ERROR,
       },
     };

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -1248,9 +1248,7 @@ export class TransactionController extends BaseController<
     txParams = normalizeTransactionParams(txParams);
 
     if (!this.#multichainTrackingHelper.has(networkClientId)) {
-      throw new Error(
-        `Network client not found - ${networkClientId as string}`,
-      );
+      throw new Error(`Network client not found - ${networkClientId}`);
     }
 
     const chainId = this.#getChainId(networkClientId);
@@ -2444,9 +2442,7 @@ export class TransactionController extends BaseController<
 
     if (
       status &&
-      [TransactionStatus.submitted, TransactionStatus.failed].includes(
-        status as TransactionStatus,
-      )
+      [TransactionStatus.submitted, TransactionStatus.failed].includes(status)
     ) {
       this.messenger.publish(
         `${controllerName}:transactionFinished`,
@@ -4466,7 +4462,7 @@ export class TransactionController extends BaseController<
       transactionMeta;
 
     const { networkConfigurationsByChainId } = this.#getNetworkState();
-    const networkConfiguration = networkConfigurationsByChainId[chainId as Hex];
+    const networkConfiguration = networkConfigurationsByChainId[chainId];
 
     const endpoint = networkConfiguration?.rpcEndpoints.find(
       (currentEndpoint) => currentEndpoint.networkClientId === networkClientId,

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -1181,7 +1181,7 @@ describe('TransactionController Integration', () => {
       ),
     ).rejects.toThrow(
       `Network client not found - ${
-        networkConfiguration.rpcEndpoints[0].networkClientId as string
+        networkConfiguration.rpcEndpoints[0].networkClientId
       }`,
     );
 

--- a/packages/transaction-controller/src/gas-flows/DefaultGasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/DefaultGasFeeFlow.ts
@@ -44,15 +44,11 @@ export class DefaultGasFeeFlow implements GasFeeFlow {
         break;
       case GAS_ESTIMATE_TYPES.LEGACY:
         log('Using legacy estimates', gasFeeEstimates);
-        response = this.#getLegacyEstimates(
-          gasFeeEstimates as LegacyGasPriceEstimate,
-        );
+        response = this.#getLegacyEstimates(gasFeeEstimates);
         break;
       case GAS_ESTIMATE_TYPES.ETH_GASPRICE:
         log('Using eth_gasPrice estimates', gasFeeEstimates);
-        response = this.#getGasPriceEstimates(
-          gasFeeEstimates as EthGasPriceEstimate,
-        );
+        response = this.#getGasPriceEstimates(gasFeeEstimates);
         break;
       default:
         throw new Error(`Unsupported gas estimate type: ${gasEstimateType}`);

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
@@ -264,7 +264,7 @@ describe('OracleLayer1GasFeeFlow', () => {
               .add(bnFromHex(OPERATOR_FEE_MOCK))
               .toString(16),
           ),
-        ) as Hex,
+        ),
       });
     });
 

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
@@ -128,7 +128,7 @@ export abstract class OracleLayer1GasFeeFlow implements Layer1GasFeeFlow {
       return {
         layer1Fee: add0x(
           padHexToEvenLength(oracleFee.add(operatorFee).toString(16)),
-        ) as Hex,
+        ),
       };
     } catch (error) {
       log('Failed to get oracle layer 1 gas fee', error);

--- a/packages/transaction-controller/src/gas-flows/RandomisedEstimationsGasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/RandomisedEstimationsGasFeeFlow.ts
@@ -183,7 +183,7 @@ export function randomiseDecimalGWEIAndConvertToHex(
 
   // Handle the case when the value is 0 or too small
   if (Number(weiDecimalValue) === 0 || effectiveDigitsToRandomise <= 0) {
-    return `0x${Number(weiDecimalValue).toString(16)}` as Hex;
+    return `0x${Number(weiDecimalValue).toString(16)}` as const;
   }
 
   // Use string manipulation to get the base part (significant digits)

--- a/packages/transaction-controller/src/helpers/AccountsApiRemoteTransactionSource.ts
+++ b/packages/transaction-controller/src/helpers/AccountsApiRemoteTransactionSource.ts
@@ -136,7 +136,7 @@ export class AccountsApiRemoteTransactionSource
     responseTransaction: GetAccountTransactionsResponse['data'][0],
   ): Promise<TransactionMeta> {
     const blockNumber = String(responseTransaction.blockNumber);
-    const chainId = `0x${responseTransaction.chainId.toString(16)}` as Hex;
+    const chainId = `0x${responseTransaction.chainId.toString(16)}` as const;
     const { hash } = responseTransaction;
     const time = new Date(responseTransaction.timestamp).getTime();
     const id = random({ msecs: time });

--- a/packages/transaction-controller/src/helpers/GasFeePoller.ts
+++ b/packages/transaction-controller/src/helpers/GasFeePoller.ts
@@ -17,10 +17,7 @@ import type {
   GasFeeEstimates,
   GasFeeFlow,
   GasFeeFlowRequest,
-  GasPriceGasFeeEstimates,
-  FeeMarketGasFeeEstimates,
   Layer1GasFeeFlow,
-  LegacyGasFeeEstimates,
   TransactionMeta,
   TransactionParams,
   TransactionBatchMeta,
@@ -528,8 +525,7 @@ function updateGasFeeParameters(
   if (isEIP1559Compatible) {
     // Handle EIP-1559 compatible transactions
     if (gasEstimateType === GasFeeEstimateType.FeeMarket) {
-      const feeMarketGasFeeEstimates =
-        gasFeeEstimates as FeeMarketGasFeeEstimates;
+      const feeMarketGasFeeEstimates = gasFeeEstimates;
       txParams.maxFeePerGas =
         feeMarketGasFeeEstimates[userFeeLevel]?.maxFeePerGas;
       txParams.maxPriorityFeePerGas =
@@ -537,14 +533,13 @@ function updateGasFeeParameters(
     }
 
     if (gasEstimateType === GasFeeEstimateType.GasPrice) {
-      const gasPriceGasFeeEstimates =
-        gasFeeEstimates as GasPriceGasFeeEstimates;
+      const gasPriceGasFeeEstimates = gasFeeEstimates;
       txParams.maxFeePerGas = gasPriceGasFeeEstimates.gasPrice;
       txParams.maxPriorityFeePerGas = gasPriceGasFeeEstimates.gasPrice;
     }
 
     if (gasEstimateType === GasFeeEstimateType.Legacy) {
-      const legacyGasFeeEstimates = gasFeeEstimates as LegacyGasFeeEstimates;
+      const legacyGasFeeEstimates = gasFeeEstimates;
       const gasPrice = legacyGasFeeEstimates[userFeeLevel];
       txParams.maxFeePerGas = gasPrice;
       txParams.maxPriorityFeePerGas = gasPrice;
@@ -555,19 +550,17 @@ function updateGasFeeParameters(
   } else {
     // Handle non-EIP-1559 transactions
     if (gasEstimateType === GasFeeEstimateType.FeeMarket) {
-      const feeMarketGasFeeEstimates =
-        gasFeeEstimates as FeeMarketGasFeeEstimates;
+      const feeMarketGasFeeEstimates = gasFeeEstimates;
       txParams.gasPrice = feeMarketGasFeeEstimates[userFeeLevel]?.maxFeePerGas;
     }
 
     if (gasEstimateType === GasFeeEstimateType.GasPrice) {
-      const gasPriceGasFeeEstimates =
-        gasFeeEstimates as GasPriceGasFeeEstimates;
+      const gasPriceGasFeeEstimates = gasFeeEstimates;
       txParams.gasPrice = gasPriceGasFeeEstimates.gasPrice;
     }
 
     if (gasEstimateType === GasFeeEstimateType.Legacy) {
-      const legacyGasFeeEstimates = gasFeeEstimates as LegacyGasFeeEstimates;
+      const legacyGasFeeEstimates = gasFeeEstimates;
       txParams.gasPrice = legacyGasFeeEstimates[userFeeLevel];
     }
 

--- a/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
@@ -217,8 +217,7 @@ describe('MultichainTrackingHelper', () => {
     it('refreshes the tracking map', () => {
       const { options, helper } = newMultichainTrackingHelper();
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (options.onNetworkStateChange as any).mock.calls[0][0]({}, []);
+      options.onNetworkStateChange.mock.calls[0][0]({}, []);
 
       expect(options.getNetworkClientRegistry).toHaveBeenCalledTimes(1);
       expect(helper.has('mainnet')).toBe(true);
@@ -230,8 +229,7 @@ describe('MultichainTrackingHelper', () => {
     it('refreshes the tracking map and excludes removed networkClientIds in the patches', () => {
       const { options, helper } = newMultichainTrackingHelper();
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (options.onNetworkStateChange as any).mock.calls[0][0]({}, [
+      options.onNetworkStateChange.mock.calls[0][0]({}, [
         {
           op: 'remove',
           path: ['networkConfigurations', 'mainnet'],

--- a/packages/transaction-controller/src/helpers/MultichainTrackingHelper.ts
+++ b/packages/transaction-controller/src/helpers/MultichainTrackingHelper.ts
@@ -178,9 +178,7 @@ export class MultichainTrackingHelper {
 
     if (!nonceTracker) {
       throw new Error(
-        `Missing nonce tracker for network client ID - ${
-          networkClientId as string
-        }`,
+        `Missing nonce tracker for network client ID - ${networkClientId}`,
       );
     }
 

--- a/packages/transaction-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.test.ts
@@ -350,7 +350,7 @@ describe('Feature Flags Utils', () => {
       mockFeatureFlags({});
 
       const params = getAcceleratedPollingParams(
-        CHAIN_ID_MOCK as Hex,
+        CHAIN_ID_MOCK,
         controllerMessenger,
       );
 
@@ -375,7 +375,7 @@ describe('Feature Flags Utils', () => {
       });
 
       const params = getAcceleratedPollingParams(
-        CHAIN_ID_MOCK as Hex,
+        CHAIN_ID_MOCK,
         controllerMessenger,
       );
 
@@ -396,7 +396,7 @@ describe('Feature Flags Utils', () => {
       });
 
       const params = getAcceleratedPollingParams(
-        CHAIN_ID_MOCK as Hex,
+        CHAIN_ID_MOCK,
         controllerMessenger,
       );
 
@@ -423,7 +423,7 @@ describe('Feature Flags Utils', () => {
       });
 
       const params = getAcceleratedPollingParams(
-        CHAIN_ID_MOCK as Hex,
+        CHAIN_ID_MOCK,
         controllerMessenger,
       );
 
@@ -450,7 +450,7 @@ describe('Feature Flags Utils', () => {
       });
 
       const params = getAcceleratedPollingParams(
-        CHAIN_ID_MOCK as Hex,
+        CHAIN_ID_MOCK,
         controllerMessenger,
       );
 
@@ -477,7 +477,7 @@ describe('Feature Flags Utils', () => {
       });
 
       const params = getAcceleratedPollingParams(
-        CHAIN_ID_MOCK as Hex,
+        CHAIN_ID_MOCK,
         controllerMessenger,
       );
 

--- a/packages/transaction-controller/src/utils/gas-fee-tokens.ts
+++ b/packages/transaction-controller/src/utils/gas-fee-tokens.ts
@@ -73,13 +73,13 @@ export async function getGasFeeTokens({
     | SimulationRequestTransaction['authorizationList']
     | undefined = authorizationListRequest?.map((authorization) => ({
     address: authorization.address,
-    from: from as Hex,
+    from,
   }));
 
   if (with7702 && !delegationAddress && !authorizationList) {
     authorizationList = buildAuthorizationList({
       chainId,
-      from: from as Hex,
+      from,
       messenger,
       publicKeyEIP7702,
     });
@@ -264,7 +264,7 @@ function buildAuthorizationList({
   return [
     {
       address: upgradeAddress,
-      from: from as Hex,
+      from,
     },
   ];
 }

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -145,7 +145,7 @@ function getMaxFeePerGas(request: GetGasFeeRequest): string | undefined {
   }
 
   if (savedGasFees) {
-    const maxFeePerGas = gweiDecimalToWeiHex(savedGasFees.maxBaseFee as string);
+    const maxFeePerGas = gweiDecimalToWeiHex(savedGasFees.maxBaseFee);
     log('Using maxFeePerGas from savedGasFees', maxFeePerGas);
     return maxFeePerGas;
   }

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -450,7 +450,7 @@ async function estimateGasUpgradeWithDataToSelf(
 
   try {
     executeGas = await simulateGas({
-      chainId: chainId as Hex,
+      chainId,
       delegationAddress,
       getSimulationConfig,
       transaction: txParams,
@@ -519,7 +519,7 @@ async function simulateGas({
       },
     ],
     overrides: {
-      [transaction.from as string]: {
+      [transaction.from]: {
         code:
           delegationAddress &&
           ((DELEGATION_PREFIX + remove0x(delegationAddress)) as Hex),
@@ -577,7 +577,7 @@ function estimateGasNode(
     params.push('latest');
 
     params.push({
-      [from as string]: {
+      [from]: {
         code: DELEGATION_PREFIX + remove0x(delegationAddress),
       },
     });

--- a/packages/transaction-controller/src/utils/transaction-type.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.ts
@@ -76,9 +76,7 @@ export async function determineTransactionType(
     TransactionType.tokenMethodTransferFrom,
     TransactionType.tokenMethodSafeTransferFrom,
     TransactionType.tokenMethodIncreaseAllowance,
-  ].find(
-    (methodName) => methodName.toLowerCase() === (name as string).toLowerCase(),
-  );
+  ].find((methodName) => methodName.toLowerCase() === name.toLowerCase());
 
   if (tokenMethodName) {
     return { type: tokenMethodName, getCodeResponse };

--- a/packages/transaction-controller/src/utils/utils.ts
+++ b/packages/transaction-controller/src/utils/utils.ts
@@ -214,7 +214,7 @@ export function bnFromHex(hex: string | Hex): BN {
  */
 export function toBN(value: unknown): BN {
   if (value instanceof BN) {
-    return value as BN;
+    return value;
   }
   if (
     typeof (BN as unknown as { isBN?: (v: unknown) => boolean }).isBN ===

--- a/packages/transaction-controller/src/utils/validation.ts
+++ b/packages/transaction-controller/src/utils/validation.ts
@@ -426,12 +426,7 @@ function ensureProperTransactionEnvelopeTypeProvided(
       break;
     case 'maxFeePerGas':
     case 'maxPriorityFeePerGas':
-      if (
-        type &&
-        !TRANSACTION_ENVELOPE_TYPES_FEE_MARKET.includes(
-          type as TransactionEnvelopeType,
-        )
-      ) {
+      if (type && !TRANSACTION_ENVELOPE_TYPES_FEE_MARKET.includes(type)) {
         throw rpcErrors.invalidParams(
           `Invalid transaction envelope type: specified type "${type}" but including maxFeePerGas and maxPriorityFeePerGas requires type: "${TRANSACTION_ENVELOPE_TYPES_FEE_MARKET.join(', ')}"`,
         );
@@ -439,12 +434,7 @@ function ensureProperTransactionEnvelopeTypeProvided(
       break;
     case 'gasPrice':
     default:
-      if (
-        type &&
-        TRANSACTION_ENVELOPE_TYPES_FEE_MARKET.includes(
-          type as TransactionEnvelopeType,
-        )
-      ) {
+      if (type && TRANSACTION_ENVELOPE_TYPES_FEE_MARKET.includes(type)) {
         throw rpcErrors.invalidParams(
           `Invalid transaction envelope type: specified type "${type}" but included a gasPrice instead of maxFeePerGas and maxPriorityFeePerGas`,
         );

--- a/packages/transaction-pay-controller/src/utils/gas.test.ts
+++ b/packages/transaction-pay-controller/src/utils/gas.test.ts
@@ -32,7 +32,7 @@ const GAS_FEE_TOKEN_MOCK = {
 } as GasFeeToken;
 
 const TRANSACTION_META_MOCK = {
-  chainId: CHAIN_ID_MOCK as Hex,
+  chainId: CHAIN_ID_MOCK,
   gasUsed: GAS_USED_MOCK,
   txParams: {
     gas: GAS_MOCK,

--- a/packages/transaction-pay-controller/src/utils/token.test.ts
+++ b/packages/transaction-pay-controller/src/utils/token.test.ts
@@ -265,7 +265,7 @@ describe('Token Utils', () => {
 
       const result = getTokenFiatRate(
         messenger,
-        TOKEN_ADDRESS_MOCK as Hex,
+        TOKEN_ADDRESS_MOCK,
         CHAIN_ID_MOCK,
       );
 
@@ -281,7 +281,7 @@ describe('Token Utils', () => {
 
       const result = getTokenFiatRate(
         messenger,
-        TOKEN_ADDRESS_MOCK as Hex,
+        TOKEN_ADDRESS_MOCK,
         CHAIN_ID_MOCK,
       );
 
@@ -303,7 +303,7 @@ describe('Token Utils', () => {
 
       const result = getTokenFiatRate(
         messenger,
-        TOKEN_ADDRESS_MOCK as Hex,
+        TOKEN_ADDRESS_MOCK,
         CHAIN_ID_MOCK,
       );
 
@@ -333,7 +333,7 @@ describe('Token Utils', () => {
 
       const result = getTokenFiatRate(
         messenger,
-        TOKEN_ADDRESS_MOCK as Hex,
+        TOKEN_ADDRESS_MOCK,
         CHAIN_ID_MOCK,
       );
 

--- a/packages/user-operation-controller/src/utils/gas-fees.ts
+++ b/packages/user-operation-controller/src/utils/gas-fees.ts
@@ -277,7 +277,7 @@ async function getSuggestedGasFees(
     return {};
   }
 
-  const maxFeePerGas = add0x(gasPriceDecimal.toString(16)) as Hex;
+  const maxFeePerGas = add0x(gasPriceDecimal.toString(16));
 
   log('Using gasPrice from network as fallback', maxFeePerGas);
 

--- a/tests/fake-provider.ts
+++ b/tests/fake-provider.ts
@@ -220,9 +220,7 @@ export class FakeProvider
 
       throw new Error(message);
     } else {
-      // We are already checking that this stub exists above.
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const stub = this.#stubs[index]!;
+      const stub = this.#stubs[index];
 
       if (stub.discardAfterMatching !== false) {
         this.#stubs.splice(index, 1);


### PR DESCRIPTION
## Explanation

The rule `@typescript-eslint/no-unnecessary-type-assertions` has been re-enabled, and all lint violations fixed with `lint:fix`.

Some instances required more manual changes, I'll leave comments in the PR for each case. Most of them were cases where a template literal was casted to a type, which this rule regarded as unnecessary. In those cases I added back an `as const` so that it didn't widen to the type `string`.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables the ESLint rule and removes redundant type assertions by preferring inference/const assertions, simplifying indexed access, and tightening types across controllers, utils, and tests.
> 
> - **Linting**
>   - **Rule re-enabled**: `@typescript-eslint/no-unnecessary-type-assertion` in `eslint.config.mjs`.
> - **Type cleanups (highlights)**
>   - **Assets controllers**: Simplify chainId/address lookups and staked-balance maps; remove `keyof` indexed access; drop redundant casts in `NftController`, `TokenBalancesController`, `TokenDetectionController`, `balances.ts`, `crypto-compare-service`, `multicall.ts`, and RPC/API balance fetchers.
>   - **Transaction controller**: Normalize error messages and gas-fee flows; remove superfluous casts in gas estimation, fee selection, transaction typing, feature flags; prefer direct types in submit history and helpers.
>   - **Signature controller**: Use inferred `SignTypedDataVersion`; simplify error typing and param normalization.
>   - **Permissions/Gator**: Prefer `as const` for hex/template literals; checksum utilities/tests updated to avoid unnecessary casts; `splitHex` returns `as const` parts.
>   - **Delegation/controller tests**: Replace casts with direct Hex types; use `as const` for derived hashes.
>   - **Core/backend & build utils**: Remove non-null and explicit casts; tighten array typing; avoid suppressed ESLint rules.
>   - **Misc tests/utils**: Simplify `Object.entries` typings, remove dead type assertions, and prefer direct values in mocks and helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec83815ac881e0232cfabd2aad88a97202378cf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->