### PR TITLE
chore(lint): Fix suppressed ESLint errors in `build-utils` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -886,19 +886,6 @@
       "count": 1
     }
   },
-  "packages/build-utils/src/transforms/remove-fenced-code.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 4
-    }
-  },
-  "packages/build-utils/src/transforms/remove-fenced-code.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 4
-    },
-    "@typescript-eslint/naming-convention": {
-      "count": 1
-    }
-  },
   "packages/chain-agnostic-permission/src/caip25Permission.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 11

--- a/packages/build-utils/src/transforms/remove-fenced-code.test.ts
+++ b/packages/build-utils/src/transforms/remove-fenced-code.test.ts
@@ -10,24 +10,30 @@ const FEATURE_A = 'feature-a';
 const FEATURE_B = 'feature-b';
 const FEATURE_C = 'feature-c';
 
-const getFeatures = ({ all, active }: FeatureLabels) => ({
+const getFeatures = ({
+  all,
+  active,
+}: FeatureLabels): {
+  all: Set<string>;
+  active: Set<string>;
+} => ({
   all: new Set(all),
   active: new Set(active),
 });
 
-const getFencedCode = (...params: string[]) =>
+const getFencedCode = (...params: string[]): string =>
   `///: BEGIN:ONLY_INCLUDE_IF(${params.join(',')})
 Conditionally_Included
 ///: END:ONLY_INCLUDE_IF
 `;
 
-const getUnfencedCode = () => `
+const getUnfencedCode = (): string => `
 Always included
 Always included
 Always included
 `;
 
-const join = (...args: string[]) => args.join('\n');
+const join = (...args: string[]): string => args.join('\n');
 
 describe('build transforms', () => {
   describe('removeFencedCode', () => {

--- a/packages/build-utils/src/transforms/remove-fenced-code.ts
+++ b/packages/build-utils/src/transforms/remove-fenced-code.ts
@@ -20,6 +20,9 @@ enum DirectiveTerminus {
 }
 
 export enum DirectiveCommand {
+  // TODO: This should be `OnlyIncludeIf`, but we need to preserve
+  // backwards-compatibility for now.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   ONLY_INCLUDE_IF = 'ONLY_INCLUDE_IF',
 }
 
@@ -364,7 +367,7 @@ function getInvalidFenceLineMessage(
   filePath: string,
   line: string,
   details: string,
-) {
+): string {
   return `Invalid fence line in file "${filePath}": "${line}":\n${details}`;
 }
 
@@ -375,7 +378,10 @@ function getInvalidFenceLineMessage(
  * @param details - An explanation of the error.
  * @returns The error message.
  */
-function getInvalidFenceStructureMessage(filePath: string, details: string) {
+function getInvalidFenceStructureMessage(
+  filePath: string,
+  details: string,
+): string {
   return `Invalid fence structure in file "${filePath}":\n${details}`;
 }
 
@@ -391,7 +397,7 @@ function getInvalidFencePairMessage(
   filePath: string,
   line: string,
   details: string,
-) {
+): string {
   return `Invalid fence pair in file "${filePath}" due to line "${line}":\n${details}`;
 }
 
@@ -407,7 +413,7 @@ function getInvalidParamsMessage(
   filePath: string,
   details: string,
   command?: string,
-) {
+): string {
   return `Invalid code fence parameters in file "${filePath}"${
     command ? `for command "${command}"` : ''
   }:\n${details}`;


### PR DESCRIPTION
## Explanation

This fixes all suppressed ESLint errors in the `build-utils` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes #7347.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit return types and minor typing tweaks in `remove-fenced-code` (impl and tests) and removes corresponding ESLint suppressions.
> 
> - **Build utils (`packages/build-utils`)**:
>   - `src/transforms/remove-fenced-code.ts`:
>     - Add explicit return types to internal helpers (e.g., `getInvalid*Message`, `multiSplice` result) and maintain `DirectiveCommand.ONLY_INCLUDE_IF` with an inline naming-convention disable and TODO.
>   - `src/transforms/remove-fenced-code.test.ts`:
>     - Add explicit return types to test helpers (`getFeatures`, `getFencedCode`, `getUnfencedCode`, `join`).
> - **Lint config**:
>   - Update `eslint-suppressions.json` to remove suppressions for `remove-fenced-code.ts` and its test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09a6de9e4d93d4bfb65ec7a856bb02a642b338fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->