### PR TITLE
feat(keyring-controller): persist vault when keyring state changes during unlock

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Expose `KeyringController:signTransaction` method through `KeyringController` messenger ([#8408](https://github.com/MetaMask/core/pull/8408))
+- Persist vault when keyring state changes during unlock ([#8415](https://github.com/MetaMask/core/pull/8415))
+  - If a keyring's serialized state differs after deserialization (e.g. a migration ran, or metadata was missing), the vault is now re-persisted so the change is not lost on the next unlock.
 
 ### Changed
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2949,8 +2949,9 @@ describe('KeyringController', () => {
       const oldState = { version: 1, foo: 'bar' };
       const newState = { version: 2, foo: 'bar' };
 
-      // A keyring that migrates its own state during deserialization:
-      // after deserialize(oldState), serialize() returns newState.
+      // A keyring that migrates its own state in-place during deserialization: after
+      // deserialize(oldState), the original `data` object is mutated and serialize()
+      // returns the updated state.
       class MigratingKeyring {
         static type = 'Migrating Keyring';
 
@@ -2963,7 +2964,9 @@ describe('KeyringController', () => {
         }
 
         async deserialize(data: Record<string, unknown>): Promise<void> {
-          this.#state = data.version === 1 ? { ...data, version: 2 } : data;
+          // Mutate in-place to simulate a keyring that upgrades its own format.
+          data.version = 2;
+          this.#state = data;
         }
 
         async getAccounts(): Promise<string[]> {
@@ -3002,6 +3005,8 @@ describe('KeyringController', () => {
 
           await controller.submitPassword(password);
 
+          // Migration should have triggered a new vault update that we need to
+          // re-encrypt:
           expect(encryptWithKeySpy).toHaveBeenCalledWith(
             defaultCredentials,
             expect.arrayContaining([

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2945,6 +2945,76 @@ describe('KeyringController', () => {
       );
     });
 
+    it('should update the vault if the keyring state changes during deserialization', async () => {
+      const oldState = { version: 1, foo: 'bar' };
+      const newState = { version: 2, foo: 'bar' };
+
+      // A keyring that migrates its own state during deserialization:
+      // after deserialize(oldState), serialize() returns newState.
+      class MigratingKeyring {
+        static type = 'Migrating Keyring';
+
+        type = 'Migrating Keyring';
+
+        #state: Record<string, unknown> = {};
+
+        async serialize(): Promise<Record<string, unknown>> {
+          return this.#state;
+        }
+
+        async deserialize(data: Record<string, unknown>): Promise<void> {
+          this.#state = data.version === 1 ? { ...data, version: 2 } : data;
+        }
+
+        async getAccounts(): Promise<string[]> {
+          return [];
+        }
+
+        async addAccounts(): Promise<string[]> {
+          return [];
+        }
+      }
+
+      await withController(
+        {
+          skipVaultCreation: true,
+          state: {
+            vault: createVault([
+              // #updateVault requires at least one HD keyring to be present.
+              {
+                type: KeyringTypes.hd,
+                data: {},
+                metadata: { id: '0', name: '' },
+              },
+              {
+                type: MigratingKeyring.type,
+                data: oldState,
+                metadata: { id: '1', name: '' },
+              },
+            ]),
+          },
+          keyringBuilders: [
+            keyringBuilderFactory(MigratingKeyring as unknown as KeyringClass),
+          ],
+        },
+        async ({ controller, encryptor }) => {
+          const encryptWithKeySpy = jest.spyOn(encryptor, 'encryptWithKey');
+
+          await controller.submitPassword(password);
+
+          expect(encryptWithKeySpy).toHaveBeenCalledWith(
+            defaultCredentials,
+            expect.arrayContaining([
+              expect.objectContaining({
+                type: MigratingKeyring.type,
+                data: newState,
+              }),
+            ]),
+          );
+        },
+      );
+    });
+
     it('should unlock the wallet if the state has a duplicate account and the encryption parameters are outdated', async () => {
       stubKeyringClassWithAccount(MockKeyring, '0x123');
       stubKeyringClassWithAccount(HdKeyring, '0x123');

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2604,12 +2604,12 @@ export class KeyringController<
     callback: MutuallyExclusiveCallback<Result>,
   ): Promise<Result> {
     return this.#withRollback(async ({ releaseLock }) => {
-      const prevState = await this.#getSessionState();
+      const oldState = await this.#getSessionState();
       const callbackResult = await callback({ releaseLock });
       const newState = await this.#getSessionState();
 
       // State is committed only if the operation is successful and need to trigger a vault update.
-      if (hasStateChanged(prevState, newState)) {
+      if (hasStateChanged(oldState, newState)) {
         await this.#updateVault();
       }
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -32,7 +32,7 @@ import { Mutex } from 'async-mutex';
 import type { MutexInterface } from 'async-mutex';
 import Wallet, { thirdparty as importers } from 'ethereumjs-wallet';
 import type { Patch } from 'immer';
-import { cloneDeep, isEqual } from 'lodash';
+import { cloneDeep } from 'lodash';
 // When generating a ULID within the same millisecond, monotonicFactory provides some guarantees regarding sort order.
 import { ulid } from 'ulid';
 
@@ -1526,7 +1526,7 @@ export class KeyringController<
     encryptionKey: string,
     encryptionSalt?: string,
   ): Promise<void> {
-    const { newMetadata } = await this.#withRollback(async () => {
+    const { hasChanged } = await this.#withRollback(async () => {
       const result = await this.#unlockKeyrings({
         encryptionKey,
         encryptionSalt,
@@ -1539,7 +1539,7 @@ export class KeyringController<
       // if new metadata has been generated during login, we
       // can attempt to upgrade the vault.
       await this.#withRollback(async () => {
-        if (newMetadata) {
+        if (hasChanged) {
           await this.#updateVault();
         }
       });
@@ -1572,7 +1572,7 @@ export class KeyringController<
    * @returns Promise resolving when the operation completes.
    */
   async submitPassword(password: string): Promise<void> {
-    const { newMetadata } = await this.#withRollback(async () => {
+    const { hasChanged } = await this.#withRollback(async () => {
       const result = await this.#unlockKeyrings({ password });
       this.#setUnlocked();
       return result;
@@ -1580,10 +1580,10 @@ export class KeyringController<
 
     try {
       // If there are stronger encryption params available, or
-      // if new metadata has been generated during login, we
+      // if the keyring state has changed during deserialization, we
       // can attempt to upgrade the vault.
       await this.#withRollback(async () => {
-        if (newMetadata || this.#isNewEncryptionAvailable()) {
+        if (hasChanged || this.#isNewEncryptionAvailable()) {
           await this.#deriveAndSetEncryptionKey(password, {
             // If the vault is being upgraded, we want to ignore the metadata
             // that is already in the vault, so we can effectively
@@ -2179,24 +2179,24 @@ export class KeyringController<
     serializedKeyrings: SerializedKeyring[],
   ): Promise<{
     keyrings: { keyring: EthKeyring; metadata: KeyringMetadata }[];
-    newMetadata: boolean;
+    hasChanged: boolean;
   }> {
     await this.#clearKeyrings();
     const keyrings: { keyring: EthKeyring; metadata: KeyringMetadata }[] = [];
-    let newMetadata = false;
+    let hasChanged = false;
 
     for (const serializedKeyring of serializedKeyrings) {
       const result = await this.#restoreKeyring(serializedKeyring);
       if (result) {
         const { keyring, metadata } = result;
         keyrings.push({ keyring, metadata });
-        if (result.newMetadata) {
-          newMetadata = true;
+        if (result.hasChanged) {
+          hasChanged = true;
         }
       }
     }
 
-    return { keyrings, newMetadata };
+    return { keyrings, hasChanged };
   }
 
   /**
@@ -2217,7 +2217,7 @@ export class KeyringController<
         },
   ): Promise<{
     keyrings: { keyring: EthKeyring; metadata: KeyringMetadata }[];
-    newMetadata: boolean;
+    hasChanged: boolean;
   }> {
     return this.#withVaultLock(async () => {
       if (!this.state.vault) {
@@ -2255,7 +2255,7 @@ export class KeyringController<
         );
       }
 
-      const { keyrings, newMetadata } =
+      const { keyrings, hasChanged } =
         await this.#restoreSerializedKeyrings(vault);
 
       const updatedKeyrings = await this.#getUpdatedKeyrings();
@@ -2266,7 +2266,7 @@ export class KeyringController<
         state.encryptionSalt = this.#encryptionKey?.salt;
       });
 
-      return { keyrings, newMetadata };
+      return { keyrings, hasChanged };
     });
   }
 
@@ -2496,30 +2496,36 @@ export class KeyringController<
   async #restoreKeyring(
     serialized: SerializedKeyring,
   ): Promise<
-    | { keyring: EthKeyring; metadata: KeyringMetadata; newMetadata: boolean }
+    | { keyring: EthKeyring; metadata: KeyringMetadata; hasChanged: boolean }
     | undefined
   > {
     this.#assertControllerMutexIsLocked();
 
     try {
       const { type, data, metadata: serializedMetadata } = serialized;
-      let newMetadata = false;
-      let metadata = serializedMetadata;
+
       const keyring = await this.#createKeyring(type, data);
+      const restoredData = await keyring.serialize();
+      let hasChanged = hasStateChanged(data, restoredData);
+
       await this.#assertNoDuplicateAccounts([keyring]);
-      // If metadata is missing, assume the data is from an installation before
-      // we had keyring metadata.
+
+      // If metadata is missing, assume the data is from an installation before we had
+      // keyring metadata.
+      let metadata = serializedMetadata;
       if (!metadata) {
-        newMetadata = true;
+        hasChanged = true;
         metadata = getDefaultKeyringMetadata();
       }
+
       // The keyring is added to the keyrings array only if it's successfully restored
       // and the metadata is successfully added to the controller
       this.#keyrings.push({
         keyring,
         metadata,
       });
-      return { keyring, metadata, newMetadata };
+
+      return { keyring, metadata, hasChanged };
     } catch (error) {
       console.error(error);
       this.#unsupportedKeyrings.push(serialized);
@@ -2598,12 +2604,12 @@ export class KeyringController<
     callback: MutuallyExclusiveCallback<Result>,
   ): Promise<Result> {
     return this.#withRollback(async ({ releaseLock }) => {
-      const oldState = JSON.stringify(await this.#getSessionState());
+      const prevState = await this.#getSessionState();
       const callbackResult = await callback({ releaseLock });
-      const newState = JSON.stringify(await this.#getSessionState());
+      const newState = await this.#getSessionState();
 
       // State is committed only if the operation is successful and need to trigger a vault update.
-      if (!isEqual(oldState, newState)) {
+      if (hasStateChanged(prevState, newState)) {
         await this.#updateVault();
       }
 
@@ -2717,6 +2723,18 @@ async function withLock<Result>(
  */
 function getDefaultKeyringMetadata(): KeyringMetadata {
   return { id: ulid(), name: '' };
+}
+
+/**
+ * Check if the state of a keyring has changed by comparing the serialized state before
+ * and after an operation.
+ *
+ * @param before - The state of the keyring before the operation.
+ * @param after - The state of the keyring after the operation.
+ * @returns True if the state has changed, false otherwise.
+ */
+function hasStateChanged(before: Json, after: Json): boolean {
+  return JSON.stringify(before) !== JSON.stringify(after);
 }
 
 export default KeyringController;

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2504,9 +2504,10 @@ export class KeyringController<
     try {
       const { type, data, metadata: serializedMetadata } = serialized;
 
+      const oldState = JSON.stringify(data);
       const keyring = await this.#createKeyring(type, data);
-      const restoredData = await keyring.serialize();
-      let hasChanged = JSON.stringify(data) !== JSON.stringify(restoredData);
+      const newState = JSON.stringify(await keyring.serialize());
+      let hasChanged = oldState !== newState;
 
       await this.#assertNoDuplicateAccounts([keyring]);
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2725,5 +2725,4 @@ function getDefaultKeyringMetadata(): KeyringMetadata {
   return { id: ulid(), name: '' };
 }
 
-
 export default KeyringController;

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2506,7 +2506,7 @@ export class KeyringController<
 
       const keyring = await this.#createKeyring(type, data);
       const restoredData = await keyring.serialize();
-      let hasChanged = hasStateChanged(data, restoredData);
+      let hasChanged = JSON.stringify(data) !== JSON.stringify(restoredData);
 
       await this.#assertNoDuplicateAccounts([keyring]);
 
@@ -2604,12 +2604,12 @@ export class KeyringController<
     callback: MutuallyExclusiveCallback<Result>,
   ): Promise<Result> {
     return this.#withRollback(async ({ releaseLock }) => {
-      const oldState = await this.#getSessionState();
+      const oldState = JSON.stringify(await this.#getSessionState());
       const callbackResult = await callback({ releaseLock });
-      const newState = await this.#getSessionState();
+      const newState = JSON.stringify(await this.#getSessionState());
 
       // State is committed only if the operation is successful and need to trigger a vault update.
-      if (hasStateChanged(oldState, newState)) {
+      if (oldState !== newState) {
         await this.#updateVault();
       }
 
@@ -2725,16 +2725,5 @@ function getDefaultKeyringMetadata(): KeyringMetadata {
   return { id: ulid(), name: '' };
 }
 
-/**
- * Check if the state of a keyring has changed by comparing the serialized state before
- * and after an operation.
- *
- * @param before - The state of the keyring before the operation.
- * @param after - The state of the keyring after the operation.
- * @returns True if the state has changed, false otherwise.
- */
-function hasStateChanged(before: Json, after: Json): boolean {
-  return JSON.stringify(before) !== JSON.stringify(after);
-}
 
 export default KeyringController;

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -4,6 +4,7 @@
    */
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "types": ["jest"],
     /**
      * Here we ensure that TypeScript resolves `@metamask/*` imports to the
      * uncompiled source code for packages that live in this repo.

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -4,7 +4,6 @@
    */
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "types": ["jest"],
     /**
      * Here we ensure that TypeScript resolves `@metamask/*` imports to the
      * uncompiled source code for packages that live in this repo.


### PR DESCRIPTION
## Explanation

Currently, if a keyring runs a migration inside `deserialize()` during unlock, the updated in-memory state is never written back to the vault. On the next unlock the migration silently re-runs against the same stale data.

This PR fixes that by comparing each keyring's re-serialized state against the original data after `#restoreKeyring`. If any keyring's state differs — whether due to a migration or missing metadata — `hasChanged` is propagated up through `#restoreSerializedKeyrings` and `#unlockKeyrings`, and the existing vault upgrade path in `submitPassword`/`submitEncryptionKey` re-persists the vault.

As part of this change, a `hasStateChanged` helper function is introduced and reused in `#persistOrRollback`, removing the dependency on lodash `isEqual` for that comparison.

## References

<!--
Are there any issues that this pull request is tied to?
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the unlock/vault-update path to trigger re-encryption/persistence based on detected keyring state changes, which could affect login performance and vault write frequency if the change detection is wrong.
> 
> **Overview**
> During `submitPassword`/`submitEncryptionKey`, the controller now tracks whether any keyring’s serialized data changes during restore (including missing metadata) and, if so, re-runs the existing vault update flow to persist the upgraded state.
> 
> Change detection is implemented in `#restoreKeyring` by comparing pre- and post-deserialization serialized payloads and is propagated via `#restoreSerializedKeyrings`/`#unlockKeyrings` as `hasChanged`; `#persistOrRollback` also switches from lodash `isEqual` to a JSON-string comparison for session-state diffs. Adds a regression test for an in-place migrating keyring and updates the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e7502642ba7c8f5a7cc2b674ff8bf88cd88869b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->