### PR TITLE
chore: Fix suppressed errors in `@metamask/accouncement-controller`

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -124,11 +124,6 @@
       "count": 2
     }
   },
-  "packages/announcement-controller/src/AnnouncementController.test.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 1
-    }
-  },
   "packages/approval-controller/src/ApprovalController.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 22

--- a/packages/announcement-controller/src/AnnouncementController.test.ts
+++ b/packages/announcement-controller/src/AnnouncementController.test.ts
@@ -7,6 +7,7 @@ import type {
   StateAnnouncementMap,
   AnnouncementControllerActions,
   AnnouncementControllerEvents,
+  AnnouncementControllerMessenger,
   AnnouncementMap,
 } from './AnnouncementController';
 import { AnnouncementController } from './AnnouncementController';
@@ -18,18 +19,13 @@ const name = 'AnnouncementController';
  *
  * @returns A restricted controller messenger.
  */
-function getMessenger() {
+function getMessenger(): AnnouncementControllerMessenger {
   const messenger = new Messenger<
     MockAnyNamespace,
     AnnouncementControllerActions,
     AnnouncementControllerEvents
   >({ namespace: MOCK_ANY_NAMESPACE });
-  return new Messenger<
-    typeof name,
-    AnnouncementControllerActions,
-    AnnouncementControllerEvents,
-    typeof messenger
-  >({
+  return new Messenger({
     namespace: name,
     parent: messenger,
   });


### PR DESCRIPTION
## Explanation

Fix suppressed lint errors in `@metamask/announcement-controller`.

## References

Closes #7341

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a suppressed lint error by enforcing explicit return types in the announcement controller tests.
> 
> - In `AnnouncementController.test.ts`: add `AnnouncementControllerMessenger` import and set `getMessenger(): AnnouncementControllerMessenger`; simplify `new Messenger` construction with type inference
> - Update `eslint-suppressions.json`: remove suppression entry for `AnnouncementController.test.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21888244a97e8fac22cf59b73e22757c4b7b2e05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->