### PR TITLE
chore: Fix suppressed lint errors in `@metamask/messenger`

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1925,22 +1925,6 @@
       "count": 1
     }
   },
-  "packages/messenger/src/Messenger.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 9
-    },
-    "id-length": {
-      "count": 1
-    }
-  },
-  "packages/messenger/src/Messenger.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 21
-    },
-    "@typescript-eslint/prefer-nullish-coalescing": {
-      "count": 4
-    }
-  },
   "packages/multichain-account-service/src/MultichainAccountService.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 1

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -103,8 +103,8 @@ describe('Messenger', () => {
         },
       );
 
-      messenger.registerActionHandler('Fixture:concat', (s: string) => {
-        message += s;
+      messenger.registerActionHandler('Fixture:concat', (input: string) => {
+        message += input;
       });
 
       messenger.call('Fixture:reset', 'hello');
@@ -929,10 +929,11 @@ describe('Messenger', () => {
         namespace: 'Fixture',
       });
       const stub = sinon.stub();
-      const handler = (current: string, previous: string | undefined) => {
+      const handler = (current: string, previous: string | undefined): void => {
         stub(current, previous);
       };
-      const selector = (state: { prop1: string; prop2: string }) => state.prop1;
+      const selector = (state: { prop1: string; prop2: string }): string =>
+        state.prop1;
       messenger.subscribe('Fixture:complexMessage', handler, selector);
       messenger.unsubscribe('Fixture:complexMessage', handler);
 
@@ -1125,11 +1126,11 @@ describe('Messenger', () => {
       class TestService {
         name = 'TestService' as const;
 
-        getType() {
+        getType(): 'api' {
           return 'api';
         }
 
-        getCount() {
+        getCount(): number {
           return 42;
         }
       }
@@ -1160,7 +1161,7 @@ describe('Messenger', () => {
 
         privateValue = 'secret';
 
-        getPrivateValue() {
+        getPrivateValue(): string {
           return this.privateValue;
         }
       }
@@ -1184,7 +1185,7 @@ describe('Messenger', () => {
       class TestService {
         name = 'TestService' as const;
 
-        async fetchData(id: string) {
+        async fetchData(id: string): Promise<string> {
           return `data-${id}`;
         }
       }
@@ -1231,7 +1232,7 @@ describe('Messenger', () => {
 
         readonly nonFunction = 'not a function';
 
-        getValue() {
+        getValue(): string {
           return 'test';
         }
       }
@@ -1267,7 +1268,7 @@ describe('Messenger', () => {
           this.name = namespace;
         }
 
-        baseMethod() {
+        baseMethod(): string {
           return 'base method';
         }
       }
@@ -1279,7 +1280,7 @@ describe('Messenger', () => {
           super({ namespace: 'ChildController' });
         }
 
-        childMethod() {
+        childMethod(): string {
           return 'child method';
         }
       }


### PR DESCRIPTION
## Explanation

All suppressed errors in the package have been fixed.

Fixes #7371

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit return types and minor typing adjustments to `Messenger` and its tests, and removes related ESLint suppressions.
> 
> - **@metamask/messenger**
>   - `packages/messenger/src/Messenger.ts`:
>     - Add explicit return types (`: void`, specific generics) to public and private methods (e.g., `registerActionHandler`, `unregisterActionHandler`, `clearActions`, `publish`, `unsubscribe`, `clearEventSubscriptions`, `clearSubscriptions`, delegation internals).
>     - Tighten delegate helpers’ types and return values; switch fallback usage to `??` in loops (`actions ?? []`, `events ?? []`).
>   - `packages/messenger/src/Messenger.test.ts`:
>     - Add explicit return types to class methods, handlers, and selectors; minor param rename (`s` → `input`).
> - **ESLint**
>   - `eslint-suppressions.json`: Remove entries for `packages/messenger/src/Messenger.ts` and `Messenger.test.ts` related to suppressed rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e27dd1a468d51103cb71d2078e49ae70b5d21b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->