### PR TITLE
feat:add `erc20-token-revocation` permission to controller state

### DIFF
--- a/packages/gator-permissions-controller/CHANGELOG.md
+++ b/packages/gator-permissions-controller/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Permission decoding now rejects `TimestampEnforcer` caveats with zero `timestampBeforeThreshold` values ([#7195](https://github.com/MetaMask/core/pull/7195))
 - Permission decoding logic for `erc20-token-revocation` permission type ([#7299](https://github.com/MetaMask/core/pull/7299))
+- Differentiate `erc20-token-revocation` permissions from `other` in controller state ([#7318](https://github.com/MetaMask/core/pull/7318))
 - Validation errors for `TimestampEnforcer` include: invalid terms length, non-zero `timestampAfterThreshold`, and zero `timestampBeforeThreshold` ([#7195](https://github.com/MetaMask/core/pull/7195))
 - Bump `@metamask/transaction-controller` from `^62.3.1` to `^62.4.0` ([#7289](https://github.com/MetaMask/core/pull/7289))
 

--- a/packages/gator-permissions-controller/src/types.ts
+++ b/packages/gator-permissions-controller/src/types.ts
@@ -8,6 +8,7 @@ import type {
   Erc20TokenPeriodicPermission,
   Rule,
   MetaMaskBasePermissionData,
+  Erc20TokenRevocationPermission,
 } from '@metamask/7715-permission-types';
 import type { Delegation } from '@metamask/delegation-core';
 import type { Hex } from '@metamask/utils';
@@ -174,6 +175,12 @@ export type StoredGatorPermissionSanitized<
  * Represents a map of gator permissions by chainId and permission type.
  */
 export type GatorPermissionsMap = {
+  'erc20-token-revocation': {
+    [chainId: Hex]: StoredGatorPermissionSanitized<
+      Signer,
+      Erc20TokenRevocationPermission
+    >[];
+  };
   'native-token-stream': {
     [chainId: Hex]: StoredGatorPermissionSanitized<
       Signer,

--- a/packages/gator-permissions-controller/src/utils.test.ts
+++ b/packages/gator-permissions-controller/src/utils.test.ts
@@ -5,6 +5,7 @@ import {
 } from './utils';
 
 const defaultGatorPermissionsMap: GatorPermissionsMap = {
+  'erc20-token-revocation': {},
   'native-token-stream': {},
   'native-token-periodic': {},
   'erc20-token-stream': {},
@@ -24,8 +25,8 @@ describe('utils - serializeGatorPermissionsMap() tests', () => {
   });
 
   it('throws an error when serialization fails', () => {
-    // Create a valid GatorPermissionsMap structure but with circular reference
     const gatorPermissionsMap = {
+      'erc20-token-revocation': {},
       'native-token-stream': {},
       'native-token-periodic': {},
       'erc20-token-stream': {},
@@ -33,9 +34,11 @@ describe('utils - serializeGatorPermissionsMap() tests', () => {
       other: {},
     };
 
-    // Add circular reference to cause JSON.stringify to fail
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (gatorPermissionsMap as any).circular = gatorPermissionsMap;
+    // explicitly cause serialization to fail
+    (gatorPermissionsMap as unknown as { toJSON: () => void }).toJSON =
+      (): void => {
+        throw new Error('Failed serialization');
+      };
 
     expect(() => {
       serializeGatorPermissionsMap(gatorPermissionsMap);


### PR DESCRIPTION
Plus minor refactor to permission map generation.

## Explanation

We recently added `erc20-token-revocation` to the permission granting flow. This change adds the type to the permission controller state, so that these permissions become differentiated in the All Permission section (rather than relegated to "other").

Also includes a minor refactor of parsing a list of stored permissions into a multi-dimensional map keyed by `permissionType | chainId`, which previously required changes to this function for every new type added. Now simply adding the permission type to the `createEmptyGatorPermissionsMap` function will be required for new permissions.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a dedicated `erc20-token-revocation` bucket to controller state and refactors permission categorization to be extensible via a centralized empty-map factory.
> 
> - **gator-permissions-controller**
>   - **State/Defaults**: Introduce `createEmptyGatorPermissionsMap()` and include `erc20-token-revocation` in default/cleared state; update getters/disable flow to use new factory.
>   - **Logic**: Rewrite `#categorizePermissionsDataByTypeAndChainId` to dynamically bucket by known permission types (fallback to `other`) instead of switch-case.
>   - **Types**: Extend `GatorPermissionsMap` to include `erc20-token-revocation` (imports `Erc20TokenRevocationPermission`).
>   - **Tests**: Update expectations for default/empty maps; add test ensuring `erc20-token-revocation` is categorized separately; preserve sanitization checks; tweak utils serialization-failure test.
>   - **Changelog**: Note differentiation of `erc20-token-revocation` from `other`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4e996d6d86a0dec820deb0cb208478613874528. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->