### PR TITLE
Fix create-package to handle JSONC files

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@typescript-eslint/parser": "^8.48.0",
     "@yarnpkg/types": "^4.0.0",
     "babel-jest": "^29.7.0",
+    "comment-json": "^4.5.1",
     "depcheck": "^1.4.7",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^9.1.0",

--- a/scripts/create-package/utils.test.ts
+++ b/scripts/create-package/utils.test.ts
@@ -1,3 +1,4 @@
+import * as commentJson from 'comment-json';
 import execa from 'execa';
 import fs from 'fs';
 import path from 'path';
@@ -60,8 +61,8 @@ describe('create-package/utils', () => {
       const monorepoFileData = await readMonorepoFiles();
 
       expect(monorepoFileData).toStrictEqual({
-        tsConfig: JSON.parse(tsConfig),
-        tsConfigBuild: JSON.parse(tsConfigBuild),
+        tsConfig: commentJson.parse(tsConfig),
+        tsConfigBuild: commentJson.parse(tsConfigBuild),
         nodeVersions: '>=18.0.0',
       });
     });
@@ -128,18 +129,29 @@ describe('create-package/utils', () => {
       expect(format).toHaveBeenCalledTimes(2);
       expect(fs.promises.writeFile).toHaveBeenCalledWith(
         expect.stringMatching(/tsconfig\.json$/u),
-        JSON.stringify({
-          references: [{ path: './packages/bar' }, { path: './packages/foo' }],
-        }),
+        JSON.stringify(
+          {
+            references: [
+              { path: './packages/bar' },
+              { path: './packages/foo' },
+            ],
+          },
+          null,
+          2,
+        ),
       );
       expect(fs.promises.writeFile).toHaveBeenCalledWith(
         expect.stringMatching(/tsconfig\.build\.json$/u),
-        JSON.stringify({
-          references: [
-            { path: './packages/bar' },
-            { path: './packages/foo/tsconfig.build.json' },
-          ],
-        }),
+        JSON.stringify(
+          {
+            references: [
+              { path: './packages/bar' },
+              { path: './packages/foo/tsconfig.build.json' },
+            ],
+          },
+          null,
+          2,
+        ),
       );
 
       // Postprocessing

--- a/scripts/create-package/utils.ts
+++ b/scripts/create-package/utils.ts
@@ -1,3 +1,4 @@
+import * as commentJson from 'comment-json';
 import execa from 'execa';
 import { promises as fs } from 'fs';
 import path from 'path';
@@ -75,8 +76,8 @@ export async function readMonorepoFiles(): Promise<MonorepoFileData> {
   ]);
 
   return {
-    tsConfig: JSON.parse(tsConfig) as Tsconfig,
-    tsConfigBuild: JSON.parse(tsConfigBuild) as Tsconfig,
+    tsConfig: commentJson.parse(tsConfig) as unknown as Tsconfig,
+    tsConfigBuild: commentJson.parse(tsConfigBuild) as unknown as Tsconfig,
     nodeVersions: (JSON.parse(packageJson) as PackageJson).engines.node,
   };
 }
