### PR TITLE
Add `setStatus` method to `ConnectivityController`

### DIFF
--- a/packages/connectivity-controller/CHANGELOG.md
+++ b/packages/connectivity-controller/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `setStatus` method to manually set connectivity status ([#7676](https://github.com/MetaMask/core/pull/7676))
-  - The method is exposed as a messenger action `ConnectivityController:setStatus`
+- Add `setConnectivityStatus` method to manually set connectivity status ([#7676](https://github.com/MetaMask/core/pull/7676))
+  - The method is exposed as a messenger action `ConnectivityController:setConnectivityStatus`
 
 ## [0.1.0]
 

--- a/packages/connectivity-controller/src/ConnectivityController-method-action-types.ts
+++ b/packages/connectivity-controller/src/ConnectivityController-method-action-types.ts
@@ -10,13 +10,13 @@ import type { ConnectivityController } from './ConnectivityController';
  *
  * @param status - The connectivity status to set.
  */
-export type ConnectivityControllerSetStatusAction = {
-  type: `ConnectivityController:setStatus`;
-  handler: ConnectivityController['setStatus'];
+export type ConnectivityControllerSetConnectivityStatusAction = {
+  type: `ConnectivityController:setConnectivityStatus`;
+  handler: ConnectivityController['setConnectivityStatus'];
 };
 
 /**
  * Union of all ConnectivityController action types.
  */
 export type ConnectivityControllerMethodActions =
-  ConnectivityControllerSetStatusAction;
+  ConnectivityControllerSetConnectivityStatusAction;

--- a/packages/connectivity-controller/src/ConnectivityController.test.ts
+++ b/packages/connectivity-controller/src/ConnectivityController.test.ts
@@ -169,14 +169,14 @@ describe('ConnectivityController', () => {
     });
   });
 
-  describe('setStatus', () => {
+  describe('setConnectivityStatus', () => {
     it('updates state when called directly', async () => {
       await withController(({ controller }) => {
         expect(controller.state.connectivityStatus).toBe(
           CONNECTIVITY_STATUSES.Online,
         );
 
-        controller.setStatus(CONNECTIVITY_STATUSES.Offline);
+        controller.setConnectivityStatus(CONNECTIVITY_STATUSES.Offline);
 
         expect(controller.state.connectivityStatus).toBe(
           CONNECTIVITY_STATUSES.Offline,
@@ -191,7 +191,7 @@ describe('ConnectivityController', () => {
         );
 
         rootMessenger.call(
-          'ConnectivityController:setStatus',
+          'ConnectivityController:setConnectivityStatus',
           CONNECTIVITY_STATUSES.Offline,
         );
 
@@ -215,7 +215,7 @@ describe('ConnectivityController', () => {
             CONNECTIVITY_STATUSES.Offline,
           );
 
-          controller.setStatus(CONNECTIVITY_STATUSES.Online);
+          controller.setConnectivityStatus(CONNECTIVITY_STATUSES.Online);
 
           expect(controller.state.connectivityStatus).toBe(
             CONNECTIVITY_STATUSES.Online,
@@ -239,7 +239,7 @@ describe('ConnectivityController', () => {
           );
 
           rootMessenger.call(
-            'ConnectivityController:setStatus',
+            'ConnectivityController:setConnectivityStatus',
             CONNECTIVITY_STATUSES.Online,
           );
 

--- a/packages/connectivity-controller/src/ConnectivityController.ts
+++ b/packages/connectivity-controller/src/ConnectivityController.ts
@@ -54,7 +54,7 @@ export function getDefaultConnectivityControllerState(): ConnectivityControllerS
   };
 }
 
-const MESSENGER_EXPOSED_METHODS = ['setStatus'] as const;
+const MESSENGER_EXPOSED_METHODS = ['setConnectivityStatus'] as const;
 
 /**
  * Retrieves the state of the {@link ConnectivityController}.
@@ -180,7 +180,7 @@ export class ConnectivityController extends BaseController<
    *
    * @param status - The connectivity status to set.
    */
-  setStatus(status: ConnectivityStatus): void {
+  setConnectivityStatus(status: ConnectivityStatus): void {
     this.update((draftState) => {
       draftState.connectivityStatus = status;
     });

--- a/packages/connectivity-controller/src/index.ts
+++ b/packages/connectivity-controller/src/index.ts
@@ -6,7 +6,7 @@ export type {
   ConnectivityControllerEvents,
   ConnectivityControllerMessenger,
 } from './ConnectivityController';
-export type { ConnectivityControllerSetStatusAction } from './ConnectivityController-method-action-types';
+export type { ConnectivityControllerSetConnectivityStatusAction } from './ConnectivityController-method-action-types';
 export type { ConnectivityAdapter, ConnectivityStatus } from './types';
 export { CONNECTIVITY_STATUSES } from './types';
 export {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Adds a `setStatus` method to `ConnectivityController` that allows programmatic control of connectivity status. The method is exposed as a messenger action for use by other controllers and services.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces programmatic control of connectivity status and exposes it to other modules via the messenger.
> 
> - Adds `setConnectivityStatus` to `ConnectivityController` and registers it via `registerMethodActionHandlers` (exposed as `ConnectivityController:setConnectivityStatus`)
> - New auto-generated `ConnectivityController-method-action-types.ts` defining `ConnectivityControllerSetConnectivityStatusAction` and method actions union
> - Expands tests to cover direct calls and messenger action flows; verifies offline→online transitions
> - Updates `index.ts` to export new action type; updates `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20f06fc4d945161d8bbd6466d298b5e2dd778988. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->