### PR TITLE
Fix: assets controller startup empty accounts

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -170,7 +170,7 @@
   },
   "packages/assets-controller/src/AssetsController.ts": {
     "no-restricted-syntax": {
-      "count": 7
+      "count": 8
     }
   },
   "packages/assets-controller/src/__fixtures__/MockAssetControllerMessenger.ts": {

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `AssetsController` no longer silently skips asset fetching on startup for returning users ([#8412](https://github.com/MetaMask/core/pull/8412))
+  - Previously, `#start()` was called at keyring unlock before `AccountTreeController.init()` had built the account tree, causing `#selectedAccounts` to return an empty array and all subscriptions and fetches to be skipped. `selectedAccountGroupChange` does not fire when the persisted selected group is unchanged, leaving the controller idle.
+  - Now subscribes to `AccountTreeController:stateChange` (the base-controller event guaranteed to fire when `init()` calls `this.update()`), so the controller re-evaluates its active state once accounts are available.
+  - `#start()` is now idempotent: it returns early when accounts or chains are not yet available, and when subscriptions are already active, preventing duplicate fetches from repeated events.
+
 ## [5.0.0]
 
 ### Changed

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -1789,4 +1789,85 @@ describe('AssetsController', () => {
       });
     });
   });
+
+  describe('account tree state change', () => {
+    it('triggers start when tree initializes after unlock with empty accounts', async () => {
+      const getAccountsMock = jest.fn().mockReturnValue([]);
+
+      const messenger: RootMessenger = new Messenger({
+        namespace: MOCK_ANY_NAMESPACE,
+      });
+      messenger.registerActionHandler(
+        'AccountTreeController:getAccountsFromSelectedAccountGroup',
+        getAccountsMock,
+      );
+      messenger.registerActionHandler(
+        'NetworkEnablementController:getState',
+        () => ({
+          enabledNetworkMap: { eip155: { '1': true } },
+          nativeAssetIdentifiers: {
+            'eip155:1': 'eip155:1/slip44:60' as `${string}:${string}/slip44:${number}`,
+          },
+        }),
+      );
+      (
+        messenger as {
+          registerActionHandler: (a: string, h: () => unknown) => void;
+        }
+      ).registerActionHandler('NetworkController:getState', () => ({
+        networkConfigurationsByChainId: {},
+        networksMetadata: {},
+      }));
+      (
+        messenger as {
+          registerActionHandler: (a: string, h: () => unknown) => void;
+        }
+      ).registerActionHandler('NetworkController:getNetworkClientById', () => ({
+        provider: {},
+      }));
+      (
+        messenger as {
+          registerActionHandler: (a: string, h: () => unknown) => void;
+        }
+      ).registerActionHandler('ClientController:getState', () => ({
+        isUiOpen: true,
+      }));
+
+      const controller = new AssetsController({
+        messenger: messenger as unknown as AssetsControllerMessenger,
+        queryApiClient: createMockQueryApiClient(),
+        subscribeToBasicFunctionalityChange: (): void => {
+          /* no-op */
+        },
+      });
+
+      const getAssetsSpy = jest.spyOn(controller, 'getAssets');
+
+      // Step 1: UI open + unlock — accounts empty, #start() is a no-op
+      (
+        messenger as unknown as {
+          publish: (topic: string, payload?: unknown) => void;
+        }
+      ).publish('ClientController:stateChange', { isUiOpen: true });
+      messenger.publish('KeyringController:unlock');
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(getAssetsSpy).not.toHaveBeenCalled();
+
+      // Step 2: AccountTreeController.init() completes — accounts now available
+      getAccountsMock.mockReturnValue([createMockInternalAccount()]);
+      (messenger.publish as CallableFunction)(
+        'AccountTreeController:stateChange',
+        {},
+        [],
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(getAssetsSpy).toHaveBeenCalledTimes(1);
+      expect(getAssetsSpy).toHaveBeenCalledWith(
+        [expect.objectContaining({ id: MOCK_ACCOUNT_ID })],
+        expect.objectContaining({ forceUpdate: true }),
+      );
+    });
+  });
 });

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -1806,7 +1806,8 @@ describe('AssetsController', () => {
         () => ({
           enabledNetworkMap: { eip155: { '1': true } },
           nativeAssetIdentifiers: {
-            'eip155:1': 'eip155:1/slip44:60' as `${string}:${string}/slip44:${number}`,
+            'eip155:1':
+              'eip155:1/slip44:60' as `${string}:${string}/slip44:${number}`,
           },
         }),
       );

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -875,7 +875,6 @@ export class AssetsController extends BaseController<
     // when init() calls this.update(). #start() is idempotent so
     // repeated fires are safe.
     this.messenger.subscribe('AccountTreeController:stateChange', () => {
-      console.log('AccountTreeController:stateChanged +++++++++++');
       this.#updateActive();
     });
 

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -1,6 +1,7 @@
 import type {
   AccountTreeControllerGetAccountsFromSelectedAccountGroupAction,
   AccountTreeControllerSelectedAccountGroupChangeEvent,
+  AccountTreeControllerStateChangeEvent,
 } from '@metamask/account-tree-controller';
 import { BaseController } from '@metamask/base-controller';
 import type {
@@ -282,6 +283,7 @@ type AllowedActions =
 type AllowedEvents =
   // AssetsController
   | AccountTreeControllerSelectedAccountGroupChangeEvent
+  | AccountTreeControllerStateChangeEvent
   | ClientControllerStateChangeEvent
   | KeyringControllerLockEvent
   | KeyringControllerUnlockEvent
@@ -864,6 +866,18 @@ export class AssetsController extends BaseController<
         this.#handleAccountGroupChanged().catch(console.error);
       },
     );
