### PR TITLE
fix(perps-controller): restore webpackIgnore comment stripped by ts-bridge

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -87,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Preserve `/* webpackIgnore: true */` magic comment in built dist files by using a variable for the MYXProvider dynamic import path, preventing ts-bridge from rewriting the AST node and stripping the comment ([#8424](https://github.com/MetaMask/core/pull/8424))
 - Fix incorrect fee estimate when flipping a position ([#8333](https://github.com/MetaMask/core/pull/8333))
 - Fix incorrect PnL and order size displayed after SL execution ([#8333](https://github.com/MetaMask/core/pull/8333))
 - Fix stop loss not showing up in recent activity ([#8333](https://github.com/MetaMask/core/pull/8333))

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -1694,8 +1694,11 @@ export class PerpsController extends BaseController<
       // IMPORTANT: Must use import() — NOT require() — for core/extension tree-shaking.
       // require() is synchronous and bundlers include it in the main bundle.
       // import() enables true code splitting so MYX is excluded when not enabled.
+      // NOTE: Uses a variable so ts-bridge does not rewrite the import
+      // specifier (which would strip the webpackIgnore magic comment).
+      const myxModulePath = './providers/MYXProvider';
       this.#myxRegistrationPromise = import(
-        /* webpackIgnore: true */ './providers/MYXProvider'
+        /* webpackIgnore: true */ myxModulePath
       )
         .then(({ MYXProvider }) => {
           this.registerMYXProvider(MYXProvider);


### PR DESCRIPTION
## Explanation

When `@metamask/perps-controller` v2.0.0 is consumed by the MetaMask extension, webpack throws a hard `MODULE_NOT_FOUND` error on the MYXProvider dynamic import.

**Root cause:** `ts-bridge`'s `getDynamicImportExtensionTransformer` creates new AST nodes (`factory.createStringLiteral`) that discard leading comments from the original source. The `/* webpackIgnore: true */` magic comment added in #8398 is present in TypeScript source but stripped from the compiled `.mjs`/`.cjs` output.

**Fix:** Extract the import path into a local variable. `ts-bridge` only transforms string literal arguments in `import()` calls, so a variable reference is left untouched — preserving both the magic comment and the original path. This avoids needing post-build scripts or build system modifications (which would violate monorepo yarn constraints).

**Long-term:** The proper fix is upstream in `@ts-bridge/cli` — the transformer should copy leading comments from original nodes to synthesized ones via `ts.setSyntheticLeadingComments()`. Once that's fixed, this workaround can be reverted.

## References

- Fixes the webpack error in MetaMask/metamask-extension#41356
- Follow-up to #8398

## Changelog

### `@metamask/perps-controller`

#### Fixed

- Preserve `/* webpackIgnore: true */` magic comment in built dist files by using a variable for the MYXProvider dynamic import path, preventing ts-bridge from rewriting the AST node and stripping the comment

## Checklist

- [x] I've updated the changelog
- [x] I've verified the fix: `dist/PerpsController.mjs` and `dist/PerpsController.cjs` both contain `/* webpackIgnore: true */`
- [x] Tests pass
- [x] Changelog validates
- [x] Yarn constraints pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to how `MYXProvider` is dynamically imported and documented in the changelog. Main risk is unintended bundler behavior if the import path variable affects tree-shaking/code-splitting in consuming builds.
> 
> **Overview**
> Ensures the `MYXProvider` dynamic import retains the `/* webpackIgnore: true */` magic comment in compiled output by moving the import specifier to a `myxModulePath` variable, avoiding `ts-bridge` rewriting that strips the comment.
> 
> Updates the perps-controller changelog to document this fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dff83af4cc0595b826191feb01ebae8bc901c671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->