### PR TITLE
fix: dont ignore to address

### DIFF
--- a/packages/gator-permissions-controller/src/GatorPermissionsController.test.ts
+++ b/packages/gator-permissions-controller/src/GatorPermissionsController.test.ts
@@ -250,7 +250,7 @@ describe('GatorPermissionsController', () => {
           result[permissionType],
         ).flat();
         flattenedStoredGatorPermissions.forEach((permission) => {
-          expect(permission.permissionResponse.to).toBeUndefined();
+          expect(permission.permissionResponse.to).toBeDefined();
           expect(permission.permissionResponse.dependencies).toBeUndefined();
         });
       };

--- a/packages/gator-permissions-controller/src/GatorPermissionsController.ts
+++ b/packages/gator-permissions-controller/src/GatorPermissionsController.ts
@@ -479,7 +479,7 @@ export default class GatorPermissionsController extends BaseController<
 
   /**
    * Sanitizes a stored gator permission for client exposure.
-   * Removes internal fields (dependencies, to)
+   * Removes internal fields (dependencies)
    *
    * @param storedGatorPermission - The stored gator permission to sanitize.
    * @returns The sanitized stored gator permission.
@@ -488,7 +488,7 @@ export default class GatorPermissionsController extends BaseController<
     storedGatorPermission: StoredGatorPermission<PermissionTypesWithCustom>,
   ): StoredGatorPermissionSanitized<PermissionTypesWithCustom> {
     const { permissionResponse } = storedGatorPermission;
-    const { dependencies, to, ...rest } = permissionResponse;
+    const { dependencies, ...rest } = permissionResponse;
     return {
       ...storedGatorPermission,
       permissionResponse: {

--- a/packages/gator-permissions-controller/src/types.ts
+++ b/packages/gator-permissions-controller/src/types.ts
@@ -116,13 +116,13 @@ export type PermissionResponse<TPermission extends PermissionTypesWithCustom> =
 
 /**
  * Represents a sanitized version of the PermissionResponse type.
- * Internal fields (dependencies, to) are removed
+ * Internal fields (dependencies) are removed
  *
  * @template Permission - The type of the permission provided.
  */
 export type PermissionResponseSanitized<
   TPermission extends PermissionTypesWithCustom,
-> = Omit<PermissionResponse<TPermission>, 'dependencies' | 'to'>;
+> = Omit<PermissionResponse<TPermission>, 'dependencies'>;
 
 /**
  * Represents a gator ERC-7715 granted(ie. signed by an user account) permission entry that is stored in profile sync.


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the recipient address is exposed to clients when reading stored permissions.
> 
> - Update `#sanitizeStoredGatorPermission` to no longer omit `permissionResponse.to` (still removes `dependencies`)
> - Narrow `PermissionResponseSanitized` to `Omit<..., 'dependencies'>` only
> - Adjust tests to expect `permissionResponse.to` to be defined and `dependencies` to be undefined
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b2a1ae6b1e29c6671a46e9f0381a2f3138e0a59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->