### PR TITLE
chore(lint): Fix suppressed ESLint errors in `eth-json-rpc-provider` package

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1052,16 +1052,6 @@
       "count": 6
     }
   },
-  "packages/eth-json-rpc-provider/src/internal-provider.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 3
-    }
-  },
-  "packages/eth-json-rpc-provider/src/internal-provider.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 2
-    }
-  },
   "packages/foundryup/src/cli.ts": {
     "no-restricted-globals": {
       "count": 1

--- a/packages/eth-json-rpc-provider/src/internal-provider.test.ts
+++ b/packages/eth-json-rpc-provider/src/internal-provider.test.ts
@@ -23,7 +23,10 @@ type ResultParam =
   | Json
   | ((req?: JsonRpcRequest, context?: MiddlewareContext) => Json);
 
-const createLegacyEngine = (method: string, result: ResultParam) => {
+const createLegacyEngine = (
+  method: string,
+  result: ResultParam,
+): JsonRpcEngine => {
   const engine = new JsonRpcEngine();
   engine.push((req, res, next, end) => {
     if (req.method === method) {
@@ -35,10 +38,17 @@ const createLegacyEngine = (method: string, result: ResultParam) => {
   return engine;
 };
 
-const createV2Engine = (method: string, result: ResultParam) => {
+const createV2Engine = (
+  method: string,
+  result: ResultParam,
+): JsonRpcEngineV2<JsonRpcRequest> => {
   return JsonRpcEngineV2.create<JsonRpcMiddleware<JsonRpcRequest>>({
     middleware: [
-      ({ request, next, context }) => {
+      ({
+        request,
+        next,
+        context,
+      }): Json | Promise<Readonly<Json> | undefined> => {
         if (request.method === method) {
           return typeof result === 'function'
             ? result(request as JsonRpcRequest, context)

--- a/packages/eth-json-rpc-provider/src/internal-provider.ts
+++ b/packages/eth-json-rpc-provider/src/internal-provider.ts
@@ -92,7 +92,7 @@ export class InternalProvider<
     // Non-polluting `any` that acts like a constraint.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     callback: (error: unknown, providerRes?: any) => void,
-  ) => {
+  ): void => {
     const jsonRpcRequest =
       convertEip1193RequestToJsonRpcRequest(eip1193Request);
     this.#handleWithCallback(jsonRpcRequest, callback);
@@ -114,7 +114,7 @@ export class InternalProvider<
     // TODO: Replace `any` with type
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     callback: (error: unknown, providerRes?: any) => void,
-  ) => {
+  ): void => {
     if (typeof callback !== 'function') {
       throw new Error('Must provide callback to "send" method.');
     }


### PR DESCRIPTION
## Explanation

This fixes all suppressed ESLint errors in the `eth-json-rpc-provider` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes #7362.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit return types in `eth-json-rpc-provider` provider and tests, removing corresponding ESLint suppressions.
> 
> - **eth-json-rpc-provider**:
>   - `packages/eth-json-rpc-provider/src/internal-provider.ts`:
>     - Add explicit `: void` return types for `sendAsync` and `send`.
>   - `packages/eth-json-rpc-provider/src/internal-provider.test.ts`:
>     - Add explicit return types to `createLegacyEngine`, `createV2Engine`, and inline middleware function signatures.
> - **Linting**:
>   - Update `eslint-suppressions.json` to remove suppressions for `internal-provider.ts` and `internal-provider.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce682260b896eeed52499bb864d353c2d18dbb2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->