### PR TITLE
chore(lint): Fix suppressed ESLint errors in `remote-feature-flag-controller` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3089,32 +3089,6 @@
       "count": 1
     }
   },
-  "packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 1
-    },
-    "promise/param-names": {
-      "count": 1
-    }
-  },
-  "packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 2
-    },
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 2
-    }
-  },
-  "packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 1
-    }
-  },
   "packages/seedless-onboarding-controller/jest.environment.js": {
     "n/no-unsupported-features/node-builtins": {
       "count": 1

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
@@ -10,6 +10,8 @@ import {
   EnvironmentType,
 } from '../remote-feature-flag-controller-types';
 
+import Mock = jest.Mock;
+
 const mockServerFeatureFlagsResponse: ApiDataResponse = [
   { feature1: false },
   { feature2: { chrome: '<109' } },
@@ -265,13 +267,15 @@ function createMockFetch({
   response?: Partial<Response>;
   error?: Error;
   delay?: number;
-}) {
+}): Mock {
   if (error) {
     return jest
       .fn()
       .mockImplementation(
         () =>
-          new Promise((_, reject) => setTimeout(() => reject(error), delay)),
+          new Promise((_resolve, reject) =>
+            setTimeout(() => reject(error), delay),
+          ),
       );
   }
 

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_MAX_RETRIES,
 } from '@metamask/controller-utils';
 import type { ServicePolicy } from '@metamask/controller-utils';
+import type { IDisposable } from 'cockatiel';
 
 import type { AbstractClientConfigApiService } from './abstract-client-config-api-service';
 import { BASE_URL } from '../constants';
@@ -154,7 +155,7 @@ export class ClientConfigApiService implements AbstractClientConfigApiService {
    * takes.
    * @returns What {@link ServicePolicy.onBreak} returns.
    */
-  onBreak(...args: Parameters<ServicePolicy['onBreak']>) {
+  onBreak(...args: Parameters<ServicePolicy['onBreak']>): IDisposable {
     return this.#policy.onBreak(...args);
   }
 
@@ -165,7 +166,7 @@ export class ClientConfigApiService implements AbstractClientConfigApiService {
    * takes.
    * @returns What {@link ServicePolicy.onDegraded} returns.
    */
-  onDegraded(...args: Parameters<ServicePolicy['onDegraded']>) {
+  onDegraded(...args: Parameters<ServicePolicy['onDegraded']>): IDisposable {
     return this.#policy.onDegraded(...args);
   }
 
@@ -194,7 +195,7 @@ export class ClientConfigApiService implements AbstractClientConfigApiService {
       throw new Error('Feature flags api did not return an array');
     }
 
-    const remoteFeatureFlags = this.flattenFeatureFlags(data);
+    const remoteFeatureFlags = this.#flattenFeatureFlags(data);
 
     return {
       remoteFeatureFlags,
@@ -211,7 +212,7 @@ export class ClientConfigApiService implements AbstractClientConfigApiService {
    * // Input: [{ flag1: true }, { flag2: [] }]
    * // Output: { flag1: true, flag2: [] }
    */
-  private flattenFeatureFlags(responseData: ApiDataResponse): FeatureFlags {
+  #flattenFeatureFlags(responseData: ApiDataResponse): FeatureFlags {
     return responseData.reduce((acc, curr) => {
       return { ...acc, ...curr };
     }, {});

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -67,14 +67,16 @@ function createController(
     getMetaMetricsId: () => string;
     clientVersion: string;
   }> = {},
-) {
+): RemoteFeatureFlagController {
   return new RemoteFeatureFlagController({
     messenger: getMessenger(),
     state: options.state,
     clientConfigApiService:
       options.clientConfigApiService ?? buildClientConfigApiService(),
     disabled: options.disabled,
-    getMetaMetricsId: options.getMetaMetricsId ?? (() => MOCK_METRICS_ID),
+    getMetaMetricsId:
+      options.getMetaMetricsId ??
+      ((): typeof MOCK_METRICS_ID => MOCK_METRICS_ID),
     clientVersion: options.clientVersion ?? MOCK_BASE_VERSION,
   });
 }

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -212,7 +212,7 @@ export class RemoteFeatureFlagController extends BaseController<
    *
    * @param remoteFeatureFlags - The new feature flags to cache.
    */
-  async #updateCache(remoteFeatureFlags: FeatureFlags) {
+  async #updateCache(remoteFeatureFlags: FeatureFlags): Promise<void> {
     const processedRemoteFeatureFlags =
       await this.#processRemoteFeatureFlags(remoteFeatureFlags);
     this.update(() => {


### PR DESCRIPTION
## Explanation

This fixes all suppressed ESLint errors in the `remote-feature-flag-controller` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes #7388.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit types and a private method refactor to the client config service, tightens test typings/utilities, and removes related ESLint suppressions.
> 
> - **Remote Feature Flag Controller**:
>   - **ClientConfigApiService (`client-config-api-service.ts`)**:
>     - Add explicit return types for `onBreak`/`onDegraded` (`IDisposable`).
>     - Refactor `flattenFeatureFlags` to private field method `#flattenFeatureFlags` and update call site.
>   - **Controller (`remote-feature-flag-controller.ts`)**:
>     - Add explicit `Promise<void>` return type to `#updateCache`.
> - **Tests**:
>   - **ClientConfigApiService test**: Import `jest.Mock`, type `createMockFetch` to return `Mock`, adjust Promise params to satisfy lint.
>   - **RemoteFeatureFlagController test**: Annotate `createController` return type; type `getMetaMetricsId` default.
> - **Tooling**:
>   - Remove corresponding entries for this package from `eslint-suppressions.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98212880f168360163898dda2aac7eb1a16d5201. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->