### PR TITLE
chore: Notification services eslint cleanup

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1575,30 +1575,6 @@
       "count": 1
     }
   },
-  "packages/notification-services-controller/src/NotificationServicesController/services/feature-announcements.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 2
-    },
-    "@typescript-eslint/naming-convention": {
-      "count": 2
-    },
-    "@typescript-eslint/prefer-nullish-coalescing": {
-      "count": 2
-    },
-    "id-length": {
-      "count": 3
-    }
-  },
-  "packages/notification-services-controller/src/NotificationServicesController/services/notification-config-cache.ts": {
-    "@typescript-eslint/naming-convention": {
-      "count": 1
-    }
-  },
-  "packages/notification-services-controller/src/NotificationServicesController/services/perp-notifications.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 1
-    }
-  },
   "packages/notification-services-controller/src/NotificationServicesController/services/perp-notifications.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 1

--- a/packages/notification-services-controller/src/NotificationServicesController/services/notification-config-cache.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/services/notification-config-cache.ts
@@ -8,10 +8,10 @@ export const NotificationConfigCacheTTL = 1000 * 60; // 60 seconds
 export class OnChainNotificationsCache {
   #cache: NotificationConfigCache | null = null;
 
-  readonly #TTL = NotificationConfigCacheTTL;
+  readonly #ttl = NotificationConfigCacheTTL;
 
   #isExpired(): boolean {
-    return !this.#cache || Date.now() - this.#cache.timestamp > this.#TTL;
+    return !this.#cache || Date.now() - this.#cache.timestamp > this.#ttl;
   }
 
   #hasAllAddresses(addresses: string[]): boolean {

--- a/packages/notification-services-controller/src/NotificationServicesController/services/perp-notifications.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/services/perp-notifications.test.ts
@@ -14,7 +14,9 @@ describe('Perps Service - createPerpOrderNotification', () => {
     jest.clearAllMocks();
   });
 
-  const arrangeMocks = () => {
+  const arrangeMocks = (): {
+    consoleErrorSpy: jest.SpyInstance<void, Parameters<typeof console.error>>;
+  } => {
     const consoleErrorSpy = jest
       .spyOn(console, 'error')
       .mockImplementation(jest.fn());


### PR DESCRIPTION
## Explanation

This PR addresses and resolves several ESLint rule violations across three files within `packages/notification-services-controller`, allowing for the removal of their corresponding suppressions from `eslint-suppressions.json`.

*   **Current state and why change?**
    ESLint suppressions were present in `eslint-suppressions.json` for rules such as `@typescript-eslint/explicit-function-return-type`, `@typescript-eslint/naming-convention`, `@typescript-eslint/prefer-nullish-coalescing`, and `id-length`. These suppressions indicated areas where the code did not conform to established linting standards. The goal is to improve code quality and maintainability by fixing these violations and removing the suppressions.

*   **What is the solution your changes offer and how does it work?**
    *   **`feature-announcements.ts`**:
        *   Explicit return types were added to `getFeatureAnnouncementUrl` and `findIncludedItem`.
        *   `prefer-nullish-coalescing` was applied by replacing `||` with `??`.
        *   `id-length` violations were resolved by renaming short, non-descriptive variables (`r`, `i`, `n`) to more explicit names (`response`, `entry`/`asset`, `item`/`rawNotification`).
        *   `@typescript-eslint/naming-convention` suppressions were added with explanations for `Entry` and `Asset` properties within the `ContentfulResult` type, as their casing is dictated by the external Contentful API response structure.
    *   **`notification-config-cache.ts`**:
        *   The private field `#TTL` was renamed to `#ttl` to conform to camelCase naming conventions for private class members.
    *   **`perp-notifications.test.ts`**:
        *   An explicit return type was added to the `arrangeMocks` test helper function.
    *   All corresponding entries for these files were removed from `eslint-suppressions.json`.

*   **Are there any changes whose purpose might not be obvious?**
    The `eslint-disable-next-line @typescript-eslint/naming-convention` comments in `feature-announcements.ts` for `Entry` and `Asset` properties are intentional. These properties directly reflect the structure of responses from the Contentful API, and renaming them would break compatibility or require complex mapping.

## References

*   Fixes ASSETS-2100

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

---
<a href="https://cursor.com/background-agent?bcId=bc-f2af14fa-6392-4945-9c74-67168ae9e6e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2af14fa-6392-4945-9c74-67168ae9e6e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes ESLint violations in feature announcements, notification config cache, and perps test, and removes their suppressions.
> 
> - **Notification Services Controller**:
>   - `services/feature-announcements.ts`:
>     - Add explicit return types to `getFeatureAnnouncementUrl` and `findIncludedItem`.
>     - Replace `||` with `??` and improve variable names (`response`, `entry`/`asset`, `item`, `rawNotification`).
>     - Add targeted `@typescript-eslint/naming-convention` disables for `includes.Entry` and `includes.Asset` to match Contentful schema.
>     - Minor refactors: safer optional access, typed mappings, and consistent `createdAt` source.
>   - `services/notification-config-cache.ts`:
>     - Rename private field `#TTL` to `#ttl` and update references.
>   - `services/perp-notifications.test.ts`:
>     - Add explicit return type to `arrangeMocks` helper.
> - **ESLint suppressions**:
>   - Remove entries for `feature-announcements.ts`, `notification-config-cache.ts`, and `perp-notifications.test.ts` from `eslint-suppressions.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6f1d914e68c2253430715d5ca933615fb665b09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->