### PR TITLE
fix: Include `WalletContext` in EIP-7715 requests

### DIFF
--- a/packages/eth-json-rpc-middleware/CHANGELOG.md
+++ b/packages/eth-json-rpc-middleware/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Include `WalletContext` in EIP-7715 requests ([#7331](https://github.com/MetaMask/core/pull/7331))
+
 ## [22.0.0]
 
 ### Added

--- a/packages/eth-json-rpc-middleware/src/methods/wallet-request-execution-permissions.test.ts
+++ b/packages/eth-json-rpc-middleware/src/methods/wallet-request-execution-permissions.test.ts
@@ -68,13 +68,14 @@ describe('wallet_requestExecutionPermissions', () => {
   let request: JsonRpcRequest;
   let params: RequestExecutionPermissionsRequestParams;
   let processRequestExecutionPermissionsMock: jest.MockedFunction<ProcessRequestExecutionPermissionsHook>;
+  let context: WalletMiddlewareParams['context'];
 
   const callMethod = async () => {
     const handler = createWalletRequestExecutionPermissionsHandler({
       processRequestExecutionPermissions:
         processRequestExecutionPermissionsMock,
     });
-    return handler({ request } as WalletMiddlewareParams);
+    return handler({ request, context } as WalletMiddlewareParams);
   };
 
   beforeEach(() => {
@@ -82,6 +83,10 @@ describe('wallet_requestExecutionPermissions', () => {
 
     request = klona(REQUEST_MOCK);
     params = request.params as RequestExecutionPermissionsRequestParams;
+
+    context = new Map([
+      ['origin', 'test-origin'],
+    ]) as WalletMiddlewareParams['context'];
 
     processRequestExecutionPermissionsMock = jest.fn();
     processRequestExecutionPermissionsMock.mockResolvedValue(RESULT_MOCK);
@@ -92,6 +97,7 @@ describe('wallet_requestExecutionPermissions', () => {
     expect(processRequestExecutionPermissionsMock).toHaveBeenCalledWith(
       params,
       request,
+      context,
     );
   });
 
@@ -108,6 +114,7 @@ describe('wallet_requestExecutionPermissions', () => {
     expect(processRequestExecutionPermissionsMock).toHaveBeenCalledWith(
       params,
       request,
+      context,
     );
   });
 
@@ -119,6 +126,7 @@ describe('wallet_requestExecutionPermissions', () => {
     expect(processRequestExecutionPermissionsMock).toHaveBeenCalledWith(
       params,
       request,
+      context,
     );
   });
 

--- a/packages/eth-json-rpc-middleware/src/methods/wallet-request-execution-permissions.ts
+++ b/packages/eth-json-rpc-middleware/src/methods/wallet-request-execution-permissions.ts
@@ -60,6 +60,7 @@ export type RequestExecutionPermissionsResult = Json &
 export type ProcessRequestExecutionPermissionsHook = (
   request: RequestExecutionPermissionsRequestParams,
   req: JsonRpcRequest,
+  context: WalletMiddlewareContext,
 ) => Promise<RequestExecutionPermissionsResult>;
 
 /**
@@ -76,7 +77,7 @@ export function createWalletRequestExecutionPermissionsHandler({
 }: {
   processRequestExecutionPermissions?: ProcessRequestExecutionPermissionsHook;
 }): JsonRpcMiddleware<JsonRpcRequest, Json, WalletMiddlewareContext> {
-  return async ({ request }) => {
+  return async ({ request, context }) => {
     if (!processRequestExecutionPermissions) {
       throw rpcErrors.methodNotSupported(
         'wallet_requestExecutionPermissions - no middleware configured',
@@ -87,6 +88,6 @@ export function createWalletRequestExecutionPermissionsHandler({
 
     validateParams(params, RequestExecutionPermissionsStruct);
 
-    return await processRequestExecutionPermissions(params, request);
+    return await processRequestExecutionPermissions(params, request, context);
   };
 }

--- a/packages/eth-json-rpc-middleware/src/methods/wallet-revoke-execution-permission.test.ts
+++ b/packages/eth-json-rpc-middleware/src/methods/wallet-revoke-execution-permission.test.ts
@@ -20,12 +20,13 @@ describe('wallet_revokeExecutionPermission', () => {
   let request: JsonRpcRequest<RevokeExecutionPermissionRequestParams>;
   let params: RevokeExecutionPermissionRequestParams;
   let processRevokeExecutionPermissionMock: jest.MockedFunction<ProcessRevokeExecutionPermissionHook>;
+  let context: WalletMiddlewareParams['context'];
 
   const callMethod = async () => {
     const handler = createWalletRevokeExecutionPermissionHandler({
       processRevokeExecutionPermission: processRevokeExecutionPermissionMock,
     });
-    return handler({ request } as WalletMiddlewareParams);
+    return handler({ request, context } as WalletMiddlewareParams);
   };
 
   beforeEach(() => {
@@ -33,6 +34,10 @@ describe('wallet_revokeExecutionPermission', () => {
 
     request = klona(REQUEST_MOCK);
     params = request.params as RevokeExecutionPermissionRequestParams;
+
+    context = new Map([
+      ['origin', 'test-origin'],
+    ]) as WalletMiddlewareParams['context'];
 
     processRevokeExecutionPermissionMock = jest.fn();
     processRevokeExecutionPermissionMock.mockResolvedValue({});
@@ -43,6 +48,7 @@ describe('wallet_revokeExecutionPermission', () => {
     expect(processRevokeExecutionPermissionMock).toHaveBeenCalledWith(
       params,
       request,
+      context,
     );
   });
 

--- a/packages/eth-json-rpc-middleware/src/methods/wallet-revoke-execution-permission.ts
+++ b/packages/eth-json-rpc-middleware/src/methods/wallet-revoke-execution-permission.ts
@@ -25,6 +25,7 @@ export type RevokeExecutionPermissionRequestParams = Infer<
 export type ProcessRevokeExecutionPermissionHook = (
   request: RevokeExecutionPermissionRequestParams,
   req: JsonRpcRequest,
+  context: WalletMiddlewareContext,
 ) => Promise<RevokeExecutionPermissionResult>;
 
 /**
@@ -41,7 +42,7 @@ export function createWalletRevokeExecutionPermissionHandler({
 }: {
   processRevokeExecutionPermission?: ProcessRevokeExecutionPermissionHook;
 }): JsonRpcMiddleware<JsonRpcRequest, Json, WalletMiddlewareContext> {
-  return async ({ request }) => {
+  return async ({ request, context }) => {
     if (!processRevokeExecutionPermission) {
       throw rpcErrors.methodNotSupported(
         'wallet_revokeExecutionPermission - no middleware configured',
@@ -52,6 +53,6 @@ export function createWalletRevokeExecutionPermissionHandler({
 
     validateParams(params, RevokeExecutionPermissionRequestParamsStruct);
 
-    return await processRevokeExecutionPermission(params, request);
+    return await processRevokeExecutionPermission(params, request, context);
   };
 }


### PR DESCRIPTION
## Explanation

`wallet_requestExecutionPermissions` and `wallet_revokeExecutionPermissions` (although the latter is not implemented in Extension) require the origin of the request in order to forward to the implementing snap.

When these methods were upgraded to JsonRpcMiddleware 2, the context was swallowed, so the origin became inaccessible. This change includes the `context: WalletContext` parameter in the call to the "process" function.

## References
Required for https://github.com/MetaMask/metamask-extension/pull/38616
Fixes https://github.com/MetaMask/metamask-extension/issues/38618

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass `WalletMiddlewareContext` to the processing hooks for `wallet_requestExecutionPermissions` and `wallet_revokeExecutionPermission`, updating tests and changelog.
> 
> - **Middleware (EIP-7715)**:
>   - `createWalletRequestExecutionPermissionsHandler` and `createWalletRevokeExecutionPermissionHandler` now receive `context` and pass `WalletMiddlewareContext` to their respective process hooks.
>   - Update hook signatures: `ProcessRequestExecutionPermissionsHook` and `ProcessRevokeExecutionPermissionHook` now include `context`.
> - **Tests**:
>   - Update tests to provide `context` and assert hooks are called with `(params, request, context)`.
> - **Changelog**:
>   - Add Fixed entry: Include `WalletContext` in EIP-7715 requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d3ebb258ecc15f92f1ef6096ca413c60cf2d3c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->