### PR TITLE
ci: Replace use of `github-tools` workflows with versioned actions

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -5,14 +5,15 @@ on:
     types: [opened, synchronize, labeled, unlabeled]
 
 jobs:
-  check_changelog:
-    uses: MetaMask/github-tools/.github/workflows/changelog-check.yml@fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
-    with:
-      action-sha: fc6fe1a3fb591f6afa61f0dbbe7698bd50fab9c7
-      base-branch: ${{ github.event.pull_request.base.ref }}
-      head-ref: ${{ github.head_ref }}
-      labels: ${{ toJSON(github.event.pull_request.labels) }}
-      pr-number: ${{ github.event.pull_request.number }}
-      repo: ${{ github.repository }}
-    secrets:
-      gh-token: ${{ secrets.GITHUB_TOKEN }}
+  check-changelog:
+    name: Check changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check changelog
+        uses: MetaMask/github-tools/.github/actions/check-changelog@v1
+        with:
+          base-branch: ${{ github.event.pull_request.base.ref }}
+          head-ref: ${{ github.head_ref }}
+          labels: ${{ toJSON(github.event.pull_request.labels) }}
+          pr-number: ${{ github.event.pull_request.number }}
+          repo: ${{ github.repository }}


### PR DESCRIPTION
## Explanation

This replaces all use of `MetaMask/github-tools` _workflows_, usually referenced by a specific commit hash, with (composite) _actions_, referenced by a version. This has several benefits:

- We can update actions used simply by creating a new release in the `github-tools` repository, propagating the changes to all repositories using the version.
   - Breaking changes can still be made by creating a major release.
- Actions have access to certain variables that workflows don't have access to, letting us omit input options like `github-tools-ref`.
- In cases where we're already running other steps, using an action avoids spinning up a new runner.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the changelog check from a reusable workflow pinned to a commit to the versioned `check-changelog@v1` action.
> 
> - **CI / GitHub Actions**:
>   - Replace reusable workflow `MetaMask/github-tools/.github/workflows/changelog-check.yml@<sha>` with composite action `MetaMask/github-tools/.github/actions/check-changelog@v1`.
>   - Rename job `check_changelog` → `check-changelog`; define runner (`ubuntu-latest`) and a single step invoking the action.
>   - Remove `action-sha` and `secrets.gh-token` inputs; keep `base-branch`, `head-ref`, `labels`, `pr-number`, and `repo` inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 568305a1dcbf5f41b485001f0fa0518da2742879. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->