### PR TITLE
feat(snap-account-service): implement `init` + `getSnaps`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 /packages/account-tree-controller            @MetaMask/accounts-engineers
 /packages/profile-sync-controller            @MetaMask/accounts-engineers
 /packages/money-account-controller           @MetaMask/accounts-engineers
+/packages/snap-account-service               @MetaMask/accounts-engineers
 
 ## Assets Team
 /packages/assets-controllers         @MetaMask/metamask-assets
@@ -226,3 +227,5 @@
 /packages/social-controllers/CHANGELOG.md @MetaMask/social-ai @MetaMask/core-platform
 /packages/money-account-controller/package.json @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/money-account-controller/CHANGELOG.md @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/snap-account-service/package.json @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/snap-account-service/CHANGELOG.md @MetaMask/accounts-engineers @MetaMask/core-platform

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Each package in this repository has its own README where you can find installati
 - [`@metamask/selected-network-controller`](packages/selected-network-controller)
 - [`@metamask/shield-controller`](packages/shield-controller)
 - [`@metamask/signature-controller`](packages/signature-controller)
+- [`@metamask/snap-account-service`](packages/snap-account-service)
 - [`@metamask/social-controllers`](packages/social-controllers)
 - [`@metamask/storage-service`](packages/storage-service)
 - [`@metamask/subscription-controller`](packages/subscription-controller)
@@ -177,6 +178,7 @@ linkStyle default opacity:0.5
   selected_network_controller(["@metamask/selected-network-controller"]);
   shield_controller(["@metamask/shield-controller"]);
   signature_controller(["@metamask/signature-controller"]);
+  snap_account_service(["@metamask/snap-account-service"]);
   social_controllers(["@metamask/social-controllers"]);
   storage_service(["@metamask/storage-service"]);
   subscription_controller(["@metamask/subscription-controller"]);

--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ linkStyle default opacity:0.5
   signature_controller --> logging_controller;
   signature_controller --> messenger;
   signature_controller --> network_controller;
+  snap_account_service --> messenger;
   social_controllers --> base_controller;
   social_controllers --> base_data_service;
   social_controllers --> controller_utils;

--- a/packages/snap-account-service/CHANGELOG.md
+++ b/packages/snap-account-service/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/core/

