### PR TITLE
[DRAFT]: FiatStrategy PoC implementation

### DIFF
--- a/packages/transaction-pay-controller/src/constants.ts
+++ b/packages/transaction-pay-controller/src/constants.ts
@@ -17,4 +17,5 @@ export enum TransactionPayStrategy {
   Bridge = 'bridge',
   Relay = 'relay',
   Test = 'test',
+  Fiat = 'fiat',
 }

--- a/packages/transaction-pay-controller/src/index.ts
+++ b/packages/transaction-pay-controller/src/index.ts
@@ -1,4 +1,7 @@
 export type {
+  FiatPaymentData,
+  FiatPaymentQuote,
+  TransactionData,
   TransactionPayControllerActions,
   TransactionPayControllerEvents,
   TransactionPayControllerGetDelegationTransactionAction,
@@ -6,6 +9,7 @@ export type {
   TransactionPayControllerGetStrategyAction,
   TransactionPayControllerMessenger,
   TransactionPayControllerOptions,
+  TransactionPayControllerSetFiatPaymentAction,
   TransactionPayControllerSetIsMaxAmountAction,
   TransactionPayControllerState,
   TransactionPayControllerStateChangeEvent,

--- a/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.ts
@@ -1,0 +1,112 @@
+import type { Hex } from '@metamask/utils';
+import { createModuleLogger } from '@metamask/utils';
+
+import { TransactionPayStrategy } from '../..';
+import { projectLogger } from '../../logger';
+import type {
+  PayStrategy,
+  PayStrategyExecuteRequest,
+  PayStrategyGetQuotesRequest,
+  TransactionPayQuote,
+} from '../../types';
+
+const log = createModuleLogger(projectLogger, 'fiat-strategy');
+
+const MOCK_TRANSACTION_HASH =
+  '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex;
+
+const POC_DELAY_MS = 5000; // 5 seconds
+
+export class FiatStrategy implements PayStrategy<void> {
+  async getQuotes(
+    request: PayStrategyGetQuotesRequest,
+  ): Promise<TransactionPayQuote<void>[]> {
+    const { messenger, requests, transaction } = request;
+
+    log('Getting fiat quotes (PoC mock)', { transactionId: transaction.id });
+
+    // Get required tokens from controller state to compute fee
+    const state = messenger.call('TransactionPayController:getState');
+    const transactionData = state.transactionData?.[transaction.id];
+    const tokens = transactionData?.tokens ?? [];
+
+    // Sum up the USD amounts of required tokens (excluding skipIfBalance)
+    const requiredTokens = tokens.filter((token) => !token.skipIfBalance);
+    const baseAmountUsd = requiredTokens.reduce(
+      (sum, token) => sum + parseFloat(token.amountUsd || '0'),
+      0,
+    );
+
+    // Compute 2% provider fee
+    const providerFeeUsd = baseAmountUsd * 0.02;
+
+    // Use the dummy request passed in (from buildFiatQuoteRequests)
+    const dummyRequest = requests[0];
+
+    // PoC: Return a single mocked quote with computed fee
+    return [
+      {
+        dust: { fiat: '0', usd: '0' },
+        estimatedDuration: POC_DELAY_MS / 1000,
+        fees: {
+          provider: {
+            fiat: providerFeeUsd.toFixed(2),
+            usd: providerFeeUsd.toFixed(2),
+          },
+          sourceNetwork: {
+            estimate: {
+              human: '0',
+              fiat: '0',
+              usd: '0',
+              raw: '0',
+            },
+            max: {
+              human: '0',
+              fiat: '0',
+              usd: '0',
+              raw: '0',
+            },
+          },
+          targetNetwork: {
+            fiat: '0',
+            usd: '0',
+          },
+        },
+        original: undefined,
+        request: dummyRequest,
+        sourceAmount: {
+          human: baseAmountUsd.toFixed(2),
+          fiat: baseAmountUsd.toFixed(2),
+          raw: baseAmountUsd.toFixed(2),
+          usd: baseAmountUsd.toFixed(2),
+        },
+        targetAmount: {
+          human: baseAmountUsd.toFixed(2),
+          fiat: baseAmountUsd.toFixed(2),
+          raw: baseAmountUsd.toFixed(2),
+          usd: baseAmountUsd.toFixed(2),
+        },
+        strategy: TransactionPayStrategy.Fiat,
+      },
+    ];
+  }
+
+  async execute(
+    request: PayStrategyExecuteRequest<void>,
+  ): ReturnType<PayStrategy<void>['execute']> {
+    const { quotes } = request;
+
+    log('Executing fiat strategy (PoC mock)', quotes);
+    log(`Waiting ${POC_DELAY_MS / 1000} seconds...`);
+
+    await this.#timeout(POC_DELAY_MS);
+
+    log('Returning mock transaction hash:', MOCK_TRANSACTION_HASH);
+
+    return { transactionHash: MOCK_TRANSACTION_HASH };
+  }
+
+  #timeout(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/packages/transaction-pay-controller/src/utils/source-amounts.ts
+++ b/packages/transaction-pay-controller/src/utils/source-amounts.ts
@@ -31,7 +31,7 @@ export function updateSourceAmounts(
   transactionData: TransactionData | undefined,
   messenger: TransactionPayControllerMessenger,
 ): void {
-  if (!transactionData) {
+  if (!transactionData || transactionData.fiatPayment) {
     return;
   }
 

--- a/packages/transaction-pay-controller/src/utils/strategy.ts
+++ b/packages/transaction-pay-controller/src/utils/strategy.ts
@@ -2,6 +2,7 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 
 import { TransactionPayStrategy } from '../constants';
 import { BridgeStrategy } from '../strategy/bridge/BridgeStrategy';
+import { FiatStrategy } from '../strategy/fiat/FiatStrategy';
 import { RelayStrategy } from '../strategy/relay/RelayStrategy';
 import { TestStrategy } from '../strategy/test/TestStrategy';
 import type { PayStrategy, TransactionPayControllerMessenger } from '../types';
@@ -43,6 +44,9 @@ export function getStrategyByName(
 
     case TransactionPayStrategy.Test:
       return new TestStrategy() as never;
+
+    case TransactionPayStrategy.Fiat:
+      return new FiatStrategy() as never;
 
     default:
       throw new Error(`Unknown strategy: ${strategyName as string}`);


### PR DESCRIPTION
- Added new strategy enum: `TransactionPayStrategy.Fiat`.
- Added fiat marker on controller state: `TransactionData.fiatPayment?: FiatPaymentData`.
- Added controller method/action: `TransactionPayController.setFiatPayment(transactionId, fiatPayment)`.
  - When fiatPayment is set, it clears token-based fields (`paymentToken`, `sourceAmounts`, `quotes`, `totals`, etc.) and stops loading.
- Added `FiatStrategy`:
  - `getQuotes()` logs `fiat-strategy` and returns a single mock quote (provider fee = 2% of required token USD sum).
  - `execute()` waits ~30s, then returns a deterministic mock hash.
- Integrated strategy resolution via `getStrategyByName()`.