### PR TITLE
Fix getNetworkClientById to be less strict about network client ID

### DIFF
--- a/packages/assets-controllers/src/AssetsContractControllerWithNetworkClientId.test.ts
+++ b/packages/assets-controllers/src/AssetsContractControllerWithNetworkClientId.test.ts
@@ -31,7 +31,7 @@ describe('AssetsContractController with NetworkClientId', () => {
           'invalidNetworkClientId',
         ),
     ).rejects.toThrow(
-      `No custom network client was found with the ID "invalidNetworkClientId".`,
+      `No network client was found with the ID "invalidNetworkClientId".`,
     );
     messenger.clearEventSubscriptions('NetworkController:networkDidChange');
   });
@@ -46,7 +46,7 @@ describe('AssetsContractController with NetworkClientId', () => {
           'invalidNetworkClientId',
         ),
     ).rejects.toThrow(
-      `No custom network client was found with the ID "invalidNetworkClientId".`,
+      `No network client was found with the ID "invalidNetworkClientId".`,
     );
     messenger.clearEventSubscriptions('NetworkController:networkDidChange');
   });
@@ -154,7 +154,7 @@ describe('AssetsContractController with NetworkClientId', () => {
           undefined,
           'invalidNetworkClientId',
         ),
-    ).rejects.toThrow('No custom network client was found');
+    ).rejects.toThrow('No network client was found');
     messenger.clearEventSubscriptions('NetworkController:networkDidChange');
   });
 
@@ -582,7 +582,7 @@ describe('AssetsContractController with NetworkClientId', () => {
           ERC721_GODS_ADDRESS,
           'invalidNetworkClientId',
         ),
-    ).rejects.toThrow('No custom network client was found');
+    ).rejects.toThrow('No network client was found');
     messenger.clearEventSubscriptions('NetworkController:networkDidChange');
   });
 
@@ -698,7 +698,7 @@ describe('AssetsContractController with NetworkClientId', () => {
           '148332',
           'invalidNetworkClientId',
         ),
-    ).rejects.toThrow('No custom network client was found');
+    ).rejects.toThrow('No network client was found');
     messenger.clearEventSubscriptions('NetworkController:networkDidChange');
   });
 
@@ -823,7 +823,7 @@ describe('AssetsContractController with NetworkClientId', () => {
           '1',
           'invalidNetworkClientId',
         ),
-    ).rejects.toThrow('No custom network client was found');
+    ).rejects.toThrow('No network client was found');
     messenger.clearEventSubscriptions('NetworkController:networkDidChange');
   });
 
@@ -873,7 +873,7 @@ describe('AssetsContractController with NetworkClientId', () => {
           ERC1155_ID,
           'invalidNetworkClientId',
         ),
-    ).rejects.toThrow('No custom network client was found');
+    ).rejects.toThrow('No network client was found');
     messenger.clearEventSubscriptions('NetworkController:networkDidChange');
   });
 

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update the default set of Infura networks to include Monad Testnet ([#7067](https://github.com/MetaMask/core/pull/7067))
 - Bump `@metamask/eth-json-rpc-middleware` from `^22.0.0` to `^22.0.1` ([#7330](https://github.com/MetaMask/core/pull/7330))
 
+### Fixed
+
+- Fix `getNetworkClientById` to look for a custom network client if given an Infura network client ID and an Infura network client is not found ([#7420](https://github.com/MetaMask/core/pull/7420))
+
 ## [27.0.0]
 
 ### Added

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1631,26 +1631,22 @@ export class NetworkController extends BaseController<
         autoManagedNetworkClientRegistry[NetworkClientType.Infura][
           networkClientId
         ];
-      // This is impossible to reach
-      /* istanbul ignore if */
-      if (!infuraNetworkClient) {
-        throw new Error(
-          `No Infura network client was found with the ID "${networkClientId}".`,
-        );
+      if (infuraNetworkClient) {
+        return infuraNetworkClient;
       }
-      return infuraNetworkClient;
     }
 
     const customNetworkClient =
       autoManagedNetworkClientRegistry[NetworkClientType.Custom][
         networkClientId
       ];
-    if (!customNetworkClient) {
-      throw new Error(
-        `No custom network client was found with the ID "${networkClientId}".`,
-      );
+    if (customNetworkClient) {
+      return customNetworkClient;
     }
-    return customNetworkClient;
+
+    throw new Error(
+      `No network client was found with the ID "${networkClientId}".`,
+    );
   }
 
   /**


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Currently, it is expected that IDs for Infura network clients match a known property in the `InfuraNetworkType` enum and that IDs for custom network clients follow a UUID format.

The way that these expectations are enforced is inconsistent: while an Infura network client ID must match an entry in the aforementioned enum — an error will be produced upon initialization otherwise — there is no such restriction for a custom network client ID.

But `getNetworkClientById` is more strict, and assumes that if given a property of `InfuraNetworkType`, it _must_ correspond to an Infura network client, failing if it cannot find one.

This causes issues with the `transaction-controller` package, because it uses a flattened version of the network client registry to know which networks should be used for tracking transactions. The flattened network client registry holds a list of network client IDs without knowing which are Infura and which are custom. When `transaction-controller` attempts to look them up again, `getNetworkClientById` throws an error. Since this operation occurs when the client starts, this ends up bricking the wallet.

Ideally, we could fix this by enforcing that custom network client IDs do _not_ match `InfuraNetworkType`. However, it is too late to make this change, and anyway, in the future, we want to consolidate Infura and custom network clients, and at that point, the network client ID format won't matter.

For these reasons, this commit changes `getNetworkClientById` to treat an Infura network client ID as a custom network client ID if no Infura network client is found.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

This PR unblocks releasing this change in `controller-utils` so that they are no longer breaking changes: https://github.com/MetaMask/core/pull/7067. There is some discussion about this in Slack.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `getNetworkClientById` to fall back to custom clients when an Infura-typed ID isn’t found and standardizes the error to `No network client was found with the ID "<id>"`; adjusts tests and changelog accordingly.
> 
> - **Network Controller**:
>   - Update `getNetworkClientById` in `packages/network-controller/src/NetworkController.ts` to:
>     - Return Infura client if present; otherwise check and return a custom client with the same ID.
>     - Throw a unified error: `No network client was found with the ID "<id>"`.
> - **Tests**:
>   - Adjust tests in `packages/network-controller/tests/NetworkController.test.ts` to reflect fallback behavior and new error message.
>   - Update `packages/assets-controllers/src/AssetsContractControllerWithNetworkClientId.test.ts` to expect the unified error message across ERC-20/721/1155 paths.
> - **Changelog**:
>   - Add Fixed entry in `packages/network-controller/CHANGELOG.md` documenting the `getNetworkClientById` fallback to custom client.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1da819ab5a842e066c460ef99c6f76115c44564. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->