### PR TITLE
chore(lint): Fix suppressed ESLint errors in `profile-metrics-controller` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2796,22 +2796,6 @@
       "count": 1
     }
   },
-  "packages/profile-metrics-controller/src/ProfileMetricsController.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 3
-    },
-    "@typescript-eslint/prefer-nullish-coalescing": {
-      "count": 2
-    }
-  },
-  "packages/profile-metrics-controller/src/ProfileMetricsService.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 3
-    },
-    "@typescript-eslint/prefer-nullish-coalescing": {
-      "count": 1
-    }
-  },
   "packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 5

--- a/packages/profile-metrics-controller/src/ProfileMetricsController.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsController.ts
@@ -258,7 +258,7 @@ export class ProfileMetricsController extends StaticIntervalPollingController()<
    * This method ensures that the first sync is only executed once,
    * and only if the user has opted in to user profile features.
    */
-  async #queueFirstSyncIfNeeded() {
+  async #queueFirstSyncIfNeeded(): Promise<void> {
     await this.#mutex.runExclusive(async () => {
       if (this.state.initialEnqueueCompleted) {
         return;
@@ -283,10 +283,10 @@ export class ProfileMetricsController extends StaticIntervalPollingController()<
    *
    * @param account - The account to sync.
    */
-  async #addAccountToQueue(account: InternalAccount) {
+  async #addAccountToQueue(account: InternalAccount): Promise<void> {
     await this.#mutex.runExclusive(async () => {
       this.update((state) => {
-        const entropySourceId = getAccountEntropySourceId(account) || 'null';
+        const entropySourceId = getAccountEntropySourceId(account) ?? 'null';
         if (!state.syncQueue[entropySourceId]) {
           state.syncQueue[entropySourceId] = [];
         }
@@ -303,7 +303,7 @@ export class ProfileMetricsController extends StaticIntervalPollingController()<
    *
    * @param account - The account address to remove.
    */
-  async #removeAccountFromQueue(account: string) {
+  async #removeAccountFromQueue(account: string): Promise<void> {
     await this.#mutex.runExclusive(async () => {
       this.update((state) => {
         for (const [entropySourceId, groupedAddresses] of Object.entries(
@@ -352,7 +352,7 @@ function groupAccountsByEntropySourceId(
   return accounts.reduce(
     (result: Record<string, AccountWithScopes[]>, account) => {
       const entropySourceId = getAccountEntropySourceId(account);
-      const key = entropySourceId || 'null';
+      const key = entropySourceId ?? 'null';
       if (!result[key]) {
         result[key] = [];
       }

--- a/packages/profile-metrics-controller/src/ProfileMetricsService.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsService.ts
@@ -6,6 +6,7 @@ import { createServicePolicy, HttpError } from '@metamask/controller-utils';
 import type { Messenger } from '@metamask/messenger';
 import { SDK } from '@metamask/profile-sync-controller';
 import type { AuthenticationController } from '@metamask/profile-sync-controller';
+import type { IDisposable } from 'cockatiel';
 
 import type { ProfileMetricsServiceMethodActions } from '.';
 
@@ -150,7 +151,7 @@ export class ProfileMetricsService {
    * {@link CockatielEvent}.
    * @see {@link createServicePolicy}
    */
-  onRetry(listener: Parameters<ServicePolicy['onRetry']>[0]) {
+  onRetry(listener: Parameters<ServicePolicy['onRetry']>[0]): IDisposable {
     return this.#policy.onRetry(listener);
   }
 
@@ -163,7 +164,7 @@ export class ProfileMetricsService {
    * {@link CockatielEvent}.
    * @see {@link createServicePolicy}
    */
-  onBreak(listener: Parameters<ServicePolicy['onBreak']>[0]) {
+  onBreak(listener: Parameters<ServicePolicy['onBreak']>[0]): IDisposable {
     return this.#policy.onBreak(listener);
   }
 
@@ -184,7 +185,9 @@ export class ProfileMetricsService {
    * @returns An object that can be used to unregister the handler. See
    * {@link CockatielEvent}.
    */
-  onDegraded(listener: Parameters<ServicePolicy['onDegraded']>[0]) {
+  onDegraded(
+    listener: Parameters<ServicePolicy['onDegraded']>[0],
+  ): IDisposable {
     return this.#policy.onDegraded(listener);
   }
 
@@ -197,7 +200,7 @@ export class ProfileMetricsService {
   async submitMetrics(data: ProfileMetricsSubmitMetricsRequest): Promise<void> {
     const authToken = await this.#messenger.call(
       'AuthenticationController:getBearerToken',
-      data.entropySourceId || undefined,
+      data.entropySourceId ?? undefined,
     );
     await this.#policy.execute(async () => {
       const url = new URL(`${this.#baseURL}/profile/accounts`);


### PR DESCRIPTION
## Explanation

This fixes all suppressed ESLint errors in the `profile-metrics-controller` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes #7385.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit return types and nullish coalescing, tightens event handler typings, and removes related ESLint suppressions for profile-metrics-controller.
> 
> - **profile-metrics-controller**:
>   - `ProfileMetricsController.ts`:
>     - Add explicit `Promise<void>` return types to `#queueFirstSyncIfNeeded`, `#addAccountToQueue`, and `#removeAccountFromQueue`.
>     - Replace `||` with `??` when computing `entropySourceId` and grouping accounts.
> - **profile-metrics-service**:
>   - `ProfileMetricsService.ts`:
>     - Import `IDisposable` and annotate `onRetry`, `onBreak`, `onDegraded` to return `IDisposable`.
>     - Use `??` when passing `entropySourceId` to `AuthenticationController:getBearerToken`.
> - **Lint configuration**:
>   - Remove ESLint suppressions for `packages/profile-metrics-controller/src/ProfileMetricsController.ts` and `ProfileMetricsService.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a4dc746309f13b28c65b99b9d98abdeca0e9688. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->