### PR TITLE
chore: Migrate SIWE dependency to @signinwithethereum/siwe v4

### DIFF
--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replace `@spruceid/siwe-parser` with `@signinwithethereum/siwe-parser` ^4.1.0 ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+  - The original package is no longer maintained by Spruce. The Ethereum Identity Foundation now maintains the successor under the `@signinwithethereum` scope. The `ParsedMessage` class API is unchanged.
+
 ## [11.20.0]
 
 ### Added

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -50,7 +50,7 @@
     "@metamask/eth-query": "^4.0.0",
     "@metamask/ethjs-unit": "^0.3.0",
     "@metamask/utils": "^11.9.0",
-    "@spruceid/siwe-parser": "2.1.0",
+    "@signinwithethereum/siwe-parser": "^4.1.0",
     "@types/bn.js": "^5.1.5",
     "bignumber.js": "^9.1.2",
     "bn.js": "^5.2.1",

--- a/packages/controller-utils/src/siwe.test.ts
+++ b/packages/controller-utils/src/siwe.test.ts
@@ -1,4 +1,4 @@
-import { ParsedMessage } from '@spruceid/siwe-parser';
+import { ParsedMessage } from '@signinwithethereum/siwe-parser';
 
 import { detectSIWE, isValidSIWEOrigin } from './siwe';
 

--- a/packages/controller-utils/src/siwe.ts
+++ b/packages/controller-utils/src/siwe.ts
@@ -1,5 +1,5 @@
 import { remove0x } from '@metamask/utils';
-import { ParsedMessage } from '@spruceid/siwe-parser';
+import { ParsedMessage } from '@signinwithethereum/siwe-parser';
 
 import { projectLogger, createModuleLogger } from './logger';
 

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replace `siwe` with `@signinwithethereum/siwe` ^4.1.0 ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+  - The original package is no longer maintained by Spruce. The Ethereum Identity Foundation now maintains the successor under the `@signinwithethereum` scope. The `SiweMessage` class API is unchanged.
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -112,9 +112,9 @@
     "@metamask/utils": "^11.9.0",
     "@noble/ciphers": "^1.3.0",
     "@noble/hashes": "^1.8.0",
+    "@signinwithethereum/siwe": "^4.1.0",
     "immer": "^9.0.6",
