### PR TITLE
chore: Fix suppressed lint errors in `accounts-controller`

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -108,29 +108,6 @@
       "count": 1
     }
   },
-  "packages/accounts-controller/src/AccountsController.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 15
-    },
-    "import-x/namespace": {
-      "count": 1
-    }
-  },
-  "packages/accounts-controller/src/AccountsController.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 10
-    }
-  },
-  "packages/accounts-controller/src/tests/mocks.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 2
-    }
-  },
-  "packages/accounts-controller/src/utils.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 3
-    }
-  },
   "packages/address-book-controller/src/AddressBookController.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 1

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -13,7 +13,10 @@ import {
   EthScope,
   KeyringAccountEntropyTypeOption,
 } from '@metamask/keyring-api';
-import { KeyringTypes } from '@metamask/keyring-controller';
+import {
+  KeyringControllerState,
+  KeyringTypes,
+} from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { MOCK_ANY_NAMESPACE, Messenger } from '@metamask/messenger';
 import type {
@@ -26,7 +29,7 @@ import type { SnapControllerState } from '@metamask/snaps-controllers';
 import { SnapStatus } from '@metamask/snaps-utils';
 import type { CaipChainId } from '@metamask/utils';
 import type { V4Options } from 'uuid';
-import * as uuid from 'uuid';
+import { v4 as uuidV4 } from 'uuid';
 
 import type {
   AccountsControllerMessenger,
@@ -56,7 +59,7 @@ type RootMessenger = Messenger<
 >;
 
 jest.mock('uuid');
-const mockUUID = jest.spyOn(uuid, 'v4');
+const mockUUID = jest.mocked(uuidV4);
 const actualUUID = jest.requireActual('uuid').v4; // We also use uuid.v4 in our mocks
 
 const defaultState: AccountsControllerState = {
@@ -154,7 +157,7 @@ class MockNormalAccountUUID {
     }
   }
 
-  mock(options?: V4Options | undefined) {
+  mock(options?: V4Options | undefined): string {
     const accountId = actualUUID(options);
 
     // If not found, we returns the generated UUID
@@ -169,7 +172,7 @@ class MockNormalAccountUUID {
  *
  * @param accounts - List of normal accounts to map with their mock ID.
  */
-function mockUUIDWithNormalAccounts(accounts: InternalAccount[]) {
+function mockUUIDWithNormalAccounts(accounts: InternalAccount[]): void {
   const mockAccountUUIDs = new MockNormalAccountUUID(accounts);
   mockUUID.mockImplementation(mockAccountUUIDs.mock.bind(mockAccountUUIDs));
 }
@@ -181,7 +184,7 @@ class MockExpectedInternalAccountBuilder {
     this.#account = JSON.parse(JSON.stringify(account)) as InternalAccount;
   }
 
-  static from(account: InternalAccount) {
+  static from(account: InternalAccount): MockExpectedInternalAccountBuilder {
     return new MockExpectedInternalAccountBuilder(account);
   }
 
@@ -245,7 +248,14 @@ function buildMessenger(): RootMessenger {
  * @param rootMessenger - The root messenger.
  * @returns The messenger for AccountsController.
  */
-function buildAccountsControllerMessenger(rootMessenger = buildMessenger()) {
+function buildAccountsControllerMessenger(
+  rootMessenger = buildMessenger(),
+): Messenger<
+  'AccountsController',
+  AllAccountsControllerActions,
+  AllAccountsControllerEvents,
+  typeof rootMessenger
+> {
   const accountsControllerMessenger = new Messenger<
     'AccountsController',
     AllAccountsControllerActions,
@@ -301,7 +311,9 @@ function setupAccountsController({
     state: { ...defaultState, ...initialState },
   });
 
-  const triggerMultichainNetworkChange = (id: NetworkClientId | CaipChainId) =>
+  const triggerMultichainNetworkChange = (
+    id: NetworkClientId | CaipChainId,
+  ): void =>
     messenger.publish('MultichainNetworkController:networkDidChange', id);
 
   return {
@@ -1714,7 +1726,11 @@ describe('AccountsController', () => {
   });
 
   describe('onSnapKeyringEvents', () => {
-    const setupTest = () => {
+    const setupTest = (): {
+      messenger: RootMessenger;
+      account: InternalAccount;
+      accountsController: AccountsController;
+    } => {
       const account = createMockInternalAccount({
         id: 'mock-id',
         name: 'Bitcoin Account',
@@ -1982,7 +1998,7 @@ describe('AccountsController', () => {
         mockGetKeyringByType.mockReturnValue([
           {
             type: KeyringTypes.snap,
-            listAccounts: async () => [],
+            listAccounts: async (): Promise<InternalAccount[]> => [],
           },
         ]),
       );
@@ -2149,7 +2165,7 @@ describe('AccountsController', () => {
         mockGetKeyringByType.mockReturnValue([
           {
             type: KeyringTypes.snap,
-            listAccounts: async () => [],
+            listAccounts: async (): Promise<InternalAccount[]> => [],
           },
         ]),
       );
@@ -2196,7 +2212,7 @@ describe('AccountsController', () => {
         mockGetKeyringByType.mockReturnValueOnce([
           {
             type: KeyringTypes.snap,
-            getAccountByAddress: () => mockSnapAccount2,
+            getAccountByAddress: (): InternalAccount => mockSnapAccount2,
           },
         ]),
       );
@@ -2268,7 +2284,7 @@ describe('AccountsController', () => {
         mockGetKeyringByType.mockReturnValueOnce([
           {
             type: KeyringTypes.snap,
-            getAccountByAddress: () => mockSnapAccount2,
+            getAccountByAddress: (): InternalAccount => mockSnapAccount2,
           },
         ]),
       );
@@ -2365,7 +2381,7 @@ describe('AccountsController', () => {
         mockGetKeyringByType.mockReturnValue([
           {
             type: KeyringTypes.snap,
-            listAccounts: async () => [],
+            listAccounts: async (): Promise<InternalAccount[]> => [],
           },
         ]),
       );
@@ -2415,7 +2431,7 @@ describe('AccountsController', () => {
         mockGetKeyringByType.mockReturnValue([
           {
             type: KeyringTypes.snap,
-            listAccounts: async () => [],
+            listAccounts: async (): Promise<InternalAccount[]> => [],
           },
         ]),
       );
@@ -2486,7 +2502,7 @@ describe('AccountsController', () => {
           mockGetKeyringByType.mockReturnValueOnce([
             {
               type: KeyringTypes.snap,
-              getAccountByAddress: () => mockSnapAccount2,
+              getAccountByAddress: (): InternalAccount => mockSnapAccount2,
             },
           ]),
         );
@@ -2587,7 +2603,7 @@ describe('AccountsController', () => {
         mockGetKeyringByType.mockReturnValueOnce([
           {
             type: KeyringTypes.snap,
-            getAccountByAddress: () => mockHdSnapAccount,
+            getAccountByAddress: (): InternalAccount => mockHdSnapAccount,
           },
         ]),
       );
@@ -3453,7 +3469,9 @@ describe('AccountsController', () => {
       keyringType: KeyringTypes.simple,
     });
 
-    const mockNewKeyringStateWith = (simpleAddressess: string[]) => {
+    const mockNewKeyringStateWith = (
+      simpleAddressess: string[],
+    ): KeyringControllerState => {
       return {
         isUnlocked: true,
         keyrings: [

--- a/packages/accounts-controller/src/tests/mocks.ts
+++ b/packages/accounts-controller/src/tests/mocks.ts
@@ -61,7 +61,10 @@ export const createMockInternalAccount = ({
   lastSelected?: number;
   options?: Record<string, unknown>;
 } = {}): InternalAccount => {
-  const getInternalAccountDefaults = () => {
+  const getInternalAccountDefaults = (): Pick<
+    InternalAccount,
+    'methods' | 'scopes'
+  > => {
     switch (type) {
       case `${EthAccountType.Eoa}`:
         return {
@@ -105,7 +108,7 @@ export const createMockInternalAccount = ({
 
 export const createExpectedInternalAccount = (
   args: Parameters<typeof createMockInternalAccount>[0],
-) => {
+): InternalAccount => {
   return createMockInternalAccount({
     ...args,
     importTime: expect.any(Number),

--- a/packages/accounts-controller/src/utils.test.ts
+++ b/packages/accounts-controller/src/utils.test.ts
@@ -28,9 +28,9 @@ describe('utils', () => {
         name: '',
       },
     };
-    const toLowerCase = (address: string) => address.toLowerCase();
-    const toUpperCase = (address: string) => address.toUpperCase();
-    const toSameValue = (address: string) => address;
+    const toLowerCase = (address: string): string => address.toLowerCase();
+    const toUpperCase = (address: string): string => address.toUpperCase();
+    const toSameValue = (address: string): string => address;
 
     it('returns the group index for a valid address', () => {
       expect(


### PR DESCRIPTION
## Explanation

All suppressed lint errors in `accounts-controller` have been fixed

## References

Fixes #7338

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes lint suppressions by adding explicit return types and stricter typings across accounts-controller code/tests, and updates UUID mocking; no runtime logic changes.
> 
> - **Accounts Controller**:
>   - Add `StatePatch` type and annotate private helpers (`#update`, `#handleOnSnapStateChange`, `#getAccountsByKeyringType`, `#getLastSelectedIndex`, `#handleOnMultichainNetworkDidChange`, `#subscribeToMessageEvents`, `#registerMessageHandlers`) with explicit return types.
>   - Type `diff` and patch helpers (`generatePatch`, `patchOf`) explicitly; no logic changes.
> - **Tests** (`packages/accounts-controller/src/*.test.ts`):
>   - Switch to `import { v4 as uuidV4 } from 'uuid'` and `jest.mocked(uuidV4)`; add explicit return types to mocks/util fns; tighten typings (e.g., `KeyringControllerState`, `InternalAccount`).
>   - Minor refactors for typed messenger builders and mock keyring methods (`listAccounts`, `getAccountByAddress`).
> - **Test Utilities** (`tests/mocks.ts`, `utils.test.ts`):
>   - Add precise return types (including `KeyringAccount['options']`) and default-resolution helpers.
> - **ESLint**:
>   - Remove suppressions for `accounts-controller` files from `eslint-suppressions.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8b8fd76e1ed576b11d4563baa9e831907b12173. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->