### PR TITLE
fix: do not fetch payment methods until a user has selected a token

### DIFF
--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `setSelectedProvider` no longer fetches payment methods when no token is selected ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+  - Previously, the `tokenSupportedByProvider` guard evaluated to `true` when no token was selected (vacuous truth), causing an unfiltered payment methods fetch with an empty `crypto` parameter. The guard now requires a token to be selected before triggering the fetch.
+
 ## [12.1.0]
 
 ### Added

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `setSelectedProvider` no longer fetches payment methods when no token is selected ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+- `setSelectedProvider` no longer fetches payment methods when no token is selected ([#8342](https://github.com/MetaMask/core/pull/8342))
   - Previously, the `tokenSupportedByProvider` guard evaluated to `true` when no token was selected (vacuous truth), causing an unfiltered payment methods fetch with an empty `crypto` parameter. The guard now requires a token to be selected before triggering the fetch.
 
 ## [12.1.0]

--- a/packages/ramps-controller/src/RampsController.test.ts
+++ b/packages/ramps-controller/src/RampsController.test.ts
@@ -2869,10 +2869,20 @@ describe('RampsController', () => {
       );
     });
 
-    it('fetches getPaymentMethods when provider has no supportedCryptoCurrencies field', async () => {
+    it('fetches getPaymentMethods when provider has no supportedCryptoCurrencies field and a token is selected', async () => {
       const providerWithoutField: Provider = { ...mockProvider };
       delete (providerWithoutField as Partial<Provider>)
         .supportedCryptoCurrencies;
+
+      const selectedToken: RampsToken = {
+        assetId: 'eip155:1/slip44:60',
+        chainId: 'eip155:1',
+        name: 'Ether',
+        symbol: 'ETH',
+        decimals: 18,
+        iconUrl: '',
+        tokenSupported: true,
+      };
 
       const getPaymentMethodsMock = jest.fn(async () => ({ payments: [] }));
 
@@ -2882,6 +2892,7 @@ describe('RampsController', () => {
             state: {
               userRegion: createMockUserRegion('us-ca'),
               providers: createResourceState([providerWithoutField], null),
+              tokens: createResourceState(null, selectedToken),
             },
           },
         },
@@ -2899,6 +2910,36 @@ describe('RampsController', () => {
           await new Promise((resolve) => setTimeout(resolve, 0));
 
           expect(getPaymentMethodsMock).toHaveBeenCalledTimes(1);
+        },
+      );
+    });
+
+    it('skips getPaymentMethods when no token is selected', async () => {
+      const getPaymentMethodsMock = jest.fn(async () => ({ payments: [] }));
+
+      await withController(
+        {
+          options: {
+            state: {
+              userRegion: createMockUserRegion('us-ca'),
+              providers: createResourceState([mockProvider], null),
+            },
+          },
+        },
+        async ({ rootMessenger }) => {
+          rootMessenger.registerActionHandler(
+            'RampsService:getPaymentMethods',
+            getPaymentMethodsMock,
+          );
+
+          rootMessenger.call(
+            'RampsController:setSelectedProvider',
+            mockProvider.id,
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 0));
+
+          expect(getPaymentMethodsMock).not.toHaveBeenCalled();
         },
       );
     });
@@ -4417,6 +4458,16 @@ describe('RampsController', () => {
     });
 
     it('does not update paymentMethods when selectedProvider changes during request', async () => {
+      const selectedToken: RampsToken = {
+        assetId: 'eip155:1/slip44:60',
+        chainId: 'eip155:1',
+        name: 'Ether',
+        symbol: 'ETH',
+        decimals: 18,
+        iconUrl: '',
+        tokenSupported: true,
+      };
+
       const providerA: Provider = {
         id: '/providers/provider-a',
         name: 'Provider A',
@@ -4472,7 +4523,7 @@ describe('RampsController', () => {
           options: {
             state: {
               userRegion: createMockUserRegion('us-ca'),
-              tokens: createResourceState(null, null),
+              tokens: createResourceState(null, selectedToken),
               providers: createResourceState([providerA, providerB], providerA),
               paymentMethods: createResourceState([], null),
             },

--- a/packages/ramps-controller/src/RampsController.ts
+++ b/packages/ramps-controller/src/RampsController.ts
@@ -1228,14 +1228,13 @@ export class RampsController extends BaseController<
     const selectedToken = this.state.tokens.selected;
     const supportedCryptos = provider.supportedCryptoCurrencies;
 
-    // Only fetch payment methods if the selected token is supported by the new
-    // provider. If it isn't, the payment methods request would fail or return
-    // empty for the wrong reason; the UI will show the Token Not Available modal
-    // so the user can change token or pick a different provider.
+    // Only fetch payment methods when a token is selected AND that token is
+    // supported by the new provider. Without a token the API receives an empty
+    // `crypto` param and returns an unfiltered list — payment methods must
+    // always be scoped to a specific token.
     const assetId = selectedToken?.assetId;
-    const tokenSupportedByProvider = !(
-      assetId && supportedCryptos?.[assetId] === false
-    );
+    const shouldFetchPaymentMethods =
+      Boolean(assetId) && !(supportedCryptos?.[assetId as string] === false);
 
     this.update((state) => {
       state.providers.selected = provider;
@@ -1243,7 +1242,7 @@ export class RampsController extends BaseController<
       resetResource(state, 'paymentMethods');
     });
 
-    if (tokenSupportedByProvider) {
+    if (shouldFetchPaymentMethods) {
       this.#fireAndForget(
         this.getPaymentMethods(regionCode, { provider: provider.id }),
       );


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Fixes a small bug where payment methods were fetched and set prematurely.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bug fix that only tightens the conditions for when `getPaymentMethods` is triggered, with updated tests and changelog entry to match.
> 
> **Overview**
> Prevents `setSelectedProvider` from calling `getPaymentMethods` unless a token is selected *and* that token isn’t explicitly excluded by the provider, avoiding unfiltered payment-method fetches with an empty `crypto` parameter.
> 
> Updates unit tests to require a selected token for the “no `supportedCryptoCurrencies` field” case and adds a new test asserting the fetch is skipped when no token is selected, plus a changelog entry documenting the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2ba97f25d760094fd3c7ca670c600c75317d95f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->