### PR TITLE
more metrics for swaps and bridge

### DIFF
--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -949,6 +949,8 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
         };
       }
       case UnifiedSwapBridgeEventName.AssetDetailTooltipClicked:
+      case UnifiedSwapBridgeEventName.AssetPickerOpened:
+      case UnifiedSwapBridgeEventName.AssetSelected:
         return baseProperties;
       // These events may be published after the bridge-controller state is reset
       // So the BridgeStatusController populates all the properties

--- a/packages/bridge-controller/src/utils/metrics/constants.ts
+++ b/packages/bridge-controller/src/utils/metrics/constants.ts
@@ -18,6 +18,8 @@ export enum UnifiedSwapBridgeEventName {
   AllQuotesSorted = `${UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY} All Quotes Sorted`,
   QuoteSelected = `${UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY} Quote Selected`,
   AssetDetailTooltipClicked = `${UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY} Asset Detail Tooltip Clicked`,
+  AssetPickerOpened = `${UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY} Asset Picker Opened`,
+  AssetSelected = `${UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY} Asset Selected`,
   QuotesValidationFailed = `${UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY} Quotes Failed Validation`,
   StatusValidationFailed = `${UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY} Status Failed Validation`,
 }

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -204,6 +204,15 @@ export type RequiredEventContextFromClient = {
     chain_name: string;
     chain_id: string;
   };
+  [UnifiedSwapBridgeEventName.AssetPickerOpened]: {
+    location: 'source' | 'destination';
+  };
+  [UnifiedSwapBridgeEventName.AssetSelected]: {
+    token_symbol: string;
+    token_address: string;
+    chain_id: CaipChainId | null;
+    location: 'source' | 'destination';
+  };
   [UnifiedSwapBridgeEventName.QuotesValidationFailed]: {
     failures: string[];
   };
@@ -260,6 +269,8 @@ export type EventPropertiesFromControllerState = {
     QuoteFetchData &
     TradeData;
   [UnifiedSwapBridgeEventName.AssetDetailTooltipClicked]: null;
+  [UnifiedSwapBridgeEventName.AssetPickerOpened]: null;
+  [UnifiedSwapBridgeEventName.AssetSelected]: null;
   [UnifiedSwapBridgeEventName.QuotesValidationFailed]: RequestParams & {
     refresh_count: number;
   };


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new `Asset Picker Opened` and `Asset Selected` metrics events and wires them into the bridge controller analytics pipeline.
> 
> - **Metrics/Telemetry**:
>   - Add new events in `utils/metrics/constants.ts`: `AssetPickerOpened`, `AssetSelected`.
>   - Extend `RequiredEventContextFromClient` in `utils/metrics/types.ts` with payloads for the new events and include them in `EventPropertiesFromControllerState`.
> - **Bridge Controller** (`bridge-controller.ts`):
>   - Handle `AssetPickerOpened` and `AssetSelected` in `#getEventProperties`, returning base properties only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 822d45bbebc481715f490e2601e1ec1945df89e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->