### PR TITLE
feat: enrich wallet get calls status error info

### DIFF
--- a/packages/eip-5792-middleware/CHANGELOG.md
+++ b/packages/eip-5792-middleware/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+
+- Add optional `error` field to `wallet_getCallsStatus` response when statusCode is 500 (REVERTED) ([#7566](https://github.com/MetaMask/core/pull/7566))
+
 ### Changed
 
 - Upgrade `@metamask/utils` from `^11.8.1` to `^11.9.0` ([#7511](https://github.com/MetaMask/core/pull/7511))

--- a/packages/eip-5792-middleware/CHANGELOG.md
+++ b/packages/eip-5792-middleware/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added 
+### Added
 
-- Add optional `error` field to `wallet_getCallsStatus` response when statusCode is 500 (REVERTED) ([#7566](https://github.com/MetaMask/core/pull/7566))
+- Add optional `error` field to `wallet_getCallsStatus` response when statusCode is 500 (REVERTED) ([#7568](https://github.com/MetaMask/core/pull/7568))
 
 ### Changed
 

--- a/packages/eip-5792-middleware/src/hooks/getCallsStatus.ts
+++ b/packages/eip-5792-middleware/src/hooks/getCallsStatus.ts
@@ -1,7 +1,6 @@
 import { JsonRpcError } from '@metamask/rpc-errors';
 import type {
   Log,
-  TransactionError,
   TransactionMeta,
   TransactionReceipt,
 } from '@metamask/transaction-controller';
@@ -35,7 +34,7 @@ export function getCallsStatus(
   }
 
   const transaction = transactions[0];
-  const { chainId, txReceipt: rawTxReceipt, error } = transaction;
+  const { chainId, txReceipt: rawTxReceipt } = transaction;
   const status = getStatusCode(transaction);
   const txReceipt = rawTxReceipt as Required<TransactionReceipt> | undefined;
   const logs = (txReceipt?.logs ?? []) as Required<Log>[];

--- a/packages/eip-5792-middleware/src/types.ts
+++ b/packages/eip-5792-middleware/src/types.ts
@@ -56,6 +56,12 @@ export type GetCallsStatusResult = {
     transactionHash: Hex;
   }[];
   capabilities?: Record<string, Json>;
+  error?: {
+    message: string;
+    code?: string;
+    name?: string;
+    rpc?: Json;
+  };
 };
 
 export type GetCallsStatusHook = (


### PR DESCRIPTION
## Explanation

### What is the current state of things and why does it need to change?

Currently, when `wallet_getCallsStatus` returns `statusCode: 500` (REVERTED), the response only includes the status code without any error context. The transaction controller may have error information available (message, code, RPC details) but it's not being surfaced in the API response, making it difficult for developers to debug why transactions failed.

### What is the solution your changes offer and how does it work?

This PR adds an optional `error` field to the `wallet_getCallsStatus` response when `statusCode: 500`. The implementation extracts error information from `transaction.error` (message, code, name, rpc) when available, and provides a default "Transaction reverted" message when error details aren't present. The error field is only included for REVERTED status, ensuring backward compatibility.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
