### PR TITLE
fix(wallet): Improve default messenger, state and instance types

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -60,7 +60,7 @@
     "@metamask/remote-feature-flag-controller": "^4.2.0",
     "@metamask/scure-bip39": "^2.1.1",
     "@metamask/transaction-controller": "^64.0.0",
-    "@metamask/utils": "^11.11.0"
+    "@metamask/utils": "^11.9.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.4.4",

--- a/packages/wallet/src/Wallet.ts
+++ b/packages/wallet/src/Wallet.ts
@@ -1,7 +1,9 @@
 import { Messenger } from '@metamask/messenger';
-import { hasProperty, type Json } from '@metamask/utils';
+import type { Json } from '@metamask/utils';
 
 import type {
+  DefaultActions,
+  DefaultEvents,
   DefaultInstances,
   DefaultState,
   RootMessenger,
@@ -15,7 +17,8 @@ export type WalletConstructorArgs = {
 };
 
 export class Wallet {
-  public messenger: RootMessenger;
+  // TODO: Expand types when passing additionalConfigurations.
+  public readonly messenger: RootMessenger<DefaultActions, DefaultEvents>;
 
   readonly #instances: DefaultInstances;
 

--- a/packages/wallet/src/Wallet.ts
+++ b/packages/wallet/src/Wallet.ts
@@ -1,8 +1,13 @@
 import { Messenger } from '@metamask/messenger';
 import type { Json } from '@metamask/utils';
 
+import type {
+  DefaultInstances,
+  DefaultState,
+  RootMessenger,
+} from './initialization';
 import { initialize } from './initialization';
-import { RootMessenger, WalletOptions } from './types';
+import type { WalletOptions } from './types';
 
 export type WalletConstructorArgs = {
   state?: Record<string, Json>;
@@ -12,7 +17,7 @@ export type WalletConstructorArgs = {
 export class Wallet {
   public messenger: RootMessenger;
 
-  readonly #instances: Record<string, Record<string, unknown>>;
+  readonly #instances: DefaultInstances;
 
   constructor({ state = {}, options }: WalletConstructorArgs) {
     this.messenger = new Messenger({
@@ -22,14 +27,14 @@ export class Wallet {
     this.#instances = initialize({ state, messenger: this.messenger, options });
   }
 
-  get state(): Record<string, unknown> {
+  get state(): DefaultState {
     return Object.entries(this.#instances).reduce<Record<string, unknown>>(
       (totalState, [name, instance]) => {
         totalState[name] = instance.state ?? null;
         return totalState;
       },
       {},
-    );
+    ) as DefaultState;
   }
 
   async destroy(): Promise<void> {

--- a/packages/wallet/src/Wallet.ts
+++ b/packages/wallet/src/Wallet.ts
@@ -1,5 +1,5 @@
 import { Messenger } from '@metamask/messenger';
-import type { Json } from '@metamask/utils';
+import { hasProperty, type Json } from '@metamask/utils';
 
 import type {
   DefaultInstances,
@@ -40,7 +40,9 @@ export class Wallet {
   async destroy(): Promise<void> {
     await Promise.all(
       Object.values(this.#instances).map((instance) => {
+        // @ts-expect-error Accessing protected property.
         if (typeof instance.destroy === 'function') {
+          // @ts-expect-error Accessing protected property.
           return instance.destroy();
         }
         return undefined;

--- a/packages/wallet/src/initialization/defaults.ts
+++ b/packages/wallet/src/initialization/defaults.ts
@@ -1,4 +1,6 @@
 import type {
+  ActionConstraint,
+  EventConstraint,
   Messenger,
   MessengerActions,
   MessengerEvents,
@@ -39,8 +41,8 @@ export type DefaultActions = MessengerActions<AllMessengers>;
 export type DefaultEvents = MessengerEvents<AllMessengers>;
 
 export type RootMessenger<
-  AllowedActions extends DefaultActions = DefaultActions,
-  AllowedEvents extends DefaultEvents = DefaultEvents,
+  AllowedActions extends ActionConstraint = ActionConstraint,
+  AllowedEvents extends EventConstraint = EventConstraint,
 > = Messenger<'Root', AllowedActions, AllowedEvents>;
 
 export type DefaultState = {

--- a/packages/wallet/src/initialization/defaults.ts
+++ b/packages/wallet/src/initialization/defaults.ts
@@ -1,0 +1,48 @@
+import type {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+
+import * as defaultConfigurations from './instances';
+import type { InitializationConfiguration, InstanceState } from './types';
+
+export { defaultConfigurations };
+
+type ExtractInstance<Config> =
+  Config extends InitializationConfiguration<infer Instance, infer _>
+    ? Instance
+    : never;
+
+type ExtractInstanceMessenger<Config> =
+  Config extends InitializationConfiguration<infer _, infer InferredMessenger>
+    ? InferredMessenger
+    : never;
+
+type ExtractName<Config> =
+  ExtractInstance<Config> extends { name: infer Name extends string }
+    ? Name
+    : never;
+
+type Configs = typeof defaultConfigurations;
+
+type AllMessengers = ExtractInstanceMessenger<Configs[keyof Configs]>;
+
+export type DefaultInstances = {
+  [Key in keyof Configs as ExtractName<Configs[Key]>]: ExtractInstance<
+    Configs[Key]
+  >;
+};
+
+export type DefaultActions = MessengerActions<AllMessengers>;
+
+export type DefaultEvents = MessengerEvents<AllMessengers>;
+
+export type RootMessenger<
+  AllowedActions extends DefaultActions = DefaultActions,
+  AllowedEvents extends DefaultEvents = DefaultEvents,
+> = Messenger<'Root', AllowedActions, AllowedEvents>;
+
+export type DefaultState = {
+  [Key in keyof DefaultInstances]: InstanceState<DefaultInstances[Key]>;
+};

--- a/packages/wallet/src/initialization/index.ts
+++ b/packages/wallet/src/initialization/index.ts
@@ -1,1 +1,8 @@
+export type {
+  DefaultActions,
+  DefaultEvents,
+  DefaultInstances,
+  DefaultState,
+  RootMessenger,
+} from './defaults';
 export { initialize } from './initialization';

--- a/packages/wallet/src/initialization/initialization.ts
+++ b/packages/wallet/src/initialization/initialization.ts
@@ -1,8 +1,9 @@
 import { Json } from '@metamask/utils';
 
-import * as defaultConfigurations from './instances';
+import type { DefaultInstances } from './defaults';
+import { defaultConfigurations, RootMessenger } from './defaults';
 import { InitializationConfiguration } from './types';
-import { RootMessenger, WalletOptions } from '../types';
+import { WalletOptions } from '../types';
 
 export type InitializeArgs = {
   state: Record<string, Json>;
@@ -19,7 +20,7 @@ export function initialize({
   messenger,
   initializationConfigurations = [],
   options,
-}: InitializeArgs): Record<string, Record<string, unknown>> {
+}: InitializeArgs): DefaultInstances {
   const overriddenConfiguration = initializationConfigurations.map(
     (config) => config.name,
   );
@@ -30,7 +31,7 @@ export function initialize({
     ),
   );
 
-  const instances: Record<string, Record<string, unknown>> = {};
+  const instances: Record<string, unknown> = {};
 
   for (const config of configurationEntries) {
     const { name } = config;
@@ -48,5 +49,5 @@ export function initialize({
     instances[name] = instance as Record<string, unknown>;
   }
 
-  return instances;
+  return instances as DefaultInstances;
 }

--- a/packages/wallet/src/initialization/types.ts
+++ b/packages/wallet/src/initialization/types.ts
@@ -7,7 +7,8 @@ import type {
   MessengerActions,
 } from '@metamask/messenger';
 
-import { RootMessenger, WalletOptions } from '../types';
+import type { WalletOptions } from '../types';
+import type { RootMessenger } from './defaults';
 
 export type InstanceState<Instance> = Instance extends { state: unknown }
   ? Instance['state']

--- a/packages/wallet/src/initialization/types.ts
+++ b/packages/wallet/src/initialization/types.ts
@@ -7,8 +7,8 @@ import type {
   MessengerActions,
 } from '@metamask/messenger';
 
-import type { WalletOptions } from '../types';
 import type { RootMessenger } from './defaults';
+import type { WalletOptions } from '../types';
 
 export type InstanceState<Instance> = Instance extends { state: unknown }
   ? Instance['state']

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,16 +1,4 @@
-import {
-  ActionConstraint,
-  EventConstraint,
-  Messenger,
-} from '@metamask/messenger';
 import type { ClientConfigApiService } from '@metamask/remote-feature-flag-controller';
-
-export type RootMessenger<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  AllowedActions extends ActionConstraint = any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  AllowedEvents extends EventConstraint = any,
-> = Messenger<'Root', AllowedActions, AllowedEvents>;
 
 export type WalletOptions = {
   infuraProjectId: string;

--- a/packages/wallet/src/utilities.ts
+++ b/packages/wallet/src/utilities.ts
@@ -61,11 +61,11 @@ export async function sendTransaction(
   transaction: TransactionParams,
   options: AddTransactionOptions,
 ): Promise<{ transactionMeta: TransactionMeta; result: Promise<string> }> {
-  const { transactionMeta, result } = (await wallet.messenger.call(
+  const { transactionMeta, result } = await wallet.messenger.call(
     'TransactionController:addTransaction',
     transaction,
     options,
-  )) as { transactionMeta: TransactionMeta; result: Promise<string> };
+  );
 
   const approvalId = transactionMeta.id;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5660,25 +5660,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.11.0":
-  version: 11.11.0
-  resolution: "@metamask/utils@npm:11.11.0"
-  dependencies:
-    "@ethereumjs/tx": "npm:^4.2.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@noble/hashes": "npm:^1.3.1"
-    "@scure/base": "npm:^1.1.3"
-    "@types/debug": "npm:^4.1.7"
-    "@types/lodash": "npm:^4.17.20"
-    debug: "npm:^4.3.4"
-    lodash: "npm:^4.17.21"
-    pony-cause: "npm:^2.1.10"
-    semver: "npm:^7.5.4"
-    uuid: "npm:^9.0.1"
-  checksum: 10/c4381b9e451a9616bde84ac659bc0d1848ef06b6e605f877bfa065b78c8ed5015706683ea88a3387de5eaeb3a50d1af9af0994f04f9e06258d992598fe2be3bf
-  languageName: node
-  linkType: hard
-
 "@metamask/utils@npm:^9.0.0":
   version: 9.3.0
   resolution: "@metamask/utils@npm:9.3.0"
@@ -5712,7 +5693,7 @@ __metadata:
     "@metamask/remote-feature-flag-controller": "npm:^4.2.0"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/transaction-controller": "npm:^64.0.0"
-    "@metamask/utils": "npm:^11.11.0"
+    "@metamask/utils": "npm:^11.9.0"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
     deepmerge: "npm:^4.2.2"


### PR DESCRIPTION
## Explanation

Infer messenger, instance and state types from `defaultConfigurations`. Which lets us remove casting due to previous lack of messenger types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly TypeScript typing refactors, but it also downgrades `@metamask/utils`, which could introduce subtle compatibility or build/runtime differences across the wallet package.
> 
> **Overview**
> Improves type-safety for the wallet initialization flow by deriving `RootMessenger`, default action/event types, instance types, and `Wallet.state` shape directly from `defaultConfigurations` (new `initialization/defaults.ts`) and re-exporting them via `initialization/index.ts`.
> 
> Updates `Wallet` and `initialize` to use these inferred types (including stricter `messenger` typing and typed `DefaultState`/`DefaultInstances`), removes the old `RootMessenger` type from `types.ts`, and adds a couple of targeted `@ts-expect-error` annotations for calling optional `destroy()`.
> 
> Also adjusts `sendTransaction` to rely on the typed return value from `messenger.call` (removing an explicit cast) and downgrades `@metamask/utils` from `^11.11.0` to `^11.9.0` (with lockfile update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e130704b5f196d9850f9c80891d70aeec19bfb2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->