### PR TITLE
chore: Re-enable `@typescript-eslint/prefer-reduce-type-parameter`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -139,7 +139,6 @@ const config = createConfig([
       '@typescript-eslint/unbound-method': 'off',
       '@typescript-eslint/prefer-enum-initializers': 'off',
       '@typescript-eslint/prefer-nullish-coalescing': 'off',
-      '@typescript-eslint/prefer-reduce-type-parameter': 'off',
       'no-restricted-syntax': 'off',
       'no-restricted-globals': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -193,20 +193,19 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
           ],
         });
 
-      const ratesPriceApi = Object.entries(nativeCurrenciesToFetch).reduce(
-        (acc, [nativeCurrency, fetchedCurrency]) => {
-          const rate =
-            priceApiExchangeRatesResponse[fetchedCurrency.toLowerCase()];
+      const ratesPriceApi = Object.entries(nativeCurrenciesToFetch).reduce<
+        CurrencyRateState['currencyRates']
+      >((acc, [nativeCurrency, fetchedCurrency]) => {
+        const rate =
+          priceApiExchangeRatesResponse[fetchedCurrency.toLowerCase()];
 
-          acc[nativeCurrency] = {
-            conversionDate: rate !== undefined ? Date.now() / 1000 : null,
-            conversionRate: rate?.value ? Number(1 / rate?.value) : null,
-            usdConversionRate: rate?.usd ? Number(1 / rate?.usd) : null,
-          };
-          return acc;
-        },
-        {} as CurrencyRateState['currencyRates'],
-      );
+        acc[nativeCurrency] = {
+          conversionDate: rate !== undefined ? Date.now() / 1000 : null,
+          conversionRate: rate?.value ? Number(1 / rate?.value) : null,
+          usdConversionRate: rate?.usd ? Number(1 / rate?.usd) : null,
+        };
+        return acc;
+      }, {});
       return ratesPriceApi;
     } catch (error) {
       console.error('Failed to fetch exchange rates.', error);
@@ -222,31 +221,27 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
         networkControllerState.networkConfigurationsByChainId;
 
       // Step 2: Build a map of nativeCurrency -> chainId(s)
-      const currencyToChainIds = Object.entries(nativeCurrenciesToFetch).reduce(
-        (acc, [nativeCurrency, fetchedCurrency]) => {
-          // Find the first chainId that has this native currency
-          const matchingEntry = (
-            Object.entries(networkConfigurations) as [
-              Hex,
-              NetworkConfiguration,
-            ][]
-          ).find(
-            ([, config]) =>
-              config.nativeCurrency.toUpperCase() ===
-              fetchedCurrency.toUpperCase(),
-          );
+      const currencyToChainIds = Object.entries(nativeCurrenciesToFetch).reduce<
+        Record<string, { fetchedCurrency: string; chainId: Hex }>
+      >((acc, [nativeCurrency, fetchedCurrency]) => {
+        // Find the first chainId that has this native currency
+        const matchingEntry = (
+          Object.entries(networkConfigurations) as [Hex, NetworkConfiguration][]
+        ).find(
+          ([, config]) =>
+            config.nativeCurrency.toUpperCase() ===
+            fetchedCurrency.toUpperCase(),
+        );
 
-          if (matchingEntry) {
-            acc[nativeCurrency] = {
-              fetchedCurrency,
-              chainId: matchingEntry[0],
-            };
-          }
+        if (matchingEntry) {
+          acc[nativeCurrency] = {
+            fetchedCurrency,
+            chainId: matchingEntry[0],
+          };
+        }
 
-          return acc;
-        },
-        {} as Record<string, { fetchedCurrency: string; chainId: Hex }>,
-      );
+        return acc;
+      }, {});
 
       // Step 3: Fetch token prices for each chainId
       const currencyToChainIdsEntries = Object.entries(currencyToChainIds);
@@ -291,17 +286,16 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
       });
 
       // Step 4: Convert to the expected format
