### PR TITLE
feat: ctrl-utils add 4 networks infura

### DIFF
--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add 4 networks to supported Infura networks list ([#7875](https://github.com/MetaMask/core/pull/7875))
+  - Add `avalanche-mainnet` to `InfuraNetworkType`, `NetworksTicker`, `BlockExplorerUrl` and `NetworkNickname`.
+  - Add `monad-mainnet` to `InfuraNetworkType`, `NetworksTicker`, `BlockExplorerUrl` and `NetworkNickname`.
+  - Add `hyperevm-mainnet` to `InfuraNetworkType`, `NetworksTicker`, `BlockExplorerUrl` and `NetworkNickname`.
+  - Add `megaeth-mainnet` to `InfuraNetworkType`, `NetworksTicker`, `BlockExplorerUrl` and `NetworkNickname`.
+
 ## [11.18.0]
 
 ### Changed

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -13,7 +13,11 @@ export const InfuraNetworkType = {
   'bsc-mainnet': 'bsc-mainnet',
   'optimism-mainnet': 'optimism-mainnet',
   'polygon-mainnet': 'polygon-mainnet',
+  'avalanche-mainnet': 'avalanche-mainnet',
   'sei-mainnet': 'sei-mainnet',
+  'monad-mainnet': 'monad-mainnet',
+  'hyperevm-mainnet': 'hyperevm-mainnet',
+  'megaeth-mainnet': 'megaeth-mainnet',
 } as const;
 
 export type InfuraNetworkType =
@@ -98,6 +102,10 @@ export enum BuiltInNetworkName {
   OptimismMainnet = 'optimism-mainnet',
   PolygonMainnet = 'polygon-mainnet',
   SeiMainnet = 'sei-mainnet',
+  AvalancheMainnet = 'avalanche-mainnet',
+  MonadMainnet = 'monad-mainnet',
+  HyperevmMainnet = 'hyperevm-mainnet',
+  MegaETHMainnet = 'megaeth-mainnet',
 }
 
 /**
@@ -125,6 +133,10 @@ export const ChainId = {
   [BuiltInNetworkName.OptimismMainnet]: '0xa', // toHex(10)
   [BuiltInNetworkName.PolygonMainnet]: '0x89', // toHex(137)
   [BuiltInNetworkName.SeiMainnet]: '0x531', // toHex(1329)
+  [BuiltInNetworkName.AvalancheMainnet]: '0xa86a', // toHex(43114)
+  [BuiltInNetworkName.MonadMainnet]: '0x8f', // toHex(143)
+  [BuiltInNetworkName.HyperevmMainnet]: '0x3e7', // toHex(999)
+  [BuiltInNetworkName.MegaETHMainnet]: '0x10e6', // toHex(4326)
 } as const;
 export type ChainId = (typeof ChainId)[keyof typeof ChainId];
 
@@ -154,6 +166,12 @@ export enum NetworksTicker {
   'optimism-mainnet' = 'ETH',
   'polygon-mainnet' = 'POL',
   'sei-mainnet' = 'SEI',
+  'avalanche-mainnet' = 'AVAX',
+  // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
+  'monad-mainnet' = 'MON',
+  'hyperevm-mainnet' = 'HYPE',
+  // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
+  'megaeth-mainnet' = 'ETH',
   rpc = '',
 }
 /* eslint-enable @typescript-eslint/naming-convention */
@@ -178,6 +196,10 @@ export const BlockExplorerUrl = {
   [BuiltInNetworkName.OptimismMainnet]: 'https://optimistic.etherscan.io',
   [BuiltInNetworkName.PolygonMainnet]: 'https://polygonscan.com',
   [BuiltInNetworkName.SeiMainnet]: 'https://seitrace.com',
+  [BuiltInNetworkName.AvalancheMainnet]: 'https://snowtrace.io',
+  [BuiltInNetworkName.MonadMainnet]: 'https://monadscan.com',
+  [BuiltInNetworkName.HyperevmMainnet]: 'https://hyperevmscan.io',
+  [BuiltInNetworkName.MegaETHMainnet]: 'https://megaeth.blockscout.com',
 } as const satisfies Record<BuiltInNetworkType, string>;
 export type BlockExplorerUrl =
   (typeof BlockExplorerUrl)[keyof typeof BlockExplorerUrl];
@@ -201,6 +223,10 @@ export const NetworkNickname = {
   [BuiltInNetworkName.OptimismMainnet]: 'Optimism Mainnet',
   [BuiltInNetworkName.PolygonMainnet]: 'Polygon Mainnet',
   [BuiltInNetworkName.SeiMainnet]: 'Sei Mainnet',
+  [BuiltInNetworkName.AvalancheMainnet]: 'Avalanche',
+  [BuiltInNetworkName.MonadMainnet]: 'Monad',
+  [BuiltInNetworkName.HyperevmMainnet]: 'HyperEVM',
+  [BuiltInNetworkName.MegaETHMainnet]: 'MegaETH',
 } as const satisfies Record<BuiltInNetworkType, string>;
 export type NetworkNickname =
   (typeof NetworkNickname)[keyof typeof NetworkNickname];


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

- This PR adds 4 networks to supported Infura networks list ([#7875](https://github.com/MetaMask/core/pull/7875))
  - Add `avalanche-mainnet` to `InfuraNetworkType`
  - Add `monad-mainnet` to `InfuraNetworkType`
  - Add `hyperevm-mainnet` to `InfuraNetworkType`
  - Add `megaeth-mainnet` to `InfuraNetworkType`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Related to: https://consensyssoftware.atlassian.net/browse/NEB-496?atlOrigin=eyJpIjoiOWI0NjhlODE2NDdkNDNiOGEwMjdmMzcwYTY4OTI0MzEiLCJwIjoiaiJ9

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constant/type expansions only; risk is limited to consumers relying on exhaustive network lists or switch statements needing to handle the new values.
> 
> **Overview**
> Adds support for four additional Infura networks in `@metamask/controller-utils`: `avalanche-mainnet`, `monad-mainnet`, `hyperevm-mainnet`, and `megaeth-mainnet`.
> 
> Updates `src/types.ts` to include these networks across `InfuraNetworkType`, `BuiltInNetworkName`, `ChainId`, `NetworksTicker`, `BlockExplorerUrl`, and `NetworkNickname`, and documents the addition in the package changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b839a84677e079b6427a5a419722f3054fbdbc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->