### PR TITLE
feat: Add types for post-quote (withdrawal) flows

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `isPostQuote` field to `MetamaskPayMetadata` type for withdrawal flows ([#7773](https://github.com/MetaMask/core/pull/7773))
+
 ## [62.11.0]
 
 ### Added

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -2082,6 +2082,12 @@ export type MetamaskPayMetadata = {
   /** Chain ID of the payment token. */
   chainId?: Hex;
 
+  /**
+   * Whether this is a post-quote transaction (e.g., withdrawal flow).
+   * When true, the token represents the destination rather than source.
+   */
+  isPostQuote?: boolean;
+
   /** Total network fee in fiat currency, including the original and bridge transactions. */
   networkFeeFiat?: string;
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `isPostQuote` and `selectedToken` fields to `TransactionData` type for withdrawal flows ([#7773](https://github.com/MetaMask/core/pull/7773))
+- Add `UpdateSelectedTokenRequest` type and related action types ([#7773](https://github.com/MetaMask/core/pull/7773))
+
 ## [12.0.2]
 
 ### Changed

--- a/packages/transaction-pay-controller/src/index.ts
+++ b/packages/transaction-pay-controller/src/index.ts
@@ -7,15 +7,18 @@ export type {
   TransactionPayControllerMessenger,
   TransactionPayControllerOptions,
   TransactionPayControllerSetIsMaxAmountAction,
+  TransactionPayControllerSetIsPostQuoteAction,
   TransactionPayControllerState,
   TransactionPayControllerStateChangeEvent,
   TransactionPayControllerUpdatePaymentTokenAction,
+  TransactionPayControllerUpdateSelectedTokenAction,
   TransactionPaymentToken,
   TransactionPayQuote,
   TransactionPayRequiredToken,
   TransactionPaySourceAmount,
   TransactionPayTotals,
   UpdatePaymentTokenRequest,
+  UpdateSelectedTokenRequest,
 } from './types';
 export { TransactionPayStrategy } from './constants';
 export { TransactionPayController } from './TransactionPayController';

--- a/packages/transaction-pay-controller/src/types.ts
+++ b/packages/transaction-pay-controller/src/types.ts
@@ -85,6 +85,18 @@ export type TransactionPayControllerUpdatePaymentTokenAction = {
   handler: (request: UpdatePaymentTokenRequest) => void;
 };
 
+/** Action to update the selected token for a transaction (used for withdrawals). */
+export type TransactionPayControllerUpdateSelectedTokenAction = {
+  type: `${typeof CONTROLLER_NAME}:updateSelectedToken`;
+  handler: (request: UpdateSelectedTokenRequest) => void;
+};
+
+/** Action to set the post-quote flag for a transaction. */
+export type TransactionPayControllerSetIsPostQuoteAction = {
+  type: `${typeof CONTROLLER_NAME}:setIsPostQuote`;
+  handler: (transactionId: string, isPostQuote: boolean) => void;
+};
+
 /** Action to set the max amount flag for a transaction. */
 export type TransactionPayControllerSetIsMaxAmountAction = {
   type: `${typeof CONTROLLER_NAME}:setIsMaxAmount`;
@@ -102,7 +114,9 @@ export type TransactionPayControllerActions =
   | TransactionPayControllerGetStateAction
   | TransactionPayControllerGetStrategyAction
   | TransactionPayControllerSetIsMaxAmountAction
-  | TransactionPayControllerUpdatePaymentTokenAction;
+  | TransactionPayControllerSetIsPostQuoteAction
+  | TransactionPayControllerUpdatePaymentTokenAction
+  | TransactionPayControllerUpdateSelectedTokenAction;
 
 export type TransactionPayControllerEvents =
   TransactionPayControllerStateChangeEvent;
@@ -142,7 +156,26 @@ export type TransactionData = {
   /** Whether the user has selected the maximum amount. */
   isMaxAmount?: boolean;
 
-  /** Source token selected for the transaction. */
+  /**
+   * Whether this is a post-quote transaction (e.g., withdrawal flow).
+   * When true, the selectedToken represents the destination token,
+   * and the quote source is derived from the transaction's native token.
+   * Used for Predict/Perps withdrawals where funds flow:
+   * withdrawal → bridge/swap → destination token
+   */
+  isPostQuote?: boolean;
+
+  /**
+   * Token selected for the transaction.
+   * - For deposits (isPostQuote=false): This is the SOURCE/payment token
+   * - For withdrawals (isPostQuote=true): This is the DESTINATION token
+   */
+  selectedToken?: TransactionPaymentToken;
+
+  /**
+   * @deprecated Use selectedToken instead. Kept for backwards compatibility.
+   * Source token selected for the transaction.
+   */
   paymentToken?: TransactionPaymentToken;
 
   /** Quotes retrieved for the transaction. */
@@ -447,6 +480,18 @@ export type UpdatePaymentTokenRequest = {
   tokenAddress: Hex;
 
   /** Chain ID of the new payment token. */
+  chainId: Hex;
+};
+
+/** Request to update the selected token for a transaction (used for withdrawals). */
+export type UpdateSelectedTokenRequest = {
+  /** ID of the transaction to update. */
+  transactionId: string;
+
+  /** Address of the selected token. */
+  tokenAddress: Hex;
+
+  /** Chain ID of the selected token. */
   chainId: Hex;
 };
 


### PR DESCRIPTION
## Explanation

Add type definitions for the withdrawal-to-any-token feature:
- Add `isPostQuote` and `selectedToken` to TransactionData
- Add `UpdateSelectedTokenRequest` type
- Add `TransactionPayControllerSetIsPostQuoteAction` action type
- Add `TransactionPayControllerUpdateSelectedTokenAction` action type
- Add `isPostQuote` to MetamaskPayMetadata in transaction-controller
- Export new types from index.ts

These types enable withdrawal flows where users can select a destination token different from the withdrawal's native token.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only additions across `transaction-controller` and `transaction-pay-controller`; low runtime risk but may require downstream updates where `paymentToken` semantics are assumed.
> 
> **Overview**
> Enables post-quote (withdrawal) flows by extending `TransactionPayController` state with `TransactionData.isPostQuote` and `selectedToken`, while marking `paymentToken` as deprecated for backward compatibility.
> 
> Adds new messenger action typings (`TransactionPayController:setIsPostQuote`, `TransactionPayController:updateSelectedToken`) plus `UpdateSelectedTokenRequest`, and exports these new types from `transaction-pay-controller`.
> 
> Extends `transaction-controller`’s `MetamaskPayMetadata` with an optional `isPostQuote` flag and updates both packages’ changelogs accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dc045fd201a97caa80a3465a2d18427c4acce83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->