### PR TITLE
fix: issue in releasing transaction controller due to core-backend dependency

### DIFF
--- a/packages/transaction-controller/src/helpers/IncomingTransactionHelper.ts
+++ b/packages/transaction-controller/src/helpers/IncomingTransactionHelper.ts
@@ -3,7 +3,6 @@ import type {
   Transaction as AccountActivityTransaction,
   WebSocketConnectionInfo,
 } from '@metamask/core-backend';
-import { WebSocketState } from '@metamask/core-backend';
 import type { Hex } from '@metamask/utils';
 // This package purposefully relies on Node's EventEmitter module.
 // eslint-disable-next-line import-x/no-nodejs-modules
@@ -35,6 +34,11 @@ export type IncomingTransactionOptions = {
 };
 
 const TAG_POLLING = 'automatic-polling';
+
+enum WebSocketState {
+  CONNECTED = 'connected',
+  DISCONNECTED = 'disconnected',
+}
 
 export class IncomingTransactionHelper {
   hub: EventEmitter;


### PR DESCRIPTION
## Explanation

Issue in releasing transaction controller due to core-backend dependency

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [X] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces dependency on `@metamask/core-backend` for `WebSocketState` by defining a local `WebSocketState` enum in `IncomingTransactionHelper.ts`.
> 
> - Removes `WebSocketState` import; adds local enum with `CONNECTED` and `DISCONNECTED`
> - Existing WebSocket connection handling in `IncomingTransactionHelper` updated to use the local enum
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9d9ecb67dba9001341a8b05316e2737533980c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->