--- a/packages/snap-account-service/CHANGELOG.md
+++ b/packages/snap-account-service/CHANGELOG.md
@@ -9,6 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `SnapAccountService` ([#8414](https://github.com/MetaMask/core/pull/8414))
+- Add `SnapAccountService` ([#8414](https://github.com/MetaMask/core/pull/8414)), ([#8418](https://github.com/MetaMask/core/pull/8418))
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/snap-account-service/CHANGELOG.md
+++ b/packages/snap-account-service/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `SnapAccountService` ([#8414](https://github.com/MetaMask/core/pull/8414))
+
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/snap-account-service/LICENSE
+++ b/packages/snap-account-service/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2026 MetaMask
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE

--- a/packages/snap-account-service/README.md
+++ b/packages/snap-account-service/README.md
@@ -1,0 +1,15 @@
+# `@metamask/snap-account-service`
+
+Service for Account Management Snaps
+
+## Installation
+
+`yarn add @metamask/snap-account-service`
+
+or
+
+`npm install @metamask/snap-account-service`
+
+## Contributing
+
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).

--- a/packages/snap-account-service/jest.config.js
+++ b/packages/snap-account-service/jest.config.js
@@ -1,0 +1,26 @@
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+const merge = require('deepmerge');
+const path = require('path');
+
+const baseConfig = require('../../jest.config.packages');
+
+const displayName = path.basename(__dirname);
+
+module.exports = merge(baseConfig, {
+  // The display name when running multiple projects
+  displayName,
+
+  // An object that configures minimum threshold enforcement for coverage results
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+});

--- a/packages/snap-account-service/package.json
+++ b/packages/snap-account-service/package.json
@@ -68,6 +68,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@metamask/messenger": "workspace:^"
+    "@metamask/messenger": "^1.1.1"
   }
 }

--- a/packages/snap-account-service/package.json
+++ b/packages/snap-account-service/package.json
@@ -48,6 +48,9 @@
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
+  "dependencies": {
+    "@metamask/messenger": "^1.1.1"
+  },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",
     "@ts-bridge/cli": "^0.6.4",
@@ -66,8 +69,5 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
-  },
-  "dependencies": {
-    "@metamask/messenger": "^1.1.1"
   }
 }

--- a/packages/snap-account-service/package.json
+++ b/packages/snap-account-service/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@metamask/snap-account-service",
+  "version": "0.0.0",
+  "description": "Service for Account Management Snaps",
+  "keywords": [
+    "MetaMask",
+    "Ethereum"
+  ],
+  "homepage": "https://github.com/MetaMask/core/tree/main/packages/snap-account-service#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/core/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/core.git"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",
+    "build:all": "ts-bridge --project tsconfig.build.json --verbose --clean",
+    "build:docs": "typedoc",
+    "changelog:update": "../../scripts/update-changelog.sh @metamask/snap-account-service",
+    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/snap-account-service",
+    "messenger-action-types:check": "tsx ../../packages/messenger-cli/src/cli.ts --check",
+    "messenger-action-types:generate": "tsx ../../packages/messenger-cli/src/cli.ts --generate",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
+    "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
+    "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+  },
+  "devDependencies": {
+    "@metamask/auto-changelog": "^3.4.4",
+    "@ts-bridge/cli": "^0.6.4",
+    "@types/jest": "^29.5.14",
+    "deepmerge": "^4.2.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
+    "tsx": "^4.20.5",
+    "typedoc": "^0.25.13",
+    "typedoc-plugin-missing-exports": "^2.0.0",
+    "typescript": "~5.3.3"
+  },
+  "engines": {
+    "node": "^18.18 || >=20"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "dependencies": {
+    "@metamask/messenger": "workspace:^"
+  }
+}

--- a/packages/snap-account-service/package.json
+++ b/packages/snap-account-service/package.json
@@ -49,7 +49,10 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/messenger": "^1.1.1"
+    "@metamask/messenger": "^1.1.1",
+    "@metamask/snaps-controllers": "^19.0.0",
+    "@metamask/snaps-sdk": "^11.0.0",
+    "@metamask/utils": "^11.9.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",

--- a/packages/snap-account-service/src/SnapAccountService-method-action-types.ts
+++ b/packages/snap-account-service/src/SnapAccountService-method-action-types.ts
@@ -1,0 +1,21 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { SnapAccountService } from './SnapAccountService';
+
+/**
+ * Returns the Snap IDs of all account management Snaps.
+ *
+ * @returns Set of Snap IDs of all account management Snaps.
+ */
+export type SnapAccountServiceGetSnapsAction = {
+  type: `SnapAccountService:getSnaps`;
+  handler: SnapAccountService['getSnaps'];
+};
+
+/**
+ * Union of all SnapAccountService action types.
+ */
+export type SnapAccountServiceMethodActions = SnapAccountServiceGetSnapsAction;

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -13,7 +13,7 @@ describe('SnapAccountService', () => {
     it('resolves without throwing', async () => {
       const { service } = createService();
 
-      await expect(service.init()).resolves.toBeUndefined();
+      expect(await service.init()).toBeUndefined();
     });
   });
 });

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -12,51 +12,6 @@ import { SnapAccountService } from './SnapAccountService';
 const MOCK_KEYRING_SNAP_ID = 'npm:@metamask/keyring-snap' as SnapId;
 const MOCK_OTHER_SNAP_ID = 'npm:@metamask/other-snap' as SnapId;
 
