### PR TITLE
Allow redelegation signing for non-root authority

### DIFF
--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 
+### Fixed
+
+- Allow external origins to sign non-root delegation (redelegation) requests for internal accounts ([#7917](https://github.com/MetaMask/core/issues/7917))
+  - Previously, `validateDelegation` blocked all delegation signing from external origins when the delegator was an internal account, including safe redelegations.
+  - Now, only root delegations (where `authority` equals the ERC-7710 root authority sentinel `0xfff…fff`) are blocked from external origins. Redelegations with a non-root authority are allowed, as they are bounded by the parent delegation's caveats.
+
 ## [39.1.2]
 
 ### Changed

--- a/packages/signature-controller/src/utils/validation.test.ts
+++ b/packages/signature-controller/src/utils/validation.test.ts
@@ -524,7 +524,7 @@ describe('Validation Utils', () => {
             ).not.toThrow();
           });
 
-          it('does not throw if external origin and delegation without authority field from internal account', () => {
+          it('throws if external origin and delegation without authority field from internal account', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
 
             data.primaryType = PRIMARY_TYPE_DELEGATION;
@@ -542,7 +542,9 @@ describe('Validation Utils', () => {
                 request: { origin: ORIGIN_MOCK } as OriginalRequest,
                 version,
               }),
-            ).not.toThrow();
+            ).toThrow(
+              'External signature requests cannot sign root delegations for internal accounts.',
+            );
           });
 
           it('does not throw if external origin in message params and redelegation from internal account', () => {

--- a/packages/signature-controller/src/utils/validation.test.ts
+++ b/packages/signature-controller/src/utils/validation.test.ts
@@ -4,6 +4,7 @@ import { SignTypedDataVersion } from '@metamask/keyring-controller';
 import type { Hex } from '@metamask/utils';
 
 import {
+  AUTHORITY_FIELD,
   PRIMARY_TYPE_DELEGATION,
   validatePersonalSignatureRequest,
   validateTypedSignatureRequest,
@@ -18,6 +19,10 @@ import type {
 const CHAIN_ID_MOCK = '0x1';
 const ORIGIN_MOCK = 'test.com';
 const INTERNAL_ACCOUNT_MOCK = '0x12345678abcd';
+const ROOT_AUTHORITY_MOCK =
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+const NON_ROOT_AUTHORITY_MOCK =
+  '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
 
 const DATA_TYPED_MOCK =
   '{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Person":[{"name":"name","type":"string"},{"name":"wallet","type":"address"}],"Mail":[{"name":"from","type":"Person"},{"name":"to","type":"Person"},{"name":"contents","type":"string"}]},"primaryType":"Mail","domain":{"name":"Ether Mail","version":"1","chainId":1,"verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"},"message":{"from":{"name":"Cow","wallet":"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"},"to":{"name":"Bob","wallet":"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"},"contents":"Hello, Bob!"}}';
@@ -409,12 +414,16 @@ describe('Validation Utils', () => {
         });
 
         describe('delegation', () => {
-          it('throws if external origin in request and delegation from internal account', () => {
+          it('throws if external origin in request and root delegation from internal account', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
 
             data.primaryType = PRIMARY_TYPE_DELEGATION;
-            data.types.Delegation = [{ name: 'delegator', type: 'address' }];
+            data.types.Delegation = [
+              { name: 'delegator', type: 'address' },
+              { name: AUTHORITY_FIELD, type: 'bytes32' },
+            ];
             data.message.delegator = INTERNAL_ACCOUNT_MOCK;
+            data.message[AUTHORITY_FIELD] = ROOT_AUTHORITY_MOCK;
 
             expect(() =>
               validateTypedSignatureRequest({
@@ -428,16 +437,20 @@ describe('Validation Utils', () => {
                 version,
               }),
             ).toThrow(
-              'External signature requests cannot sign delegations for internal accounts.',
+              'External signature requests cannot sign root delegations for internal accounts.',
             );
           });
 
-          it('throws if external origin in message params and delegation from internal account', () => {
+          it('throws if external origin in message params and root delegation from internal account', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
 
             data.primaryType = PRIMARY_TYPE_DELEGATION;
-            data.types.Delegation = [{ name: 'delegator', type: 'address' }];
+            data.types.Delegation = [
+              { name: 'delegator', type: 'address' },
+              { name: AUTHORITY_FIELD, type: 'bytes32' },
+            ];
             data.message.delegator = INTERNAL_ACCOUNT_MOCK;
+            data.message[AUTHORITY_FIELD] = ROOT_AUTHORITY_MOCK;
 
             expect(() =>
               validateTypedSignatureRequest({
@@ -452,16 +465,20 @@ describe('Validation Utils', () => {
                 version,
               }),
             ).toThrow(
-              'External signature requests cannot sign delegations for internal accounts.',
+              'External signature requests cannot sign root delegations for internal accounts.',
             );
           });
 
-          it('throws if external origin and delegation from internal account with different case', () => {
+          it('throws if external origin and root delegation from internal account with different case', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
 
             data.primaryType = PRIMARY_TYPE_DELEGATION;
-            data.types.Delegation = [{ name: 'delegator', type: 'address' }];
+            data.types.Delegation = [
+              { name: 'delegator', type: 'address' },
+              { name: AUTHORITY_FIELD, type: 'bytes32' },
+            ];
             data.message.delegator = INTERNAL_ACCOUNT_MOCK;
+            data.message[AUTHORITY_FIELD] = ROOT_AUTHORITY_MOCK;
 
             expect(() =>
               validateTypedSignatureRequest({
@@ -478,16 +495,92 @@ describe('Validation Utils', () => {
                 version,
               }),
             ).toThrow(
-              'External signature requests cannot sign delegations for internal accounts.',
+              'External signature requests cannot sign root delegations for internal accounts.',
             );
           });
 
-          it('does not throw if internal origin and delegation from internal account', () => {
+          it('does not throw if external origin and redelegation (non-root authority) from internal account', () => {
+            const data = JSON.parse(DATA_TYPED_MOCK);
+
+            data.primaryType = PRIMARY_TYPE_DELEGATION;
+            data.types.Delegation = [
+              { name: 'delegator', type: 'address' },
+              { name: AUTHORITY_FIELD, type: 'bytes32' },
+            ];
+            data.message.delegator = INTERNAL_ACCOUNT_MOCK;
+            data.message[AUTHORITY_FIELD] = NON_ROOT_AUTHORITY_MOCK;
+
+            expect(() =>
+              validateTypedSignatureRequest({
+                currentChainId: CHAIN_ID_MOCK,
+                internalAccounts: ['0x1234', INTERNAL_ACCOUNT_MOCK],
+                messageData: {
+                  data,
+                  from: '0x3244e191f1b4903970224322180f1fbbc415696b',
+                },
+                request: { origin: ORIGIN_MOCK } as OriginalRequest,
+                version,
+              }),
+            ).not.toThrow();
+          });
+
+          it('does not throw if external origin and delegation without authority field from internal account', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
 
             data.primaryType = PRIMARY_TYPE_DELEGATION;
             data.types.Delegation = [{ name: 'delegator', type: 'address' }];
             data.message.delegator = INTERNAL_ACCOUNT_MOCK;
+
+            expect(() =>
+              validateTypedSignatureRequest({
+                currentChainId: CHAIN_ID_MOCK,
+                internalAccounts: ['0x1234', INTERNAL_ACCOUNT_MOCK],
+                messageData: {
+                  data,
+                  from: '0x3244e191f1b4903970224322180f1fbbc415696b',
+                },
+                request: { origin: ORIGIN_MOCK } as OriginalRequest,
+                version,
+              }),
+            ).not.toThrow();
+          });
+
+          it('does not throw if external origin in message params and redelegation from internal account', () => {
+            const data = JSON.parse(DATA_TYPED_MOCK);
+
+            data.primaryType = PRIMARY_TYPE_DELEGATION;
+            data.types.Delegation = [
+              { name: 'delegator', type: 'address' },
+              { name: AUTHORITY_FIELD, type: 'bytes32' },
+            ];
+            data.message.delegator = INTERNAL_ACCOUNT_MOCK;
+            data.message[AUTHORITY_FIELD] = NON_ROOT_AUTHORITY_MOCK;
+
+            expect(() =>
+              validateTypedSignatureRequest({
+                currentChainId: CHAIN_ID_MOCK,
+                internalAccounts: ['0x1234', INTERNAL_ACCOUNT_MOCK],
+                messageData: {
+                  data,
+                  from: '0x3244e191f1b4903970224322180f1fbbc415696b',
+                  origin: ORIGIN_MOCK,
+                },
+                request: REQUEST_MOCK,
+                version,
+              }),
+            ).not.toThrow();
+          });
+
+          it('does not throw if internal origin and root delegation from internal account', () => {
+            const data = JSON.parse(DATA_TYPED_MOCK);
+
+            data.primaryType = PRIMARY_TYPE_DELEGATION;
+            data.types.Delegation = [
+              { name: 'delegator', type: 'address' },
+              { name: AUTHORITY_FIELD, type: 'bytes32' },
+            ];
+            data.message.delegator = INTERNAL_ACCOUNT_MOCK;
+            data.message[AUTHORITY_FIELD] = ROOT_AUTHORITY_MOCK;
 
             expect(() =>
               validateTypedSignatureRequest({
@@ -503,12 +596,16 @@ describe('Validation Utils', () => {
             ).not.toThrow();
           });
 
-          it('does not throw if no origin and delegation from internal account', () => {
+          it('does not throw if no origin and root delegation from internal account', () => {
             const data = JSON.parse(DATA_TYPED_MOCK);
 
             data.primaryType = PRIMARY_TYPE_DELEGATION;
-            data.types.Delegation = [{ name: 'delegator', type: 'address' }];
+            data.types.Delegation = [
+              { name: 'delegator', type: 'address' },
+              { name: AUTHORITY_FIELD, type: 'bytes32' },
+            ];
             data.message.delegator = INTERNAL_ACCOUNT_MOCK;
+            data.message[AUTHORITY_FIELD] = ROOT_AUTHORITY_MOCK;
 
             expect(() =>
               validateTypedSignatureRequest({

--- a/packages/signature-controller/src/utils/validation.ts
+++ b/packages/signature-controller/src/utils/validation.ts
@@ -20,6 +20,16 @@ import type {
 
 export const PRIMARY_TYPE_DELEGATION = 'Delegation';
 export const DELEGATOR_FIELD = 'delegator';
+export const AUTHORITY_FIELD = 'authority';
+
+/**
+ * The root authority sentinel value per ERC-7710.
+ * When `authority` equals this value, the delegation is a root delegation
+ * (the EOA is the original delegator). Any other value indicates a
+ * redelegation, which is safe for external origins to sign.
+ */
+const ROOT_AUTHORITY =
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
 /**
  * Validate a personal signature request.
@@ -285,9 +295,14 @@ function validateDelegation({
         internalAccount.toLowerCase() === delegatorAddressLowercase,
     );
 
-    if (isOriginExternal && isSignerInternal) {
+    const authority = (
+      (data.message as Record<string, Json>)?.[AUTHORITY_FIELD] as string
+    )?.toLowerCase();
+    const isRootAuthority = authority === ROOT_AUTHORITY;
+
+    if (isOriginExternal && isSignerInternal && isRootAuthority) {
       throw new Error(
-        `External signature requests cannot sign delegations for internal accounts.`,
+        `External signature requests cannot sign root delegations for internal accounts.`,
       );
     }
   }

--- a/packages/signature-controller/src/utils/validation.ts
+++ b/packages/signature-controller/src/utils/validation.ts
@@ -298,9 +298,13 @@ function validateDelegation({
     const authority = (
       (data.message as Record<string, Json>)?.[AUTHORITY_FIELD] as string
     )?.toLowerCase();
-    const isRootAuthority = authority === ROOT_AUTHORITY;
 
-    if (isOriginExternal && isSignerInternal && isRootAuthority) {
+    // If `authority` is missing or equals ROOT_AUTHORITY,
+    // we treat it as a root delegation and block it
+    // from external origins.
+    const isRedelegation = Boolean(authority) && authority !== ROOT_AUTHORITY;
+
+    if (isOriginExternal && isSignerInternal && !isRedelegation) {
       throw new Error(
         `External signature requests cannot sign root delegations for internal accounts.`,
       );


### PR DESCRIPTION
## Explanation

Right now, `validateDelegation` rejects any delegation signing request from an external origin if the delegator matches an internal account. The problem is this catches redelegations too, which shouldn't be blocked — a redelegation is already scoped by whatever the parent delegation allows, so there's no privilege escalation risk.

The fix checks the `authority` field in the EIP-712 message before deciding whether to throw. If `authority` is the root sentinel (`0xfff…fff`), the request is a root delegation and we still block it for external origins. Anything else is a redelegation and gets let through.

Worth noting: I defined `ROOT_AUTHORITY` locally in `validation.ts` instead of pulling it from `@metamask/delegation-core` to avoid adding a new dependency to `signature-controller`. The comparison is case-insensitive to stay consistent with how `delegator` matching already works.

## References

- Fixes #7917

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes signature validation rules for `Delegation` typed data based on the `authority` field, which affects security-sensitive gating of what external origins are allowed to sign.
> 
> **Overview**
> **Relaxes delegation signature validation for external origins.** `validateDelegation` now blocks only *root* delegations for internal accounts by checking the EIP-712 `authority` field against the ERC-7710 root sentinel, while allowing non-root *redelegations* to be signed externally.
> 
> Updates tests and error messaging to distinguish root delegations vs redelegations, and documents the behavior in the package changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7377fbd94bb1bde533e97f49521e066d7ecb0ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->