### PR TITLE
chore(ramps-controller): fix changelog formatting

### DIFF
--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-
 ### Changed
 
 - **BREAKING:** Rename `OnRampService` to `RampsService` and `OnRampEnvironment` to `RampsEnvironment` ([#7502](https://github.com/MetaMask/core/pull/7502))
@@ -27,6 +25,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `OnRampService` for interacting with the OnRamp API
   - Add geolocation detection via IP address lookup
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@1.0.0...@metamask/ramps-controller@2.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@1.0.0...HEAD
 [1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/ramps-controller@1.0.0


### PR DESCRIPTION
## Explanation

The CHANGELOG.md for `@metamask/ramps-controller` had several formatting issues that were causing CI to fail:

- Entries in an "Uncategorized" section that needed proper categorization
- Some entries referenced the wrong PR (#7316 instead of #7502)
- Missing PR links on some entries
- Non-consumer facing dev entries (dev-watch.js, link-ramp-controller.js scripts) that should not be in the changelog

Additionally, the changes from #7502 rename public APIs (`OnRampService` → `RampsService`, action types, etc.) which are breaking changes. Per semver, this requires a major version bump from 1.0.0 to 2.0.0 rather than a patch release.

This PR fixes the changelog formatting and updates the version to 2.0.0 to properly reflect the breaking nature of the API changes.

## References

- Related to #7502

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up @metamask/ramps-controller CHANGELOG: removes dev-only entries, marks breaking API renames, and fixes PR references and entries.
> 
> - **Changelog (packages/ramps-controller/CHANGELOG.md)**:
>   - Mark breaking changes in `Unreleased` for renaming `OnRampService` → `RampsService`, `OnRampEnvironment` → `RampsEnvironment`, and action type namespace updates, with links to `#7502`.
>   - Remove non-consumer dev entries from `Added` section.
>   - Correct and link PR references; update `Fixed` entry for `RampsService#getGeolocation` to include `#7502`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d05ac8a5431301eba3d61b9e4184c5dad8a9d754. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->