### PR TITLE
make new variables optional

### DIFF
--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -28,8 +28,8 @@ export const DEFAULT_CACHE_DURATION = 24 * 60 * 60 * 1000; // 1 day
 
 export type RemoteFeatureFlagControllerState = {
   remoteFeatureFlags: FeatureFlags;
-  localOverrides: FeatureFlags;
-  rawRemoteFeatureFlags: FeatureFlags;
+  localOverrides?: FeatureFlags;
+  rawRemoteFeatureFlags?: FeatureFlags;
   cacheTimestamp: number;
 };
 


### PR DESCRIPTION
## Explanation

The `localOverrides` and `rawRemoteFeatureFlags` properties were recently added to `RemoteFeatureFlagControllerState` in PR #7271 as required properties. However, consumers with existing persisted state from before these properties were added will experience TypeScript errors when their state is loaded, since these properties won't exist in the persisted data but are marked as required.

This PR marks `localOverrides` and `rawRemoteFeatureFlags` as optional in the `RemoteFeatureFlagControllerState` type to ensure backwards compatibility with existing persisted state. The `getDefaultRemoteFeatureFlagControllerState()` function continues to initialize these properties with empty objects, so newly created state will still have them populated.

## References

- Related to #7271

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them