### PR TITLE
feat(keyring-controller): add `withController` for atomic operations over multiple keyrings

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `withKeyringV2` method and `KeyringController:withKeyringV2` messenger action for atomic operations using the `KeyringV2` API ([#8390](https://github.com/MetaMask/core/pull/8390))
   - Accepts a `KeyringSelectorV2` to select keyrings by `type`, `address`, `id`, or `filter`.
   - Ships with default V2 builders for HD (`HdKeyringV2`) and Simple (`SimpleKeyringV2`) keyrings; additional builders can be registered via the `keyringV2Builders` constructor option.
+- Add `withController` method for atomically adding and removing keyrings within a single transaction, via a `RestrictedController` object with `addNewKeyring` and `removeKeyring`
 
 ### Changed
 

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `withController` action to run atomic operations on multiple keyrings (within a single transaction) ([#8416](https://github.com/MetaMask/core/pull/8416))
-  - This action takes a subset of the controllr (a `RestrictedController` object) that exposes `addNewKeyring` and `removeKeyring` methods to add and remove keyring during that transaction call.
+  - This action uses a `RestrictedController` object that exposes `addNewKeyring` and `removeKeyring` methods to add and remove keyring during the transaction (atomic) call.
 - Expose `KeyringController:signTransaction` method through `KeyringController` messenger ([#8408](https://github.com/MetaMask/core/pull/8408))
 - Persist vault when keyring state changes during unlock ([#8415](https://github.com/MetaMask/core/pull/8415))
   - If a keyring's serialized state differs after deserialization (e.g. a migration ran, or metadata was missing), the vault is now re-persisted so the change is not lost on the next unlock.

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `withController` action to run atomic operations on multiple keyrings (within a single transaction) ([#8416](https://github.com/MetaMask/core/pull/8416))
+  - This action takes a subset of the controllr (a `RestrictedController` object) that exposes `addNewKeyring` and `removeKeyring` methods to add and remove keyring during that transaction call.
 - Expose `KeyringController:signTransaction` method through `KeyringController` messenger ([#8408](https://github.com/MetaMask/core/pull/8408))
 - Persist vault when keyring state changes during unlock ([#8415](https://github.com/MetaMask/core/pull/8415))
   - If a keyring's serialized state differs after deserialization (e.g. a migration ran, or metadata was missing), the vault is now re-persisted so the change is not lost on the next unlock.
@@ -22,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `withKeyringV2` method and `KeyringController:withKeyringV2` messenger action for atomic operations using the `KeyringV2` API ([#8390](https://github.com/MetaMask/core/pull/8390))
   - Accepts a `KeyringSelectorV2` to select keyrings by `type`, `address`, `id`, or `filter`.
   - Ships with default V2 builders for HD (`HdKeyringV2`) and Simple (`SimpleKeyringV2`) keyrings; additional builders can be registered via the `keyringV2Builders` constructor option.
-- Add `withController` method for atomically adding and removing keyrings within a single transaction, via a `RestrictedController` object with `addNewKeyring` and `removeKeyring`
 
 ### Changed
 

--- a/packages/keyring-controller/src/KeyringController-method-action-types.ts
+++ b/packages/keyring-controller/src/KeyringController-method-action-types.ts
@@ -272,24 +272,6 @@ export type KeyringControllerWithKeyringAction = {
 };
 
 /**
- * Execute an operation against all keyrings as a mutually exclusive atomic
- * operation. The operation receives a {@link RestrictedController} instance
- * that exposes a read-only live view of all keyrings as well as
- * `addNewKeyring` and `removeKeyring` methods to stage mutations.
- *
- * The method automatically persists changes at the end of the function
- * execution, or rolls back the changes if an error is thrown.
- *
- * @param operation - Function to execute with the restricted controller.
- * @returns Promise resolving to the result of the function execution.
- * @template CallbackResult - The type of the value resolved by the callback function.
- */
-export type KeyringControllerWithControllerAction = {
-  type: `KeyringController:withController`;
-  handler: KeyringController['withController'];
-};
-
-/**
  * Select a keyring and execute the given operation with the selected
  * keyring, **without** acquiring the controller's mutual exclusion lock.
  *
@@ -394,6 +376,24 @@ export type KeyringControllerWithKeyringV2UnsafeAction = {
 };
 
 /**
+ * Execute an operation against all keyrings as a mutually exclusive atomic
+ * operation. The operation receives a {@link RestrictedController} instance
+ * that exposes a read-only live view of all keyrings as well as
+ * `addNewKeyring` and `removeKeyring` methods to stage mutations.
+ *
+ * The method automatically persists changes at the end of the function
+ * execution, or rolls back the changes if an error is thrown.
+ *
+ * @param operation - Function to execute with the restricted controller.
+ * @returns Promise resolving to the result of the function execution.
+ * @template CallbackResult - The type of the value resolved by the callback function.
+ */
+export type KeyringControllerWithControllerAction = {
+  type: `KeyringController:withController`;
+  handler: KeyringController['withController'];
+};
+
+/**
  * Union of all KeyringController action types.
  */
 export type KeyringControllerMethodActions =
@@ -417,7 +417,7 @@ export type KeyringControllerMethodActions =
   | KeyringControllerPatchUserOperationAction
   | KeyringControllerSignUserOperationAction
   | KeyringControllerWithKeyringAction
-  | KeyringControllerWithControllerAction
   | KeyringControllerWithKeyringUnsafeAction
   | KeyringControllerWithKeyringV2Action
-  | KeyringControllerWithKeyringV2UnsafeAction;
+  | KeyringControllerWithKeyringV2UnsafeAction
+  | KeyringControllerWithControllerAction;

--- a/packages/keyring-controller/src/KeyringController-method-action-types.ts
+++ b/packages/keyring-controller/src/KeyringController-method-action-types.ts
@@ -272,6 +272,24 @@ export type KeyringControllerWithKeyringAction = {
 };
 
 /**
+ * Execute an operation against all keyrings as a mutually exclusive atomic
+ * operation. The operation receives a {@link RestrictedController} instance
+ * that exposes a read-only live view of all keyrings as well as
+ * `addNewKeyring` and `removeKeyring` methods to stage mutations.
+ *
+ * The method automatically persists changes at the end of the function
+ * execution, or rolls back the changes if an error is thrown.
+ *
+ * @param operation - Function to execute with the restricted controller.
+ * @returns Promise resolving to the result of the function execution.
+ * @template CallbackResult - The type of the value resolved by the callback function.
+ */
+export type KeyringControllerWithControllerAction = {
+  type: `KeyringController:withController`;
+  handler: KeyringController['withController'];
+};
+
+/**
  * Select a keyring and execute the given operation with the selected
  * keyring, **without** acquiring the controller's mutual exclusion lock.
  *
@@ -399,6 +417,7 @@ export type KeyringControllerMethodActions =
   | KeyringControllerPatchUserOperationAction
   | KeyringControllerSignUserOperationAction
   | KeyringControllerWithKeyringAction
+  | KeyringControllerWithControllerAction
   | KeyringControllerWithKeyringUnsafeAction
   | KeyringControllerWithKeyringV2Action
   | KeyringControllerWithKeyringV2UnsafeAction;

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -4068,6 +4068,244 @@ describe('KeyringController', () => {
     });
   });
 
+  describe('withController', () => {
+    it('throws if the controller is locked', async () => {
+      await withController(
+        { skipVaultCreation: true },
+        async ({ controller }) => {
+          await expect(
+            controller.withController(jest.fn()),
+          ).rejects.toThrow(KeyringControllerErrorMessage.ControllerLocked);
+        },
+      );
+    });
+
+    it('provides the current keyrings to the callback', async () => {
+      await withController(async ({ controller, initialState }) => {
+        await controller.withController(async (restrictedController) => {
+          expect(restrictedController.keyrings).toHaveLength(1);
+          expect(restrictedController.keyrings[0].metadata).toStrictEqual(
+            initialState.keyrings[0].metadata,
+          );
+        });
+      });
+    });
+
+    it('returns the result of the callback', async () => {
+      await withController(async ({ controller }) => {
+        const result = await controller.withController(async () => 'hello');
+        expect(result).toBe('hello');
+      });
+    });
+
+    it('throws if the callback returns a raw keyring instance', async () => {
+      await withController(async ({ controller }) => {
+        await expect(
+          controller.withController(async (restrictedController) => {
+            return restrictedController.keyrings[0].keyring;
+          }),
+        ).rejects.toThrow(
+          KeyringControllerErrorMessage.UnsafeDirectKeyringAccess,
+        );
+      });
+    });
+
+    describe('addNewKeyring', () => {
+      it('creates an initialized keyring and stages it for commit', async () => {
+        const mockAddress = '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4';
+        stubKeyringClassWithAccount(MockKeyring, mockAddress);
+
+        await withController(
+          { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
+          async ({ controller }) => {
+            await controller.withController(async (restrictedController) => {
+              const entry = await restrictedController.addNewKeyring(
+                MockKeyring.type,
+              );
+
+              expect(entry.keyring).toBeInstanceOf(MockKeyring);
+              expect(entry.metadata.id).toBeDefined();
+            });
+
+            expect(controller.state.keyrings).toHaveLength(2);
+          },
+        );
+      });
+
+      it('appears immediately in restrictedController.keyrings', async () => {
+        const mockAddress = '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4';
+        stubKeyringClassWithAccount(MockKeyring, mockAddress);
+
+        await withController(
+          { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
+          async ({ controller }) => {
+            await controller.withController(async (restrictedController) => {
+              expect(restrictedController.keyrings).toHaveLength(1);
+              await restrictedController.addNewKeyring(MockKeyring.type);
+              expect(restrictedController.keyrings).toHaveLength(2);
+            });
+          },
+        );
+      });
+
+      it('destroys created keyrings and does not commit them if the callback throws', async () => {
+        const mockAddress = '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4';
+        stubKeyringClassWithAccount(MockKeyring, mockAddress);
+        const destroySpy = jest
+          .spyOn(MockKeyring.prototype, 'destroy')
+          .mockResolvedValue(undefined);
+
+        await withController(
+          { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
+          async ({ controller }) => {
+            await expect(
+              controller.withController(async (restrictedController) => {
+                await restrictedController.addNewKeyring(MockKeyring.type);
+                throw new Error('Oops');
+              }),
+            ).rejects.toThrow('Oops');
+
+            expect(destroySpy).toHaveBeenCalledTimes(1);
+            expect(controller.state.keyrings).toHaveLength(1);
+          },
+        );
+      });
+    });
+
+    describe('removeKeyring', () => {
+      it('removes a keyring by id and commits the removal', async () => {
+        const mockAddress = '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4';
+        stubKeyringClassWithAccount(MockKeyring, mockAddress);
+
+        await withController(
+          { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
+          async ({ controller }) => {
+            await controller.addNewKeyring(MockKeyring.type);
+            const idToRemove =
+              controller.state.keyrings[1].metadata.id;
+
+            await controller.withController(async (restrictedController) => {
+              await restrictedController.removeKeyring(idToRemove);
+            });
+
+            expect(controller.state.keyrings).toHaveLength(1);
+            expect(
+              controller.state.keyrings.find(
+                (k) => k.metadata.id === idToRemove,
+              ),
+            ).toBeUndefined();
+          },
+        );
+      });
+
+      it('disappears from restrictedController.keyrings immediately', async () => {
+        const mockAddress = '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4';
+        stubKeyringClassWithAccount(MockKeyring, mockAddress);
+
+        await withController(
+          { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
+          async ({ controller }) => {
+            await controller.addNewKeyring(MockKeyring.type);
+            const idToRemove =
+              controller.state.keyrings[1].metadata.id;
+
+            await controller.withController(async (restrictedController) => {
+              expect(restrictedController.keyrings).toHaveLength(2);
+              await restrictedController.removeKeyring(idToRemove);
+              expect(restrictedController.keyrings).toHaveLength(1);
+            });
+          },
+        );
+      });
+
+      it('destroys the removed keyring', async () => {
+        const mockAddress = '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4';
+        stubKeyringClassWithAccount(MockKeyring, mockAddress);
+        const destroySpy = jest
+          .spyOn(MockKeyring.prototype, 'destroy')
+          .mockResolvedValue(undefined);
+
+        await withController(
+          { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
+          async ({ controller }) => {
+            await controller.addNewKeyring(MockKeyring.type);
+            const idToRemove =
+              controller.state.keyrings[1].metadata.id;
+
+            await controller.withController(async (restrictedController) => {
+              await restrictedController.removeKeyring(idToRemove);
+            });
+
+            expect(destroySpy).toHaveBeenCalledTimes(1);
+          },
+        );
+      });
+
+      it('throws KeyringNotFound for an unknown id', async () => {
+        await withController(async ({ controller }) => {
+          await expect(
+            controller.withController(async (restrictedController) => {
+              await restrictedController.removeKeyring('non-existent-id');
+            }),
+          ).rejects.toThrow(KeyringControllerErrorMessage.KeyringNotFound);
+        });
+      });
+
+      it('destroys a keyring that was created then removed within the same callback', async () => {
+        const mockAddress = '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4';
+        stubKeyringClassWithAccount(MockKeyring, mockAddress);
+        const destroySpy = jest
+          .spyOn(MockKeyring.prototype, 'destroy')
+          .mockResolvedValue(undefined);
+
+        await withController(
+          { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
+          async ({ controller }) => {
+            await controller.withController(async (restrictedController) => {
+              const { metadata } = await restrictedController.addNewKeyring(
+                MockKeyring.type,
+              );
+              await restrictedController.removeKeyring(metadata.id);
+            });
+
+            expect(destroySpy).toHaveBeenCalledTimes(1);
+            expect(controller.state.keyrings).toHaveLength(1);
+          },
+        );
+      });
+    });
+
+    it('rolls back on error', async () => {
+      await withController(async ({ controller, initialState }) => {
+        await expect(
+          controller.withController(async (restrictedController) => {
+            await restrictedController.addNewKeyring(KeyringTypes.simple);
+            throw new Error('Oops');
+          }),
+        ).rejects.toThrow('Oops');
+
+        expect(controller.state.keyrings).toHaveLength(
+          initialState.keyrings.length,
+        );
+        expect(await controller.getAccounts()).toStrictEqual(
+          initialState.keyrings[0].accounts,
+        );
+      });
+    });
+
+    it('does not update the vault if no keyrings change', async () => {
+      await withController(async ({ controller, encryptor }) => {
+        const encryptSpy = jest.spyOn(encryptor, 'encrypt');
+
+        await controller.withController(async () => {
+          // no-op
+        });
+
+        expect(encryptSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('withKeyringUnsafe', () => {
     it('calls the given function without acquiring the lock', async () => {
       await withController(async ({ controller }) => {

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -5263,6 +5263,28 @@ describe('KeyringController', () => {
       });
     });
 
+    describe('withController', () => {
+      it('should call withController', async () => {
+        await withController(async ({ messenger }) => {
+          const operation = jest.fn().mockResolvedValue('result');
+
+          const actionReturnValue = await messenger.call(
+            'KeyringController:withController',
+            operation,
+          );
+
+          expect(operation).toHaveBeenCalledWith(
+            expect.objectContaining({
+              keyrings: expect.any(Array),
+              addNewKeyring: expect.any(Function),
+              removeKeyring: expect.any(Function),
+            }),
+          );
+          expect(actionReturnValue).toBe('result');
+        });
+      });
+    });
+
     describe('addNewKeyring', () => {
       it('should call addNewKeyring', async () => {
         const mockKeyringMetadata: KeyringMetadata = {

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -4110,6 +4110,18 @@ describe('KeyringController', () => {
       });
     });
 
+    it('throws if the callback returns a raw keyring (v2) instance', async () => {
+      await withController(async ({ controller }) => {
+        await expect(
+          controller.withController(async (restrictedController) => {
+            return restrictedController.keyrings[0].keyringV2;
+          }),
+        ).rejects.toThrow(
+          KeyringControllerErrorMessage.UnsafeDirectKeyringAccess,
+        );
+      });
+    });
+
     describe('addNewKeyring', () => {
       it('creates an initialized keyring and stages it for commit', async () => {
         const mockAddress = '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4';

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -4073,9 +4073,9 @@ describe('KeyringController', () => {
       await withController(
         { skipVaultCreation: true },
         async ({ controller }) => {
-          await expect(
-            controller.withController(jest.fn()),
-          ).rejects.toThrow(KeyringControllerErrorMessage.ControllerLocked);
+          await expect(controller.withController(jest.fn())).rejects.toThrow(
+            KeyringControllerErrorMessage.ControllerLocked,
+          );
         },
       );
     });
@@ -4181,8 +4181,7 @@ describe('KeyringController', () => {
           { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
           async ({ controller }) => {
             await controller.addNewKeyring(MockKeyring.type);
-            const idToRemove =
-              controller.state.keyrings[1].metadata.id;
+            const idToRemove = controller.state.keyrings[1].metadata.id;
 
             await controller.withController(async (restrictedController) => {
               await restrictedController.removeKeyring(idToRemove);
@@ -4206,8 +4205,7 @@ describe('KeyringController', () => {
           { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
           async ({ controller }) => {
             await controller.addNewKeyring(MockKeyring.type);
-            const idToRemove =
-              controller.state.keyrings[1].metadata.id;
+            const idToRemove = controller.state.keyrings[1].metadata.id;
 
             await controller.withController(async (restrictedController) => {
               expect(restrictedController.keyrings).toHaveLength(2);
@@ -4229,8 +4227,7 @@ describe('KeyringController', () => {
           { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
           async ({ controller }) => {
             await controller.addNewKeyring(MockKeyring.type);
-            const idToRemove =
-              controller.state.keyrings[1].metadata.id;
+            const idToRemove = controller.state.keyrings[1].metadata.id;
 
             await controller.withController(async (restrictedController) => {
               await restrictedController.removeKeyring(idToRemove);

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -4272,6 +4272,22 @@ describe('KeyringController', () => {
         });
       });
 
+      it('throws CannotRemovePrimaryHdKeyring when attempting to remove the primary HD keyring', async () => {
+        await withController(async ({ controller }) => {
+          const primaryId = controller.state.keyrings[0].metadata.id;
+
+          await expect(
+            controller.withController(async (restrictedController) => {
+              await restrictedController.removeKeyring(primaryId);
+            }),
+          ).rejects.toThrow(
+            KeyringControllerErrorMessage.CannotRemovePrimaryKeyring,
+          );
+
+          expect(controller.state.keyrings).toHaveLength(1);
+        });
+      });
+
       it('destroys a keyring that was created then removed within the same callback', async () => {
         const mockAddress = '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4';
         stubKeyringClassWithAccount(MockKeyring, mockAddress);

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -4144,6 +4144,18 @@ describe('KeyringController', () => {
         );
       });
 
+      it('populates keyringV2 when a V2 builder is registered for the type', async () => {
+        await withController(async ({ controller }) => {
+          await controller.withController(async (restrictedController) => {
+            const entry = await restrictedController.addNewKeyring(
+              KeyringTypes.simple,
+            );
+
+            expect(entry.keyringV2).toBeDefined();
+          });
+        });
+      });
+
       it('appears immediately in restrictedController.keyrings', async () => {
         const mockAddress = '0x4584d2B4905087A100420AFfCe1b2d73fC69B8E4';
         stubKeyringClassWithAccount(MockKeyring, mockAddress);

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -250,6 +250,43 @@ type KeyringEntry = {
 };
 
 /**
+ * A restricted view of the {@link KeyringController} exposed to the callback
+ * passed to {@link KeyringController.withController}.
+ *
+ * It provides a read-only live view of all keyrings and the ability to stage
+ * keyring additions and removals atomically within a single transaction.
+ */
+export type RestrictedController = {
+  /**
+   * Read-only live view of all keyrings in the current transaction (original
+   * keyrings plus any added, minus any removed so far in this callback).
+   */
+  readonly keyrings: ReadonlyArray<{
+    keyring: EthKeyring;
+    metadata: KeyringMetadata;
+  }>;
+  /**
+   * Create a new keyring of the given type and stage it for commit. The new
+   * entry is immediately visible in {@link RestrictedController.keyrings}.
+   *
+   * @param type - The type of keyring to create.
+   * @param opts - Optional data to pass to the keyring builder.
+   * @returns The newly created `{ keyring, metadata }` entry.
+   */
+  addNewKeyring(
+    type: string,
+    opts?: unknown,
+  ): Promise<{ keyring: EthKeyring; metadata: KeyringMetadata }>;
+  /**
+   * Stage the keyring with the given id for removal. The keyring is
+   * immediately removed from {@link RestrictedController.keyrings}.
+   *
+   * @param id - The id of the keyring to remove.
+   */
+  removeKeyring(id: string): Promise<void>;
+};
+
+/**
  * A strategy for importing an account
  */
 export enum AccountImportStrategy {
@@ -1854,6 +1891,87 @@ export class KeyringController<
         await operation({ keyring, metadata }),
         keyring,
       );
+    });
+  }
+
+  /**
+   * Execute an operation against all keyrings as a mutually exclusive atomic
+   * operation. The operation receives a {@link RestrictedController} instance
+   * that exposes a read-only live view of all keyrings as well as
+   * `addNewKeyring` and `removeKeyring` methods to stage mutations.
+   *
+   * The method automatically persists changes at the end of the function
+   * execution, or rolls back the changes if an error is thrown.
+   *
+   * @param operation - Function to execute with the restricted controller.
+   * @returns Promise resolving to the result of the function execution.
+   * @template CallbackResult - The type of the value resolved by the callback function.
+   */
+  async withController<CallbackResult = void>(
+    operation: (
+      restrictedController: RestrictedController,
+    ) => Promise<CallbackResult>,
+  ): Promise<CallbackResult> {
+    this.#assertIsUnlocked();
+
+    return this.#persistOrRollback(async () => {
+      const liveKeyrings = [...this.#keyrings];
+      const createdEntries = new Set<{
+        keyring: EthKeyring;
+        metadata: KeyringMetadata;
+      }>();
+      const removedEntries = new Set<{
+        keyring: EthKeyring;
+        metadata: KeyringMetadata;
+      }>();
+
+      const restrictedController: RestrictedController = {
+        get keyrings() {
+          return Object.freeze([...liveKeyrings]) as RestrictedController['keyrings'];
+        },
+        addNewKeyring: async (type: string, opts?: unknown) => {
+          const keyring = await this.#createKeyring(type, opts);
+          const entry = { keyring, metadata: getDefaultKeyringMetadata() };
+          liveKeyrings.push(entry);
+          createdEntries.add(entry);
+          return entry;
+        },
+        removeKeyring: async (id: string) => {
+          const idx = liveKeyrings.findIndex((e) => e.metadata.id === id);
+          if (idx === -1) {
+            throw new KeyringControllerError(
+              KeyringControllerErrorMessage.KeyringNotFound,
+            );
+          }
+          const [removed] = liveKeyrings.splice(idx, 1) as [
+            { keyring: EthKeyring; metadata: KeyringMetadata },
+          ];
+          removedEntries.add(removed);
+        },
+      };
+
+      let result: CallbackResult;
+      try {
+        result = await operation(restrictedController);
+      } catch (error) {
+        await Promise.all(
+          [...createdEntries].map(({ keyring }) =>
+            this.#destroyKeyring(keyring),
+          ),
+        );
+        throw error;
+      }
+
+      await Promise.all(
+        [...removedEntries].map(({ keyring }) => this.#destroyKeyring(keyring)),
+      );
+      this.#keyrings = liveKeyrings;
+
+      for (const { keyring } of this.#keyrings) {
+        this.#assertNoUnsafeDirectKeyringAccess(result, keyring);
+      }
+
+      return result;
     });
   }
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2184,7 +2184,12 @@ export class KeyringController<
 
       // As usual, we want to prevent returning direct references to keyring instances, so we check
       // the result for any unsafe direct access before returning.
-      for (const { keyring, keyringV2 } of this.#keyrings) {
+      for (const { keyring, keyringV2 } of [
+        ...this.#keyrings,
+        // We also check for keyrings that got removed during the operation, since the result could
+        // still have references to them.
+        ...removedEntries,
+      ]) {
         this.#assertNoUnsafeDirectKeyringAccess(result, keyring);
         if (keyringV2) {
           this.#assertNoUnsafeDirectKeyringAccess(result, keyringV2);

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -67,6 +67,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'patchUserOperation',
   'signUserOperation',
   'addNewAccount',
+  'withController',
   'withKeyring',
   'withKeyringUnsafe',
   'withKeyringV2',

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1943,7 +1943,9 @@ export class KeyringController<
         entries: Iterable<KeyringEntry>,
       ): Promise<void> => {
         await Promise.all(
-          [...entries].map(({ keyring }) => this.#destroyKeyring(keyring)),
+          [...entries].map(({ keyring, keyringV2 }) =>
+            this.#destroyKeyring(keyring, keyringV2),
+          ),
         );
       };
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1911,9 +1911,7 @@ export class KeyringController<
         // We freeze the array to prevent direct mutations, but the keyring instances
         // themselves are not frozen, allowing safe read-only access.
         get keyrings() {
-          return Object.freeze([
-            ...restrictedEntries,
-          ]) as RestrictedController['keyrings'];
+          return Object.freeze([...restrictedEntries]);
         },
 
         // Method to create a new keyring and adds it to the restricted entries.

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -262,10 +262,7 @@ export type RestrictedController = {
    * Read-only live view of all keyrings in the current transaction (original
    * keyrings plus any added, minus any removed so far in this callback).
    */
-  readonly keyrings: ReadonlyArray<{
-    keyring: EthKeyring;
-    metadata: KeyringMetadata;
-  }>;
+  readonly keyrings: readonly KeyringEntry[];
   /**
    * Create a new keyring of the given type and stage it for commit. The new
    * entry is immediately visible in {@link RestrictedController.keyrings}.
@@ -706,10 +703,7 @@ function isSerializedKeyringsArray(
 async function displayForKeyring({
   keyring,
   metadata,
-}: {
-  keyring: EthKeyring;
-  metadata: KeyringMetadata;
-}): Promise<KeyringObject> {
+}: KeyringEntry): Promise<KeyringObject> {
   const accounts = await keyring.getAccounts();
 
   return {
@@ -1803,13 +1797,7 @@ export class KeyringController<
     CallbackResult = void,
   >(
     selector: KeyringSelector<SelectedKeyring>,
-    operation: ({
-      keyring,
-      metadata,
-    }: {
-      keyring: SelectedKeyring;
-      metadata: KeyringMetadata;
-    }) => Promise<CallbackResult>,
+    operation: ({ keyring, metadata }: KeyringEntry) => Promise<CallbackResult>,
     // eslint-disable-next-line @typescript-eslint/unified-signatures
     options:
       | { createIfMissing?: false }
@@ -1836,13 +1824,7 @@ export class KeyringController<
     CallbackResult = void,
   >(
     selector: KeyringSelector<SelectedKeyring>,
-    operation: ({
-      keyring,
-      metadata,
-    }: {
-      keyring: SelectedKeyring;
-      metadata: KeyringMetadata;
-    }) => Promise<CallbackResult>,
+    operation: ({ keyring, metadata }: KeyringEntry) => Promise<CallbackResult>,
   ): Promise<CallbackResult>;
 
   async withKeyring<
@@ -1850,13 +1832,7 @@ export class KeyringController<
     CallbackResult = void,
   >(
     selector: KeyringSelector<SelectedKeyring>,
-    operation: ({
-      keyring,
-      metadata,
-    }: {
-      keyring: SelectedKeyring;
-      metadata: KeyringMetadata;
-    }) => Promise<CallbackResult>,
+    operation: ({ keyring, metadata }: KeyringEntry) => Promise<CallbackResult>,
     options:
       | { createIfMissing?: false }
       | { createIfMissing: true; createWithData?: unknown } = {
@@ -1916,58 +1892,81 @@ export class KeyringController<
     this.#assertIsUnlocked();
 
     return this.#persistOrRollback(async () => {
-      const liveKeyrings = [...this.#keyrings];
-      const createdEntries = new Set<{
-        keyring: EthKeyring;
-        metadata: KeyringMetadata;
-      }>();
-      const removedEntries = new Set<{
-        keyring: EthKeyring;
-        metadata: KeyringMetadata;
-      }>();
+      // Track created and removed keyrings during the operation execution.
+      const createdEntries = new Set<KeyringEntry>();
+      const removedEntries = new Set<KeyringEntry>();
 
+      // Copy of the current keyrings that is mutated during the operation execution.
+      const restrictedEntries = [...this.#keyrings];
+
+      // The restricted controller proxies the current keyrings and allows staging
+      // mutations that are only applied to the real keyrings if the operation
+      // completes successfully. This allows us to have a single source of truth
+      // for the keyrings during the operation execution, and to automatically
+      // roll back any changes if an error is thrown.
       const restrictedController: RestrictedController = {
+        // We freeze the array to prevent direct mutations, but the keyring instances
+        // themselves are not frozen, allowing safe read-only access.
         get keyrings() {
-          return Object.freeze([...liveKeyrings]) as RestrictedController['keyrings'];
+          return Object.freeze([
+            ...restrictedEntries,
+          ]) as RestrictedController['keyrings'];
         },
+
+        // Method to create a new keyring and adds it to the restricted entries.
         addNewKeyring: async (type: string, opts?: unknown) => {
           const keyring = await this.#createKeyring(type, opts);
           const entry = { keyring, metadata: getDefaultKeyringMetadata() };
-          liveKeyrings.push(entry);
+
+          restrictedEntries.push(entry);
           createdEntries.add(entry);
+
           return entry;
         },
+
+        // Method to remove a keyring from the restricted entries.
         removeKeyring: async (id: string) => {
-          const idx = liveKeyrings.findIndex((e) => e.metadata.id === id);
-          if (idx === -1) {
+          const index = restrictedEntries.findIndex(
+            (entry) => entry.metadata.id === id,
+          );
+          if (index === -1) {
             throw new KeyringControllerError(
               KeyringControllerErrorMessage.KeyringNotFound,
             );
           }
-          const [removed] = liveKeyrings.splice(idx, 1) as [
-            { keyring: EthKeyring; metadata: KeyringMetadata },
+
+          const [removed] = restrictedEntries.splice(index, 1) as [
+            KeyringEntry,
           ];
           removedEntries.add(removed);
         },
+      };
+
+      const destroyKeyrings = async (
+        entries: Iterable<KeyringEntry>,
+      ): Promise<void> => {
+        await Promise.all(
+          [...entries].map(({ keyring }) => this.#destroyKeyring(keyring)),
+        );
       };
 
       let result: CallbackResult;
       try {
         result = await operation(restrictedController);
       } catch (error) {
-        await Promise.all(
-          [...createdEntries].map(({ keyring }) =>
-            this.#destroyKeyring(keyring),
-          ),
-        );
+        await destroyKeyrings(createdEntries);
+
         throw error;
       }
 
-      await Promise.all(
-        [...removedEntries].map(({ keyring }) => this.#destroyKeyring(keyring)),
-      );
-      this.#keyrings = liveKeyrings;
+      await destroyKeyrings(removedEntries);
 
+      // We update the real keyrings only after the operation completes successfully, so that
+      // they will be persisted in the vault.
+      this.#keyrings = restrictedEntries;
+
+      // As usual, we want to prevent returning direct references to keyring instances, so we check
+      // the result for any unsafe direct access before returning.
       for (const { keyring } of this.#keyrings) {
         this.#assertNoUnsafeDirectKeyringAccess(result, keyring);
       }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1878,112 +1878,6 @@ export class KeyringController<
   }
 
   /**
-   * Execute an operation against all keyrings as a mutually exclusive atomic
-   * operation. The operation receives a {@link RestrictedController} instance
-   * that exposes a read-only live view of all keyrings as well as
-   * `addNewKeyring` and `removeKeyring` methods to stage mutations.
-   *
-   * The method automatically persists changes at the end of the function
-   * execution, or rolls back the changes if an error is thrown.
-   *
-   * @param operation - Function to execute with the restricted controller.
-   * @returns Promise resolving to the result of the function execution.
-   * @template CallbackResult - The type of the value resolved by the callback function.
-   */
-  async withController<CallbackResult = void>(
-    operation: (
-      restrictedController: RestrictedController,
-    ) => Promise<CallbackResult>,
-  ): Promise<CallbackResult> {
-    this.#assertIsUnlocked();
-
-    return this.#persistOrRollback(async () => {
-      // Track created and removed keyrings during the operation execution.
-      const createdEntries = new Set<KeyringEntry>();
-      const removedEntries = new Set<KeyringEntry>();
-
-      // Copy of the current keyrings that is mutated during the operation execution.
-      const restrictedEntries = [...this.#keyrings];
-
-      // The restricted controller proxies the current keyrings and allows staging
-      // mutations that are only applied to the real keyrings if the operation
-      // completes successfully. This allows us to have a single source of truth
-      // for the keyrings during the operation execution, and to automatically
-      // roll back any changes if an error is thrown.
-      const restrictedController: RestrictedController = {
-        // We freeze the array to prevent direct mutations, but the keyring instances
-        // themselves are not frozen, allowing safe read-only access.
-        get keyrings() {
-          return Object.freeze([...restrictedEntries]);
-        },
-
-        // Method to create a new keyring and adds it to the restricted entries.
-        addNewKeyring: async (type: string, opts?: unknown) => {
-          const entry = await this.#createKeyring(type, opts);
-
-          restrictedEntries.push(entry);
-          createdEntries.add(entry);
-
-          return entry;
-        },
-
-        // Method to remove a keyring from the restricted entries.
-        removeKeyring: async (id: string) => {
-          const index = restrictedEntries.findIndex(
-            (entry) => entry.metadata.id === id,
-          );
-          if (index === -1) {
-            throw new KeyringControllerError(
-              KeyringControllerErrorMessage.KeyringNotFound,
-            );
-          }
-
-          const [removed] = restrictedEntries.splice(index, 1) as [
-            KeyringEntry,
-          ];
-          removedEntries.add(removed);
-        },
-      };
-
-      const destroyKeyrings = async (
-        entries: Iterable<KeyringEntry>,
-      ): Promise<void> => {
-        await Promise.all(
-          [...entries].map(({ keyring, keyringV2 }) =>
-            this.#destroyKeyring(keyring, keyringV2),
-          ),
-        );
-      };
-
-      let result: CallbackResult;
-      try {
-        result = await operation(restrictedController);
-      } catch (error) {
-        await destroyKeyrings(createdEntries);
-
-        throw error;
-      }
-
-      await destroyKeyrings(removedEntries);
-
-      // We update the real keyrings only after the operation completes successfully, so that
-      // they will be persisted in the vault.
-      this.#keyrings = restrictedEntries;
-
-      // As usual, we want to prevent returning direct references to keyring instances, so we check
-      // the result for any unsafe direct access before returning.
-      for (const { keyring, keyringV2 } of this.#keyrings) {
-        this.#assertNoUnsafeDirectKeyringAccess(result, keyring);
-        if (keyringV2) {
-          this.#assertNoUnsafeDirectKeyringAccess(result, keyringV2);
-        }
-      }
-
-      return result;
-    });
-  }
-
-  /**
    * Select a keyring and execute the given operation with the selected
    * keyring, **without** acquiring the controller's mutual exclusion lock.
    *
@@ -2193,6 +2087,112 @@ export class KeyringController<
       await operation({ keyring, metadata }),
       keyring,
     );
+  }
+
+  /**
+   * Execute an operation against all keyrings as a mutually exclusive atomic
+   * operation. The operation receives a {@link RestrictedController} instance
+   * that exposes a read-only live view of all keyrings as well as
+   * `addNewKeyring` and `removeKeyring` methods to stage mutations.
+   *
+   * The method automatically persists changes at the end of the function
+   * execution, or rolls back the changes if an error is thrown.
+   *
+   * @param operation - Function to execute with the restricted controller.
+   * @returns Promise resolving to the result of the function execution.
+   * @template CallbackResult - The type of the value resolved by the callback function.
+   */
+  async withController<CallbackResult = void>(
+    operation: (
+      restrictedController: RestrictedController,
+    ) => Promise<CallbackResult>,
+  ): Promise<CallbackResult> {
+    this.#assertIsUnlocked();
+
+    return this.#persistOrRollback(async () => {
+      // Track created and removed keyrings during the operation execution.
+      const createdEntries = new Set<KeyringEntry>();
+      const removedEntries = new Set<KeyringEntry>();
+
+      // Copy of the current keyrings that is mutated during the operation execution.
+      const restrictedEntries = [...this.#keyrings];
+
+      // The restricted controller proxies the current keyrings and allows staging
+      // mutations that are only applied to the real keyrings if the operation
+      // completes successfully. This allows us to have a single source of truth
+      // for the keyrings during the operation execution, and to automatically
+      // roll back any changes if an error is thrown.
+      const restrictedController: RestrictedController = {
+        // We freeze the array to prevent direct mutations, but the keyring instances
+        // themselves are not frozen, allowing safe read-only access.
+        get keyrings() {
+          return Object.freeze([...restrictedEntries]);
+        },
+
+        // Method to create a new keyring and adds it to the restricted entries.
+        addNewKeyring: async (type: string, opts?: unknown) => {
+          const entry = await this.#createKeyring(type, opts);
+
+          restrictedEntries.push(entry);
+          createdEntries.add(entry);
+
+          return entry;
+        },
+
+        // Method to remove a keyring from the restricted entries.
+        removeKeyring: async (id: string) => {
+          const index = restrictedEntries.findIndex(
+            (entry) => entry.metadata.id === id,
+          );
+          if (index === -1) {
+            throw new KeyringControllerError(
+              KeyringControllerErrorMessage.KeyringNotFound,
+            );
+          }
+
+          const [removed] = restrictedEntries.splice(index, 1) as [
+            KeyringEntry,
+          ];
+          removedEntries.add(removed);
+        },
+      };
+
+      const destroyKeyrings = async (
+        entries: Iterable<KeyringEntry>,
+      ): Promise<void> => {
+        await Promise.all(
+          [...entries].map(({ keyring, keyringV2 }) =>
+            this.#destroyKeyring(keyring, keyringV2),
+          ),
+        );
+      };
+
+      let result: CallbackResult;
+      try {
+        result = await operation(restrictedController);
+      } catch (error) {
+        await destroyKeyrings(createdEntries);
+
+        throw error;
+      }
+
+      await destroyKeyrings(removedEntries);
+
+      // We update the real keyrings only after the operation completes successfully, so that
+      // they will be persisted in the vault.
+      this.#keyrings = restrictedEntries;
+
+      // As usual, we want to prevent returning direct references to keyring instances, so we check
+      // the result for any unsafe direct access before returning.
+      for (const { keyring, keyringV2 } of this.#keyrings) {
+        this.#assertNoUnsafeDirectKeyringAccess(result, keyring);
+        if (keyringV2) {
+          this.#assertNoUnsafeDirectKeyringAccess(result, keyringV2);
+        }
+      }
+
+      return result;
+    });
   }
 
   async getAccountKeyringType(account: string): Promise<string> {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1832,7 +1832,13 @@ export class KeyringController<
     CallbackResult = void,
   >(
     selector: KeyringSelector<SelectedKeyring>,
-    operation: ({ keyring, metadata }: KeyringEntry) => Promise<CallbackResult>,
+    operation: ({
+      keyring,
+      metadata,
+    }: {
+      keyring: SelectedKeyring;
+      metadata: KeyringMetadata;
+    }) => Promise<CallbackResult>,
     options:
       | { createIfMissing?: false }
       | { createIfMissing: true; createWithData?: unknown } = {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -233,6 +233,9 @@ export type KeyringMetadata = {
   name: string;
 };
 
+/**
+ * A keyring entry, including the keyring instance (+ v2 instance) and its metadata.
+ */
 type KeyringEntry = {
   /**
    * The keyring instance.

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -236,7 +236,7 @@ export type KeyringMetadata = {
 /**
  * A keyring entry, including the keyring instance (+ v2 instance) and its metadata.
  */
-type KeyringEntry = {
+export type KeyringEntry = {
   /**
    * The keyring instance.
    */
@@ -274,10 +274,7 @@ export type RestrictedController = {
    * @param opts - Optional data to pass to the keyring builder.
    * @returns The newly created `{ keyring, metadata }` entry.
    */
-  addNewKeyring(
-    type: string,
-    opts?: unknown,
-  ): Promise<{ keyring: EthKeyring; metadata: KeyringMetadata }>;
+  addNewKeyring(type: string, opts?: unknown): Promise<KeyringEntry>;
   /**
    * Stage the keyring with the given id for removal. The keyring is
    * immediately removed from {@link RestrictedController.keyrings}.

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1966,8 +1966,11 @@ export class KeyringController<
 
       // As usual, we want to prevent returning direct references to keyring instances, so we check
       // the result for any unsafe direct access before returning.
-      for (const { keyring } of this.#keyrings) {
+      for (const { keyring, keyringV2 } of this.#keyrings) {
         this.#assertNoUnsafeDirectKeyringAccess(result, keyring);
+        if (keyringV2) {
+          this.#assertNoUnsafeDirectKeyringAccess(result, keyringV2);
+        }
       }
 
       return result;

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1913,8 +1913,7 @@ export class KeyringController<
 
         // Method to create a new keyring and adds it to the restricted entries.
         addNewKeyring: async (type: string, opts?: unknown) => {
-          const keyring = await this.#createKeyring(type, opts);
-          const entry = { keyring, metadata: getDefaultKeyringMetadata() };
+          const entry = await this.#createKeyring(type, opts);
 
           restrictedEntries.push(entry);
           createdEntries.add(entry);

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2150,6 +2150,11 @@ export class KeyringController<
             );
           }
 
+          this.#assertNotRemovingPrimaryKeyring(
+            restrictedEntries[index],
+            restrictedEntries,
+          );
+
           const [removed] = restrictedEntries.splice(index, 1) as [
             KeyringEntry,
           ];
@@ -3096,6 +3101,27 @@ export class KeyringController<
     if (!this.#controllerOperationMutex.isLocked()) {
       throw new KeyringControllerError(
         KeyringControllerErrorMessage.ControllerLockRequired,
+      );
+    }
+  }
+
+  /**
+   * Assert that the given keyring entry is not the primary HD keyring.
+   *
+   * @param entry - The keyring entry to check.
+   * @param keyrings - The current list of keyring entries.
+   * @throws If the entry is the primary keyring.
+   */
+  #assertNotRemovingPrimaryKeyring(
+    entry: KeyringEntry,
+    keyrings: KeyringEntry[],
+  ): void {
+    if (
+      keyrings[0] === entry &&
+      entry.keyring.type === (KeyringTypes.hd as string)
+    ) {
+      throw new KeyringControllerError(
+        KeyringControllerErrorMessage.CannotRemovePrimaryKeyring,
       );
     }
   }

--- a/packages/keyring-controller/src/constants.ts
+++ b/packages/keyring-controller/src/constants.ts
@@ -39,4 +39,5 @@ export enum KeyringControllerErrorMessage {
   LastAccountInPrimaryKeyring = 'KeyringController - Last account in primary keyring cannot be removed',
   EncryptionKeyNotSet = 'KeyringController - Encryption key not set',
   KeyringV2NotSupported = 'KeyringController - The selected keyring does not support the KeyringV2 API.',
+  CannotRemovePrimaryKeyring = 'KeyringController - Cannot remove the primary keyring',
 }

--- a/packages/keyring-controller/src/index.ts
+++ b/packages/keyring-controller/src/index.ts
@@ -19,6 +19,7 @@ export type {
   KeyringControllerPrepareUserOperationAction,
   KeyringControllerPatchUserOperationAction,
   KeyringControllerSignUserOperationAction,
+  KeyringControllerWithControllerAction,
   KeyringControllerWithKeyringAction,
   KeyringControllerWithKeyringUnsafeAction,
   KeyringControllerWithKeyringV2Action,

--- a/packages/keyring-controller/tests/mocks/mockKeyring.ts
+++ b/packages/keyring-controller/tests/mocks/mockKeyring.ts
@@ -32,4 +32,8 @@ export class MockKeyring implements EthKeyring {
   async deserialize(_: unknown): Promise<void> {
     return Promise.resolve();
   }
+
+  async destroy(): Promise<void> {
+    return Promise.resolve();
+  }
 }


### PR DESCRIPTION
## Explanation

Today there's no way to make multiple operations in an "atomic" (read transactional) way.

A good example of this is if you want to use a keyring using `withKeyring` that's not existing yet (I'm omitting the `createIfMissing` variants, as we wanted to move away from this pattern).

To do this in a safe way, you usually have to use your own lock to make sure you can get-or-create the keyring and prevent concurrent keyring creations.

This new `withController` is based on the `withKeyring` but with an access to a "restricted" state and methods of the controller. This way, you can interact with multiple keyring at once while being guarded (to prevent race-conditions) by the controller's global lock.

The former problem can then be written that way now:

```ts
const account = await keyringController.withController(async (controller) => {
  // Here, `controller.keyrings` is a "view" on the existing keyrings (instances), only valid
  // for this block.
  let keyring: MyKeyring | undefined = controller.keyrings.find(isMyKeyring);
  if (!keyring) {
    const { keyring: myKeyring } = await controller.addNewKeyring({ type: 'My Keyring', data: { ... }});
    keyring = myKeyring;
  }
  
  const [account] = await keyring.createAccounts(...);
  return account;
});
```

This will also be used to write the migration from the existing `SnapKeyring` (1 for ALL Snaps) to multiple `SnapKeyring` (1 PER Snap) in a safe way like:

```ts
await keyringController.withController(async (controller) => {
  const accounts: Map<SnapId, KeyringAccount[]> = new Map();

  // Get existing Snap accounts from the single Snap keyring instance we have today.
  const keyring: SnapKeyring | undefined = controller.keyrings.find(isSnapKeyring);
  if (keyring) {
    for (const account of keyring.listAccounts()) {
      accounts[account.metadata.snap.id] ??= [];
      accounts[account.metadata.snap.id].push(account);
    }
  }
  
  // Re-create all new Snap keyrings, 1 per Snap.
  for (const [snapId, snapAccounts] of accounts.entries()) {
    await controller.addNewKeyring({ type: 'Snap keyring', data: snapAccounts });
  }
  
  // We can safely remove the existing Snap keyring now.
  await controller.removeKeyring(...);
});
```

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new transactional API that can create/remove keyrings and then persist/rollback state, which touches keyring lifecycle and vault persistence paths. Risk is moderate due to potential edge cases around staged mutations, keyring destruction, and primary keyring protection.
> 
> **Overview**
> Adds `KeyringController.withController` (and messenger action `KeyringController:withController`) to run **single-lock, atomic operations across multiple keyrings** via a `RestrictedController` that exposes a live read-only view plus staged `addNewKeyring`/`removeKeyring` mutations.
> 
> On success it commits staged keyring list changes, persists via existing persist/rollback flow, and destroys removed keyrings; on error it rolls back and destroys any newly created keyrings. The PR also blocks removal of the primary HD keyring (`CannotRemovePrimaryKeyring`), extends `KeyringEntry`/callback typings, updates mocks to include `destroy`, and adds comprehensive unit + messenger tests for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ae24f643bfb15f9356ca49c8802e4557ce87478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->