### PR TITLE
fix(core-backend): fix auth token caching to not cache null/undefines values

### DIFF
--- a/packages/core-backend/src/api/ApiPlatformClient.test.ts
+++ b/packages/core-backend/src/api/ApiPlatformClient.test.ts
@@ -260,14 +260,15 @@ describe('ApiPlatformClient', () => {
       expect(cachedData).toBeUndefined();
     });
 
-    it('invalidates auth token cache', async () => {
+    it('resets auth token cache (completely removes it)', async () => {
       const queryKey = ['auth', 'bearerToken'];
       client.setCachedData(queryKey, 'test-token');
 
       await client.invalidateAuthToken();
 
-      const queryState = client.queryClient.getQueryState(queryKey);
-      expect(queryState?.isInvalidated).toBe(true);
+      // resetQueries removes the query from cache entirely
+      const cachedData = client.queryClient.getQueryData(queryKey);
+      expect(cachedData).toBeUndefined();
     });
 
     it('invalidates balances cache via accounts client', async () => {

--- a/packages/core-backend/src/api/ApiPlatformClient.ts
+++ b/packages/core-backend/src/api/ApiPlatformClient.ts
@@ -39,11 +39,11 @@ import type { QueryKey } from '@tanstack/query-core';
 
 // Import API clients from subfolders
 import { AccountsApiClient } from './accounts';
+import { authQueryKeys } from './base-client';
 import { PricesApiClient } from './prices';
 import {
   STALE_TIMES,
   GC_TIMES,
-  authQueryKeys,
   shouldRetry,
   calculateRetryDelay,
 } from './shared-types';
@@ -184,9 +184,12 @@ export class ApiPlatformClient {
   /**
    * Invalidate the cached auth token.
    * Call this when the user logs out or the token expires.
+   *
+   * Uses resetQueries() instead of invalidateQueries() to completely remove
+   * the cached value, ensuring the next request fetches a fresh token immediately.
    */
   async invalidateAuthToken(): Promise<void> {
-    await this.#sharedQueryClient.invalidateQueries({
+    await this.#sharedQueryClient.resetQueries({
       queryKey: authQueryKeys.bearerToken(),
     });
   }

--- a/packages/core-backend/src/api/shared-types.ts
+++ b/packages/core-backend/src/api/shared-types.ts
@@ -2,7 +2,7 @@
  * Shared types, constants, and utilities for the API Platform Client.
  */
 
-import type { QueryClient, QueryKey } from '@tanstack/query-core';
+import type { QueryClient } from '@tanstack/query-core';
 
 // ============================================================================
 // SHARED TYPES
@@ -186,14 +186,6 @@ export const RETRY_CONFIG = {
   MAX_RETRIES: 3,
   BASE_DELAY: 1000,
   MAX_DELAY: 5_000,
-} as const;
-
-// ============================================================================
-// QUERY KEYS (Auth only - client-specific keys in their respective folders)
-// ============================================================================
-
-export const authQueryKeys = {
-  bearerToken: (): QueryKey => ['auth', 'bearerToken'],
 } as const;
 
 // ============================================================================


### PR DESCRIPTION
## Explanation

- Change auth token caching to only cache valid tokens, ensuring token is available immediately after sign-in
- Change invalidateAuthToken() to use resetQueries() for immediate cache removal instead of invalidateQueries()

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves auth token handling and cache invalidation across the core backend.
> 
> - Uses `fetchQuery` in `BaseApiClient.fetch` to cache only valid bearer tokens (throws when absent), preventing null/undefined from being cached and omitting `Authorization` when no token is available
> - Switches auth token invalidation to `resetQueries` to completely remove the cached token; adds `invalidateAuthToken` to `BaseApiClient` and updates `ApiPlatformClient.invalidateAuthToken`
> - Moves `authQueryKeys` from `shared-types` to `base-client` and updates imports; removes `authQueryKeys` export from `shared-types`
> - Updates tests to assert token header omission and full cache removal for auth token
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e220830fb26c95c713ed3f4e3f6446aa49e8f87a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->