### PR TITLE
fix(STX-340): use medium fee for gas fee in submission

### DIFF
--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/controller-utils` from `^11.17.0` to `^11.18.0` ([#7583](https://github.com/MetaMask/core/pull/7583))
 - Bump `@metamask/network-controller` from `^27.1.0` to `^27.2.0` ([#7583](https://github.com/MetaMask/core/pull/7583))
 
+### Fixed
+
+- Use `BRIDGE_PREFERRED_GAS_ESTIMATE` from `@metamask/bridge-controller` for gas price estimates to align with validation ([#7582](https://github.com/MetaMask/core/pull/7582))
+
 ## [64.3.0]
 
 ### Changed

--- a/packages/bridge-status-controller/src/utils/gas.ts
+++ b/packages/bridge-status-controller/src/utils/gas.ts
@@ -1,3 +1,4 @@
+import { BRIDGE_PREFERRED_GAS_ESTIMATE } from '@metamask/bridge-controller';
 import type { TokenAmountValues, TxData } from '@metamask/bridge-controller';
 import { toHex } from '@metamask/controller-utils';
 import type {
@@ -21,7 +22,8 @@ const getTransaction1559GasFeeEstimates = (
   txGasFeeEstimates: FeeMarketGasFeeEstimates,
   estimatedBaseFee: string,
 ) => {
-  const { maxFeePerGas, maxPriorityFeePerGas } = txGasFeeEstimates?.high ?? {};
+  const { maxFeePerGas, maxPriorityFeePerGas } =
+    txGasFeeEstimates?.[BRIDGE_PREFERRED_GAS_ESTIMATE] ?? {};
 
   const baseAndPriorityFeePerGas = maxPriorityFeePerGas
     ? new BigNumber(estimatedBaseFee, 10)


### PR DESCRIPTION
## Explanation

### Fix: Align bridge transaction gas price with validation

## Problem

Users could submit bridge/swap transactions that fail with "insufficient funds" despite the UI showing sufficient balance. This occurred because:

- **Validation** (in `bridge-controller`) uses `medium` gas price estimates
- **Submission** (in `bridge-status-controller`) was using `high` gas price estimates

This mismatch allowed transactions to pass validation but fail immediately at submission time. In the STX case it times-out in Sentinel. 

## Example (uses a non STX transaction for simplicity but the same happens with STX)

A swap of ~0.002854 ETH → USDC on Base:

{
  "quote": {
    "srcTokenAmount": "2829027500000000",
    "gasLimit": 726516,
    "effectiveGas": 431877
  }
}Submission failed with:

{
  "error": {
    "code": -32003,
    "message": "insufficient funds for gas * price + value: have 2860507066881008 want 2864770358251460"
  }
}The user had **0.00286 ETH** but the transaction required **0.00286 ETH** (4.26 gwei more than available) due to the higher `high` gas price at submission.

## Fix

Changed `bridge-status-controller` to use `medium` gas estimates on submission (matching validation):

An alternate fix would be to use `high` on validation but it would prevent more swaps to go through. 
NB: this happens in the non-gasless cases so irrespective of the fix we will see less and less occurrences of this issue as we release gasless swaps and auto-upgrade on all networks and clients.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns gas estimation used at submission with validation to prevent mismatches (e.g., insufficient funds).
> 
> - In `gas.ts`, select `maxFeePerGas`/`maxPriorityFeePerGas` from `txGasFeeEstimates[BRIDGE_PREFERRED_GAS_ESTIMATE]` instead of hardcoded `high`
> - Tests updated in `gas.test.ts` to validate preferred estimate usage, adjust fixtures to `Medium`, and improve missing-estimate handling
> - Changelog updated under Unreleased to note the fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcfac09fe7868cf276ad9c519e87d1510c7fe562. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->