### PR TITLE
chore(lint): Fix suppressed ESLint errors in `base-controller` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -699,28 +699,6 @@
       "count": 3
     }
   },
-  "packages/base-controller/src/BaseController.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 15
-    },
-    "import-x/namespace": {
-      "count": 13
-    },
-    "no-new": {
-      "count": 2
-    }
-  },
-  "packages/base-controller/src/BaseController.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 3
-    },
-    "@typescript-eslint/naming-convention": {
-      "count": 3
-    },
-    "id-denylist": {
-      "count": 1
-    }
-  },
   "packages/bridge-controller/src/bridge-controller.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 2

--- a/packages/base-controller/src/BaseController.test.ts
+++ b/packages/base-controller/src/BaseController.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable jest/no-export */
-import { MOCK_ANY_NAMESPACE, Messenger } from '@metamask/messenger';
 import type { MockAnyNamespace } from '@metamask/messenger';
+import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 import type { Json } from '@metamask/utils';
 import type { Draft, Patch } from 'immer';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 
 import type {
   ControllerActions,
@@ -67,16 +67,19 @@ export class CountController extends BaseController<
     callback: (
       state: Draft<CountControllerState>,
     ) => void | CountControllerState,
-  ) {
-    const res = super.update(callback);
-    return res;
+  ): {
+    nextState: CountControllerState;
+    patches: Patch[];
+    inversePatches: Patch[];
+  } {
+    return super.update(callback);
   }
 
-  applyPatches(patches: Patch[]) {
+  applyPatches(patches: Patch[]): void {
     super.applyPatches(patches);
   }
 
-  destroy() {
+  destroy(): void {
     super.destroy();
   }
 }
@@ -140,16 +143,19 @@ class MessagesController extends BaseController<
     callback: (
       state: Draft<MessagesControllerState>,
     ) => void | MessagesControllerState,
-  ) {
-    const res = super.update(callback);
-    return res;
+  ): {
+    nextState: MessagesControllerState;
+    patches: Patch[];
+    inversePatches: Patch[];
+  } {
+    return super.update(callback);
   }
 
