### PR TITLE
fix(AssetController): switch price from Controller to state

### DIFF
--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -199,6 +199,7 @@ describe('AssetsController', () => {
       expect(defaultState).toStrictEqual({
         assetsMetadata: {},
         assetsBalance: {},
+        assetsPrice: {},
         customAssets: {},
       });
     });
@@ -210,6 +211,7 @@ describe('AssetsController', () => {
         expect(controller.state).toStrictEqual({
           assetsMetadata: {},
           assetsBalance: {},
+          assetsPrice: {},
           customAssets: {},
         });
       });
@@ -578,6 +580,29 @@ describe('AssetsController', () => {
         await controller.handleAssetsUpdate({}, 'TestSource');
 
         expect(controller.state.assetsBalance).toStrictEqual({});
+      });
+    });
+
+    it('updates state with price data', async () => {
+      await withController(async ({ controller }) => {
+        await controller.handleAssetsUpdate(
+          {
+            assetsPrice: {
+              [MOCK_ASSET_ID]: {
+                price: 1.0,
+                pricePercentChange1d: 0.5,
+                lastUpdated: Date.now(),
+              },
+            },
+          },
+          'TestSource',
+        );
+
+        expect(controller.state.assetsPrice[MOCK_ASSET_ID]).toBeDefined();
+        expect(
+          (controller.state.assetsPrice[MOCK_ASSET_ID] as { price: number })
+            .price,
+        ).toBe(1.0);
       });
     });
   });

