### PR TITLE
chore(lint): Fix suppressed ESLint errors in `permission-controller` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2466,66 +2466,6 @@
       "count": 1
     }
   },
-  "packages/permission-controller/src/Caveat.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 9
-    }
-  },
-  "packages/permission-controller/src/Caveat.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 1
-    }
-  },
-  "packages/permission-controller/src/PermissionController.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 57
-    },
-    "no-new": {
-      "count": 1
-    }
-  },
-  "packages/permission-controller/src/PermissionController.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 8
-    },
-    "@typescript-eslint/prefer-enum-initializers": {
-      "count": 4
-    },
-    "no-restricted-syntax": {
-      "count": 25
-    }
-  },
-  "packages/permission-controller/src/SubjectMetadataController.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 2
-    }
-  },
-  "packages/permission-controller/src/SubjectMetadataController.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 1
-    },
-    "@typescript-eslint/prefer-nullish-coalescing": {
-      "count": 4
-    },
-    "no-restricted-syntax": {
-      "count": 4
-    }
-  },
-  "packages/permission-controller/src/errors.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 3
-    }
-  },
-  "packages/permission-controller/src/rpc-methods/requestPermissions.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 1
-    }
-  },
-  "packages/permission-controller/src/utils.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 1
-    }
-  },
   "packages/permission-log-controller/src/PermissionLogController.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 4

