### PR TITLE
fix: Remove dynamic imports, move myx to optional dependencies

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -77,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **BREAKING:** Remove `adaptMarketFromMYX`, `adaptPriceFromMYX`, `adaptMarketDataFromMYX`, `filterMYXExclusiveMarkets`, `isOverlappingMarket`, `buildPoolSymbolMap`, `buildSymbolPoolsMap`, and `extractSymbolFromPoolId` from the public package exports to prevent `@myx-trade/sdk` from being included in the static webpack bundle
+- **BREAKING:** Remove `adaptMarketFromMYX`, `adaptPriceFromMYX`, `adaptMarketDataFromMYX`, `filterMYXExclusiveMarkets`, `isOverlappingMarket`, `buildPoolSymbolMap`, `buildSymbolPoolsMap`, and `extractSymbolFromPoolId` from the public package exports to prevent `@myx-trade/sdk` from being included in the static webpack bundle ([#8374](https://github.com/MetaMask/core/pull/8374))
   - These functions are still used internally by `MYXProvider`, which is loaded via dynamic import
   - Consumers that imported these utilities directly should instead import from `@metamask/perps-controller/src/utils/myxAdapter` or duplicate the logic locally
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -75,6 +75,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.0` ([#8364](https://github.com/MetaMask/core/pull/8364))
 
+### Removed
+
+- **BREAKING:** Remove `adaptMarketFromMYX`, `adaptPriceFromMYX`, `adaptMarketDataFromMYX`, `filterMYXExclusiveMarkets`, `isOverlappingMarket`, `buildPoolSymbolMap`, `buildSymbolPoolsMap`, and `extractSymbolFromPoolId` from the public package exports to prevent `@myx-trade/sdk` from being included in the static webpack bundle
+  - These functions are still used internally by `MYXProvider`, which is loaded via dynamic import
+  - Consumers that imported these utilities directly should instead import from `@metamask/perps-controller/src/utils/myxAdapter` or duplicate the logic locally
+
 ### Fixed
 
 - Fix incorrect fee estimate when flipping a position ([#8333](https://github.com/MetaMask/core/pull/8333))

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -61,9 +61,6 @@
     "reselect": "^5.1.1",
     "uuid": "^8.3.2"
   },
-  "optionalDependencies": {
-    "@myx-trade/sdk": "^0.1.265"
-  },
   "devDependencies": {
     "@metamask/account-tree-controller": "^7.0.0",
     "@metamask/auto-changelog": "^3.4.4",
@@ -84,6 +81,9 @@
     "typedoc": "^0.25.13",
     "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "~5.3.3"
+  },
+  "optionalDependencies": {
+    "@myx-trade/sdk": "^0.1.265"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -56,11 +56,13 @@
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.0",
     "@metamask/utils": "^11.9.0",
-    "@myx-trade/sdk": "^0.1.265",
     "@nktkas/hyperliquid": "^0.30.2",
     "bignumber.js": "^9.1.2",
     "reselect": "^5.1.1",
     "uuid": "^8.3.2"
+  },
+  "optionalDependencies": {
+    "@myx-trade/sdk": "^0.1.265"
   },
   "devDependencies": {
     "@metamask/account-tree-controller": "^7.0.0",

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -1694,7 +1694,9 @@ export class PerpsController extends BaseController<
       // IMPORTANT: Must use import() — NOT require() — for core/extension tree-shaking.
       // require() is synchronous and bundlers include it in the main bundle.
       // import() enables true code splitting so MYX is excluded when not enabled.
-      this.#myxRegistrationPromise = import(/* webpackIgnore: true */ './providers/MYXProvider')
+      this.#myxRegistrationPromise = import(
+        /* webpackIgnore: true */ './providers/MYXProvider'
+      )
         .then(({ MYXProvider }) => {
           this.registerMYXProvider(MYXProvider);
           return undefined;

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -1694,7 +1694,7 @@ export class PerpsController extends BaseController<
       // IMPORTANT: Must use import() — NOT require() — for core/extension tree-shaking.
       // require() is synchronous and bundlers include it in the main bundle.
       // import() enables true code splitting so MYX is excluded when not enabled.
-      this.#myxRegistrationPromise = import('./providers/MYXProvider')
+      this.#myxRegistrationPromise = import(/* webpackIgnore: true */ './providers/MYXProvider')
         .then(({ MYXProvider }) => {
           this.registerMYXProvider(MYXProvider);
           return undefined;

--- a/packages/perps-controller/src/index.ts
+++ b/packages/perps-controller/src/index.ts
@@ -464,16 +464,6 @@ export {
 } from './utils';
 export type { HyperLiquidMarketData } from './utils';
 export {
-  adaptMarketFromMYX,
-  adaptPriceFromMYX,
-  adaptMarketDataFromMYX,
-  filterMYXExclusiveMarkets,
-  isOverlappingMarket,
-  buildPoolSymbolMap,
-  buildSymbolPoolsMap,
-  extractSymbolFromPoolId,
-} from './utils';
-export {
   MAX_MARKET_PATTERN_LENGTH,
   escapeRegex,
   validateMarketPattern,

--- a/packages/perps-controller/src/utils/index.ts
+++ b/packages/perps-controller/src/utils/index.ts
@@ -24,7 +24,6 @@ export * from './hyperLiquidOrderBookProcessor';
 export * from './hyperLiquidValidation';
 export * from './idUtils';
 export * from './marketDataTransform';
-export * from './myxAdapter';
 export * from './marketUtils';
 export * from './orderCalculations';
 export * from './rewardsUtils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4791,6 +4791,9 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.3.3"
     uuid: "npm:^8.3.2"
+  dependenciesMeta:
+    "@myx-trade/sdk":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Explanation

Fixes two related issues that caused webpack build failures and LavaMoat policy violations in the MetaMask extension when consuming @metamask/perps-controller@2.0.0: @myx-trade/sdk was being pulled into the static bundle, and webpack was failing to statically resolve MYXProvider.mjs which was intentionally excluded from the published dist/.

**Root Cause**

Two separate problems stemmed from the same underlying issue — MYX-related code was leaking into the static import graph even though MYX is not yet ready to ship.

Problem 1 — @myx-trade/sdk in the static bundle (LavaMoat violation)

The static import chain was:

```
dist/index.mjs
  → dist/utils/index.mjs        (export * from './myxAdapter')
  → dist/utils/myxAdapter.mjs   (imports MYXDirection, MYXDirectionEnum, etc.)
  → dist/types/myx-types.mjs    (re-exports values from @myx-trade/sdk)
  → @myx-trade/sdk              ← webpack pulls this in statically
```

Because myxAdapter.ts was re-exported from the package's public barrel (utils/index.ts → index.ts), webpack included @myx-trade/sdk in the bundle at build time. LavaMoat then flagged it because there was no policy entry for it.

Problem 2 — webpack static analysis failure on missing MYXProvider.mjs

`dist/PerpsController.mjs` contained `import('./providers/MYXProvider.mjs')` without a `webpackIgnore` hint. `MYXProvider.mjs` was intentionally excluded from the published dist (via package.json files exclusions), but webpack's static analysis tried to resolve it at build time before the runtime handleMYXImportError catch handler could do anything.

**Changes**

src/utils/index.ts — Remove export * from './myxAdapter' from the utils barrel. This severs myxAdapter.ts from the static import graph entirely.

src/index.ts — Remove the eight myxAdapter functions (adaptMarketFromMYX, adaptPriceFromMYX, adaptMarketDataFromMYX, filterMYXExclusiveMarkets, isOverlappingMarket, buildPoolSymbolMap, buildSymbolPoolsMap, extractSymbolFromPoolId) from the package's public exports. A codebase-wide search confirmed zero external consumers of these functions — they are used only internally by MYXProvider, which continues to import them directly via relative path and remains fully functional inside the dynamic-import boundary.

src/PerpsController.ts — Add /* webpackIgnore: true */ to the MYXProvider dynamic import. This instructs webpack to skip static resolution entirely. The existing handleMYXImportError catch handler already gracefully swallows the module-not-found error at runtime.

package.json — Move @myx-trade/sdk from dependencies to optionalDependencies. This prevents the extension (and other consumers) from installing it automatically, while keeping it available for developers working on MYX locally.

After These Changes
@myx-trade/sdk is only reachable through the dynamic-import boundary (MYXProvider), so webpack never processes it at build time and LavaMoat never needs a policy entry for it.

Breaking Change
The eight MYX adapter functions listed above are no longer public exports of @metamask/perps-controller. Since no external consumers were found, the practical impact is zero.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a **breaking API surface change** (removing MYX adapter utilities from public exports) and alters bundling behavior via dynamic-import hints and optional dependency resolution, which could impact downstream builds.
> 
> **Overview**
> Prevents MYX-related code (and `@myx-trade/sdk`) from being pulled into consumers’ static bundles by making `@myx-trade/sdk` an `optionalDependencies` entry and removing `myxAdapter` re-exports from the public barrels (`src/utils/index.ts` and `src/index.ts`).
> 
> Updates the MYX provider dynamic import in `PerpsController` to include `/* webpackIgnore: true */` so webpack doesn’t try to statically resolve the intentionally-unshipped `MYXProvider` module; documents the **BREAKING** removal of the MYX adapter exports in the changelog and marks the dependency optional in `yarn.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fd55600353c2c0d8ef697b365a163da3f5c8fa1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->