### PR TITLE
chore: Improve `makeRequest` test utility function

### DIFF
--- a/packages/json-rpc-engine/tests/utils.ts
+++ b/packages/json-rpc-engine/tests/utils.ts
@@ -6,11 +6,8 @@ import type { JsonRpcNotification } from '../src/v2/utils';
 
 const jsonrpc = '2.0' as const;
 
-export const makeRequest = <
-  Input extends Partial<JsonRpcRequest>,
-  Output extends Input & JsonRpcRequest,
->(
-  request: Input = {} as Input,
+export const makeRequest = <Request extends JsonRpcRequest = JsonRpcRequest>(
+  request: Partial<Request> = {},
 ) =>
   ({
     jsonrpc,
@@ -19,7 +16,7 @@ export const makeRequest = <
 
     params: request.params === undefined ? [] : request.params,
     ...request,
-  }) as Output;
+  }) as Request;
 
 export const makeNotification = <Request extends Partial<JsonRpcRequest>>(
   params: Request = {} as Request,


### PR DESCRIPTION
## Explanation

The `makeRequest` utility function is now easier to control the return type of using a type parameter, while still defaulting to the correct type by default most of the time.

The previous version of this utility function frequently required a type cast to prevent the return type from being resolved to `never`. It was technically possible to specify the return type with a type parameter, but it was onerous because the exact input type would also be required as the first parameter.

This was done to simplify a later PR (#7296) that enables a lint rule preventing unnecessary type assertions. The rule ended up breaking these tests because the cast impacted how the type was inferred in a way that the rule didn't predict.

## References

Relates to #7296

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the `makeRequest` test util to a simpler generic signature and updates tests to use explicit generics and local type aliases instead of casts.
> 
> - **Tests/Utils**:
>   - **`makeRequest`**: Simplify to `<Request extends JsonRpcRequest = JsonRpcRequest>(request: Partial<Request>) => Request`; remove dual generics and `never`-prone casting.
> - **Tests**:
>   - Replace casts with generic usage (e.g., `makeRequest<JsonRpcRequest>()`).
>   - Introduce local alias `NumericIdRequest` and use `makeRequest<NumericIdRequest>({...})` where needed.
>   - Minor assertion updates to align with new typing (no runtime behavior changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 554f7d8d71fcc6b40dae9c2ca8c0708dc65c21e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->