-describe('SnapAccountService', () => {
-  describe('init', () => {
-    it('resolves without throwing when there are no snaps', async () => {
-      const { service } = setup({ snaps: [] });
-
-      expect(await service.init()).toBeUndefined();
-    });
-
-    it('stores snap IDs that have the endowment:keyring permission', async () => {
-      const { service } = setup({
-        snaps: [buildSnap(MOCK_KEYRING_SNAP_ID, { 'endowment:keyring': {} })],
-      });
-
-      await service.init();
-
-      expect(service.getSnaps().has(MOCK_KEYRING_SNAP_ID)).toBe(true);
-    });
-
-    it('does not store snap IDs that lack the endowment:keyring permission', async () => {
-      const { service } = setup({
-        snaps: [buildSnap(MOCK_OTHER_SNAP_ID, {})],
-      });
-
-      await service.init();
-
-      expect(service.getSnaps().has(MOCK_OTHER_SNAP_ID)).toBe(false);
-    });
-
-    it('handles a mix of keyring and non-keyring snaps', async () => {
-      const { service } = setup({
-        snaps: [
-          buildSnap(MOCK_KEYRING_SNAP_ID, { 'endowment:keyring': {} }),
-          buildSnap(MOCK_OTHER_SNAP_ID, {}),
-        ],
-      });
-
-      await service.init();
-
-      expect(service.getSnaps().has(MOCK_KEYRING_SNAP_ID)).toBe(true);
-      expect(service.getSnaps().has(MOCK_OTHER_SNAP_ID)).toBe(false);
-      expect(service.getSnaps().size).toBe(1);
-    });
-  });
-});
-
 /**
  * The type of the messenger populated with all external actions and events
  * required by the service under test.
@@ -126,3 +81,64 @@ function setup({ snaps }: { snaps: ReturnType<typeof buildSnap>[] }): {
 
   return { service, rootMessenger, messenger };
 }
+
+describe('SnapAccountService', () => {
+  describe('init', () => {
+    it('resolves without throwing when there are no snaps', async () => {
+      const { service } = setup({ snaps: [] });
+
+      expect(await service.init()).toBeUndefined();
+    });
+
+    it('stores snap IDs that have the endowment:keyring permission', async () => {
+      const { service } = setup({
+        snaps: [buildSnap(MOCK_KEYRING_SNAP_ID, { 'endowment:keyring': {} })],
+      });
+
+      await service.init();
+
+      expect(service.getSnaps().has(MOCK_KEYRING_SNAP_ID)).toBe(true);
+    });
+
+    it('does not store snap IDs that lack the endowment:keyring permission', async () => {
+      const { service } = setup({
+        snaps: [buildSnap(MOCK_OTHER_SNAP_ID, {})],
+      });
+
+      await service.init();
+
+      expect(service.getSnaps().has(MOCK_OTHER_SNAP_ID)).toBe(false);
+    });
+
+    it('handles a mix of keyring and non-keyring snaps', async () => {
+      const { service } = setup({
+        snaps: [
+          buildSnap(MOCK_KEYRING_SNAP_ID, { 'endowment:keyring': {} }),
+          buildSnap(MOCK_OTHER_SNAP_ID, {}),
+        ],
+      });
+
+      await service.init();
+
+      expect(service.getSnaps().has(MOCK_KEYRING_SNAP_ID)).toBe(true);
+      expect(service.getSnaps().has(MOCK_OTHER_SNAP_ID)).toBe(false);
+      expect(service.getSnaps().size).toBe(1);
+    });
+  });
+
+  describe('getSnaps', () => {
+    it('returns the set of account management snap IDs via the messenger action', async () => {
+      const { rootMessenger, service } = setup({
+        snaps: [buildSnap(MOCK_KEYRING_SNAP_ID, { 'endowment:keyring': {} })],
+      });
+
+      await service.init();
+
+      expect(
+        rootMessenger
+          .call('SnapAccountService:getSnaps')
+          .has(MOCK_KEYRING_SNAP_ID),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -4,16 +4,55 @@ import type {
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
+import type { SnapId } from '@metamask/snaps-sdk';
 
 import type { SnapAccountServiceMessenger } from './SnapAccountService';
 import { SnapAccountService } from './SnapAccountService';
 
+const MOCK_KEYRING_SNAP_ID = 'npm:@metamask/keyring-snap' as SnapId;
+const MOCK_OTHER_SNAP_ID = 'npm:@metamask/other-snap' as SnapId;
+
 describe('SnapAccountService', () => {
   describe('init', () => {
-    it('resolves without throwing', async () => {
-      const { service } = createService();
+    it('resolves without throwing when there are no snaps', async () => {
+      const { service } = setup({ snaps: [] });
 
       expect(await service.init()).toBeUndefined();
+    });
+
+    it('stores snap IDs that have the endowment:keyring permission', async () => {
+      const { service } = setup({
+        snaps: [buildSnap(MOCK_KEYRING_SNAP_ID, { 'endowment:keyring': {} })],
+      });
+
+      await service.init();
+
+      expect(service.getSnaps().has(MOCK_KEYRING_SNAP_ID)).toBe(true);
+    });
+
+    it('does not store snap IDs that lack the endowment:keyring permission', async () => {
+      const { service } = setup({
+        snaps: [buildSnap(MOCK_OTHER_SNAP_ID, {})],
+      });
+
+      await service.init();
+
+      expect(service.getSnaps().has(MOCK_OTHER_SNAP_ID)).toBe(false);
+    });
+
+    it('handles a mix of keyring and non-keyring snaps', async () => {
+      const { service } = setup({
+        snaps: [
+          buildSnap(MOCK_KEYRING_SNAP_ID, { 'endowment:keyring': {} }),
+          buildSnap(MOCK_OTHER_SNAP_ID, {}),
+        ],
+      });
+
+      await service.init();
+
+      expect(service.getSnaps().has(MOCK_KEYRING_SNAP_ID)).toBe(true);
+      expect(service.getSnaps().has(MOCK_OTHER_SNAP_ID)).toBe(false);
+      expect(service.getSnaps().size).toBe(1);
     });
   });
 });
@@ -29,48 +68,61 @@ type RootMessenger = Messenger<
 >;
 
 /**
- * Constructs the root messenger for the service under test.
+ * Builds a minimal snap object for use in tests.
  *
- * @returns The root messenger.
+ * @param id - The snap ID.
+ * @param initialPermissions - The snap's initial permissions.
+ * @returns A minimal snap object.
  */
