### PR TITLE
feat: Add forceRefreshTokenList method to TokenListController

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `forceRefreshTokenList()` method to `TokenListController` to allow manual refresh of token cache ([#39628](https://github.com/MetaMask/metamask-extension/issues/39628))
+  - Add `TokenListController:forceRefreshTokenList` messenger action
+  - Method bypasses cache validation to fetch fresh token data from API
+  - Useful for refreshing stale token data on Base chain and other supported networks
 - Add `HYPEREVM` support ([#7790](https://github.com/MetaMask/core/pull/7790))
   - Add `HYPEREVM` in `SupportedTokenDetectionNetworks`
   - Add `HYPEREVM` in `SUPPORTED_NETWORKS_ACCOUNTS_API_V4`

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -2117,6 +2117,184 @@ describe('TokenListController', () => {
       controller.destroy();
     });
   });
+
+  describe('forceRefreshTokenList', () => {
+    it('should force refresh token list even when cache is valid', async () => {
+      nock(tokenService.TOKEN_END_POINT_API)
+        .get(getTokensPath(ChainId.mainnet))
+        .reply(200, sampleMainnetTokenList)
+        .persist();
+
+      const messenger = getMessenger();
+      const restrictedMessenger = getRestrictedMessenger(messenger);
+      const controller = new TokenListController({
+        chainId: ChainId.mainnet,
+        messenger: restrictedMessenger,
+        cacheRefreshThreshold: 4 * 60 * 60 * 1000, // 4 hours
+      });
+      await controller.initialize();
+
+      // First fetch to populate cache
+      await controller.fetchTokenList(ChainId.mainnet);
+      const initialTimestamp =
+        controller.state.tokensChainsCache[ChainId.mainnet]?.timestamp;
+      expect(initialTimestamp).toBeDefined();
+
+      // Wait a bit to ensure timestamp would be different
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Force refresh - should bypass cache validation
+      await controller.forceRefreshTokenList(ChainId.mainnet);
+
+      const refreshedTimestamp =
+        controller.state.tokensChainsCache[ChainId.mainnet]?.timestamp;
+      expect(refreshedTimestamp).toBeDefined();
+      expect(refreshedTimestamp).toBeGreaterThan(initialTimestamp as number);
+
+      // Verify data is still correct
+      expect(
+        controller.state.tokensChainsCache[ChainId.mainnet].data,
+      ).toStrictEqual(
+        sampleSingleChainState.tokensChainsCache[ChainId.mainnet].data,
+      );
+
+      controller.destroy();
+    });
+
+    it('should work via messenger action', async () => {
+      nock(tokenService.TOKEN_END_POINT_API)
+        .get(getTokensPath(ChainId.mainnet))
+        .reply(200, sampleMainnetTokenList)
+        .persist();
+
+      const messenger = getMessenger();
+      const restrictedMessenger = getRestrictedMessenger(messenger);
+      const controller = new TokenListController({
+        chainId: ChainId.mainnet,
+        messenger: restrictedMessenger,
+      });
+      await controller.initialize();
+
+      // First fetch to populate cache
+      await controller.fetchTokenList(ChainId.mainnet);
+      const initialTimestamp =
+        controller.state.tokensChainsCache[ChainId.mainnet]?.timestamp;
+      expect(initialTimestamp).toBeDefined();
+
+      // Wait a bit to ensure timestamp would be different
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Force refresh via messenger action
+      await messenger.call('TokenListController:forceRefreshTokenList', ChainId.mainnet);
+
+      const refreshedTimestamp =
+        controller.state.tokensChainsCache[ChainId.mainnet]?.timestamp;
+      expect(refreshedTimestamp).toBeDefined();
+      expect(refreshedTimestamp).toBeGreaterThan(initialTimestamp as number);
+
+      controller.destroy();
+    });
+
+    it('should not refresh for unsupported networks', async () => {
+      const messenger = getMessenger();
+      const restrictedMessenger = getRestrictedMessenger(messenger);
+      const controller = new TokenListController({
+        chainId: ChainId.mainnet,
+        messenger: restrictedMessenger,
+      });
+      await controller.initialize();
+
+      const unsupportedChainId = '0x1337' as Hex;
+      const initialState = { ...controller.state.tokensChainsCache };
+
+      // Should return early without error
+      await controller.forceRefreshTokenList(unsupportedChainId);
+
+      // State should remain unchanged
+      expect(controller.state.tokensChainsCache).toStrictEqual(initialState);
+
+      controller.destroy();
+    });
+
+    it('should handle API errors gracefully', async () => {
+      nock(tokenService.TOKEN_END_POINT_API)
+        .get(getTokensPath(ChainId.mainnet))
+        .reply(500, { error: 'Internal Server Error' })
+        .persist();
+
+      const messenger = getMessenger();
+      const restrictedMessenger = getRestrictedMessenger(messenger);
+      const controller = new TokenListController({
+        chainId: ChainId.mainnet,
+        messenger: restrictedMessenger,
+        state: {
+          tokensChainsCache: {
+            [ChainId.mainnet]: {
+              data: sampleMainnetTokensChainsCache,
+              timestamp: Date.now(),
+            },
+          },
+        },
+      });
+      await controller.initialize();
+
+      const existingCache = controller.state.tokensChainsCache[ChainId.mainnet];
+      expect(existingCache).toBeDefined();
+
+      // Force refresh should handle error gracefully
+      await controller.forceRefreshTokenList(ChainId.mainnet);
+
+      // Cache should remain unchanged on error
+      expect(controller.state.tokensChainsCache[ChainId.mainnet]).toStrictEqual(
+        existingCache,
+      );
+
+      controller.destroy();
+    });
+
+    it('should refresh Base chain (0x2105) token list', async () => {
+      const baseChainId = '0x2105' as Hex;
+      const baseTokenList = [
+        {
+          address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          symbol: 'USDC',
+          decimals: 6,
+          occurrences: 5,
+          name: 'USD Coin',
+          aggregators: ['CoinGecko', '1inch'],
+          iconUrl: `https://static.cx.metamask.io/api/v1/tokenIcons/${convertHexToDecimal(baseChainId)}/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913.png`,
+        },
+      ];
+
+      nock(tokenService.TOKEN_END_POINT_API)
+        .get(getTokensPath(baseChainId))
+        .reply(200, baseTokenList)
+        .persist();
+
+      const messenger = getMessenger();
+      const restrictedMessenger = getRestrictedMessenger(messenger);
+      const controller = new TokenListController({
+        chainId: baseChainId,
+        messenger: restrictedMessenger,
+        cacheRefreshThreshold: 4 * 60 * 60 * 1000, // 4 hours
+      });
+      await controller.initialize();
+
+      // Force refresh Base chain
+      await controller.forceRefreshTokenList(baseChainId);
+
+      const cache = controller.state.tokensChainsCache[baseChainId];
+      expect(cache).toBeDefined();
+      expect(cache?.data).toBeDefined();
+      expect(cache?.timestamp).toBeDefined();
+      expect(cache?.data['0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913']).toBeDefined();
+      expect(
+        cache?.data['0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'].symbol,
+      ).toBe('USDC');
+
+      controller.destroy();
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
## Description

This PR adds a `forceRefreshTokenList()` method to `TokenListController` to allow manual refresh of token cache, bypassing cache validation. This addresses the issue where Base chain (and other chains) token cache can remain stale for extended periods.

## Related Issue

Fixes #39628

## Explanation

### What is the current state of things and why does it need to change?

Currently, `TokenListController` caches token list data in `tokensChainsCache` with a 4-hour TTL. The `fetchTokenList()` method checks cache validity using `isCacheValid()` and returns early if the cache is still valid, preventing fresh data from being fetched even when upstream token lists have been updated. This is particularly problematic on Base chain (chainId: 8453 / 0x2105) where users have reported stale token data persisting for days, with no way to manually trigger a refresh.

### What is the solution your changes offer and how does it work?

The solution adds a new `forceRefreshTokenList(chainId: Hex)` method that bypasses cache validation entirely. When called, it:
1. Checks if the chain supports token lists
2. Fetches fresh data from the Token Service API regardless of cache validity
3. Updates the cache with new data and timestamp
4. Handles API errors gracefully by preserving existing cache

The method is also exposed via a messenger action `TokenListController:forceRefreshTokenList`, allowing external controllers and UI components to programmatically trigger cache refreshes when needed.

### Are there any changes whose purpose might not obvious to those unfamiliar with the domain?

- The method is registered in the `initialize()` method rather than the constructor to ensure the controller is fully set up before action handlers are registered
- The method follows the same error handling pattern as `fetchTokenList()` to maintain consistency
- Cache persistence happens automatically via the existing state change subscription mechanism

### If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?

No other packages were updated. All changes are contained within `@metamask/assets-controllers`.

### If you had to upgrade a dependency, why did you do so?

No dependencies were upgraded.

## References
https://github.com/MetaMask/metamask-extension/issues/39628
- Fixes #39628 - Base chain tokensChainsCache not refreshing, stale token data persists with no manual refresh trigger

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed
- [x] I've introduced breaking changes in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

## Changes

- **Added** `forceRefreshTokenList()` method to `TokenListController`
- **Added** `TokenListController:forceRefreshTokenList` messenger action
- **Added** comprehensive test coverage for force refresh functionality
- **Updated** CHANGELOG.md

## Testing

-  Force refresh when cache is valid
-  Messenger action integration
-  Unsupported network handling
-  API error handling
-  Base chain (0x2105) specific test

## Usage

// Direct method call
await tokenListController.forceRefreshTokenList('0x2105'); // Base chain

// Via messenger action
await messenger.call('TokenListController:forceRefreshTokenList', '0x2105');

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public API and messenger action that triggers network calls and state updates regardless of cache TTL, so misuse could increase request volume or alter refresh behavior across clients; logic change is localized and covered by new tests.
> 
> **Overview**
> Adds `TokenListController.forceRefreshTokenList(chainId)` and a new messenger action `TokenListController:forceRefreshTokenList` to bypass cache TTL and fetch fresh token data on demand.
> 
> Refactors fetching so both normal refresh and forced refresh share an internal `#fetchAndUpdateTokenList` helper, and ensures the new action handler is registered on `initialize()` and unregistered on `destroy()`.
> 
> Expands `TokenListController` tests to cover forced refresh behavior (valid cache, messenger invocation, unsupported networks, API error no-op, and Base `0x2105` refresh) and updates the package changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ef68d88811d601e0985764877bc427823e9e8af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->