### PR TITLE
chore: batch account creation

### DIFF
--- a/packages/multichain-account-service/src/MultichainAccountWallet.ts
+++ b/packages/multichain-account-service/src/MultichainAccountWallet.ts
@@ -585,10 +585,68 @@ export class MultichainAccountWallet<
       // from there).
       let maxGroupIndex = this.getNextGroupIndex();
 
+      // Track which providers have been batch-processed to skip sequential discovery
+      const batchProcessedProviders = new Set<Bip44AccountProvider<Account>>();
+
+      // OPTIMIZATION: Batch EVM account discovery to avoid N vault updates.
+      // First, find how many active accounts exist (read-only, no vault writes),
+      // then create them all in a single withKeyring call (one vault write).
+      const evmProvider = this.#providers.find(
+        (p) => p instanceof EvmAccountProvider,
+      ) as EvmAccountProvider | undefined;
+
+      if (evmProvider) {
+        try {
+          this.#log(
+            `[EVM] Batch discovery: checking for active accounts starting at index ${maxGroupIndex}...`,
+          );
+
+          const activeCount = await evmProvider.findActiveAccountCount({
+            entropySource: this.#entropySource,
+            startIndex: maxGroupIndex,
+          });
+
+          if (activeCount > 0) {
+            this.#log(
+              `[EVM] Found ${activeCount} active accounts. Creating in batch...`,
+            );
+            await evmProvider.bulkCreateAccounts({
+              entropySource: this.#entropySource,
+              count: maxGroupIndex + activeCount,
+            });
+            maxGroupIndex += activeCount;
+            this.#log(
+              `[EVM] Batch creation complete. New maxGroupIndex: ${maxGroupIndex}`,
+            );
+          } else {
+            this.#log(`[EVM] No new active accounts found.`);
+          }
+
+          // Mark EVM as batch-processed so we skip sequential discovery for it
+          batchProcessedProviders.add(
+            evmProvider as unknown as Bip44AccountProvider<Account>,
+          );
+        } catch (error) {
+          this.#log(
+            `${WARNING_PREFIX} [EVM] Batch discovery failed, falling back to sequential:`,
+            error,
+          );
+          // Don't add to batchProcessedProviders - will fall through to sequential discovery
+        }
+      }
+
       // One serialized loop per provider; all run concurrently
       const runProviderDiscovery = async (
         context: AccountProviderDiscoveryContext<Account>,
       ) => {
+        // Skip providers that were already batch-processed
+        if (batchProcessedProviders.has(context.provider)) {
+          this.#log(
+            `[${context.provider.getName()}] Skipping sequential discovery (batch-processed)`,
+          );
+          return;
+        }
+
         const providerName = context.provider.getName();
         const message = (stepName: string, groupIndex: number) =>
           `[${providerName}] Discovery ${stepName} for group index: ${groupIndex}`;


### PR DESCRIPTION
## Explanation

This batches some calls during account creation after SRP import. It reduced time it took from ~35s to ~9s on my device for SRP with ~250 accounts.

I am not sure if this is worth merging because of https://github.com/MetaMask/core/pull/6654

<img width="1511" height="631" alt="Screenshot 2025-12-12 at 18 38 26" src="https://github.com/user-attachments/assets/aee6a592-009c-4deb-89ef-fb182719acf4" />
<img width="1430" height="643" alt="Screenshot 2025-12-12 at 18 38 01" src="https://github.com/user-attachments/assets/31db8121-2d71-4aaa-b478-3aa126cc8ddd" />



## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Batches EVM account discovery/creation and debounces wallet/group syncs to cut redundant vault updates during large imports.
> 
> - **MultichainAccountService**:
>   - Add debounced sync pipeline (50ms) using `#pendingWalletSyncs` and `#pendingGroupSyncs`; replace immediate `wallet.sync()`/`group.sync()` on account add with queued flush via `#scheduleSync()` and `#flushSyncs()`.
> - **MultichainAccountWallet**:
>   - Optimize discovery: detect contiguous active EVM accounts, then batch-create them and skip sequential EVM discovery; update `maxGroupIndex` accordingly.
> - **EvmAccountProvider**:
>   - Add `findActiveAccountCount` (checks activity via `eth_getTransactionCount`), `bulkCreateAccounts` (single keyring write), and internal `#createAccountsBatch` helper; expose address/tx-count helpers for discovery flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9466cfd37cfb6846c54faa148528c48febf3300. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->