-function createRootMessenger(): RootMessenger {
-  return new Messenger({ namespace: MOCK_ANY_NAMESPACE });
+function buildSnap(
+  id: SnapId,
+  initialPermissions: Record<string, unknown>,
+): {
+  id: SnapId;
+  initialPermissions: Record<string, unknown>;
+  version: string;
+  enabled: boolean;
+  blocked: boolean;
+} {
+  return {
+    id,
+    initialPermissions,
+    version: '1.0.0',
+    enabled: true,
+    blocked: false,
+  };
 }
 
 /**
- * Constructs the messenger for the service under test.
+ * Sets up the service under test with its required mocks.
  *
- * @param rootMessenger - The root messenger.
- * @returns The service-specific messenger.
+ * @param args - The setup arguments.
+ * @param args.snaps - The snaps that `SnapController:getRunnableSnaps` will return.
+ * @returns The service and its messengers.
  */
-function createServiceMessenger(
-  rootMessenger: RootMessenger,
-): SnapAccountServiceMessenger {
-  return new Messenger({
-    namespace: 'SnapAccountService',
-    parent: rootMessenger,
-  });
-}
-
-/**
- * Constructs the service under test with sensible defaults.
- *
- * @param args - The arguments to this function.
- * @param args.options - The options that the service constructor takes.
- * @returns The new service, root messenger, and service messenger.
- */
-function createService({
-  options = {},
-}: {
-  options?: Partial<ConstructorParameters<typeof SnapAccountService>[0]>;
-} = {}): {
+function setup({ snaps }: { snaps: ReturnType<typeof buildSnap>[] }): {
   service: SnapAccountService;
   rootMessenger: RootMessenger;
   messenger: SnapAccountServiceMessenger;
 } {
-  const rootMessenger = createRootMessenger();
-  const messenger = createServiceMessenger(rootMessenger);
-  const service = new SnapAccountService({ messenger, ...options });
+  const rootMessenger: RootMessenger = new Messenger({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+  const messenger: SnapAccountServiceMessenger = new Messenger({
+    namespace: 'SnapAccountService',
+    parent: rootMessenger,
+  });
+
+  rootMessenger.delegate({
+    actions: ['SnapController:getRunnableSnaps'],
+    messenger,
+  });
+  rootMessenger.registerActionHandler(
+    'SnapController:getRunnableSnaps',
+    jest.fn().mockReturnValue(snaps),
+  );
+
+  const service = new SnapAccountService({ messenger });
 
   return { service, rootMessenger, messenger };
 }

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -1,0 +1,76 @@
+import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
+import type {
+  MockAnyNamespace,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+
+import type { SnapAccountServiceMessenger } from './SnapAccountService';
+import { SnapAccountService } from './SnapAccountService';
+
+describe('SnapAccountService', () => {
+  describe('init', () => {
+    it('resolves without throwing', async () => {
+      const { service } = createService();
+
+      await expect(service.init()).resolves.toBeUndefined();
+    });
+  });
+});
+
+/**
+ * The type of the messenger populated with all external actions and events
+ * required by the service under test.
+ */
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  MessengerActions<SnapAccountServiceMessenger>,
+  MessengerEvents<SnapAccountServiceMessenger>
+>;
+
+/**
+ * Constructs the root messenger for the service under test.
+ *
+ * @returns The root messenger.
+ */
+function createRootMessenger(): RootMessenger {
+  return new Messenger({ namespace: MOCK_ANY_NAMESPACE });
+}
+
+/**
+ * Constructs the messenger for the service under test.
+ *
+ * @param rootMessenger - The root messenger.
+ * @returns The service-specific messenger.
+ */
+function createServiceMessenger(
+  rootMessenger: RootMessenger,
+): SnapAccountServiceMessenger {
+  return new Messenger({
+    namespace: 'SnapAccountService',
+    parent: rootMessenger,
+  });
+}
+
+/**
+ * Constructs the service under test with sensible defaults.
+ *
+ * @param args - The arguments to this function.
+ * @param args.options - The options that the service constructor takes.
+ * @returns The new service, root messenger, and service messenger.
+ */
+function createService({
+  options = {},
+}: {
+  options?: Partial<ConstructorParameters<typeof SnapAccountService>[0]>;
+} = {}): {
+  service: SnapAccountService;
+  rootMessenger: RootMessenger;
+  messenger: SnapAccountServiceMessenger;
+} {
+  const rootMessenger = createRootMessenger();
+  const messenger = createServiceMessenger(rootMessenger);
+  const service = new SnapAccountService({ messenger, ...options });
+
+  return { service, rootMessenger, messenger };
+}

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -1,0 +1,80 @@
+import type { Messenger } from '@metamask/messenger';
+
+/**
+ * The name of the {@link SnapAccountService}, used to namespace the service's
+ * actions and events.
+ */
+export const serviceName = 'SnapAccountService';
+
+// === MESSENGER ===
+
+/**
+ * All of the methods within {@link SnapAccountService} that are exposed via
+ * the messenger.
+ */
+const MESSENGER_EXPOSED_METHODS = [] as const;
+
+/**
+ * Actions that {@link SnapAccountService} exposes to other consumers.
+ */
+export type SnapAccountServiceActions = never;
+
+/**
+ * Actions from other messengers that {@link SnapAccountService} calls.
+ */
+type AllowedActions = never;
+
+/**
+ * Events that {@link SnapAccountService} exposes to other consumers.
+ */
+export type SnapAccountServiceEvents = never;
+
+/**
+ * Events from other messengers that {@link SnapAccountService} subscribes to.
+ */
+type AllowedEvents = never;
+
+/**
+ * The messenger which is restricted to actions and events accessed by
+ * {@link SnapAccountService}.
+ */
+export type SnapAccountServiceMessenger = Messenger<
+  typeof serviceName,
+  SnapAccountServiceActions | AllowedActions,
+  SnapAccountServiceEvents | AllowedEvents
+>;
+
+/**
+ * Service responsible for managing account management snaps.
+ */
+export class SnapAccountService {
+  /**
+   * The name of the service.
+   */
+  readonly name: typeof serviceName;
+
+  readonly #messenger: SnapAccountServiceMessenger;
+
+  /**
+   * Constructs a new {@link SnapAccountService}.
+   *
+   * @param args - The constructor arguments.
+   * @param args.messenger - The messenger suited for this service.
+   */
+  constructor({ messenger }: { messenger: SnapAccountServiceMessenger }) {
+    this.name = serviceName;
+    this.#messenger = messenger;
+
+    this.#messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
+    );
+  }
+
+  /**
+   * Initializes the snap account service.
+   */
+  async init(): Promise<void> {
+    // TODO: Add initialization logic here.
+  }
+}

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -1,12 +1,14 @@
 import type { Messenger } from '@metamask/messenger';
+import type { SnapControllerGetRunnableSnapsAction } from '@metamask/snaps-controllers';
+import type { Snap, SnapId } from '@metamask/snaps-sdk';
+
+import { projectLogger as log } from './logger';
 
 /**
  * The name of the {@link SnapAccountService}, used to namespace the service's
  * actions and events.
  */
 export const serviceName = 'SnapAccountService';
-
-// === MESSENGER ===
 
 /**
  * All of the methods within {@link SnapAccountService} that are exposed via
@@ -22,7 +24,7 @@ export type SnapAccountServiceActions = never;
 /**
  * Actions from other messengers that {@link SnapAccountService} calls.
  */
-type AllowedActions = never;
+type AllowedActions = SnapControllerGetRunnableSnapsAction;
 
 /**
  * Events that {@link SnapAccountService} exposes to other consumers.
@@ -45,6 +47,16 @@ export type SnapAccountServiceMessenger = Messenger<
 >;
 
 /**
+ * Checks if a given Snap is an account management Snap.
+ *
+ * @param snap - The Snap to check.
+ * @returns True if the Snap is an account management Snap, false otherwise.
+ */
+function isAccountManagementSnap(snap: Snap): boolean {
+  return snap.initialPermissions['endowment:keyring'] !== undefined;
+}
+
+/**
  * Service responsible for managing account management snaps.
  */
 export class SnapAccountService {
@@ -54,6 +66,8 @@ export class SnapAccountService {
   readonly name: typeof serviceName;
 
   readonly #messenger: SnapAccountServiceMessenger;
+
+  readonly #snaps: Set<SnapId> = new Set();
 
   /**
    * Constructs a new {@link SnapAccountService}.
@@ -72,9 +86,24 @@ export class SnapAccountService {
   }
 
   /**
-   * Initializes the snap account service.
+   * Initializes the Snap account service.
    */
   async init(): Promise<void> {
-    // TODO: Add initialization logic here.
+    const snaps = this.#messenger.call('SnapController:getRunnableSnaps');
+    for (const snap of snaps) {
+      if (isAccountManagementSnap(snap)) {
+        log(`Found account management Snap: ${snap.id}`);
+        this.#snaps.add(snap.id);
+      }
+    }
+  }
+
+  /**
+   * Returns the Snap IDs of all account management Snaps.
+   *
+   * @returns Set of Snap IDs of all account management Snaps.
+   */
+  getSnaps(): Set<SnapId> {
+    return this.#snaps;
   }
 }

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -3,6 +3,7 @@ import type { SnapControllerGetRunnableSnapsAction } from '@metamask/snaps-contr
 import type { Snap, SnapId } from '@metamask/snaps-sdk';
 
 import { projectLogger as log } from './logger';
+import { SnapAccountServiceMethodActions } from './SnapAccountService-method-action-types';
 
 /**
  * The name of the {@link SnapAccountService}, used to namespace the service's
@@ -14,12 +15,12 @@ export const serviceName = 'SnapAccountService';
  * All of the methods within {@link SnapAccountService} that are exposed via
  * the messenger.
  */
-const MESSENGER_EXPOSED_METHODS = [] as const;
+const MESSENGER_EXPOSED_METHODS = ['getSnaps'] as const;
 
 /**
  * Actions that {@link SnapAccountService} exposes to other consumers.
  */
-export type SnapAccountServiceActions = never;
+export type SnapAccountServiceActions = SnapAccountServiceMethodActions;
 
 /**
  * Actions from other messengers that {@link SnapAccountService} calls.

--- a/packages/snap-account-service/src/index.ts
+++ b/packages/snap-account-service/src/index.ts
@@ -1,0 +1,6 @@
+export { SnapAccountService } from './SnapAccountService';
+export type {
+  SnapAccountServiceActions,
+  SnapAccountServiceEvents,
+  SnapAccountServiceMessenger,
+} from './SnapAccountService';

--- a/packages/snap-account-service/src/logger.ts
+++ b/packages/snap-account-service/src/logger.ts
@@ -1,0 +1,7 @@
+/* istanbul ignore file */
+
+import { createProjectLogger, createModuleLogger } from '@metamask/utils';
+
+export const projectLogger = createProjectLogger('snap-account-service');
+
+export { createModuleLogger };

--- a/packages/snap-account-service/tsconfig.build.json
+++ b/packages/snap-account-service/tsconfig.build.json
@@ -5,8 +5,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "references": [
-    { "path": "../messenger/tsconfig.build.json" }
-  ],
+  "references": [{ "path": "../messenger/tsconfig.build.json" }],
   "include": ["../../types", "./src"]
 }

--- a/packages/snap-account-service/tsconfig.build.json
+++ b/packages/snap-account-service/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.packages.build.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [
+    { "path": "../messenger/tsconfig.build.json" }
+  ],
+  "include": ["../../types", "./src"]
+}

--- a/packages/snap-account-service/tsconfig.json
+++ b/packages/snap-account-service/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  },
+  "references": [
+    { "path": "../messenger" }
+  ],
+  "include": ["../../types", "./src"]
+}

--- a/packages/snap-account-service/tsconfig.json
+++ b/packages/snap-account-service/tsconfig.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../messenger" }
-  ],
+  "references": [{ "path": "../messenger" }],
   "include": ["../../types", "./src"]
 }

