### PR TITLE
ci: Remove unnecessary checkout in `check-skip-merge-queue` job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,6 @@ jobs:
     outputs:
       skip-merge-queue: ${{ steps.check-skip-merge-queue.outputs.up-to-date }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        if: github.event_name == 'merge_group'
       - name: Check pull request merge queue status
         id: check-skip-merge-queue
         if: github.event_name == 'merge_group'


### PR DESCRIPTION
## Explanation

`check-skip-merge-queue` previously required a checkout because the action was in the local repo, but since we moved it to `MetaMask/github-tools`,  this is no longer necessary.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Removes `actions/checkout` from `check-skip-merge-queue`; it now directly runs `MetaMask/github-tools/.github/actions/check-skip-merge-queue@v1` when `github.event_name == 'merge_group'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04b6e08268562df0a38fdfa5d26de1e8c7b47210. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->