### PR TITLE
chore(lint): Fix suppressed ESLint errors in `composable-controller` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -950,20 +950,6 @@
       "count": 2
     }
   },
-  "packages/composable-controller/src/ComposableController.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 2
-    },
-    "@typescript-eslint/naming-convention": {
-      "count": 16
-    },
-    "import-x/namespace": {
-      "count": 3
-    },
-    "no-new": {
-      "count": 2
-    }
-  },
   "packages/core-backend/src/AccountActivityService.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 4

--- a/packages/composable-controller/src/ComposableController.test.ts
+++ b/packages/composable-controller/src/ComposableController.test.ts
@@ -15,7 +15,7 @@ import type {
   MockAnyNamespace,
 } from '@metamask/messenger';
 import type { Patch } from 'immer';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 
 import type {
   ChildControllerStateChangeEvents,
@@ -77,7 +77,7 @@ class FooController extends BaseController<
     });
   }
 
-  updateFoo(foo: string) {
+  updateFoo(foo: string): void {
     super.update((state) => {
       state.foo = foo;
     });
@@ -126,7 +126,7 @@ class QuzController extends BaseController<
     });
   }
 
-  updateQuz(quz: string) {
+  updateQuz(quz: string): void {
     super.update((state) => {
       state.quz = quz;
     });
@@ -142,8 +142,10 @@ type ComposableControllerMessenger<State extends StateConstraint> = Messenger<
 >;
 
 type ControllersMap = {
+  /* eslint-disable @typescript-eslint/naming-convention */
   FooController: FooController;
   QuzController: QuzController;
+  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 describe('ComposableController', () => {
@@ -154,8 +156,10 @@ describe('ComposableController', () => {
   describe('BaseController', () => {
     it('should compose controller state', () => {
       type ComposableControllerState = {
+        /* eslint-disable @typescript-eslint/naming-convention */
         QuzController: QuzControllerState;
         FooController: FooControllerState;
+        /* eslint-enable @typescript-eslint/naming-convention */
       };
       const messenger: RootMessenger = new Messenger({
         namespace: MOCK_ANY_NAMESPACE,
@@ -206,7 +210,9 @@ describe('ComposableController', () => {
 
     it('should notify listeners of nested state change', () => {
       type ComposableControllerState = {
+        /* eslint-disable @typescript-eslint/naming-convention */
         FooController: FooControllerState;
+        /* eslint-enable @typescript-eslint/naming-convention */
       };
       const messenger = new Messenger<
         MockAnyNamespace,
@@ -236,6 +242,7 @@ describe('ComposableController', () => {
         messenger: composableControllerMessenger,
         events: ['FooController:stateChange'],
       });
+      // eslint-disable-next-line no-new
       new ComposableController<
         ComposableControllerState,
         Pick<ControllersMap, keyof ComposableControllerState>
@@ -264,8 +271,10 @@ describe('ComposableController', () => {
 
   it('should notify listeners of BaseController state change', () => {
     type ComposableControllerState = {
+      /* eslint-disable @typescript-eslint/naming-convention */
       QuzController: QuzControllerState;
       FooController: FooControllerState;
+      /* eslint-enable @typescript-eslint/naming-convention */
     };
     const messenger = new Messenger<
       MockAnyNamespace,
@@ -310,6 +319,7 @@ describe('ComposableController', () => {
       messenger: composableControllerMessenger,
       events: ['QuzController:stateChange', 'FooController:stateChange'],
     });
+    // eslint-disable-next-line no-new
     new ComposableController<
       ComposableControllerState,
       Pick<ControllersMap, keyof ComposableControllerState>
@@ -338,7 +348,9 @@ describe('ComposableController', () => {
 
   it('should not throw if child state change event subscription fails', () => {
     type ComposableControllerState = {
+      /* eslint-disable @typescript-eslint/naming-convention */
       FooController: FooControllerState;
+      /* eslint-enable @typescript-eslint/naming-convention */
     };
     const messenger = new Messenger<
       MockAnyNamespace,
@@ -426,7 +438,9 @@ describe('ComposableController', () => {
 
   it('should throw if composing a controller that does not extend from BaseController', () => {
     type ComposableControllerState = {
+      /* eslint-disable @typescript-eslint/naming-convention */
       FooController: FooControllerState;
+      /* eslint-enable @typescript-eslint/naming-convention */
     };
     const notController = new JsonRpcEngine();
     const messenger = new Messenger<
@@ -462,6 +476,7 @@ describe('ComposableController', () => {
     expect(
       () =>
         new ComposableController<
+          /* eslint-disable @typescript-eslint/naming-convention */
           // @ts-expect-error - Suppressing type error to test for runtime error handling
           ComposableControllerState & {
             JsonRpcEngine: Record<string, unknown>;
@@ -470,6 +485,7 @@ describe('ComposableController', () => {
             JsonRpcEngine: typeof notController;
             FooController: FooController;
           }
+          /* eslint-enable @typescript-eslint/naming-convention */
         >({
           controllers: {
             JsonRpcEngine: notController,
@@ -483,7 +499,9 @@ describe('ComposableController', () => {
   describe('metadata', () => {
     it('includes expected state in debug snapshots', () => {
       type ComposableControllerState = {
+        /* eslint-disable @typescript-eslint/naming-convention */
         FooController: FooControllerState;
+        /* eslint-enable @typescript-eslint/naming-convention */
       };
       const messenger = new Messenger<
         MockAnyNamespace,
@@ -543,7 +561,9 @@ describe('ComposableController', () => {
 
     it('includes expected state in state logs', () => {
       type ComposableControllerState = {
+        /* eslint-disable @typescript-eslint/naming-convention */
         FooController: FooControllerState;
+        /* eslint-enable @typescript-eslint/naming-convention */
       };
       const messenger = new Messenger<
         MockAnyNamespace,
@@ -597,7 +617,9 @@ describe('ComposableController', () => {
 
     it('persists expected state', () => {
       type ComposableControllerState = {
+        /* eslint-disable @typescript-eslint/naming-convention */
         FooController: FooControllerState;
+        /* eslint-enable @typescript-eslint/naming-convention */
       };
       const messenger = new Messenger<
         MockAnyNamespace,
@@ -657,7 +679,9 @@ describe('ComposableController', () => {
 
     it('exposes expected state to UI', () => {
       type ComposableControllerState = {
+        /* eslint-disable @typescript-eslint/naming-convention */
         FooController: FooControllerState;
+        /* eslint-enable @typescript-eslint/naming-convention */
       };
       const messenger = new Messenger<
         MockAnyNamespace,


### PR DESCRIPTION
## Explanation

This fixes all suppressed ESLint errors in the `composable-controller` package. Mainly disabling the naming convention rule, since the naming convention used in in this package is intentional.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes #7350.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes ESLint violations in `packages/composable-controller/src/ComposableController.test.ts` (return types, `sinon` import, scoped rule disables) and removes the file’s suppressions from `eslint-suppressions.json`.
> 
> - **Composable Controller tests (`packages/composable-controller/src/ComposableController.test.ts`)**:
>   - Switch `sinon` import to default import.
>   - Add explicit `void` return types to `updateFoo`/`updateQuz`.
>   - Add scoped ESLint disables for `@typescript-eslint/naming-convention` and `no-new` where needed.
>   - Minor typing/annotation cleanups; test behavior unchanged.
> - **Linting**:
>   - Remove suppressions for `ComposableController.test.ts` from `eslint-suppressions.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c65764f2c975577e6f723bbf97c7c1d5a9a0892a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->