--- a/packages/snap-account-service/typedoc.json
+++ b/packages/snap-account-service/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "out": "docs",
+  "tsconfig": "./tsconfig.build.json"
+}

--- a/teams.json
+++ b/teams.json
@@ -75,5 +75,6 @@
   "metamask/remote-feature-flag-controller": "team-extension-platform,team-mobile-platform",
   "metamask/storage-service": "team-extension-platform,team-mobile-platform",
   "metamask/config-registry-controller": "team-networks",
-  "metamask/money-account-controller": "team-accounts-framework"
+  "metamask/money-account-controller": "team-accounts-framework",
+  "metamask/snap-account-service": "team-accounts-framework"
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -221,6 +221,9 @@
       "path": "./packages/signature-controller/tsconfig.build.json"
     },
     {
+      "path": "./packages/snap-account-service/tsconfig.build.json"
+    },
+    {
       "path": "./packages/social-controllers/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -213,6 +213,9 @@
       "path": "./packages/signature-controller"
     },
     {
+      "path": "./packages/snap-account-service"
+    },
+    {
       "path": "./packages/social-controllers"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4368,7 +4368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/messenger@npm:^1.1.1, @metamask/messenger@workspace:packages/messenger":
+"@metamask/messenger@npm:^1.1.1, @metamask/messenger@workspace:^, @metamask/messenger@workspace:packages/messenger":
   version: 0.0.0-use.local
   resolution: "@metamask/messenger@workspace:packages/messenger"
   dependencies:
@@ -5265,6 +5265,24 @@ __metadata:
   checksum: 10/296ac7c578bd35792c7e3942a9a0b7d9d7af76cf98358b97403c1ed483faa3c2fe6c71b1c3f8c7719fbfcf9fc73e5fa8707c89ac277ee9ce6c8bc4c694b2059d
   languageName: node
   linkType: hard
+
+"@metamask/snap-account-service@workspace:packages/snap-account-service":
+  version: 0.0.0-use.local
+  resolution: "@metamask/snap-account-service@workspace:packages/snap-account-service"
+  dependencies:
+    "@metamask/auto-changelog": "npm:^3.4.4"
+    "@metamask/messenger": "workspace:^"
+    "@ts-bridge/cli": "npm:^0.6.4"
+    "@types/jest": "npm:^29.5.14"
+    deepmerge: "npm:^4.2.2"
+    jest: "npm:^29.7.0"
+    ts-jest: "npm:^29.2.5"
+    tsx: "npm:^4.20.5"
+    typedoc: "npm:^0.25.13"
+    typedoc-plugin-missing-exports: "npm:^2.0.0"
+    typescript: "npm:~5.3.3"
+  languageName: unknown
+  linkType: soft
 
 "@metamask/snaps-controllers@npm:^19.0.0":
   version: 19.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4368,7 +4368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/messenger@npm:^1.1.1, @metamask/messenger@workspace:^, @metamask/messenger@workspace:packages/messenger":
+"@metamask/messenger@npm:^1.1.1, @metamask/messenger@workspace:packages/messenger":
   version: 0.0.0-use.local
   resolution: "@metamask/messenger@workspace:packages/messenger"
   dependencies:
@@ -5271,7 +5271,7 @@ __metadata:
   resolution: "@metamask/snap-account-service@workspace:packages/snap-account-service"
   dependencies:
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/messenger": "workspace:^"
+    "@metamask/messenger": "npm:^1.1.1"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
     deepmerge: "npm:^4.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5272,6 +5272,9 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/messenger": "npm:^1.1.1"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/utils": "npm:^11.9.0"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
     deepmerge: "npm:^4.2.2"


### PR DESCRIPTION
## Explanation

Implementing a proper `init` and `getSnaps` method.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
