### PR TITLE
feat: transaction timeout

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Automatically fail pending transactions if no receipt and hash not recognised by network after multiple attempts ([#7329](https://github.com/MetaMask/core/pull/7329))
+  - Add optional `isTimeoutEnabled` callback to disable for specific transactions.
+  - Ignores transactions with future nonce.
+  - Threshold determined by feature flag.
+
 ### Fixed
 
 - Prevent `TransactionController:transactionApproved` event firing if keyring throws during signing ([#7410](https://github.com/MetaMask/core/pull/7410))

--- a/packages/transaction-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.test.ts
@@ -19,6 +19,7 @@ import {
   getGasEstimateBuffer,
   FeatureFlag,
   getIncomingTransactionsPollingInterval,
+  getTimeoutAttempts,
 } from './feature-flags';
 import { isValidSignature } from './signature';
 import type { TransactionControllerMessenger } from '..';
@@ -724,6 +725,80 @@ describe('Feature Flags Utils', () => {
       expect(getIncomingTransactionsPollingInterval(controllerMessenger)).toBe(
         5000,
       );
+    });
+  });
+
+  describe('getTimeoutAttempts', () => {
+    it('returns undefined if no feature flags set', () => {
+      mockFeatureFlags({});
+
+      expect(
+        getTimeoutAttempts(CHAIN_ID_MOCK, controllerMessenger),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined if timeoutAttempts not set', () => {
+      mockFeatureFlags({
+        [FeatureFlag.Transactions]: {},
+      });
+
+      expect(
+        getTimeoutAttempts(CHAIN_ID_MOCK, controllerMessenger),
+      ).toBeUndefined();
+    });
+
+    it('returns default value if no chain-specific config', () => {
+      mockFeatureFlags({
+        [FeatureFlag.Transactions]: {
+          timeoutAttempts: {
+            default: 3,
+          },
+        },
+      });
+
+      expect(getTimeoutAttempts(CHAIN_ID_MOCK, controllerMessenger)).toBe(3);
+    });
+
+    it('returns chain-specific value when available', () => {
+      mockFeatureFlags({
+        [FeatureFlag.Transactions]: {
+          timeoutAttempts: {
+            default: 3,
+            perChainConfig: {
+              [CHAIN_ID_MOCK]: 5,
+            },
+          },
+        },
+      });
+
+      expect(getTimeoutAttempts(CHAIN_ID_MOCK, controllerMessenger)).toBe(5);
+    });
+
+    it('returns chain-specific zero value when explicitly set', () => {
+      mockFeatureFlags({
+        [FeatureFlag.Transactions]: {
+          timeoutAttempts: {
+            default: 3,
+            perChainConfig: {
+              [CHAIN_ID_MOCK]: 0,
+            },
+          },
+        },
+      });
+
+      expect(getTimeoutAttempts(CHAIN_ID_MOCK, controllerMessenger)).toBe(0);
+    });
+
+    it('returns default zero value when explicitly set', () => {
+      mockFeatureFlags({
+        [FeatureFlag.Transactions]: {
+          timeoutAttempts: {
+            default: 0,
+          },
+        },
+      });
+
+      expect(getTimeoutAttempts(CHAIN_ID_MOCK, controllerMessenger)).toBe(0);
     });
   });
 });

--- a/packages/transaction-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.ts
@@ -155,6 +155,23 @@ export type TransactionControllerFeatureFlags = {
        */
       default?: GasEstimateFallback;
     };
+
+    /**
+     * Number of attempts to wait before automatically marking a transaction as failed
+     * if it has no receipt status and hash is not found on the network.
+     */
+    timeoutAttempts?: {
+      /** Automatic fail threshold on a per-chain basis. */
+      perChainConfig?: {
+        [chainId: Hex]: number;
+      };
+
+      /**
+       * Default automatic fail threshold.
+       * This value is used when no specific threshold is found for a chain ID.
+       */
+      default?: number;
+    };
   };
 };
 
@@ -380,6 +397,29 @@ export function getIncomingTransactionsPollingInterval(
   return (
     featureFlags?.[FeatureFlag.IncomingTransactions]?.pollingIntervalMs ??
     DEFAULT_INCOMING_TRANSACTIONS_POLLING_INTERVAL_MS
+  );
+}
+
+/**
+ * Retrieves the number of attempts to wait before automatically marking a transaction as dropped
+ * if it has no receipt status.
+ *
+ * @param chainId - The chain ID.
+ * @param messenger - The controller messenger instance.
+ * @returns The threshold number of attempts, or undefined if the feature is disabled.
+ */
+export function getTimeoutAttempts(
+  chainId: Hex,
+  messenger: TransactionControllerMessenger,
+): number | undefined {
+  const featureFlags = getFeatureFlags(messenger);
+
+  const timeoutAttemptsFlags =
+    featureFlags?.[FeatureFlag.Transactions]?.timeoutAttempts;
+
+  return (
+    timeoutAttemptsFlags?.perChainConfig?.[chainId] ??
+    timeoutAttemptsFlags?.default
   );
 }
 


### PR DESCRIPTION
## Explanation

Automatically fail pending transactions if no receipt and hash is not recognised by network after multiple attempts.

Threshold is defined in new feature flag, supporting chain specific and default values.

Ignores transactions with future nonce or if new optional `isTimeoutEnabled` callback returns `false`.

## References

Related to [#23563](https://github.com/MetaMask/metamask-mobile/issues/23563)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automatically fails pending transactions with no receipt and not found on-network after a feature-flagged number of attempts, with per-transaction opt-out.
> 
> - **Pending Transaction Handling**:
>   - Add timeout logic in `helpers/PendingTransactionTracker.ts` to fail transactions lacking a receipt and absent from the network (`getTransactionByHash`) after `getTimeoutAttempts` threshold.
>     - Skips when nonce is in the future; resets counter if transaction later appears; emits failure with `Transaction not found on network after timeout`.
>     - Uses new `isTimeoutEnabled` hook; tracks attempts per `hash`; leverages messenger feature flags.
>   - Integrate into `TransactionController` by adding `hooks.isTimeoutEnabled` and passing it to `PendingTransactionTracker`.
> - **Feature Flags**:
>   - Add `getTimeoutAttempts` in `utils/feature-flags.ts` (per-chain and default support).
> - **Tests**:
>   - Update `PendingTransactionTracker.test.ts` to mock specific RPC calls and cover timeout paths, counter reset, and edge cases.
>   - Add tests for `getTimeoutAttempts` in `utils/feature-flags.test.ts`.
> - **Docs/Changelog**:
>   - Update `CHANGELOG.md` with the new auto-fail behavior and configuration details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2efcfbaf707983e5d2b31ab0a31e2e2da90fbc6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->