-      const ratesFromTokenPricesService = ratesFromTokenPrices.reduce(
-        (acc, rate) => {
-          acc[rate.nativeCurrency] = {
-            conversionDate: rate.conversionDate,
-            conversionRate: rate.conversionRate,
-            usdConversionRate: rate.usdConversionRate,
-          };
-          return acc;
-        },
-        {} as CurrencyRateState['currencyRates'],
-      );
+      const ratesFromTokenPricesService = ratesFromTokenPrices.reduce<
+        CurrencyRateState['currencyRates']
+      >((acc, rate) => {
+        acc[rate.nativeCurrency] = {
+          conversionDate: rate.conversionDate,
+          conversionRate: rate.conversionRate,
+          usdConversionRate: rate.usdConversionRate,
+        };
+        return acc;
+      }, {});
 
       return ratesFromTokenPricesService;
     } catch (error) {
@@ -310,17 +304,16 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
         error,
       );
       // Return null state for all requested currencies
-      return Object.keys(nativeCurrenciesToFetch).reduce(
-        (acc, nativeCurrency) => {
-          acc[nativeCurrency] = {
-            conversionDate: null,
-            conversionRate: null,
-            usdConversionRate: null,
-          };
-          return acc;
-        },
-        {} as CurrencyRateState['currencyRates'],
-      );
+      return Object.keys(nativeCurrenciesToFetch).reduce<
+        CurrencyRateState['currencyRates']
+      >((acc, nativeCurrency) => {
+        acc[nativeCurrency] = {
+          conversionDate: null,
+          conversionRate: null,
+          usdConversionRate: null,
+        };
+        return acc;
+      }, {});
     }
   }
 
@@ -341,19 +334,18 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
       // For preloaded testnets (Goerli, Sepolia) we want to fetch exchange rate for real ETH.
       // Map each native currency to the symbol we want to fetch for it.
       const testnetSymbols = Object.values(TESTNET_TICKER_SYMBOLS);
-      const nativeCurrenciesToFetch = nativeCurrencies.reduce(
-        (acc, nativeCurrency) => {
-          if (!nativeCurrency) {
-            return acc;
-          }
-
-          acc[nativeCurrency] = testnetSymbols.includes(nativeCurrency)
-            ? FALL_BACK_VS_CURRENCY
-            : nativeCurrency;
+      const nativeCurrenciesToFetch = nativeCurrencies.reduce<
+        Record<string, string>
+      >((acc, nativeCurrency) => {
+        if (!nativeCurrency) {
           return acc;
-        },
-        {} as Record<string, string>,
-      );
+        }
+
+        acc[nativeCurrency] = testnetSymbols.includes(nativeCurrency)
+          ? FALL_BACK_VS_CURRENCY
+          : nativeCurrency;
+        return acc;
+      }, {});
 
       const rates = await this.#fetchExchangeRatesWithFallback(
         nativeCurrenciesToFetch,

--- a/packages/assets-controllers/src/DeFiPositionsController/group-defi-positions.ts
+++ b/packages/assets-controllers/src/DeFiPositionsController/group-defi-positions.ts
@@ -143,12 +143,12 @@ function processToken<T extends Balance>(
     return tokenWithoutUnderlyings;
   });
 
