### PR TITLE
chore(lint): Fix suppressed ESLint errors in `eip-7702-internal-rpc-middleware` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1039,31 +1039,6 @@
       "count": 1
     }
   },
-  "packages/eip-7702-internal-rpc-middleware/src/utils.ts": {
-    "id-length": {
-      "count": 1
-    }
-  },
-  "packages/eip-7702-internal-rpc-middleware/src/wallet_getAccountUpgradeStatus.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 1
-    }
-  },
-  "packages/eip-7702-internal-rpc-middleware/src/wallet_getAccountUpgradeStatus.ts": {
-    "no-negated-condition": {
-      "count": 1
-    }
-  },
-  "packages/eip-7702-internal-rpc-middleware/src/wallet_upgradeAccount.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 1
-    }
-  },
-  "packages/eip-7702-internal-rpc-middleware/src/wallet_upgradeAccount.ts": {
-    "no-negated-condition": {
-      "count": 1
-    }
-  },
   "packages/eip1193-permission-middleware/src/wallet-getPermissions.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 2

--- a/packages/eip-7702-internal-rpc-middleware/src/utils.ts
+++ b/packages/eip-7702-internal-rpc-middleware/src/utils.ts
@@ -76,7 +76,8 @@ function formatValidationError(error: StructError, message: string): string {
   return `${message}\n\n${error
     .failures()
     .map(
-      (f) => `${f.path.join(' > ')}${f.path.length ? ' - ' : ''}${f.message}`,
+      (failure) =>
+        `${failure.path.join(' > ')}${failure.path.length ? ' - ' : ''}${failure.message}`,
     )
     .join('\n')}`;
 }

--- a/packages/eip-7702-internal-rpc-middleware/src/wallet_getAccountUpgradeStatus.test.ts
+++ b/packages/eip-7702-internal-rpc-middleware/src/wallet_getAccountUpgradeStatus.test.ts
@@ -7,7 +7,13 @@ import { walletGetAccountUpgradeStatus } from './wallet_getAccountUpgradeStatus'
 const TEST_ACCOUNT = '0x1234567890123456789012345678901234567890';
 const NETWORK_CLIENT_ID = 'mainnet';
 
-const createTestHooks = () => {
+const createTestHooks = (): {
+  getCode: jest.Mock;
+  getCurrentChainIdForDomain: jest.Mock;
+  getSelectedNetworkClientIdForChain: jest.Mock;
+  getPermittedAccountsForOrigin: jest.Mock;
+  isEip7702Supported: jest.Mock;
+} => {
   const getCode = jest.fn();
   const getCurrentChainIdForDomain = jest.fn().mockReturnValue('0x1');
   const getPermittedAccountsForOrigin = jest
@@ -27,7 +33,7 @@ const createTestHooks = () => {
     getSelectedNetworkClientIdForChain,
     getPermittedAccountsForOrigin,
     isEip7702Supported,
-  };
+  } as const;
 };
 
 const createTestRequest = (

--- a/packages/eip-7702-internal-rpc-middleware/src/wallet_getAccountUpgradeStatus.ts
+++ b/packages/eip-7702-internal-rpc-middleware/src/wallet_getAccountUpgradeStatus.ts
@@ -75,9 +75,7 @@ export async function walletGetAccountUpgradeStatus(
 
   // Use current chain ID if not provided
   let targetChainId: Hex;
-  if (chainId !== undefined) {
-    targetChainId = chainId;
-  } else {
+  if (chainId === undefined) {
     const currentChainIdForDomain = hooks.getCurrentChainIdForDomain(origin);
     if (!currentChainIdForDomain) {
       throw rpcErrors.invalidParams({
@@ -85,6 +83,8 @@ export async function walletGetAccountUpgradeStatus(
       });
     }
     targetChainId = currentChainIdForDomain;
+  } else {
+    targetChainId = chainId;
   }
 
   const { isSupported } = await hooks.isEip7702Supported({

--- a/packages/eip-7702-internal-rpc-middleware/src/wallet_upgradeAccount.test.ts
+++ b/packages/eip-7702-internal-rpc-middleware/src/wallet_upgradeAccount.test.ts
@@ -7,7 +7,12 @@ import { walletUpgradeAccount } from './wallet_upgradeAccount';
 const TEST_ACCOUNT = '0x1234567890123456789012345678901234567890';
 const UPGRADE_CONTRACT = '0x0000000000000000000000000000000000000000';
 
-const createTestHooks = () => {
+const createTestHooks = (): {
+  upgradeAccount: jest.Mock;
+  getCurrentChainIdForDomain: jest.Mock;
+  isEip7702Supported: jest.Mock;
+  getPermittedAccountsForOrigin: jest.Mock;
+} => {
   const upgradeAccount = jest.fn();
   const getCurrentChainIdForDomain = jest.fn().mockReturnValue('0x1');
   const getPermittedAccountsForOrigin = jest
@@ -34,7 +39,7 @@ const createTestHooks = () => {
     getCurrentChainIdForDomain,
     isEip7702Supported,
     getPermittedAccountsForOrigin,
-  };
+  } as const;
 };
 
 const createTestRequest = (

--- a/packages/eip-7702-internal-rpc-middleware/src/wallet_upgradeAccount.ts
+++ b/packages/eip-7702-internal-rpc-middleware/src/wallet_upgradeAccount.ts
@@ -51,9 +51,7 @@ export async function walletUpgradeAccount(
 
   // Use current app selected chain ID if not passed as a param
   let targetChainId: Hex;
-  if (chainId !== undefined) {
-    targetChainId = chainId;
-  } else {
+  if (chainId === undefined) {
     const currentChainIdForDomain = hooks.getCurrentChainIdForDomain(origin);
     if (!currentChainIdForDomain) {
       throw rpcErrors.invalidParams({
@@ -61,6 +59,8 @@ export async function walletUpgradeAccount(
       });
     }
     targetChainId = currentChainIdForDomain;
+  } else {
+    targetChainId = chainId;
   }
 
   try {


### PR DESCRIPTION
## Explanation

This fixes all suppressed ESLint errors in the `eip-7702-internal-rpc-middleware` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes #7356.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes ESLint suppressions and updates EIP-7702 middleware/tests to satisfy lint rules (explicit return types, variable naming, and conditional logic).
> 
> - **Lint fixes in `packages/eip-7702-internal-rpc-middleware`**:
>   - `wallet_getAccountUpgradeStatus.ts` and `wallet_upgradeAccount.ts`: refactor chain ID selection to check `chainId === undefined` first; minor logic reordering for clarity.
>   - `utils.ts`: rename callback variable in `formatValidationError` map for clarity and rule compliance.
>   - Tests (`wallet_getAccountUpgradeStatus.test.ts`, `wallet_upgradeAccount.test.ts`): add explicit return types to factory helpers and return objects `as const`.
> - **Config**:
>   - `eslint-suppressions.json`: remove suppression entries for `eip-7702-internal-rpc-middleware` files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb475fee5997adb321e25ac13866671e20b2603e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->