--- a/packages/assets-controller/src/data-sources/PriceDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/PriceDataSource.test.ts
@@ -234,10 +234,10 @@ describe('PriceDataSource', () => {
     );
     expect(response.assetsPrice?.[MOCK_NATIVE_ASSET]).toStrictEqual({
       price: 2500,
-      priceChange24h: 2.5,
+      pricePercentChange1d: 2.5,
       lastUpdated: expect.any(Number),
       marketCap: 1000000000,
-      volume24h: 50000000,
+      totalVolume: 50000000,
     });
 
     controller.destroy();
@@ -632,10 +632,10 @@ describe('PriceDataSource', () => {
     );
     expect(context.response.assetsPrice?.[MOCK_TOKEN_ASSET]).toStrictEqual({
       price: 1.0,
-      priceChange24h: 2.5,
+      pricePercentChange1d: 2.5,
       lastUpdated: expect.any(Number),
       marketCap: 1000000000,
-      volume24h: 50000000,
+      totalVolume: 50000000,
     });
     expect(next).toHaveBeenCalledWith(context);
 

--- a/packages/assets-controller/src/types.ts
+++ b/packages/assets-controller/src/types.ts
@@ -184,25 +184,56 @@ export type AssetMetadata =
 export type BaseAssetPrice = {
   /** Current price in USD */
   price: number;
-  /** 24h price change percentage */
-  priceChange24h?: number;
   /** Timestamp of last price update */
   lastUpdated: number;
 };
 
 /**
  * Price data for fungible tokens (native, ERC20, SPL)
+ * Matches V3SpotPricesResponse from the Price API.
  */
 export type FungibleAssetPrice = {
+  /** CoinGecko ID */
+  id?: string;
+  /** Current price in USD */
+  price: number;
   /** Market capitalization */
   marketCap?: number;
+  /** All-time high price */
+  allTimeHigh?: number;
+  /** All-time low price */
+  allTimeLow?: number;
   /** 24h trading volume */
-  volume24h?: number;
+  totalVolume?: number;
+  /** 24h high price */
+  high1d?: number;
+  /** 24h low price */
+  low1d?: number;
   /** Circulating supply */
   circulatingSupply?: number;
-  /** Total supply */
-  totalSupply?: number;
-} & BaseAssetPrice;
+  /** Fully diluted market cap */
+  dilutedMarketCap?: number;
+  /** 24h market cap change percentage */
+  marketCapPercentChange1d?: number;
+  /** 24h price change in USD */
+  priceChange1d?: number;
+  /** 1h price change percentage */
+  pricePercentChange1h?: number;
+  /** 24h price change percentage */
+  pricePercentChange1d?: number;
+  /** 7d price change percentage */
+  pricePercentChange7d?: number;
+  /** 14d price change percentage */
+  pricePercentChange14d?: number;
+  /** 30d price change percentage */
+  pricePercentChange30d?: number;
+  /** 200d price change percentage */
+  pricePercentChange200d?: number;
+  /** 1y price change percentage */
+  pricePercentChange1y?: number;
+  /** Timestamp of last price update (added by client) */
+  lastUpdated: number;
+};
 
 /**
  * Price data for NFT collections
@@ -324,6 +355,7 @@ export type DataResponse = {
  * - assetsMetadata keys: CAIP-19 asset IDs (e.g., "eip155:1/erc20:0x...")
  * - assetsBalance outer keys: Account IDs (InternalAccount.id UUIDs)
  * - assetsBalance inner keys: CAIP-19 asset IDs
+ * - assetsPrice keys: CAIP-19 asset IDs
  * - customAssets outer keys: Account IDs (InternalAccount.id UUIDs)
  * - customAssets inner values: CAIP-19 asset IDs array
  */
@@ -332,6 +364,8 @@ export type AssetsControllerStateInternal = {
   assetsMetadata: Record<Caip19AssetId, AssetMetadata>;
   /** Per-account balance data */
   assetsBalance: Record<AccountId, Record<Caip19AssetId, AssetBalance>>;
+  /** Price data for assets */
+  assetsPrice: Record<Caip19AssetId, AssetPrice>;
   /** Custom assets added by users per account */
   customAssets: Record<AccountId, Caip19AssetId[]>;
 };


### PR DESCRIPTION
## Explanation

**Current State:**
- Asset price data in `AssetsController` was stored in a private class attribute (`#assetsPrice`) rather than in the controller state
- The `FungibleAssetPrice` type didn't match the full API response from the Price API V3 spot-prices endpoint
- Price data transformation involved unnecessary intermediate steps

**Solution:**
- Moved `assetsPrice` from a class attribute to the controller state, making it accessible via `state.assetsPrice` and enabling proper state change events
- Updated `FungibleAssetPrice` type to be a flat structure that matches the complete V3SpotPricesResponse from the Price API, including all market data fields (price, marketCap, allTimeHigh, allTimeLow, totalVolume, high1d, low1d, circulatingSupply, dilutedMarketCap, priceChange1d, pricePercentChange1h/1d/7d/14d/30d/200d/1y, etc.)
- Simplified `PriceDataSource` by removing the unnecessary `transformMarketDataToAssetPrice` function and directly spreading the API response with a `lastUpdated` timestamp
- Set `persist: false` for `assetsPrice` state metadata since prices should be refreshed on app load rather than persisted stale

**Notable Changes:**
- `FungibleAssetPrice` field renames: `priceChange24h` → `pricePercentChange1d`, `volume24h` → `totalVolume` (matching API response)
- Added `assetsPrice` to `AssetsControllerStateInternal` type for internal type consistency

## References

<!-- Add any related issues or PRs here -->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves price data into controller state and aligns types with Price API v3.
> 
> - Adds `assetsPrice` to `AssetsController` state (defaulted, non-persistent), removes private `#assetsPrice`, integrates into state updates, normalization, and `getAssets` fiat calculations; publishes `priceChanged` events
> - Updates state metadata to include `assetsPrice` with `persist: false`
> - Simplifies `PriceDataSource`: fetches v3 spot prices and writes market data directly to `response.assetsPrice` with `lastUpdated`; removes transform helper; middleware and fetch both use the same path
> - Expands `FungibleAssetPrice` to mirror API fields and renames keys (e.g., `priceChange24h` → `pricePercentChange1d`, `volume24h` → `totalVolume`); updates `AssetsControllerStateInternal` to include `assetsPrice`
> - Refreshes tests to cover new state shape, field names, and price update flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2aeb5184db23d8e1fd18304ea6137ef92041284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->