### PR TITLE
fix(AssetController): get relevant metadata

### DIFF
--- a/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
@@ -63,9 +63,17 @@ function createMockAssetResponse(
     symbol: 'TEST',
     decimals: 18,
     iconUrl: 'https://example.com/icon.png',
-    iconUrlThumbnail: 'https://example.com/icon-thumb.png',
+    coingeckoId: 'test-token',
+    occurrences: 5,
+    aggregators: ['metamask'],
+    labels: ['defi'],
+    erc20Permit: true,
+    fees: { avgFee: 0, maxFee: 0, minFee: 0 },
+    honeypotStatus: { honeypotIs: false },
+    storage: { balance: 1, approval: 2 },
+    isContractVerified: true,
     ...overrides,
-  } as V3AssetResponse;
+  };
 }
 
 function createDataRequest(overrides?: Partial<DataRequest>): DataRequest {
@@ -197,15 +205,32 @@ describe('TokenDataSource', () => {
 
     await controller.assetsMiddleware(context, next);
 
-    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith([
-      MOCK_TOKEN_ASSET,
-    ]);
+    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith(
+      [MOCK_TOKEN_ASSET],
+      {
+        includeIconUrl: true,
+        includeLabels: true,
+        includeMarketData: true,
+        includeMetadata: true,
+        includeRwaData: true,
+      },
+    );
     expect(context.response.assetsMetadata?.[MOCK_TOKEN_ASSET]).toStrictEqual({
       type: 'erc20',
       name: 'Test Token',
       symbol: 'TEST',
       decimals: 18,
       image: 'https://example.com/icon.png',
+      coingeckoId: 'test-token',
+      occurrences: 5,
+      aggregators: ['metamask'],
+      labels: ['defi'],
+      erc20Permit: true,
+      fees: { avgFee: 0, maxFee: 0, minFee: 0 },
+      honeypotStatus: { honeypotIs: false },
+      storage: { balance: 1, approval: 2 },
+      isContractVerified: true,
+      description: undefined,
     });
     expect(next).toHaveBeenCalledWith(context);
   });
@@ -295,9 +320,16 @@ describe('TokenDataSource', () => {
 
     await controller.assetsMiddleware(context, next);
 
-    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith([
-      MOCK_TOKEN_ASSET,
-    ]);
+    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith(
+      [MOCK_TOKEN_ASSET],
+      {
+        includeIconUrl: true,
+        includeLabels: true,
+        includeMarketData: true,
+        includeMetadata: true,
+        includeRwaData: true,
+      },
+    );
   });
 
   it('middleware filters assets by supported networks', async () => {
@@ -320,9 +352,16 @@ describe('TokenDataSource', () => {
 
     await controller.assetsMiddleware(context, next);
 
-    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith([
-      MOCK_TOKEN_ASSET,
-    ]);
+    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith(
+      [MOCK_TOKEN_ASSET],
+      {
+        includeIconUrl: true,
+        includeLabels: true,
+        includeMarketData: true,
+        includeMetadata: true,
+        includeRwaData: true,
+      },
+    );
   });
 
   it('middleware passes to next when no assets from supported networks', async () => {
@@ -446,33 +485,6 @@ describe('TokenDataSource', () => {
     expect(context.response.assetsMetadata?.[MOCK_SPL_ASSET]?.type).toBe('spl');
   });
 
-  it('middleware uses iconUrlThumbnail when iconUrl is not available', async () => {
-    const { controller } = setupController({
-      supportedNetworks: ['eip155:1'],
-      assetsResponse: [
-        createMockAssetResponse(MOCK_TOKEN_ASSET, {
-          iconUrl: undefined,
-          iconUrlThumbnail: 'https://example.com/thumb.png',
-        }),
-      ],
-    });
-
-    const next = jest.fn().mockResolvedValue(undefined);
-    const context = createMiddlewareContext({
-      response: {
-        detectedAssets: {
-          'mock-account-id': [MOCK_TOKEN_ASSET],
-        },
-      },
-    });
-
-    await controller.assetsMiddleware(context, next);
-
-    expect(context.response.assetsMetadata?.[MOCK_TOKEN_ASSET]?.image).toBe(
-      'https://example.com/thumb.png',
-    );
-  });
-
   it('middleware merges metadata into existing response', async () => {
     const anotherAsset =
       'eip155:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f' as Caip19AssetId;
@@ -535,6 +547,13 @@ describe('TokenDataSource', () => {
 
     expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith(
       expect.arrayContaining([MOCK_TOKEN_ASSET, secondAsset]),
+      {
+        includeIconUrl: true,
+        includeLabels: true,
+        includeMarketData: true,
+        includeMetadata: true,
+        includeRwaData: true,
+      },
     );
     expect(context.response.assetsMetadata?.[MOCK_TOKEN_ASSET]).toBeDefined();
     expect(context.response.assetsMetadata?.[secondAsset]).toBeDefined();
@@ -558,9 +577,16 @@ describe('TokenDataSource', () => {
 
     await controller.assetsMiddleware(context, next);
 
-    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith([
-      MOCK_TOKEN_ASSET,
-    ]);
+    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith(
+      [MOCK_TOKEN_ASSET],
+      {
+        includeIconUrl: true,
+        includeLabels: true,
+        includeMarketData: true,
+        includeMetadata: true,
+        includeRwaData: true,
+      },
+    );
   });
 
   it('middleware includes partial support networks', async () => {
@@ -585,9 +611,16 @@ describe('TokenDataSource', () => {
 
     await controller.assetsMiddleware(context, next);
 
-    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith([
-      MOCK_TOKEN_ASSET,
-    ]);
+    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith(
+      [MOCK_TOKEN_ASSET],
+      {
+        includeIconUrl: true,
+        includeLabels: true,
+        includeMarketData: true,
+        includeMetadata: true,
+        includeRwaData: true,
+      },
+    );
   });
 
   it('middleware filters out invalid CAIP asset IDs', async () => {
@@ -610,8 +643,15 @@ describe('TokenDataSource', () => {
 
     await controller.assetsMiddleware(context, next);
 
-    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith([
-      MOCK_TOKEN_ASSET,
-    ]);
+    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith(
+      [MOCK_TOKEN_ASSET],
+      {
+        includeIconUrl: true,
+        includeLabels: true,
+        includeMarketData: true,
+        includeMetadata: true,
+        includeRwaData: true,
+      },
+    );
   });
 });

--- a/packages/assets-controller/src/index.ts
+++ b/packages/assets-controller/src/index.ts
@@ -36,6 +36,11 @@ export type {
   // Asset types
   AssetType,
   TokenStandard,
+  // Contract data types
+  TokenFees,
+  HoneypotStatus,
+  StorageSlots,
+  LocalizedDescription,
   // Metadata types
   BaseAssetMetadata,
   FungibleAssetMetadata,

--- a/packages/assets-controller/src/types.ts
+++ b/packages/assets-controller/src/types.ts
@@ -66,19 +66,70 @@ export type BaseAssetMetadata = {
   image?: string;
 };
 
+// ============================================================================
+// TOKEN CONTRACT DATA TYPES
+// ============================================================================
+
+/** Fee information for token transfers */
+export type TokenFees = {
+  avgFee: number;
+  maxFee: number;
+  minFee: number;
+};
+
+/** Honeypot detection status */
+export type HoneypotStatus = {
+  honeypotIs: boolean;
+  goPlus?: boolean;
+};
+
+/** Storage slot information for the contract */
+export type StorageSlots = {
+  balance: number;
+  approval: number;
+};
+
+/** Localized description */
+export type LocalizedDescription = {
+  en: string;
+};
+
+// ============================================================================
+// ASSET METADATA TYPES
+// ============================================================================
+
 /**
- * Metadata for fungible tokens
- * Asset Type: "fungible"
- * Includes: native, ERC-20, SPL, and other fungible token standards
+ * Metadata for fungible tokens.
+ * Structure mirrors V3AssetResponse from the Tokens API.
+ *
+ * Differences from V3AssetResponse:
+ * - `type` is derived from assetId namespace (not in API response)
+ * - `image` maps from API's `iconUrl`
+ * - `assetId` is not stored (used as the key)
  */
 export type FungibleAssetMetadata = {
+  /** Token type derived from assetId namespace */
   type: 'native' | 'erc20' | 'spl';
-  /** Spam detection flag */
-  isSpam?: boolean;
-  /** Verification status */
-  verified?: boolean;
-  /** Token list memberships */
-  collections?: string[];
+  /** CoinGecko ID for price lookups */
+  coingeckoId?: string;
+  /** Number of token list occurrences */
+  occurrences?: number;
+  /** DEX/aggregator integrations */
+  aggregators?: string[];
+  /** Asset labels/tags (e.g., "stable_coin") */
+  labels?: string[];
+  /** Whether the token supports ERC-20 permit */
+  erc20Permit?: boolean;
+  /** Fee information for token transfers */
+  fees?: TokenFees;
+  /** Honeypot detection status */
+  honeypotStatus?: HoneypotStatus;
+  /** Storage slot information for the contract */
+  storage?: StorageSlots;
+  /** Whether the contract is verified */
+  isContractVerified?: boolean;
+  /** Localized description */
+  description?: LocalizedDescription;
 } & BaseAssetMetadata;
 
 /**

--- a/packages/core-backend/src/api/tokens/client.test.ts
+++ b/packages/core-backend/src/api/tokens/client.test.ts
@@ -82,8 +82,16 @@ describe('TokensApiClient', () => {
           name: 'Test Token',
           symbol: 'TKN',
           decimals: 18,
-          address: '0xtoken',
-          chainId: 1,
+          iconUrl: 'https://example.com/icon.png',
+          coingeckoId: 'test-token',
+          occurrences: 5,
+          aggregators: ['metamask'],
+          labels: ['defi'],
+          erc20Permit: true,
+          fees: { avgFee: 0, maxFee: 0, minFee: 0 },
+          honeypotStatus: { honeypotIs: false },
+          storage: { balance: 1, approval: 2 },
+          isContractVerified: true,
         },
       ];
       mockFetch.mockResolvedValueOnce(createMockResponse(mockResponse));

--- a/packages/core-backend/src/api/tokens/client.ts
+++ b/packages/core-backend/src/api/tokens/client.ts
@@ -12,6 +12,7 @@ import type {
   V1TokenSupportedNetworksResponse,
   V2TokenSupportedNetworksResponse,
   V3AssetResponse,
+  V3AssetsQueryOptions,
 } from './types';
 import { BaseApiClient, API_URLS, STALE_TIMES, GC_TIMES } from '../base-client';
 import type { FetchOptions } from '../shared-types';
@@ -91,22 +92,31 @@ export class TokensApiClient extends BaseApiClient {
    * Fetch assets by IDs (v3) with caching.
    *
    * @param assetIds - Array of CAIP-19 asset IDs.
-   * @param options - Fetch options including cache settings.
+   * @param queryOptions - Query options to include additional data in response.
+   * @param fetchOptions - Fetch options including cache settings.
    * @returns Array of asset responses.
    */
   async fetchV3Assets(
     assetIds: string[],
-    options?: FetchOptions,
+    queryOptions?: V3AssetsQueryOptions,
+    fetchOptions?: FetchOptions,
   ): Promise<V3AssetResponse[]> {
     return this.queryClient.fetchQuery({
-      queryKey: ['tokens', 'v3Assets', { assetIds: [...assetIds].sort() }],
+      queryKey: [
+        'tokens',
+        'v3Assets',
+        { assetIds: [...assetIds].sort(), ...queryOptions },
+      ],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V3AssetResponse[]>(API_URLS.TOKENS, '/v3/assets', {
           signal,
-          params: { assetIds },
+          params: {
+            assetIds,
+            ...queryOptions,
+          },
         }),
-      staleTime: options?.staleTime ?? STALE_TIMES.TOKEN_METADATA,
-      gcTime: options?.gcTime ?? GC_TIMES.EXTENDED,
+      staleTime: fetchOptions?.staleTime ?? STALE_TIMES.TOKEN_METADATA,
+      gcTime: fetchOptions?.gcTime ?? GC_TIMES.EXTENDED,
     });
   }
 }

--- a/packages/core-backend/src/api/tokens/index.ts
+++ b/packages/core-backend/src/api/tokens/index.ts
@@ -7,4 +7,9 @@ export type {
   V1TokenSupportedNetworksResponse,
   V2TokenSupportedNetworksResponse,
   V3AssetResponse,
+  V3AssetsQueryOptions,
+  V3AssetFees,
+  V3AssetHoneypotStatus,
+  V3AssetStorage,
+  V3AssetDescription,
 } from './types';

--- a/packages/core-backend/src/api/tokens/types.ts
+++ b/packages/core-backend/src/api/tokens/types.ts
@@ -22,17 +22,81 @@ export type V2TokenSupportedNetworksResponse = {
 // ASSET TYPES
 // ============================================================================
 
-/** Asset by CAIP-19 ID response */
+/** Query options for V3 Assets endpoint */
+export type V3AssetsQueryOptions = {
+  /** Include icon URL in response */
+  includeIconUrl?: boolean;
+  /** Include market data in response */
+  includeMarketData?: boolean;
+  /** Include metadata in response */
+  includeMetadata?: boolean;
+  /** Include labels in response */
+  includeLabels?: boolean;
+  /** Include RWA data in response */
+  includeRwaData?: boolean;
+};
+
+// ============================================================================
+// V3 ASSET RESPONSE TYPES
+// ============================================================================
+
+/** Fee information for an asset */
+export type V3AssetFees = {
+  avgFee: number;
+  maxFee: number;
+  minFee: number;
+};
+
+/** Honeypot detection status */
+export type V3AssetHoneypotStatus = {
+  honeypotIs: boolean;
+  goPlus?: boolean;
+};
+
+/** Storage slot information for the contract */
+export type V3AssetStorage = {
+  balance: number;
+  approval: number;
+};
+
+/** Localized description */
+export type V3AssetDescription = {
+  en: string;
+};
+
+/**
+ * Asset response from V3 Assets endpoint.
+ * All fields are stored in state (FungibleAssetMetadata).
+ */
 export type V3AssetResponse = {
+  /** CAIP-19 asset ID (e.g., "eip155:1/erc20:0x...") */
   assetId: string;
+  /** Asset display name */
   name: string;
+  /** Asset symbol */
   symbol: string;
+  /** Decimal places */
   decimals: number;
-  address: string;
-  chainId: number | string;
+  /** Icon URL (maps to `image` in state) */
   iconUrl?: string;
-  iconUrlThumbnail?: string;
+  /** CoinGecko ID for price lookups */
   coingeckoId?: string;
+  /** Number of token list occurrences */
   occurrences?: number;
+  /** DEX/aggregator integrations */
   aggregators?: string[];
+  /** Asset labels/tags (e.g., "stable_coin") */
+  labels?: string[];
+  /** Whether the token supports ERC-20 permit */
+  erc20Permit?: boolean;
+  /** Fee information */
+  fees?: V3AssetFees;
+  /** Honeypot detection status */
+  honeypotStatus?: V3AssetHoneypotStatus;
+  /** Storage slot information */
+  storage?: V3AssetStorage;
+  /** Whether the contract is verified */
+  isContractVerified?: boolean;
+  /** Localized description (maps to metadata.description in state) */
+  description?: V3AssetDescription;
 };


### PR DESCRIPTION
## Explanation

### Current State
The `TokenDataSource` in `@metamask/assets-controller` fetches token metadata from the Tokens API v3 endpoint but was not storing all available metadata fields in state. The `V3AssetResponse` type did not accurately reflect the actual API response structure, and `FungibleAssetMetadata` was missing several useful fields returned by the API.

### Solution
This PR aligns the types and transformation logic to capture all relevant metadata from the V3 Assets API:

**`@metamask/core-backend` changes:**
- Updated `V3AssetResponse` type to match the actual API response structure
- Added new types: `V3AssetFees`, `V3AssetHoneypotStatus`, `V3AssetStorage`, `V3AssetDescription`
- Added query options support via `V3AssetsQueryOptions`

**`@metamask/assets-controller` changes:**
- Extended `FungibleAssetMetadata` with new fields: `erc20Permit`, `fees`, `honeypotStatus`, `storage`, `isContractVerified`, `description`
- Added corresponding types: `TokenFees`, `HoneypotStatus`, `StorageSlots`, `LocalizedDescription`
- Updated `transformV3AssetResponseToMetadata` to properly map all fields from the API response to state

### New Fields Stored in State
| Field | Type | Description |
|-------|------|-------------|
| `erc20Permit` | `boolean` | Whether the token supports ERC-20 permit |
| `fees` | `TokenFees` | Fee information (avgFee, maxFee, minFee) |
| `honeypotStatus` | `HoneypotStatus` | Honeypot detection status |
| `storage` | `StorageSlots` | Storage slot information (balance, approval) |
| `isContractVerified` | `boolean` | Whether the contract is verified |
| `description` | `LocalizedDescription` | Localized description (`{ en: string }`) |

## References

- Related to the AssetsController middleware architecture
- Tokens API v3 endpoint: `tokens.api.cx.metamask.io`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Tokens API v3 types and enriches stored token metadata across packages.
> 
> - Core Backend: updates `V3AssetResponse` to real API shape; adds `V3AssetFees`, `V3AssetHoneypotStatus`, `V3AssetStorage`, `V3AssetDescription`; introduces `V3AssetsQueryOptions`; `tokens.fetchV3Assets` now accepts query options, passes them as params, and keys cache by them; barrel exports updated
> - Assets Controller: extends `FungibleAssetMetadata` and new contract-related types; `TokenDataSource` now passes include flags to `fetchV3Assets` and maps all returned fields (incl. `erc20Permit`, `fees`, `honeypotStatus`, `storage`, `isContractVerified`, `description`); removes fallback to `iconUrlThumbnail`
> - Tests updated to reflect new types, query options, and stored metadata
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f741833af28f7f375fb62428427da14903a51b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->