### PR TITLE
refactor: Extract shared buildTokenData utility (preparation for withdrawals to any token)

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Extract shared `buildTokenData` utility and add `TokenListController` fallback for token lookups ([#7774](https://github.com/MetaMask/core/pull/7774))
+
 ## [12.0.2]
 
 ### Changed

--- a/packages/transaction-pay-controller/src/actions/update-payment-token.test.ts
+++ b/packages/transaction-pay-controller/src/actions/update-payment-token.test.ts
@@ -2,12 +2,8 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import { noop } from 'lodash';
 
 import { updatePaymentToken } from './update-payment-token';
-import type { TransactionData } from '../types';
-import {
-  getTokenBalance,
-  getTokenInfo,
-  getTokenFiatRate,
-} from '../utils/token';
+import type { TransactionData, TransactionPaymentToken } from '../types';
+import { buildTokenData } from '../utils/token';
 import { getTransaction } from '../utils/transaction';
 
 jest.mock('../utils/token');
@@ -18,18 +14,25 @@ const CHAIN_ID_MOCK = '0x1';
 const FROM_MOCK = '0x456';
 const TRANSACTION_ID_MOCK = '123-456';
 
+const PAYMENT_TOKEN_MOCK: TransactionPaymentToken = {
+  address: TOKEN_ADDRESS_MOCK,
+  balanceFiat: '2.46',
+  balanceHuman: '1.23',
+  balanceRaw: '1230000',
+  balanceUsd: '3.69',
+  chainId: CHAIN_ID_MOCK,
+  decimals: 6,
+  symbol: 'TST',
+};
+
 describe('Update Payment Token Action', () => {
-  const getTokenBalanceMock = jest.mocked(getTokenBalance);
-  const getTokenInfoMock = jest.mocked(getTokenInfo);
-  const getTokenFiatRateMock = jest.mocked(getTokenFiatRate);
+  const buildTokenDataMock = jest.mocked(buildTokenData);
   const getTransactionMock = jest.mocked(getTransaction);
 
   beforeEach(() => {
     jest.resetAllMocks();
 
-    getTokenInfoMock.mockReturnValue({ decimals: 6, symbol: 'TST' });
-    getTokenBalanceMock.mockReturnValue('1230000');
-    getTokenFiatRateMock.mockReturnValue({ fiatRate: '2.0', usdRate: '3.0' });
+    buildTokenDataMock.mockReturnValue(PAYMENT_TOKEN_MOCK);
 
     getTransactionMock.mockReturnValue({
       id: TRANSACTION_ID_MOCK,
@@ -52,43 +55,23 @@ describe('Update Payment Token Action', () => {
       },
     );
 
+    expect(buildTokenDataMock).toHaveBeenCalledWith({
+      chainId: CHAIN_ID_MOCK,
+      from: FROM_MOCK,
+      messenger: {},
+      tokenAddress: TOKEN_ADDRESS_MOCK,
+    });
+
     expect(updateTransactionDataMock).toHaveBeenCalledTimes(1);
 
     const transactionDataMock = {} as TransactionData;
     updateTransactionDataMock.mock.calls[0][1](transactionDataMock);
 
-    expect(transactionDataMock.paymentToken).toStrictEqual({
-      address: TOKEN_ADDRESS_MOCK,
-      balanceFiat: '2.46',
-      balanceHuman: '1.23',
-      balanceRaw: '1230000',
-      balanceUsd: '3.69',
-      chainId: CHAIN_ID_MOCK,
-      decimals: 6,
-      symbol: 'TST',
-    });
+    expect(transactionDataMock.paymentToken).toStrictEqual(PAYMENT_TOKEN_MOCK);
   });
 
-  it('throws if decimals not found', () => {
-    getTokenInfoMock.mockReturnValue(undefined);
-
-    expect(() =>
-      updatePaymentToken(
-        {
-          chainId: CHAIN_ID_MOCK,
-          tokenAddress: TOKEN_ADDRESS_MOCK,
-          transactionId: TRANSACTION_ID_MOCK,
-        },
-        {
-          messenger: {} as never,
-          updateTransactionData: noop,
-        },
-      ),
-    ).toThrow('Payment token not found');
-  });
-
-  it('throws if token fiat rate not found', () => {
-    getTokenFiatRateMock.mockReturnValue(undefined);
+  it('throws if token data not found', () => {
+    buildTokenDataMock.mockReturnValue(undefined);
 
     expect(() =>
       updatePaymentToken(

--- a/packages/transaction-pay-controller/src/actions/update-payment-token.ts
+++ b/packages/transaction-pay-controller/src/actions/update-payment-token.ts
@@ -1,19 +1,13 @@
 import { createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
-import { BigNumber } from 'bignumber.js';
 
 import type { TransactionPayControllerMessenger } from '..';
 import { projectLogger } from '../logger';
 import type {
-  TransactionPaymentToken,
   UpdatePaymentTokenRequest,
   UpdateTransactionDataCallback,
 } from '../types';
-import {
-  getTokenBalance,
-  getTokenFiatRate,
-  getTokenInfo,
-} from '../utils/token';
+import { buildTokenData } from '../utils/token';
 import { getTransaction } from '../utils/transaction';
 
 const log = createModuleLogger(projectLogger, 'update-payment-token');
@@ -42,7 +36,7 @@ export function updatePaymentToken(
     throw new Error('Transaction not found');
   }
 
-  const paymentToken = getPaymentToken({
+  const paymentToken = buildTokenData({
     chainId,
     from: transaction?.txParams.from as Hex,
     messenger,
@@ -58,64 +52,4 @@ export function updatePaymentToken(
   updateTransactionData(transactionId, (data) => {
     data.paymentToken = paymentToken;
   });
-}
-
-/**
- * Generate the full payment token data from a token address and chain ID.
- *
- * @param request - The payment token request parameters.
- * @param request.chainId - The chain ID.
- * @param request.from - The address to get the token balance for.
- * @param request.messenger - The transaction pay controller messenger.
- * @param request.tokenAddress - The token address.
- * @returns The payment token or undefined if the token data could not be retrieved.
- */
-function getPaymentToken({
-  chainId,
-  from,
-  messenger,
-  tokenAddress,
-}: {
-  chainId: Hex;
-  from: Hex;
-  messenger: TransactionPayControllerMessenger;
-  tokenAddress: Hex;
-}): TransactionPaymentToken | undefined {
-  const { decimals, symbol } =
-    getTokenInfo(messenger, tokenAddress, chainId) ?? {};
-
-  if (decimals === undefined || !symbol) {
-    return undefined;
-  }
-
-  const tokenFiatRate = getTokenFiatRate(messenger, tokenAddress, chainId);
-
-  if (tokenFiatRate === undefined) {
-    return undefined;
-  }
-
-  const balance = getTokenBalance(messenger, from, chainId, tokenAddress);
-  const balanceRawValue = new BigNumber(balance);
-  const balanceHumanValue = new BigNumber(balance).shiftedBy(-decimals);
-  const balanceRaw = balanceRawValue.toFixed(0);
-  const balanceHuman = balanceHumanValue.toString(10);
-
-  const balanceFiat = balanceHumanValue
-    .multipliedBy(tokenFiatRate.fiatRate)
-    .toString(10);
-
-  const balanceUsd = balanceHumanValue
-    .multipliedBy(tokenFiatRate.usdRate)
-    .toString(10);
-
-  return {
-    address: tokenAddress,
-    balanceFiat,
-    balanceHuman,
-    balanceRaw,
-    balanceUsd,
-    chainId,
-    decimals,
-    symbol,
-  };
 }

--- a/packages/transaction-pay-controller/src/tests/messenger-mock.ts
+++ b/packages/transaction-pay-controller/src/tests/messenger-mock.ts
@@ -2,6 +2,7 @@ import type { TokensControllerGetStateAction } from '@metamask/assets-controller
 import type { TokenBalancesControllerGetStateAction } from '@metamask/assets-controllers';
 import type { TokenRatesControllerGetStateAction } from '@metamask/assets-controllers';
 import type { AccountTrackerControllerGetStateAction } from '@metamask/assets-controllers';
+import type { GetTokenListState } from '@metamask/assets-controllers';
 import type { BridgeStatusControllerGetStateAction } from '@metamask/bridge-status-controller';
 import type {
   MessengerActions,
@@ -91,6 +92,10 @@ export function getMessengerMock({
 
   const getTokensControllerStateMock: jest.MockedFn<
     TokensControllerGetStateAction['handler']
+  > = jest.fn();
+
+  const getTokenListControllerStateMock: jest.MockedFn<
+    GetTokenListState['handler']
   > = jest.fn();
 
   const getTokenBalanceControllerStateMock: jest.MockedFn<
@@ -198,6 +203,11 @@ export function getMessengerMock({
     );
 
     messenger.registerActionHandler(
+      'TokenListController:getState',
+      getTokenListControllerStateMock,
+    );
+
+    messenger.registerActionHandler(
       'TokenBalancesController:getState',
       getTokenBalanceControllerStateMock,
     );
@@ -263,6 +273,7 @@ export function getMessengerMock({
     getRemoteFeatureFlagControllerStateMock,
     getStrategyMock,
     getTokenBalanceControllerStateMock,
+    getTokenListControllerStateMock,
     getTokenRatesControllerStateMock,
     getTokensControllerStateMock,
     getTransactionControllerStateMock,


### PR DESCRIPTION
## Explanation
This PR is a pure refactoring + a small enhancement. No withdrawal-specific code.

What it does:
Extracts the token building logic from update-payment-token.ts into a shared buildTokenData() function
Adds getTokenInfoFromTokenList() fallback - looks up tokens from TokenListController if not in user's added tokens

Both are generic utilities that work for any token lookup. The withdrawal-specific code (updateSelectedToken, setIsPostQuote, post-quote logic in buildQuoteRequests) will be in another PR.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how token decimals/symbol are resolved (new `TokenListController` fallback), which can affect balance/fiat calculations and any flows depending on token metadata.
> 
> **Overview**
> **Refactors payment token construction** by extracting the inlined logic in `update-payment-token` into a shared `buildTokenData` utility in `utils/token`.
> 
> **Enhances token lookups** by updating `getTokenInfo` to fall back to `TokenListController` when a token isn’t in the user’s added tokens, and updates the test messenger mock + unit tests to cover the new behavior.
> 
> Updates the package `CHANGELOG.md` to document the refactor and fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a1613ff565a5a750b38eba09cb2ef91b25cb850. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->