### PR TITLE
fix: remove duplicate type

### DIFF
--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -21,10 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `RemoteFeatureFlagControllerremoveFlagOverrideAction`
   - `RemoteFeatureFlagControllerclearAllFlagOverridesAction`
 
-### Fixed
-
-- Remove duplicate type definition to maintain a single source of truth
-
 ## [3.0.0]
 
 ### Added


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

### Current State and Problem

A duplicate type definition was present in the codebase, causing potential confusion and maintenance issues. The same type was being exported from multiple locations, which could lead to inconsistencies and makes the codebase harder to maintain.

### Solution

Removed the duplicate type definition, keeping a single source of truth for the type. This simplifies the codebase and ensures type consistency across the package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the duplicate `RemoteFeatureFlagControllerState` type from `remote-feature-flag-controller-types.ts`.
> 
> - **Types**:
>   - Remove duplicate `RemoteFeatureFlagControllerState` from `packages/remote-feature-flag-controller/src/remote-feature-flag-controller-types.ts` to avoid redundancy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3521c2cf574638af67e450e4026a54e9d2675e2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->