### PR TITLE
fix: add Gnosis, Scroll, MSU non-zero native addr

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/transaction-controller` from `^62.7.0` to `^62.8.0` ([#7596](https://github.com/MetaMask/core/pull/7596))
 - `AccountTrackerController` now triggers an immediate balance refresh when the keyring is unlocked, instead of waiting for the next polling cycle ([#7585](https://github.com/MetaMask/core/pull/7585))
 
+### Fixed
+
+- Add missing native coin non-zero address for networks: Gnosis and MSU ([#7592](https://github.com/MetaMask/core/pull/7592))
+
 ## [95.0.0]
 
 ### Added

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -221,6 +221,8 @@ const chainIdToNativeTokenAddress: Record<Hex, Hex> = {
   '0x89': '0x0000000000000000000000000000000000001010', // Polygon
   '0x440': '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000', // Metis Andromeda
   '0x1388': '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000', // Mantle
+  '0x64': '0xe91d153e0b41518a2ce8dd3d7944fa863463a97d', // Gnosis
+  '0x10b3e': '0xf2b51cc1850fed939658317a22d73d3482767591', // MapleStory Universe (MSU aka Henesys)
 };
 
 /**


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Gnosis and MapleStory Universe (MSU aka Henesys) have the particularity of have a native token that has an address different from `0x0000000000000000000000000000000000000000`.
This PR adds those networks to the list `chainIdToNativeTokenAddress`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures native price lookups use the correct non-zero addresses.
> 
> - Add mappings in `chainIdToNativeTokenAddress` for `0x64` (Gnosis) and `0x10b3e` (MapleStory Universe) in `codefi-v2.ts` so `getNativeTokenAddress` returns their specific addresses
> - Update `CHANGELOG.md` under **Fixed** to note the added native coin non-zero addresses
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcce0da028a86619383d1cbbf86da7f71c2cc68e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->