### PR TITLE
chore(lint): Fix suppressed ESLint errors in `core-backend` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -910,39 +910,6 @@
       "count": 2
     }
   },
-  "packages/core-backend/src/AccountActivityService.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 4
-    }
-  },
-  "packages/core-backend/src/BackendWebSocketService.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 10
-    },
-    "@typescript-eslint/naming-convention": {
-      "count": 4
-    },
-    "no-restricted-globals": {
-      "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 4
-    }
-  },
-  "packages/core-backend/src/BackendWebSocketService.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 4
-    },
-    "@typescript-eslint/naming-convention": {
-      "count": 2
-    },
-    "camelcase": {
-      "count": 3
-    },
-    "no-restricted-globals": {
-      "count": 1
-    }
-  },
   "packages/delegation-controller/src/DelegationController.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 3

--- a/packages/core-backend/src/AccountActivityService.test.ts
+++ b/packages/core-backend/src/AccountActivityService.test.ts
@@ -31,7 +31,7 @@ type RootMessenger = Messenger<
 >;
 
 // Helper function for completing async operations
-const completeAsyncOperations = async (timeoutMs = 0) => {
+const completeAsyncOperations = async (timeoutMs = 0): Promise<void> => {
   await flushPromises();
   // Allow nested async operations to complete
   if (timeoutMs > 0) {
@@ -200,7 +200,23 @@ const getMessenger = (): {
  */
 const createIndependentService = (options?: {
   subscriptionNamespace?: string;
-}) => {
+}): {
+  service: AccountActivityService;
+  messenger: AccountActivityServiceMessenger;
+  rootMessenger: RootMessenger;
+  mocks: {
+    getSelectedAccount: jest.Mock;
+    connect: jest.Mock;
+    subscribe: jest.Mock;
+    channelHasSubscription: jest.Mock;
+    getSubscriptionsByChannel: jest.Mock;
+    findSubscriptionsByChannelPrefix: jest.Mock;
+    forceReconnection: jest.Mock;
+    addChannelCallback: jest.Mock;
+    removeChannelCallback: jest.Mock;
+  };
+  destroy: () => void;
+} => {
   const { subscriptionNamespace } = options ?? {};
 
   const messengerSetup = getMessenger();
@@ -216,7 +232,7 @@ const createIndependentService = (options?: {
     rootMessenger: messengerSetup.rootMessenger,
     mocks: messengerSetup.mocks,
     // Convenience cleanup method
-    destroy: () => {
+    destroy: (): void => {
       service.destroy();
     },
   };
@@ -230,7 +246,24 @@ const createIndependentService = (options?: {
  */
 const createServiceWithTestAccount = (
   accountAddress: string = '0x1234567890123456789012345678901234567890',
-) => {
+): {
+  service: AccountActivityService;
+  messenger: AccountActivityServiceMessenger;
+  rootMessenger: RootMessenger;
+  mocks: {
+    getSelectedAccount: jest.Mock;
+    connect: jest.Mock;
+    subscribe: jest.Mock;
+    channelHasSubscription: jest.Mock;
+    getSubscriptionsByChannel: jest.Mock;
+    findSubscriptionsByChannelPrefix: jest.Mock;
+    forceReconnection: jest.Mock;
+    addChannelCallback: jest.Mock;
+    removeChannelCallback: jest.Mock;
+  };
+  destroy: () => void;
+  mockSelectedAccount: InternalAccount;
+} => {
   const serviceSetup = createIndependentService();
 
   // Create mock selected account

--- a/packages/core-backend/src/BackendWebSocketService.test.ts
+++ b/packages/core-backend/src/BackendWebSocketService.test.ts
@@ -9,6 +9,7 @@ import {
   BackendWebSocketService,
   getCloseReason,
   WebSocketState,
+  WebSocketSubscription,
 } from './BackendWebSocketService';
 import type {
   BackendWebSocketServiceOptions,
@@ -45,6 +46,7 @@ type RootMessenger = Messenger<
  */
 class MockWebSocket extends EventTarget {
   // WebSocket state constants
+  /* eslint-disable @typescript-eslint/naming-convention */
   public static readonly CONNECTING = 0;
 
   public static readonly OPEN = 1;
@@ -52,16 +54,17 @@ class MockWebSocket extends EventTarget {
   public static readonly CLOSING = 2;
 
   public static readonly CLOSED = 3;
+  /* eslint-enable @typescript-eslint/naming-convention */
 
   // Track total instances created for testing
-  private static instanceCount = 0;
+  static #instanceCount = 0;
 
   public static getInstanceCount(): number {
-    return MockWebSocket.instanceCount;
+    return MockWebSocket.#instanceCount;
   }
 
   public static resetInstanceCount(): void {
-    MockWebSocket.instanceCount = 0;
+    MockWebSocket.#instanceCount = 0;
   }
 
   // WebSocket properties
@@ -83,15 +86,15 @@ class MockWebSocket extends EventTarget {
   public send: jest.Mock<void, [string]> = jest.fn();
 
   // Test utilities
-  private _lastSentMessage: string | null = null;
+  #lastSentMessage: string | null = null;
 
   get lastSentMessage(): string | null {
-    return this._lastSentMessage;
+    return this.#lastSentMessage;
   }
 
-  private _openTriggered = false;
+  #openTriggered = false;
 
-  private _onopen: ((event: Event) => void) | null = null;
+  #onOpen: ((event: Event) => void) | null = null;
 
   public autoConnect: boolean = true;
 
@@ -100,7 +103,7 @@ class MockWebSocket extends EventTarget {
     { autoConnect = true }: { autoConnect?: boolean } = {},
   ) {
     super();
-    MockWebSocket.instanceCount += 1;
+    MockWebSocket.#instanceCount += 1;
     this.url = url;
     // TypeScript has issues with jest.spyOn on WebSocket methods, so using direct assignment
     // Store reference to simulateClose for use in close()
@@ -112,17 +115,17 @@ class MockWebSocket extends EventTarget {
     });
     // eslint-disable-next-line jest/prefer-spy-on
     this.send = jest.fn().mockImplementation((data: string) => {
-      this._lastSentMessage = data;
+      this.#lastSentMessage = data;
     });
     this.autoConnect = autoConnect;
     (global as GlobalWithWebSocket).lastWebSocket = this;
   }
 
   set onopen(handler: ((event: Event) => void) | null) {
-    this._onopen = handler;
+    this.#onOpen = handler;
     if (
       handler &&
-      !this._openTriggered &&
+      !this.#openTriggered &&
       this.readyState === MockWebSocket.CONNECTING &&
       this.autoConnect
     ) {
@@ -131,33 +134,33 @@ class MockWebSocket extends EventTarget {
     }
   }
 
-  get onopen() {
-    return this._onopen;
+  get onopen(): ((event: Event) => void) | null {
+    return this.#onOpen;
   }
 
-  public triggerOpen() {
+  public triggerOpen(): void {
     if (
-      !this._openTriggered &&
-      this._onopen &&
+      !this.#openTriggered &&
+      this.#onOpen &&
       this.readyState === MockWebSocket.CONNECTING
     ) {
-      this._openTriggered = true;
+      this.#openTriggered = true;
       this.readyState = MockWebSocket.OPEN;
       const event = new Event('open');
-      this._onopen(event);
+      this.#onOpen(event);
       this.dispatchEvent(event);
     }
   }
 
-  public simulateClose(code = 1000, reason = '') {
+  public simulateClose(code = 1000, reason = ''): void {
     this.readyState = MockWebSocket.CLOSED;
-    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins, no-restricted-globals
     const event = new CloseEvent('close', { code, reason });
     this.onclose?.(event);
     this.dispatchEvent(event);
   }
 
-  public simulateMessage(data: string | object) {
+  public simulateMessage(data: string | object): void {
     const messageData = typeof data === 'string' ? data : JSON.stringify(data);
     const event = new MessageEvent('message', { data: messageData });
 
@@ -168,14 +171,14 @@ class MockWebSocket extends EventTarget {
     this.dispatchEvent(event);
   }
 
-  public simulateError() {
+  public simulateError(): void {
     const event = new Event('error');
     this.onerror?.(event);
     this.dispatchEvent(event);
   }
 
   public getLastSentMessage(): string | null {
-    return this._lastSentMessage;
+    return this.#lastSentMessage;
   }
 }
 
@@ -200,7 +203,11 @@ function getRootMessenger(): RootMessenger {
  *
  * @returns Object containing the messenger and mock action functions
  */
-const getMessenger = () => {
+const getMessenger = (): {
+  rootMessenger: RootMessenger;
+  messenger: BackendWebSocketServiceMessenger;
+  mocks: { getBearerToken: jest.Mock };
+} => {
   // Create a unique root messenger for each test
   const rootMessenger = getRootMessenger();
   const messenger = new Messenger<
@@ -262,7 +269,7 @@ const TEST_CONSTANTS = {
 const createResponseMessage = (
   requestId: string,
   data: Record<string, unknown>,
-) => ({
+): { id: string; data: Record<string, unknown> } => ({
   id: requestId,
   data: {
     requestId,
@@ -358,7 +365,7 @@ const setupBackendWebSocketService = ({
     ...options,
   });
 
-  const completeAsyncOperations = async (advanceMs = 10) => {
+  const completeAsyncOperations = async (advanceMs = 10): Promise<void> => {
     await flushPromises();
     if (advanceMs > 0) {
       jest.advanceTimersByTime(advanceMs);
@@ -377,7 +384,7 @@ const setupBackendWebSocketService = ({
     mocks,
     completeAsyncOperations,
     getMockWebSocket,
-    cleanup: () => {
+    cleanup: (): void => {
       service?.destroy();
       jest.useRealTimers();
       jest.restoreAllMocks();
@@ -445,7 +452,7 @@ const createSubscription = async (
     subscriptionId?: string;
     channelType?: string;
   },
-) => {
+): Promise<WebSocketSubscription> => {
   const {
     channels,
     callback,


### PR DESCRIPTION
## Explanation

This fixes all suppressed ESLint errors in the `core-backend` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes #7352.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit return/param types and private fields, tightens generics, and minor variable renames across `core-backend` WebSocket service and tests; removes corresponding ESLint suppressions.
> 
> - **Core Backend**:
>   - **`packages/core-backend/src/BackendWebSocketService.ts`**:
>     - Add explicit return types to async handlers and internal helpers (e.g., `#connectionPromise`, `ws.onopen/onclose/onmessage`).
>     - Tighten generics for `sendRequest` (`T` → `Type`).
>     - Rename internal var `connectionDuration_ms` to `connectionDurationMs` while preserving output key.
>   - **Tests**:
>     - **`packages/core-backend/src/BackendWebSocketService.test.ts`**:
>       - Add explicit types to helpers and setup utilities; import and return `WebSocketSubscription` in helpers.
>       - Refactor `MockWebSocket` to use `#private` fields and add type-safe accessors; annotate methods.
>     - **`packages/core-backend/src/AccountActivityService.test.ts`**:
>       - Add explicit return types to helpers and factory functions; type returned structures; annotate `destroy`.
> - **Lint**:
>   - **`eslint-suppressions.json`**: Remove suppressions for updated `core-backend` files now conforming to rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb7e9ee18ee56f68fba9d74dd18c7f834aa04db1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->