@@ -111,11 +112,11 @@ export async function finalizeAndWriteData(
   updateTsConfigs(packageData, monorepoFileData);
   await writeJsonFile(
     REPO_TS_CONFIG,
-    JSON.stringify(monorepoFileData.tsConfig),
+    commentJson.stringify(monorepoFileData.tsConfig, null, 2),
   );
   await writeJsonFile(
     REPO_TS_CONFIG_BUILD,
-    JSON.stringify(monorepoFileData.tsConfigBuild),
+    commentJson.stringify(monorepoFileData.tsConfigBuild, null, 2),
   );
 
   // Postprocess

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,80 +7,204 @@
    * (indirectly) extends it.
    */
   "references": [
-    { "path": "./packages/account-tree-controller/tsconfig.build.json" },
-    { "path": "./packages/accounts-controller/tsconfig.build.json" },
-    { "path": "./packages/address-book-controller/tsconfig.build.json" },
-    { "path": "./packages/analytics-controller/tsconfig.build.json" },
-    { "path": "./packages/announcement-controller/tsconfig.build.json" },
-    { "path": "./packages/app-metadata-controller/tsconfig.build.json" },
-    { "path": "./packages/approval-controller/tsconfig.build.json" },
-    { "path": "./packages/assets-controllers/tsconfig.build.json" },
-    { "path": "./packages/assets-controller/tsconfig.build.json" },
-    { "path": "./packages/core-backend/tsconfig.build.json" },
-    { "path": "./packages/base-controller/tsconfig.build.json" },
-    { "path": "./packages/bridge-controller/tsconfig.build.json" },
-    { "path": "./packages/bridge-status-controller/tsconfig.build.json" },
-    { "path": "./packages/build-utils/tsconfig.build.json" },
-    { "path": "./packages/chain-agnostic-permission/tsconfig.build.json" },
-    { "path": "./packages/claims-controller/tsconfig.build.json" },
-    { "path": "./packages/composable-controller/tsconfig.build.json" },
-    { "path": "./packages/controller-utils/tsconfig.build.json" },
-    { "path": "./packages/delegation-controller/tsconfig.build.json" },
-    { "path": "./packages/earn-controller/tsconfig.build.json" },
-    { "path": "./packages/eip-5792-middleware/tsconfig.build.json" },
+    {
+      "path": "./packages/account-tree-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/accounts-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/address-book-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/analytics-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/announcement-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/app-metadata-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/approval-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/assets-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/assets-controllers/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/base-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/bridge-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/bridge-status-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/build-utils/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/chain-agnostic-permission/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/claims-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/composable-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/controller-utils/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/core-backend/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/delegation-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/earn-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/eip-5792-middleware/tsconfig.build.json"
+    },
     {
       "path": "./packages/eip-7702-internal-rpc-middleware/tsconfig.build.json"
     },
-    { "path": "./packages/eip1193-permission-middleware/tsconfig.build.json" },
-    { "path": "./packages/ens-controller/tsconfig.build.json" },
-    { "path": "./packages/error-reporting-service/tsconfig.build.json" },
-    { "path": "./packages/eth-block-tracker/tsconfig.build.json" },
-    { "path": "./packages/eth-json-rpc-middleware/tsconfig.build.json" },
-    { "path": "./packages/eth-json-rpc-provider/tsconfig.build.json" },
-    { "path": "./packages/foundryup/tsconfig.build.json" },
-    { "path": "./packages/gas-fee-controller/tsconfig.build.json" },
-    { "path": "./packages/gator-permissions-controller/tsconfig.build.json" },
-    { "path": "./packages/json-rpc-engine/tsconfig.build.json" },
-    { "path": "./packages/json-rpc-middleware-stream/tsconfig.build.json" },
-    { "path": "./packages/keyring-controller/tsconfig.build.json" },
-    { "path": "./packages/logging-controller/tsconfig.build.json" },
-    { "path": "./packages/message-manager/tsconfig.build.json" },
-    { "path": "./packages/messenger/tsconfig.build.json" },
-    { "path": "./packages/multichain-account-service/tsconfig.build.json" },
-    { "path": "./packages/multichain-api-middleware/tsconfig.build.json" },
-    { "path": "./packages/multichain-network-controller/tsconfig.build.json" },
+    {
+      "path": "./packages/eip1193-permission-middleware/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/ens-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/error-reporting-service/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/eth-block-tracker/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/eth-json-rpc-middleware/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/eth-json-rpc-provider/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/foundryup/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/gas-fee-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/gator-permissions-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/json-rpc-engine/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/json-rpc-middleware-stream/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/keyring-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/logging-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/message-manager/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/messenger/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/multichain-account-service/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/multichain-api-middleware/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/multichain-network-controller/tsconfig.build.json"
+    },
     {
       "path": "./packages/multichain-transactions-controller/tsconfig.build.json"
     },
-    { "path": "./packages/name-controller/tsconfig.build.json" },
-    { "path": "./packages/network-controller/tsconfig.build.json" },
-    { "path": "./packages/network-enablement-controller/tsconfig.build.json" },
+    {
+      "path": "./packages/name-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/network-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/network-enablement-controller/tsconfig.build.json"
+    },
     {
       "path": "./packages/notification-services-controller/tsconfig.build.json"
     },
-    { "path": "./packages/permission-controller/tsconfig.build.json" },
-    { "path": "./packages/permission-log-controller/tsconfig.build.json" },
-    { "path": "./packages/phishing-controller/tsconfig.build.json" },
-    { "path": "./packages/polling-controller/tsconfig.build.json" },
-    { "path": "./packages/preferences-controller/tsconfig.build.json" },
-    { "path": "./packages/profile-metrics-controller/tsconfig.build.json" },
-    { "path": "./packages/profile-sync-controller/tsconfig.build.json" },
-    { "path": "./packages/ramps-controller/tsconfig.build.json" },
-    { "path": "./packages/rate-limit-controller/tsconfig.build.json" },
-    { "path": "./packages/remote-feature-flag-controller/tsconfig.build.json" },
-    { "path": "./packages/sample-controllers/tsconfig.build.json" },
-    { "path": "./packages/seedless-onboarding-controller/tsconfig.build.json" },
-    { "path": "./packages/selected-network-controller/tsconfig.build.json" },
-    { "path": "./packages/shield-controller/tsconfig.build.json" },
-    { "path": "./packages/signature-controller/tsconfig.build.json" },
-    { "path": "./packages/storage-service/tsconfig.build.json" },
-    { "path": "./packages/subscription-controller/tsconfig.build.json" },
+    {
+      "path": "./packages/permission-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/permission-log-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/phishing-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/polling-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/preferences-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/profile-metrics-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/profile-sync-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/ramps-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/rate-limit-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/remote-feature-flag-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/sample-controllers/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/seedless-onboarding-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/selected-network-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/shield-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/signature-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/storage-service/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/subscription-controller/tsconfig.build.json"
+    },
     {
       "path": "./packages/token-search-discovery-controller/tsconfig.build.json"
     },
-    { "path": "./packages/transaction-controller/tsconfig.build.json" },
-    { "path": "./packages/transaction-pay-controller/tsconfig.build.json" },
-    { "path": "./packages/user-operation-controller/tsconfig.build.json" }
+    {
+      "path": "./packages/transaction-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/transaction-pay-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/user-operation-controller/tsconfig.build.json"
+    }
   ],
   "files": [],
   "include": []

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,68 +8,192 @@
     "noEmit": true
   },
   "references": [
-    { "path": "./packages/account-tree-controller" },
-    { "path": "./packages/accounts-controller" },
-    { "path": "./packages/address-book-controller" },
-    { "path": "./packages/analytics-controller" },
-    { "path": "./packages/announcement-controller" },
-    { "path": "./packages/app-metadata-controller" },
-    { "path": "./packages/approval-controller" },
-    { "path": "./packages/assets-controller" },
-    { "path": "./packages/assets-controllers" },
-    { "path": "./packages/base-controller" },
-    { "path": "./packages/bridge-controller" },
-    { "path": "./packages/bridge-status-controller" },
-    { "path": "./packages/build-utils" },
-    { "path": "./packages/chain-agnostic-permission" },
-    { "path": "./packages/claims-controller" },
-    { "path": "./packages/composable-controller" },
-    { "path": "./packages/controller-utils" },
-    { "path": "./packages/core-backend" },
-    { "path": "./packages/delegation-controller" },
-    { "path": "./packages/earn-controller" },
-    { "path": "./packages/eip1193-permission-middleware" },
-    { "path": "./packages/ens-controller" },
-    { "path": "./packages/error-reporting-service" },
-    { "path": "./packages/eth-block-tracker" },
-    { "path": "./packages/eth-json-rpc-middleware" },
-    { "path": "./packages/eth-json-rpc-provider" },
-    { "path": "./packages/foundryup" },
-    { "path": "./packages/gas-fee-controller" },
-    { "path": "./packages/gator-permissions-controller" },
-    { "path": "./packages/json-rpc-engine" },
-    { "path": "./packages/json-rpc-middleware-stream" },
-    { "path": "./packages/keyring-controller" },
-    { "path": "./packages/message-manager" },
-    { "path": "./packages/messenger" },
-    { "path": "./packages/multichain-account-service" },
-    { "path": "./packages/multichain-api-middleware" },
-    { "path": "./packages/multichain-network-controller" },
-    { "path": "./packages/multichain-transactions-controller" },
-    { "path": "./packages/name-controller" },
-    { "path": "./packages/network-controller" },
-    { "path": "./packages/network-enablement-controller" },
-    { "path": "./packages/notification-services-controller" },
-    { "path": "./packages/permission-controller" },
-    { "path": "./packages/permission-log-controller" },
-    { "path": "./packages/phishing-controller" },
-    { "path": "./packages/polling-controller" },
-    { "path": "./packages/preferences-controller" },
-    { "path": "./packages/profile-metrics-controller" },
-    { "path": "./packages/profile-sync-controller" },
-    { "path": "./packages/ramps-controller" },
-    { "path": "./packages/rate-limit-controller" },
-    { "path": "./packages/remote-feature-flag-controller" },
-    { "path": "./packages/sample-controllers" },
-    { "path": "./packages/seedless-onboarding-controller" },
-    { "path": "./packages/selected-network-controller" },
-    { "path": "./packages/shield-controller" },
-    { "path": "./packages/signature-controller" },
-    { "path": "./packages/subscription-controller" },
-    { "path": "./packages/token-search-discovery-controller" },
-    { "path": "./packages/transaction-controller" },
-    { "path": "./packages/transaction-pay-controller" },
-    { "path": "./packages/user-operation-controller" }
+    {
+      "path": "./packages/account-tree-controller"
+    },
+    {
+      "path": "./packages/accounts-controller"
+    },
+    {
+      "path": "./packages/address-book-controller"
+    },
+    {
+      "path": "./packages/analytics-controller"
+    },
+    {
+      "path": "./packages/announcement-controller"
+    },
+    {
+      "path": "./packages/app-metadata-controller"
+    },
+    {
+      "path": "./packages/approval-controller"
+    },
+    {
+      "path": "./packages/assets-controller"
+    },
+    {
+      "path": "./packages/assets-controllers"
+    },
+    {
+      "path": "./packages/base-controller"
+    },
+    {
+      "path": "./packages/bridge-controller"
+    },
+    {
+      "path": "./packages/bridge-status-controller"
+    },
+    {
+      "path": "./packages/build-utils"
+    },
+    {
+      "path": "./packages/chain-agnostic-permission"
+    },
+    {
+      "path": "./packages/claims-controller"
+    },
+    {
+      "path": "./packages/composable-controller"
+    },
+    {
+      "path": "./packages/controller-utils"
+    },
+    {
+      "path": "./packages/core-backend"
+    },
+    {
+      "path": "./packages/delegation-controller"
+    },
+    {
+      "path": "./packages/earn-controller"
+    },
+    {
+      "path": "./packages/eip1193-permission-middleware"
+    },
+    {
+      "path": "./packages/ens-controller"
+    },
+    {
+      "path": "./packages/error-reporting-service"
+    },
+    {
+      "path": "./packages/eth-block-tracker"
+    },
+    {
+      "path": "./packages/eth-json-rpc-middleware"
+    },
+    {
+      "path": "./packages/eth-json-rpc-provider"
+    },
+    {
+      "path": "./packages/foundryup"
+    },
+    {
+      "path": "./packages/gas-fee-controller"
+    },
+    {
+      "path": "./packages/gator-permissions-controller"
+    },
+    {
+      "path": "./packages/json-rpc-engine"
+    },
+    {
+      "path": "./packages/json-rpc-middleware-stream"
+    },
+    {
+      "path": "./packages/keyring-controller"
+    },
+    {
+      "path": "./packages/message-manager"
+    },
+    {
+      "path": "./packages/messenger"
+    },
+    {
+      "path": "./packages/multichain-account-service"
+    },
+    {
+      "path": "./packages/multichain-api-middleware"
+    },
+    {
+      "path": "./packages/multichain-network-controller"
+    },
+    {
+      "path": "./packages/multichain-transactions-controller"
+    },
+    {
+      "path": "./packages/name-controller"
+    },
+    {
+      "path": "./packages/network-controller"
+    },
+    {
+      "path": "./packages/network-enablement-controller"
+    },
+    {
+      "path": "./packages/notification-services-controller"
+    },
+    {
+      "path": "./packages/permission-controller"
+    },
+    {
+      "path": "./packages/permission-log-controller"
+    },
+    {
+      "path": "./packages/phishing-controller"
+    },
+    {
+      "path": "./packages/polling-controller"
+    },
+    {
+      "path": "./packages/preferences-controller"
+    },
+    {
+      "path": "./packages/profile-metrics-controller"
+    },
+    {
+      "path": "./packages/profile-sync-controller"
+    },
+    {
+      "path": "./packages/ramps-controller"
+    },
+    {
+      "path": "./packages/rate-limit-controller"
+    },
+    {
+      "path": "./packages/remote-feature-flag-controller"
+    },
+    {
+      "path": "./packages/sample-controllers"
+    },
+    {
+      "path": "./packages/seedless-onboarding-controller"
+    },
+    {
+      "path": "./packages/selected-network-controller"
+    },
+    {
+      "path": "./packages/shield-controller"
+    },
+    {
+      "path": "./packages/signature-controller"
+    },
+    {
+      "path": "./packages/subscription-controller"
+    },
+    {
+      "path": "./packages/token-search-discovery-controller"
+    },
+    {
+      "path": "./packages/transaction-controller"
+    },
+    {
+      "path": "./packages/transaction-pay-controller"
+    },
+    {
+      "path": "./packages/user-operation-controller"
+    }
   ],
   "files": [],
   "include": ["./types", "./scripts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3057,6 +3057,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.48.0"
     "@yarnpkg/types": "npm:^4.0.0"
     babel-jest: "npm:^29.7.0"
+    comment-json: "npm:^4.5.1"
     depcheck: "npm:^1.4.7"
     eslint: "npm:^9.39.1"
     eslint-config-prettier: "npm:^9.1.0"
@@ -6688,6 +6689,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-timsort@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "array-timsort@npm:1.0.3"
+  checksum: 10/f417f073b3733baec3a80decdf5d45bf763f04676ef3610b0e71f9b1d88c6e4c38154c05b28b31529d308bfd0e043d08059fcd9df966245a1276af15b5584936
+  languageName: node
+  linkType: hard
+
 "array-union@npm:^2.1.0":
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
@@ -7441,6 +7449,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"comment-json@npm:^4.5.1":
+  version: 4.5.1
+  resolution: "comment-json@npm:4.5.1"
+  dependencies:
+    array-timsort: "npm:^1.0.3"
+    core-util-is: "npm:^1.0.3"
+    esprima: "npm:^4.0.1"
+  checksum: 10/3bdd2703f26690537f65ef708d62aae3980dba6fc566e82a71d95511b413a6f5f285af9af0415e4739dc6f363db24225e46f5267c576f249100cdb28c3adb00d
+  languageName: node
+  linkType: hard
+
 "comment-parser@npm:1.4.1":
   version: 1.4.1
   resolution: "comment-parser@npm:1.4.1"
@@ -7555,7 +7574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-util-is@npm:~1.0.0":
+"core-util-is@npm:^1.0.3, core-util-is@npm:~1.0.0":
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
   checksum: 10/9de8597363a8e9b9952491ebe18167e3b36e7707569eed0ebf14f8bba773611376466ae34575bca8cfe3c767890c859c74056084738f09d4e4a6f902b2ad7d99


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Since comments were added to `tsconfig.json` and `tsconfig.build.json` files, the `create-package` tool no longer works.

This commit fixes the tool by using the `comment-json` package to parse JSONC files while retaining comments. Note that I needed to reformat `tsconfig.json` and `tsconfig.build.json` in this PR due to the way that I need to use `comment-json`. If we don't do this, then the next time someone runs `create-package` then the diffs for these files will be large.

## Manual testing steps

Run `yarn create-package --name foo-controller --description "This is the FooController"`. It should work.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix create-package to support JSONC**
> 
> - Use `comment-json` in `scripts/create-package/utils.ts` to parse and stringify `tsconfig.json` and `tsconfig.build.json` while preserving comments
> - Update `finalizeAndWriteData` to write JSON with consistent indentation; adjust tests in `utils.test.ts` to expect pretty-printed output
> - Reformat root `tsconfig.json` and `tsconfig.build.json` to expanded, consistently formatted references
> - Add `comment-json` to `devDependencies` and update `yarn.lock`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6296348502dde610cb1e66986373f96149345ab1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->