### PR TITLE
chore(lint): Fix suppressed ESLint errors in `polling-controller` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2775,27 +2775,6 @@
       "count": 1
     }
   },
-  "packages/polling-controller/src/BlockTrackerPollingController.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 5
-    },
-    "@typescript-eslint/naming-convention": {
-      "count": 1
-    }
-  },
-  "packages/polling-controller/src/StaticIntervalPollingController.test.ts": {
-    "id-denylist": {
-      "count": 1
-    }
-  },
-  "packages/polling-controller/src/StaticIntervalPollingController.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 7
-    },
-    "@typescript-eslint/naming-convention": {
-      "count": 1
-    }
-  },
   "packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 5

--- a/packages/polling-controller/src/BlockTrackerPollingController.ts
+++ b/packages/polling-controller/src/BlockTrackerPollingController.ts
@@ -26,6 +26,9 @@ export type BlockTrackerPollingInput = {
  * @param Base - The base class to mix onto.
  * @returns The composed class.
  */
+// This is a function that's used as class, and the return type is inferred from
+// the class defined inside the function scope, so this can't be easily typed.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/naming-convention
 function BlockTrackerPollingControllerMixin<
   TBase extends Constructor,
   PollingInput extends BlockTrackerPollingInput,
@@ -40,7 +43,7 @@ function BlockTrackerPollingControllerMixin<
       networkClientId: NetworkClientId,
     ): NetworkClient | undefined;
 
-    _startPolling(input: PollingInput) {
+    _startPolling(input: PollingInput): void {
       const key = getKey(input);
 
       if (this.#activeListeners[key]) {
@@ -61,7 +64,7 @@ function BlockTrackerPollingControllerMixin<
       }
     }
 
-    _stopPollingByPollingTokenSetId(key: PollingTokenSetId) {
+    _stopPollingByPollingTokenSetId(key: PollingTokenSetId): void {
       const { networkClientId } = JSON.parse(key);
       const networkClient = this._getNetworkClientById(
         networkClientId as NetworkClientId,
@@ -86,10 +89,16 @@ class Empty {}
 
 export const BlockTrackerPollingControllerOnly = <
   PollingInput extends BlockTrackerPollingInput,
+  // The return type is inferred from the class defined inside the function
+  // scope, so this can't be easily typed.
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 >() => BlockTrackerPollingControllerMixin<typeof Empty, PollingInput>(Empty);
 
 export const BlockTrackerPollingController = <
   PollingInput extends BlockTrackerPollingInput,
+  // The return type is inferred from the class defined inside the function
+  // scope, so this can't be easily typed.
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 >() =>
   BlockTrackerPollingControllerMixin<typeof BaseController, PollingInput>(
     BaseController,

--- a/packages/polling-controller/src/StaticIntervalPollingController.test.ts
+++ b/packages/polling-controller/src/StaticIntervalPollingController.test.ts
@@ -25,7 +25,7 @@ class ChildBlockTrackerPollingController extends StaticIntervalPollingController
   any
 > {
   executePollPromises: {
-    reject: (err: unknown) => void;
+    reject: (error: unknown) => void;
     resolve: () => void;
   }[] = [];
 

--- a/packages/polling-controller/src/StaticIntervalPollingController.ts
+++ b/packages/polling-controller/src/StaticIntervalPollingController.ts
@@ -18,6 +18,9 @@ import type {
  * @param Base - The base class to mix onto.
  * @returns The composed class.
  */
+// This is a function that's used as class, and the return type is inferred from
+// the class defined inside the function scope, so this can't be easily typed.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/naming-convention
 function StaticIntervalPollingControllerMixin<
   TBase extends Constructor,
   PollingInput extends Json,
@@ -30,15 +33,15 @@ function StaticIntervalPollingControllerMixin<
 
     #intervalLength: number | undefined = 1000;
 
-    setIntervalLength(intervalLength: number) {
+    setIntervalLength(intervalLength: number): void {
       this.#intervalLength = intervalLength;
     }
 
-    getIntervalLength() {
+    getIntervalLength(): number | undefined {
       return this.#intervalLength;
     }
 
-    _startPolling(input: PollingInput) {
+    _startPolling(input: PollingInput): void {
       if (!this.#intervalLength) {
         throw new Error('intervalLength must be defined and greater than 0');
       }
@@ -65,7 +68,7 @@ function StaticIntervalPollingControllerMixin<
       ));
     }
 
-    _stopPollingByPollingTokenSetId(key: PollingTokenSetId) {
+    _stopPollingByPollingTokenSetId(key: PollingTokenSetId): void {
       const intervalId = this.#intervalIds[key];
       if (intervalId) {
         clearTimeout(intervalId);
@@ -81,8 +84,14 @@ class Empty {}
 
 export const StaticIntervalPollingControllerOnly = <
   PollingInput extends Json,
+  // The return type is inferred from the class defined inside the function
+  // scope, so this can't be easily typed.
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 >() => StaticIntervalPollingControllerMixin<typeof Empty, PollingInput>(Empty);
 
+// The return type is inferred from the class defined inside the function
+// scope, so this can't be easily typed.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const StaticIntervalPollingController = <PollingInput extends Json>() =>
   StaticIntervalPollingControllerMixin<typeof BaseController, PollingInput>(
     BaseController,


### PR DESCRIPTION
## Explanation

This fixes all suppressed ESLint errors in the `polling-controller` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes #7383.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit return types and targeted ESLint-disable annotations to polling controller mixins and tests, removing related suppressions.
> 
> - **Polling Controller**:
>   - **BlockTrackerPollingController** (`packages/polling-controller/src/BlockTrackerPollingController.ts`):
>     - Add explicit return types to `_startPolling` and `_stopPollingByPollingTokenSetId`.
>     - Document/annotate mixin factory and exported helpers with ESLint disables for inferred return types.
>   - **StaticIntervalPollingController** (`packages/polling-controller/src/StaticIntervalPollingController.ts`):
>     - Add explicit return types to `setIntervalLength`, `getIntervalLength`, `_startPolling`, and `_stopPollingByPollingTokenSetId`.
>     - Document/annotate mixin factory and exported helpers with ESLint disables for inferred return types.
>   - **Tests** (`packages/polling-controller/src/StaticIntervalPollingController.test.ts`):
>     - Rename callback param `err` to `error` in deferred promise handlers.
> - **ESLint Suppressions**:
>   - Remove suppressions for updated polling-controller files in `eslint-suppressions.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91d0c5a150d2ce44782947b4413467d2d075beb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->