### PR TITLE
[DO NOT MERGE]: testing bugbot changes

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -10,13 +10,13 @@ For files matching the pattern `.*(Controller|-controller)\.(ts|js)$`:
 
 - Ensure that the file follows the [controller guidelines](../docs/code-guidelines/controller-guidelines.md).
   - Add a non-blocking bug with a title referencing the controller guideline that is being violated.
-  - Body: "Please review the controller guidelines and follow the recommendations." followed by an explanation of the guideline that is being violated.
+  - Body: "Please review the [controller guidelines](https://github.com/MetaMask/core/blob/main/docs/code-guidelines/controller-guidelines.md) and follow the recommendations." followed by an explanation of the guideline that is being violated.
 
 ## Data service guidelines
 
 For files matching the pattern `.*(Service|-service)\.(ts|js)$`:
 
-- Ensure that the file follows the [data service guidelines](../docs/code-guidelines/data-services.md).
+- Ensure that the file follows the [data service guidelines](https://github.com/MetaMask/core/blob/main/docs/code-guidelines/data-services.md).
   - Add a non-blocking bug with a title referencing the data service guideline that is being violated.
   - Body: "Please review the data service guidelines and follow the recommendations." followed by an explanation of the guideline that is being violated.
 
@@ -24,6 +24,6 @@ For files matching the pattern `.*(Service|-service)\.(ts|js)$`:
 
 For files matching the pattern `.*test\.(ts|js)$`:
 
-- Ensure that the file follows the [unit testing guidelines](../docs/processes/testing.md).
+- Ensure that the file follows the [unit testing guidelines](https://github.com/MetaMask/core/blob/main/docs/processes/testing.md).
   - Add a non-blocking bug with a title referencing the unit testing guideline that is being violated.
   - Body: "Please review the unit testing guidelines and follow the recommendations." followed by an explanation of the guideline that is being violated.

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -201,6 +201,9 @@ describe('AssetsController', () => {
         assetsBalance: {},
         assetsPrice: {},
         customAssets: {},
+        assetsDetails: {},
+        assetCount: 0,
+        internalCache: {},
       });
     });
   });
@@ -213,6 +216,9 @@ describe('AssetsController', () => {
           assetsBalance: {},
           assetsPrice: {},
           customAssets: {},
+          assetsDetails: {},
+          assetCount: 0,
+          internalCache: {},
         });
       });
     });
@@ -242,8 +248,27 @@ describe('AssetsController', () => {
     });
   });
 
+  describe('setAssetPrice', () => {
+    it('updates price for asset', async () => {
+      await withController(async ({ controller }) => {
+        controller.setAssetPrice(MOCK_ASSET_ID, { usd: 1.5 });
+        expect(controller.state.assetsPrice[MOCK_ASSET_ID]).toStrictEqual({
+          usd: 1.5,
+        });
+      });
+    });
+
+    // eslint-disable-next-line jest/expect-expect
+    it('getActiveAssetIds returns keys from assetsMetadata', async () => {
+      await withController(async ({ controller }) => {
+        controller.getActiveAssetIds();
+      });
+    });
+  });
+
   describe('addCustomAsset', () => {
-    it('adds a custom asset to an account', async () => {
+    // eslint-disable-next-line jest/no-focused-tests
+    it.only('adds a custom asset to an account', async () => {
       await withController(async ({ controller }) => {
         await controller.addCustomAsset(MOCK_ACCOUNT_ID, MOCK_ASSET_ID);
 

--- a/packages/assets-controller/src/index.ts
+++ b/packages/assets-controller/src/index.ts
@@ -1,3 +1,5 @@
+export * from './logger';
+
 // Main controller export
 export {
   AssetsController,
@@ -25,6 +27,7 @@ export type {
   AssetsControllerPriceChangedEvent,
   AssetsControllerAssetsDetectedEvent,
   AssetsControllerEvents,
+  AssetsControllerDataRefreshedEvent,
 } from './AssetsController';
 
 // Core types


### PR DESCRIPTION
## Explanation

A few changes made by AI that don't follow the standards of the repo to test the bugbot behaviors.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new state fields and new APIs/events in `AssetsController`, which may affect consumers that assume the previous state shape or rely on messenger-based events. Test changes also introduce a focused `it.only`, which could inadvertently skip the rest of the suite if merged.
> 
> **Overview**
> **AssetsController now exposes additional state and update hooks.** The controller state gains `assetsDetails`, `assetCount`, and `internalCache` (with updated default state and metadata), and the constructor optionally accepts `onStateChange` to receive `AssetsController:stateChange` updates.
> 
> **Adds a manual price update API and a local refresh signal.** New `setAssetPrice` mutates `assetsPrice` and emits a `dataRefreshed` signal via a new internal `hub` (`SimpleEventEmitter`), plus `getActiveAssetIds` to list assets from `assetsMetadata`. The PR also tweaks typing in middleware execution (`state as unknown as AssetsControllerStateInternal`) and marks newly added custom assets in `assetsDetails`.
> 
> **Tests and tooling:** updates `AssetsController` tests for the new state shape and adds coverage for `setAssetPrice`/`getActiveAssetIds`, and introduces `.cursor/BUGBOT.md` PR review guidelines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82dc3bfe89fc4ac4807cdea42244403568b05875. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->