-  const marketValue = processedTokens.reduce(
+  const marketValue = processedTokens.reduce<number | undefined>(
     (acc, t) =>
       acc === undefined || t.marketValue === undefined
         ? undefined
         : acc + t.marketValue,
-    0 as number | undefined,
+    0,
   );
 
   return {

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -102,13 +102,11 @@ const sampleMainnetTokenList = [
   },
 ];
 
-const sampleMainnetTokensChainsCache = sampleMainnetTokenList.reduce(
-  (output, current) => {
+const sampleMainnetTokensChainsCache =
+  sampleMainnetTokenList.reduce<TokenListMap>((output, current) => {
     output[current.address] = current;
     return output;
-  },
-  {} as TokenListMap,
-);
+  }, {});
 
 const sampleBinanceTokenList = [
   {
@@ -146,13 +144,11 @@ const sampleBinanceTokenList = [
   },
 ];
 
-const sampleBinanceTokensChainsCache = sampleBinanceTokenList.reduce(
-  (output, current) => {
+const sampleBinanceTokensChainsCache =
+  sampleBinanceTokenList.reduce<TokenListMap>((output, current) => {
     output[current.address] = current;
     return output;
-  },
-  {} as TokenListMap,
-);
+  }, {});
 
 const sampleSingleChainState = {
   tokenList: {
@@ -315,13 +311,11 @@ const sampleSepoliaTokenList = [
   },
 ];
 
-const sampleSepoliaTokensChainCache = sampleSepoliaTokenList.reduce(
-  (output, current) => {
+const sampleSepoliaTokensChainCache =
+  sampleSepoliaTokenList.reduce<TokenListMap>((output, current) => {
     output[current.address] = current;
     return output;
-  },
-  {} as TokenListMap,
-);
+  }, {});
 
 const sampleTwoChainState = {
   tokenList: {

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -519,13 +519,10 @@ export class TokensController extends BaseController<
       ...(allTokens[interactingChainId]?.[this.#getSelectedAccount().address] ||
         []),
       ...tokensToImport,
-    ].reduce(
-      (output, token) => {
-        output[toChecksumHexAddress(token.address)] = token;
-        return output;
-      },
-      {} as { [address: string]: Token },
-    );
+    ].reduce<{ [address: string]: Token }>((output, token) => {
+      output[toChecksumHexAddress(token.address)] = token;
+      return output;
+    }, {});
     try {
       tokensToImport.forEach((tokenToAdd) => {
         const { address, symbol, decimals, image, aggregators, name } =

--- a/packages/assets-controllers/src/assetsUtil.ts
+++ b/packages/assets-controllers/src/assetsUtil.ts
@@ -385,13 +385,10 @@ export async function fetchTokenContractExchangeRates({
           })),
           currency: nativeCurrency,
         })
-      ).reduce(
-        (acc, tokenPrice) => {
-          acc[tokenPrice.tokenAddress] = tokenPrice;
-          return acc;
-        },
-        {} as Record<Hex, EvmAssetWithMarketData>,
-      );
+      ).reduce<Record<Hex, EvmAssetWithMarketData>>((acc, tokenPrice) => {
+        acc[tokenPrice.tokenAddress] = tokenPrice;
+        return acc;
+      }, {});
 
       return {
         ...allTokenPricesByTokenAddress,

--- a/packages/bridge-controller/src/utils/assets.ts
+++ b/packages/bridge-controller/src/utils/assets.ts
@@ -26,17 +26,16 @@ export const toExchangeRates = (
     [assetId: CaipAssetType]: { [currency: string]: string } | undefined;
   },
 ) => {
-  const exchangeRates = Object.entries(pricesByAssetId).reduce(
-    (acc, [assetId, prices]) => {
-      if (prices) {
-        acc[assetId as CaipAssetType] = {
-          exchangeRate: prices[currency],
-          usdExchangeRate: prices.usd,
-        };
-      }
-      return acc;
-    },
-    {} as Record<CaipAssetType, ExchangeRate>,
-  );
+  const exchangeRates = Object.entries(pricesByAssetId).reduce<
+    Record<CaipAssetType, ExchangeRate>
+  >((acc, [assetId, prices]) => {
+    if (prices) {
+      acc[assetId as CaipAssetType] = {
+        exchangeRate: prices[currency],
+        usdExchangeRate: prices.usd,
+      };
+    }
+    return acc;
+  }, {});
   return exchangeRates;
 };

--- a/packages/bridge-controller/src/utils/fetch.ts
+++ b/packages/bridge-controller/src/utils/fetch.ts
@@ -207,22 +207,21 @@ const fetchAssetPricesForCurrency = async (request: {
     return {};
   }
 
-  return Object.entries(priceApiResponse).reduce(
-    (acc, [assetId, currencyToPrice]) => {
-      if (!currencyToPrice) {
-        return acc;
-      }
-      if (!acc[assetId as CaipAssetType]) {
-        acc[assetId as CaipAssetType] = {};
-      }
-      if (currencyToPrice[currency]) {
-        acc[assetId as CaipAssetType][currency] =
-          currencyToPrice[currency].toString();
-      }
+  return Object.entries(priceApiResponse).reduce<
+    Record<CaipAssetType, { [currency: string]: string }>
+  >((acc, [assetId, currencyToPrice]) => {
+    if (!currencyToPrice) {
       return acc;
-    },
-    {} as Record<CaipAssetType, { [currency: string]: string }>,
-  );
+    }
+    if (!acc[assetId as CaipAssetType]) {
+      acc[assetId as CaipAssetType] = {};
+    }
+    if (currencyToPrice[currency]) {
+      acc[assetId as CaipAssetType][currency] =
+        currencyToPrice[currency].toString();
+    }
+    return acc;
+  }, {});
 };
 
 /**
@@ -246,23 +245,22 @@ export const fetchAssetPrices = async (
         await fetchAssetPricesForCurrency({ ...args, currency }),
     ),
   ).then((priceApiResponse) => {
-    return priceApiResponse.reduce(
-      (acc, result) => {
-        if (result.status === 'fulfilled') {
-          Object.entries(result.value).forEach(([assetId, currencyToPrice]) => {
-            const existingPrices = acc[assetId as CaipAssetType];
-            if (!existingPrices) {
-              acc[assetId as CaipAssetType] = {};
-            }
-            Object.entries(currencyToPrice).forEach(([currency, price]) => {
-              acc[assetId as CaipAssetType][currency] = price;
-            });
+    return priceApiResponse.reduce<
+      Record<CaipAssetType, { [currency: string]: string }>
+    >((acc, result) => {
+      if (result.status === 'fulfilled') {
+        Object.entries(result.value).forEach(([assetId, currencyToPrice]) => {
+          const existingPrices = acc[assetId as CaipAssetType];
+          if (!existingPrices) {
+            acc[assetId as CaipAssetType] = {};
+          }
+          Object.entries(currencyToPrice).forEach(([currency, price]) => {
+            acc[assetId as CaipAssetType][currency] = price;
           });
-        }
-        return acc;
-      },
-      {} as Record<CaipAssetType, { [currency: string]: string }>,
-    );
+        });
+      }
+      return acc;
+    }, {});
   });
 
   return combinedPrices;

--- a/packages/earn-controller/src/selectors.ts
+++ b/packages/earn-controller/src/selectors.ts
@@ -21,13 +21,13 @@ export const selectLendingMarketsForChainId = (chainId: number) =>
 export const selectLendingMarketsByProtocolAndId = createSelector(
   selectLendingMarkets,
   (markets) => {
-    return markets.reduce(
+    return markets.reduce<Record<string, Record<string, LendingMarket>>>(
       (acc, market) => {
         acc[market.protocol] = acc[market.protocol] || {};
         acc[market.protocol][market.id] = market;
         return acc;
       },
-      {} as Record<string, Record<string, LendingMarket>>,
+      {},
     );
   },
 );
@@ -44,14 +44,11 @@ export const selectLendingMarketForProtocolAndId = (
 export const selectLendingMarketsByChainId = createSelector(
   selectLendingMarkets,
   (markets) => {
-    return markets.reduce(
-      (acc, market) => {
-        acc[market.chainId] = acc[market.chainId] || [];
-        acc[market.chainId].push(market);
-        return acc;
-      },
-      {} as Record<number, LendingMarket[]>,
-    );
+    return markets.reduce<Record<number, LendingMarket[]>>((acc, market) => {
+      acc[market.chainId] = acc[market.chainId] || [];
+      acc[market.chainId].push(market);
+      return acc;
+    }, {});
   },
 );
 
@@ -72,35 +69,30 @@ export const selectLendingPositionsWithMarket = createSelector(
 export const selectLendingPositionsByChainId = createSelector(
   selectLendingPositionsWithMarket,
   (positionsWithMarket) => {
-    return positionsWithMarket.reduce(
-      (acc, position) => {
-        const chainId = position.market?.chainId;
-        if (chainId) {
-          acc[chainId] = acc[chainId] || [];
-          acc[chainId].push(position);
-        }
-        return acc;
-      },
-      {} as Record<number, LendingPositionWithMarket[]>,
-    );
+    return positionsWithMarket.reduce<
+      Record<number, LendingPositionWithMarket[]>
+    >((acc, position) => {
+      const chainId = position.market?.chainId;
+      if (chainId) {
+        acc[chainId] = acc[chainId] || [];
+        acc[chainId].push(position);
+      }
+      return acc;
+    }, {});
   },
 );
 
 export const selectLendingPositionsByProtocolChainIdMarketId = createSelector(
   selectLendingPositionsWithMarket,
   (positionsWithMarket) =>
-    positionsWithMarket.reduce(
-      (acc, position) => {
-        acc[position.protocol] ??= {};
-        acc[position.protocol][position.chainId] ??= {};
-        acc[position.protocol][position.chainId][position.marketId] = position;
-        return acc;
-      },
-      {} as Record<
-        string,
-        Record<string, Record<string, LendingPositionWithMarket>>
-      >,
-    ),
+    positionsWithMarket.reduce<
+      Record<string, Record<string, Record<string, LendingPositionWithMarket>>>
+    >((acc, position) => {
+      acc[position.protocol] ??= {};
+      acc[position.protocol][position.chainId] ??= {};
+      acc[position.protocol][position.chainId][position.marketId] = position;
+      return acc;
+    }, {}),
 );
 
 export const selectLendingMarketsWithPosition = createSelector(
@@ -122,46 +114,43 @@ export const selectLendingMarketsWithPosition = createSelector(
 export const selectLendingMarketsByTokenAddress = createSelector(
   selectLendingMarketsWithPosition,
   (marketsWithPosition) => {
-    return marketsWithPosition.reduce(
-      (acc, market) => {
-        if (market.underlying?.address) {
-          acc[market.underlying.address] = acc[market.underlying.address] || [];
-          acc[market.underlying.address].push(market);
-        }
-        return acc;
-      },
-      {} as Record<string, LendingMarketWithPosition[]>,
-    );
+    return marketsWithPosition.reduce<
+      Record<string, LendingMarketWithPosition[]>
+    >((acc, market) => {
+      if (market.underlying?.address) {
+        acc[market.underlying.address] = acc[market.underlying.address] || [];
+        acc[market.underlying.address].push(market);
+      }
+      return acc;
+    }, {});
   },
 );
 
 export const selectLendingPositionsByProtocol = createSelector(
   selectLendingPositionsWithMarket,
   (positionsWithMarket) => {
-    return positionsWithMarket.reduce(
-      (acc, position) => {
-        acc[position.protocol] = acc[position.protocol] || [];
-        acc[position.protocol].push(position);
-        return acc;
-      },
-      {} as Record<string, LendingPositionWithMarket[]>,
-    );
+    return positionsWithMarket.reduce<
+      Record<string, LendingPositionWithMarket[]>
+    >((acc, position) => {
+      acc[position.protocol] = acc[position.protocol] || [];
+      acc[position.protocol].push(position);
+      return acc;
+    }, {});
   },
 );
 
 export const selectLendingMarketByProtocolAndTokenAddress = createSelector(
   selectLendingMarketsWithPosition,
   (marketsWithPosition) => {
-    return marketsWithPosition.reduce(
-      (acc, market) => {
-        if (market.underlying?.address) {
-          acc[market.protocol] = acc[market.protocol] || {};
-          acc[market.protocol][market.underlying.address] = market;
-        }
-        return acc;
-      },
-      {} as Record<string, Record<string, LendingMarketWithPosition>>,
-    );
+    return marketsWithPosition.reduce<
+      Record<string, Record<string, LendingMarketWithPosition>>
+    >((acc, market) => {
+      if (market.underlying?.address) {
+        acc[market.protocol] = acc[market.protocol] || {};
+        acc[market.protocol][market.underlying.address] = market;
+      }
+      return acc;
+    }, {});
   },
 );
 
@@ -177,35 +166,33 @@ export const selectLendingMarketForProtocolAndTokenAddress = (
 
 export const selectLendingMarketsByChainIdAndOutputTokenAddress =
   createSelector(selectLendingMarketsWithPosition, (marketsWithPosition) =>
-    marketsWithPosition.reduce(
-      (acc, market) => {
-        if (market.outputToken?.address) {
-          acc[market.chainId] = acc?.[market.chainId] || {};
-          acc[market.chainId][market.outputToken.address] =
-            acc?.[market.chainId]?.[market.outputToken.address] || [];
-          acc[market.chainId][market.outputToken.address].push(market);
-        }
-        return acc;
-      },
-      {} as Record<string, Record<string, LendingMarketWithPosition[]>>,
-    ),
+    marketsWithPosition.reduce<
+      Record<string, Record<string, LendingMarketWithPosition[]>>
+    >((acc, market) => {
+      if (market.outputToken?.address) {
+        acc[market.chainId] = acc?.[market.chainId] || {};
+        acc[market.chainId][market.outputToken.address] =
+          acc?.[market.chainId]?.[market.outputToken.address] || [];
+        acc[market.chainId][market.outputToken.address].push(market);
+      }
+      return acc;
+    }, {}),
   );
 
 export const selectLendingMarketsByChainIdAndTokenAddress = createSelector(
   selectLendingMarketsWithPosition,
   (marketsWithPosition) =>
-    marketsWithPosition.reduce(
-      (acc, market) => {
-        if (market.underlying?.address) {
-          acc[market.chainId] = acc?.[market.chainId] || {};
-          acc[market.chainId][market.underlying.address] =
-            acc?.[market.chainId]?.[market.underlying.address] || [];
-          acc[market.chainId][market.underlying.address].push(market);
-        }
-        return acc;
-      },
-      {} as Record<string, Record<string, LendingMarketWithPosition[]>>,
-    ),
+    marketsWithPosition.reduce<
+      Record<string, Record<string, LendingMarketWithPosition[]>>
+    >((acc, market) => {
+      if (market.underlying?.address) {
+        acc[market.chainId] = acc?.[market.chainId] || {};
+        acc[market.chainId][market.underlying.address] =
+          acc?.[market.chainId]?.[market.underlying.address] || [];
+        acc[market.chainId][market.underlying.address].push(market);
+      }
+      return acc;
+    }, {}),
 );
 
 export const selectIsLendingEligible = (state: EarnControllerState) =>

--- a/packages/gator-permissions-controller/src/GatorPermissionsController.ts
+++ b/packages/gator-permissions-controller/src/GatorPermissionsController.ts
@@ -513,7 +513,7 @@ export default class GatorPermissionsController extends BaseController<
       return defaultGatorPermissionsMap;
     }
 
-    return storedGatorPermissions.reduce(
+    return storedGatorPermissions.reduce<GatorPermissionsMap>(
       (gatorPermissionsMap, storedGatorPermission) => {
         const { permissionResponse } = storedGatorPermission;
         const permissionType = permissionResponse.permission.type;
@@ -564,7 +564,7 @@ export default class GatorPermissionsController extends BaseController<
         'erc20-token-stream': {},
         'erc20-token-periodic': {},
         other: {},
-      } as GatorPermissionsMap,
+      },
     );
   }
 

--- a/packages/network-enablement-controller/src/selectors.ts
+++ b/packages/network-enablement-controller/src/selectors.ts
@@ -65,15 +65,14 @@ export const createSelectorForEnabledNetworksForNamespace = (
 export const selectAllEnabledNetworks = createSelector(
   selectEnabledNetworkMap,
   (enabledNetworkMap) => {
-    return Object.keys(enabledNetworkMap).reduce(
-      (acc, ns) => {
-        acc[ns] = Object.entries(enabledNetworkMap[ns])
-          .filter(([, enabled]) => enabled)
-          .map(([id]) => id);
-        return acc;
-      },
-      {} as Record<CaipNamespace, string[]>,
-    );
+    return Object.keys(enabledNetworkMap).reduce<
+      Record<CaipNamespace, string[]>
+    >((acc, ns) => {
+      acc[ns] = Object.entries(enabledNetworkMap[ns])
+        .filter(([, enabled]) => enabled)
+        .map(([id]) => id);
+      return acc;
+    }, {});
   },
 );
 

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -2362,7 +2362,9 @@ export class PermissionController<
     const { caveatPairs, leftUniqueCaveats, rightUniqueCaveats } =
       collectUniqueAndPairedCaveats(leftPermission, rightPermission);
 
-    const [mergedCaveats, caveatDiffMap] = caveatPairs.reduce(
+    const [mergedCaveats, caveatDiffMap] = caveatPairs.reduce<
+      [CaveatConstraint[], CaveatDiffMap<CaveatConstraint>]
+    >(
       ([caveats, diffMap], [leftCaveat, rightCaveat]) => {
         const [newCaveat, diff] = this.#mergeCaveat(leftCaveat, rightCaveat);
 
@@ -2375,7 +2377,7 @@ export class PermissionController<
 
         return [caveats, diffMap];
       },
-      [[], {}] as [CaveatConstraint[], CaveatDiffMap<CaveatConstraint>],
+      [[], {}],
     );
 
     const mergedRightUniqueCaveats = rightUniqueCaveats.map((caveat) => {

--- a/packages/selected-network-controller/src/SelectedNetworkController.ts
+++ b/packages/selected-network-controller/src/SelectedNetworkController.ts
@@ -199,16 +199,12 @@ export class SelectedNetworkController extends BaseController<
         if (patch) {
           const networkClientIdToChainId = Object.values(
             networkConfigurationsByChainId,
-          ).reduce(
-            (acc, network) => {
-              network.rpcEndpoints.forEach(
-                ({ networkClientId }) =>
-                  (acc[networkClientId] = network.chainId),
-              );
-              return acc;
-            },
-            {} as Record<string, Hex>,
-          );
+          ).reduce<Record<string, Hex>>((acc, network) => {
+            network.rpcEndpoints.forEach(
+              ({ networkClientId }) => (acc[networkClientId] = network.chainId),
+            );
+            return acc;
+          }, {});
 
           Object.entries(this.state.domains).forEach(
             ([domain, networkClientIdForDomain]) => {


### PR DESCRIPTION
## Explanation

The ESLint rule `@typescript-eslint/prefer-reduce-type-parameter` has been re-enabled, and all violations were auto-fixed.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables @typescript-eslint/prefer-reduce-type-parameter and updates reduce usages across controllers/tests to use generic type parameters and correct initial values.
> 
> - **ESLint**:
>   - Re-enables `@typescript-eslint/prefer-reduce-type-parameter` in `eslint.config.mjs`.
> - **Type fixes (reduce)**:
>   - Replace accumulator type assertions with generic `reduce<...>` across codebase, initializing with proper empty objects or values:
>     - `assets-controllers`: `CurrencyRateController`, `TokensController`, `assetsUtil`, `DeFiPositionsController/group-defi-positions.ts` (also types `number | undefined`).
>     - `bridge-controller`: `utils/assets.ts`, `utils/fetch.ts` (spot prices aggregation).
>     - `earn-controller`: `selectors.ts` (market/position grouping maps).
>     - `gator-permissions-controller`: categorize permissions map construction.
>     - `network-enablement-controller`: `selectors.ts` (enabled networks aggregation).
>     - `permission-controller`: merge caveats uses typed tuple accumulator.
>     - `selected-network-controller`: map `networkClientId` to `chainId`.
>     - Tests: `TokenListController.test.ts` (token cache maps).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25ddf2d1ce516818ba3e14dbe172bd3d79c54721. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->