### PR TITLE
fix(AssetControllers): assetMetadata undefined unit

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed call to NFT collections endpoint ([#7687](https://github.com/MetaMask/core/pull/7687))
+
+### Fixed
+
+- Fix crash in `selectAllMultichainAssets` selector when asset metadata is missing `units` property ([#7702](https://github.com/MetaMask/core/pull/7702))
 - Bump `@metamask/multichain-account-service` from `^5.0.0` to `^5.1.0` ([#7678](https://github.com/MetaMask/core/pull/7678))
 - Set zero address for native token of Henesys/MSU ([#7666](https://github.com/MetaMask/core/pull/7666))
 

--- a/packages/assets-controllers/src/selectors/token-selectors.ts
+++ b/packages/assets-controllers/src/selectors/token-selectors.ts
@@ -395,7 +395,7 @@ const selectAllMultichainAssets = createAssetListSelector(
             }
           | undefined = multichainBalances[accountId]?.[assetId];
 
-        const decimals = assetMetadata.units.find(
+        const decimals = assetMetadata.units?.find(
           (unit) =>
             unit.name === assetMetadata.name &&
             unit.symbol === assetMetadata.symbol,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This fixes when assetMetadata.units is undefined

<img width="968" height="586" alt="image" src="https://github.com/user-attachments/assets/649557e2-35ac-454e-9e6e-587832d8ceed" />

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes selector crash for missing metadata**
> 
> - Update `selectAllMultichainAssets` to use `assetMetadata.units?.find(...)`, avoiding crashes when `units` is absent in asset metadata
> - Add corresponding entry under **Fixed** in `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9beb09fa9155816dcce969afa3cd537fa233dbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->