### PR TITLE
feat: skip simulation when enforced simulations container is active

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Skip simulation when transaction `containerTypes` includes `EnforcedSimulations` ([#8431](https://github.com/MetaMask/core/pull/8431))
 - Bump `@metamask/accounts-controller` from `^37.1.1` to `^37.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Skip simulation when transaction `containerTypes` includes `EnforcedSimulations` ([#8431](https://github.com/MetaMask/core/pull/8431))
 - Preserve `submittedTime` if already set by a publish hook instead of overwriting it ([#8439](https://github.com/MetaMask/core/pull/8439))
 
 ## [64.1.0]

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -30,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Skip simulation when transaction `containerTypes` includes `EnforcedSimulations` ([#8431](https://github.com/MetaMask/core/pull/8431))
 - Bump `@metamask/accounts-controller` from `^37.1.1` to `^37.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `MantleLayer1GasFeeFlow` with `tokenRatio` conversion for accurate MNT-denominated gas estimates for Mantle and MantleSepolia ([#8386](https://github.com/MetaMask/core/pull/8386))
 
+### Changed
+
+- Skip simulation when transaction `containerTypes` includes `EnforcedSimulations` ([#8431](https://github.com/MetaMask/core/pull/8431))
+
 ## [64.2.0]
 
 ### Added
@@ -19,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Skip simulation when transaction `containerTypes` includes `EnforcedSimulations` ([#8431](https://github.com/MetaMask/core/pull/8431))
 - Preserve `submittedTime` if already set by a publish hook instead of overwriting it ([#8439](https://github.com/MetaMask/core/pull/8439))
 
 ## [64.1.0]

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2345,6 +2345,37 @@ describe('TransactionController', () => {
       });
     });
 
+    it('skips simulation when containerTypes includes EnforcedSimulations', async () => {
+      const { controller } = setupController();
+
+      const { transactionMeta } = await controller.addTransaction(
+        {
+          from: ACCOUNT_MOCK,
+          to: ACCOUNT_MOCK,
+        },
+        {
+          networkClientId: NETWORK_CLIENT_ID_MOCK,
+        },
+      );
+
+      await flushPromises();
+
+      expect(getBalanceChangesMock).toHaveBeenCalledTimes(1);
+
+      shouldResimulateMock.mockReturnValue({
+        blockTime: 123,
+        resimulate: true,
+      });
+
+      await controller.updateEditableParams(transactionMeta.id, {
+        containerTypes: [TransactionContainerType.EnforcedSimulations],
+      });
+
+      await flushPromises();
+
+      expect(getBalanceChangesMock).toHaveBeenCalledTimes(1);
+    });
+
     describe('with beforeSign hook', () => {
       it('calls beforeSign hook', async () => {
         const beforeSignHook = jest.fn().mockResolvedValueOnce({});

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -122,7 +122,6 @@ import type {
   TransactionBatchMeta,
   AfterSimulateHook,
   BeforeSignHook,
-  TransactionContainerType,
   GetSimulationConfig,
   AddTransactionOptions,
   PublishHookResult,
@@ -131,6 +130,7 @@ import type {
 } from './types';
 import {
   GasFeeEstimateLevel,
+  TransactionContainerType,
   TransactionEnvelopeType,
   TransactionType,
   TransactionStatus,
@@ -4253,6 +4253,7 @@ export class TransactionController extends BaseController<
   ): Promise<void> {
     const {
       chainId,
+      containerTypes,
       id: transactionId,
       nestedTransactions,
       networkClientId,
@@ -4272,7 +4273,10 @@ export class TransactionController extends BaseController<
     let isGasFeeSponsored = false;
 
     const isBalanceChangesSkipped =
-      this.#skipSimulationTransactionIds.has(transactionId);
+      this.#skipSimulationTransactionIds.has(transactionId) ||
+      Boolean(
+        containerTypes?.includes(TransactionContainerType.EnforcedSimulations),
+      );
 
     if (this.#isSimulationEnabled() && !isBalanceChangesSkipped) {
       const balanceChangesResult = await this.#trace(
@@ -4336,7 +4340,15 @@ export class TransactionController extends BaseController<
         txMeta.isGasFeeSponsored = isGasFeeSponsored;
         txMeta.gasUsed = gasUsed;
 
-        if (!isBalanceChangesSkipped) {
+        const skipBalanceChanges =
+          this.#skipSimulationTransactionIds.has(transactionId) ||
+          Boolean(
+            txMeta.containerTypes?.includes(
+              TransactionContainerType.EnforcedSimulations,
+            ),
+          );
+
+        if (!skipBalanceChanges) {
           txMeta.simulationData = simulationData;
         }
       },

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -4241,6 +4241,15 @@ export class TransactionController extends BaseController<
     return transactionMeta;
   }
 
+  #isBalanceChangesSkipped(transactionMeta: TransactionMeta): boolean {
+    return (
+      this.#skipSimulationTransactionIds.has(transactionMeta.id) ||
+      transactionMeta.containerTypes?.includes(
+        TransactionContainerType.EnforcedSimulations,
+      ) === true
+    );
+  }
+
   async #updateSimulationData(
     transactionMeta: TransactionMeta,
     {
@@ -4253,7 +4262,6 @@ export class TransactionController extends BaseController<
   ): Promise<void> {
     const {
       chainId,
-      containerTypes,
       id: transactionId,
       nestedTransactions,
       networkClientId,
@@ -4273,10 +4281,7 @@ export class TransactionController extends BaseController<
     let isGasFeeSponsored = false;
 
     const isBalanceChangesSkipped =
-      this.#skipSimulationTransactionIds.has(transactionId) ||
-      Boolean(
-        containerTypes?.includes(TransactionContainerType.EnforcedSimulations),
-      );
+      this.#isBalanceChangesSkipped(transactionMeta);
 
     if (this.#isSimulationEnabled() && !isBalanceChangesSkipped) {
       const balanceChangesResult = await this.#trace(
@@ -4340,15 +4345,7 @@ export class TransactionController extends BaseController<
         txMeta.isGasFeeSponsored = isGasFeeSponsored;
         txMeta.gasUsed = gasUsed;
 
-        const skipBalanceChanges =
-          this.#skipSimulationTransactionIds.has(transactionId) ||
-          Boolean(
-            txMeta.containerTypes?.includes(
-              TransactionContainerType.EnforcedSimulations,
-            ),
-          );
-
-        if (!skipBalanceChanges) {
+        if (!this.#isBalanceChangesSkipped(txMeta)) {
           txMeta.simulationData = simulationData;
         }
       },


### PR DESCRIPTION
## Explanation

When a transaction has the `EnforcedSimulations` container type, the simulation is redundant since the enforced simulation flow handles balance change protection separately. This PR skips the standard simulation in that case to avoid unnecessary network calls and potential conflicts.

## Changes

- Skip balance change simulation when `containerTypes` includes `EnforcedSimulations`
- Re-check `containerTypes` in the update callback to handle the race condition where simulation starts before the container type is set
- Use fresh state from `skipSimulationTransactionIds` in the callback instead of a stale closure, fixing an issue where toggling enforced simulations off would not restore balance changes

## References

- Extension PR: https://github.com/MetaMask/metamask-extension/pull/41126

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when/if `simulationData` is produced and persisted during transaction updates, which could affect balance-change protection behavior and downstream consumers that expect simulation results. Scope is contained and covered by a new unit test, but it touches core transaction lifecycle logic.
> 
> **Overview**
> Transactions marked with `containerTypes: [EnforcedSimulations]` now **skip balance-change simulation** (and avoid `getBalanceChanges` calls) when editable params change and would otherwise trigger re-simulation.
> 
> The simulation update path now re-checks the latest `containerTypes`/skip state inside the state update callback via a new `#isBalanceChangesSkipped` helper to avoid race conditions and prevent persisting `simulationData` when simulation is meant to be bypassed. Changelog updated and a regression test added to assert simulation is not re-run in this mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b0199344332668aa99d7b118e5202fb45d7acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->