--- a/packages/permission-controller/src/Caveat.test.ts
+++ b/packages/permission-controller/src/Caveat.test.ts
@@ -4,14 +4,14 @@ import * as errors from './errors';
 
 describe('decorateWithCaveats', () => {
   it('decorates a method with caveat', async () => {
-    const methodImplementation = () => [1, 2, 3];
+    const methodImplementation = (): number[] => [1, 2, 3];
 
     const caveatSpecifications = {
       reverse: {
         type: 'reverse',
         decorator:
           (method: () => Promise<unknown[]>, _caveat: Caveat<string, null>) =>
-          async () => {
+          async (): Promise<unknown[]> => {
             return (await method()).reverse();
           },
       },
@@ -41,14 +41,14 @@ describe('decorateWithCaveats', () => {
   });
 
   it('decorates a method with multiple caveats', async () => {
-    const methodImplementation = () => [1, 2, 3];
+    const methodImplementation = (): number[] => [1, 2, 3];
 
     const caveatSpecifications = {
       reverse: {
         type: 'reverse',
         decorator:
           (method: () => Promise<unknown[]>, _caveat: Caveat<string, null>) =>
-          async () => {
+          async (): Promise<unknown[]> => {
             return (await method()).reverse();
           },
       },
@@ -56,7 +56,7 @@ describe('decorateWithCaveats', () => {
         type: 'slice',
         decorator:
           (method: () => Promise<unknown[]>, caveat: Caveat<string, number>) =>
-          async () => {
+          async (): Promise<unknown[]> => {
             return (await method()).slice(0, caveat.value);
           },
       },
@@ -89,7 +89,7 @@ describe('decorateWithCaveats', () => {
   });
 
   it('returns the unmodified method implementation if there are no caveats', () => {
-    const methodImplementation = () => [1, 2, 3];
+    const methodImplementation = (): number[] => [1, 2, 3];
 
     const permission: PermissionConstraint = {
       id: 'foo',
@@ -109,14 +109,14 @@ describe('decorateWithCaveats', () => {
   });
 
   it('throws an error if the caveat type is unrecognized', () => {
-    const methodImplementation = () => [1, 2, 3];
+    const methodImplementation = (): number[] => [1, 2, 3];
 
     const caveatSpecifications = {
       reverse: {
         type: 'reverse',
         decorator:
           (method: () => Promise<unknown[]>, _caveat: Caveat<string, null>) =>
-          async () => {
+          async (): Promise<unknown[]> => {
             return (await method()).reverse();
           },
       },
@@ -144,7 +144,7 @@ describe('decorateWithCaveats', () => {
   });
 
   it('throws an error if no decorator is present', async () => {
-    const methodImplementation = () => [1, 2, 3];
+    const methodImplementation = (): number[] => [1, 2, 3];
 
     const caveatSpecifications = {
       reverse: {

--- a/packages/permission-controller/src/Caveat.ts
+++ b/packages/permission-controller/src/Caveat.ts
@@ -319,7 +319,7 @@ export function decorateWithCaveats<
 
   let decorated = async (
     args: Parameters<RestrictedMethod<RestrictedMethodParameters, Json>>[0],
-  ) => methodImplementation(args);
+  ): Promise<Json> => methodImplementation(args);
 
   for (const caveat of caveats) {
     const specification =

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -15,14 +15,17 @@ import {
 } from '@metamask/utils';
 import assert from 'assert';
 
-import type {
+import {
   AsyncRestrictedMethod,
   Caveat,
   CaveatConstraint,
   CaveatMutator,
+  CaveatSpecificationMap,
   ExtractSpecifications,
   PermissionConstraint,
   PermissionControllerMessenger,
+  PermissionControllerOptions,
+  PermissionControllerState,
   PermissionOptions,
   PermissionsRequest,
   RestrictedMethodOptions,
@@ -68,7 +71,7 @@ type NoopCaveat = Caveat<typeof CaveatTypes.noopCaveat, null>;
 const primitiveArrayMerger = <Element extends string | null | number>(
   a: Element[],
   b: Element[],
-) => {
+): [Element[], Element[]] | [] => {
   const diff = b.filter((element) => !a.includes(element));
 
   if (diff.length > 0) {
@@ -87,7 +90,9 @@ const primitiveArrayMerger = <Element extends string | null | number>(
  *
  * @returns The caveat specifications.
  */
-function getDefaultCaveatSpecifications() {
+// TODO: Replace `any` with proper type if possible.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getDefaultCaveatSpecifications(): CaveatSpecificationMap<any> {
   return {
     [CaveatTypes.filterArrayResponse]: {
       type: CaveatTypes.filterArrayResponse,
@@ -253,8 +258,8 @@ const PermissionNames = {
 } as const;
 
 // Default side-effect implementations.
-const onPermittedSideEffect = () => Promise.resolve('foo');
-const onFailureSideEffect = () => Promise.resolve();
+const onPermittedSideEffect = (): Promise<string> => Promise.resolve('foo');
+const onFailureSideEffect = (): Promise<void> => Promise.resolve();
 
 /**
  * Gets the mocks for the side effect handlers of the permissions that have side effects.
@@ -266,7 +271,15 @@ const onFailureSideEffect = () => Promise.resolve();
  *
  * @returns The side effect mocks.
  */
-function getSideEffectHandlerMocks() {
+function getSideEffectHandlerMocks(): Record<
+  | typeof PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects
+  | typeof PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects2
+  | typeof PermissionKeys.wallet_noopWithPermittedSideEffects,
+  {
+    onPermitted: jest.Mock<ReturnType<typeof onPermittedSideEffect>>;
+    onFailure?: jest.Mock<ReturnType<typeof onFailureSideEffect>>;
+  }
+> {
   return {
     [PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects]: {
       onPermitted: jest.fn(onPermittedSideEffect),
@@ -288,6 +301,8 @@ function getSideEffectHandlerMocks() {
  *
  * @returns The permission specifications.
  */
+// The return type of this is quite complicated.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function getDefaultPermissionSpecificationsAndMocks() {
   const sideEffectMocks = getSideEffectHandlerMocks();
 
@@ -300,7 +315,9 @@ function getDefaultPermissionSpecificationsAndMocks() {
           CaveatTypes.filterArrayResponse,
           CaveatTypes.reverseArrayResponse,
         ],
-        methodImplementation: (_args: RestrictedMethodOptions<Json[]>) => {
+        methodImplementation: (
+          _args: RestrictedMethodOptions<Json[]>,
+        ): string[] => {
           return ['a', 'b', 'c'];
         },
       },
@@ -313,10 +330,10 @@ function getDefaultPermissionSpecificationsAndMocks() {
         ],
         methodImplementation: (
           _args: RestrictedMethodOptions<Record<string, Json>>,
-        ) => {
+        ): { a: string; b: string; c: string } => {
           return { a: 'x', b: 'y', c: 'z' };
         },
-        validator: (permission: PermissionConstraint) => {
+        validator: (permission: PermissionConstraint): void => {
           // A dummy validator for a caveat type that should be impossible to add
           assert.ok(
             !permission.caveats?.some(
@@ -332,7 +349,7 @@ function getDefaultPermissionSpecificationsAndMocks() {
         allowedCaveats: null,
         methodImplementation: ({
           params,
-        }: RestrictedMethodOptions<[number]>) => {
+        }: RestrictedMethodOptions<[number]>): number => {
           if (!Array.isArray(params)) {
             throw new Error(
               `Invalid ${PermissionKeys.wallet_doubleNumber} request`,
@@ -345,7 +362,7 @@ function getDefaultPermissionSpecificationsAndMocks() {
         permissionType: PermissionType.RestrictedMethod,
         targetName: PermissionKeys.wallet_noop,
         allowedCaveats: null,
-        methodImplementation: (_args: RestrictedMethodOptions<null>) => {
+        methodImplementation: (_args: RestrictedMethodOptions<null>): null => {
           return null;
         },
       },
@@ -354,18 +371,18 @@ function getDefaultPermissionSpecificationsAndMocks() {
         targetName:
           PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects,
         allowedCaveats: null,
-        methodImplementation: (_args: RestrictedMethodOptions<null>) => {
+        methodImplementation: (_args: RestrictedMethodOptions<null>): null => {
           return null;
         },
         sideEffect: {
-          onPermitted: () =>
+          onPermitted: (): Promise<string> =>
             sideEffectMocks[
               PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects
             ].onPermitted(),
-          onFailure: () =>
+          onFailure: async (): Promise<void> =>
             sideEffectMocks[
               PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects
-            ].onFailure(),
+            ]?.onFailure?.(),
         },
       },
       [PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects2]: {
@@ -373,29 +390,29 @@ function getDefaultPermissionSpecificationsAndMocks() {
         targetName:
           PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects2,
         allowedCaveats: null,
-        methodImplementation: (_args: RestrictedMethodOptions<null>) => {
+        methodImplementation: (_args: RestrictedMethodOptions<null>): null => {
           return null;
         },
         sideEffect: {
-          onPermitted: () =>
+          onPermitted: (): Promise<string> =>
             sideEffectMocks[
               PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects2
             ].onPermitted(),
-          onFailure: () =>
+          onFailure: async (): Promise<void> =>
             sideEffectMocks[
               PermissionKeys.wallet_noopWithPermittedAndFailureSideEffects2
-            ].onFailure(),
+            ]?.onFailure?.(),
         },
       },
       [PermissionKeys.wallet_noopWithPermittedSideEffects]: {
         permissionType: PermissionType.RestrictedMethod,
         targetName: PermissionKeys.wallet_noopWithPermittedSideEffects,
         allowedCaveats: null,
-        methodImplementation: (_args: RestrictedMethodOptions<null>) => {
+        methodImplementation: (_args: RestrictedMethodOptions<null>): null => {
           return null;
         },
         sideEffect: {
-          onPermitted: () =>
+          onPermitted: (): Promise<string> =>
             sideEffectMocks[
               PermissionKeys.wallet_noopWithPermittedSideEffects
             ].onPermitted(),
@@ -405,14 +422,14 @@ function getDefaultPermissionSpecificationsAndMocks() {
       [PermissionKeys.wallet_noopWithValidator]: {
         permissionType: PermissionType.RestrictedMethod,
         targetName: PermissionKeys.wallet_noopWithValidator,
-        methodImplementation: (_args: RestrictedMethodOptions<null>) => {
+        methodImplementation: (_args: RestrictedMethodOptions<null>): null => {
           return null;
         },
         allowedCaveats: [
           CaveatTypes.noopCaveat,
           CaveatTypes.filterArrayResponse,
         ],
-        validator: (permission: PermissionConstraint) => {
+        validator: (permission: PermissionConstraint): void => {
           if (
             permission.caveats?.some(
               ({ type }) => type !== CaveatTypes.noopCaveat,
@@ -425,14 +442,14 @@ function getDefaultPermissionSpecificationsAndMocks() {
       [PermissionKeys.wallet_noopWithRequiredCaveat]: {
         permissionType: PermissionType.RestrictedMethod,
         targetName: PermissionKeys.wallet_noopWithRequiredCaveat,
-        methodImplementation: (_args: RestrictedMethodOptions<null>) => {
+        methodImplementation: (_args: RestrictedMethodOptions<null>): null => {
           return null;
         },
         allowedCaveats: [CaveatTypes.noopCaveat],
         factory: (
           options: PermissionOptions<NoopWithRequiredCaveat>,
           _requestData?: Record<string, unknown>,
-        ) => {
+        ): NoopWithRequiredCaveat => {
           return constructPermission<NoopWithRequiredCaveat>({
             ...options,
             caveats: [
@@ -443,7 +460,7 @@ function getDefaultPermissionSpecificationsAndMocks() {
             ],
           });
         },
-        validator: (permission: PermissionConstraint) => {
+        validator: (permission: PermissionConstraint): void => {
           if (
             permission.caveats?.length !== 1 ||
             !permission.caveats?.some(
@@ -461,14 +478,14 @@ function getDefaultPermissionSpecificationsAndMocks() {
       [PermissionKeys.wallet_noopWithFactory]: {
         permissionType: PermissionType.RestrictedMethod,
         targetName: PermissionKeys.wallet_noopWithFactory,
-        methodImplementation: (_args: RestrictedMethodOptions<null>) => {
+        methodImplementation: (_args: RestrictedMethodOptions<null>): null => {
           return null;
         },
         allowedCaveats: [CaveatTypes.filterArrayResponse],
         factory: (
           options: PermissionOptions<NoopWithFactoryPermission>,
           requestData?: Record<string, unknown>,
-        ) => {
+        ): NoopWithFactoryPermission => {
           if (!requestData) {
             throw new Error('requestData is required');
           }
@@ -490,7 +507,7 @@ function getDefaultPermissionSpecificationsAndMocks() {
       [PermissionKeys.wallet_noopWithManyCaveats]: {
         permissionType: PermissionType.RestrictedMethod,
         targetName: PermissionKeys.wallet_noopWithManyCaveats,
-        methodImplementation: (_args: RestrictedMethodOptions<null>) => {
+        methodImplementation: (_args: RestrictedMethodOptions<null>): null => {
           return null;
         },
         allowedCaveats: [
@@ -503,7 +520,7 @@ function getDefaultPermissionSpecificationsAndMocks() {
         permissionType: PermissionType.RestrictedMethod,
         targetName: PermissionKeys.snap_foo,
         allowedCaveats: null,
-        methodImplementation: (_args: RestrictedMethodOptions<null>) => {
+        methodImplementation: (_args: RestrictedMethodOptions<null>): null => {
           return null;
         },
         subjectTypes: [SubjectType.Snap],
@@ -511,13 +528,17 @@ function getDefaultPermissionSpecificationsAndMocks() {
       [PermissionKeys.endowmentAnySubject]: {
         permissionType: PermissionType.Endowment,
         targetName: PermissionKeys.endowmentAnySubject,
-        endowmentGetter: (_options: EndowmentGetterParams) => ['endowment1'],
+        endowmentGetter: (_options: EndowmentGetterParams): string[] => [
+          'endowment1',
+        ],
         allowedCaveats: null,
       },
       [PermissionKeys.endowmentSnapsOnly]: {
         permissionType: PermissionType.Endowment,
         targetName: PermissionKeys.endowmentSnapsOnly,
-        endowmentGetter: (_options: EndowmentGetterParams) => ['endowment2'],
+        endowmentGetter: (_options: EndowmentGetterParams): string[] => [
+          'endowment2',
+        ],
         allowedCaveats: [CaveatTypes.endowmentCaveat],
         subjectTypes: [SubjectType.Snap],
       },
@@ -532,6 +553,8 @@ function getDefaultPermissionSpecificationsAndMocks() {
  *
  * @returns The permission specifications.
  */
+// The return type of this is quite complicated.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function getDefaultPermissionSpecifications() {
   return getDefaultPermissionSpecificationsAndMocks()[0];
 }
@@ -617,7 +640,7 @@ function getPermissionControllerMessenger(
  *
  * @returns The unrestricted methods array
  */
-function getDefaultUnrestrictedMethods() {
+function getDefaultUnrestrictedMethods(): readonly string[] {
   return Object.freeze(['wallet_unrestrictedMethod']);
 }
 
@@ -627,7 +650,7 @@ function getDefaultUnrestrictedMethods() {
  *
  * @returns The existing mock state
  */
-function getExistingPermissionState() {
+function getExistingPermissionState(): PermissionControllerState<PermissionConstraint> {
   return {
     subjects: {
       'metamask.io': {
@@ -660,7 +683,12 @@ function getExistingPermissionState() {
  * @param opts - Permission controller options.
  * @returns The permission controller constructor options.
  */
-function getPermissionControllerOptions(opts?: Record<string, unknown>) {
+function getPermissionControllerOptions(
+  opts?: Record<string, unknown>,
+): PermissionControllerOptions<
+  DefaultPermissionSpecifications,
+  DefaultCaveatSpecifications
+> {
   return {
     caveatSpecifications: getDefaultCaveatSpecifications(),
     messenger: getPermissionControllerMessenger(),
@@ -680,7 +708,10 @@ function getPermissionControllerOptions(opts?: Record<string, unknown>) {
  */
 function getDefaultPermissionController(
   opts = getPermissionControllerOptions(),
-) {
+): PermissionController<
+  DefaultPermissionSpecifications,
+  DefaultCaveatSpecifications
+> {
   return new PermissionController<
     (typeof opts.permissionSpecifications)[keyof typeof opts.permissionSpecifications],
     (typeof opts.caveatSpecifications)[keyof typeof opts.caveatSpecifications]
@@ -695,7 +726,10 @@ function getDefaultPermissionController(
  * @returns The default permission controller for testing, with some initial
  * state.
  */
-function getDefaultPermissionControllerWithState() {
+function getDefaultPermissionControllerWithState(): PermissionController<
+  DefaultPermissionSpecifications,
+  DefaultCaveatSpecifications
+> {
   return new PermissionController<
     DefaultPermissionSpecifications,
     DefaultCaveatSpecifications
@@ -720,7 +754,9 @@ function getPermissionMatcher({
   parentCapability: string;
   caveats?: CaveatConstraint[] | null | typeof expect.objectContaining;
   invoker?: string;
-}) {
+  // `expect.objectContaining` returns `any`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+}): any {
   return expect.objectContaining({
     id: expect.any(String),
     parentCapability,
@@ -1991,7 +2027,10 @@ describe('PermissionController', () => {
      *
      * @returns The permission controller instance
      */
-    const getMultiCaveatController = () => {
+    const getMultiCaveatController = (): PermissionController<
+      DefaultPermissionSpecifications,
+      DefaultCaveatSpecifications
+    > => {
       const controller = getDefaultPermissionController();
 
       controller.grantPermissions({
@@ -2044,7 +2083,7 @@ describe('PermissionController', () => {
       overrides: Partial<
         Record<MultiCaveatOrigins, ReturnType<typeof getPermissionMatcher>>
       > = {},
-    ) => {
+    ): PermissionControllerState<PermissionConstraint> => {
       return {
         subjects: {
           [MultiCaveatOrigins.A]: {
@@ -2199,7 +2238,7 @@ describe('PermissionController', () => {
       const controller = getMultiCaveatController();
 
       let counter = 0;
-      const mutator = () => {
+      const mutator: CaveatMutator<Caveat<string, Json>> = () => {
         counter += 1;
         return counter === 1
           ? { operation: CaveatMutatorOperation.Noop as const }
@@ -2304,7 +2343,6 @@ describe('PermissionController', () => {
       );
 
       const matcher = getMultiCaveatStateMatcher();
-      // @ts-expect-error Intentional destructive testing
       delete matcher.subjects[MultiCaveatOrigins.A];
 
       expect(controller.state).toStrictEqual(matcher);
@@ -2870,35 +2908,37 @@ describe('PermissionController', () => {
       // Create a cycle. This will cause our JSON validity check to error.
       circular.circular = circular;
 
-      [{ foo: () => undefined }, circular, { foo: BigInt(10) }].forEach(
-        (invalidValue) => {
-          expect(() =>
-            controller.grantPermissions({
-              subject: { origin },
-              approvedPermissions: {
-                wallet_getSecretArray: {
-                  caveats: [
-                    {
-                      type: CaveatTypes.filterArrayResponse,
-                      // @ts-expect-error Intentional destructive testing
-                      value: invalidValue,
-                    },
-                  ],
-                },
+      [
+        { foo: (): undefined => undefined },
+        circular,
+        { foo: BigInt(10) },
+      ].forEach((invalidValue) => {
+        expect(() =>
+          controller.grantPermissions({
+            subject: { origin },
+            approvedPermissions: {
+              wallet_getSecretArray: {
+                caveats: [
+                  {
+                    type: CaveatTypes.filterArrayResponse,
+                    // @ts-expect-error Intentional destructive testing
+                    value: invalidValue,
+                  },
+                ],
               },
-            }),
-          ).toThrow(
-            new errors.CaveatInvalidJsonError(
-              {
-                type: CaveatTypes.filterArrayResponse,
-                value: invalidValue,
-              },
-              origin,
-              PermissionNames.wallet_getSecretArray,
-            ),
-          );
-        },
-      );
+            },
+          }),
+        ).toThrow(
+          new errors.CaveatInvalidJsonError(
+            {
+              type: CaveatTypes.filterArrayResponse,
+              value: invalidValue,
+            },
+            origin,
+            PermissionNames.wallet_getSecretArray,
+          ),
+        );
+      });
     });
 
     it('throws if caveat validation fails', () => {
@@ -3083,7 +3123,7 @@ describe('PermissionController', () => {
     it('incrementally updates a caveat of an existing permission', () => {
       const controller = getDefaultPermissionController();
       const origin = 'metamask.io';
-      const getCaveat = (...values: string[]) => ({
+      const getCaveat = (...values: string[]): Caveat<string, Json> => ({
         type: CaveatTypes.filterArrayResponse,
         value: values,
       });
@@ -3123,7 +3163,9 @@ describe('PermissionController', () => {
   });
 
   describe('requesting permissions', () => {
-    const getAnyPermissionsDiffMatcher = () =>
+    // `expect.objectContaining` returns `any`.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getAnyPermissionsDiffMatcher = (): any =>
       expect.objectContaining({
         currentPermissions: expect.any(Object),
         permissionDiffMap: expect.any(Object),
@@ -3133,7 +3175,11 @@ describe('PermissionController', () => {
       'requestPermissions',
       'requestPermissionsIncremental',
     ] as const)('%s', (requestFunctionName) => {
-      const getRequestDataDiffProperty = () =>
+      const getRequestDataDiffProperty = (): {
+        // `expect.objectContaining` returns `any`.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        diff?: any;
+      } =>
         requestFunctionName === 'requestPermissionsIncremental'
           ? { diff: getAnyPermissionsDiffMatcher() }
           : {};
@@ -3653,7 +3699,7 @@ describe('PermissionController', () => {
 
         sideEffectMocks[
           PermissionNames.wallet_noopWithPermittedAndFailureSideEffects
-        ].onFailure.mockImplementation(() =>
+        ]?.onFailure?.mockImplementation(() =>
           Promise.reject(new Error('error')),
         );
 
@@ -4625,9 +4671,13 @@ describe('PermissionController', () => {
         const callActionSpy = jest.spyOn(messenger, 'call');
 
         // The metadata is valid, but the permissions are invalid
-        const getInvalidRequestObject = (invalidPermissions: unknown) => {
+        const getInvalidRequestObject = (
+          invalidPermissions: unknown,
+        ): PermissionsRequest => {
           return {
             metadata: { origin, id },
+
+            // @ts-expect-error Intentional destructive testing.
             permissions: invalidPermissions,
           };
         };
@@ -4822,12 +4872,16 @@ describe('PermissionController', () => {
       const caveatType2 = CaveatTypes.filterObjectResponse;
       const caveatType3 = CaveatTypes.noopCaveat;
 
-      const makeCaveat = (type: string, value: Json) => ({ type, value });
-      const makeCaveat1 = (...value: string[]) =>
+      const makeCaveat = (type: string, value: Json): Caveat<string, Json> => ({
+        type,
+        value,
+      });
+      const makeCaveat1 = (...value: string[]): Caveat<string, Json> =>
         makeCaveat(caveatType1, value);
-      const makeCaveat2 = (...value: string[]) =>
+      const makeCaveat2 = (...value: string[]): Caveat<string, Json> =>
         makeCaveat(caveatType2, value);
-      const makeCaveat3 = () => makeCaveat(caveatType3, null);
+      const makeCaveat3 = (): Caveat<string, Json> =>
+        makeCaveat(caveatType3, null);
 
       it.each([
         ['neither A nor B have caveats', null, null],
@@ -4960,7 +5014,9 @@ describe('PermissionController', () => {
           const getPermissionDiffMatcher = (
             previousCaveats: CaveatConstraint[] | null,
             diff: Record<string, Json[] | null>,
-          ) =>
+            // `expect.objectContaining` returns `any`.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ): any =>
             expect.objectContaining({
               currentPermissions: expect.objectContaining({
                 [PermissionNames.wallet_noopWithManyCaveats]:
@@ -5090,11 +5146,10 @@ describe('PermissionController', () => {
 
       it('throws if merged caveats produce an invalid permission', async () => {
         const caveatSpecifications = getDefaultCaveatSpecifications();
-        // @ts-expect-error Intentional destructive testing
-        caveatSpecifications[CaveatTypes.filterArrayResponse].merger = () => [
-          'foo',
-          'foo',
-        ];
+        caveatSpecifications[CaveatTypes.filterArrayResponse].merger = (): [
+          string,
+          string,
+        ] => ['foo', 'foo'];
 
         const options = getPermissionControllerOptions({
           caveatSpecifications,
@@ -5546,8 +5601,8 @@ describe('PermissionController', () => {
     it('throws if the restricted method returns undefined', async () => {
       const permissionSpecifications = getDefaultPermissionSpecifications();
       // @ts-expect-error Intentional destructive testing
-      permissionSpecifications.wallet_doubleNumber.methodImplementation = () =>
-        undefined;
+      permissionSpecifications.wallet_doubleNumber.methodImplementation =
+        (): undefined => undefined;
 
       const controller = new PermissionController<
         DefaultPermissionSpecifications,
@@ -6091,6 +6146,7 @@ describe('PermissionController', () => {
         state,
       });
 
+      // eslint-disable-next-line no-new
       new PermissionController<
         DefaultPermissionSpecifications,
         DefaultCaveatSpecifications
@@ -6286,8 +6342,8 @@ describe('PermissionController', () => {
     it('returns an error if the restricted method returns undefined', async () => {
       const permissionSpecifications = getDefaultPermissionSpecifications();
       // @ts-expect-error Intentional destructive testing
-      permissionSpecifications.wallet_doubleNumber.methodImplementation = () =>
-        undefined;
+      permissionSpecifications.wallet_doubleNumber.methodImplementation =
+        (): undefined => undefined;
 
       const controller = new PermissionController<
         DefaultPermissionSpecifications,

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -220,7 +220,9 @@ export type PermissionControllerState<Permission> =
  * @template Permission - The controller's permission type union.
  * @returns The state metadata
  */
-function getStateMetadata<Permission extends PermissionConstraint>() {
+function getStateMetadata<
+  Permission extends PermissionConstraint,
+>(): StateMetadata<PermissionControllerState<Permission>> {
   return {
     subjects: {
       includeInStateLogs: true,
@@ -237,7 +239,9 @@ function getStateMetadata<Permission extends PermissionConstraint>() {
  * @template Permission - The controller's permission type union.
  * @returns The default state of the controller
  */
-function getDefaultState<Permission extends PermissionConstraint>() {
+function getDefaultState<
+  Permission extends PermissionConstraint,
+>(): PermissionControllerState<Permission> {
   return { subjects: {} } as PermissionControllerState<Permission>;
 }
 
@@ -445,10 +449,10 @@ export type GenericPermissionController = PermissionController<
  * Describes the possible results of a {@link CaveatMutator} function.
  */
 export enum CaveatMutatorOperation {
-  Noop,
-  UpdateValue,
-  DeleteCaveat,
-  RevokePermission,
+  Noop = 0,
+  UpdateValue = 1,
+  DeleteCaveat = 2,
+  RevokePermission = 3,
 }
 
 /**
@@ -595,15 +599,15 @@ export class PermissionController<
   >,
   PermissionControllerMessenger
 > {
-  private readonly _caveatSpecifications: Readonly<
+  readonly #caveatSpecifications: Readonly<
     CaveatSpecificationMap<ControllerCaveatSpecification>
   >;
 
-  private readonly _permissionSpecifications: Readonly<
+  readonly #permissionSpecifications: Readonly<
     PermissionSpecificationMap<ControllerPermissionSpecification>
   >;
 
-  private readonly _unrestrictedMethods: ReadonlySet<string>;
+  readonly #unrestrictedMethods: ReadonlySet<string>;
 
   /**
    * The names of all JSON-RPC methods that will be ignored by the controller.
@@ -611,7 +615,7 @@ export class PermissionController<
    * @returns The names of all unrestricted JSON-RPC methods
    */
   public get unrestrictedMethods(): ReadonlySet<string> {
-    return this._unrestrictedMethods;
+    return this.#unrestrictedMethods;
   }
 
   /**
@@ -678,21 +682,21 @@ export class PermissionController<
       },
     });
 
-    this._unrestrictedMethods = new Set(unrestrictedMethods);
-    this._caveatSpecifications = deepFreeze({ ...caveatSpecifications });
+    this.#unrestrictedMethods = new Set(unrestrictedMethods);
+    this.#caveatSpecifications = deepFreeze({ ...caveatSpecifications });
 
-    this.validatePermissionSpecifications(
+    this.#validatePermissionSpecifications(
       permissionSpecifications,
-      this._caveatSpecifications,
+      this.#caveatSpecifications,
     );
 
-    this._permissionSpecifications = deepFreeze({
+    this.#permissionSpecifications = deepFreeze({
       ...permissionSpecifications,
     });
 
-    this.registerMessageHandlers();
+    this.#registerMessageHandlers();
     this.createPermissionMiddleware = getPermissionMiddlewareFactory({
-      executeRestrictedMethod: this._executeRestrictedMethod.bind(this),
+      executeRestrictedMethod: this.#executeRestrictedMethod.bind(this),
       getRestrictedMethod: this.getRestrictedMethod.bind(this),
       isUnrestrictedMethod: this.unrestrictedMethods.has.bind(
         this.unrestrictedMethods,
@@ -706,7 +710,7 @@ export class PermissionController<
    * @param targetName - The name of the permission specification to get.
    * @returns The permission specification with the specified target name.
    */
-  private getPermissionSpecification<
+  #getPermissionSpecification<
     TargetName extends ControllerPermissionSpecification['targetName'],
   >(
     targetName: TargetName,
@@ -714,7 +718,7 @@ export class PermissionController<
     ControllerPermissionSpecification,
     TargetName
   > {
-    return this._permissionSpecifications[targetName];
+    return this.#permissionSpecifications[targetName];
   }
 
   /**
@@ -723,10 +727,10 @@ export class PermissionController<
    * @param caveatType - The type of the caveat specification to get.
    * @returns The caveat specification with the specified type.
    */
-  private getCaveatSpecification<
+  #getCaveatSpecification<
     CaveatType extends ControllerCaveatSpecification['type'],
-  >(caveatType: CaveatType) {
-    return this._caveatSpecifications[caveatType];
+  >(caveatType: CaveatType): ControllerCaveatSpecification {
+    return this.#caveatSpecifications[caveatType];
   }
 
   /**
@@ -739,7 +743,7 @@ export class PermissionController<
   #expectGetCaveatMerger<
     CaveatType extends ControllerCaveatSpecification['type'],
   >(caveatType: CaveatType): CaveatValueMerger<Json> {
-    const { merger } = this.getCaveatSpecification(caveatType);
+    const { merger } = this.#getCaveatSpecification(caveatType);
 
     if (merger === undefined) {
       throw new CaveatMergerDoesNotExistError(caveatType);
@@ -757,10 +761,10 @@ export class PermissionController<
    * @param caveatSpecifications - The caveat specifications passed to this
    * controller.
    */
-  private validatePermissionSpecifications(
+  #validatePermissionSpecifications(
     permissionSpecifications: PermissionSpecificationMap<ControllerPermissionSpecification>,
     caveatSpecifications: CaveatSpecificationMap<ControllerCaveatSpecification>,
-  ) {
+  ): void {
     Object.entries<ControllerPermissionSpecification>(
       permissionSpecifications,
     ).forEach(
@@ -815,7 +819,7 @@ export class PermissionController<
   /**
    * Constructor helper for registering the controller's messenger actions.
    */
-  private registerMessageHandlers(): void {
+  #registerMessageHandlers(): void {
     this.messenger.registerActionHandler(
       `${controllerName}:clearPermissions` as const,
       () => this.clearState(),
@@ -943,7 +947,7 @@ export class PermissionController<
    * @returns The specification object corresponding to the given type and
    * target name.
    */
-  private getTypedPermissionSpecification<Type extends PermissionType>(
+  #getTypedPermissionSpecification<Type extends PermissionType>(
     permissionType: Type,
     targetName: string,
     requestingOrigin?: string,
@@ -959,11 +963,11 @@ export class PermissionController<
             requestingOrigin,
           );
 
-    if (!this.targetExists(targetName)) {
+    if (!this.#targetExists(targetName)) {
       throw failureError;
     }
 
-    const specification = this.getPermissionSpecification(targetName);
+    const specification = this.#getPermissionSpecification(targetName);
     if (!hasSpecificationType(specification, permissionType)) {
       throw failureError;
     }
@@ -987,7 +991,7 @@ export class PermissionController<
     method: string,
     origin?: string,
   ): RestrictedMethod<RestrictedMethodParameters, Json> {
-    return this.getTypedPermissionSpecification(
+    return this.#getTypedPermissionSpecification(
       PermissionType.RestrictedMethod,
       method,
       origin,
@@ -1137,7 +1141,7 @@ export class PermissionController<
             throw new PermissionDoesNotExistError(origin, target);
           }
 
-          this.deletePermission(draftState.subjects, origin, target);
+          this.#deletePermission(draftState.subjects, origin, target);
         });
       });
     });
@@ -1164,7 +1168,7 @@ export class PermissionController<
         const { permissions } = subject;
 
         if (hasProperty(permissions as Record<string, unknown>, target)) {
-          this.deletePermission(draftState.subjects, origin, target);
+          this.#deletePermission(draftState.subjects, origin, target);
         }
       });
     });
@@ -1180,7 +1184,7 @@ export class PermissionController<
    * to delete.
    * @param target - The target name of the permission to delete.
    */
-  private deletePermission(
+  #deletePermission(
     subjects: Draft<PermissionControllerSubjects<PermissionConstraint>>,
     origin: OriginString,
     target: ExtractPermission<
@@ -1295,7 +1299,7 @@ export class PermissionController<
       throw new CaveatAlreadyExistsError(origin, target, caveatType);
     }
 
-    this.setCaveat(origin, target, caveatType, caveatValue);
+    this.#setCaveat(origin, target, caveatType, caveatValue);
   }
 
   /**
@@ -1337,7 +1341,7 @@ export class PermissionController<
       throw new CaveatDoesNotExistError(origin, target, caveatType);
     }
 
-    this.setCaveat(origin, target, caveatType, caveatValue);
+    this.#setCaveat(origin, target, caveatType, caveatValue);
   }
 
   /**
@@ -1358,7 +1362,7 @@ export class PermissionController<
    * @param caveatType - The type of the caveat to set.
    * @param caveatValue - The value of the caveat to set.
    */
-  private setCaveat<
+  #setCaveat<
     TargetName extends ExtractPermission<
       ControllerPermissionSpecification,
       ControllerCaveatSpecification
@@ -1392,7 +1396,7 @@ export class PermissionController<
         type: caveatType,
         value: caveatValue,
       };
-      this.validateCaveat(caveat, origin, target);
+      this.#validateCaveat(caveat, origin, target);
 
       let addedCaveat = false;
       if (permission.caveats) {
@@ -1419,7 +1423,7 @@ export class PermissionController<
       // Mutating a caveat does not warrant permission validation, but mutating
       // the caveat array does.
       if (addedCaveat) {
-        this.validateModifiedPermission(permission, origin, {
+        this.#validateModifiedPermission(permission, origin, {
           invokePermissionValidator: true,
           performCaveatValidation: false, // We just validated the caveat
         });
@@ -1489,7 +1493,7 @@ export class PermissionController<
               (targetCaveat as Mutable<CaveatConstraint, 'value'>).value =
                 mutatorResult.value;
 
-              this.validateCaveat(
+              this.#validateCaveat(
                 targetCaveat,
                 subject.origin,
                 permission.parentCapability,
@@ -1497,11 +1501,11 @@ export class PermissionController<
               break;
 
             case CaveatMutatorOperation.DeleteCaveat:
-              this.deleteCaveat(permission, targetCaveatType, subject.origin);
+              this.#deleteCaveat(permission, targetCaveatType, subject.origin);
               break;
 
             case CaveatMutatorOperation.RevokePermission:
-              this.deletePermission(
+              this.#deletePermission(
                 draftState.subjects,
                 subject.origin,
                 permission.parentCapability,
@@ -1548,7 +1552,7 @@ export class PermissionController<
         throw new CaveatDoesNotExistError(origin, target, caveatType);
       }
 
-      this.deleteCaveat(permission, caveatType, origin);
+      this.#deleteCaveat(permission, caveatType, origin);
     });
   }
 
@@ -1564,7 +1568,7 @@ export class PermissionController<
    * @param caveatType - The type of the caveat to delete.
    * @param origin - The origin the permission subject.
    */
-  private deleteCaveat<
+  #deleteCaveat<
     CaveatType extends ExtractCaveats<ControllerCaveatSpecification>['type'],
   >(
     permission: Draft<PermissionConstraint>,
@@ -1598,7 +1602,7 @@ export class PermissionController<
       permission.caveats.splice(caveatIndex, 1);
     }
 
-    this.validateModifiedPermission(permission, origin, {
+    this.#validateModifiedPermission(permission, origin, {
       invokePermissionValidator: true,
       performCaveatValidation: false, // No caveat object was mutated
     });
@@ -1608,28 +1612,28 @@ export class PermissionController<
    * Validates the specified modified permission. Should **always** be invoked
    * on a permission when its caveat array has been mutated.
    *
-   * Just like {@link PermissionController.validatePermission}, except that the
+   * Just like {@link PermissionController.#validatePermission}, except that the
    * corresponding target name and specification are retrieved first, and an
    * error is thrown if the target name does not exist.
    *
    * @param permission - The modified permission to validate.
    * @param origin - The origin associated with the permission.
-   * @param validationFlags - Validation flags. See {@link PermissionController.validatePermission}.
+   * @param validationFlags - Validation flags. See {@link PermissionController.#validatePermission}.
    */
-  private validateModifiedPermission(
+  #validateModifiedPermission(
     permission: Draft<PermissionConstraint>,
     origin: OriginString,
     validationFlags: PermissionValidationFlags,
   ): void {
     /* istanbul ignore if: this should be impossible */
-    if (!this.targetExists(permission.parentCapability)) {
+    if (!this.#targetExists(permission.parentCapability)) {
       throw new Error(
         `Fatal: Existing permission target "${permission.parentCapability}" has no specification.`,
       );
     }
 
-    this.validatePermission(
-      this.getPermissionSpecification(permission.parentCapability),
+    this.#validatePermission(
+      this.#getPermissionSpecification(permission.parentCapability),
       permission as PermissionConstraint,
       origin,
       validationFlags,
@@ -1643,10 +1647,10 @@ export class PermissionController<
    * @param target - The requested permission target.
    * @returns Whether the permission target exists.
    */
-  private targetExists(
+  #targetExists(
     target: string,
   ): target is ControllerPermissionSpecification['targetName'] {
-    return hasProperty(this._permissionSpecifications, target);
+    return hasProperty(this.#permissionSpecifications, target);
   }
 
   /**
@@ -1781,7 +1785,7 @@ export class PermissionController<
     for (const [requestedTarget, approvedPermission] of Object.entries(
       approvedPermissions,
     )) {
-      if (!this.targetExists(requestedTarget)) {
+      if (!this.#targetExists(requestedTarget)) {
         throw methodNotFound(requestedTarget);
       }
 
@@ -1802,10 +1806,10 @@ export class PermissionController<
         ControllerPermissionSpecification,
         ControllerCaveatSpecification
       >['parentCapability'];
-      const specification = this.getPermissionSpecification(targetName);
+      const specification = this.#getPermissionSpecification(targetName);
 
       // The requested caveats are validated here.
-      const caveats = this.constructCaveats(
+      const caveats = this.#constructCaveats(
         origin,
         targetName,
         approvedPermission.caveats,
@@ -1834,14 +1838,14 @@ export class PermissionController<
         )[0];
       }
 
-      this.validatePermission(specification, permission, origin, {
+      this.#validatePermission(specification, permission, origin, {
         invokePermissionValidator: true,
         performCaveatValidation: true,
       });
       permissions[targetName] = permission;
     }
 
-    this.setValidatedPermissions(origin, permissions);
+    this.#setValidatedPermissions(origin, permissions);
     return permissions;
   }
 
@@ -1863,10 +1867,10 @@ export class PermissionController<
    * @param validationOptions.invokePermissionValidator - Whether to invoke the
    * permission's consumer-specified validator function, if any.
    * @param validationOptions.performCaveatValidation - Whether to invoke
-   * {@link PermissionController.validateCaveat} on each of the permission's
+   * {@link PermissionController.#validateCaveat} on each of the permission's
    * caveats.
    */
-  private validatePermission(
+  #validatePermission(
     specification: PermissionSpecificationConstraint,
     permission: PermissionConstraint,
     origin: OriginString,
@@ -1907,7 +1911,7 @@ export class PermissionController<
       const seenCaveatTypes = new Set<string>();
       caveats?.forEach((caveat) => {
         if (performCaveatValidation) {
-          this.validateCaveat(caveat, origin, targetName);
+          this.#validateCaveat(caveat, origin, targetName);
         }
 
         if (!allowedCaveats?.includes(caveat.type)) {
@@ -1936,7 +1940,7 @@ export class PermissionController<
    * @param origin - The origin of the grantee subject.
    * @param permissions - The new permissions for the grantee subject.
    */
-  private setValidatedPermissions(
+  #setValidatedPermissions(
     origin: OriginString,
     permissions: Record<
       string,
@@ -1966,7 +1970,7 @@ export class PermissionController<
    * @param requestedCaveats - The requested caveats to construct.
    * @returns The constructed caveats.
    */
-  private constructCaveats(
+  #constructCaveats(
     origin: OriginString,
     target: ExtractPermission<
       ControllerPermissionSpecification,
@@ -1975,7 +1979,7 @@ export class PermissionController<
     requestedCaveats?: unknown[] | null,
   ): NonEmptyArray<ExtractCaveats<ControllerCaveatSpecification>> | undefined {
     const caveatArray = requestedCaveats?.map((requestedCaveat) => {
-      this.validateCaveat(requestedCaveat, origin, target);
+      this.#validateCaveat(requestedCaveat, origin, target);
 
       // Reassign so that we have a fresh object.
       const { type, value } = requestedCaveat as CaveatConstraint;
@@ -2000,11 +2004,7 @@ export class PermissionController<
    * permission.
    * @param target - The target name associated with the parent permission.
    */
-  private validateCaveat(
-    caveat: unknown,
-    origin: OriginString,
-    target: string,
-  ): void {
+  #validateCaveat(caveat: unknown, origin: OriginString, target: string): void {
     if (!isPlainObject(caveat)) {
       throw new InvalidCaveatError(caveat, origin, target);
     }
@@ -2017,7 +2017,7 @@ export class PermissionController<
       throw new InvalidCaveatTypeError(caveat, origin, target);
     }
 
-    const specification = this.getCaveatSpecification(caveat.type);
+    const specification = this.#getCaveatSpecification(caveat.type);
     if (!specification) {
       throw new UnrecognizedCaveatTypeError(caveat.type, origin, target);
     }
@@ -2082,7 +2082,7 @@ export class PermissionController<
   > {
     const { origin } = subject;
     const { id = nanoid(), preserveExistingPermissions = true } = options;
-    this.validateRequestedPermissions(origin, requestedPermissions);
+    this.#validateRequestedPermissions(origin, requestedPermissions);
 
     const metadata = {
       ...options.metadata,
@@ -2095,7 +2095,7 @@ export class PermissionController<
       permissions: requestedPermissions,
     };
 
-    const approvedRequest = await this.requestUserApproval(permissionsRequest);
+    const approvedRequest = await this.#requestUserApproval(permissionsRequest);
     return await this.#handleApprovedPermissions({
       subject,
       metadata,
@@ -2158,7 +2158,7 @@ export class PermissionController<
   > {
     const { origin } = subject;
     const { id = nanoid() } = options;
-    this.validateRequestedPermissions(origin, requestedPermissions);
+    this.#validateRequestedPermissions(origin, requestedPermissions);
 
     const currentPermissions = this.getPermissions(origin) ?? {};
     const [newPermissions, permissionDiffMap] =
@@ -2177,7 +2177,7 @@ export class PermissionController<
       // It does not spark joy to run this validation again after the merger operation.
       // But, optimizing this procedure is probably not worth it, especially considering
       // that the worst-case scenario for validation degrades to the below function call.
-      this.validateRequestedPermissions(origin, newPermissions);
+      this.#validateRequestedPermissions(origin, newPermissions);
     } catch (error) {
       if (error instanceof Error) {
         throw new InvalidMergedPermissionsError(
@@ -2205,7 +2205,7 @@ export class PermissionController<
       },
     };
 
-    const approvedRequest = await this.requestUserApproval(permissionsRequest);
+    const approvedRequest = await this.#requestUserApproval(permissionsRequest);
     return await this.#handleApprovedPermissions({
       subject,
       metadata,
@@ -2229,7 +2229,7 @@ export class PermissionController<
    * @param origin - The origin of the grantee subject.
    * @param requestedPermissions - The requested permissions.
    */
-  private validateRequestedPermissions(
+  #validateRequestedPermissions(
     origin: OriginString,
     requestedPermissions: unknown,
   ): void {
@@ -2250,7 +2250,7 @@ export class PermissionController<
     for (const targetName of Object.keys(requestedPermissions)) {
       const permission = requestedPermissions[targetName];
 
-      if (!this.targetExists(targetName)) {
+      if (!this.#targetExists(targetName)) {
         throw methodNotFound(targetName, { origin, requestedPermissions });
       }
 
@@ -2267,8 +2267,8 @@ export class PermissionController<
 
       // Here we validate the permission without invoking its validator, if any.
       // The validator will be invoked after the permission has been approved.
-      this.validatePermission(
-        this.getPermissionSpecification(targetName),
+      this.#validatePermission(
+        this.#getPermissionSpecification(targetName),
         // Typecast: The permission is still a "PlainObject" here.
         permission as PermissionConstraint,
         origin,
@@ -2456,7 +2456,9 @@ export class PermissionController<
    * @param permissionsRequest - The permissions request object.
    * @returns The approved permissions request object.
    */
-  private async requestUserApproval(permissionsRequest: PermissionsRequest) {
+  async #requestUserApproval(
+    permissionsRequest: PermissionsRequest,
+  ): Promise<PermissionsRequest> {
     const { origin, id } = permissionsRequest.metadata;
     const approvedRequest = await this.messenger.call(
       'ApprovalController:addRequest',
@@ -2469,7 +2471,7 @@ export class PermissionController<
       true,
     );
 
-    this.validateApprovedPermissions(approvedRequest, { id, origin });
+    this.#validateApprovedPermissions(approvedRequest, { id, origin });
     return approvedRequest as PermissionsRequest;
   }
 
@@ -2503,9 +2505,9 @@ export class PermissionController<
       approvedRequest;
     const approvedMetadata: ApprovedPermissionsMetadata = { ...metadata };
 
-    const sideEffects = this.getSideEffects(approvedPermissions);
+    const sideEffects = this.#getSideEffects(approvedPermissions);
     if (Object.values(sideEffects.permittedHandlers).length > 0) {
-      const sideEffectsData = await this.executeSideEffects(
+      const sideEffectsData = await this.#executeSideEffects(
         sideEffects,
         approvedRequest,
       );
@@ -2533,11 +2535,11 @@ export class PermissionController<
    * @param permissions - The approved permissions.
    * @returns The {@link SideEffects} object containing the handlers arrays.
    */
-  private getSideEffects(permissions: RequestedPermissions) {
+  #getSideEffects(permissions: RequestedPermissions): SideEffects {
     return Object.keys(permissions).reduce<SideEffects>(
       (sideEffectList, targetName) => {
-        if (this.targetExists(targetName)) {
-          const specification = this.getPermissionSpecification(targetName);
+        if (this.#targetExists(targetName)) {
+          const specification = this.#getPermissionSpecification(targetName);
 
           if (specification.sideEffect) {
             sideEffectList.permittedHandlers[targetName] =
@@ -2559,14 +2561,14 @@ export class PermissionController<
    * Executes the side-effects of the approved permissions while handling the errors if any.
    * It will pass an instance of the {@link messenger} and the request data associated with the permission request to the handlers through its params.
    *
-   * @param sideEffects - the side-effect record created by {@link getSideEffects}
+   * @param sideEffects - the side-effect record created by {@link #getSideEffects}
    * @param requestData - the permissions requestData.
    * @returns the value returned by all the `onPermitted` handlers in an array.
    */
-  private async executeSideEffects(
+  async #executeSideEffects(
     sideEffects: SideEffects,
     requestData: PermissionsRequest,
-  ) {
+  ): Promise<unknown[]> {
     const { permittedHandlers, failureHandlers } = sideEffects;
     const params = {
       requestData,
@@ -2620,7 +2622,7 @@ export class PermissionController<
    * request must have the required `metadata` and `permissions` properties,
    * the `id` and `origin` of the `metadata` must match the original request
    * metadata, and the requested permissions must be valid per
-   * {@link PermissionController.validateRequestedPermissions}. Any extra
+   * {@link PermissionController.#validateRequestedPermissions}. Any extra
    * metadata properties are ignored.
    *
    * An error is thrown if validation fails.
@@ -2628,10 +2630,10 @@ export class PermissionController<
    * @param approvedRequest - The approved permissions request object.
    * @param originalMetadata - The original request metadata.
    */
-  private validateApprovedPermissions(
+  #validateApprovedPermissions(
     approvedRequest: unknown,
     originalMetadata: PermissionsRequestMetadata,
-  ) {
+  ): void {
     const { id, origin } = originalMetadata;
 
     if (
@@ -2664,7 +2666,7 @@ export class PermissionController<
     }
 
     try {
-      this.validateRequestedPermissions(origin, permissions);
+      this.#validateRequestedPermissions(origin, permissions);
     } catch (error) {
       if (error instanceof Error) {
         // Re-throw as an internal error; we should never receive invalid approved
@@ -2688,12 +2690,12 @@ export class PermissionController<
   async acceptPermissionsRequest(request: PermissionsRequest): Promise<void> {
     const { id } = request.metadata;
 
-    if (!this.hasApprovalRequest({ id })) {
+    if (!this.#hasApprovalRequest({ id })) {
       throw new PermissionsRequestNotFoundError(id);
     }
 
     if (Object.keys(request.permissions).length === 0) {
-      this._rejectPermissionsRequest(
+      this.#rejectPermissionsRequest(
         id,
         invalidParams({
           message: 'Must request at least one permission.',
@@ -2711,7 +2713,7 @@ export class PermissionController<
     } catch (error) {
       // If accepting unexpectedly fails, reject the request and re-throw the
       // error
-      this._rejectPermissionsRequest(id, error);
+      this.#rejectPermissionsRequest(id, error);
       throw error;
     }
   }
@@ -2723,11 +2725,11 @@ export class PermissionController<
    * @param id - The id of the request to be rejected.
    */
   async rejectPermissionsRequest(id: string): Promise<void> {
-    if (!this.hasApprovalRequest({ id })) {
+    if (!this.#hasApprovalRequest({ id })) {
       throw new PermissionsRequestNotFoundError(id);
     }
 
-    this._rejectPermissionsRequest(id, userRejectedRequest());
+    this.#rejectPermissionsRequest(id, userRejectedRequest());
   }
 
   /**
@@ -2740,7 +2742,7 @@ export class PermissionController<
    * @param options.id - The id of the approval request to check for.
    * @returns Whether the specified request exists.
    */
-  private hasApprovalRequest(options: { id: string }): boolean {
+  #hasApprovalRequest(options: { id: string }): boolean {
     return this.messenger.call('ApprovalController:hasRequest', options);
   }
 
@@ -2755,7 +2757,7 @@ export class PermissionController<
    * @param error - The error associated with the rejection.
    * @returns Nothing
    */
-  private _rejectPermissionsRequest(id: string, error: unknown): void {
+  #rejectPermissionsRequest(id: string, error: unknown): void {
     return this.messenger.call('ApprovalController:rejectRequest', id, error);
   }
 
@@ -2783,7 +2785,7 @@ export class PermissionController<
       throw unauthorized({ data: { origin, targetName } });
     }
 
-    return this.getTypedPermissionSpecification(
+    return this.#getTypedPermissionSpecification(
       PermissionType.Endowment,
       targetName,
       origin,
@@ -2826,7 +2828,7 @@ export class PermissionController<
     // Throws if the method does not exist
     const methodImplementation = this.getRestrictedMethod(targetName, origin);
 
-    const result = await this._executeRestrictedMethod(
+    const result = await this.#executeRestrictedMethod(
       methodImplementation,
       { origin },
       targetName,
@@ -2860,7 +2862,7 @@ export class PermissionController<
    * @param params - Params needed for executing the restricted method
    * @returns The result of the restricted method implementation
    */
-  private _executeRestrictedMethod(
+  #executeRestrictedMethod(
     methodImplementation: RestrictedMethod<RestrictedMethodParameters, Json>,
     subject: PermissionSubjectMetadata,
     method: ExtractPermission<
@@ -2879,7 +2881,7 @@ export class PermissionController<
     return decorateWithCaveats(
       methodImplementation,
       permission,
-      this._caveatSpecifications,
+      this.#caveatSpecifications,
     )({ method, params, context: { origin } });
   }
 }

--- a/packages/permission-controller/src/SubjectMetadataController.test.ts
+++ b/packages/permission-controller/src/SubjectMetadataController.test.ts
@@ -7,7 +7,10 @@ import type {
 } from '@metamask/messenger';
 import type { Json } from '@metamask/utils';
 
-import type { SubjectMetadataControllerMessenger } from './SubjectMetadataController';
+import type {
+  SubjectMetadata,
+  SubjectMetadataControllerMessenger,
+} from './SubjectMetadataController';
 import {
   SubjectMetadataController,
   SubjectType,
@@ -43,7 +46,15 @@ function getRootMessenger(): RootMessenger {
  *
  * @returns A tuple containing the messenger and a spy for the "hasPermission" action handler
  */
-function getSubjectMetadataControllerMessenger() {
+function getSubjectMetadataControllerMessenger(): readonly [
+  Messenger<
+    typeof controllerName,
+    AllSubjectMetadataControllerActions,
+    AllSubjectMetadataControllerEvents,
+    RootMessenger
+  >,
+  jest.Mock,
+] {
   const rootMessenger = getRootMessenger();
 
   const hasPermissionsSpy = jest.fn();
@@ -84,7 +95,7 @@ function getSubjectMetadata(
   name: string | null = null,
   subjectType: SubjectType | null = null,
   opts?: Record<string, Json>,
-) {
+): SubjectMetadata {
   return {
     origin,
     name,

--- a/packages/permission-controller/src/errors.ts
+++ b/packages/permission-controller/src/errors.ts
@@ -1,4 +1,8 @@
-import type { DataWithOptionalCause } from '@metamask/rpc-errors';
+import {
+  DataWithOptionalCause,
+  EthereumProviderError,
+  OptionalDataWithOptionalCause,
+} from '@metamask/rpc-errors';
 import {
   errorCodes,
   providerErrors,
@@ -21,7 +25,9 @@ type UnauthorizedArg = {
  * @param opts - Optional arguments that add extra context
  * @returns The built error
  */
-export function unauthorized(opts: UnauthorizedArg) {
+export function unauthorized(
+  opts: UnauthorizedArg,
+): EthereumProviderError<UnauthorizedArg> {
   return providerErrors.unauthorized({
     message:
       'Unauthorized to perform action. Try requesting the required permission(s) first. For more information, see: https://docs.metamask.io/guide/rpc-api.html#permissions',
@@ -36,7 +42,10 @@ export function unauthorized(opts: UnauthorizedArg) {
  * @param data - Optional data for context.
  * @returns The built error
  */
-export function methodNotFound(method: string, data?: DataWithOptionalCause) {
+export function methodNotFound(
+  method: string,
+  data?: DataWithOptionalCause,
+): JsonRpcError<OptionalDataWithOptionalCause> {
   const message = `The method "${method}" does not exist / is not available.`;
 
   const opts: Parameters<typeof rpcErrors.methodNotFound>[0] = { message };
@@ -57,7 +66,9 @@ type InvalidParamsArg = {
  * @param opts - Optional arguments that add extra context
  * @returns The built error
  */
-export function invalidParams(opts: InvalidParamsArg) {
+export function invalidParams(
+  opts: InvalidParamsArg,
+): JsonRpcError<DataWithOptionalCause> {
   return rpcErrors.invalidParams({
     data: opts.data,
     message: opts.message,

--- a/packages/permission-controller/src/permission-middleware.ts
+++ b/packages/permission-controller/src/permission-middleware.ts
@@ -14,14 +14,22 @@ import type {
 import type {
   GenericPermissionController,
   PermissionSubjectMetadata,
+  RestrictedMethod,
   RestrictedMethodParameters,
 } from '.';
 import { internalError } from './errors';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { PermissionController } from './PermissionController';
 
+type ExecuteRestrictedMethod = (
+  methodImplementation: RestrictedMethod<RestrictedMethodParameters, Json>,
+  subject: PermissionSubjectMetadata,
+  method: string,
+  params?: RestrictedMethodParameters,
+) => ReturnType<RestrictedMethod<RestrictedMethodParameters, Json>>;
+
 type PermissionMiddlewareFactoryOptions = {
-  executeRestrictedMethod: GenericPermissionController['_executeRestrictedMethod'];
+  executeRestrictedMethod: ExecuteRestrictedMethod;
   getRestrictedMethod: GenericPermissionController['getRestrictedMethod'];
   isUnrestrictedMethod: (method: string) => boolean;
 };
@@ -42,7 +50,7 @@ type PermissionMiddlewareFactoryOptions = {
  * will be executed. Otherwise, an "unauthorized" error will be returned.
  *
  * @param options - Options bag.
- * @param options.executeRestrictedMethod - {@link PermissionController._executeRestrictedMethod}.
+ * @param options.executeRestrictedMethod - `PermissionController.executeRestrictedMethod`.
  * @param options.getRestrictedMethod - {@link PermissionController.getRestrictedMethod}.
  * @param options.isUnrestrictedMethod - A function that checks whether a
  * particular method is unrestricted.

--- a/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/requestPermissions.test.ts
@@ -64,7 +64,7 @@ describe('requestPermissions RPC method', () => {
       });
 
     const engine = new JsonRpcEngine();
-    const end = () => undefined; // this won't be called
+    const end = (): undefined => undefined; // this won't be called
 
     // Pass the middleware function to createAsyncMiddleware so the error
     // is catched.

--- a/packages/permission-controller/src/utils.ts
+++ b/packages/permission-controller/src/utils.ts
@@ -93,7 +93,11 @@ export type PermittedHandlerExport<
 export function collectUniqueAndPairedCaveats(
   leftPermission: Partial<PermissionConstraint> | undefined,
   rightPermission: Partial<PermissionConstraint>,
-) {
+): {
+  caveatPairs: [CaveatConstraint, CaveatConstraint][];
+  leftUniqueCaveats: CaveatConstraint[];
+  rightUniqueCaveats: CaveatConstraint[];
+} {
   const leftCaveats = leftPermission?.caveats?.slice() ?? [];
   const rightCaveats = rightPermission.caveats?.slice() ?? [];
   const leftUniqueCaveats: CaveatConstraint[] = [];


### PR DESCRIPTION
## Explanation

This fixes all suppressed ESLint errors in the `permission-controller` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes #7380.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit return types and stricter TypeScript typings across permission-controller (core, middleware, errors, tests), refactoring internals to private class fields and tightening APIs with minor non-functional changes.
> 
> - **Core (permission-controller)**:
>   - Convert internals to private class fields (e.g., `#caveatSpecifications`, `#permissionSpecifications`, `#unrestrictedMethods`) and private helpers (e.g., `#getPermissionSpecification`, `#validatePermission`, `#requestUserApproval`).
>   - Add explicit return types and generics throughout (controllers, caveat decorators, mergers, mutators, helpers).
>   - Initialize `CaveatMutatorOperation` enum values and tighten types for caveat merging, construction, and validation.
>   - Use nullish coalescing in `SubjectMetadataController.addSubjectMetadata` and refactor cache/trim logic with private fields and static `#getTrimmedState`.
>   - Ensure `decorateWithCaveats` wrapper has explicit `Promise<Json>` return.
> - **Middleware**:
>   - Introduce `ExecuteRestrictedMethod` type; pass `executeRestrictedMethod` via factory; tighten middleware typings and undefined-result handling.
> - **Errors**:
>   - Type return values for `unauthorized`, `methodNotFound`, and `invalidParams`; import needed types from `@metamask/rpc-errors`.
> - **Tests**:
>   - Add explicit return types, stronger typings for mocks/utilities, optional chaining for side-effect handlers, and minor refactors in test helpers.
> - **Config**:
>   - Remove `permission-controller` entries from `eslint-suppressions.json` for resolved rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2acb726580811febe1faaf8611f83f607fa64630. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->