### PR TITLE
chore: Transfer `token-search-discovery-controller` ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,7 @@
 ## Assets Team
 /packages/assets-controllers         @MetaMask/metamask-assets
 /packages/network-enablement-controller @MetaMask/metamask-assets
+/packages/token-search-discovery-controller @MetaMask/metamask-assets
 
 ## Confirmations Team
 /packages/address-book-controller           @MetaMask/confirmations
@@ -54,9 +55,6 @@
 ## Mobile Platform Team
 /packages/app-metadata-controller @MetaMask/mobile-platform
 /packages/analytics-controller    @MetaMask/mobile-platform @MetaMask/extension-platform
-
-## Portfolio Team
-/packages/token-search-discovery-controller      @MetaMask/portfolio
 
 ## Wallet Integrations Team
 /packages/chain-agnostic-permission        @MetaMask/wallet-integrations
@@ -166,8 +164,8 @@
 /packages/user-operation-controller/CHANGELOG.md  @MetaMask/confirmations @MetaMask/core-platform
 /packages/multichain-transactions-controller/package.json @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/multichain-transactions-controller/CHANGELOG.md @MetaMask/accounts-engineers @MetaMask/core-platform
-/packages/token-search-discovery-controller/package.json      @MetaMask/portfolio @MetaMask/core-platform
-/packages/token-search-discovery-controller/CHANGELOG.md      @MetaMask/portfolio @MetaMask/core-platform
+/packages/token-search-discovery-controller/package.json      @MetaMask/metamask-assets @MetaMask/core-platform
+/packages/token-search-discovery-controller/CHANGELOG.md      @MetaMask/metamask-assets @MetaMask/core-platform
 /packages/bridge-controller/package.json                 @MetaMask/swaps-engineers @MetaMask/core-platform
 /packages/bridge-controller/CHANGELOG.md                 @MetaMask/swaps-engineers @MetaMask/core-platform
 /packages/remote-feature-flag-controller/package.json @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform

--- a/teams.json
+++ b/teams.json
@@ -26,7 +26,7 @@
   "metamask/bridge-controller": "team-swaps-and-bridge",
   "metamask/bridge-status-controller": "team-swaps-and-bridge",
   "metamask/app-metadata-controller": "team-mobile-platform",
-  "metamask/token-search-discovery-controller": "team-portfolio",
+  "metamask/token-search-discovery-controller": "team-assets",
   "metamask/delegation-controller": "team-delegation",
   "metamask/chain-agnostic-permission": "team-wallet-integrations",
   "metamask/eip1193-permission-middleware": "team-wallet-integrations",


### PR DESCRIPTION
## Explanation

Ownership of the package `@metamask/token-search-discovery-controller` has been transferrd to the assets team at the request of @dylanbutler1

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reassigns `token-search-discovery-controller` ownership from Portfolio to Assets across CODEOWNERS and teams mapping.
> 
> - **Ownership**
>   - Update `.github/CODEOWNERS` to assign `/packages/token-search-discovery-controller` to `@MetaMask/metamask-assets`.
>   - Update package release ownership for `packages/token-search-discovery-controller/{package.json,CHANGELOG.md}` to `@MetaMask/metamask-assets`.
>   - Remove the Portfolio team section related to this package from CODEOWNERS.
> - **Teams Mapping**
>   - Change `teams.json` mapping for `metamask/token-search-discovery-controller` to `team-assets`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e96f8e279a07e53a1596db30624e9a1767dd7dfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->