-    "loglevel": "^1.8.1",
-    "siwe": "^2.3.2"
+    "loglevel": "^1.8.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-siwe.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-siwe.ts
@@ -1,4 +1,4 @@
-import { SiweMessage } from 'siwe';
+import { SiweMessage } from '@signinwithethereum/siwe';
 
 import {
   SIWE_LOGIN_URL,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3278,7 +3278,7 @@ __metadata:
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-unit": "npm:^0.3.0"
     "@metamask/utils": "npm:^11.9.0"
-    "@spruceid/siwe-parser": "npm:2.1.0"
+    "@signinwithethereum/siwe-parser": "npm:^4.1.0"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/bn.js": "npm:^5.1.5"
     "@types/jest": "npm:^29.5.14"
@@ -4979,6 +4979,7 @@ __metadata:
     "@metamask/utils": "npm:^11.9.0"
     "@noble/ciphers": "npm:^1.3.0"
     "@noble/hashes": "npm:^1.8.0"
+    "@signinwithethereum/siwe": "npm:^4.1.0"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
     deepmerge: "npm:^4.2.2"
@@ -4988,7 +4989,6 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     loglevel: "npm:^1.8.1"
     nock: "npm:^13.3.1"
-    siwe: "npm:^2.3.2"
     ts-jest: "npm:^29.2.5"
     tsx: "npm:^4.20.5"
     typedoc: "npm:^0.25.13"
@@ -5806,7 +5806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1.1.2, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:^1.7.1, @noble/hashes@npm:^1.8.0, @noble/hashes@npm:~1.8.0":
+"@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:^1.7.0, @noble/hashes@npm:^1.7.1, @noble/hashes@npm:^1.8.0, @noble/hashes@npm:~1.8.0":
   version: 1.8.0
   resolution: "@noble/hashes@npm:1.8.0"
   checksum: 10/474b7f56bc6fb2d5b3a42132561e221b0ea4f91e590f4655312ca13667840896b34195e2b53b7f097ec080a1fdd3b58d902c2a8d0fbdf51d2e238b53808a177e
@@ -6127,6 +6127,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@signinwithethereum/siwe-parser@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@signinwithethereum/siwe-parser@npm:4.1.0"
+  dependencies:
+    "@noble/hashes": "npm:^1.7.0"
+    apg-js: "npm:^4.4.0"
+  checksum: 10/35f97335717491482c6a1b615a2d6d67bf9384fe0e613db3de5c6c42e600cb913cef93cecb8bf1725afa5560ba56aa2aa45be8d22da147b0de2b290610a09cfc
+  languageName: node
+  linkType: hard
+
+"@signinwithethereum/siwe@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@signinwithethereum/siwe@npm:4.1.0"
+  dependencies:
+    "@signinwithethereum/siwe-parser": "npm:^4.1.0"
+  peerDependencies:
+    ethers: ^5.7.0 || ^6.13.0
+    viem: ^2.7.0
+  peerDependenciesMeta:
+    ethers:
+      optional: true
+    viem:
+      optional: true
+  checksum: 10/28317bb8038664f3b236ba7b218f10d1a66267a3eb78b003f6c102e4d13ba4df584a379dc8b2730d3a884546d868557ee508b8600aea76f6db9517d2e20ef51a
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
@@ -6225,63 +6252,6 @@ __metadata:
   bin:
     errors: bin/cli.mjs
   checksum: 10/4191f96cad47c64266ec501ae1911a6245fd02b2f68a2c53c3dabbc63eb7c5462f170a765b584348b195da2387e7ca02096d792c67352c2c30a4f3a3cc7e4270
-  languageName: node
-  linkType: hard
-
-"@spruceid/siwe-parser@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@spruceid/siwe-parser@npm:2.1.0"
-  dependencies:
-    "@noble/hashes": "npm:^1.1.2"
-    apg-js: "npm:^4.1.1"
-    uri-js: "npm:^4.4.1"
-    valid-url: "npm:^1.0.9"
-  checksum: 10/12198f613f15000b5ec2e2f59c4c3c34918c88d48e0c2e2cfdb34ce926b89a13b6f18e7612777ffb8fa25ca2c226577e47c72592e76823b03770b67c54f78d38
-  languageName: node
-  linkType: hard
-
-"@spruceid/siwe-parser@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@spruceid/siwe-parser@npm:2.1.2"
-  dependencies:
-    "@noble/hashes": "npm:^1.1.2"
-    apg-js: "npm:^4.3.0"
-    uri-js: "npm:^4.4.1"
-    valid-url: "npm:^1.0.9"
-  checksum: 10/48459fe3b4d4b3091375ee87af700864c9023d4a1271d34850c6d27475e5d93a45d1efe8a71da367ad838b6921ced60c387d54737edd0a7a0d8e4e0a3cc2b8b7
-  languageName: node
-  linkType: hard
-
-"@stablelib/binary@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@stablelib/binary@npm:1.0.1"
-  dependencies:
-    "@stablelib/int": "npm:^1.0.1"
-  checksum: 10/c5ed769e2b5d607a5cdb72d325fcf98db437627862fade839daad934bd9ccf02a6f6e34f9de8cb3b18d72fce2ba6cc019a5d22398187d7d69d2607165f27f8bf
-  languageName: node
-  linkType: hard
-
-"@stablelib/int@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@stablelib/int@npm:1.0.1"
-  checksum: 10/65bfbf50a382eea70c68e05366bf379cfceff8fbc076f1c267ef2f2411d7aed64fd140c415cb6c29f19a3910d3b8b7805d4b32ad5721a5007a8e744a808c7ae3
-  languageName: node
-  linkType: hard
-
-"@stablelib/random@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "@stablelib/random@npm:1.0.2"
-  dependencies:
-    "@stablelib/binary": "npm:^1.0.1"
-    "@stablelib/wipe": "npm:^1.0.1"
-  checksum: 10/f5ace0a588dc4c21f01cb85837892d4c872e994ae77a58a8eb7dd61aa0b26fb1e9b46b0445e71af57d963ef7d9f5965c64258fc0d04df7b2947bc48f2d3560c5
-  languageName: node
-  linkType: hard
-
-"@stablelib/wipe@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@stablelib/wipe@npm:1.0.1"
-  checksum: 10/287802eb146810a46ba72af70b82022caf83a8aeebde23605f5ee0decf64fe2b97a60c856e43b6617b5801287c30cfa863cfb0469e7fcde6f02d143cf0c6cbf4
   languageName: node
   linkType: hard
 
@@ -7237,7 +7207,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apg-js@npm:^4.1.1, apg-js@npm:^4.3.0":
+"apg-js@npm:^4.4.0":
   version: 4.4.0
   resolution: "apg-js@npm:4.4.0"
   checksum: 10/425f19096026742f5f156f26542b68f55602aa60f0c4ae2d72a0a888cf15fe9622223191202262dd8979d76a6125de9d8fd164d56c95fb113f49099f405eb08c
@@ -13665,20 +13635,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"siwe@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "siwe@npm:2.3.2"
-  dependencies:
-    "@spruceid/siwe-parser": "npm:^2.1.2"
-    "@stablelib/random": "npm:^1.0.1"
-    uri-js: "npm:^4.4.1"
-    valid-url: "npm:^1.0.9"
-  peerDependencies:
-    ethers: ^5.6.8 || ^6.0.8
-  checksum: 10/6ea5ad9a9046fa916f85bf9d3092bc898f7e339d9c552714ea53ecc17daa4f78300c3cf7cc9c70fe57baf77dcee5cb38c6e1d692400b874cd84d297b1261918c
-  languageName: node
-  linkType: hard
-
 "slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -14608,13 +14564,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/5f9c15e6f5a2b8eae75332a3317e46e995a1763efe1b91e57bc5064e36f0feba734367c88013d53255bdf09fb9204bf3598d2ca0c3f468c8726095b1c3551926
-  languageName: node
-  linkType: hard
-
-"valid-url@npm:^1.0.9":
-  version: 1.0.9
-  resolution: "valid-url@npm:1.0.9"
-  checksum: 10/343dfaf85eb3691dc8eb93f7bc007be1ee6091e6c6d1a68bf633cb85e4bf2930e34ca9214fb2c3330de5b652510b257a8ee1ff0a0a37df0925e9dabf93ee512d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#edit:
## superseeded by https://github.com/MetaMask/core/pull/8497

.




## Explanation

### Current state

The monorepo depends on two SIWE (Sign-In With Ethereum / EIP-4361) packages originally maintained by Spruce:

- `@spruceid/siwe-parser` v2.1.0 — used by `@metamask/controller-utils` to detect and parse SIWE messages via `detectSIWE()`
- `siwe` v2.3.2 — used by `@metamask/profile-sync-controller` to construct SIWE login messages via `new SiweMessage({...}).prepareMessage()`

#### The Spruce `siwe` package is no longer maintained.

Stewardship of the SIWE standard [has moved to the Ethereum Identity Foundation](https://x.com/BrantlyMillegan/status/1956389297461899533) ([GitHub](https://github.com/signinwithethereum)).
[`@signinwithethereum/siwe`](https://www.npmjs.com/package/@signinwithethereum/siwe) is the official successor TypeScript implementation.


### Similar migrations: 
x402-foundation/x402 https://github.com/x402-foundation/x402/pull/1917,
magiclabs/magic-js https://github.com/magiclabs/magic-js/pull/1074


### What this PR does

Swaps the abandoned packages for the actively maintained successors. The `ParsedMessage` and `SiweMessage` class APIs are identical - same constructors, same fields, same methods. This is purely a dependency swap with import path updates.

**Files changed:**

| Package | File | Change |
|---|---|---|
| `controller-utils` | `package.json` | Replaced dependency |
| `controller-utils` | `src/siwe.ts` | Import path updated |
| `controller-utils` | `src/siwe.test.ts` | Import path updated |
| `profile-sync-controller` | `package.json` | Replaced dependency |
| `profile-sync-controller` | `src/sdk/authentication-jwt-bearer/flow-siwe.ts` | Import path updated |

### EIP-55 patches in client repos become obsolete

The old version strictly rejected non checksummed Ethereum addresses in SIWE messages. Because many dApps produce lowercase addresses, both MetaMask client repos maintain patches to disable the check — otherwise `detectSIWE` returns `{ isSIWEMessage: false }` and users don't see the specialized SIWE approval screen.

`@signinwithethereum/siwe-parser` v4.2.0 ([release notes](https://github.com/signinwithethereum/siwe/releases/tag/%40signinwithethereum%2Fsiwe%404.2.0)) relaxes this:

- All-lowercase and all-uppercase addresses now parse successfully with a non-fatal warning on the new `warnings: string[]` field of `ParsedMessage`
- Only mixed-case addresses with an incorrect checksum still fail to parse
- Verification is case-insensitive for EOA signature recovery
- Object-constructed `SiweMessage` instances are normalized to EIP-55

If the client repos upgrade to this version of `controller-utils`, they can delete these patches and any related `package.json` resolutions:

- [`metamask-extension/.yarn/patches/@spruceid-siwe-parser-npm-2.1.0-060b7ede7a.patch`](https://github.com/MetaMask/metamask-extension/blob/main/.yarn/patches/@spruceid-siwe-parser-npm-2.1.0-060b7ede7a.patch)
- [`metamask-mobile/patches/@spruceid+siwe-parser+2.1.0.patch`](https://github.com/MetaMask/metamask-mobile/blob/main/patches/@spruceid+siwe-parser+2.1.0.patch)

## References

- [Release notes for v4.2.0](https://github.com/signinwithethereum/siwe/releases/tag/%40signinwithethereum%2Fsiwe%404.2.0)
- [New maintainer repo](https://github.com/signinwithethereum/siwe)
- [`@signinwithethereum/siwe-parser` on npm](https://www.npmjs.com/package/@signinwithethereum/siwe-parser)
- [`@signinwithethereum/siwe` on npm](https://www.npmjs.com/package/@signinwithethereum/siwe)
- [EIP-4361 spec](https://eips.ethereum.org/EIPS/eip-4361)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
