### PR TITLE
chore(lint): Fix suppressed ESLint errors in `storage-service` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3437,14 +3437,6 @@
       "count": 2
     }
   },
-  "packages/storage-service/src/InMemoryStorageAdapter.test.ts": {
-    "id-denylist": {
-      "count": 1
-    },
-    "require-atomic-updates": {
-      "count": 1
-    }
-  },
   "packages/subscription-controller/src/SubscriptionController.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 4

--- a/packages/storage-service/src/InMemoryStorageAdapter.test.ts
+++ b/packages/storage-service/src/InMemoryStorageAdapter.test.ts
@@ -51,7 +51,8 @@ describe('InMemoryStorageAdapter', () => {
         parseError,
       );
 
-      // Restore
+      // Restore original `JSON.parse`.
+      // eslint-disable-next-line require-atomic-updates
       JSON.parse = originalParse;
       consoleErrorSpy.mockRestore();
     });
@@ -69,7 +70,7 @@ describe('InMemoryStorageAdapter', () => {
 
     it('stores objects', async () => {
       const adapter = new InMemoryStorageAdapter();
-      const obj = { foo: 'bar', num: 123 };
+      const obj = { foo: 'bar', number: 123 };
 
       await adapter.setItem('TestNamespace', 'key', obj);
       const response = await adapter.getItem('TestNamespace', 'key');


### PR DESCRIPTION
## Explanation

This fixes some suppressed ESLint errors in the `storage-service` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes #7394.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes ESLint issues in `InMemoryStorageAdapter.test.ts` and removes its suppressions from `eslint-suppressions.json`.
> 
> - **storage-service**:
>   - Update `packages/storage-service/src/InMemoryStorageAdapter.test.ts`:
>     - Add explicit comment and `eslint-disable-next-line require-atomic-updates` when restoring `JSON.parse`.
>     - Rename test object property from `num` to `number`.
> - **Lint config**:
>   - Remove suppressions for `packages/storage-service/src/InMemoryStorageAdapter.test.ts` from `eslint-suppressions.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29fb0225a5882ac0983fc40a0586c96f26154292. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->