### PR TITLE
feat(social-controllers): add intent and category fields to Trade type

### DIFF
--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `intent` and optional `category` fields to `Trade` type ([#8410](https://github.com/MetaMask/core/pull/8410))
+- Export `TradeStruct` superstruct schema; derive `Trade` type via `Infer` ([#8410](https://github.com/MetaMask/core/pull/8410))
+- Narrow `direction` to `'buy' | 'sell'` and `intent` to `'enter' | 'exit'` on `Trade` type ([#8410](https://github.com/MetaMask/core/pull/8410))
 
 ### Changed
 

--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `intent` and optional `category` fields to `Trade` type ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.1.0` to `^1.1.1` ([#8373](https://github.com/MetaMask/core/pull/8373))

--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `intent` and optional `category` fields to `Trade` type ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Add `intent` and optional `category` fields to `Trade` type ([#8410](https://github.com/MetaMask/core/pull/8410))
 
 ### Changed
 

--- a/packages/social-controllers/src/SocialService.test.ts
+++ b/packages/social-controllers/src/SocialService.test.ts
@@ -24,6 +24,7 @@ const mockSocialHandles = {
 
 const mockTrade = {
   direction: 'buy',
+  intent: 'enter',
   tokenAmount: 1.5,
   usdCost: 3000,
   timestamp: 1700000000,

--- a/packages/social-controllers/src/SocialService.ts
+++ b/packages/social-controllers/src/SocialService.ts
@@ -58,6 +58,8 @@ const ProfileSummaryStruct = structType({
 
 const TradeStruct = structType({
   direction: string(),
+  intent: string(),
+  category: optional(string()),
   tokenAmount: number(),
   usdCost: number(),
   timestamp: number(),

--- a/packages/social-controllers/src/SocialService.ts
+++ b/packages/social-controllers/src/SocialService.ts
@@ -36,6 +36,7 @@ import type {
   UnfollowOptions,
   UnfollowResponse,
 } from './social-types';
+import { TradeStruct } from './social-types';
 import type { SocialServiceMethodActions } from './SocialService-method-action-types';
 
 // ---------------------------------------------------------------------------
@@ -54,16 +55,6 @@ const ProfileSummaryStruct = structType({
   address: string(),
   name: string(),
   imageUrl: optional(nullable(string())),
-});
-
-const TradeStruct = structType({
-  direction: string(),
-  intent: string(),
-  category: optional(string()),
-  tokenAmount: number(),
-  usdCost: number(),
-  timestamp: number(),
-  transactionHash: string(),
 });
 
 const PositionStruct = structType({

--- a/packages/social-controllers/src/index.ts
+++ b/packages/social-controllers/src/index.ts
@@ -36,6 +36,7 @@ export type {
   SocialServiceUnfollowAction,
 } from './SocialService-method-action-types';
 
+export { TradeStruct } from './social-types';
 export type {
   FetchFollowersOptions,
   FetchFollowingOptions,

--- a/packages/social-controllers/src/social-types.ts
+++ b/packages/social-controllers/src/social-types.ts
@@ -1,3 +1,12 @@
+import type { Infer } from '@metamask/superstruct';
+import {
+  enums,
+  number,
+  optional,
+  string,
+  type as structType,
+} from '@metamask/superstruct';
+
 // ---------------------------------------------------------------------------
 // Shared sub-types
 // ---------------------------------------------------------------------------
@@ -26,25 +35,17 @@ export type SocialHandles = {
   lens?: string | null;
 };
 
-/**
- * A single trade within a position.
- */
-export type Trade = {
-  /** "buy" or "sell" (semi-deprecated by Clicker in favor of intent). */
-  direction: string;
-  /** "enter" or "exit" — preferred over direction. */
-  intent: string;
-  /** Trade category from Clicker (e.g. "receive" for airdrops/transfers). */
-  category?: string;
-  /** Quantity traded. */
-  tokenAmount: number;
-  /** USD value of the trade. */
-  usdCost: number;
-  /** Unix timestamp. */
-  timestamp: number;
-  /** On-chain transaction hash. */
-  transactionHash: string;
-};
+export const TradeStruct = structType({
+  direction: enums(['buy', 'sell']),
+  intent: enums(['enter', 'exit']),
+  category: optional(string()),
+  tokenAmount: number(),
+  usdCost: number(),
+  timestamp: number(),
+  transactionHash: string(),
+});
+
+export type Trade = Infer<typeof TradeStruct>;
 
 // ---------------------------------------------------------------------------
 // Leaderboard

--- a/packages/social-controllers/src/social-types.ts
+++ b/packages/social-controllers/src/social-types.ts
@@ -30,8 +30,12 @@ export type SocialHandles = {
  * A single trade within a position.
  */
 export type Trade = {
-  /** "buy" or "sell". */
+  /** "buy" or "sell" (semi-deprecated by Clicker in favor of intent). */
   direction: string;
+  /** "enter" or "exit" — preferred over direction. */
+  intent: string;
+  /** Trade category from Clicker (e.g. "receive" for airdrops/transfers). */
+  category?: string;
   /** Quantity traded. */
   tokenAmount: number;
   /** USD value of the trade. */


### PR DESCRIPTION
## Explanation

Add `intent` ("enter" | "exit") as the preferred alternative to the semi-deprecated `direction` field, and `category` (optional) to distinguish trade types (e.g. "receive" for airdrops/transfers).

[TSA-371](https://consensyssoftware.atlassian.net/browse/TSA-371)

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


[TSA-371]: https://consensyssoftware.atlassian.net/browse/TSA-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the `Trade` contract and superstruct validation to require a new `intent` field and restrict `direction`/`intent` to enums, which may break consumers or reject older API responses that don’t include these fields.
> 
> **Overview**
> Extends the `Trade` model to include required `intent` (`'enter' | 'exit'`) and optional `category`, and narrows `direction` to `'buy' | 'sell'`.
> 
> Moves the trade validation schema into `social-types` as exported `TradeStruct`, derives `Trade` via `Infer`, and updates `SocialService` position validation and tests to use the new schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba3a5a520de67595347134844ff3e9ac3d351b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->