### PR TITLE
chore(lint): Fix suppressed ESLint errors in `multichain-network-controller` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1503,21 +1503,6 @@
       "count": 4
     }
   },
-  "packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 2
-    }
-  },
-  "packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 3
-    }
-  },
-  "packages/multichain-network-controller/src/utils.ts": {
-    "@typescript-eslint/prefer-nullish-coalescing": {
-      "count": 1
-    }
-  },
   "packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts": {
     "jest/unbound-method": {
       "count": 1

--- a/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.test.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.test.ts
@@ -26,6 +26,7 @@ import type {
   NetworkControllerGetSelectedChainIdAction,
   NetworkControllerRemoveNetworkAction,
   NetworkControllerFindNetworkClientIdByChainIdAction,
+  NetworkState,
 } from '@metamask/network-controller';
 import { KnownCaipNamespace } from '@metamask/utils';
 import type { CaipAccountId } from '@metamask/utils';
@@ -131,7 +132,36 @@ function setupController({
     Parameters<NetworkControllerFindNetworkClientIdByChainIdAction['handler']>
   >;
   mockNetworkService?: AbstractMultichainNetworkService;
-} = {}) {
+} = {}): {
+  messenger: RootMessenger;
+  controller: MultichainNetworkController;
+  mockGetNetworkState: jest.Mock<
+    NetworkState,
+    Parameters<NetworkControllerGetStateAction['handler']>
+  >;
+  mockSetActiveNetwork: jest.Mock<
+    ReturnType<NetworkControllerSetActiveNetworkAction['handler']>,
+    Parameters<NetworkControllerSetActiveNetworkAction['handler']>
+  >;
+  mockRemoveNetwork: jest.Mock<
+    ReturnType<NetworkControllerRemoveNetworkAction['handler']>,
+    Parameters<NetworkControllerRemoveNetworkAction['handler']>
+  >;
+  mockGetSelectedChainId: jest.Mock<
+    ReturnType<NetworkControllerGetSelectedChainIdAction['handler']>,
+    Parameters<NetworkControllerGetSelectedChainIdAction['handler']>
+  >;
+  mockFindNetworkClientIdByChainId: jest.Mock<
+    ReturnType<NetworkControllerFindNetworkClientIdByChainIdAction['handler']>,
+    Parameters<NetworkControllerFindNetworkClientIdByChainIdAction['handler']>
+  >;
+  publishSpy: jest.SpyInstance<
+    ReturnType<MultichainNetworkControllerMessenger['publish']>,
+    Parameters<MultichainNetworkControllerMessenger['publish']>
+  >;
+  triggerSelectedAccountChange: (accountType: TestKeyringAccountType) => void;
+  networkService: AbstractMultichainNetworkService;
+} {
   const messenger = getRootMessenger();
 
   // Register action handlers
@@ -229,7 +259,7 @@ function setupController({
 
   const triggerSelectedAccountChange = (
     accountType: TestKeyringAccountType,
-  ) => {
+  ): void => {
     const mockAccountAddressByAccountType: Record<
       TestKeyringAccountType,
       string

--- a/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.ts
@@ -249,7 +249,7 @@ export class MultichainNetworkController extends BaseController<
    *
    * @param account - The account that was changed
    */
-  #handleOnSelectedAccountChange(account: InternalAccount) {
+  #handleOnSelectedAccountChange(account: InternalAccount): void {
     const { type: accountType, scopes } = account;
     const isEvmAccount = isEvmAccountType(accountType);
 
@@ -290,7 +290,7 @@ export class MultichainNetworkController extends BaseController<
   /**
    * Subscribes to message events.
    */
-  #subscribeToMessageEvents() {
+  #subscribeToMessageEvents(): void {
     // Handle network switch when account is changed
     this.messenger.subscribe(
       'AccountsController:selectedAccountChange',
@@ -301,7 +301,7 @@ export class MultichainNetworkController extends BaseController<
   /**
    * Registers message handlers.
    */
-  #registerMessageHandlers() {
+  #registerMessageHandlers(): void {
     this.messenger.registerActionHandler(
       'MultichainNetworkController:setActiveNetwork',
       this.setActiveNetwork.bind(this),

--- a/packages/multichain-network-controller/src/utils.ts
+++ b/packages/multichain-network-controller/src/utils.ts
@@ -100,7 +100,7 @@ export const toMultichainNetworkConfiguration = (
     defaultRpcEndpointIndex,
     nativeCurrency,
     blockExplorerUrls,
-    defaultBlockExplorerUrlIndex,
+    defaultBlockExplorerUrlIndex = 0,
   } = network;
   return {
     chainId: toEvmCaipChainId(chainId),
@@ -108,7 +108,7 @@ export const toMultichainNetworkConfiguration = (
     name: name || rpcEndpoints[defaultRpcEndpointIndex].url,
     nativeCurrency,
     blockExplorerUrls,
-    defaultBlockExplorerUrlIndex: defaultBlockExplorerUrlIndex || 0,
+    defaultBlockExplorerUrlIndex,
   };
 };
 


### PR DESCRIPTION
## Explanation

This fixes all suppressed ESLint errors in the `multichain-network-controller` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes #7374.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit return types and tighter typings across the multichain network controller and tests, and simplifies a default value in utils; updates ESLint suppressions accordingly.
> 
> - **multichain-network-controller**:
>   - `MultichainNetworkController.ts`: Add explicit `: void` return types to private methods (`#handleOnSelectedAccountChange`, `#subscribeToMessageEvents`, `#registerMessageHandlers`).
>   - `MultichainNetworkController.test.ts`: Strengthen typings (import `NetworkState`, explicit return type for `setupController`, mark `triggerSelectedAccountChange` as `: void`).
>   - `utils.ts`: Use default destructuring `defaultBlockExplorerUrlIndex = 0` and pass through without `||` fallback in `toMultichainNetworkConfiguration`.
> - **ESLint**:
>   - Update `eslint-suppressions.json` to remove suppressions for the affected files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcb36318e2304cbae5e2cbf3d99769af61402339. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->