+
+    // Catch the initial tree build. On returning users,
+    // `selectedAccountGroupChange` does NOT fire when the persisted group
+    // is unchanged, and `accountTreeChange` doesn't fire either (init()
+    // rebuilds from persisted accounts without publishing it).
+    // The base-controller `:stateChange` event is guaranteed to fire
+    // when init() calls this.update(). #start() is idempotent so
+    // repeated fires are safe.
+    this.messenger.subscribe('AccountTreeController:stateChange', () => {
+      console.log('AccountTreeController:stateChanged +++++++++++');
+      this.#updateActive();
+    });
 
     // Subscribe to network enablement changes (only enabledNetworkMap)
     this.messenger.subscribe(
@@ -2047,18 +2061,30 @@ export class AssetsController extends BaseController<
 
   /**
    * Start asset tracking: subscribe to updates and fetch current balances.
-   * Called when app opens, account changes, or keyring unlocks.
+   * Idempotent — returns early if accounts/chains are not yet available or
+   * subscriptions are already active.
    */
   #start(): void {
+    const accounts = this.#selectedAccounts;
+    const chainIds = [...this.#enabledChains];
+
+    if (accounts.length === 0 || chainIds.length === 0) {
+      return;
+    }
+
+    if (this.#activeSubscriptions.size > 0) {
+      return;
+    }
+
     log('Starting asset tracking', {
-      selectedAccountCount: this.#selectedAccounts.length,
-      enabledChainCount: this.#enabledChains.size,
+      selectedAccountCount: accounts.length,
+      enabledChainCount: chainIds.length,
     });
 
     this.#subscribeAssets();
     this.#ensureNativeBalancesDefaultZero();
-    this.getAssets(this.#selectedAccounts, {
-      chainIds: [...this.#enabledChains],
+    this.getAssets(accounts, {
+      chainIds,
       forceUpdate: true,
     }).catch((error) => {
       log('Failed to fetch assets', error);


### PR DESCRIPTION
## Explanation

**Current state:** On returning users (those with persisted accounts), `AssetsController.#start()` was called at keyring unlock time before `AccountTreeController.init()` had completed building the account tree. At that point, `#selectedAccounts` returned an empty array, so no subscriptions were set up and no asset fetch was triggered. The controller would then sit idle because:

- `AccountTreeController:selectedAccountGroupChange` only fires when the selected group *changes* — on returning users the persisted group is unchanged, so this event is skipped.
- `AccountTreeController:accountTreeChange` is not published by `init()` — it only fires when accounts are added/removed *after* initialization.

This meant asset balances, metadata, and prices were never loaded until the user manually switched accounts or networks.

**Solution:** Two changes working together:

1. **Subscribe to `AccountTreeController:stateChange`** — the base-controller event that is guaranteed to fire when `init()` calls `this.update()` to build the tree. When this fires, `#updateActive()` is called, which calls `#start()` now that accounts are available.

2. **Make `#start()` idempotent** — it now returns early if accounts/chains are not yet available (so the initial unlock call is a safe no-op), and also returns early if subscriptions are already active (so multiple subsequent `stateChange` firings — e.g. from snap accounts being added — don't trigger redundant fetches).

This follows the same pattern used by `DeFiPositionsController`, which also gets accounts lazily from `AccountTreeController` rather than eagerly at unlock time.

## References

<!--
Are there any issues that this pull request is tied to?
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `AssetsController` startup/lifecycle logic and subscription gating, which could change when/ how often asset fetches run if the new idempotency checks miss an edge case.
> 
> **Overview**
> Fixes a startup race where `AssetsController` could remain idle for returning users by additionally reacting to `AccountTreeController:stateChange` and re-evaluating active tracking once the account tree is initialized.
> 
> Makes `#start()` idempotent by returning early when no accounts/chains are available and when subscriptions are already active, preventing duplicate subscriptions/fetches from repeated events; adds a regression test for the unlock-then-tree-init flow and documents the fix in the assets-controller changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ad3c3928adf6e1dc4a1a0f607a108f94c0c753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->