-  applyPatches(patches: Patch[]) {
+  applyPatches(patches: Patch[]): void {
     super.applyPatches(patches);
   }
 
-  destroy() {
+  destroy(): void {
     super.destroy();
   }
 }
@@ -172,6 +178,8 @@ describe('BaseController', () => {
 
   it('should allow getting state via the getState action', () => {
     const messenger = getCountMessenger();
+
+    // eslint-disable-next-line no-new
     new CountController({
       messenger,
       name: countControllerName,
@@ -542,6 +550,8 @@ describe('BaseController', () => {
 
   it('should throw when unsubscribing listener who was never subscribed', () => {
     const messenger = getCountMessenger();
+
+    // eslint-disable-next-line no-new
     new CountController({
       messenger,
       name: 'CountController',
@@ -633,19 +643,19 @@ describe('BaseController', () => {
         messenger.registerActionHandler('VisitorController:clear', this.clear);
       }
 
-      clear = () => {
+      clear: () => void = () => {
         this.update(() => {
           return { visitors: [] };
         });
       };
 
-      addVisitor(visitor: string) {
+      addVisitor(visitor: string): void {
         this.update(({ visitors }) => {
           return { visitors: [...visitors, visitor] };
         });
       }
 
-      destroy() {
+      destroy(): void {
         super.destroy();
       }
     }
@@ -709,19 +719,21 @@ describe('BaseController', () => {
         messenger.subscribe('VisitorController:stateChange', this.onVisit);
       }
 
-      onVisit = ({ visitors }: VisitorControllerState) => {
+      onVisit: ({ visitors }: VisitorControllerState) => void = ({
+        visitors,
+      }: VisitorControllerState) => {
         if (visitors.length > this.state.maxVisitors) {
           this.messenger.call('VisitorController:clear');
         }
       };
 
-      updateMax = (max: number) => {
+      updateMax: (max: number) => void = (max: number) => {
         this.update(() => {
           return { maxVisitors: max };
         });
       };
 
-      destroy() {
+      destroy(): void {
         super.destroy();
       }
     }
@@ -876,7 +888,7 @@ describe('deriveStateFromMetadata', () => {
 
     if (property !== 'usedInUi') {
       it('should use function to derive state', () => {
-        const normalizeTransactionHash = (hash: string) => {
+        const normalizeTransactionHash = (hash: string): string => {
           return hash.toLowerCase();
         };
 
@@ -900,7 +912,12 @@ describe('deriveStateFromMetadata', () => {
       });
 
       it('should allow returning a partial object from a deriver', () => {
-        const getDerivedTxMeta = (txMeta: { hash: string; value: number }) => {
+        const getDerivedTxMeta = (txMeta: {
+          hash: string;
+          value: number;
+        }): {
+          value: number;
+        } => {
           return { value: txMeta.value };
         };
 
@@ -931,7 +948,7 @@ describe('deriveStateFromMetadata', () => {
           hash: string;
           value: number;
           history: { hash: string; value: number }[];
-        }) => {
+        }): { history: { value: number }[]; value: number } => {
           return {
             history: txMeta.history.map((entry) => {
               return { value: entry.value };

--- a/packages/base-controller/src/BaseController.ts
+++ b/packages/base-controller/src/BaseController.ts
@@ -29,7 +29,7 @@ export type StateConstraint = Record<string, Json>;
  * @param patches - A list of patches describing any changes (see here for more
  * information: https://immerjs.github.io/immer/docs/patches)
  */
-export type StateChangeListener<T> = (state: T, patches: Patch[]) => void;
+export type StateChangeListener<Type> = (state: Type, patches: Patch[]) => void;
 
 /**
  * An function to derive state.
@@ -40,7 +40,7 @@ export type StateChangeListener<T> = (state: T, patches: Patch[]) => void;
  * @param value - A piece of controller state.
  * @returns Something derived from controller state.
  */
-export type StateDeriver<T extends Json> = (value: T) => Json;
+export type StateDeriver<Type extends Json> = (value: Type) => Json;
 
 /**
  * State metadata.
@@ -48,8 +48,8 @@ export type StateDeriver<T extends Json> = (value: T) => Json;
  * This metadata describes which parts of state should be persisted, and how to
  * get an anonymized representation of the state.
  */
-export type StateMetadata<T extends StateConstraint> = {
-  [P in keyof T]-?: StatePropertyMetadata<T[P]>;
+export type StateMetadata<Type extends StateConstraint> = {
+  [Key in keyof Type]-?: StatePropertyMetadata<Type[Key]>;
 };
 
 /**
@@ -276,7 +276,7 @@ export class BaseController<
    *
    * @returns The current state.
    */
-  get state() {
+  get state(): ControllerState {
     return this.#internalState;
   }
 
@@ -309,7 +309,7 @@ export class BaseController<
     const [nextState, patches, inversePatches] = (
       produceWithPatches as unknown as (
         state: ControllerState,
-        cb: typeof callback,
+        callbackFn: typeof callback,
       ) => [ControllerState, Patch[], Patch[]]
     )(this.#internalState, callback);
 
@@ -333,7 +333,7 @@ export class BaseController<
    * @param patches - An array of immer patches that are to be applied to make
    * or undo changes.
    */
-  protected applyPatches(patches: Patch[]) {
+  protected applyPatches(patches: Patch[]): void {
     const nextState = applyPatches(this.#internalState, patches);
     this.#internalState = nextState;
     this.#messenger.publish(
@@ -352,7 +352,7 @@ export class BaseController<
    * least ensures this instance won't be responsible for preventing the
    * listeners from being garbage collected.
    */
-  protected destroy() {
+  protected destroy(): void {
     this.messenger.clearEventSubscriptions(`${this.name}:stateChange`);
   }
 }


### PR DESCRIPTION
## Explanation

This fixes all suppressed ESLint errors in the `base-controller` package.

## References

Closes #7344.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors BaseController types and tests to satisfy ESLint by adding explicit return types, refining generics, and cleaning up imports; removes related suppressions.
> 
> - **Core (`packages/base-controller/src/BaseController.ts`)**
>   - Add explicit return types to `state` getter, `applyPatches`, `destroy`, and `update` result.
>   - Rename generic/type params for clarity (`T`→`Type`), and tighten typings (`StateChangeListener`, `StateDeriver`, `StateMetadata`).
>   - Minor callback param rename in `produceWithPatches` cast (`callbackFn`).
> - **Tests (`packages/base-controller/src/BaseController.test.ts`)**
>   - Add explicit return types to controller overrides and helper functions; annotate arrow properties.
>   - Switch `sinon` import to default; reorder imports; add `// eslint-disable-next-line no-new` where needed.
> - **Lint config**
>   - Update `eslint-suppressions.json` to remove suppressions for `base-controller` files now addressed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71469bde7870f26efea8da85b77ad7378ec5e9c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->