### PR TITLE
fix(keyring-controller): force state update after clearing keyrings

### DIFF
--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2526,6 +2526,13 @@ export class KeyringController<
     }
     this.#keyrings = [];
     this.#unsupportedKeyrings = [];
+
+    // We force this state update since the `AccountsController` is mirroring
+    // the keyrings array in its state (using `InternalAccount`s), and we want to
+    // ensure it's updated after a clear operation too.
+    this.update((state) => {
+      state.keyrings = [];
+    });
   }
 
   /**


### PR DESCRIPTION
## Explanation

If a keyring using a specific SRP gets cleared and re-created (during restore flow), there's a brief time window where the keyring is effectively destroyed and re-recreated, though, the `AccountsController` will not see this state update and won't mirror back this change for `InternalAccount`s.

This could lead to inconsistencies if the keyring is cleared but cannot be re-created for some reason.

Also, this prevents the `AccountsController` to automatically re-wrap EVM accounts (which are still not using the `KeyringAccount` object shape) properly and might be using an old account representation (we use this mechanism to sometimes migrate account objects automatically, and that would by-pass this migration in some very edge-cases).

## References

TODO

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
